### PR TITLE
Alert UX: preview text, SMTP validation, CPU default note (#109)

### DIFF
--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -205,6 +205,8 @@
                                          TextAlignment="Center"/>
                                 <TextBlock Text="x historical average" VerticalAlignment="Center"/>
                             </StackPanel>
+                            <TextBlock x:Name="AlertPreviewText" FontSize="11" FontStyle="Italic" Foreground="Gray"
+                                       TextWrapping="Wrap" Margin="0,12,0,0"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -322,6 +324,8 @@
                             <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
                                 <Button x:Name="TestEmailButton" Content="Send Test Email" Padding="10,3"
                                         Click="TestEmailButton_Click"/>
+                                <Button x:Name="ValidateSmtpButton" Content="Validate Settings" Padding="10,3" Margin="8,0,0,0"
+                                        Click="ValidateSmtpButton_Click"/>
                                 <TextBlock x:Name="TestEmailStatusText" FontStyle="Italic" Foreground="Gray"
                                            VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
                             </StackPanel>

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -113,6 +113,9 @@
                     <TextBox x:Name="AlertCpuThresholdBox" Width="45" Text="80" Margin="6,0,0,0" VerticalAlignment="Center"/>
                     <TextBlock Text="%" VerticalAlignment="Center" Margin="2,0,0,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock Text="(default 80% — Lite collects directly from DMVs so catches spikes faster than Dashboard)"
+                               FontSize="10" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="8,0,0,0"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertBlockingCheckBox" Content="Blocking sessions &#x2265;" VerticalAlignment="Center"
@@ -152,6 +155,8 @@
                     <TextBlock Text="x historical average" VerticalAlignment="Center" Margin="2,0,0,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
+                <TextBlock x:Name="AlertPreviewText" FontSize="11" FontStyle="Italic"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap" Margin="20,10,0,0"/>
             </StackPanel>
         </Border>
 
@@ -206,8 +211,13 @@
                     <TextBox Grid.Row="5" Grid.Column="1" x:Name="SmtpRecipientsBox" Margin="0,0,0,4"
                              ToolTip="Comma-separated email addresses"/>
 
-                    <Button Grid.Row="6" Grid.Column="1" x:Name="TestEmailButton" Content="Send Test Email"
-                            Click="TestEmailButton_Click" HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                    <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestEmailButton" Content="Send Test Email" Click="TestEmailButton_Click"/>
+                        <Button x:Name="ValidateSmtpButton" Content="Validate Settings" Margin="8,0,0,0"
+                                Click="ValidateSmtpButton_Click"/>
+                        <TextBlock x:Name="SmtpStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
                 </Grid>
             </StackPanel>
         </Border>


### PR DESCRIPTION
## Summary
- Live preview text below alert thresholds shows exactly what's enabled: "Will alert when: blocking > 30s, CPU > 90%, ..."
- "Validate Settings" button on SMTP config checks for empty/invalid fields before you need to send a test email
- Lite CPU threshold row now explains why the default is 80% (Lite collects directly from DMVs, catches spikes faster)
- Preview text updates dynamically as checkboxes and thresholds change

## Test plan
- [ ] Dashboard Settings > Notifications: verify preview text updates as you toggle checkboxes and change values
- [ ] Dashboard Settings > Email Alerts: click "Validate Settings" with empty fields, verify warning
- [ ] Dashboard Settings > Email Alerts: fill all fields, click "Validate Settings", verify success message
- [ ] Lite Settings > Notifications: verify preview text and CPU explanation note
- [ ] Lite Settings > Email Alerts: verify "Validate Settings" button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)