### PR TITLE
Update installer version from 1.0.0 to 1.2.0 (fixes #148)

### DIFF
--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
+    <InformationalVersion>1.2.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/InstallerGui/InstallerGui.csproj
+++ b/InstallerGui/InstallerGui.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>PerformanceMonitorInstallerGui</AssemblyName>
     <RootNamespace>PerformanceMonitorInstallerGui</RootNamespace>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary
- Both CLI and GUI installer projects had hardcoded version 1.0.0 while Dashboard and Lite were at 1.2.0
- This caused `config.installation_history` to show `installer_version = 1.0.0.0` after installing the current release
- Updated Version, AssemblyVersion, FileVersion, and InformationalVersion to 1.2.0

## Test plan
- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [ ] Run installer, verify `config.installation_history` shows 1.2.0

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)