### PR TITLE
Add dev branch to CI build trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   release:
     types: [created]
 


### PR DESCRIPTION
## Summary
- Adds `dev` to the `pull_request` trigger in `build.yml` so PRs targeting `dev` get build validation
- Enables CI to run against PR #102 (NuGet updates) and all future dev PRs

## Test plan
- [ ] Verify CI triggers on PRs to dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)