### PR TITLE
Fix Dashboard sub-tab badges and DuckDB dismissed column migration

### DIFF
--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -320,7 +320,8 @@ public class DuckDbInitializer
             _logger?.LogInformation("Running migration to v9: adding dismissed column to config_alert_log");
             try
             {
-                await ExecuteNonQueryAsync(connection, "ALTER TABLE config_alert_log ADD COLUMN IF NOT EXISTS dismissed BOOLEAN NOT NULL DEFAULT false");
+                /* DuckDB does not support ADD COLUMN with NOT NULL — use nullable with DEFAULT */
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE config_alert_log ADD COLUMN IF NOT EXISTS dismissed BOOLEAN DEFAULT false");
             }
             catch
             {


### PR DESCRIPTION
## Summary

- Dashboard sub-tab badges (Locking, Memory, Resource Metrics) now update when alerts fire from the independent alert engine. Previously only the server-level Overview badge updated.
- Fix deadlock badge race condition: `EvaluateAlertConditionsAsync` consumed the previous deadlock count before `UpdateTabBadgeFromAlertHealth` could compute the delta, so the Locking badge never appeared for deadlock alerts.
- Fix DuckDB v9 migration silently failing — `ALTER TABLE ADD COLUMN` does not support `NOT NULL` constraint in DuckDB. Changed to nullable with `DEFAULT false`.

## Test plan

- [x] Dashboard builds with 0 errors
- [x] Lite builds with 0 errors
- [x] CPU alert fires → Resource Metrics badge appears
- [x] Deadlock alert fires → Locking badge appears
- [x] Lite alerts history grid shows data after migration fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)