### PR TITLE
Exclude WAITFOR queries from top queries views

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -748,6 +748,7 @@ namespace PerformanceMonitorDashboard.Services
                 OR (qs.last_execution_time >= @fromDate AND qs.last_execution_time <= @toDate)
                 OR (qs.first_execution_time <= @fromDate AND qs.last_execution_time >= @toDate)))
         )
+        AND qs.query_text NOT LIKE N'WAITFOR%'
         ORDER BY
             qs.avg_worker_time_ms DESC;";
 
@@ -989,6 +990,7 @@ namespace PerformanceMonitorDashboard.Services
                 OR (qss.last_execution_time >= @fromDate AND qss.last_execution_time <= @toDate)
                 OR (qss.first_execution_time <= @fromDate AND qss.last_execution_time >= @toDate)))
         )
+        AND qss.query_sql_text NOT LIKE N'WAITFOR%'
         ORDER BY
             qss.avg_cpu_time_ms DESC
         OPTION

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -69,6 +69,7 @@ FROM query_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
+AND   query_text NOT LIKE 'WAITFOR%'
 GROUP BY database_name, query_hash
 ORDER BY SUM(delta_elapsed_time) DESC
 LIMIT $4";

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -47,6 +47,7 @@ FROM query_store_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
+AND   query_text NOT LIKE 'WAITFOR%'
 GROUP BY database_name, query_id, plan_id, query_hash
 ORDER BY SUM(execution_count) * AVG(avg_duration_ms) DESC
 LIMIT $4";


### PR DESCRIPTION
## Summary
- Filter out WAITFOR-based queries from all top queries display views
- Applies to both Dashboard (query stats + Query Store) and Lite (query stats + Query Store)
- Data stays in the database — only filtered at read/display time

Closes #4

## Test plan
- [x] Dashboard builds clean (0 warnings, 0 errors)
- [x] Lite builds clean (0 warnings, 0 errors)
- [ ] Dashboard top queries no longer show WAITFOR entries
- [ ] Lite top queries and Query Store no longer show WAITFOR entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)