### PR TITLE
Fix query_cost overflow and add Last Error At column

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1008,6 +1008,9 @@
                                     <DataGridTextColumn Binding="{Binding LastRunFormatted}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastRunFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Run" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding LastErrorFormatted}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastErrorFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error At" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding LastError}" Width="*">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastError" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>

--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -31,7 +31,8 @@ SELECT
     AVG(duration_ms) AS avg_duration_ms,
     MAX(CASE WHEN status = 'SUCCESS' THEN collection_time END) AS last_success_time,
     MAX(collection_time) AS last_run_time,
-    MAX(CASE WHEN status = 'ERROR' THEN error_message END) AS last_error
+    MAX(CASE WHEN status = 'ERROR' THEN error_message END) AS last_error,
+    MAX(CASE WHEN status = 'ERROR' THEN collection_time END) AS last_error_time
 FROM collection_log
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -54,7 +55,8 @@ ORDER BY collector_name";
                 AvgDurationMs = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
                 LastSuccessTime = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
                 LastRunTime = reader.IsDBNull(6) ? null : reader.GetDateTime(6),
-                LastError = reader.IsDBNull(7) ? null : reader.GetString(7)
+                LastError = reader.IsDBNull(7) ? null : reader.GetString(7),
+                LastErrorTime = reader.IsDBNull(8) ? null : reader.GetDateTime(8)
             });
         }
 
@@ -141,6 +143,7 @@ public class CollectorHealthRow
     public DateTime? LastSuccessTime { get; set; }
     public DateTime? LastRunTime { get; set; }
     public string? LastError { get; set; }
+    public DateTime? LastErrorTime { get; set; }
 
     public double FailureRatePercent => TotalRuns > 0 ? (double)ErrorCount / TotalRuns * 100 : 0;
     public double HoursSinceLastSuccess => LastSuccessTime.HasValue
@@ -170,5 +173,9 @@ public class CollectorHealthRow
     public string LastRunFormatted => LastRunTime.HasValue
         ? LastRunTime.Value.ToLocalTime().ToString("MM/dd HH:mm:ss")
         : "Never";
+
+    public string LastErrorFormatted => LastErrorTime.HasValue
+        ? LastErrorTime.Value.ToLocalTime().ToString("MM/dd HH:mm:ss")
+        : "";
 }
 

--- a/Lite/Services/RemoteCollectorService.MemoryGrants.cs
+++ b/Lite/Services/RemoteCollectorService.MemoryGrants.cs
@@ -79,7 +79,7 @@ OPTION(RECOMPILE);";
                 reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
                 reader.IsDBNull(10) ? false : Convert.ToBoolean(reader.GetValue(10)),
                 reader.IsDBNull(11) ? 0 : Convert.ToInt32(reader.GetValue(11)),
-                reader.IsDBNull(12) ? 0m : Convert.ToDecimal(reader.GetValue(12))));
+                reader.IsDBNull(12) ? 0m : SafeToDecimal(reader.GetValue(12))));
         }
         sqlSw.Stop();
 

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -518,6 +518,32 @@ public partial class RemoteCollectorService
     }
 
     /// <summary>
+    /// Safely converts a SQL Server float/real value to decimal.
+    /// Returns 0 for Infinity, NaN, or values outside decimal range.
+    /// </summary>
+    protected static decimal SafeToDecimal(object value)
+    {
+        try
+        {
+            if (value is double d)
+            {
+                if (double.IsInfinity(d) || double.IsNaN(d))
+                    return 0m;
+            }
+            else if (value is float f)
+            {
+                if (float.IsInfinity(f) || float.IsNaN(f))
+                    return 0m;
+            }
+            return Convert.ToDecimal(value);
+        }
+        catch (OverflowException)
+        {
+            return 0m;
+        }
+    }
+
+    /// <summary>
     /// Deterministic hash code for a string. .NET Core randomizes string.GetHashCode()
     /// per process, so we use a simple FNV-1a hash to get a stable value across restarts.
     /// </summary>


### PR DESCRIPTION
## Summary

Two small fixes from testing the new Collection Health tab:

1. **SafeToDecimal() for query_cost** — `sys.dm_exec_query_memory_grants.query_cost` is a SQL Server `float` that can be `Infinity` or `NaN` for degenerate query plans. `Convert.ToDecimal()` can't represent these and throws "Value was either too large or too small for an Int64". New `SafeToDecimal()` helper handles this gracefully.

2. **Last Error At column** — The Health Summary grid showed *what* the last error was but not *when* it happened. Added `last_error_time` to the query and a "Last Error At" column so you can tell if an error is current or ancient history.

## Test plan

- [x] `dotnet build -c Debug` — builds clean
- [ ] Launch Lite, check Collection Health → Health Summary — "Last Error At" column shows timestamp for collectors that have errored
- [ ] Memory grant collector no longer errors on queries with extreme cost values

🤖 Generated with [Claude Code](https://claude.com/claude-code)