### PR TITLE
Fix: Add missing hover tooltips to 4 Lite charts (#121)

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -45,6 +45,10 @@ public partial class ServerTab : UserControl
     private Helpers.ChartHoverHelper? _tempDbFileIoHover;
     private Helpers.ChartHoverHelper? _fileIoReadHover;
     private Helpers.ChartHoverHelper? _fileIoWriteHover;
+    private Helpers.ChartHoverHelper? _collectorDurationHover;
+    private Helpers.ChartHoverHelper? _queryDurationTrendHover;
+    private Helpers.ChartHoverHelper? _procDurationTrendHover;
+    private Helpers.ChartHoverHelper? _queryStoreDurationTrendHover;
 
     /* Column filtering */
     private Popup? _filterPopup;
@@ -138,6 +142,10 @@ public partial class ServerTab : UserControl
         _tempDbFileIoHover = new Helpers.ChartHoverHelper(TempDbFileIoChart, "ms");
         _fileIoReadHover = new Helpers.ChartHoverHelper(FileIoReadChart, "ms");
         _fileIoWriteHover = new Helpers.ChartHoverHelper(FileIoWriteChart, "ms");
+        _collectorDurationHover = new Helpers.ChartHoverHelper(CollectorDurationChart, "ms");
+        _queryDurationTrendHover = new Helpers.ChartHoverHelper(QueryDurationTrendChart, "ms/sec");
+        _procDurationTrendHover = new Helpers.ChartHoverHelper(ProcDurationTrendChart, "ms/sec");
+        _queryStoreDurationTrendHover = new Helpers.ChartHoverHelper(QueryStoreDurationTrendChart, "ms/sec");
 
         /* Initial load is triggered by MainWindow.ConnectToServer calling RefreshData()
            after collectors finish - no Loaded handler needed */


### PR DESCRIPTION
## Summary
- CollectorDurationChart (Collection Health > Duration Trends)
- QueryDurationTrendChart, ProcDurationTrendChart, QueryStoreDurationTrendChart (Query Stats tab)

All 4 were missing `ChartHoverHelper` wiring that every other chart in Lite has.

Closes #121

## Test plan
- [ ] Open Lite, navigate to Collection Health > Duration Trends
- [ ] Hover over data points — info box should appear with series name and value
- [ ] Check Query Stats duration trend charts for the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)