### PR TITLE
Lite overview: show Online/Offline status

### DIFF
--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -12,6 +12,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
         </ResourceDictionary>
     </Window.Resources>
     <Grid>
@@ -190,37 +191,55 @@
                                         <Border Background="{DynamicResource BackgroundLightBrush}"
                                                 BorderBrush="{Binding CardBorderBrush}"
                                                 BorderThickness="2" CornerRadius="6"
-                                                Padding="16" Margin="6"
+                                                Margin="6"
                                                 Width="260" MinHeight="160"
                                                 Cursor="Hand"
                                                 MouseLeftButtonDown="OverviewCard_MouseLeftButtonDown">
-                                            <StackPanel>
-                                                <TextBlock Text="{Binding DisplayName}" FontSize="16" FontWeight="SemiBold"
-                                                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,12"/>
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="*"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                    </Grid.RowDefinitions>
-                                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="CPU:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CpuDisplay}" Foreground="{Binding CpuBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Memory:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding MemoryDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Blocking:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BlockingDisplay}" Foreground="{Binding BlockingBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Deadlocks:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding DeadlockDisplay}" Foreground="{Binding DeadlockBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Last Collect:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding LastCollectionDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                </Grid>
-                                            </StackPanel>
+                                            <Grid>
+                                                <StackPanel Margin="16">
+                                                    <DockPanel Margin="0,0,0,4">
+                                                        <TextBlock Text="{Binding DisplayName}" FontSize="16" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                                                        <Ellipse Width="10" Height="10" Fill="{Binding StatusBrush}"
+                                                                 HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                                    </DockPanel>
+                                                    <TextBlock Text="{Binding StatusDisplay}" Foreground="{Binding StatusBrush}"
+                                                               FontSize="11" Margin="0,0,0,10"/>
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+                                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="CPU:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
+                                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CpuDisplay}" Foreground="{Binding CpuBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Memory:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
+                                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding MemoryDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Blocking:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
+                                                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BlockingDisplay}" Foreground="{Binding BlockingBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Deadlocks:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
+                                                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding DeadlockDisplay}" Foreground="{Binding DeadlockBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Last Collect:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding LastCollectionDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                    </Grid>
+                                                </StackPanel>
+                                                <!-- Offline overlay -->
+                                                <Border Background="#80000000" CornerRadius="6"
+                                                        Visibility="{Binding IsOffline, Converter={StaticResource BoolToVisibility}}">
+                                                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                                                        <TextBlock Text="&#x2717;" FontSize="28" Foreground="#EF4444"
+                                                                   HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Offline" FontSize="13" Foreground="#EF4444"
+                                                                   FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                                                    </StackPanel>
+                                                </Border>
+                                            </Grid>
                                         </Border>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -340,6 +340,8 @@ public partial class MainWindow : Window
                     if (summary != null)
                     {
                         summary.ServerName = server.ServerName;
+                        var connStatus = _serverManager.GetConnectionStatus(server.Id);
+                        summary.IsOnline = connStatus.IsOnline;
                         summaries.Add(summary);
                     }
                 }

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -125,6 +125,7 @@ public class ServerSummaryItem
     public string DisplayName { get; set; } = "";
     public string ServerName { get; set; } = "";
     public int ServerId { get; set; }
+    public bool? IsOnline { get; set; }
     public double? CpuPercent { get; set; }
     public double? MemoryMb { get; set; }
     public int BlockingCount { get; set; }
@@ -137,11 +138,21 @@ public class ServerSummaryItem
     public string DeadlockDisplay => DeadlockCount > 0 ? DeadlockCount.ToString() : "0";
     public string LastCollectionDisplay => LastCollectionTime.HasValue ? ServerTimeHelper.FormatServerTime(LastCollectionTime, "HH:mm:ss") : "Never";
 
+    /* Connection status */
+    public string StatusDisplay => IsOnline switch { true => "Online", false => "Offline", _ => "Unknown" };
+    public SolidColorBrush StatusBrush => MakeBrush(IsOnline switch { true => "#4CAF50", false => "#EF4444", _ => "#888888" });
+    public bool IsOffline => IsOnline == false;
+
     /* Color coding */
     public SolidColorBrush CpuBrush => MakeBrush(CpuPercent >= 80 ? "#F44336" : CpuPercent >= 50 ? "#FF9800" : "#4CAF50");
     public SolidColorBrush BlockingBrush => MakeBrush(BlockingCount > 0 ? "#FF9800" : "#4CAF50");
     public SolidColorBrush DeadlockBrush => MakeBrush(DeadlockCount > 0 ? "#F44336" : "#4CAF50");
-    public SolidColorBrush CardBorderBrush => MakeBrush(DeadlockCount > 0 ? "#F44336" : BlockingCount > 0 ? "#FF9800" : CpuPercent >= 80 ? "#FF9800" : "#555555");
+    public SolidColorBrush CardBorderBrush => MakeBrush(
+        IsOnline == false ? "#EF4444" :
+        DeadlockCount > 0 ? "#F44336" :
+        BlockingCount > 0 ? "#FF9800" :
+        CpuPercent >= 80 ? "#FF9800" :
+        "#555555");
 
     private static SolidColorBrush MakeBrush(string hex)
     {


### PR DESCRIPTION
## Summary
- Overview cards now show Online/Offline status with colored dot and label
- Offline servers get a red border and semi-transparent overlay with red X
- Uses existing `ServerManager.GetConnectionStatus()` — no new infrastructure needed

Closes #2

## Test plan
- [x] Builds clean (0 warnings, 0 errors)
- [x] Online servers show green dot + "Online"
- [x] Offline servers show red dot + "Offline" + overlay + red border
- [x] Verified with mix of online (sql2022, sql2025) and offline (cloud, sql2016-2019) servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)