### PR TITLE
Add avg ms per wait chart toggle (#22)

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -142,7 +142,14 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Grid.Row="0" Text="Wait Stats Over Time" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5">
+                            <TextBlock Text="Wait Stats Over Time" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                            <TextBlock Text="Metric:" VerticalAlignment="Center" Margin="0,0,4,0" FontSize="11"/>
+                            <ComboBox x:Name="WaitStatsMetricCombo" SelectedIndex="0" SelectionChanged="WaitStatsMetric_SelectionChanged" FontSize="11" Padding="4,2">
+                                <ComboBoxItem Content="Wait Time (ms/sec)"/>
+                                <ComboBoxItem Content="Avg Wait Time (ms/wait)"/>
+                            </ComboBox>
+                        </StackPanel>
                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="WaitStatsDetailChart"/>
                     </Grid>
                 </Border>

--- a/Dashboard/Helpers/ChartHoverHelper.cs
+++ b/Dashboard/Helpers/ChartHoverHelper.cs
@@ -18,7 +18,7 @@ internal sealed class ChartHoverHelper
     private readonly List<(ScottPlot.Plottables.Scatter Scatter, string Label)> _scatters = new();
     private readonly Popup _popup;
     private readonly TextBlock _text;
-    private readonly string _unit;
+    private string _unit;
     private DateTime _lastUpdate;
 
     public ChartHoverHelper(ScottPlot.WPF.WpfPlot chart, string unit)
@@ -52,6 +52,8 @@ internal sealed class ChartHoverHelper
         chart.MouseMove += OnMouseMove;
         chart.MouseLeave += OnMouseLeave;
     }
+
+    public string Unit { get => _unit; set => _unit = value; }
 
     public void Clear() => _scatters.Clear();
 

--- a/Dashboard/Models/WaitStatsDataPoint.cs
+++ b/Dashboard/Models/WaitStatsDataPoint.cs
@@ -16,5 +16,6 @@ namespace PerformanceMonitorDashboard.Models
         public string WaitType { get; set; } = string.Empty;
         public decimal WaitTimeMsPerSecond { get; set; }
         public decimal SignalWaitTimeMsPerSecond { get; set; }
+        public decimal AvgMsPerWait { get; set; }
     }
 }

--- a/Dashboard/Services/DatabaseService.ResourceMetrics.cs
+++ b/Dashboard/Services/DatabaseService.ResourceMetrics.cs
@@ -1723,6 +1723,14 @@ WITH
                 ORDER BY
                     ws.collection_time
             ),
+        waiting_tasks_delta =
+            ws.waiting_tasks_count - LAG(ws.waiting_tasks_count, 1, ws.waiting_tasks_count) OVER
+            (
+                PARTITION BY
+                    ws.wait_type
+                ORDER BY
+                    ws.collection_time
+            ),
         interval_seconds =
             DATEDIFF
             (
@@ -1754,6 +1762,12 @@ SELECT
             WHEN wd.interval_seconds > 0
             THEN CAST(wd.signal_wait_time_ms_delta AS decimal(19, 4)) / wd.interval_seconds
             ELSE 0
+        END,
+    avg_ms_per_wait =
+        CASE
+            WHEN wd.waiting_tasks_delta > 0
+            THEN CAST(wd.wait_time_ms_delta AS decimal(19, 4)) / wd.waiting_tasks_delta
+            ELSE 0
         END
 FROM wait_deltas AS wd
 WHERE wd.wait_time_ms_delta > 0
@@ -1782,6 +1796,14 @@ WITH
             ),
         signal_wait_time_ms_delta =
             ws.signal_wait_time_ms - LAG(ws.signal_wait_time_ms, 1, ws.signal_wait_time_ms) OVER
+            (
+                PARTITION BY
+                    ws.wait_type
+                ORDER BY
+                    ws.collection_time
+            ),
+        waiting_tasks_delta =
+            ws.waiting_tasks_count - LAG(ws.waiting_tasks_count, 1, ws.waiting_tasks_count) OVER
             (
                 PARTITION BY
                     ws.wait_type
@@ -1818,6 +1840,12 @@ SELECT
             WHEN wd.interval_seconds > 0
             THEN CAST(wd.signal_wait_time_ms_delta AS decimal(19, 4)) / wd.interval_seconds
             ELSE 0
+        END,
+    avg_ms_per_wait =
+        CASE
+            WHEN wd.waiting_tasks_delta > 0
+            THEN CAST(wd.wait_time_ms_delta AS decimal(19, 4)) / wd.waiting_tasks_delta
+            ELSE 0
         END
 FROM wait_deltas AS wd
 WHERE wd.wait_time_ms_delta > 0
@@ -1840,7 +1868,8 @@ ORDER BY
                     CollectionTime = reader.GetDateTime(0),
                     WaitType = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
                     WaitTimeMsPerSecond = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2), CultureInfo.InvariantCulture),
-                    SignalWaitTimeMsPerSecond = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3), CultureInfo.InvariantCulture)
+                    SignalWaitTimeMsPerSecond = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3), CultureInfo.InvariantCulture),
+                    AvgMsPerWait = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4), CultureInfo.InvariantCulture)
                 });
             }
 
@@ -1890,6 +1919,12 @@ WITH
                 PARTITION BY ws.wait_type
                 ORDER BY ws.collection_time
             ),
+        waiting_tasks_delta =
+            ws.waiting_tasks_count - LAG(ws.waiting_tasks_count, 1, ws.waiting_tasks_count) OVER
+            (
+                PARTITION BY ws.wait_type
+                ORDER BY ws.collection_time
+            ),
         interval_seconds =
             DATEDIFF(SECOND, LAG(ws.collection_time, 1, ws.collection_time) OVER
             (
@@ -1911,6 +1946,10 @@ SELECT
     signal_wait_time_ms_per_second =
         CASE WHEN wd.interval_seconds > 0
         THEN CAST(wd.signal_wait_time_ms_delta AS decimal(19, 4)) / wd.interval_seconds
+        ELSE 0 END,
+    avg_ms_per_wait =
+        CASE WHEN wd.waiting_tasks_delta > 0
+        THEN CAST(wd.wait_time_ms_delta AS decimal(19, 4)) / wd.waiting_tasks_delta
         ELSE 0 END
 FROM wait_deltas AS wd
 WHERE wd.wait_time_ms_delta > 0
@@ -1939,6 +1978,12 @@ WITH
                 PARTITION BY ws.wait_type
                 ORDER BY ws.collection_time
             ),
+        waiting_tasks_delta =
+            ws.waiting_tasks_count - LAG(ws.waiting_tasks_count, 1, ws.waiting_tasks_count) OVER
+            (
+                PARTITION BY ws.wait_type
+                ORDER BY ws.collection_time
+            ),
         interval_seconds =
             DATEDIFF(SECOND, LAG(ws.collection_time, 1, ws.collection_time) OVER
             (
@@ -1959,6 +2004,10 @@ SELECT
     signal_wait_time_ms_per_second =
         CASE WHEN wd.interval_seconds > 0
         THEN CAST(wd.signal_wait_time_ms_delta AS decimal(19, 4)) / wd.interval_seconds
+        ELSE 0 END,
+    avg_ms_per_wait =
+        CASE WHEN wd.waiting_tasks_delta > 0
+        THEN CAST(wd.wait_time_ms_delta AS decimal(19, 4)) / wd.waiting_tasks_delta
         ELSE 0 END
 FROM wait_deltas AS wd
 WHERE wd.wait_time_ms_delta > 0
@@ -1982,7 +2031,8 @@ ORDER BY wd.collection_time, wd.wait_type;";
                     CollectionTime = reader.GetDateTime(0),
                     WaitType = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
                     WaitTimeMsPerSecond = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2), CultureInfo.InvariantCulture),
-                    SignalWaitTimeMsPerSecond = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3), CultureInfo.InvariantCulture)
+                    SignalWaitTimeMsPerSecond = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3), CultureInfo.InvariantCulture),
+                    AvgMsPerWait = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4), CultureInfo.InvariantCulture)
                 });
             }
 

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -145,7 +145,20 @@
                         </Grid>
                     </Border>
 
-                    <ScottPlot:WpfPlot Grid.Column="1" x:Name="WaitStatsChart"/>
+                    <Grid Grid.Column="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,4,0,0">
+                            <TextBlock Text="Metric:" VerticalAlignment="Center" Margin="0,0,6,0" FontSize="11"/>
+                            <ComboBox x:Name="WaitStatsMetricCombo" SelectedIndex="0" SelectionChanged="WaitStatsMetric_SelectionChanged" FontSize="11" Padding="4,2">
+                                <ComboBoxItem Content="Wait Time (ms/sec)"/>
+                                <ComboBoxItem Content="Avg Wait Time (ms/wait)"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="WaitStatsChart"/>
+                    </Grid>
                 </Grid>
             </TabItem>
 

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -18,7 +18,7 @@ internal sealed class ChartHoverHelper
     private readonly List<(ScottPlot.Plottables.Scatter Scatter, string Label)> _scatters = new();
     private readonly Popup _popup;
     private readonly TextBlock _text;
-    private readonly string _unit;
+    private string _unit;
     private DateTime _lastUpdate;
 
     public ChartHoverHelper(ScottPlot.WPF.WpfPlot chart, string unit)
@@ -52,6 +52,8 @@ internal sealed class ChartHoverHelper
         chart.MouseMove += OnMouseMove;
         chart.MouseLeave += OnMouseLeave;
     }
+
+    public string Unit { get => _unit; set => _unit = value; }
 
     public void Clear() => _scatters.Clear();
 


### PR DESCRIPTION
## Summary
- Added **Metric** dropdown to wait stats chart in both Dashboard and Lite
- Two modes: "Wait Time (ms/sec)" (default) and "Avg Wait Time (ms/wait)"
- Avg mode computes `delta_wait_time_ms / delta_waiting_tasks` per collection interval
- Hover tooltips and Y-axis labels update to match the selected metric
- Lite `WaitStatsRow` gains `AvgWaitMsPerTask` computed property for future grid use
- No schema changes — `waiting_tasks_count` was already collected in both apps

## Why
Total wait time (ms/sec) answers "where is time going?" but avg ms/wait answers "which waits are individually the slowest?" — e.g., CXPACKET dominates total time but each wait is trivial, while RESOURCE_SEMAPHORE may be low total but each wait is brutal.

## Test plan
- [x] Lite: toggle between ms/sec and ms/wait — chart redraws, Y-axis and tooltip units update
- [x] Dashboard: same toggle behavior on Wait Stats Detail chart
- [x] Both build with 0 errors
- [x] Values look reasonable (high-volume waits show low avg, low-volume waits show high avg)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)