### PR TITLE
Fix Wait Stats selection with poison waits + top 10 (#12)

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -112,6 +112,7 @@
                         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="5,2">
                             <Button Content="Top Waits" Click="WaitTypes_SelectAll_Click" Padding="6,2" FontSize="10" Margin="0,0,5,0"/>
                             <Button Content="Clear All" Click="WaitTypes_ClearAll_Click" Padding="6,2" FontSize="10"/>
+                            <TextBlock x:Name="WaitTypeCountText" Text="0 / 20 selected" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
                         </StackPanel>
                         <TextBox Grid.Row="2" x:Name="WaitTypeSearchBox" Margin="5,2" Height="24" FontSize="11"
                                  TextChanged="WaitTypeSearch_TextChanged"

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -1862,6 +1862,17 @@ namespace PerformanceMonitorDashboard.Controls
                 .ToList();
             _waitTypeItems = sorted;
             ApplyWaitTypeSearchFilter();
+            UpdateWaitTypeCount();
+        }
+
+        private void UpdateWaitTypeCount()
+        {
+            if (_waitTypeItems == null || WaitTypeCountText == null) return;
+            int count = _waitTypeItems.Count(x => x.IsSelected);
+            WaitTypeCountText.Text = $"{count} / 20 selected";
+            WaitTypeCountText.Foreground = count >= 20
+                ? new System.Windows.Media.SolidColorBrush((System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString("#E57373")!)
+                : (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush");
         }
 
         private void WaitTypeSearch_TextChanged(object sender, TextChangedEventArgs e)
@@ -1916,6 +1927,7 @@ namespace PerformanceMonitorDashboard.Controls
                 item.IsSelected = false;
             }
             _isUpdatingWaitTypeSelection = false;
+            UpdateWaitTypeCount();
             await UpdateWaitStatsDetailChartAsync();
         }
 
@@ -2030,12 +2042,14 @@ namespace PerformanceMonitorDashboard.Controls
             var colors = new[] {
                 ScottPlot.Colors.Blue, ScottPlot.Colors.Green, ScottPlot.Colors.Orange, ScottPlot.Colors.Red,
                 ScottPlot.Colors.Purple, ScottPlot.Colors.Cyan, ScottPlot.Colors.Magenta, ScottPlot.Colors.DarkGreen,
-                ScottPlot.Colors.Navy, ScottPlot.Colors.Brown, ScottPlot.Colors.Teal, ScottPlot.Colors.Olive
+                ScottPlot.Colors.Navy, ScottPlot.Colors.Brown, ScottPlot.Colors.Teal, ScottPlot.Colors.Olive,
+                ScottPlot.Colors.Coral, ScottPlot.Colors.SkyBlue, ScottPlot.Colors.Gold, ScottPlot.Colors.MediumPurple,
+                ScottPlot.Colors.Salmon, ScottPlot.Colors.LimeGreen, ScottPlot.Colors.SandyBrown, ScottPlot.Colors.SlateGray
             };
 
             // Get all time points across all wait types for gap filling
             int colorIndex = 0;
-            foreach (var waitType in selectedWaitTypes.Take(12)) // Limit to 12 wait types
+            foreach (var waitType in selectedWaitTypes.Take(20)) // Limit to 20 wait types
             {
                 // Get data for this wait type
                 var waitTypeData = data

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -79,15 +79,14 @@ namespace PerformanceMonitorDashboard.Helpers
                     if (w.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                         defaults.Add(w);
 
-            // 4. Top 10 by total wait time (items not already in the set), hard cap at 12 total
+            // 4. Top 10 by total wait time (items not already in the set), hard cap at 20 total
             int added = 0;
             foreach (var w in availableWaitTypes)
             {
-                if (defaults.Count >= 12) break;
+                if (defaults.Count >= 20) break;
                 if (added >= 10) break;
-                if (!defaults.Contains(w))
+                if (defaults.Add(w))
                 {
-                    defaults.Add(w);
                     added++;
                 }
             }

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -127,6 +127,7 @@
                             <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,4">
                                 <Button Content="Top Waits" Click="WaitTypeSelectAll_Click" Padding="6,2" Margin="0,0,4,0" FontSize="11"/>
                                 <Button Content="Clear All" Click="WaitTypeClearAll_Click" Padding="6,2" FontSize="11"/>
+                                <TextBlock x:Name="WaitTypeCountText" Text="0 / 20 selected" FontSize="10" Foreground="{StaticResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBox Grid.Row="2" x:Name="WaitTypeSearchBox" TextChanged="WaitTypeSearch_TextChanged"
                                      Margin="0,0,0,4" Padding="4,2"/>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -50,7 +50,8 @@ public partial class ServerTab : UserControl
     {
         "#2eaef1", "#F44336", "#4CAF50", "#FFC107", "#9C27B0",
         "#FF9800", "#00BCD4", "#E91E63", "#8BC34A", "#3F51B5",
-        "#CDDC39", "#795548"
+        "#CDDC39", "#795548", "#FF7F50", "#87CEEB", "#FFD700",
+        "#9370DB", "#FA8072", "#32CD32", "#F4A460", "#708090"
     };
 
     public int UtcOffsetMinutes { get; }
@@ -992,7 +993,7 @@ public partial class ServerTab : UserControl
     private static readonly string[] UsualSuspectWaits = { "SOS_SCHEDULER_YIELD", "CXPACKET", "CXCONSUMER", "PAGEIOLATCH_SH", "PAGEIOLATCH_EX", "WRITELOG" };
     private static readonly string[] UsualSuspectPrefixes = { "PAGELATCH_" };
 
-    private static HashSet<string> GetDefaultWaitTypes(IList<string> availableWaitTypes)
+    private static HashSet<string> GetDefaultWaitTypes(List<string> availableWaitTypes)
     {
         var defaults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var w in PoisonWaits)
@@ -1006,7 +1007,7 @@ public partial class ServerTab : UserControl
         int added = 0;
         foreach (var w in availableWaitTypes)
         {
-            if (defaults.Count >= 12) break;
+            if (defaults.Count >= 20) break;
             if (added >= 10) break;
             if (!defaults.Contains(w)) { defaults.Add(w); added++; }
         }
@@ -1036,6 +1037,17 @@ public partial class ServerTab : UserControl
             .ThenBy(x => x.DisplayName)
             .ToList();
         ApplyWaitTypeFilter();
+        UpdateWaitTypeCount();
+    }
+
+    private void UpdateWaitTypeCount()
+    {
+        if (_waitTypeItems == null || WaitTypeCountText == null) return;
+        int count = _waitTypeItems.Count(x => x.IsSelected);
+        WaitTypeCountText.Text = $"{count} / 20 selected";
+        WaitTypeCountText.Foreground = count >= 20
+            ? new SolidColorBrush((System.Windows.Media.Color)ColorConverter.ConvertFromString("#E57373")!)
+            : (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush");
     }
 
     private void ApplyWaitTypeFilter()
@@ -1084,7 +1096,7 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var selected = _waitTypeItems.Where(i => i.IsSelected).Take(12).ToList();
+            var selected = _waitTypeItems.Where(i => i.IsSelected).Take(20).ToList();
 
             ClearChart(WaitStatsChart);
             ApplyDarkTheme(WaitStatsChart);


### PR DESCRIPTION
## Summary
- **Smart default selection**: Replace broken "select first 12" logic with poison waits (THREADPOOL, RESOURCE_SEMAPHORE, RESOURCE_SEMAPHORE_QUERY_COMPILE) + usual suspects (SOS_SCHEDULER_YIELD, CXPACKET, CXCONSUMER, PAGEIOLATCH_SH/EX, PAGELATCH_%, WRITELOG) + top 10 by total wait time
- **Expand chart limit**: 12 → 20 simultaneous wait types with extended color palettes in both apps
- **Selection counter**: "X / 20 selected" label next to buttons, turns red at cap
- **Relabel button**: "Select All" → "Top Waits" for truth in advertising
- **Consistent sorting**: Both Dashboard and Lite now sort wait types alphabetically (checked first)

## Test plan
- [ ] Dashboard: Resources → Wait Stats Detail — verify poison waits + usual suspects auto-checked on first load
- [ ] Dashboard: Click "Top Waits" — reapplies smart defaults
- [ ] Dashboard: Manually check/uncheck waits — counter updates, chart renders up to 20
- [ ] Lite: Wait Stats tab — same behavior as Dashboard
- [ ] Verify PAGELATCH_% prefix matching (all variants auto-checked)
- [ ] Verify "Clear All" zeros the counter and clears chart

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)