### PR TITLE
Add --reset-schedule flag for CLI and GUI installers

### DIFF
--- a/InstallerGui/MainWindow.xaml
+++ b/InstallerGui/MainWindow.xaml
@@ -180,6 +180,12 @@
                           Margin="0,0,0,10"
                           Foreground="{DynamicResource ForegroundBrush}"/>
 
+                <!-- Reset Schedule Checkbox -->
+                <CheckBox x:Name="ResetScheduleCheckBox"
+                          Content="Reset collection schedule to recommended defaults"
+                          Margin="0,0,0,10"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
+
                 <!-- Validation Checkbox -->
                 <CheckBox x:Name="ValidationCheckBox"
                           Content="Run validation after install (recommended)"

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -394,10 +394,12 @@ namespace PerformanceMonitorInstallerGui
                 Execute installation
                 Community dependencies install automatically before validation (98_validate)
                 */
+                bool resetSchedule = ResetScheduleCheckBox.IsChecked == true;
                 _installationResult = await InstallationService.ExecuteInstallationAsync(
                     _connectionString,
                     _sqlFiles,
                     isCleanInstall,
+                    resetSchedule,
                     progress,
                     preValidationAction: async () =>
                     {


### PR DESCRIPTION
## Summary
- Adds `--reset-schedule` CLI flag that truncates `config.collection_schedule` before re-populating with current recommended defaults
- Adds "Reset collection schedule to recommended defaults" checkbox in GUI installer
- Both installers prepend `TRUNCATE TABLE config.collection_schedule; GO` to the `04_create_schedule_table.sql` content at runtime when the flag/checkbox is set

## Why
When we tune the default schedule (e.g., PR #88 bumped cheap collectors from 5-min to 1-min), existing users keep the old schedule because `04_` uses `WHERE NOT EXISTS` inserts. This flag lets users opt in to the latest recommended frequencies on re-install.

## Test plan
- [x] CLI: `--reset-schedule` on sql2022 update install — schedule reset to 33 collectors with current frequencies
- [x] CLI: Without flag — existing schedule preserved (only new collectors added via WHERE NOT EXISTS)
- [x] GUI: Checkbox wired to `ExecuteInstallationAsync` resetSchedule parameter
- [ ] GUI: Visual test of checkbox and install flow

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)