### PR TITLE
Fix collector duration chart timezone offset

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -1948,7 +1948,7 @@ public partial class ServerTab : UserControl
             var points = group.OrderBy(d => d.CollectionTime).ToList();
             if (points.Count < 2) continue;
 
-            var times = points.Select(d => d.CollectionTime.ToLocalTime().ToOADate()).ToArray();
+            var times = points.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
             var durations = points.Select(d => (double)d.DurationMs!.Value).ToArray();
 
             var scatter = CollectorDurationChart.Plot.Add.Scatter(times, durations);


### PR DESCRIPTION
## Summary
- Collector duration trend chart used `.ToLocalTime()` while all other charts use `.AddMinutes(UtcOffsetMinutes)` for server time
- Caused the chart x-axis to show local machine time instead of server time, appearing 3 hours off from every other chart

## Test plan
- [x] Single line change, build verified earlier this session
- [ ] Launch Lite, confirm collector duration chart times align with other charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)