### PR TITLE
Lite: per-server collector health in status bar

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -30,6 +30,7 @@ public partial class ServerTab : UserControl
     private readonly ServerConnection _server;
     private readonly LocalDataService _dataService;
     private readonly int _serverId;
+    public int ServerId => _serverId;
     private readonly CredentialService _credentialService;
     private readonly DispatcherTimer _refreshTimer;
     private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.Panels.LegendPanel?> _legendPanels = new();

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -219,6 +219,8 @@ public partial class MainWindow : Window
         {
             ServerTimeHelper.UtcOffsetMinutes = serverTab.UtcOffsetMinutes;
         }
+
+        UpdateCollectorHealth();
     }
 
     private void RefreshServerList()
@@ -290,7 +292,13 @@ public partial class MainWindow : Window
             return;
         }
 
-        var health = _collectorService.GetHealthSummary();
+        int? selectedServerId = null;
+        if (ServerTabControl.SelectedItem is TabItem { Content: ServerTab serverTab })
+        {
+            selectedServerId = serverTab.ServerId;
+        }
+
+        var health = _collectorService.GetHealthSummary(selectedServerId);
 
         if (health.TotalCollectors == 0)
         {


### PR DESCRIPTION
## Summary
- Status bar now shows collector health filtered by the currently selected server tab
- Overview tab continues to show global health across all servers
- Switching tabs immediately updates the status bar

Closes #5

## Test plan
- [x] Builds clean (0 warnings, 0 errors)
- [x] Overview tab shows global errors (includes offline servers)
- [x] Healthy server tabs show "Collectors: N OK"
- [x] Tab switching updates status bar immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)