### PR TITLE
Update schema version assertion to v10 in tests

### DIFF
--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -96,7 +96,7 @@ public class DuckDbSchemaTests : IDisposable
         cmd.CommandText = "SELECT MAX(version) FROM schema_version";
         var version = Convert.ToInt32(await cmd.ExecuteScalarAsync());
 
-        Assert.Equal(9, version);
+        Assert.Equal(10, version);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class DuckDbSchemaTests : IDisposable
         cmd.CommandText = "SELECT MAX(version) FROM schema_version";
         var version = Convert.ToInt32(await cmd.ExecuteScalarAsync());
 
-        Assert.Equal(9, version);
+        Assert.Equal(10, version);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Updates hardcoded schema version assertion from 9 to 10 in DuckDbSchemaTests to match the v10 migration added in PR #95

## Test plan
- [x] Fixes the two failing CI tests: `InitializeAsync_SetsCorrectSchemaVersion` and `InitializeAsync_IsIdempotent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)