### PR TITLE
Handle permission denied errors gracefully in collector health (fixes #150)

### DIFF
--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -153,7 +153,7 @@ public partial class RemoteCollectorService
     /// <summary>
     /// Records a collector execution result for health tracking.
     /// </summary>
-    private void RecordCollectorResult(int serverId, string collectorName, bool success, string? errorMessage = null)
+    private void RecordCollectorResult(int serverId, string collectorName, string status, string? errorMessage = null)
     {
         lock (_healthLock)
         {
@@ -164,11 +164,19 @@ public partial class RemoteCollectorService
                 _collectorHealth[key] = entry;
             }
 
-            if (success)
+            if (status == "SUCCESS")
             {
                 entry.LastSuccessTime = DateTime.UtcNow;
                 entry.ConsecutiveErrors = 0;
                 entry.TotalSuccesses++;
+            }
+            else if (status == "PERMISSIONS")
+            {
+                /* Permission errors are not transient — don't count as failures
+                   (which would show FAILING) but don't count as success either.
+                   Record the error message so the user can see what's wrong. */
+                entry.LastErrorTime = DateTime.UtcNow;
+                entry.LastErrorMessage = errorMessage;
             }
             else
             {
@@ -337,6 +345,7 @@ public partial class RemoteCollectorService
             }
             else if (ex.Number == 229 || ex.Number == 297 || ex.Number == 300)
             {
+                status = "PERMISSIONS";
                 _logger?.LogWarning("Collector '{Collector}' permission denied for server '{Server}': {Message}",
                     collectorName, server.DisplayName, ex.Message);
             }
@@ -369,7 +378,7 @@ public partial class RemoteCollectorService
         }
 
         // Track collector health
-        RecordCollectorResult(GetServerId(server), collectorName, status == "SUCCESS", errorMessage);
+        RecordCollectorResult(GetServerId(server), collectorName, status, errorMessage);
 
         // Log the collection attempt
         await LogCollectionAsync(GetServerId(server), server.DisplayName, collectorName, startTime, status, errorMessage, rowsCollected, _lastSqlMs, _lastDuckDbMs);


### PR DESCRIPTION
## Summary
- Permission errors (SQL 229/297/300) now log as PERMISSIONS status instead of ERROR
- Don't increment ConsecutiveErrors — status bar won't show "erroring" for permission issues
- Collection health grid shows NO_PERMISSIONS when a collector has only permission errors
- Error message still visible so users know which grants are needed

## Test plan
- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [ ] Connect with a limited-permission account, verify running_jobs shows NO_PERMISSIONS instead of FAILING
- [ ] Verify status bar doesn't flag permission errors as "erroring"

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)