### PR TITLE
Visual polish: MinHeight/MinWidth, spacing resources, InstallerGui theme

### DIFF
--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:controls="clr-namespace:PerformanceMonitorDashboard.Controls"
         Title="Performance Monitor Dashboard"
         Height="700" Width="1400"
+        MinHeight="600" MinWidth="900"
         WindowStartupLocation="CenterScreen"
         WindowState="Maximized"
         Background="{DynamicResource BackgroundBrush}">

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <!-- ============================================ -->
     <!-- Darling Data Dark Theme                      -->
@@ -32,6 +33,18 @@
     <Color x:Key="WarningColor">#FFD54F</Color>
     <Color x:Key="ErrorColor">#E57373</Color>
     <Color x:Key="InfoColor">#2eaef1</Color>
+
+    <!-- Spacing Scale -->
+    <sys:Double x:Key="SpacingXS">2</sys:Double>
+    <sys:Double x:Key="SpacingSm">4</sys:Double>
+    <sys:Double x:Key="SpacingMd">8</sys:Double>
+    <sys:Double x:Key="SpacingLg">12</sys:Double>
+    <sys:Double x:Key="SpacingXL">16</sys:Double>
+
+    <!-- Corner Radius -->
+    <CornerRadius x:Key="CornerRadiusSm">2</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusMd">4</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusLg">6</CornerRadius>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>

--- a/InstallerGui/MainWindow.xaml
+++ b/InstallerGui/MainWindow.xaml
@@ -6,8 +6,8 @@
         MinHeight="600" MinWidth="700"
         WindowStartupLocation="CenterScreen"
         WindowState="Maximized"
-        Background="#333333"
-        Foreground="#FFFFFF">
+        Background="{DynamicResource BackgroundBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/InstallerGui/Themes/DarkTheme.xaml
+++ b/InstallerGui/Themes/DarkTheme.xaml
@@ -11,15 +11,15 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="#5bc4f5"/>
     <SolidColorBrush x:Key="AccentPressedBrush" Color="#1a9ae0"/>
 
-    <SolidColorBrush x:Key="BackgroundDarkBrush" Color="#252525"/>
-    <SolidColorBrush x:Key="BackgroundBrush" Color="#333333"/>
-    <SolidColorBrush x:Key="BackgroundLightBrush" Color="#404040"/>
-    <SolidColorBrush x:Key="BackgroundLighterBrush" Color="#4a4a4a"/>
+    <SolidColorBrush x:Key="BackgroundDarkBrush" Color="#111217"/>
+    <SolidColorBrush x:Key="BackgroundBrush" Color="#181b1f"/>
+    <SolidColorBrush x:Key="BackgroundLightBrush" Color="#22252b"/>
+    <SolidColorBrush x:Key="BackgroundLighterBrush" Color="#2a2d35"/>
 
-    <SolidColorBrush x:Key="ForegroundBrush" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="#858585"/>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="#E4E6EB"/>
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="#6B7280"/>
 
-    <SolidColorBrush x:Key="BorderBrush" Color="#555555"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#2a2d35"/>
 
     <!-- ============================================ -->
     <!-- TextBlock Style                              -->

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:controls="clr-namespace:PerformanceMonitorLite.Controls"
         Title="Performance Monitor Lite"
         Height="700" Width="1200"
+        MinHeight="600" MinWidth="900"
         WindowStartupLocation="CenterScreen"
         WindowState="Maximized"
         Icon="EDD.ico"

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <!-- ============================================ -->
     <!-- Darling Data Dark Theme                      -->
@@ -32,6 +33,18 @@
     <Color x:Key="WarningColor">#FFD54F</Color>
     <Color x:Key="ErrorColor">#E57373</Color>
     <Color x:Key="InfoColor">#2eaef1</Color>
+
+    <!-- Spacing Scale -->
+    <sys:Double x:Key="SpacingXS">2</sys:Double>
+    <sys:Double x:Key="SpacingSm">4</sys:Double>
+    <sys:Double x:Key="SpacingMd">8</sys:Double>
+    <sys:Double x:Key="SpacingLg">12</sys:Double>
+    <sys:Double x:Key="SpacingXL">16</sys:Double>
+
+    <!-- Corner Radius -->
+    <CornerRadius x:Key="CornerRadiusSm">2</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusMd">4</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusLg">6</CornerRadius>
 
     <!-- Brushes -->
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>


### PR DESCRIPTION
## Summary
- **MinHeight/MinWidth** on Dashboard (600x900) and Lite (600x900) MainWindows — prevents windows from being resized too small
- **Spacing scale resources** (`SpacingXS=2` through `SpacingXL=16`) and **corner radius resources** (`CornerRadiusSm=2`, `Md=4`, `Lg=6`) added to both DarkTheme.xaml files — available for future use, no visual change yet
- **InstallerGui theme alignment** — colors updated from neutral grays (#333333/#404040/#555555) to the Grafana-inspired blue-gray palette (#181b1f/#22252b/#2a2d35) matching Dashboard and Lite

Partial fix for #110

## Test plan
- [ ] Dashboard: try resizing below 900x600 — should stop at minimum
- [ ] Lite: same minimum size check
- [ ] InstallerGui: launch and verify dark blue-gray background matches Dashboard/Lite feel
- [ ] All three apps build with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)