### PR TITLE
Add hover tooltips to all Dashboard charts

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -99,6 +99,12 @@ namespace PerformanceMonitorDashboard.Controls
         private Helpers.ChartHoverHelper? _fileIoWriteHover;
         private Helpers.ChartHoverHelper? _perfmonHover;
         private Helpers.ChartHoverHelper? _waitStatsHover;
+        private Helpers.ChartHoverHelper? _tempdbStatsHover;
+        private Helpers.ChartHoverHelper? _tempDbLatencyHover;
+        private Helpers.ChartHoverHelper? _serverTrendsCpuHover;
+        private Helpers.ChartHoverHelper? _serverTrendsTempdbHover;
+        private Helpers.ChartHoverHelper? _serverTrendsMemoryHover;
+        private Helpers.ChartHoverHelper? _serverTrendsPerfmonHover;
         // Column filter popup and state
         private Popup? _filterPopup;
         private ColumnFilterPopup? _filterPopupContent;
@@ -130,6 +136,12 @@ namespace PerformanceMonitorDashboard.Controls
             _fileIoWriteHover = new Helpers.ChartHoverHelper(UserDbWriteLatencyChart, "ms");
             _perfmonHover = new Helpers.ChartHoverHelper(PerfmonCountersChart, "");
             _waitStatsHover = new Helpers.ChartHoverHelper(WaitStatsDetailChart, "ms/sec");
+            _tempdbStatsHover = new Helpers.ChartHoverHelper(TempdbStatsChart, "MB");
+            _tempDbLatencyHover = new Helpers.ChartHoverHelper(TempDbLatencyChart, "ms");
+            _serverTrendsCpuHover = new Helpers.ChartHoverHelper(ServerUtilTrendsCpuChart, "%");
+            _serverTrendsTempdbHover = new Helpers.ChartHoverHelper(ServerUtilTrendsTempdbChart, "MB");
+            _serverTrendsMemoryHover = new Helpers.ChartHoverHelper(ServerUtilTrendsMemoryChart, "MB");
+            _serverTrendsPerfmonHover = new Helpers.ChartHoverHelper(ServerUtilTrendsPerfmonChart, "/sec");
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -491,6 +503,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[TempDbLatencyChart] = null;
             }
             TempDbLatencyChart.Plot.Clear();
+            _tempDbLatencyHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(TempDbLatencyChart);
 
             if (data != null && data.Count > 0)
@@ -516,6 +529,7 @@ namespace PerformanceMonitorDashboard.Controls
                 readScatter.MarkerSize = 5;
                 readScatter.Color = TabHelpers.ChartColors[0];
                 readScatter.LegendText = "Read Latency";
+                _tempDbLatencyHover?.Add(readScatter, "Read Latency");
 
                 // Write Latency series
                 var (writeXs, writeYs) = TabHelpers.FillTimeSeriesGaps(
@@ -526,6 +540,7 @@ namespace PerformanceMonitorDashboard.Controls
                 writeScatter.MarkerSize = 5;
                 writeScatter.Color = TabHelpers.ChartColors[2];
                 writeScatter.LegendText = "Write Latency";
+                _tempDbLatencyHover?.Add(writeScatter, "Write Latency");
 
                 // Store legend panel reference for removal on refresh (ScottPlot issue #4717)
                 _legendPanels[TempDbLatencyChart] = TempDbLatencyChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
@@ -562,6 +577,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[TempdbStatsChart] = null;
             }
             TempdbStatsChart.Plot.Clear();
+            _tempdbStatsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(TempdbStatsChart);
 
             var dataList = data?.OrderBy(d => d.CollectionTime).ToList() ?? new List<TempdbStatsItem>();
@@ -576,6 +592,7 @@ namespace PerformanceMonitorDashboard.Controls
                 userScatter.MarkerSize = 5;
                 userScatter.Color = TabHelpers.ChartColors[0];
                 userScatter.LegendText = "User Objects";
+                _tempdbStatsHover?.Add(userScatter, "User Objects");
 
                 // Version Store series
                 var (versionXs, versionYs) = TabHelpers.FillTimeSeriesGaps(
@@ -586,6 +603,7 @@ namespace PerformanceMonitorDashboard.Controls
                 versionScatter.MarkerSize = 5;
                 versionScatter.Color = TabHelpers.ChartColors[1];
                 versionScatter.LegendText = "Version Store";
+                _tempdbStatsHover?.Add(versionScatter, "Version Store");
 
                 // Internal Objects series
                 var (internalXs, internalYs) = TabHelpers.FillTimeSeriesGaps(
@@ -596,6 +614,7 @@ namespace PerformanceMonitorDashboard.Controls
                 internalScatter.MarkerSize = 5;
                 internalScatter.Color = TabHelpers.ChartColors[2];
                 internalScatter.LegendText = "Internal Objects";
+                _tempdbStatsHover?.Add(internalScatter, "Internal Objects");
 
                 // Unallocated (free space) series
                 var (unallocXs, unallocYs) = TabHelpers.FillTimeSeriesGaps(
@@ -608,6 +627,7 @@ namespace PerformanceMonitorDashboard.Controls
                     unallocScatter.MarkerSize = 5;
                     unallocScatter.Color = TabHelpers.ChartColors[9];
                     unallocScatter.LegendText = "Unallocated";
+                    _tempdbStatsHover?.Add(unallocScatter, "Unallocated");
                 }
 
                 // Top Task Total MB series (worst session's usage)
@@ -979,6 +999,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[ServerUtilTrendsCpuChart] = null;
             }
             ServerUtilTrendsCpuChart.Plot.Clear();
+            _serverTrendsCpuHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsCpuChart);
 
             var dataList = cpuData?.OrderBy(d => d.EventTime).ToList() ?? new List<CpuSpikeItem>();
@@ -993,6 +1014,7 @@ namespace PerformanceMonitorDashboard.Controls
                 sqlScatter.MarkerSize = 5;
                 sqlScatter.Color = TabHelpers.ChartColors[0];
                 sqlScatter.LegendText = "SQL CPU";
+                _serverTrendsCpuHover?.Add(sqlScatter, "SQL CPU");
 
                 // Other CPU series
                 var (otherXs, otherYs) = TabHelpers.FillTimeSeriesGaps(
@@ -1003,6 +1025,7 @@ namespace PerformanceMonitorDashboard.Controls
                 otherScatter.MarkerSize = 5;
                 otherScatter.Color = TabHelpers.ChartColors[2];
                 otherScatter.LegendText = "Other CPU";
+                _serverTrendsCpuHover?.Add(otherScatter, "Other CPU");
 
                 _legendPanels[ServerUtilTrendsCpuChart] = ServerUtilTrendsCpuChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                 ServerUtilTrendsCpuChart.Plot.Legend.FontSize = 12;
@@ -1038,6 +1061,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[ServerUtilTrendsTempdbChart] = null;
             }
             ServerUtilTrendsTempdbChart.Plot.Clear();
+            _serverTrendsTempdbHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsTempdbChart);
 
             var dataList = tempdbData?.OrderBy(d => d.CollectionTime).ToList() ?? new List<TempdbStatsItem>();
@@ -1056,12 +1080,14 @@ namespace PerformanceMonitorDashboard.Controls
                 userScatter.MarkerSize = 5;
                 userScatter.Color = TabHelpers.ChartColors[1];
                 userScatter.LegendText = "User Objects";
+                _serverTrendsTempdbHover?.Add(userScatter, "User Objects");
 
                 var versionScatter = ServerUtilTrendsTempdbChart.Plot.Add.Scatter(versionXs, versionYs);
                 versionScatter.LineWidth = 2;
                 versionScatter.MarkerSize = 5;
                 versionScatter.Color = TabHelpers.ChartColors[2];
                 versionScatter.LegendText = "Version Store";
+                _serverTrendsTempdbHover?.Add(versionScatter, "Version Store");
 
                 _legendPanels[ServerUtilTrendsTempdbChart] = ServerUtilTrendsTempdbChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                 ServerUtilTrendsTempdbChart.Plot.Legend.FontSize = 12;
@@ -1097,6 +1123,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[ServerUtilTrendsMemoryChart] = null;
             }
             ServerUtilTrendsMemoryChart.Plot.Clear();
+            _serverTrendsMemoryHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsMemoryChart);
 
             var dataList = memoryData?.OrderBy(d => d.CollectionTime).ToList() ?? new List<MemoryStatsItem>();
@@ -1151,12 +1178,14 @@ namespace PerformanceMonitorDashboard.Controls
                 bufferScatter.MarkerSize = 5;
                 bufferScatter.Color = TabHelpers.ChartColors[4];
                 bufferScatter.LegendText = "Buffer Pool";
+                _serverTrendsMemoryHover?.Add(bufferScatter, "Buffer Pool");
 
                 var cacheScatter = ServerUtilTrendsMemoryChart.Plot.Add.Scatter(cacheXs, cacheYs);
                 cacheScatter.LineWidth = 2;
                 cacheScatter.MarkerSize = 5;
                 cacheScatter.Color = TabHelpers.ChartColors[5];
                 cacheScatter.LegendText = "Plan Cache";
+                _serverTrendsMemoryHover?.Add(cacheScatter, "Plan Cache");
 
                 _legendPanels[ServerUtilTrendsMemoryChart] = ServerUtilTrendsMemoryChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                 ServerUtilTrendsMemoryChart.Plot.Legend.FontSize = 12;
@@ -1200,6 +1229,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[ServerUtilTrendsPerfmonChart] = null;
             }
             ServerUtilTrendsPerfmonChart.Plot.Clear();
+            _serverTrendsPerfmonHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsPerfmonChart);
 
             var allData = (perfmonData ?? Enumerable.Empty<PerfmonStatsItem>()).ToList();
@@ -1234,6 +1264,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = color;
                     scatter.LegendText = counterName.Replace("/sec", "", StringComparison.Ordinal);
+                    _serverTrendsPerfmonHover?.Add(scatter, counterName);
                     linesAdded++;
                 }
             }

--- a/Dashboard/Controls/SystemEventsContent.xaml.cs
+++ b/Dashboard/Controls/SystemEventsContent.xaml.cs
@@ -102,12 +102,53 @@ namespace PerformanceMonitorDashboard.Controls
         // Legend panel references for edge-based legends (ScottPlot issue #4717 workaround)
         private Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.IPanel?> _legendPanels = new();
 
+        // Chart hover tooltips
+        private Helpers.ChartHoverHelper? _badPagesHover;
+        private Helpers.ChartHoverHelper? _dumpRequestsHover;
+        private Helpers.ChartHoverHelper? _accessViolationsHover;
+        private Helpers.ChartHoverHelper? _writeAccessViolationsHover;
+        private Helpers.ChartHoverHelper? _nonYieldingTasksHover;
+        private Helpers.ChartHoverHelper? _latchWarningsHover;
+        private Helpers.ChartHoverHelper? _sickSpinlocksHover;
+        private Helpers.ChartHoverHelper? _cpuComparisonHover;
+        private Helpers.ChartHoverHelper? _severeErrorsHover;
+        private Helpers.ChartHoverHelper? _ioIssuesHover;
+        private Helpers.ChartHoverHelper? _longestPendingIoHover;
+        private Helpers.ChartHoverHelper? _schedulerIssuesHover;
+        private Helpers.ChartHoverHelper? _memoryConditionsHover;
+        private Helpers.ChartHoverHelper? _cpuTasksHover;
+        private Helpers.ChartHoverHelper? _memoryBrokerHover;
+        private Helpers.ChartHoverHelper? _memoryBrokerRatioHover;
+        private Helpers.ChartHoverHelper? _memoryNodeOomHover;
+        private Helpers.ChartHoverHelper? _memoryNodeOomUtilHover;
+        private Helpers.ChartHoverHelper? _memoryNodeOomMemoryHover;
+
         public SystemEventsContent()
         {
             InitializeComponent();
             SetupChartContextMenus();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+
+            _badPagesHover = new Helpers.ChartHoverHelper(BadPagesChart, "events");
+            _dumpRequestsHover = new Helpers.ChartHoverHelper(DumpRequestsChart, "events");
+            _accessViolationsHover = new Helpers.ChartHoverHelper(AccessViolationsChart, "events");
+            _writeAccessViolationsHover = new Helpers.ChartHoverHelper(WriteAccessViolationsChart, "events");
+            _nonYieldingTasksHover = new Helpers.ChartHoverHelper(NonYieldingTasksChart, "events");
+            _latchWarningsHover = new Helpers.ChartHoverHelper(LatchWarningsChart, "events");
+            _sickSpinlocksHover = new Helpers.ChartHoverHelper(SickSpinlocksChart, "backoffs");
+            _cpuComparisonHover = new Helpers.ChartHoverHelper(CpuComparisonChart, "%");
+            _severeErrorsHover = new Helpers.ChartHoverHelper(SevereErrorsChart, "events");
+            _ioIssuesHover = new Helpers.ChartHoverHelper(IOIssuesChart, "events");
+            _longestPendingIoHover = new Helpers.ChartHoverHelper(LongestPendingIOChart, "ms");
+            _schedulerIssuesHover = new Helpers.ChartHoverHelper(SchedulerIssuesChart, "ms");
+            _memoryConditionsHover = new Helpers.ChartHoverHelper(MemoryConditionsChart, "events");
+            _cpuTasksHover = new Helpers.ChartHoverHelper(CPUTasksChart, "workers");
+            _memoryBrokerHover = new Helpers.ChartHoverHelper(MemoryBrokerChart, "");
+            _memoryBrokerRatioHover = new Helpers.ChartHoverHelper(MemoryBrokerRatioChart, "");
+            _memoryNodeOomHover = new Helpers.ChartHoverHelper(MemoryNodeOOMChart, "events");
+            _memoryNodeOomUtilHover = new Helpers.ChartHoverHelper(MemoryNodeOOMUtilChart, "%");
+            _memoryNodeOomMemoryHover = new Helpers.ChartHoverHelper(MemoryNodeOOMMemoryChart, "MB");
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -409,6 +450,7 @@ namespace PerformanceMonitorDashboard.Controls
             bool hasData = orderedData.Count > 0;
             // Bad Pages Detected Chart
             BadPagesChart.Plot.Clear();
+            _badPagesHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(BadPagesChart);
             if (hasData)
             {
@@ -419,6 +461,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[3];
+                _badPagesHover?.Add(scatter, "Bad Pages");
             }
             else
             {
@@ -437,6 +480,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             // Interval Dump Requests Chart
             DumpRequestsChart.Plot.Clear();
+            _dumpRequestsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(DumpRequestsChart);
             if (hasData)
             {
@@ -447,6 +491,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[2];
+                _dumpRequestsHover?.Add(scatter, "Dump Requests");
             }
             else
             {
@@ -465,6 +510,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             // Access Violations Chart
             AccessViolationsChart.Plot.Clear();
+            _accessViolationsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(AccessViolationsChart);
             if (hasData)
             {
@@ -475,6 +521,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[4];
+                _accessViolationsHover?.Add(scatter, "Access Violations");
             }
             else
             {
@@ -493,6 +540,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             // Write Access Violations Chart
             WriteAccessViolationsChart.Plot.Clear();
+            _writeAccessViolationsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(WriteAccessViolationsChart);
             if (hasData)
             {
@@ -503,6 +551,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[0];
+                _writeAccessViolationsHover?.Add(scatter, "Write Access Violations");
             }
             else
             {
@@ -533,6 +582,7 @@ namespace PerformanceMonitorDashboard.Controls
             bool hasData = orderedData.Count > 0;
             // Non-Yielding Tasks Chart
             NonYieldingTasksChart.Plot.Clear();
+            _nonYieldingTasksHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(NonYieldingTasksChart);
             if (hasData)
             {
@@ -543,6 +593,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[3];
+                _nonYieldingTasksHover?.Add(scatter, "Non-Yielding Tasks");
             }
             else
             {
@@ -561,6 +612,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             // Latch Warnings Chart
             LatchWarningsChart.Plot.Clear();
+            _latchWarningsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(LatchWarningsChart);
             if (hasData)
             {
@@ -571,6 +623,7 @@ namespace PerformanceMonitorDashboard.Controls
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
                 scatter.Color = TabHelpers.ChartColors[2];
+                _latchWarningsHover?.Add(scatter, "Latch Warnings");
             }
             else
             {
@@ -594,6 +647,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[SickSpinlocksChart] = null;
             }
             SickSpinlocksChart.Plot.Clear();
+            _sickSpinlocksHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(SickSpinlocksChart);
             if (hasData)
             {
@@ -624,6 +678,7 @@ namespace PerformanceMonitorDashboard.Controls
                         scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
                         scatter.LegendText = spinlockType ?? "Unknown";
+                        _sickSpinlocksHover?.Add(scatter, spinlockType ?? "Unknown");
                         colorIndex++;
                     }
                 }
@@ -656,6 +711,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[CpuComparisonChart] = null;
             }
             CpuComparisonChart.Plot.Clear();
+            _cpuComparisonHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(CpuComparisonChart);
             if (hasData)
             {
@@ -668,6 +724,7 @@ namespace PerformanceMonitorDashboard.Controls
                 sysScatter.MarkerSize = 5;
                 sysScatter.Color = TabHelpers.ChartColors[0];
                 sysScatter.LegendText = "System CPU %";
+                _cpuComparisonHover?.Add(sysScatter, "System CPU %");
 
                 // SQL CPU series
                 var (sqlXs, sqlYs) = TabHelpers.FillTimeSeriesGaps(
@@ -678,6 +735,7 @@ namespace PerformanceMonitorDashboard.Controls
                 sqlScatter.MarkerSize = 5;
                 sqlScatter.Color = TabHelpers.ChartColors[1];
                 sqlScatter.LegendText = "SQL CPU %";
+                _cpuComparisonHover?.Add(sqlScatter, "SQL CPU %");
 
                 _legendPanels[CpuComparisonChart] = CpuComparisonChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                 CpuComparisonChart.Plot.Legend.FontSize = 12;
@@ -750,6 +808,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[SevereErrorsChart] = null;
             }
             SevereErrorsChart.Plot.Clear();
+            _severeErrorsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(SevereErrorsChart);
 
             var dataList = data?.ToList() ?? new List<HealthParserSevereErrorItem>();
@@ -775,6 +834,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[3];
                     scatter.LegendText = "Error Count";
+                    _severeErrorsHover?.Add(scatter, "Error Count");
 
                     _legendPanels[SevereErrorsChart] = SevereErrorsChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                     SevereErrorsChart.Plot.Legend.FontSize = 12;
@@ -894,6 +954,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[IOIssuesChart] = null;
             }
             IOIssuesChart.Plot.Clear();
+            _ioIssuesHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(IOIssuesChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).OrderBy(d => d.EventTime).ToList() ?? new List<HealthParserIOIssueItem>();
@@ -921,6 +982,7 @@ namespace PerformanceMonitorDashboard.Controls
                         scatter.MarkerSize = 5;
                         scatter.Color = TabHelpers.ChartColors[3];
                         scatter.LegendText = "Latch Timeouts";
+                        _ioIssuesHover?.Add(scatter, "Latch Timeouts");
                     }
 
                     if (longIos.Any(c => c > 0))
@@ -931,6 +993,7 @@ namespace PerformanceMonitorDashboard.Controls
                         scatter.MarkerSize = 5;
                         scatter.Color = TabHelpers.ChartColors[2];
                         scatter.LegendText = "Long IOs";
+                        _ioIssuesHover?.Add(scatter, "Long IOs");
                     }
 
                     _legendPanels[IOIssuesChart] = IOIssuesChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
@@ -969,6 +1032,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[LongestPendingIOChart] = null;
             }
             LongestPendingIOChart.Plot.Clear();
+            _longestPendingIoHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(LongestPendingIOChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue && !string.IsNullOrEmpty(d.LongestPendingRequestsFilePath)).ToList() ?? new List<HealthParserIOIssueItem>();
@@ -1022,6 +1086,7 @@ namespace PerformanceMonitorDashboard.Controls
                             scatter.MarkerSize = 5;
                             scatter.Color = colors[colorIndex % colors.Length];
                             scatter.LegendText = fileName;
+                            _longestPendingIoHover?.Add(scatter, fileName);
                             colorIndex++;
                         }
                     }
@@ -1091,6 +1156,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[SchedulerIssuesChart] = null;
             }
             SchedulerIssuesChart.Plot.Clear();
+            _schedulerIssuesHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(SchedulerIssuesChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).ToList() ?? new List<HealthParserSchedulerIssueItem>();
@@ -1123,6 +1189,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[2];
                     scatter.LegendText = "Total Non-Yield Time";
+                    _schedulerIssuesHover?.Add(scatter, "Total Non-Yield Time");
 
                     _legendPanels[SchedulerIssuesChart] = SchedulerIssuesChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                     SchedulerIssuesChart.Plot.Legend.FontSize = 12;
@@ -1244,6 +1311,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[MemoryConditionsChart] = null;
             }
             MemoryConditionsChart.Plot.Clear();
+            _memoryConditionsHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(MemoryConditionsChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).ToList() ?? new List<HealthParserMemoryConditionItem>();
@@ -1270,6 +1338,7 @@ namespace PerformanceMonitorDashboard.Controls
                         scatter.MarkerSize = 5;
                         scatter.Color = TabHelpers.ChartColors[3];
                         scatter.LegendText = "OOM Exceptions";
+                        _memoryConditionsHover?.Add(scatter, "OOM Exceptions");
                         hasData = true;
 
                         _legendPanels[MemoryConditionsChart] = MemoryConditionsChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
@@ -1343,6 +1412,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[CPUTasksChart] = null;
             }
             CPUTasksChart.Plot.Clear();
+            _cpuTasksHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(CPUTasksChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).ToList() ?? new List<HealthParserCPUTasksItem>();
@@ -1368,6 +1438,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[0];
                     scatter.LegendText = "Workers Created";
+                    _cpuTasksHover?.Add(scatter, "Workers Created");
 
                     // Max Workers threshold line (horizontal)
                     var maxWorkersValue = dataList.Max(d => d.MaxWorkers ?? 0);
@@ -1549,6 +1620,8 @@ namespace PerformanceMonitorDashboard.Controls
             double xMax = rangeEnd.ToOADate();
 
             /* Clear both charts */
+            _memoryBrokerHover?.Clear();
+            _memoryBrokerRatioHover?.Clear();
             foreach (var chart in new[] { MemoryBrokerChart, MemoryBrokerRatioChart })
             {
                 if (_legendPanels.TryGetValue(chart, out var existingPanel) && existingPanel != null)
@@ -1589,7 +1662,9 @@ namespace PerformanceMonitorDashboard.Controls
                         scatter.LineWidth = 2;
                         scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
-                        scatter.LegendText = brokerGroup.Key.Length > 25 ? brokerGroup.Key.Substring(0, 25) + "..." : brokerGroup.Key;
+                        var brokerLabel = brokerGroup.Key.Length > 25 ? brokerGroup.Key.Substring(0, 25) + "..." : brokerGroup.Key;
+                        scatter.LegendText = brokerLabel;
+                        _memoryBrokerHover?.Add(scatter, brokerLabel);
                         colorIndex++;
                     }
                 }
@@ -1616,6 +1691,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[0];
                     scatter.LegendText = "Memory Ratio";
+                    _memoryBrokerRatioHover?.Add(scatter, "Memory Ratio");
                 }
 
                 if (overallData.Count >= 1)
@@ -1630,6 +1706,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[2];
                     scatter.LegendText = "Overall";
+                    _memoryBrokerRatioHover?.Add(scatter, "Overall");
                 }
 
                 if (hasRatioData)
@@ -1773,6 +1850,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[MemoryNodeOOMChart] = null;
             }
             MemoryNodeOOMChart.Plot.Clear();
+            _memoryNodeOomHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(MemoryNodeOOMChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).ToList() ?? new List<HealthParserMemoryNodeOOMItem>();
@@ -1797,6 +1875,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[3];
                     scatter.LegendText = "OOM Event Count";
+                    _memoryNodeOomHover?.Add(scatter, "OOM Event Count");
 
                     _legendPanels[MemoryNodeOOMChart] = MemoryNodeOOMChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                     MemoryNodeOOMChart.Plot.Legend.FontSize = 12;
@@ -1833,6 +1912,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[MemoryNodeOOMUtilChart] = null;
             }
             MemoryNodeOOMUtilChart.Plot.Clear();
+            _memoryNodeOomUtilHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(MemoryNodeOOMUtilChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue && d.MemoryUtilizationPct.HasValue).ToList() ?? new List<HealthParserMemoryNodeOOMItem>();
@@ -1849,6 +1929,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[0];
+                    _memoryNodeOomUtilHover?.Add(scatter, "Memory Utilization %");
                 }
             }
 
@@ -1881,6 +1962,7 @@ namespace PerformanceMonitorDashboard.Controls
                 _legendPanels[MemoryNodeOOMMemoryChart] = null;
             }
             MemoryNodeOOMMemoryChart.Plot.Clear();
+            _memoryNodeOomMemoryHover?.Clear();
             TabHelpers.ApplyDarkModeToChart(MemoryNodeOOMMemoryChart);
 
             var dataList = data?.Where(d => d.EventTime.HasValue).ToList() ?? new List<HealthParserMemoryNodeOOMItem>();
@@ -1900,6 +1982,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[1];
                     scatter.LegendText = "Target";
+                    _memoryNodeOomMemoryHover?.Add(scatter, "Target");
                 }
 
                 // Committed Memory (Orange)
@@ -1914,6 +1997,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[2];
                     scatter.LegendText = "Committed";
+                    _memoryNodeOomMemoryHover?.Add(scatter, "Committed");
                 }
 
                 // Total Page File (Purple)
@@ -1928,6 +2012,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[4];
                     scatter.LegendText = "Total Page File";
+                    _memoryNodeOomMemoryHover?.Add(scatter, "Total Page File");
                 }
 
                 // Available Page File (Cyan)
@@ -1942,6 +2027,7 @@ namespace PerformanceMonitorDashboard.Controls
                     scatter.MarkerSize = 5;
                     scatter.Color = TabHelpers.ChartColors[5];
                     scatter.LegendText = "Avail Page File";
+                    _memoryNodeOomMemoryHover?.Add(scatter, "Avail Page File");
                 }
 
                 if (hasData)


### PR DESCRIPTION
## Summary
- Wire `ChartHoverHelper` to every chart in the Dashboard that was missing mouse-over hover tooltips, matching the Lite app's behavior (closes #70)
- Shows series name, value, and timestamp on hover for all scatter-plot charts

## Changes
- **MemoryContent.xaml.cs** — 5 charts: overview, grants, clerks, plan cache, pressure events
- **QueryPerformanceContent.xaml.cs** — 4 charts: query/proc/QS durations, execution counts
- **SystemEventsContent.xaml.cs** — 19 charts: corruption, contention, severe errors, IO issues, scheduler, memory conditions, CPU tasks, memory broker, node OOM
- **ResourceMetricsContent.xaml.cs** — 6 charts: CPU utilization, TempDB stats/latency, server trends (CPU, TempDB, memory, perfmon)
- **ServerTab.xaml.cs** — 9 charts: resource overview (CPU, memory, IO, waits) + locking trends (lock waits, blocking events/duration, deadlocks/wait time)

## Test Plan
- [x] Build succeeds with 0 errors, 0 warnings
- [x] Hover tooltips appear on all Resource Metrics > Server Trends charts
- [x] Hover tooltips appear on all Resource Metrics > TempDB Stats charts
- [x] Hover tooltips appear on Overview > Resource Overview charts
- [x] Hover tooltips appear on Locking > Trends charts
- [x] Hover tooltips appear on Memory, Query Performance, and System Events charts
- [x] Tooltip shows correct series name, formatted value, and timestamp

Generated with [Claude Code](https://claude.com/claude-code)