### PR TITLE
Add setting to control server tab auto-focus

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -533,7 +533,12 @@ namespace PerformanceMonitorDashboard
 
             ServerTabControl.Items.Add(tabItem);
             _openTabs[server.Id] = tabItem;
-            ServerTabControl.SelectedItem = tabItem;
+
+            var prefs = _preferencesService.GetPreferences();
+            if (prefs.FocusServerTabOnClick)
+            {
+                ServerTabControl.SelectedItem = tabItem;
+            }
 
             _serverManager.UpdateLastConnected(server.Id);
         }

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -100,6 +100,9 @@ namespace PerformanceMonitorDashboard.Models
         public bool McpEnabled { get; set; } = false;
         public int McpPort { get; set; } = 5150;
 
+        // Navigation settings
+        public bool FocusServerTabOnClick { get; set; } = true;
+
         // Update check settings
         public bool CheckForUpdatesOnStartup { get; set; } = true;
 

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -54,7 +54,7 @@
 
                         <!-- Default Time Range Section -->
                         <TextBlock Text="Default Time Range" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
-                        <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
                             <TextBlock Text="Show data from last:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                             <ComboBox x:Name="DefaultTimeRangeComboBox" Width="120" SelectionChanged="DefaultTimeRangeComboBox_Changed">
                                 <ComboBoxItem Content="1 hour" Tag="1"/>
@@ -63,6 +63,12 @@
                                 <ComboBoxItem Content="7 days" Tag="168"/>
                             </ComboBox>
                         </StackPanel>
+
+                        <!-- Navigation Section -->
+                        <TextBlock Text="Navigation" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
+                        <CheckBox x:Name="FocusServerTabCheckBox"
+                                  Content="Focus server tab when clicking a server card"
+                                  Margin="0,0,0,0"/>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -86,6 +86,9 @@ namespace PerformanceMonitorDashboard
                 DefaultTimeRangeComboBox.SelectedIndex = 2; // 24 hours
             }
 
+            // Navigation settings
+            FocusServerTabCheckBox.IsChecked = prefs.FocusServerTabOnClick;
+
             // Query logging settings
             LogSlowQueriesCheckBox.IsChecked = prefs.LogSlowQueries;
             QueryLogger.SetEnabled(prefs.LogSlowQueries);
@@ -419,6 +422,9 @@ namespace PerformanceMonitorDashboard
             {
                 prefs.DefaultHoursBack = int.Parse(rangeItem.Tag.ToString()!, CultureInfo.InvariantCulture);
             }
+
+            // Save navigation settings
+            prefs.FocusServerTabOnClick = FocusServerTabCheckBox.IsChecked == true;
 
             // Save query logging settings
             prefs.LogSlowQueries = LogSlowQueriesCheckBox.IsChecked == true;


### PR DESCRIPTION
## Summary
- Adds `FocusServerTabOnClick` boolean user preference (default: `true`)
- When disabled, clicking a server card in Overview creates the tab without switching to it
- Clicking an already-open server tab always focuses it regardless of setting
- New "Navigation" section in Settings > General with checkbox

Closes #71

## Changes
- `Dashboard/Models/UserPreferences.cs` — new `FocusServerTabOnClick` property
- `Dashboard/MainWindow.xaml.cs` — conditional focus in `OpenServerTab()`
- `Dashboard/SettingsWindow.xaml` — checkbox under new Navigation section
- `Dashboard/SettingsWindow.xaml.cs` — load/save preference

## Test Plan
- [x] Builds clean (0 warnings, 0 errors)
- [ ] With setting ON (default): clicking a server card focuses the new tab
- [ ] With setting OFF: clicking a server card creates tab but stays on current view
- [ ] Clicking an already-open server always focuses it regardless of setting
- [ ] Setting persists across app restarts

Generated with [Claude Code](https://claude.com/claude-code)