### PR TITLE
Fix Lite tooltips to use dark theme globally

### DIFF
--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -649,13 +649,7 @@ public partial class MainWindow : Window
                     if (border.Child is TextBlock text)
                     {
                         text.Text = totalAlerts > 99 ? "99+" : totalAlerts.ToString();
-                        text.ToolTip = new System.Windows.Controls.ToolTip
-                        {
-                            Content = $"Blocking: {blockingCount}, Deadlocks: {deadlockCount}\nRight-click to dismiss",
-                            Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x1E, 0x1E, 0x2E)),
-                            Foreground = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xE4, 0xE6, 0xEB)),
-                            BorderBrush = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x3A, 0x3D, 0x45))
-                        };
+                        text.ToolTip = $"Blocking: {blockingCount}, Deadlocks: {deadlockCount}\nRight-click to dismiss";
                     }
                 }
                 else

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -1063,7 +1063,7 @@
     <!-- ============================================ -->
     <!-- ToolTip Style                                -->
     <!-- ============================================ -->
-    <Style x:Key="DarkToolTip" TargetType="ToolTip">
+    <Style TargetType="ToolTip">
         <Setter Property="Background" Value="{StaticResource BackgroundLightBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{StaticResource BorderLightBrush}"/>


### PR DESCRIPTION
## Summary
- Remove `x:Key="DarkToolTip"` from `Lite/Themes/DarkTheme.xaml` to make the ToolTip style implicit — all tooltips now automatically use dark background/foreground without needing explicit `Style="{StaticResource DarkToolTip}"`
- Simplify the alert badge tooltip in `MainWindow.xaml.cs` from an explicit styled `ToolTip` object back to a plain string (the implicit style handles the theming)

Closes #120

## Test plan
- [ ] Launch Lite, connect to a server
- [ ] Hover over any DataGrid column header, row cell, or button — tooltip should have dark background (#1E1E2E) and light text
- [ ] Hover over the alert badge (when alerts are present) — tooltip should also be dark
- [ ] Verify no tooltips show the default Windows light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)