### PR TITLE
Dashboard: always show legends on Performance Trends charts

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -915,18 +915,13 @@ namespace PerformanceMonitorDashboard.Controls
                     dataList.Select(d => d.CollectionTime),
                     dataList.Select(d => d.AvgDurationMs));
 
-                if (xs.Length > 0)
-                {
-                    var scatter = chart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
-                    scatter.Color = color;
-                    scatter.LegendText = legendText;
+                var scatter = chart.Plot.Add.Scatter(xs, ys);
+                scatter.LineWidth = 2;
+                scatter.MarkerSize = 5;
+                scatter.Color = color;
+                scatter.LegendText = legendText;
 
-                    _legendPanels[chart] = chart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
-                    chart.Plot.Legend.FontSize = 12;
-                }
-                else
+                if (xs.Length == 0)
                 {
                     double xCenter = xMin + (xMax - xMin) / 2;
                     var noDataText = chart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
@@ -934,6 +929,9 @@ namespace PerformanceMonitorDashboard.Controls
                     noDataText.LabelFontColor = ScottPlot.Colors.Gray;
                     noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
                 }
+
+                _legendPanels[chart] = chart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
+                chart.Plot.Legend.FontSize = 12;
 
                 chart.Plot.Axes.DateTimeTicksBottom();
                 chart.Plot.Axes.SetLimitsX(xMin, xMax);
@@ -971,18 +969,13 @@ namespace PerformanceMonitorDashboard.Controls
                 dataList.Select(d => d.CollectionTime),
                 dataList.Select(d => (double)d.ExecutionsPerSecond));
 
-            if (xs.Length > 0)
-            {
-                var scatter = QueryPerfTrendsExecChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
-                scatter.Color = ScottPlot.Colors.Blue;
-                scatter.LegendText = "Executions/sec";
+            var scatter = QueryPerfTrendsExecChart.Plot.Add.Scatter(xs, ys);
+            scatter.LineWidth = 2;
+            scatter.MarkerSize = 5;
+            scatter.Color = ScottPlot.Colors.Blue;
+            scatter.LegendText = "Executions/sec";
 
-                _legendPanels[QueryPerfTrendsExecChart] = QueryPerfTrendsExecChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
-                QueryPerfTrendsExecChart.Plot.Legend.FontSize = 12;
-            }
-            else
+            if (xs.Length == 0)
             {
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = QueryPerfTrendsExecChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
@@ -990,6 +983,9 @@ namespace PerformanceMonitorDashboard.Controls
                 noDataText.LabelFontColor = ScottPlot.Colors.Gray;
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
+
+            _legendPanels[QueryPerfTrendsExecChart] = QueryPerfTrendsExecChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
+            QueryPerfTrendsExecChart.Plot.Legend.FontSize = 12;
 
             QueryPerfTrendsExecChart.Plot.Axes.DateTimeTicksBottom();
             QueryPerfTrendsExecChart.Plot.Axes.SetLimitsX(xMin, xMax);


### PR DESCRIPTION
## Summary
- Scatter series and legend are now created unconditionally on all 4 Performance Trends charts
- When no data exists, the legend still shows the series name alongside the "No data" message
- Previously, legends were only created inside the data-exists branch, so empty charts had no legend

Closes #11

## Test plan
- [x] Builds clean (0 warnings, 0 errors)
- [x] Charts with data: legend + line visible as before
- [x] Charts with no data: legend shows series name + "No data" message
- [x] Verified behavior consistent with Lite dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)