### PR TITLE
Fix release asset upload permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- Adds `contents: write` permission to build workflow so `gh release upload` can attach ZIP assets
- This was the cause of the 403 error during the v1.2.0 release CI

## Test plan
- [ ] Re-run release build after merging to main