### PR TITLE
Fix deadlock charts not populating data

### DIFF
--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -1122,7 +1122,7 @@
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="*"/>
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Blocking Events (Delta)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <TextBlock Grid.Row="0" Text="Blocking Events" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
                                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsBlockingEventsChart"/>
                                     </Grid>
                                 </Border>
@@ -1133,7 +1133,7 @@
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="*"/>
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Blocking Duration (Delta ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <TextBlock Grid.Row="0" Text="Blocking Duration (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
                                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDurationChart"/>
                                     </Grid>
                                 </Border>
@@ -1144,7 +1144,7 @@
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="*"/>
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Deadlock Count (Delta)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <TextBlock Grid.Row="0" Text="Deadlock Count" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
                                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlocksChart"/>
                                     </Grid>
                                 </Border>
@@ -1155,7 +1155,7 @@
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="*"/>
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Deadlock Wait Time (Delta ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <TextBlock Grid.Row="0" Text="Deadlock Wait Time (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
                                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlockWaitTimeChart"/>
                                     </Grid>
                                 </Border>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1661,13 +1661,13 @@ namespace PerformanceMonitorDashboard
             var orderedData = data?.OrderBy(d => d.CollectionTime).ToList() ?? new List<BlockingDeadlockStatsItem>();
 
             // Get all unique time points for consistent X-axis across all charts
-            // Blocking Events Delta Chart
+            // Blocking Events Chart (raw per-interval count, not delta)
             BlockingStatsBlockingEventsChart.Plot.Clear();
             _blockingEventsHover?.Clear();
             ApplyDarkModeToChart(BlockingStatsBlockingEventsChart);
             var (blockingXs, blockingYs) = TabHelpers.FillTimeSeriesGaps(
                 orderedData.Select(d => d.CollectionTime),
-                orderedData.Select(d => (double)d.BlockingEventCountDelta));
+                orderedData.Select(d => (double)d.BlockingEventCount));
             if (blockingXs.Length > 0)
             {
                 var scatter = BlockingStatsBlockingEventsChart.Plot.Add.Scatter(blockingXs, blockingYs);
@@ -1691,13 +1691,13 @@ namespace PerformanceMonitorDashboard
             LockChartVerticalAxis(BlockingStatsBlockingEventsChart);
             BlockingStatsBlockingEventsChart.Refresh();
 
-            // Blocking Duration Delta Chart
+            // Blocking Duration Chart (raw per-interval total, not delta)
             BlockingStatsDurationChart.Plot.Clear();
             _blockingDurationHover?.Clear();
             ApplyDarkModeToChart(BlockingStatsDurationChart);
             var (durationXs, durationYs) = TabHelpers.FillTimeSeriesGaps(
                 orderedData.Select(d => d.CollectionTime),
-                orderedData.Select(d => (double)d.TotalBlockingDurationMsDelta));
+                orderedData.Select(d => (double)d.TotalBlockingDurationMs));
             if (durationXs.Length > 0)
             {
                 var scatter = BlockingStatsDurationChart.Plot.Add.Scatter(durationXs, durationYs);
@@ -1721,13 +1721,13 @@ namespace PerformanceMonitorDashboard
             LockChartVerticalAxis(BlockingStatsDurationChart);
             BlockingStatsDurationChart.Refresh();
 
-            // Deadlock Count Delta Chart
+            // Deadlock Count Chart (raw per-interval count, not delta)
             BlockingStatsDeadlocksChart.Plot.Clear();
             _deadlocksHover?.Clear();
             ApplyDarkModeToChart(BlockingStatsDeadlocksChart);
             var (deadlockXs, deadlockYs) = TabHelpers.FillTimeSeriesGaps(
                 orderedData.Select(d => d.CollectionTime),
-                orderedData.Select(d => (double)d.DeadlockCountDelta));
+                orderedData.Select(d => (double)d.DeadlockCount));
             if (deadlockXs.Length > 0)
             {
                 var scatter = BlockingStatsDeadlocksChart.Plot.Add.Scatter(deadlockXs, deadlockYs);
@@ -1751,13 +1751,13 @@ namespace PerformanceMonitorDashboard
             LockChartVerticalAxis(BlockingStatsDeadlocksChart);
             BlockingStatsDeadlocksChart.Refresh();
 
-            // Deadlock Wait Time Chart
+            // Deadlock Wait Time Chart (raw per-interval total, not delta)
             BlockingStatsDeadlockWaitTimeChart.Plot.Clear();
             _deadlockWaitTimeHover?.Clear();
             ApplyDarkModeToChart(BlockingStatsDeadlockWaitTimeChart);
             var (deadlockWaitXs, deadlockWaitYs) = TabHelpers.FillTimeSeriesGaps(
                 orderedData.Select(d => d.CollectionTime),
-                orderedData.Select(d => (double)d.TotalDeadlockWaitTimeMsDelta));
+                orderedData.Select(d => (double)d.TotalDeadlockWaitTimeMs));
             if (deadlockWaitXs.Length > 0)
             {
                 var scatter = BlockingStatsDeadlockWaitTimeChart.Plot.Add.Scatter(deadlockWaitXs, deadlockWaitYs);

--- a/install/25_process_deadlock_xml.sql
+++ b/install/25_process_deadlock_xml.sql
@@ -129,7 +129,7 @@ BEGIN
             BEGIN
                 SELECT
                     @start_date = MIN(dx.event_time),
-                    @end_date = MAX(dx.event_time)
+                    @end_date = DATEADD(SECOND, 1, MAX(dx.event_time))
                 FROM collect.deadlock_xml AS dx
                 WHERE dx.is_processed = 0
                 AND   dx.event_time IS NOT NULL

--- a/install/26_blocking_deadlock_analyzer.sql
+++ b/install/26_blocking_deadlock_analyzer.sql
@@ -102,7 +102,7 @@ BEGIN
 
             RAISERROR(N'Aggregating blocking and deadlock events from the last %d hour(s)', 0, 1, @lookback_hours) WITH NOWAIT;
             RAISERROR(N'Blocking: counting events from %s', 0, 1, @blocking_range) WITH NOWAIT;
-            RAISERROR(N'Deadlock: counting events from %s (interval-based)', 0, 1, @deadlock_range) WITH NOWAIT;
+            RAISERROR(N'Deadlock: counting events collected from %s (by collection_time)', 0, 1, @deadlock_range) WITH NOWAIT;
         END;
 
         /*
@@ -188,8 +188,8 @@ BEGIN
                     total_deadlock_wait_time_ms = SUM(bl.wait_time),
                     victim_count = SUM(CASE WHEN bl.deadlock_group LIKE N'%- VICTIM' THEN 1 ELSE 0 END)
                 FROM collect.deadlocks AS bl
-                WHERE bl.event_date >= @last_deadlock_collection
-                AND   bl.event_date < @start_time
+                WHERE bl.collection_time >= @last_deadlock_collection
+                AND   bl.collection_time < @start_time
                 GROUP BY
                     bl.database_name
             )


### PR DESCRIPTION
## Summary
- Fix Locking > Trends deadlock charts showing empty when deadlock data exists
- Four-layer fix across Dashboard charts, XAML titles, and two SQL collectors

## Changes
**Dashboard (ServerTab.xaml.cs):** Plot raw per-interval columns (`DeadlockCount`, `BlockingEventCount`, etc.) instead of delta columns. The delta framework incorrectly computed `current - previous = 0` for values that are already per-interval counts.

**Dashboard (ServerTab.xaml):** Remove "(Delta)" from all four Locking > Trends chart titles.

**Analyzer (26_blocking_deadlock_analyzer.sql):** Filter `collect.deadlocks` on `collection_time` instead of `event_date`. Deadlock XE events have significant collection lag (e.g., 170+ minutes), so filtering on `event_date` missed late-arriving rows.

**Process XML (25_process_deadlock_xml.sql):** Add +1 second buffer to `@end_date` when derived from a single unprocessed row. `sp_BlitzLock` uses strict `< @EndDate`, so when `@start_date = @end_date` (single event), nothing matched.

## Test Plan
- [x] Generated test deadlock on sql2022, verified full pipeline: XE capture → deadlock_xml → sp_BlitzLock → collect.deadlocks → blocking_deadlock_stats → Dashboard charts
- [x] Verified analyzer correctly picks up late-arriving deadlocks using collection_time filter
- [x] Dashboard Locking > Trends shows deadlock data in both Deadlock Count and Deadlock Wait Time charts
- [x] Chart titles no longer say "(Delta)"
- [x] Build succeeds with no errors

Closes #73

Generated with [Claude Code](https://claude.com/claude-code)