### PR TITLE
Use DuckDbInitializer.CurrentSchemaVersion in tests instead of hardcoded value

### DIFF
--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -96,7 +96,7 @@ public class DuckDbSchemaTests : IDisposable
         cmd.CommandText = "SELECT MAX(version) FROM schema_version";
         var version = Convert.ToInt32(await cmd.ExecuteScalarAsync());
 
-        Assert.Equal(10, version);
+        Assert.Equal(DuckDbInitializer.CurrentSchemaVersion, version);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class DuckDbSchemaTests : IDisposable
         cmd.CommandText = "SELECT MAX(version) FROM schema_version";
         var version = Convert.ToInt32(await cmd.ExecuteScalarAsync());
 
-        Assert.Equal(10, version);
+        Assert.Equal(DuckDbInitializer.CurrentSchemaVersion, version);
     }
 
     [Fact]

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -19,7 +19,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    private const int CurrentSchemaVersion = 10;
+    internal const int CurrentSchemaVersion = 10;
 
     public DuckDbInitializer(string databasePath, ILogger<DuckDbInitializer>? logger = null)
     {

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -28,6 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Lite.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- DuckDB for local data storage -->
     <PackageReference Include="DuckDB.NET.Data" Version="1.2.1" />
     <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.2.1" />


### PR DESCRIPTION
## Summary
- Made `CurrentSchemaVersion` internal (was private) and added `InternalsVisibleTo` for the test project
- Tests now reference `DuckDbInitializer.CurrentSchemaVersion` directly instead of a hardcoded integer
- Schema version bumps no longer require updating tests

## Test plan
- [x] All 6 DuckDbSchemaTests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)