### PR TITLE
Fix chart X-axis timezone double-conversion

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -811,8 +811,8 @@ public partial class ServerTab : UserControl
         DateTime rangeStart, rangeEnd;
         if (fromDate.HasValue && toDate.HasValue)
         {
-            rangeStart = fromDate.Value.AddMinutes(UtcOffsetMinutes);
-            rangeEnd = toDate.Value.AddMinutes(UtcOffsetMinutes);
+            rangeStart = fromDate.Value;
+            rangeEnd = toDate.Value;
         }
         else
         {
@@ -881,8 +881,8 @@ public partial class ServerTab : UserControl
         DateTime rangeStart, rangeEnd;
         if (fromDate.HasValue && toDate.HasValue)
         {
-            rangeStart = fromDate.Value.AddMinutes(UtcOffsetMinutes);
-            rangeEnd = toDate.Value.AddMinutes(UtcOffsetMinutes);
+            rangeStart = fromDate.Value;
+            rangeEnd = toDate.Value;
         }
         else
         {
@@ -1184,8 +1184,8 @@ public partial class ServerTab : UserControl
             DateTime rangeStart, rangeEnd;
             if (IsCustomRange && fromDate.HasValue && toDate.HasValue)
             {
-                rangeStart = fromDate.Value.AddMinutes(UtcOffsetMinutes);
-                rangeEnd = toDate.Value.AddMinutes(UtcOffsetMinutes);
+                rangeStart = fromDate.Value;
+                rangeEnd = toDate.Value;
             }
             else
             {
@@ -1325,8 +1325,8 @@ public partial class ServerTab : UserControl
             DateTime rangeStart, rangeEnd;
             if (IsCustomRange && fromDate.HasValue && toDate.HasValue)
             {
-                rangeStart = fromDate.Value.AddMinutes(UtcOffsetMinutes);
-                rangeEnd = toDate.Value.AddMinutes(UtcOffsetMinutes);
+                rangeStart = fromDate.Value;
+                rangeEnd = toDate.Value;
             }
             else
             {


### PR DESCRIPTION
## Summary

Fixes #49 — Custom date range chart X-axis was shifted by the server's UTC offset because `fromDate`/`toDate` (already in server time) had `UtcOffsetMinutes` added again.

- Removed redundant `.AddMinutes(UtcOffsetMinutes)` from 4 chart range-setting blocks
- Affects: wait stats, perfmon, blocking trend, deadlock trend charts

## Test plan

- [x] `dotnet build -c Debug` — builds clean
- [x] Set custom range 08:00-12:00, verify X-axis shows 08:00-12:00 (not shifted)
- [ ] Verify non-custom ranges (1h, 4h, etc.) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)