### PR TITLE
Match Dashboard chart grid lines to Lite (WithAlpha 40)

### DIFF
--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -132,7 +132,7 @@ namespace PerformanceMonitorDashboard.Helpers
             var darkBackground = ScottPlot.Color.FromHex("#22252b");
             var darkerBackground = ScottPlot.Color.FromHex("#111217");
             var textColor = ScottPlot.Color.FromHex("#9DA5B4");
-            var gridColor = ScottPlot.Colors.White.WithAlpha(20);
+            var gridColor = ScottPlot.Colors.White.WithAlpha(40);
 
             chart.Plot.FigureBackground.Color = darkBackground;
             chart.Plot.DataBackground.Color = darkerBackground;


### PR DESCRIPTION
One-liner: Dashboard was at 20, Lite at 40. User confirmed Lite looks good.