### PR TITLE
Visual polish: grid lines, sidebar icons, button hover transitions

### DIFF
--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -132,7 +132,7 @@ namespace PerformanceMonitorDashboard.Helpers
             var darkBackground = ScottPlot.Color.FromHex("#22252b");
             var darkerBackground = ScottPlot.Color.FromHex("#111217");
             var textColor = ScottPlot.Color.FromHex("#9DA5B4");
-            var gridColor = ScottPlot.Colors.White.WithAlpha(20);
+            var gridColor = ScottPlot.Colors.White.WithAlpha(40);
 
             chart.Plot.FigureBackground.Color = darkBackground;
             chart.Plot.DataBackground.Color = darkerBackground;

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -172,14 +172,22 @@
                             Margin="0,0,0,12"/>
                     <Separator/>
                     <Button x:Name="SettingsButton"
-                            Content="Settings"
                             Click="Settings_Click"
                             Height="28"
-                            Margin="0,8,0,6"/>
+                            Margin="0,8,0,6">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="Settings" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
                     <Button x:Name="HelpButton"
-                            Content="Help / About"
                             Click="Help_Click"
-                            Height="28"/>
+                            Height="28">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE897;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="Help / About" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Grid>
         </Border>

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -115,7 +115,20 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource BackgroundLighterBrush}"/>
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation Storyboard.TargetName="border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)" To="{StaticResource BackgroundLighterColor}" Duration="0:0:0.12"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation Storyboard.TargetName="border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)" To="{StaticResource BackgroundLightColor}" Duration="0:0:0.12"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{StaticResource AccentPressedBrush}"/>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -1475,7 +1475,7 @@ public partial class ServerTab : UserControl
         var darkBackground = ScottPlot.Color.FromHex("#22252b");
         var darkerBackground = ScottPlot.Color.FromHex("#111217");
         var textColor = ScottPlot.Color.FromHex("#9DA5B4");
-        var gridColor = ScottPlot.Colors.White.WithAlpha(20);
+        var gridColor = ScottPlot.Colors.White.WithAlpha(40);
 
         chart.Plot.FigureBackground.Color = darkBackground;
         chart.Plot.DataBackground.Color = darkerBackground;

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -150,8 +150,18 @@
                     <StackPanel>
                         <Button x:Name="AddServerButton" Content="+ Add Server" Click="AddServerButton_Click"/>
                         <Button x:Name="ManageServersButton" Content="Manage Servers" Click="ManageServersButton_Click" Margin="0,8,0,0"/>
-                        <Button x:Name="SettingsButton" Content="Settings" Click="SettingsButton_Click" Margin="0,8,0,0"/>
-                        <Button Content="About" Click="AboutButton_Click" Margin="0,8,0,0"/>
+                        <Button x:Name="SettingsButton" Click="SettingsButton_Click" Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Settings" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="AboutButton_Click" Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE897;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="About" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -115,7 +115,20 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource BackgroundLighterBrush}"/>
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation Storyboard.TargetName="border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)" To="{StaticResource BackgroundLighterColor}" Duration="0:0:0.12"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation Storyboard.TargetName="border" Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)" To="{StaticResource BackgroundLightColor}" Duration="0:0:0.12"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{StaticResource AccentPressedBrush}"/>

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -123,7 +123,7 @@ public partial class ProcedureHistoryWindow : Window
         var darkBg = ScottPlot.Color.FromHex("#22252b");
         var darkerBg = ScottPlot.Color.FromHex("#111217");
         var text = ScottPlot.Color.FromHex("#9DA5B4");
-        var grid = ScottPlot.Colors.White.WithAlpha(20);
+        var grid = ScottPlot.Colors.White.WithAlpha(40);
 
         chart.Plot.FigureBackground.Color = darkBg;
         chart.Plot.DataBackground.Color = darkerBg;

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -158,7 +158,7 @@ public partial class QueryStatsHistoryWindow : Window
         var darkBg = ScottPlot.Color.FromHex("#22252b");
         var darkerBg = ScottPlot.Color.FromHex("#111217");
         var text = ScottPlot.Color.FromHex("#9DA5B4");
-        var grid = ScottPlot.Colors.White.WithAlpha(20);
+        var grid = ScottPlot.Colors.White.WithAlpha(40);
 
         chart.Plot.FigureBackground.Color = darkBg;
         chart.Plot.DataBackground.Color = darkerBg;

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -161,7 +161,7 @@ public partial class QueryStoreHistoryWindow : Window
         var darkBg = ScottPlot.Color.FromHex("#22252b");
         var darkerBg = ScottPlot.Color.FromHex("#111217");
         var text = ScottPlot.Color.FromHex("#9DA5B4");
-        var grid = ScottPlot.Colors.White.WithAlpha(20);
+        var grid = ScottPlot.Colors.White.WithAlpha(40);
 
         chart.Plot.FigureBackground.Color = darkBg;
         chart.Plot.DataBackground.Color = darkerBg;


### PR DESCRIPTION
## Summary
- **Chart grid lines**: Opacity increased from 8% to 16% (`WithAlpha(20)` → `WithAlpha(40)`) across all 5 chart theme setup locations — grid lines are now visible against the dark background without being distracting
- **Sidebar icons**: Settings (⚙) and Help/About (?) buttons now have Segoe MDL2 Assets icons for faster visual scanning
- **Button hover transitions**: Default button style now uses a 120ms `ColorAnimation` instead of an instant background swap — feels smoother and more polished

Partial fix for #110

## Test plan
- [ ] Charts: grid lines should be subtly visible (not too bright, not invisible)
- [ ] Sidebar: Settings and Help/About buttons should show small icons before text
- [ ] Buttons: hover over any button and observe a smooth fade transition (~120ms)
- [ ] No visual regression on accent buttons, tab close buttons, or disabled buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)