### PR TITLE
Lite: make filter-active indicator more obvious

### DIFF
--- a/Lite/Services/DataGridFilterManager.cs
+++ b/Lite/Services/DataGridFilterManager.cs
@@ -118,7 +118,7 @@ public class DataGridFilterManager<T> : IDataGridFilterManager
 
                     var textBlock = new TextBlock
                     {
-                        Text = "\uE71C",
+                        Text = hasActive ? "\uE16E" : "\uE71C",
                         FontFamily = new FontFamily("Segoe MDL2 Assets"),
                         Foreground = hasActive
                             ? new SolidColorBrush(Color.FromRgb(0xFF, 0xD7, 0x00))

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -357,9 +357,13 @@
     <!-- Column Filter Button Style when filter is active -->
     <Style x:Key="ColumnFilterButtonActiveStyle" TargetType="Button" BasedOn="{StaticResource ColumnFilterButtonStyle}">
         <Setter Property="Foreground" Value="#FFD700"/>
+        <Setter Property="Background" Value="#33FFD700"/>
+        <Setter Property="Content" Value="&#xE16E;"/>
+        <Setter Property="ToolTip" Value="Filter active — click to modify"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Foreground" Value="#FFEC8B"/>
+                <Setter Property="Background" Value="#55FFD700"/>
             </Trigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
## Summary
- Active column filter icon changes from outline (⧩) to filled funnel for a stronger visual signal
- Adds a semi-transparent gold background behind the active filter icon
- Hover brightens both icon color and background
- Adds "Filter active — click to modify" tooltip on active filters
- Also updates `DataGridFilterManager.cs` which dynamically creates filter button content

Partial fix for #110

## Test plan
- [ ] Open any DataGrid tab in Lite (e.g., Wait Stats, Query Stats)
- [ ] Click a filter button and apply a filter
- [ ] Verify the filter icon changes to a filled funnel with gold background
- [ ] Hover over the active filter — should brighten
- [ ] Clear the filter — icon should revert to outline style

🤖 Generated with [Claude Code](https://claude.com/claude-code)