### PR TITLE
Fix minimize-to-tray setting ignored in both apps (#53)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -185,7 +185,7 @@ namespace PerformanceMonitorDashboard
 
         private void InitializeNotificationService()
         {
-            _notificationService = new NotificationService(this);
+            _notificationService = new NotificationService(this, _preferencesService);
             _notificationService.Initialize();
         }
 
@@ -756,7 +756,7 @@ namespace PerformanceMonitorDashboard
 
         private void Settings_Click(object sender, RoutedEventArgs e)
         {
-            var dialog = new SettingsWindow();
+            var dialog = new SettingsWindow(_preferencesService);
             dialog.Owner = this;
             if (dialog.ShowDialog() == true)
             {

--- a/Dashboard/Services/NotificationService.cs
+++ b/Dashboard/Services/NotificationService.cs
@@ -208,7 +208,7 @@ namespace PerformanceMonitorDashboard.Services
             // Trigger settings via the main window
             if (_mainWindow is MainWindow mainWin)
             {
-                var settingsWindow = new SettingsWindow { Owner = mainWin };
+                var settingsWindow = new SettingsWindow(_preferencesService) { Owner = mainWin };
                 settingsWindow.ShowDialog();
             }
         }

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -11,20 +11,21 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard
 {
     public partial class SettingsWindow : Window
     {
-        private readonly UserPreferencesService _preferencesService;
+        private readonly IUserPreferencesService _preferencesService;
         private bool _isLoading = true;
 
-        public SettingsWindow()
+        public SettingsWindow(IUserPreferencesService preferencesService)
         {
             InitializeComponent();
 
-            _preferencesService = new UserPreferencesService();
+            _preferencesService = preferencesService;
             LoadSettings();
             _isLoading = false;
         }
@@ -495,7 +496,7 @@ namespace PerformanceMonitorDashboard
 
             try
             {
-                var emailService = EmailAlertService.Current ?? new EmailAlertService(_preferencesService);
+                var emailService = EmailAlertService.Current ?? new EmailAlertService((UserPreferencesService)_preferencesService);
                 var error = await emailService.SendTestEmailAsync(testPrefs);
 
                 if (error == null)

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -56,6 +56,9 @@ public partial class App : Application
     public static bool AlertDeadlockEnabled { get; set; } = true;
     public static int AlertDeadlockThreshold { get; set; } = 1;
 
+    /* System tray settings */
+    public static bool MinimizeToTray { get; set; } = true;
+
     /* Update check settings */
     public static bool CheckForUpdatesOnStartup { get; set; } = true;
 
@@ -198,6 +201,9 @@ public partial class App : Application
             if (root.TryGetProperty("alert_blocking_threshold", out v)) AlertBlockingThreshold = v.GetInt32();
             if (root.TryGetProperty("alert_deadlock_enabled", out v)) AlertDeadlockEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_deadlock_threshold", out v)) AlertDeadlockThreshold = v.GetInt32();
+
+            /* System tray settings */
+            if (root.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.GetBoolean();
 
             /* Update check settings */
             if (root.TryGetProperty("check_for_updates_on_startup", out v)) CheckForUpdatesOnStartup = v.GetBoolean();

--- a/Lite/Services/SystemTrayService.cs
+++ b/Lite/Services/SystemTrayService.cs
@@ -107,7 +107,7 @@ public class SystemTrayService : IDisposable
 
     private void MainWindow_StateChanged(object? sender, EventArgs e)
     {
-        if (_mainWindow.WindowState == WindowState.Minimized)
+        if (_mainWindow.WindowState == WindowState.Minimized && App.MinimizeToTray)
         {
             _mainWindow.Hide();
         }

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -97,6 +97,8 @@
         <Border Grid.Row="4" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
             <StackPanel>
                 <TextBlock Text="Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <CheckBox x:Name="MinimizeToTrayCheckBox" Content="Minimize to system tray" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
                 <CheckBox x:Name="AlertsEnabledCheckBox" Content="Enable notifications" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}" Checked="AlertsEnabledCheckBox_Changed" Unchecked="AlertsEnabledCheckBox_Changed"/>
                 <CheckBox x:Name="NotifyConnectionCheckBox" Content="Connection lost / restored" Margin="20,6,0,0"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -221,6 +221,7 @@ public partial class SettingsWindow : Window
 
     private void LoadAlertSettings()
     {
+        MinimizeToTrayCheckBox.IsChecked = App.MinimizeToTray;
         AlertsEnabledCheckBox.IsChecked = App.AlertsEnabled;
         NotifyConnectionCheckBox.IsChecked = App.NotifyConnectionChanges;
         AlertCpuCheckBox.IsChecked = App.AlertCpuEnabled;
@@ -234,6 +235,7 @@ public partial class SettingsWindow : Window
 
     private void SaveAlertSettings()
     {
+        App.MinimizeToTray = MinimizeToTrayCheckBox.IsChecked == true;
         App.AlertsEnabled = AlertsEnabledCheckBox.IsChecked == true;
         App.NotifyConnectionChanges = NotifyConnectionCheckBox.IsChecked == true;
         App.AlertCpuEnabled = AlertCpuCheckBox.IsChecked == true;
@@ -260,6 +262,7 @@ public partial class SettingsWindow : Window
                 root = new JsonObject();
             }
 
+            root["minimize_to_tray"] = App.MinimizeToTray;
             root["alerts_enabled"] = App.AlertsEnabled;
             root["notify_connection_changes"] = App.NotifyConnectionChanges;
             root["alert_cpu_enabled"] = App.AlertCpuEnabled;

--- a/Lite/config/settings.json
+++ b/Lite/config/settings.json
@@ -3,7 +3,7 @@
   "archive_retention_days": 90,
   "default_time_range_hours": 24,
   "theme": "light",
-  "minimize_to_tray": false,
+  "minimize_to_tray": true,
   "start_collection_on_launch": true,
   "mcp_enabled": false,
   "mcp_port": 5151


### PR DESCRIPTION
## Summary
- **Dashboard**: `SettingsWindow` was creating its own `UserPreferencesService` instance, so toggling "Minimize to system tray" off had no effect — `MainWindow` still read the stale in-memory value (`true`). Fixed by sharing the same instance via constructor injection.
- **Lite**: `SystemTrayService` always hid the window on minimize with no preference check. Added `App.MinimizeToTray` property wired to `settings.json` (key already existed but was unused), added checkbox to Settings UI.

## Test plan
- [ ] Dashboard: Open Settings → Notifications → uncheck "Minimize to system tray" → OK → minimize app → should stay on taskbar
- [ ] Dashboard: Re-check the setting → OK → minimize → should hide to tray
- [ ] Lite: Open Settings → uncheck "Minimize to system tray" → Save → minimize → should stay on taskbar
- [ ] Lite: Re-check → Save → minimize → should hide to tray
- [ ] Both: Setting persists across app restart

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)