### PR TITLE
Fix release asset upload permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Hotfix: adds contents:write to build workflow so release uploads work.