### PR TITLE
Add Restore Defaults button and alert threshold validation (#109)

### DIFF
--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -108,7 +108,11 @@
                         </StackPanel>
 
                         <!-- Performance Alerts Section -->
-                        <TextBlock Text="Performance Alerts" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <TextBlock Text="Performance Alerts" FontWeight="Bold" FontSize="13" VerticalAlignment="Center"/>
+                            <Button x:Name="RestoreAlertDefaultsButton" Content="Restore Defaults" Padding="8,2" Margin="12,0,0,0"
+                                    FontSize="11" VerticalAlignment="Center" Click="RestoreAlertDefaultsButton_Click"/>
+                        </StackPanel>
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                                 <CheckBox x:Name="NotifyOnBlockingCheckBox"

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -247,6 +247,17 @@ namespace PerformanceMonitorDashboard
             UpdateAlertNotificationStates();
         }
 
+        private void RestoreAlertDefaultsButton_Click(object sender, RoutedEventArgs e)
+        {
+            BlockingThresholdTextBox.Text = "30";
+            DeadlockThresholdTextBox.Text = "1";
+            CpuThresholdTextBox.Text = "90";
+            PoisonWaitThresholdTextBox.Text = "500";
+            LongRunningQueryThresholdTextBox.Text = "30";
+            TempDbSpaceThresholdTextBox.Text = "80";
+            LongRunningJobMultiplierTextBox.Text = "3";
+        }
+
         private void UpdateAlertNotificationStates()
         {
             bool notificationsEnabled = NotificationsEnabledCheckBox.IsChecked == true;
@@ -440,41 +451,57 @@ namespace PerformanceMonitorDashboard
             prefs.NotifyOnConnectionLost = NotifyConnectionLostCheckBox.IsChecked == true;
             prefs.NotifyOnConnectionRestored = NotifyConnectionRestoredCheckBox.IsChecked == true;
 
-            // Save alert notification settings
+            // Save alert notification settings with validation
+            var validationErrors = new System.Collections.Generic.List<string>();
+
             prefs.NotifyOnBlocking = NotifyOnBlockingCheckBox.IsChecked == true;
             if (int.TryParse(BlockingThresholdTextBox.Text, out int blockingThreshold) && blockingThreshold > 0)
-            {
                 prefs.BlockingThresholdSeconds = blockingThreshold;
-            }
+            else if (prefs.NotifyOnBlocking)
+                validationErrors.Add("Blocking threshold must be a positive number");
+
             prefs.NotifyOnDeadlock = NotifyOnDeadlockCheckBox.IsChecked == true;
             if (int.TryParse(DeadlockThresholdTextBox.Text, out int deadlockThreshold) && deadlockThreshold > 0)
-            {
                 prefs.DeadlockThreshold = deadlockThreshold;
-            }
+            else if (prefs.NotifyOnDeadlock)
+                validationErrors.Add("Deadlock threshold must be a positive number");
+
             prefs.NotifyOnHighCpu = NotifyOnHighCpuCheckBox.IsChecked == true;
             if (int.TryParse(CpuThresholdTextBox.Text, out int cpuThreshold) && cpuThreshold > 0 && cpuThreshold <= 100)
-            {
                 prefs.CpuThresholdPercent = cpuThreshold;
-            }
+            else if (prefs.NotifyOnHighCpu)
+                validationErrors.Add("CPU threshold must be between 1 and 100");
+
             prefs.NotifyOnPoisonWaits = NotifyOnPoisonWaitsCheckBox.IsChecked == true;
             if (int.TryParse(PoisonWaitThresholdTextBox.Text, out int poisonWaitThreshold) && poisonWaitThreshold > 0)
-            {
                 prefs.PoisonWaitThresholdMs = poisonWaitThreshold;
-            }
+            else if (prefs.NotifyOnPoisonWaits)
+                validationErrors.Add("Poison wait threshold must be a positive number");
+
             prefs.NotifyOnLongRunningQueries = NotifyOnLongRunningQueriesCheckBox.IsChecked == true;
             if (int.TryParse(LongRunningQueryThresholdTextBox.Text, out int lrqThreshold) && lrqThreshold > 0)
-            {
                 prefs.LongRunningQueryThresholdMinutes = lrqThreshold;
-            }
+            else if (prefs.NotifyOnLongRunningQueries)
+                validationErrors.Add("Long-running query threshold must be a positive number");
+
             prefs.NotifyOnTempDbSpace = NotifyOnTempDbSpaceCheckBox.IsChecked == true;
             if (int.TryParse(TempDbSpaceThresholdTextBox.Text, out int tempDbThreshold) && tempDbThreshold > 0 && tempDbThreshold <= 100)
-            {
                 prefs.TempDbSpaceThresholdPercent = tempDbThreshold;
-            }
+            else if (prefs.NotifyOnTempDbSpace)
+                validationErrors.Add("TempDB space threshold must be between 1 and 100");
+
             prefs.NotifyOnLongRunningJobs = NotifyOnLongRunningJobsCheckBox.IsChecked == true;
             if (int.TryParse(LongRunningJobMultiplierTextBox.Text, out int jobMultiplier) && jobMultiplier > 0)
-            {
                 prefs.LongRunningJobMultiplier = jobMultiplier;
+            else if (prefs.NotifyOnLongRunningJobs)
+                validationErrors.Add("Job multiplier must be a positive number");
+
+            if (validationErrors.Count > 0)
+            {
+                MessageBox.Show(
+                    "Some alert thresholds have invalid values and were not changed:\n\n" +
+                    string.Join("\n", validationErrors),
+                    "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
 
             // Save SMTP email settings

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -96,7 +96,11 @@
         <!-- Notifications -->
         <Border Grid.Row="4" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
             <StackPanel>
-                <TextBlock Text="Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                    <Button x:Name="RestoreAlertDefaultsButton" Content="Restore Defaults" Margin="12,0,0,0"
+                            FontSize="11" VerticalAlignment="Center" Click="RestoreAlertDefaultsButton_Click"/>
+                </StackPanel>
                 <CheckBox x:Name="MinimizeToTrayCheckBox" Content="Minimize to system tray" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}"/>
                 <CheckBox x:Name="AlertsEnabledCheckBox" Content="Enable notifications" Margin="0,8,0,0"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -314,6 +314,17 @@ public partial class SettingsWindow : Window
         UpdateAlertControlStates();
     }
 
+    private void RestoreAlertDefaultsButton_Click(object sender, RoutedEventArgs e)
+    {
+        AlertCpuThresholdBox.Text = "80";
+        AlertBlockingThresholdBox.Text = "1";
+        AlertDeadlockThresholdBox.Text = "1";
+        AlertPoisonWaitThresholdBox.Text = "500";
+        AlertLongRunningQueryThresholdBox.Text = "30";
+        AlertTempDbSpaceThresholdBox.Text = "80";
+        AlertLongRunningJobMultiplierBox.Text = "3";
+    }
+
     private void UpdateAlertControlStates()
     {
         bool enabled = AlertsEnabledCheckBox.IsChecked == true;


### PR DESCRIPTION
## Summary
- Add "Restore Defaults" button to alert threshold settings in both Dashboard and Lite
- Dashboard now warns when saving invalid threshold values instead of silently ignoring them
- Updated issue #109 checklist (4 items checked off)

## Test plan
- [ ] Open Dashboard Settings > Notifications, verify "Restore Defaults" button resets thresholds
- [ ] Enter invalid values (e.g., "abc", "0"), click OK — verify warning dialog appears
- [ ] Open Lite Settings > Notifications, verify "Restore Defaults" button resets thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)