### PR TITLE
Increase tab close button target size (18x18 → 22x22)

### DIFF
--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -231,12 +231,12 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="White"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Width" Value="18"/>
-        <Setter Property="Height" Value="18"/>
+        <Setter Property="Width" Value="22"/>
+        <Setter Property="Height" Value="22"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Margin" Value="6,0,0,0"/>
         <Setter Property="Cursor" Value="Hand"/>
-        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontSize" Value="15"/>
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="ToolTip" Value="Close tab"/>

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -222,12 +222,12 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="White"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Width" Value="18"/>
-        <Setter Property="Height" Value="18"/>
+        <Setter Property="Width" Value="22"/>
+        <Setter Property="Height" Value="22"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Margin" Value="6,0,0,0"/>
         <Setter Property="Cursor" Value="Hand"/>
-        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontSize" Value="15"/>
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="ToolTip" Value="Close tab"/>


### PR DESCRIPTION
## Summary
- Increase tab close button from 18x18 to 22x22 pixels in both Dashboard and Lite
- Font size bumped from 14 to 15 to stay proportional
- Reduces accidental mis-clicks when closing server tabs

Partial fix for #110

## Test plan
- [ ] Open multiple server tabs in Dashboard and Lite
- [ ] Verify close button (×) is slightly larger but still proportional to tab header
- [ ] Verify clicking close still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)