### PR TITLE
Add alert types, alerts history view, column filtering, and dismiss/hide (#52, #56-59)

### DIFF
--- a/Dashboard/Controls/AlertsHistoryContent.xaml
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml
@@ -1,0 +1,157 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.AlertsHistoryContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Context Menu for DataGrid Copy/Export -->
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+
+            <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
+            </Style>
+
+            <Style x:Key="AlertRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource DefaultRowStyle}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsCritical}" Value="True">
+                        <Setter Property="Background" Value="#33DC2626"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsWarning}" Value="True">
+                        <Setter Property="Background" Value="#33D97706"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsResolved}" Value="True">
+                        <Setter Property="Background" Value="#3322C55E"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header Controls -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,5" Background="{DynamicResource BackgroundLightBrush}" Height="40">
+            <TextBlock Text="Alert History" VerticalAlignment="Center" Margin="5,0,10,0" FontWeight="Bold" FontSize="14"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock Text="Time Range:" VerticalAlignment="Center" Margin="5,0,4,0"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            <ComboBox x:Name="TimeRangeComboBox" Width="100" VerticalAlignment="Center"
+                      SelectionChanged="TimeRangeComboBox_SelectionChanged">
+                <ComboBoxItem Content="Last 1 Hour" Tag="1"/>
+                <ComboBoxItem Content="Last 4 Hours" Tag="4"/>
+                <ComboBoxItem Content="Last 24 Hours" Tag="24" IsSelected="True"/>
+                <ComboBoxItem Content="Last 7 Days" Tag="168"/>
+                <ComboBoxItem Content="All" Tag="0"/>
+            </ComboBox>
+            <TextBlock Text="Server:" VerticalAlignment="Center" Margin="12,0,4,0"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            <ComboBox x:Name="ServerFilterComboBox" Width="160" VerticalAlignment="Center"
+                      SelectionChanged="ServerFilterComboBox_SelectionChanged">
+                <ComboBoxItem Content="All Servers" IsSelected="True"/>
+            </ComboBox>
+            <Button Content="Refresh" Click="RefreshButton_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"
+                    Style="{StaticResource SuccessButton}"/>
+            <Button x:Name="DismissSelectedButton" Content="Dismiss Selected" Click="DismissSelected_Click"
+                    Margin="8,0,0,0" Padding="10,4" MinWidth="90" IsEnabled="False"/>
+            <Button Content="Dismiss All" Click="DismissAll_Click"
+                    Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+            <TextBlock x:Name="AlertCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center"
+                       FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+        </StackPanel>
+
+        <!-- DataGrid -->
+        <Grid Grid.Row="1">
+            <DataGrid x:Name="AlertsDataGrid"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserSortColumns="True"
+                      GridLinesVisibility="Horizontal"
+                      CanUserResizeColumns="True"
+                      SelectionMode="Extended"
+                      SelectionChanged="AlertsDataGrid_SelectionChanged"
+                      RowStyle="{StaticResource AlertRowStyle}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding TimeLocal}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TimeLocal" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ServerName}" Width="140">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerName" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Server" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MetricName}" Width="160">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MetricName" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Alert Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding CurrentValue}" Width="200">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CurrentValue" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Value" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ThresholdValue}" Width="140">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ThresholdValue" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Threshold" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding NotificationType}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NotificationType" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Channel" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding StatusDisplay}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StatusDisplay" Click="AlertFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <!-- Empty State -->
+            <TextBlock x:Name="NoAlertsMessage"
+                       Text="No alerts recorded in the selected time range"
+                       FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="Collapsed"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    public partial class AlertsHistoryContent : UserControl
+    {
+        private List<AlertHistoryDisplayItem> _allAlerts = new();
+
+        /* Column filter state */
+        private readonly Dictionary<string, ColumnFilterState> _columnFilters = new();
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
+
+        public AlertsHistoryContent()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Refreshes the alert history from the in-memory log.
+        /// </summary>
+        public void RefreshAlerts()
+        {
+            LoadAlerts();
+        }
+
+        private void LoadAlerts()
+        {
+            var service = EmailAlertService.Current;
+            if (service == null)
+            {
+                AlertsDataGrid.ItemsSource = null;
+                NoAlertsMessage.Visibility = Visibility.Visible;
+                AlertCountIndicator.Text = "";
+                return;
+            }
+
+            var hoursBack = GetSelectedHoursBack();
+            var entries = service.GetAlertHistory(hoursBack > 0 ? hoursBack : 8760, 500);
+
+            _allAlerts = entries.Select(e => new AlertHistoryDisplayItem
+            {
+                AlertTime = e.AlertTime,
+                ServerName = e.ServerName,
+                MetricName = e.MetricName,
+                CurrentValue = e.CurrentValue,
+                ThresholdValue = e.ThresholdValue,
+                NotificationType = e.NotificationType,
+                StatusDisplay = GetStatusDisplay(e),
+                IsResolved = e.MetricName.Contains("Cleared") || e.MetricName.Contains("Resolved"),
+                IsCritical = e.MetricName.Contains("Deadlock") || e.MetricName.Contains("Poison"),
+                IsWarning = !e.MetricName.Contains("Cleared") && !e.MetricName.Contains("Resolved")
+                            && !e.MetricName.Contains("Deadlock") && !e.MetricName.Contains("Poison")
+            }).ToList();
+
+            ApplyFilters();
+        }
+
+        private void ApplyFilters()
+        {
+            var filtered = _allAlerts.AsEnumerable();
+
+            /* Server filter */
+            if (ServerFilterComboBox.SelectedIndex > 0 &&
+                ServerFilterComboBox.SelectedItem is ComboBoxItem serverItem)
+            {
+                var serverName = serverItem.Content?.ToString();
+                if (!string.IsNullOrEmpty(serverName))
+                    filtered = filtered.Where(a => a.ServerName == serverName);
+            }
+
+            /* Column filters */
+            if (_columnFilters.Count > 0)
+            {
+                filtered = filtered.Where(item =>
+                {
+                    foreach (var filter in _columnFilters.Values)
+                    {
+                        if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                            return false;
+                    }
+                    return true;
+                });
+            }
+
+            var list = filtered.ToList();
+            AlertsDataGrid.ItemsSource = list;
+            NoAlertsMessage.Visibility = list.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            AlertCountIndicator.Text = list.Count > 0 ? $"{list.Count} alert(s)" : "";
+
+            /* Populate server filter if needed */
+            PopulateServerFilter();
+        }
+
+        private void PopulateServerFilter()
+        {
+            var servers = _allAlerts
+                .Select(a => a.ServerName)
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Distinct()
+                .OrderBy(s => s)
+                .ToList();
+
+            var currentSelection = ServerFilterComboBox.SelectedIndex > 0
+                ? (ServerFilterComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString()
+                : null;
+
+            /* Only rebuild if the list changed */
+            var existingServers = ServerFilterComboBox.Items
+                .OfType<ComboBoxItem>()
+                .Skip(1)
+                .Select(i => i.Content?.ToString())
+                .ToList();
+
+            if (servers.SequenceEqual(existingServers)) return;
+
+            ServerFilterComboBox.SelectionChanged -= ServerFilterComboBox_SelectionChanged;
+
+            while (ServerFilterComboBox.Items.Count > 1)
+                ServerFilterComboBox.Items.RemoveAt(1);
+
+            foreach (var server in servers)
+            {
+                ServerFilterComboBox.Items.Add(new ComboBoxItem { Content = server });
+            }
+
+            /* Restore selection */
+            if (currentSelection != null)
+            {
+                for (int i = 1; i < ServerFilterComboBox.Items.Count; i++)
+                {
+                    if ((ServerFilterComboBox.Items[i] as ComboBoxItem)?.Content?.ToString() == currentSelection)
+                    {
+                        ServerFilterComboBox.SelectedIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            ServerFilterComboBox.SelectionChanged += ServerFilterComboBox_SelectionChanged;
+        }
+
+        private int GetSelectedHoursBack()
+        {
+            if (TimeRangeComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tagStr)
+            {
+                return int.TryParse(tagStr, out var hours) ? hours : 24;
+            }
+            return 24;
+        }
+
+        private static string GetStatusDisplay(AlertLogEntry entry)
+        {
+            if (entry.NotificationType == "email")
+            {
+                if (entry.AlertSent) return "Sent";
+                return !string.IsNullOrEmpty(entry.SendError) ? "Failed" : "Not sent";
+            }
+            return entry.AlertSent ? "Delivered" : "Shown";
+        }
+
+        #region Event Handlers
+
+        private void TimeRangeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (IsLoaded)
+                LoadAlerts();
+        }
+
+        private void ServerFilterComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (IsLoaded)
+                ApplyFilters();
+        }
+
+        private void RefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            LoadAlerts();
+        }
+
+        private void AlertsDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            DismissSelectedButton.IsEnabled = AlertsDataGrid.SelectedItems.Count > 0;
+        }
+
+        private void DismissSelected_Click(object sender, RoutedEventArgs e)
+        {
+            var service = EmailAlertService.Current;
+            if (service == null) return;
+
+            var selected = AlertsDataGrid.SelectedItems
+                .OfType<AlertHistoryDisplayItem>()
+                .ToList();
+
+            if (selected.Count == 0) return;
+
+            var keys = selected
+                .Select(s => (s.AlertTime, s.ServerName, s.MetricName))
+                .ToList();
+
+            service.HideAlerts(keys);
+            LoadAlerts();
+        }
+
+        private void DismissAll_Click(object sender, RoutedEventArgs e)
+        {
+            var service = EmailAlertService.Current;
+            if (service == null) return;
+
+            var displayCount = AlertsDataGrid.ItemsSource is ICollection<AlertHistoryDisplayItem> coll ? coll.Count : 0;
+            if (displayCount == 0) return;
+
+            var result = MessageBox.Show(
+                $"Dismiss all {displayCount} visible alert(s)?\n\nDismissed alerts are hidden from this view but preserved in the log.",
+                "Dismiss All Alerts",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question);
+
+            if (result != MessageBoxResult.Yes) return;
+
+            var hoursBack = GetSelectedHoursBack();
+            string? serverName = null;
+            if (ServerFilterComboBox.SelectedIndex > 0 &&
+                ServerFilterComboBox.SelectedItem is ComboBoxItem serverItem)
+            {
+                serverName = serverItem.Content?.ToString();
+            }
+
+            service.HideAllAlerts(hoursBack > 0 ? hoursBack : 8760, serverName);
+            LoadAlerts();
+        }
+
+        #endregion
+
+        #region Column Filter Handlers
+
+        private void AlertFilter_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string columnName) return;
+            ShowFilterPopup(button, columnName);
+        }
+
+        private void ShowFilterPopup(Button button, string columnName)
+        {
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            _columnFilters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+
+            if (e.FilterState.IsActive)
+                _columnFilters[e.FilterState.ColumnName] = e.FilterState;
+            else
+                _columnFilters.Remove(e.FilterState.ColumnName);
+
+            ApplyFilters();
+            UpdateFilterButtonStyles();
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+        }
+
+        private void UpdateFilterButtonStyles()
+        {
+            foreach (var column in AlertsDataGrid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton?.Tag is string columnName)
+                    {
+                        bool hasActive = _columnFilters.TryGetValue(columnName, out var filter) && filter.IsActive;
+
+                        var textBlock = new System.Windows.Controls.TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActive
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.Content = textBlock;
+                        filterButton.ToolTip = hasActive && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    var headers = dataGrid.Columns
+                        .OfType<DataGridBoundColumn>()
+                        .Select(c => TabHelpers.GetColumnHeader(c))
+                        .ToList();
+                    sb.AppendLine(string.Join("\t", headers));
+
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = $"alert_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+                            var headers = dataGrid.Columns
+                                .OfType<DataGridBoundColumn>()
+                                .Select(c => TabHelpers.EscapeCsvField(TabHelpers.GetColumnHeader(c)))
+                                .ToList();
+                            sb.AppendLine(string.Join(",", headers));
+
+                            foreach (var item in dataGrid.Items)
+                            {
+                                var values = TabHelpers.GetRowValues(dataGrid, item);
+                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                            }
+
+                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
+                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}",
+                                "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}",
+                                "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+
+    public class AlertHistoryDisplayItem
+    {
+        public DateTime AlertTime { get; set; }
+        public string TimeLocal => AlertTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+        public string ServerName { get; set; } = "";
+        public string MetricName { get; set; } = "";
+        public string CurrentValue { get; set; } = "";
+        public string ThresholdValue { get; set; } = "";
+        public string NotificationType { get; set; } = "";
+        public string StatusDisplay { get; set; } = "";
+        public bool IsResolved { get; set; }
+        public bool IsCritical { get; set; }
+        public bool IsWarning { get; set; }
+    }
+}

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -146,6 +146,12 @@
                             Style="{StaticResource AccentButton}"
                             Height="32"
                             Margin="0,0,0,8"/>
+                    <Button x:Name="AlertsHistoryButton"
+                            Content="Alerts"
+                            Click="AlertsHistory_Click"
+                            Style="{StaticResource AccentButton}"
+                            Height="32"
+                            Margin="0,0,0,8"/>
                     <Separator Margin="0,0,0,8"/>
                     <Button x:Name="RefreshAllButton"
                             Content="&#x21BB; Refresh All Status"

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -44,6 +44,8 @@ namespace PerformanceMonitorDashboard
         private bool _isReallyClosing = false;
         private TabItem? _nocTab;
         private LandingPage? _landingPage;
+        private TabItem? _alertsTab;
+        private AlertsHistoryContent? _alertsHistoryContent;
         private McpHostService? _mcpHostService;
         private CancellationTokenSource? _mcpCts;
 
@@ -58,11 +60,20 @@ namespace PerformanceMonitorDashboard
         private readonly ConcurrentDictionary<string, bool> _activeBlockingAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeDeadlockAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeHighCpuAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastPoisonWaitAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activePoisonWaitAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastLongRunningQueryAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activeLongRunningQueryAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastTempDbSpaceAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activeTempDbSpaceAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastLongRunningJobAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activeLongRunningJobAlert = new();
         private readonly ConcurrentDictionary<string, long> _previousDeadlockCounts = new();
 
         private const double ExpandedWidth = 250;
         private const double CollapsedWidth = 52;
         private const string NocTabId = "__NOC_OVERVIEW__";
+        private const string AlertsTabId = "__ALERTS_HISTORY__";
 
         public MainWindow()
         {
@@ -129,6 +140,8 @@ namespace PerformanceMonitorDashboard
             LoadServerList();
             InitializeNotificationService();
             OpenNocTab();
+            OpenAlertsTab();
+            ServerTabControl.SelectedItem = _nocTab; /* Keep Overview as the active tab */
             LoadSidebarState();
             ConfigureConnectionStatusTimer();
             ConfigureAlertCheckTimer();
@@ -227,6 +240,9 @@ namespace PerformanceMonitorDashboard
                     Logger.Error($"[MCP] Error stopping MCP server: {ex.Message}", ex);
                 }
             }
+
+            // Save alert history to disk
+            _emailAlertService?.SaveAlertLog();
 
             // Clean up notification service
             _notificationService?.Dispose();
@@ -569,6 +585,53 @@ namespace PerformanceMonitorDashboard
             OpenNocTab();
         }
 
+        private void AlertsHistory_Click(object sender, RoutedEventArgs e)
+        {
+            OpenAlertsTab();
+        }
+
+        private void OpenAlertsTab()
+        {
+            if (_alertsTab != null && ServerTabControl.Items.Contains(_alertsTab))
+            {
+                ServerTabControl.SelectedItem = _alertsTab;
+                _alertsHistoryContent?.RefreshAlerts();
+                return;
+            }
+
+            _alertsHistoryContent = new AlertsHistoryContent();
+
+            var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };
+            var headerText = new TextBlock
+            {
+                Text = "Alert History",
+                VerticalAlignment = VerticalAlignment.Center,
+                FontWeight = FontWeights.SemiBold
+            };
+            var closeButton = new Button
+            {
+                Style = (Style)FindResource("TabCloseButton"),
+                Tag = AlertsTabId
+            };
+            closeButton.Click += CloseTab_Click;
+            headerPanel.Children.Add(headerText);
+            headerPanel.Children.Add(closeButton);
+
+            _alertsTab = new TabItem
+            {
+                Header = headerPanel,
+                Content = _alertsHistoryContent,
+                Tag = AlertsTabId
+            };
+
+            /* Insert after NOC tab if present, otherwise at position 0 */
+            var insertIndex = _nocTab != null && ServerTabControl.Items.Contains(_nocTab) ? 1 : 0;
+            ServerTabControl.Items.Insert(insertIndex, _alertsTab);
+            ServerTabControl.SelectedItem = _alertsTab;
+
+            _alertsHistoryContent.RefreshAlerts();
+        }
+
         private void CloseTab_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && button.Tag is string tabId)
@@ -581,6 +644,15 @@ namespace PerformanceMonitorDashboard
                         ServerTabControl.Items.Remove(_nocTab);
                         _nocTab = null;
                         _landingPage = null;
+                    }
+                }
+                else if (tabId == AlertsTabId)
+                {
+                    if (_alertsTab != null)
+                    {
+                        ServerTabControl.Items.Remove(_alertsTab);
+                        _alertsTab = null;
+                        _alertsHistoryContent = null;
                     }
                 }
                 else if (_openTabs.TryGetValue(tabId, out var tabToClose))
@@ -826,6 +898,38 @@ namespace PerformanceMonitorDashboard
             }
         }
 
+        /// <summary>
+        /// Updates a server tab badge from AlertHealthResult (used by the alert engine).
+        /// Constructs a minimal ServerHealthStatus for the badge evaluation.
+        /// </summary>
+        private void UpdateTabBadgeFromAlertHealth(string serverId, AlertHealthResult health)
+        {
+            if (!_tabBadges.ContainsKey(serverId)) return;
+
+            /* Build a minimal ServerHealthStatus with the fields ShouldShowBadge needs */
+            var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == serverId);
+            if (server == null) return;
+
+            var status = new ServerHealthStatus(server)
+            {
+                IsOnline = health.IsOnline,
+                CpuPercent = health.CpuPercent,
+                OtherCpuPercent = health.OtherCpuPercent,
+                LongestBlockedSeconds = health.LongestBlockedSeconds,
+                TotalBlocked = health.TotalBlocked
+            };
+
+            /* Set deadlock count twice to generate a delta.
+               First set establishes baseline (delta=0), second set creates actual delta. */
+            if (_previousDeadlockCounts.TryGetValue(serverId, out var prevDlCount))
+            {
+                status.DeadlockCount = prevDlCount;
+                status.DeadlockCount = health.DeadlockCount;
+            }
+
+            UpdateTabBadge(serverId, status);
+        }
+
         #region Independent Alert Engine
 
         private void ConfigureAlertCheckTimer()
@@ -850,6 +954,9 @@ namespace PerformanceMonitorDashboard
         private async void AlertCheckTimer_Tick(object? sender, EventArgs e)
         {
             await CheckAllServerAlertsAsync();
+
+            /* Auto-refresh alert history if the tab is open */
+            _alertsHistoryContent?.RefreshAlerts();
         }
 
         /// <summary>
@@ -871,11 +978,15 @@ namespace PerformanceMonitorDashboard
                     var connectionString = server.GetConnectionString(_credentialService);
                     var databaseService = new DatabaseService(connectionString);
                     var connStatus = _serverManager.GetConnectionStatus(server.Id);
-                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition);
+                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition, prefs.LongRunningQueryThresholdMinutes, prefs.LongRunningJobMultiplier);
 
                     if (health.IsOnline)
                     {
                         await EvaluateAlertConditionsAsync(server.Id, server.DisplayName, health, databaseService);
+
+                        /* Update tab badges from alert health data.
+                           This ensures badges update even when the NOC view isn't active. */
+                        await Dispatcher.InvokeAsync(() => UpdateTabBadgeFromAlertHealth(server.Id, health));
                     }
                 }
                 catch (Exception ex)
@@ -1022,6 +1133,161 @@ namespace PerformanceMonitorDashboard
                 _emailAlertService.RecordAlert(serverId, serverName, "CPU Resolved",
                     cpuText, $"{prefs.CpuThresholdPercent}%", true, "tray");
             }
+
+            /* Poison wait alerts */
+            var triggeredWaits = prefs.NotifyOnPoisonWaits
+                ? health.PoisonWaits.FindAll(w => w.AvgMsPerWait >= prefs.PoisonWaitThresholdMs)
+                : new List<PoisonWaitDelta>();
+
+            if (triggeredWaits.Count > 0)
+            {
+                _activePoisonWaitAlert[serverId] = true;
+                if (!_lastPoisonWaitAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= AlertCooldown)
+                {
+                    var worst = triggeredWaits[0];
+                    _notificationService?.ShowPoisonWaitNotification(serverName, worst.WaitType, worst.AvgMsPerWait);
+                    _lastPoisonWaitAlert[serverId] = now;
+
+                    var allWaitNames = string.Join(", ", triggeredWaits.ConvertAll(w => $"{w.WaitType} ({w.AvgMsPerWait:F0}ms)"));
+                    _emailAlertService.RecordAlert(serverId, serverName, "Poison Wait",
+                        allWaitNames,
+                        $"{prefs.PoisonWaitThresholdMs}ms avg", true, "tray");
+
+                    var poisonContext = BuildPoisonWaitContext(triggeredWaits);
+
+                    await _emailAlertService.TrySendAlertEmailAsync(
+                        "Poison Wait",
+                        serverName,
+                        allWaitNames,
+                        $"{prefs.PoisonWaitThresholdMs}ms avg",
+                        serverId,
+                        poisonContext);
+                }
+            }
+            else if (_activePoisonWaitAlert.TryRemove(serverId, out var wasPoisonWait) && wasPoisonWait)
+            {
+                _notificationService?.ShowNotification("Poison Waits Cleared",
+                    $"{serverName}: Poison wait avg below threshold");
+                _emailAlertService.RecordAlert(serverId, serverName, "Poison Waits Cleared",
+                    "0", $"{prefs.PoisonWaitThresholdMs}ms avg", true, "tray");
+            }
+
+            /* Long-running query alerts */
+            bool longRunningTriggered = prefs.NotifyOnLongRunningQueries
+                && health.LongRunningQueries.Count > 0;
+
+            if (longRunningTriggered)
+            {
+                _activeLongRunningQueryAlert[serverId] = true;
+                if (!_lastLongRunningQueryAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= AlertCooldown)
+                {
+                    var worst = health.LongRunningQueries[0];
+                    var elapsedMinutes = worst.ElapsedSeconds / 60;
+                    var preview = Truncate(worst.QueryText, 80);
+                    _notificationService?.ShowLongRunningQueryNotification(
+                        serverName, worst.SessionId, elapsedMinutes, preview);
+                    _lastLongRunningQueryAlert[serverId] = now;
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Query",
+                        $"Session #{worst.SessionId} running {elapsedMinutes}m",
+                        $"{prefs.LongRunningQueryThresholdMinutes}m", true, "tray");
+
+                    var lrqContext = BuildLongRunningQueryContext(health.LongRunningQueries);
+
+                    await _emailAlertService.TrySendAlertEmailAsync(
+                        "Long-Running Query",
+                        serverName,
+                        $"{health.LongRunningQueries.Count} query(s), longest {elapsedMinutes}m",
+                        $"{prefs.LongRunningQueryThresholdMinutes}m",
+                        serverId,
+                        lrqContext);
+                }
+            }
+            else if (_activeLongRunningQueryAlert.TryRemove(serverId, out var wasLongRunning) && wasLongRunning)
+            {
+                _notificationService?.ShowNotification("Long-Running Queries Cleared",
+                    $"{serverName}: No queries over threshold");
+                _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Queries Cleared",
+                    "0", $"{prefs.LongRunningQueryThresholdMinutes}m", true, "tray");
+            }
+
+            /* TempDB space alerts */
+            bool tempDbExceeded = prefs.NotifyOnTempDbSpace
+                && health.TempDbSpace != null
+                && health.TempDbSpace.UsedPercent >= prefs.TempDbSpaceThresholdPercent;
+
+            if (tempDbExceeded)
+            {
+                var tempDb = health.TempDbSpace!;
+                _activeTempDbSpaceAlert[serverId] = true;
+                if (!_lastTempDbSpaceAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= AlertCooldown)
+                {
+                    _notificationService?.ShowTempDbSpaceNotification(serverName, tempDb.UsedPercent);
+                    _lastTempDbSpaceAlert[serverId] = now;
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "TempDB Space",
+                        $"{tempDb.UsedPercent:F0}% used ({tempDb.TotalReservedMb:F0} MB)",
+                        $"{prefs.TempDbSpaceThresholdPercent}%", true, "tray");
+
+                    var tempDbContext = BuildTempDbSpaceContext(tempDb);
+
+                    await _emailAlertService.TrySendAlertEmailAsync(
+                        "TempDB Space",
+                        serverName,
+                        $"{tempDb.UsedPercent:F0}% used ({tempDb.TotalReservedMb:F0} MB)",
+                        $"{prefs.TempDbSpaceThresholdPercent}%",
+                        serverId,
+                        tempDbContext);
+                }
+            }
+            else if (_activeTempDbSpaceAlert.TryRemove(serverId, out var wasTempDb) && wasTempDb)
+            {
+                var pct = health.TempDbSpace != null ? $"{health.TempDbSpace.UsedPercent:F0}%" : "N/A";
+                _notificationService?.ShowNotification("TempDB Space Resolved",
+                    $"{serverName}: TempDB usage back to {pct}");
+                _emailAlertService.RecordAlert(serverId, serverName, "TempDB Space Resolved",
+                    pct, $"{prefs.TempDbSpaceThresholdPercent}%", true, "tray");
+            }
+
+            /* Anomalous Agent job alerts */
+            bool anomalousJobsTriggered = prefs.NotifyOnLongRunningJobs
+                && health.AnomalousJobs.Count > 0;
+
+            if (anomalousJobsTriggered)
+            {
+                _activeLongRunningJobAlert[serverId] = true;
+                var worst = health.AnomalousJobs[0];
+                var jobKey = $"{serverId}:{worst.JobId}:{worst.StartTime:O}";
+
+                if (!_lastLongRunningJobAlert.TryGetValue(jobKey, out var lastAlert) || (now - lastAlert) >= AlertCooldown)
+                {
+                    var currentMinutes = worst.CurrentDurationSeconds / 60;
+                    _notificationService?.ShowLongRunningJobNotification(
+                        serverName, worst.JobName, currentMinutes, worst.PercentOfAverage ?? 0);
+                    _lastLongRunningJobAlert[jobKey] = now;
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Job",
+                        $"{worst.JobName} at {worst.PercentOfAverage:F0}% of avg ({currentMinutes}m)",
+                        $"{prefs.LongRunningJobMultiplier}x avg", true, "tray");
+
+                    var jobContext = BuildAnomalousJobContext(health.AnomalousJobs);
+
+                    await _emailAlertService.TrySendAlertEmailAsync(
+                        "Long-Running Job",
+                        serverName,
+                        $"{health.AnomalousJobs.Count} job(s) exceeding {prefs.LongRunningJobMultiplier}x average",
+                        $"{prefs.LongRunningJobMultiplier}x historical avg",
+                        serverId,
+                        jobContext);
+                }
+            }
+            else if (_activeLongRunningJobAlert.TryRemove(serverId, out var wasJob) && wasJob)
+            {
+                _notificationService?.ShowNotification("Long-Running Jobs Cleared",
+                    $"{serverName}: No jobs exceeding threshold");
+                _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Jobs Cleared",
+                    "0", $"{prefs.LongRunningJobMultiplier}x avg", true, "tray");
+            }
         }
 
         private static string Truncate(string text, int maxLength = 300)
@@ -1137,6 +1403,110 @@ namespace PerformanceMonitorDashboard
                 Logger.Error($"Failed to fetch deadlock detail for email: {ex.Message}");
                 return null;
             }
+        }
+
+        private static AlertContext? BuildPoisonWaitContext(List<PoisonWaitDelta> triggeredWaits)
+        {
+            if (triggeredWaits.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var w in triggeredWaits)
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = w.WaitType,
+                    Fields = new()
+                    {
+                        ("Avg ms/wait", $"{w.AvgMsPerWait:F1}"),
+                        ("Delta wait ms", $"{w.DeltaMs:N0}"),
+                        ("Delta tasks", $"{w.DeltaTasks:N0}")
+                    }
+                });
+            }
+            return context;
+        }
+
+        private static AlertContext? BuildLongRunningQueryContext(List<LongRunningQueryInfo> queries)
+        {
+            if (queries.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var q in queries.GetRange(0, Math.Min(3, queries.Count)))
+            {
+                var item = new AlertDetailItem
+                {
+                    Heading = $"Session #{q.SessionId} — {q.ElapsedSeconds / 60}m {q.ElapsedSeconds % 60}s",
+                    Fields = new()
+                };
+
+                if (!string.IsNullOrEmpty(q.DatabaseName))
+                    item.Fields.Add(("Database", q.DatabaseName));
+                if (!string.IsNullOrEmpty(q.ProgramName))
+                    item.Fields.Add(("Program", q.ProgramName));
+                if (!string.IsNullOrEmpty(q.QueryText))
+                    item.Fields.Add(("Query", Truncate(q.QueryText)));
+                item.Fields.Add(("CPU Time", $"{q.CpuTimeMs:N0} ms"));
+                item.Fields.Add(("Reads", $"{q.Reads:N0}"));
+                item.Fields.Add(("Writes", $"{q.Writes:N0}"));
+                if (!string.IsNullOrEmpty(q.WaitType))
+                    item.Fields.Add(("Wait Type", q.WaitType));
+                if (q.BlockingSessionId.HasValue && q.BlockingSessionId.Value > 0)
+                    item.Fields.Add(("Blocked By", $"Session #{q.BlockingSessionId.Value}"));
+
+                context.Details.Add(item);
+            }
+            return context;
+        }
+
+        private static AlertContext? BuildAnomalousJobContext(List<AnomalousJobInfo> jobs)
+        {
+            if (jobs.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var j in jobs.GetRange(0, Math.Min(3, jobs.Count)))
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = j.JobName,
+                    Fields = new()
+                    {
+                        ("Current Duration", FormatDuration(j.CurrentDurationSeconds)),
+                        ("Avg Duration", FormatDuration(j.AvgDurationSeconds)),
+                        ("P95 Duration", FormatDuration(j.P95DurationSeconds)),
+                        ("% of Average", j.PercentOfAverage.HasValue ? $"{j.PercentOfAverage:F0}%" : "N/A"),
+                        ("Started", j.StartTime.ToString("yyyy-MM-dd HH:mm:ss"))
+                    }
+                });
+            }
+            return context;
+        }
+
+        private static string FormatDuration(long seconds)
+        {
+            if (seconds < 60) return $"{seconds}s";
+            if (seconds < 3600) return $"{seconds / 60}m {seconds % 60}s";
+            return $"{seconds / 3600}h {(seconds % 3600) / 60}m";
+        }
+
+        private static AlertContext? BuildTempDbSpaceContext(TempDbSpaceInfo tempDb)
+        {
+            var context = new AlertContext();
+            context.Details.Add(new AlertDetailItem
+            {
+                Heading = $"TempDB — {tempDb.UsedPercent:F0}% Used",
+                Fields = new()
+                {
+                    ("Total Reserved", $"{tempDb.TotalReservedMb:F0} MB"),
+                    ("Unallocated", $"{tempDb.UnallocatedMb:F0} MB"),
+                    ("User Objects", $"{tempDb.UserObjectReservedMb:F0} MB"),
+                    ("Internal Objects", $"{tempDb.InternalObjectReservedMb:F0} MB"),
+                    ("Version Store", $"{tempDb.VersionStoreReservedMb:F0} MB"),
+                    ("Top Consumer", tempDb.TopConsumerSessionId > 0
+                        ? $"Session #{tempDb.TopConsumerSessionId} ({tempDb.TopConsumerMb:F0} MB)"
+                        : "None")
+                }
+            });
+            return context;
         }
 
         #endregion

--- a/Dashboard/Models/AlertHealthResult.cs
+++ b/Dashboard/Models/AlertHealthResult.cs
@@ -6,11 +6,13 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System.Collections.Generic;
+
 namespace PerformanceMonitorDashboard.Models
 {
     /// <summary>
     /// Lightweight result from alert-only health queries.
-    /// Contains only the 3 metrics needed for alert evaluation (CPU, blocking, deadlocks).
+    /// Contains only the metrics needed for alert evaluation (CPU, blocking, deadlocks, poison waits).
     /// Used by MainWindow's independent alert timer to avoid running all 9 NOC queries.
     /// </summary>
     public class AlertHealthResult
@@ -20,6 +22,10 @@ namespace PerformanceMonitorDashboard.Models
         public long TotalBlocked { get; set; }
         public decimal LongestBlockedSeconds { get; set; }
         public long DeadlockCount { get; set; }
+        public List<PoisonWaitDelta> PoisonWaits { get; set; } = new();
+        public List<LongRunningQueryInfo> LongRunningQueries { get; set; } = new();
+        public TempDbSpaceInfo? TempDbSpace { get; set; }
+        public List<AnomalousJobInfo> AnomalousJobs { get; set; } = new();
         public bool IsOnline { get; set; } = true;
 
         /// <summary>

--- a/Dashboard/Models/AnomalousJobInfo.cs
+++ b/Dashboard/Models/AnomalousJobInfo.cs
@@ -1,0 +1,21 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class AnomalousJobInfo
+    {
+        public string JobName { get; set; } = "";
+        public string JobId { get; set; } = "";
+        public long CurrentDurationSeconds { get; set; }
+        public long AvgDurationSeconds { get; set; }
+        public long P95DurationSeconds { get; set; }
+        public decimal? PercentOfAverage { get; set; }
+        public DateTime StartTime { get; set; }
+    }
+}

--- a/Dashboard/Models/LongRunningQueryInfo.cs
+++ b/Dashboard/Models/LongRunningQueryInfo.cs
@@ -1,0 +1,22 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class LongRunningQueryInfo
+    {
+        public int SessionId { get; set; }
+        public string DatabaseName { get; set; } = "";
+        public string QueryText { get; set; } = "";
+        public string ProgramName { get; set; } = "";
+        public long ElapsedSeconds { get; set; }
+        public long CpuTimeMs { get; set; }
+        public long Reads { get; set; }
+        public long Writes { get; set; }
+        public string? WaitType { get; set; }
+        public int? BlockingSessionId { get; set; }
+    }
+}

--- a/Dashboard/Models/PoisonWaitDelta.cs
+++ b/Dashboard/Models/PoisonWaitDelta.cs
@@ -1,0 +1,16 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class PoisonWaitDelta
+    {
+        public string WaitType { get; set; } = "";
+        public long DeltaMs { get; set; }
+        public long DeltaTasks { get; set; }
+        public double AvgMsPerWait { get; set; }
+    }
+}

--- a/Dashboard/Models/TempDbSpaceInfo.cs
+++ b/Dashboard/Models/TempDbSpaceInfo.cs
@@ -1,0 +1,23 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class TempDbSpaceInfo
+    {
+        public double TotalReservedMb { get; set; }
+        public double UnallocatedMb { get; set; }
+        public double UserObjectReservedMb { get; set; }
+        public double InternalObjectReservedMb { get; set; }
+        public double VersionStoreReservedMb { get; set; }
+        public int TopConsumerSessionId { get; set; }
+        public double TopConsumerMb { get; set; }
+
+        public double UsedPercent => TotalReservedMb + UnallocatedMb > 0
+            ? TotalReservedMb / (TotalReservedMb + UnallocatedMb) * 100
+            : 0;
+    }
+}

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -78,6 +78,14 @@ namespace PerformanceMonitorDashboard.Models
         public int DeadlockThreshold { get; set; } = 1; // Alert when deadlocks >= X since last check
         public bool NotifyOnHighCpu { get; set; } = true;
         public int CpuThresholdPercent { get; set; } = 90; // Alert when CPU > X%
+        public bool NotifyOnPoisonWaits { get; set; } = true;
+        public int PoisonWaitThresholdMs { get; set; } = 500; // Alert when avg ms per wait > X
+        public bool NotifyOnLongRunningQueries { get; set; } = true;
+        public int LongRunningQueryThresholdMinutes { get; set; } = 30; // Alert when query runs > X minutes
+        public bool NotifyOnTempDbSpace { get; set; } = true;
+        public int TempDbSpaceThresholdPercent { get; set; } = 80; // Alert when TempDB used > X%
+        public bool NotifyOnLongRunningJobs { get; set; } = true;
+        public int LongRunningJobMultiplier { get; set; } = 3; // Alert when job runs > Nx historical average
 
         // SMTP email alert settings
         public bool SmtpEnabled { get; set; } = false;

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorDashboard.Helpers;
@@ -119,7 +120,7 @@ namespace PerformanceMonitorDashboard.Services
         /// Lightweight alert-only health check. Runs 3 queries instead of 9.
         /// Used by MainWindow's independent alert timer.
         /// </summary>
-        public async Task<AlertHealthResult> GetAlertHealthAsync(int engineEdition = 0)
+        public async Task<AlertHealthResult> GetAlertHealthAsync(int engineEdition = 0, int longRunningQueryThresholdMinutes = 30, int longRunningJobMultiplier = 3)
         {
             var result = new AlertHealthResult();
 
@@ -133,8 +134,12 @@ namespace PerformanceMonitorDashboard.Services
                 var cpuTask = GetCpuPercentAsync(connection, engineEdition);
                 var blockingTask = GetBlockingValuesAsync(connection);
                 var deadlockTask = GetDeadlockCountAsync(connection);
+                var poisonWaitTask = GetPoisonWaitDeltasAsync(connection);
+                var longRunningTask = GetLongRunningQueriesAsync(connection, longRunningQueryThresholdMinutes);
+                var tempDbTask = GetTempDbSpaceAsync(connection);
+                var anomalousJobTask = GetAnomalousJobsAsync(connection, longRunningJobMultiplier);
 
-                await Task.WhenAll(cpuTask, blockingTask, deadlockTask);
+                await Task.WhenAll(cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask);
 
                 var cpuResult = await cpuTask;
                 result.CpuPercent = cpuResult.SqlCpu;
@@ -145,6 +150,10 @@ namespace PerformanceMonitorDashboard.Services
                 result.LongestBlockedSeconds = blockingResult.LongestBlockedSeconds;
 
                 result.DeadlockCount = await deadlockTask;
+                result.PoisonWaits = await poisonWaitTask;
+                result.LongRunningQueries = await longRunningTask;
+                result.TempDbSpace = await tempDbTask;
+                result.AnomalousJobs = await anomalousJobTask;
             }
             catch (Exception ex)
             {
@@ -537,6 +546,212 @@ namespace PerformanceMonitorDashboard.Services
             {
                 Logger.Warning($"Failed to get last deadlock event time: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Gets recent poison wait deltas (THREADPOOL, RESOURCE_SEMAPHORE, RESOURCE_SEMAPHORE_QUERY_COMPILE)
+        /// from collected wait stats. Returns entries where avg ms per wait exceeds zero.
+        /// </summary>
+        private async Task<List<PoisonWaitDelta>> GetPoisonWaitDeltasAsync(SqlConnection connection)
+        {
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT TOP (3)
+                    wait_type,
+                    wait_time_ms_delta,
+                    waiting_tasks_count_delta,
+                    avg_ms_per_wait =
+                        CASE WHEN waiting_tasks_count_delta > 0
+                        THEN CAST(wait_time_ms_delta AS decimal(19, 2)) / waiting_tasks_count_delta
+                        ELSE 0 END
+                FROM collect.wait_stats
+                WHERE wait_type IN (N'THREADPOOL', N'RESOURCE_SEMAPHORE', N'RESOURCE_SEMAPHORE_QUERY_COMPILE')
+                AND waiting_tasks_count_delta > 0
+                AND collection_time >= DATEADD(MINUTE, -10, SYSDATETIME())
+                ORDER BY collection_time DESC
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            var results = new List<PoisonWaitDelta>();
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    results.Add(new PoisonWaitDelta
+                    {
+                        WaitType = reader.GetString(0),
+                        DeltaMs = Convert.ToInt64(reader.GetValue(1), System.Globalization.CultureInfo.InvariantCulture),
+                        DeltaTasks = Convert.ToInt64(reader.GetValue(2), System.Globalization.CultureInfo.InvariantCulture),
+                        AvgMsPerWait = Convert.ToDouble(reader.GetValue(3), System.Globalization.CultureInfo.InvariantCulture)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to get poison wait deltas: {ex.Message}");
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Gets currently running queries that exceed the duration threshold.
+        /// Uses live DMV data (sys.dm_exec_requests) for immediate detection.
+        /// </summary>
+        private async Task<List<LongRunningQueryInfo>> GetLongRunningQueriesAsync(SqlConnection connection, int thresholdMinutes)
+        {
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT TOP (5)
+                    r.session_id,
+                    DB_NAME(r.database_id) AS database_name,
+                    SUBSTRING(t.text, 1, 300) AS query_text,
+                    s.program_name,
+                    r.total_elapsed_time / 1000 AS elapsed_seconds,
+                    r.cpu_time AS cpu_time_ms,
+                    r.reads,
+                    r.writes,
+                    r.wait_type,
+                    r.blocking_session_id
+                FROM sys.dm_exec_requests AS r
+                CROSS APPLY sys.dm_exec_sql_text(r.sql_handle) AS t
+                JOIN sys.dm_exec_sessions AS s ON s.session_id = r.session_id
+                WHERE r.session_id > 50
+                AND r.total_elapsed_time >= @thresholdMs
+                ORDER BY r.total_elapsed_time DESC
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            var results = new List<LongRunningQueryInfo>();
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                cmd.Parameters.AddWithValue("@thresholdMs", (long)thresholdMinutes * 60 * 1000);
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    results.Add(new LongRunningQueryInfo
+                    {
+                        SessionId = reader.GetInt32(0),
+                        DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        ProgramName = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                        ElapsedSeconds = Convert.ToInt64(reader.GetValue(4), System.Globalization.CultureInfo.InvariantCulture),
+                        CpuTimeMs = Convert.ToInt64(reader.GetValue(5), System.Globalization.CultureInfo.InvariantCulture),
+                        Reads = Convert.ToInt64(reader.GetValue(6), System.Globalization.CultureInfo.InvariantCulture),
+                        Writes = Convert.ToInt64(reader.GetValue(7), System.Globalization.CultureInfo.InvariantCulture),
+                        WaitType = reader.IsDBNull(8) ? null : reader.GetString(8),
+                        BlockingSessionId = reader.IsDBNull(9) ? null : (int?)Convert.ToInt32(reader.GetValue(9), System.Globalization.CultureInfo.InvariantCulture)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to get long-running queries: {ex.Message}");
+            }
+
+            return results;
+        }
+
+        private async Task<List<AnomalousJobInfo>> GetAnomalousJobsAsync(SqlConnection connection, int multiplier)
+        {
+            var results = new List<AnomalousJobInfo>();
+            var thresholdPercent = multiplier * 100;
+
+            var query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT TOP (5)
+                    job_name,
+                    CAST(job_id AS VARCHAR(36)),
+                    current_duration_seconds,
+                    avg_duration_seconds,
+                    p95_duration_seconds,
+                    percent_of_average,
+                    start_time
+                FROM collect.running_jobs
+                WHERE collection_time = (SELECT MAX(collection_time) FROM collect.running_jobs)
+                AND avg_duration_seconds >= 60
+                AND percent_of_average >= @thresholdPercent
+                ORDER BY percent_of_average DESC
+                OPTION(MAXDOP 1);";
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                cmd.Parameters.AddWithValue("@thresholdPercent", thresholdPercent);
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    results.Add(new AnomalousJobInfo
+                    {
+                        JobName = reader.GetString(0),
+                        JobId = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        CurrentDurationSeconds = Convert.ToInt64(reader.GetValue(2), System.Globalization.CultureInfo.InvariantCulture),
+                        AvgDurationSeconds = Convert.ToInt64(reader.GetValue(3), System.Globalization.CultureInfo.InvariantCulture),
+                        P95DurationSeconds = reader.IsDBNull(4) ? 0 : Convert.ToInt64(reader.GetValue(4), System.Globalization.CultureInfo.InvariantCulture),
+                        PercentOfAverage = reader.IsDBNull(5) ? null : Convert.ToDecimal(reader.GetValue(5), System.Globalization.CultureInfo.InvariantCulture),
+                        StartTime = reader.GetDateTime(6)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to get anomalous jobs: {ex.Message}");
+            }
+
+            return results;
+        }
+
+        private async Task<TempDbSpaceInfo?> GetTempDbSpaceAsync(SqlConnection connection)
+        {
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT TOP (1)
+                    total_reserved_mb,
+                    unallocated_mb,
+                    user_object_reserved_mb,
+                    internal_object_reserved_mb,
+                    version_store_reserved_mb,
+                    top_task_total_mb,
+                    top_task_session_id
+                FROM collect.tempdb_stats
+                ORDER BY collection_time DESC
+                OPTION(MAXDOP 1);";
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                if (await reader.ReadAsync())
+                {
+                    return new TempDbSpaceInfo
+                    {
+                        TotalReservedMb = reader.IsDBNull(0) ? 0 : Convert.ToDouble(reader.GetValue(0), System.Globalization.CultureInfo.InvariantCulture),
+                        UnallocatedMb = reader.IsDBNull(1) ? 0 : Convert.ToDouble(reader.GetValue(1), System.Globalization.CultureInfo.InvariantCulture),
+                        UserObjectReservedMb = reader.IsDBNull(2) ? 0 : Convert.ToDouble(reader.GetValue(2), System.Globalization.CultureInfo.InvariantCulture),
+                        InternalObjectReservedMb = reader.IsDBNull(3) ? 0 : Convert.ToDouble(reader.GetValue(3), System.Globalization.CultureInfo.InvariantCulture),
+                        VersionStoreReservedMb = reader.IsDBNull(4) ? 0 : Convert.ToDouble(reader.GetValue(4), System.Globalization.CultureInfo.InvariantCulture),
+                        TopConsumerMb = reader.IsDBNull(5) ? 0 : Convert.ToDouble(reader.GetValue(5), System.Globalization.CultureInfo.InvariantCulture),
+                        TopConsumerSessionId = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6), System.Globalization.CultureInfo.InvariantCulture)
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to get TempDB space: {ex.Message}");
+            }
+
+            return null;
         }
     }
 }

--- a/Dashboard/Services/EmailTemplateBuilder.cs
+++ b/Dashboard/Services/EmailTemplateBuilder.cs
@@ -69,6 +69,10 @@ namespace PerformanceMonitorDashboard.Services
                 "Blocking Detected" => ("#D97706", "ALERT"),
                 "Deadlocks Detected" => ("#DC2626", "ALERT"),
                 "High CPU" => ("#F59E0B", "WARNING"),
+                "Poison Wait" => ("#DC2626", "CRITICAL"),
+                "Long-Running Query" => ("#D97706", "WARNING"),
+                "TempDB Space" => ("#D97706", "WARNING"),
+                "Long-Running Job" => ("#D97706", "WARNING"),
                 _ => ("#2eaef1", "INFO")
             };
         }

--- a/Dashboard/Services/NotificationService.cs
+++ b/Dashboard/Services/NotificationService.cs
@@ -195,6 +195,51 @@ namespace PerformanceMonitorDashboard.Services
                 NotificationType.Warning);
         }
 
+        public void ShowPoisonWaitNotification(string serverName, string waitType, double avgMs)
+        {
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotifyOnPoisonWaits) return;
+
+            ShowNotification(
+                "Poison Wait",
+                $"{serverName}: {waitType} avg {avgMs:F0}ms/wait",
+                NotificationType.Error);
+        }
+
+        public void ShowLongRunningQueryNotification(string serverName, int sessionId, long elapsedMinutes, string queryPreview)
+        {
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotifyOnLongRunningQueries) return;
+
+            var preview = string.IsNullOrEmpty(queryPreview) ? "" : $" — {queryPreview}";
+            ShowNotification(
+                "Long-Running Query",
+                $"{serverName}: Session #{sessionId} running {elapsedMinutes}m{preview}",
+                NotificationType.Warning);
+        }
+
+        public void ShowTempDbSpaceNotification(string serverName, double usedPercent)
+        {
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotifyOnTempDbSpace) return;
+
+            ShowNotification(
+                "TempDB Space",
+                $"{serverName}: TempDB {usedPercent:F0}% used",
+                NotificationType.Warning);
+        }
+
+        public void ShowLongRunningJobNotification(string serverName, string jobName, long currentMinutes, decimal percentOfAvg)
+        {
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotifyOnLongRunningJobs) return;
+
+            ShowNotification(
+                "Long-Running Job",
+                $"{serverName}: {jobName} at {percentOfAvg:F0}% of avg ({currentMinutes}m)",
+                NotificationType.Warning);
+        }
+
         private void ShowMainWindow()
         {
             _mainWindow.Show();

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -143,6 +143,58 @@
                                          TextAlignment="Center"/>
                                 <TextBlock Text="%" VerticalAlignment="Center"/>
                             </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnPoisonWaitsCheckBox"
+                                          Content="Poison waits (THREADPOOL, etc.) avg wait &#x2265;"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnPoisonWaitsCheckBox_Changed"
+                                          Unchecked="NotifyOnPoisonWaitsCheckBox_Changed"/>
+                                <TextBox x:Name="PoisonWaitThresholdTextBox"
+                                         Width="50"
+                                         Margin="8,0,8,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="ms" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnLongRunningQueriesCheckBox"
+                                          Content="Long-running queries over"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnLongRunningQueriesCheckBox_Changed"
+                                          Unchecked="NotifyOnLongRunningQueriesCheckBox_Changed"/>
+                                <TextBox x:Name="LongRunningQueryThresholdTextBox"
+                                         Width="50"
+                                         Margin="8,0,8,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="minutes" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnTempDbSpaceCheckBox"
+                                          Content="TempDB space usage over"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnTempDbSpaceCheckBox_Changed"
+                                          Unchecked="NotifyOnTempDbSpaceCheckBox_Changed"/>
+                                <TextBox x:Name="TempDbSpaceThresholdTextBox"
+                                         Width="50"
+                                         Margin="8,0,8,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="%" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnLongRunningJobsCheckBox"
+                                          Content="Agent jobs running over"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnLongRunningJobsCheckBox_Changed"
+                                          Unchecked="NotifyOnLongRunningJobsCheckBox_Changed"/>
+                                <TextBox x:Name="LongRunningJobMultiplierTextBox"
+                                         Width="50"
+                                         Margin="8,0,8,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="x historical average" VerticalAlignment="Center"/>
+                            </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -114,6 +114,14 @@ namespace PerformanceMonitorDashboard
             DeadlockThresholdTextBox.Text = prefs.DeadlockThreshold.ToString(CultureInfo.InvariantCulture);
             NotifyOnHighCpuCheckBox.IsChecked = prefs.NotifyOnHighCpu;
             CpuThresholdTextBox.Text = prefs.CpuThresholdPercent.ToString(CultureInfo.InvariantCulture);
+            NotifyOnPoisonWaitsCheckBox.IsChecked = prefs.NotifyOnPoisonWaits;
+            PoisonWaitThresholdTextBox.Text = prefs.PoisonWaitThresholdMs.ToString(CultureInfo.InvariantCulture);
+            NotifyOnLongRunningQueriesCheckBox.IsChecked = prefs.NotifyOnLongRunningQueries;
+            LongRunningQueryThresholdTextBox.Text = prefs.LongRunningQueryThresholdMinutes.ToString(CultureInfo.InvariantCulture);
+            NotifyOnTempDbSpaceCheckBox.IsChecked = prefs.NotifyOnTempDbSpace;
+            TempDbSpaceThresholdTextBox.Text = prefs.TempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
+            NotifyOnLongRunningJobsCheckBox.IsChecked = prefs.NotifyOnLongRunningJobs;
+            LongRunningJobMultiplierTextBox.Text = prefs.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
 
             UpdateNotificationCheckboxStates();
 
@@ -212,6 +220,30 @@ namespace PerformanceMonitorDashboard
             UpdateAlertNotificationStates();
         }
 
+        private void NotifyOnPoisonWaitsCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
+        private void NotifyOnLongRunningQueriesCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
+        private void NotifyOnTempDbSpaceCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
+        private void NotifyOnLongRunningJobsCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
         private void UpdateAlertNotificationStates()
         {
             bool notificationsEnabled = NotificationsEnabledCheckBox.IsChecked == true;
@@ -221,6 +253,14 @@ namespace PerformanceMonitorDashboard
             DeadlockThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnDeadlockCheckBox.IsChecked == true;
             NotifyOnHighCpuCheckBox.IsEnabled = notificationsEnabled;
             CpuThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnHighCpuCheckBox.IsChecked == true;
+            NotifyOnPoisonWaitsCheckBox.IsEnabled = notificationsEnabled;
+            PoisonWaitThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnPoisonWaitsCheckBox.IsChecked == true;
+            NotifyOnLongRunningQueriesCheckBox.IsEnabled = notificationsEnabled;
+            LongRunningQueryThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningQueriesCheckBox.IsChecked == true;
+            NotifyOnTempDbSpaceCheckBox.IsEnabled = notificationsEnabled;
+            TempDbSpaceThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnTempDbSpaceCheckBox.IsChecked == true;
+            NotifyOnLongRunningJobsCheckBox.IsEnabled = notificationsEnabled;
+            LongRunningJobMultiplierTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningJobsCheckBox.IsChecked == true;
         }
 
         private void UpdateNotificationCheckboxStates()
@@ -409,6 +449,26 @@ namespace PerformanceMonitorDashboard
             if (int.TryParse(CpuThresholdTextBox.Text, out int cpuThreshold) && cpuThreshold > 0 && cpuThreshold <= 100)
             {
                 prefs.CpuThresholdPercent = cpuThreshold;
+            }
+            prefs.NotifyOnPoisonWaits = NotifyOnPoisonWaitsCheckBox.IsChecked == true;
+            if (int.TryParse(PoisonWaitThresholdTextBox.Text, out int poisonWaitThreshold) && poisonWaitThreshold > 0)
+            {
+                prefs.PoisonWaitThresholdMs = poisonWaitThreshold;
+            }
+            prefs.NotifyOnLongRunningQueries = NotifyOnLongRunningQueriesCheckBox.IsChecked == true;
+            if (int.TryParse(LongRunningQueryThresholdTextBox.Text, out int lrqThreshold) && lrqThreshold > 0)
+            {
+                prefs.LongRunningQueryThresholdMinutes = lrqThreshold;
+            }
+            prefs.NotifyOnTempDbSpace = NotifyOnTempDbSpaceCheckBox.IsChecked == true;
+            if (int.TryParse(TempDbSpaceThresholdTextBox.Text, out int tempDbThreshold) && tempDbThreshold > 0 && tempDbThreshold <= 100)
+            {
+                prefs.TempDbSpaceThresholdPercent = tempDbThreshold;
+            }
+            prefs.NotifyOnLongRunningJobs = NotifyOnLongRunningJobsCheckBox.IsChecked == true;
+            if (int.TryParse(LongRunningJobMultiplierTextBox.Text, out int jobMultiplier) && jobMultiplier > 0)
+            {
+                prefs.LongRunningJobMultiplier = jobMultiplier;
             }
 
             // Save SMTP email settings

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -55,6 +55,14 @@ public partial class App : Application
     public static int AlertBlockingThreshold { get; set; } = 1;
     public static bool AlertDeadlockEnabled { get; set; } = true;
     public static int AlertDeadlockThreshold { get; set; } = 1;
+    public static bool AlertPoisonWaitEnabled { get; set; } = true;
+    public static int AlertPoisonWaitThresholdMs { get; set; } = 500;
+    public static bool AlertLongRunningQueryEnabled { get; set; } = true;
+    public static int AlertLongRunningQueryThresholdMinutes { get; set; } = 30;
+    public static bool AlertTempDbSpaceEnabled { get; set; } = true;
+    public static int AlertTempDbSpaceThresholdPercent { get; set; } = 80;
+    public static bool AlertLongRunningJobEnabled { get; set; } = true;
+    public static int AlertLongRunningJobMultiplier { get; set; } = 3;
 
     /* System tray settings */
     public static bool MinimizeToTray { get; set; } = true;
@@ -201,6 +209,14 @@ public partial class App : Application
             if (root.TryGetProperty("alert_blocking_threshold", out v)) AlertBlockingThreshold = v.GetInt32();
             if (root.TryGetProperty("alert_deadlock_enabled", out v)) AlertDeadlockEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_deadlock_threshold", out v)) AlertDeadlockThreshold = v.GetInt32();
+            if (root.TryGetProperty("alert_poison_wait_enabled", out v)) AlertPoisonWaitEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_poison_wait_threshold_ms", out v)) AlertPoisonWaitThresholdMs = v.GetInt32();
+            if (root.TryGetProperty("alert_long_running_query_enabled", out v)) AlertLongRunningQueryEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_long_running_query_threshold_minutes", out v)) AlertLongRunningQueryThresholdMinutes = v.GetInt32();
+            if (root.TryGetProperty("alert_tempdb_space_enabled", out v)) AlertTempDbSpaceEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.GetInt32();
+            if (root.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.GetInt32();
 
             /* System tray settings */
             if (root.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.GetBoolean();

--- a/Lite/Controls/AlertsHistoryTab.xaml
+++ b/Lite/Controls/AlertsHistoryTab.xaml
@@ -1,0 +1,156 @@
+<UserControl x:Class="PerformanceMonitorLite.Controls.AlertsHistoryTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+
+            <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
+            </Style>
+
+            <Style x:Key="AlertRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource DefaultRowStyle}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsCritical}" Value="True">
+                        <Setter Property="Background" Value="#33DC2626"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsWarning}" Value="True">
+                        <Setter Property="Background" Value="#33D97706"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsResolved}" Value="True">
+                        <Setter Property="Background" Value="#3322C55E"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header Controls -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+            <TextBlock Text="Alert History" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock Text="Time Range:" VerticalAlignment="Center" Margin="5,0,4,0"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            <ComboBox x:Name="TimeRangeComboBox" Width="100" VerticalAlignment="Center"
+                      SelectionChanged="TimeRangeComboBox_SelectionChanged">
+                <ComboBoxItem Content="Last 1 Hour" Tag="1"/>
+                <ComboBoxItem Content="Last 4 Hours" Tag="4"/>
+                <ComboBoxItem Content="Last 24 Hours" Tag="24" IsSelected="True"/>
+                <ComboBoxItem Content="Last 7 Days" Tag="168"/>
+                <ComboBoxItem Content="All" Tag="8760"/>
+            </ComboBox>
+            <TextBlock Text="Server:" VerticalAlignment="Center" Margin="12,0,4,0"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            <ComboBox x:Name="ServerFilterComboBox" Width="160" VerticalAlignment="Center"
+                      SelectionChanged="ServerFilterComboBox_SelectionChanged">
+                <ComboBoxItem Content="All Servers" Tag="" IsSelected="True"/>
+            </ComboBox>
+            <Button Content="Refresh" Click="RefreshButton_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+            <Button x:Name="DismissSelectedButton" Content="Dismiss Selected" Click="DismissSelected_Click"
+                    Margin="8,0,0,0" Padding="10,4" MinWidth="90" IsEnabled="False"/>
+            <Button Content="Dismiss All" Click="DismissAll_Click"
+                    Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+            <TextBlock x:Name="AlertCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center"
+                       FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+        </StackPanel>
+
+        <!-- DataGrid -->
+        <Grid Grid.Row="1" Margin="10,0,10,10">
+            <DataGrid x:Name="AlertsDataGrid"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserSortColumns="True"
+                      GridLinesVisibility="Horizontal"
+                      CanUserResizeColumns="True"
+                      HeadersVisibility="Column"
+                      SelectionMode="Extended"
+                      SelectionChanged="AlertsDataGrid_SelectionChanged"
+                      RowStyle="{StaticResource AlertRowStyle}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding TimeLocal}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ServerName}" Width="140">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Server" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MetricName}" Width="160">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MetricName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Alert Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding CurrentValueDisplay}" Width="160">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CurrentValueDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Value" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ThresholdValueDisplay}" Width="120">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ThresholdValueDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Threshold" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding NotificationType}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NotificationType" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Channel" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding StatusDisplay}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StatusDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <!-- Empty State -->
+            <TextBlock x:Name="NoAlertsMessage"
+                       Text="No alerts recorded in the selected time range"
+                       FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Visibility="Collapsed"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using Microsoft.Win32;
+using PerformanceMonitorLite.Controls;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Controls;
+
+public partial class AlertsHistoryTab : UserControl
+{
+    private LocalDataService? _dataService;
+    private DataGridFilterManager<AlertHistoryRow>? _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public AlertsHistoryTab()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Initializes the control with required dependencies.
+    /// </summary>
+    public void Initialize(LocalDataService dataService)
+    {
+        _dataService = dataService;
+        _filterManager = new DataGridFilterManager<AlertHistoryRow>(AlertsDataGrid);
+    }
+
+    /// <summary>
+    /// Refreshes the alert history data.
+    /// </summary>
+    public async void RefreshAlerts()
+    {
+        await LoadAlertsAsync();
+    }
+
+    private async System.Threading.Tasks.Task LoadAlertsAsync()
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var hoursBack = GetSelectedHoursBack();
+            int? serverId = GetSelectedServerId();
+
+            var alerts = await _dataService.GetAlertHistoryAsync(hoursBack, 500, serverId);
+
+            if (_filterManager != null)
+                _filterManager.UpdateData(alerts);
+            else
+                AlertsDataGrid.ItemsSource = alerts;
+
+            var displayCount = AlertsDataGrid.ItemsSource is ICollection<AlertHistoryRow> coll ? coll.Count : alerts.Count;
+            NoAlertsMessage.Visibility = displayCount == 0 ? Visibility.Visible : Visibility.Collapsed;
+            AlertCountIndicator.Text = displayCount > 0 ? $"{displayCount} alert(s)" : "";
+
+            PopulateServerFilter(alerts);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("AlertsHistory", $"Failed to load alert history: {ex.Message}");
+        }
+    }
+
+    private void PopulateServerFilter(List<AlertHistoryRow> alerts)
+    {
+        var servers = alerts
+            .Select(a => (a.ServerId, a.ServerName))
+            .Where(s => !string.IsNullOrEmpty(s.ServerName))
+            .Distinct()
+            .OrderBy(s => s.ServerName)
+            .ToList();
+
+        var currentSelection = ServerFilterComboBox.SelectedIndex > 0
+            ? (ServerFilterComboBox.SelectedItem as ComboBoxItem)?.Tag?.ToString()
+            : null;
+
+        var existingIds = ServerFilterComboBox.Items
+            .OfType<ComboBoxItem>()
+            .Skip(1)
+            .Select(i => i.Tag?.ToString())
+            .ToList();
+
+        var newIds = servers.Select(s => s.ServerId.ToString()).ToList();
+        if (newIds.SequenceEqual(existingIds)) return;
+
+        ServerFilterComboBox.SelectionChanged -= ServerFilterComboBox_SelectionChanged;
+
+        while (ServerFilterComboBox.Items.Count > 1)
+            ServerFilterComboBox.Items.RemoveAt(1);
+
+        foreach (var (serverId, serverName) in servers)
+        {
+            ServerFilterComboBox.Items.Add(new ComboBoxItem
+            {
+                Content = serverName,
+                Tag = serverId.ToString()
+            });
+        }
+
+        if (currentSelection != null)
+        {
+            for (int i = 1; i < ServerFilterComboBox.Items.Count; i++)
+            {
+                if ((ServerFilterComboBox.Items[i] as ComboBoxItem)?.Tag?.ToString() == currentSelection)
+                {
+                    ServerFilterComboBox.SelectedIndex = i;
+                    break;
+                }
+            }
+        }
+
+        ServerFilterComboBox.SelectionChanged += ServerFilterComboBox_SelectionChanged;
+    }
+
+    private int GetSelectedHoursBack()
+    {
+        if (TimeRangeComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tagStr)
+            return int.TryParse(tagStr, out var hours) ? hours : 24;
+        return 24;
+    }
+
+    private int? GetSelectedServerId()
+    {
+        if (ServerFilterComboBox.SelectedIndex > 0 &&
+            ServerFilterComboBox.SelectedItem is ComboBoxItem item &&
+            item.Tag is string tagStr &&
+            int.TryParse(tagStr, out var serverId))
+        {
+            return serverId;
+        }
+        return null;
+    }
+
+    #region Column Filter Handlers
+
+    private void FilterButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+            _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+
+        ColumnFilterState? existingFilter = null;
+        _filterManager?.Filters.TryGetValue(columnName, out existingFilter);
+        _filterPopupContent!.Initialize(columnName, existingFilter);
+
+        _filterPopup.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+
+        _filterManager?.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private async void TimeRangeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (IsLoaded)
+            await LoadAlertsAsync();
+    }
+
+    private async void ServerFilterComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (IsLoaded)
+            await LoadAlertsAsync();
+    }
+
+    private async void RefreshButton_Click(object sender, RoutedEventArgs e)
+    {
+        await LoadAlertsAsync();
+    }
+
+    private void AlertsDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        DismissSelectedButton.IsEnabled = AlertsDataGrid.SelectedItems.Count > 0;
+    }
+
+    private async void DismissSelected_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService == null) return;
+
+        var selected = AlertsDataGrid.SelectedItems
+            .OfType<AlertHistoryRow>()
+            .ToList();
+
+        if (selected.Count == 0) return;
+
+        try
+        {
+            await _dataService.DismissAlertsAsync(selected);
+            await LoadAlertsAsync();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("AlertsHistory", $"Failed to dismiss selected alerts: {ex.Message}");
+        }
+    }
+
+    private async void DismissAll_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService == null) return;
+
+        var displayCount = AlertsDataGrid.ItemsSource is System.Collections.ICollection coll ? coll.Count : 0;
+        if (displayCount == 0) return;
+
+        var result = MessageBox.Show(
+            $"Dismiss all {displayCount} visible alert(s)?\n\nDismissed alerts are hidden from this view but remain in the database.",
+            "Dismiss All Alerts",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes) return;
+
+        try
+        {
+            var hoursBack = GetSelectedHoursBack();
+            int? serverId = GetSelectedServerId();
+            await _dataService.DismissAllVisibleAlertsAsync(hoursBack, serverId);
+            await LoadAlertsAsync();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("AlertsHistory", $"Failed to dismiss all alerts: {ex.Message}");
+        }
+    }
+
+    #endregion
+
+    #region Context Menu Handlers
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
+
+        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
+        if (value.Length > 0) Clipboard.SetDataObject(value, false);
+    }
+
+    private void CopyRow_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem == null) return;
+
+        var sb = new StringBuilder();
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(GetCellValue(col, grid.CurrentItem));
+            sb.Append('\t');
+        }
+        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
+    }
+
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.Items == null) return;
+
+        var sb = new StringBuilder();
+
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(col.Header?.ToString() ?? "");
+            sb.Append('\t');
+        }
+        sb.AppendLine();
+
+        foreach (var item in grid.Items)
+        {
+            foreach (var col in grid.Columns)
+            {
+                sb.Append(GetCellValue(col, item));
+                sb.Append('\t');
+            }
+            sb.AppendLine();
+        }
+
+        Clipboard.SetDataObject(sb.ToString(), false);
+    }
+
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.Items == null || grid.Items.Count == 0) return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            DefaultExt = ".csv",
+            FileName = $"alert_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        var sb = new StringBuilder();
+
+        var headers = new List<string>();
+        foreach (var col in grid.Columns)
+            headers.Add(CsvEscape(col.Header?.ToString() ?? ""));
+        sb.AppendLine(string.Join(",", headers));
+
+        foreach (var item in grid.Items)
+        {
+            var values = new List<string>();
+            foreach (var col in grid.Columns)
+                values.Add(CsvEscape(GetCellValue(col, item)));
+            sb.AppendLine(string.Join(",", values));
+        }
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static DataGrid? FindParentDataGrid(MenuItem menuItem)
+    {
+        var contextMenu = menuItem.Parent as ContextMenu;
+        var target = contextMenu?.PlacementTarget as FrameworkElement;
+        while (target != null && target is not DataGrid)
+            target = System.Windows.Media.VisualTreeHelper.GetParent(target) as FrameworkElement;
+        return target as DataGrid;
+    }
+
+    private static string GetCellValue(DataGridColumn col, object item)
+    {
+        if (col is DataGridBoundColumn boundCol && boundCol.Binding is Binding binding)
+        {
+            var prop = item.GetType().GetProperty(binding.Path.Path);
+            return prop?.GetValue(item)?.ToString() ?? "";
+        }
+        return "";
+    }
+
+    private static string CsvEscape(string value)
+    {
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        return value;
+    }
+
+    #endregion
+}

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -19,7 +19,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    private const int CurrentSchemaVersion = 8;
+    private const int CurrentSchemaVersion = 9;
 
     public DuckDbInitializer(string databasePath, ILogger<DuckDbInitializer>? logger = null)
     {
@@ -311,6 +311,21 @@ public class DuckDbInitializer
                    Must drop/recreate because DuckDB appender writes by position. */
             _logger?.LogInformation("Running migration to v8: rebuilding procedure_stats for min/max/spills columns");
             await ExecuteNonQueryAsync(connection, "DROP TABLE IF EXISTS procedure_stats");
+        }
+
+        if (fromVersion < 9)
+        {
+            /* v9: Added dismissed column to config_alert_log for hide/dismiss functionality.
+                   Safe to ALTER because this table uses INSERT (not appender). */
+            _logger?.LogInformation("Running migration to v9: adding dismissed column to config_alert_log");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE config_alert_log ADD COLUMN IF NOT EXISTS dismissed BOOLEAN NOT NULL DEFAULT false");
+            }
+            catch
+            {
+                /* Table doesn't exist yet — will be created with correct schema below */
+            }
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -500,7 +500,8 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
     threshold_value DOUBLE NOT NULL,
     alert_sent BOOLEAN NOT NULL DEFAULT false,
     notification_type VARCHAR NOT NULL DEFAULT 'tray',
-    send_error VARCHAR
+    send_error VARCHAR,
+    dismissed BOOLEAN NOT NULL DEFAULT false
 )";
 
     /// <summary>

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="PerformanceMonitorLite.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:PerformanceMonitorLite.Controls"
         Title="Performance Monitor Lite"
         Height="700" Width="1200"
         WindowStartupLocation="CenterScreen"
@@ -245,6 +246,9 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </ScrollViewer>
+                    </TabItem>
+                    <TabItem Header="Alert History" x:Name="AlertsTab">
+                        <controls:AlertsHistoryTab x:Name="AlertsHistoryContent"/>
                     </TabItem>
                 </TabControl>
             </Grid>

--- a/Lite/Services/EmailTemplateBuilder.cs
+++ b/Lite/Services/EmailTemplateBuilder.cs
@@ -71,6 +71,10 @@ internal static class EmailTemplateBuilder
             "Blocking Detected" => ("#D97706", "ALERT"),
             "Deadlocks Detected" => ("#DC2626", "ALERT"),
             "High CPU" => ("#F59E0B", "WARNING"),
+            "Poison Wait" => ("#DC2626", "CRITICAL"),
+            "Long-Running Query" => ("#D97706", "WARNING"),
+            "TempDB Space" => ("#D97706", "WARNING"),
+            "Long-Running Job" => ("#D97706", "WARNING"),
             _ => ("#2eaef1", "INFO")
         };
     }

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    /// <summary>
+    /// Gets alert history from the config_alert_log table (excludes dismissed alerts).
+    /// </summary>
+    public async Task<List<AlertHistoryRow>> GetAlertHistoryAsync(int hoursBack = 24, int limit = 500, int? serverId = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        if (serverId.HasValue)
+        {
+            command.CommandText = @"
+SELECT
+    alert_time,
+    server_id,
+    server_name,
+    metric_name,
+    current_value,
+    threshold_value,
+    alert_sent,
+    notification_type,
+    send_error
+FROM config_alert_log
+WHERE alert_time >= $1
+AND   server_id = $2
+AND   dismissed = FALSE
+ORDER BY alert_time DESC
+LIMIT $3";
+            command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+            command.Parameters.Add(new DuckDBParameter { Value = serverId.Value });
+            command.Parameters.Add(new DuckDBParameter { Value = limit });
+        }
+        else
+        {
+            command.CommandText = @"
+SELECT
+    alert_time,
+    server_id,
+    server_name,
+    metric_name,
+    current_value,
+    threshold_value,
+    alert_sent,
+    notification_type,
+    send_error
+FROM config_alert_log
+WHERE alert_time >= $1
+AND   dismissed = FALSE
+ORDER BY alert_time DESC
+LIMIT $2";
+            command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+            command.Parameters.Add(new DuckDBParameter { Value = limit });
+        }
+
+        var items = new List<AlertHistoryRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new AlertHistoryRow
+            {
+                AlertTime = reader.GetDateTime(0),
+                ServerId = (int)ToInt64(reader.GetValue(1)),
+                ServerName = reader.GetString(2),
+                MetricName = reader.GetString(3),
+                CurrentValue = Convert.ToDouble(reader.GetValue(4)),
+                ThresholdValue = Convert.ToDouble(reader.GetValue(5)),
+                AlertSent = reader.GetBoolean(6),
+                NotificationType = reader.GetString(7),
+                SendError = reader.IsDBNull(8) ? null : reader.GetString(8)
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Dismisses specific alerts by marking them as dismissed in DuckDB.
+    /// Identifies rows by (alert_time, server_id, metric_name) composite key.
+    /// </summary>
+    public async Task DismissAlertsAsync(List<AlertHistoryRow> alerts)
+    {
+        if (alerts.Count == 0) return;
+
+        using var connection = await OpenConnectionAsync();
+
+        foreach (var alert in alerts)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+UPDATE config_alert_log
+SET    dismissed = TRUE
+WHERE  alert_time = $1
+AND    server_id = $2
+AND    metric_name = $3";
+            command.Parameters.Add(new DuckDBParameter { Value = alert.AlertTime });
+            command.Parameters.Add(new DuckDBParameter { Value = alert.ServerId });
+            command.Parameters.Add(new DuckDBParameter { Value = alert.MetricName });
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    /// <summary>
+    /// Dismisses all visible (non-dismissed) alerts matching the current filter criteria.
+    /// </summary>
+    public async Task DismissAllVisibleAlertsAsync(int hoursBack, int? serverId = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        if (serverId.HasValue)
+        {
+            command.CommandText = @"
+UPDATE config_alert_log
+SET    dismissed = TRUE
+WHERE  alert_time >= $1
+AND    server_id = $2
+AND    dismissed = FALSE";
+            command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+            command.Parameters.Add(new DuckDBParameter { Value = serverId.Value });
+        }
+        else
+        {
+            command.CommandText = @"
+UPDATE config_alert_log
+SET    dismissed = TRUE
+WHERE  alert_time >= $1
+AND    dismissed = FALSE";
+            command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+        }
+
+        await command.ExecuteNonQueryAsync();
+    }
+}
+
+public class AlertHistoryRow
+{
+    public DateTime AlertTime { get; set; }
+    public int ServerId { get; set; }
+    public string ServerName { get; set; } = "";
+    public string MetricName { get; set; } = "";
+    public double CurrentValue { get; set; }
+    public double ThresholdValue { get; set; }
+    public bool AlertSent { get; set; }
+    public string NotificationType { get; set; } = "";
+    public string? SendError { get; set; }
+
+    public string TimeLocal => AlertTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+    public string CurrentValueDisplay => FormatValue(MetricName, CurrentValue);
+    public string ThresholdValueDisplay => FormatValue(MetricName, ThresholdValue);
+
+    public string StatusDisplay
+    {
+        get
+        {
+            if (NotificationType == "email")
+                return AlertSent ? "Sent" : (!string.IsNullOrEmpty(SendError) ? "Failed" : "Not sent");
+            return AlertSent ? "Delivered" : "Shown";
+        }
+    }
+
+    public bool IsResolved => MetricName.Contains("Cleared") || MetricName.Contains("Resolved");
+    public bool IsCritical => MetricName.Contains("Deadlock") || MetricName.Contains("Poison");
+    public bool IsWarning => !IsResolved && !IsCritical;
+
+    private static string FormatValue(string metricName, double value)
+    {
+        if (metricName.Contains("CPU")) return $"{value:F0}%";
+        if (metricName.Contains("TempDB")) return $"{value:F0}%";
+        return $"{value:G}";
+    }
+}

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -148,6 +148,124 @@ ORDER BY collection_time";
 
         return items;
     }
+
+    /// <summary>
+    /// Gets the latest poison wait deltas for alert checking.
+    /// Returns entries where delta_waiting_tasks > 0 with computed avg ms per wait.
+    /// </summary>
+    public async Task<List<PoisonWaitDelta>> GetLatestPoisonWaitAvgsAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT
+    wait_type,
+    delta_wait_time_ms AS delta_ms,
+    delta_waiting_tasks AS delta_tasks,
+    CASE WHEN delta_waiting_tasks > 0
+    THEN CAST(delta_wait_time_ms AS DOUBLE) / delta_waiting_tasks
+    ELSE 0 END AS avg_ms_per_wait
+FROM wait_stats
+WHERE server_id = $1
+AND wait_type IN ('THREADPOOL', 'RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE')
+AND delta_waiting_tasks > 0
+ORDER BY collection_time DESC
+LIMIT 3";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<PoisonWaitDelta>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new PoisonWaitDelta
+            {
+                WaitType = reader.GetString(0),
+                DeltaMs = reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
+                DeltaTasks = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                AvgMsPerWait = reader.IsDBNull(3) ? 0 : reader.GetDouble(3)
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets long-running queries from the latest collection snapshot.
+    /// Returns sessions whose total elapsed time exceeds the given threshold.
+    /// </summary>
+    public async Task<List<LongRunningQueryInfo>> GetLongRunningQueriesAsync(int serverId, int thresholdMinutes)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var thresholdMs = (long)thresholdMinutes * 60 * 1000;
+
+        command.CommandText = @"
+SELECT
+    session_id,
+    database_name,
+    SUBSTRING(query_text, 1, 300) AS query_text,
+    total_elapsed_time_ms / 1000 AS elapsed_seconds,
+    cpu_time_ms,
+    reads,
+    writes,
+    wait_type,
+    blocking_session_id
+FROM query_snapshots
+WHERE server_id = $1
+AND collection_time = (SELECT MAX(collection_time) FROM query_snapshots WHERE server_id = $1)
+AND session_id > 50
+AND total_elapsed_time_ms >= $2
+ORDER BY total_elapsed_time_ms DESC
+LIMIT 5";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = thresholdMs });
+
+        var items = new List<LongRunningQueryInfo>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new LongRunningQueryInfo
+            {
+                SessionId = reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ElapsedSeconds = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                CpuTimeMs = reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                Reads = reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
+                Writes = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                WaitType = reader.IsDBNull(7) ? null : reader.GetString(7),
+                BlockingSessionId = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8)
+            });
+        }
+
+        return items;
+    }
+}
+
+public class LongRunningQueryInfo
+{
+    public int SessionId { get; set; }
+    public string DatabaseName { get; set; } = "";
+    public string QueryText { get; set; } = "";
+    public string ProgramName { get; set; } = "";
+    public long ElapsedSeconds { get; set; }
+    public long CpuTimeMs { get; set; }
+    public long Reads { get; set; }
+    public long Writes { get; set; }
+    public string? WaitType { get; set; }
+    public int? BlockingSessionId { get; set; }
+}
+
+public class PoisonWaitDelta
+{
+    public string WaitType { get; set; } = "";
+    public long DeltaMs { get; set; }
+    public long DeltaTasks { get; set; }
+    public double AvgMsPerWait { get; set; }
 }
 
 public class WaitStatsRow

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -120,6 +120,34 @@
                               Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="AlertDeadlockThresholdBox" Width="45" Text="1" Margin="6,0,0,0" VerticalAlignment="Center"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertPoisonWaitCheckBox" Content="Poison waits (THREADPOOL, etc.) avg wait &#x2265;" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertPoisonWaitThresholdBox" Width="45" Text="500" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="ms" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLongRunningQueryCheckBox" Content="Long-running queries over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLongRunningQueryThresholdBox" Width="45" Text="30" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertTempDbSpaceCheckBox" Content="TempDB space usage over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertTempDbSpaceThresholdBox" Width="45" Text="80" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="%" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLongRunningJobCheckBox" Content="Agent jobs running over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLongRunningJobMultiplierBox" Width="35" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="x historical average" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
             </StackPanel>
         </Border>
 

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -230,6 +230,14 @@ public partial class SettingsWindow : Window
         AlertBlockingThresholdBox.Text = App.AlertBlockingThreshold.ToString();
         AlertDeadlockCheckBox.IsChecked = App.AlertDeadlockEnabled;
         AlertDeadlockThresholdBox.Text = App.AlertDeadlockThreshold.ToString();
+        AlertPoisonWaitCheckBox.IsChecked = App.AlertPoisonWaitEnabled;
+        AlertPoisonWaitThresholdBox.Text = App.AlertPoisonWaitThresholdMs.ToString();
+        AlertLongRunningQueryCheckBox.IsChecked = App.AlertLongRunningQueryEnabled;
+        AlertLongRunningQueryThresholdBox.Text = App.AlertLongRunningQueryThresholdMinutes.ToString();
+        AlertTempDbSpaceCheckBox.IsChecked = App.AlertTempDbSpaceEnabled;
+        AlertTempDbSpaceThresholdBox.Text = App.AlertTempDbSpaceThresholdPercent.ToString();
+        AlertLongRunningJobCheckBox.IsChecked = App.AlertLongRunningJobEnabled;
+        AlertLongRunningJobMultiplierBox.Text = App.AlertLongRunningJobMultiplier.ToString();
         UpdateAlertControlStates();
     }
 
@@ -247,6 +255,18 @@ public partial class SettingsWindow : Window
         App.AlertDeadlockEnabled = AlertDeadlockCheckBox.IsChecked == true;
         if (int.TryParse(AlertDeadlockThresholdBox.Text, out var deadlock) && deadlock > 0)
             App.AlertDeadlockThreshold = deadlock;
+        App.AlertPoisonWaitEnabled = AlertPoisonWaitCheckBox.IsChecked == true;
+        if (int.TryParse(AlertPoisonWaitThresholdBox.Text, out var poisonWait) && poisonWait > 0)
+            App.AlertPoisonWaitThresholdMs = poisonWait;
+        App.AlertLongRunningQueryEnabled = AlertLongRunningQueryCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLongRunningQueryThresholdBox.Text, out var lrq) && lrq > 0)
+            App.AlertLongRunningQueryThresholdMinutes = lrq;
+        App.AlertTempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true;
+        if (int.TryParse(AlertTempDbSpaceThresholdBox.Text, out var tempDb) && tempDb > 0 && tempDb <= 100)
+            App.AlertTempDbSpaceThresholdPercent = tempDb;
+        App.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult >= 2 && jobMult <= 20)
+            App.AlertLongRunningJobMultiplier = jobMult;
 
         var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
         try
@@ -271,6 +291,14 @@ public partial class SettingsWindow : Window
             root["alert_blocking_threshold"] = App.AlertBlockingThreshold;
             root["alert_deadlock_enabled"] = App.AlertDeadlockEnabled;
             root["alert_deadlock_threshold"] = App.AlertDeadlockThreshold;
+            root["alert_poison_wait_enabled"] = App.AlertPoisonWaitEnabled;
+            root["alert_poison_wait_threshold_ms"] = App.AlertPoisonWaitThresholdMs;
+            root["alert_long_running_query_enabled"] = App.AlertLongRunningQueryEnabled;
+            root["alert_long_running_query_threshold_minutes"] = App.AlertLongRunningQueryThresholdMinutes;
+            root["alert_tempdb_space_enabled"] = App.AlertTempDbSpaceEnabled;
+            root["alert_tempdb_space_threshold_percent"] = App.AlertTempDbSpaceThresholdPercent;
+            root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
+            root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
 
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(settingsPath, root.ToJsonString(options));
@@ -296,6 +324,14 @@ public partial class SettingsWindow : Window
         AlertBlockingThresholdBox.IsEnabled = enabled;
         AlertDeadlockCheckBox.IsEnabled = enabled;
         AlertDeadlockThresholdBox.IsEnabled = enabled;
+        AlertPoisonWaitCheckBox.IsEnabled = enabled;
+        AlertPoisonWaitThresholdBox.IsEnabled = enabled;
+        AlertLongRunningQueryCheckBox.IsEnabled = enabled;
+        AlertLongRunningQueryThresholdBox.IsEnabled = enabled;
+        AlertTempDbSpaceCheckBox.IsEnabled = enabled;
+        AlertTempDbSpaceThresholdBox.IsEnabled = enabled;
+        AlertLongRunningJobCheckBox.IsEnabled = enabled;
+        AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
     }
 
     private void LoadSmtpSettings()


### PR DESCRIPTION
## Summary
- Alert types expanded with severity classification (critical, warning, resolved)
- Alerts History view added to both Dashboard and Lite with time range and server filters
- Column-level filtering added to Alerts History DataGrids
- Dismiss/hide functionality: Dashboard persists to JSON on exit, Lite uses DuckDB `dismissed` column (schema v9)

## Test plan
- [x] Both apps build with 0 errors
- [x] Dashboard: Alerts sidebar button opens Alerts History tab
- [x] Lite: Alerts tab shows alert history from DuckDB
- [x] Time range and server filters work correctly
- [x] Dismiss Selected / Dismiss All work in both apps
- [x] Dashboard alert log persists across app restart via JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)