### PR TITLE
Remove HideGrid() from all Dashboard charts

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -268,7 +268,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryStatsOverviewChart.Plot.Axes.DateTimeTicksBottom();
             MemoryStatsOverviewChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryStatsOverviewChart.Plot.YLabel("MB");
-            MemoryStatsOverviewChart.Plot.HideGrid();
             // Fixed negative space for legend
             MemoryStatsOverviewChart.Plot.Axes.AutoScaleY();
             var memOverviewLimits = MemoryStatsOverviewChart.Plot.Axes.GetLimits();
@@ -476,7 +475,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryGrantsChart.Plot.Axes.DateTimeTicksBottom();
             MemoryGrantsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryGrantsChart.Plot.YLabel("MB");
-            MemoryGrantsChart.Plot.HideGrid();
             // Fixed negative space for legend
             MemoryGrantsChart.Plot.Axes.AutoScaleY();
             var grantsLimits = MemoryGrantsChart.Plot.Axes.GetLimits();
@@ -587,7 +585,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryClerksChart.Plot.Axes.DateTimeTicksBottom();
             MemoryClerksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryClerksChart.Plot.YLabel("MB");
-            MemoryClerksChart.Plot.HideGrid();
             // Fixed negative space for legend
             MemoryClerksChart.Plot.Axes.AutoScaleY();
             var clerksLimits = MemoryClerksChart.Plot.Axes.GetLimits();
@@ -737,7 +734,6 @@ namespace PerformanceMonitorDashboard.Controls
             PlanCacheChart.Plot.Axes.DateTimeTicksBottom();
             PlanCacheChart.Plot.Axes.SetLimitsX(xMin, xMax);
             PlanCacheChart.Plot.YLabel("MB");
-            PlanCacheChart.Plot.HideGrid();
             // Fixed negative space for legend
             PlanCacheChart.Plot.Axes.AutoScaleY();
             var planCacheLimits = PlanCacheChart.Plot.Axes.GetLimits();
@@ -857,7 +853,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryPressureEventsChart.Plot.Axes.DateTimeTicksBottom();
             MemoryPressureEventsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryPressureEventsChart.Plot.YLabel("Event Count");
-            MemoryPressureEventsChart.Plot.HideGrid();
             // Fixed negative space for legend
             MemoryPressureEventsChart.Plot.Axes.AutoScaleY();
             var pressureLimits = MemoryPressureEventsChart.Plot.Axes.GetLimits();

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -971,7 +971,6 @@ namespace PerformanceMonitorDashboard.Controls
                 chart.Plot.Axes.DateTimeTicksBottom();
                 chart.Plot.Axes.SetLimitsX(xMin, xMax);
                 chart.Plot.YLabel("Duration (ms/sec)");
-                chart.Plot.HideGrid();
                 TabHelpers.LockChartVerticalAxis(chart);
                 chart.Refresh();
             }
@@ -1027,7 +1026,6 @@ namespace PerformanceMonitorDashboard.Controls
             QueryPerfTrendsExecChart.Plot.Axes.DateTimeTicksBottom();
             QueryPerfTrendsExecChart.Plot.Axes.SetLimitsX(xMin, xMax);
             QueryPerfTrendsExecChart.Plot.YLabel("Executions/sec");
-            QueryPerfTrendsExecChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(QueryPerfTrendsExecChart);
             QueryPerfTrendsExecChart.Refresh();
         }

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -358,7 +358,6 @@ namespace PerformanceMonitorDashboard.Controls
             LatchStatsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(LatchStatsChart);
             LatchStatsChart.Plot.YLabel("Wait Time (ms/sec)");
-            LatchStatsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(LatchStatsChart);
             LatchStatsChart.Refresh();
         }
@@ -450,7 +449,6 @@ namespace PerformanceMonitorDashboard.Controls
             SpinlockStatsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(SpinlockStatsChart);
             SpinlockStatsChart.Plot.YLabel("Collisions/sec");
-            SpinlockStatsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(SpinlockStatsChart);
             SpinlockStatsChart.Refresh();
         }
@@ -559,7 +557,6 @@ namespace PerformanceMonitorDashboard.Controls
             TempDbLatencyChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(TempDbLatencyChart);
             TempDbLatencyChart.Plot.YLabel("Latency (ms)");
-            TempDbLatencyChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(TempDbLatencyChart);
             TempDbLatencyChart.Refresh();
         }
@@ -665,7 +662,6 @@ namespace PerformanceMonitorDashboard.Controls
             TempdbStatsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TempdbStatsChart.Plot.Axes.AutoScaleY();
             TempdbStatsChart.Plot.YLabel("MB");
-            TempdbStatsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(TempdbStatsChart);
             TempdbStatsChart.Refresh();
         }
@@ -837,7 +833,6 @@ namespace PerformanceMonitorDashboard.Controls
             SessionStatsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(SessionStatsChart);
             SessionStatsChart.Plot.YLabel("Session Count");
-            SessionStatsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(SessionStatsChart);
             SessionStatsChart.Refresh();
         }
@@ -951,7 +946,6 @@ namespace PerformanceMonitorDashboard.Controls
             chart.Plot.Axes.DateTimeTicksBottom();
             chart.Plot.Axes.SetLimitsX(xMin, xMax);
             chart.Plot.YLabel(yLabel);
-            chart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(chart);
             chart.Refresh();
         }
@@ -1043,7 +1037,6 @@ namespace PerformanceMonitorDashboard.Controls
             ServerUtilTrendsCpuChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(ServerUtilTrendsCpuChart);
             ServerUtilTrendsCpuChart.Plot.YLabel("CPU %");
-            ServerUtilTrendsCpuChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(ServerUtilTrendsCpuChart);
             ServerUtilTrendsCpuChart.Refresh();
         }
@@ -1105,7 +1098,6 @@ namespace PerformanceMonitorDashboard.Controls
             ServerUtilTrendsTempdbChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(ServerUtilTrendsTempdbChart);
             ServerUtilTrendsTempdbChart.Plot.YLabel("MB");
-            ServerUtilTrendsTempdbChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(ServerUtilTrendsTempdbChart);
             ServerUtilTrendsTempdbChart.Refresh();
         }
@@ -1211,7 +1203,6 @@ namespace PerformanceMonitorDashboard.Controls
             ServerUtilTrendsMemoryChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(ServerUtilTrendsMemoryChart);
             ServerUtilTrendsMemoryChart.Plot.YLabel("MB");
-            ServerUtilTrendsMemoryChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(ServerUtilTrendsMemoryChart);
             ServerUtilTrendsMemoryChart.Refresh();
         }
@@ -1287,7 +1278,6 @@ namespace PerformanceMonitorDashboard.Controls
             ServerUtilTrendsPerfmonChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(ServerUtilTrendsPerfmonChart);
             ServerUtilTrendsPerfmonChart.Plot.YLabel("Per Second");
-            ServerUtilTrendsPerfmonChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(ServerUtilTrendsPerfmonChart);
             ServerUtilTrendsPerfmonChart.Refresh();
         }
@@ -1791,7 +1781,6 @@ namespace PerformanceMonitorDashboard.Controls
             PerfmonCountersChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(PerfmonCountersChart);
             PerfmonCountersChart.Plot.YLabel("Value/sec");
-            PerfmonCountersChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(PerfmonCountersChart);
             PerfmonCountersChart.Refresh();
         }
@@ -2167,7 +2156,6 @@ namespace PerformanceMonitorDashboard.Controls
             WaitStatsDetailChart.Plot.Axes.SetLimitsX(xMin, xMax);
             TabHelpers.SetChartYLimitsWithLegendPadding(WaitStatsDetailChart);
             WaitStatsDetailChart.Plot.YLabel(useAvgPerWait ? "Avg Wait Time (ms/wait)" : "Wait Time (ms/sec)");
-            WaitStatsDetailChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(WaitStatsDetailChart);
             WaitStatsDetailChart.Refresh();
         }

--- a/Dashboard/Controls/SystemEventsContent.xaml.cs
+++ b/Dashboard/Controls/SystemEventsContent.xaml.cs
@@ -474,7 +474,6 @@ namespace PerformanceMonitorDashboard.Controls
             BadPagesChart.Plot.Axes.DateTimeTicksBottom();
             BadPagesChart.Plot.Axes.SetLimitsX(xMin, xMax);
             BadPagesChart.Plot.YLabel("Count");
-            BadPagesChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(BadPagesChart);
             BadPagesChart.Refresh();
 
@@ -504,7 +503,6 @@ namespace PerformanceMonitorDashboard.Controls
             DumpRequestsChart.Plot.Axes.DateTimeTicksBottom();
             DumpRequestsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             DumpRequestsChart.Plot.YLabel("Count");
-            DumpRequestsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(DumpRequestsChart);
             DumpRequestsChart.Refresh();
 
@@ -534,7 +532,6 @@ namespace PerformanceMonitorDashboard.Controls
             AccessViolationsChart.Plot.Axes.DateTimeTicksBottom();
             AccessViolationsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             AccessViolationsChart.Plot.YLabel("Count");
-            AccessViolationsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(AccessViolationsChart);
             AccessViolationsChart.Refresh();
 
@@ -564,7 +561,6 @@ namespace PerformanceMonitorDashboard.Controls
             WriteAccessViolationsChart.Plot.Axes.DateTimeTicksBottom();
             WriteAccessViolationsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             WriteAccessViolationsChart.Plot.YLabel("Count");
-            WriteAccessViolationsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(WriteAccessViolationsChart);
             WriteAccessViolationsChart.Refresh();
         }
@@ -606,7 +602,6 @@ namespace PerformanceMonitorDashboard.Controls
             NonYieldingTasksChart.Plot.Axes.DateTimeTicksBottom();
             NonYieldingTasksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             NonYieldingTasksChart.Plot.YLabel("Count");
-            NonYieldingTasksChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(NonYieldingTasksChart);
             NonYieldingTasksChart.Refresh();
 
@@ -636,7 +631,6 @@ namespace PerformanceMonitorDashboard.Controls
             LatchWarningsChart.Plot.Axes.DateTimeTicksBottom();
             LatchWarningsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             LatchWarningsChart.Plot.YLabel("Count");
-            LatchWarningsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(LatchWarningsChart);
             LatchWarningsChart.Refresh();
 
@@ -700,7 +694,6 @@ namespace PerformanceMonitorDashboard.Controls
             SickSpinlocksChart.Plot.Axes.DateTimeTicksBottom();
             SickSpinlocksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             SickSpinlocksChart.Plot.YLabel("Backoffs");
-            SickSpinlocksChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(SickSpinlocksChart);
             SickSpinlocksChart.Refresh();
 
@@ -752,7 +745,6 @@ namespace PerformanceMonitorDashboard.Controls
             CpuComparisonChart.Plot.Axes.SetLimitsX(xMin, xMax);
             CpuComparisonChart.Plot.Axes.SetLimitsY(0, 100); // Fixed Y-axis for CPU percentage
             CpuComparisonChart.Plot.YLabel("CPU %");
-            CpuComparisonChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(CpuComparisonChart);
             CpuComparisonChart.Refresh();
         }
@@ -853,7 +845,6 @@ namespace PerformanceMonitorDashboard.Controls
             SevereErrorsChart.Plot.Axes.DateTimeTicksBottom();
             SevereErrorsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             SevereErrorsChart.Plot.YLabel("Event Count");
-            SevereErrorsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(SevereErrorsChart);
             SevereErrorsChart.Refresh();
         }
@@ -1013,7 +1004,6 @@ namespace PerformanceMonitorDashboard.Controls
             IOIssuesChart.Plot.Axes.DateTimeTicksBottom();
             IOIssuesChart.Plot.Axes.SetLimitsX(xMin, xMax);
             IOIssuesChart.Plot.YLabel("Count");
-            IOIssuesChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(IOIssuesChart);
             IOIssuesChart.Refresh();
         }
@@ -1108,7 +1098,6 @@ namespace PerformanceMonitorDashboard.Controls
             LongestPendingIOChart.Plot.Axes.DateTimeTicksBottom();
             LongestPendingIOChart.Plot.Axes.SetLimitsX(xMin, xMax);
             LongestPendingIOChart.Plot.YLabel("Duration (ms)");
-            LongestPendingIOChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(LongestPendingIOChart);
             LongestPendingIOChart.Refresh();
         }
@@ -1208,7 +1197,6 @@ namespace PerformanceMonitorDashboard.Controls
             SchedulerIssuesChart.Plot.Axes.DateTimeTicksBottom();
             SchedulerIssuesChart.Plot.Axes.SetLimitsX(xMin, xMax);
             SchedulerIssuesChart.Plot.YLabel("Total Non-Yield Time (ms)");
-            SchedulerIssuesChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(SchedulerIssuesChart);
             SchedulerIssuesChart.Refresh();
         }
@@ -1359,7 +1347,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryConditionsChart.Plot.Axes.DateTimeTicksBottom();
             MemoryConditionsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryConditionsChart.Plot.YLabel("Count");
-            MemoryConditionsChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(MemoryConditionsChart);
             MemoryConditionsChart.Refresh();
         }
@@ -1532,7 +1519,6 @@ namespace PerformanceMonitorDashboard.Controls
             CPUTasksChart.Plot.Axes.DateTimeTicksBottom();
             CPUTasksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             CPUTasksChart.Plot.YLabel("Workers");
-            CPUTasksChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(CPUTasksChart);
             CPUTasksChart.Refresh();
         }
@@ -1739,7 +1725,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 chart.Plot.Axes.DateTimeTicksBottom();
                 chart.Plot.Axes.SetLimitsX(xMin, xMax);
-                chart.Plot.HideGrid();
                 TabHelpers.LockChartVerticalAxis(chart);
                 chart.Refresh();
             }
@@ -1894,7 +1879,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryNodeOOMChart.Plot.Axes.DateTimeTicksBottom();
             MemoryNodeOOMChart.Plot.Axes.SetLimitsX(xMin, xMax);
             MemoryNodeOOMChart.Plot.YLabel("Event Count");
-            MemoryNodeOOMChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(MemoryNodeOOMChart);
             MemoryNodeOOMChart.Refresh();
         }
@@ -1944,7 +1928,6 @@ namespace PerformanceMonitorDashboard.Controls
 
             MemoryNodeOOMUtilChart.Plot.Axes.DateTimeTicksBottom();
             MemoryNodeOOMUtilChart.Plot.Axes.SetLimitsX(xMin, xMax);
-            MemoryNodeOOMUtilChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(MemoryNodeOOMUtilChart);
             MemoryNodeOOMUtilChart.Refresh();
         }
@@ -2048,7 +2031,6 @@ namespace PerformanceMonitorDashboard.Controls
 
             MemoryNodeOOMMemoryChart.Plot.Axes.DateTimeTicksBottom();
             MemoryNodeOOMMemoryChart.Plot.Axes.SetLimitsX(xMin, xMax);
-            MemoryNodeOOMMemoryChart.Plot.HideGrid();
             TabHelpers.LockChartVerticalAxis(MemoryNodeOOMMemoryChart);
             MemoryNodeOOMMemoryChart.Refresh();
         }

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1658,7 +1658,6 @@ namespace PerformanceMonitorDashboard
             BlockingStatsBlockingEventsChart.Plot.Axes.DateTimeTicksBottom();
             BlockingStatsBlockingEventsChart.Plot.Axes.SetLimitsX(xMin, xMax);
             BlockingStatsBlockingEventsChart.Plot.YLabel("Count");
-            BlockingStatsBlockingEventsChart.Plot.HideGrid();
             LockChartVerticalAxis(BlockingStatsBlockingEventsChart);
             BlockingStatsBlockingEventsChart.Refresh();
 
@@ -1688,7 +1687,6 @@ namespace PerformanceMonitorDashboard
             BlockingStatsDurationChart.Plot.Axes.DateTimeTicksBottom();
             BlockingStatsDurationChart.Plot.Axes.SetLimitsX(xMin, xMax);
             BlockingStatsDurationChart.Plot.YLabel("Duration (ms)");
-            BlockingStatsDurationChart.Plot.HideGrid();
             LockChartVerticalAxis(BlockingStatsDurationChart);
             BlockingStatsDurationChart.Refresh();
 
@@ -1718,7 +1716,6 @@ namespace PerformanceMonitorDashboard
             BlockingStatsDeadlocksChart.Plot.Axes.DateTimeTicksBottom();
             BlockingStatsDeadlocksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             BlockingStatsDeadlocksChart.Plot.YLabel("Count");
-            BlockingStatsDeadlocksChart.Plot.HideGrid();
             LockChartVerticalAxis(BlockingStatsDeadlocksChart);
             BlockingStatsDeadlocksChart.Refresh();
 
@@ -1748,7 +1745,6 @@ namespace PerformanceMonitorDashboard
             BlockingStatsDeadlockWaitTimeChart.Plot.Axes.DateTimeTicksBottom();
             BlockingStatsDeadlockWaitTimeChart.Plot.Axes.SetLimitsX(xMin, xMax);
             BlockingStatsDeadlockWaitTimeChart.Plot.YLabel("Duration (ms)");
-            BlockingStatsDeadlockWaitTimeChart.Plot.HideGrid();
             LockChartVerticalAxis(BlockingStatsDeadlockWaitTimeChart);
             BlockingStatsDeadlockWaitTimeChart.Refresh();
         }
@@ -1811,8 +1807,6 @@ namespace PerformanceMonitorDashboard
             LockWaitStatsChart.Plot.YLabel("Wait Time (ms/sec)");
             _legendPanels[LockWaitStatsChart] = LockWaitStatsChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
             LockWaitStatsChart.Plot.Legend.FontSize = 12;
-            LockWaitStatsChart.Plot.HideGrid();
-
             LockChartVerticalAxis(LockWaitStatsChart);
             LockWaitStatsChart.Refresh();
         }
@@ -2239,7 +2233,6 @@ namespace PerformanceMonitorDashboard
             ResourceOverviewCpuChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ResourceOverviewCpuChart.Plot.Axes.SetLimitsY(0, 100);
             ResourceOverviewCpuChart.Plot.YLabel("CPU %");
-            ResourceOverviewCpuChart.Plot.HideGrid();
             LockChartVerticalAxis(ResourceOverviewCpuChart);
             ResourceOverviewCpuChart.Refresh();
         }
@@ -2302,8 +2295,6 @@ namespace PerformanceMonitorDashboard
             ResourceOverviewMemoryChart.Plot.Axes.DateTimeTicksBottom();
             ResourceOverviewMemoryChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ResourceOverviewMemoryChart.Plot.YLabel("MB");
-            ResourceOverviewMemoryChart.Plot.HideGrid();
-
             LockChartVerticalAxis(ResourceOverviewMemoryChart);
             ResourceOverviewMemoryChart.Refresh();
         }
@@ -2382,8 +2373,6 @@ namespace PerformanceMonitorDashboard
             ResourceOverviewIoChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ResourceOverviewIoChart.Plot.Axes.AutoScaleY();
             ResourceOverviewIoChart.Plot.YLabel("Latency (ms)");
-            ResourceOverviewIoChart.Plot.HideGrid();
-
             LockChartVerticalAxis(ResourceOverviewIoChart);
             ResourceOverviewIoChart.Refresh();
         }
@@ -2456,8 +2445,6 @@ namespace PerformanceMonitorDashboard
             ResourceOverviewWaitChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ResourceOverviewWaitChart.Plot.Axes.AutoScaleY();
             ResourceOverviewWaitChart.Plot.YLabel("Wait Time (ms/sec)");
-            ResourceOverviewWaitChart.Plot.HideGrid();
-
             LockChartVerticalAxis(ResourceOverviewWaitChart);
             ResourceOverviewWaitChart.Refresh();
         }


### PR DESCRIPTION
Root cause found: every Dashboard chart called Plot.HideGrid() after applying the dark theme, negating the grid color. Removed all 50 calls. Grid lines now match Lite.