### PR TITLE
Fix text clipping in DataGrid rows

### DIFF
--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -228,7 +228,7 @@
                     <TabItem Header="Server Config Changes">
                         <Grid>
                         <DataGrid x:Name="ServerConfigChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
@@ -345,7 +345,7 @@
                     <TabItem Header="Database Config Changes">
                         <Grid>
                         <DataGrid x:Name="DatabaseConfigChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
@@ -415,7 +415,7 @@
                     <TabItem Header="Trace Flag Changes">
                         <Grid>
                         <DataGrid x:Name="TraceFlagChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
@@ -593,7 +593,7 @@
                     <TabItem Header="Running Jobs">
                         <Grid>
                             <DataGrid x:Name="RunningJobsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Resources>
                                     <Style TargetType="DataGridRow">
@@ -705,7 +705,7 @@
                     <TabItem Header="Blocking">
                         <Grid>
                         <DataGrid x:Name="BlockingEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
@@ -889,7 +889,7 @@
                     <TabItem Header="Deadlocks">
                         <Grid>
                         <DataGrid x:Name="DeadlocksDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>


### PR DESCRIPTION
## Summary

- Increased `RowHeight` from 25 to 28 on all 6 DataGrids in ServerTab
- Fixes text overlap on systems with certain DPI/font settings (reported on Windows Server 2019)

Closes #72

## Test plan

- [ ] Visual check that Running Jobs rows display without overlap
- [ ] Verify other DataGrid tabs (Config Changes, Trace Flags, Blocking, Deadlocks) also look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)