### PR TITLE
Pass @skip_locks and @skip_waits to health collector wrapper

### DIFF
--- a/install/28_collect_system_health_wrapper.sql
+++ b/install/28_collect_system_health_wrapper.sql
@@ -36,6 +36,8 @@ ALTER PROCEDURE
     @what_to_check varchar(10) = 'all', /*What portion of data to collect (all, waits, cpu, memory, disk, system, locking)*/
     @hours_back integer = 1, /*How many hours back to analyze*/
     @warnings_only bit = 1, /*Only collect data from recorded warnings*/
+    @skip_locks bit = 1, /*Skip the blocking and deadlocks section*/
+    @skip_waits bit = 1, /*Skip the wait stats section*/
     @log_retention_days integer = 30, /*Days to retain sp_HealthParser data*/
     @procedure_database sysname = NULL, /*Database where sp_HealthParser is installed (NULL = search PerformanceMonitor then master)*/
     @debug bit = 0 /*Print debugging information*/
@@ -164,6 +166,8 @@ BEGIN
             @start_date = @start_date,
             @end_date = @end_date,
             @warnings_only = @warnings_only,
+            @skip_locks = @skip_locks,
+            @skip_waits = @skip_waits,
             @log_to_table = 1,
             @log_database_name = N''PerformanceMonitor'',
             @log_schema_name = N''collect'',
@@ -173,11 +177,13 @@ BEGIN
 
         EXECUTE sys.sp_executesql
             @sql,
-            N'@what_to_check varchar(10), @start_date datetimeoffset(7), @end_date datetimeoffset(7), @warnings_only bit, @log_retention_days integer, @debug bit',
+            N'@what_to_check varchar(10), @start_date datetimeoffset(7), @end_date datetimeoffset(7), @warnings_only bit, @skip_locks bit, @skip_waits bit, @log_retention_days integer, @debug bit',
             @what_to_check = @what_to_check,
             @start_date = @start_date,
             @end_date = @end_date,
             @warnings_only = @warnings_only,
+            @skip_locks = @skip_locks,
+            @skip_waits = @skip_waits,
             @log_retention_days = @log_retention_days,
             @debug = @debug;
         


### PR DESCRIPTION
## Summary

- Adds `@skip_locks bit = 1` and `@skip_waits bit = 1` parameters to `collect.system_health_collector`
- Passes both through to sp_HealthParser via dynamic SQL
- Both default to 1 since the dashboard doesn't display blocking/deadlock or wait stats data

## Performance impact

Collection time drops from **43 seconds to 1.6 seconds** (27x improvement).

## Dependency

Requires sp_HealthParser 3.3+ with the `@skip_waits` parameter (DarlingData PR [#666](https://github.com/erikdarlingdata/DarlingData/pull/666) / [#667](https://github.com/erikdarlingdata/DarlingData/pull/667)).

## Test plan

- [x] Deployed sp_HealthParser 3.3 to SQL2022
- [x] Tested all parameter combinations with timing benchmarks
- [x] Verified dashboard tables still populated, wait tables correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)