### PR TITLE
Fix mutex crash on app exit (fixes #89)

### DIFF
--- a/Dashboard/App.xaml.cs
+++ b/Dashboard/App.xaml.cs
@@ -20,13 +20,14 @@ namespace PerformanceMonitorDashboard
     {
         private const string MutexName = "PerformanceMonitorDashboard_SingleInstance";
         private Mutex? _singleInstanceMutex;
+        private bool _ownsMutex;
 
         protected override void OnStartup(StartupEventArgs e)
         {
             // Check for existing instance
-            _singleInstanceMutex = new Mutex(true, MutexName, out bool isNewInstance);
+            _singleInstanceMutex = new Mutex(true, MutexName, out _ownsMutex);
 
-            if (!isNewInstance)
+            if (!_ownsMutex)
             {
                 // Another instance is already running - activate it and exit
                 NativeMethods.BroadcastShowMessage();
@@ -58,8 +59,10 @@ namespace PerformanceMonitorDashboard
                 mainWin.ExitApplication();
             }
 
-            // Release the mutex
-            _singleInstanceMutex?.ReleaseMutex();
+            if (_ownsMutex)
+            {
+                _singleInstanceMutex?.ReleaseMutex();
+            }
             _singleInstanceMutex?.Dispose();
 
             base.OnExit(e);

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -20,6 +20,7 @@ public partial class App : Application
 {
     private const string MutexName = "PerformanceMonitorLite_SingleInstance";
     private Mutex? _singleInstanceMutex;
+    private bool _ownsMutex;
 
     /// <summary>
     /// Gets the application data directory where config and data files are stored.
@@ -119,9 +120,9 @@ public partial class App : Application
     {
 
         // Check for existing instance
-        _singleInstanceMutex = new Mutex(true, MutexName, out bool isNewInstance);
+        _singleInstanceMutex = new Mutex(true, MutexName, out _ownsMutex);
 
-        if (!isNewInstance)
+        if (!_ownsMutex)
         {
             MessageBox.Show(
                 "Performance Monitor Lite is already running.",
@@ -168,8 +169,10 @@ public partial class App : Application
         AppLogger.Info("App", "Shutting down");
         AppLogger.Shutdown();
 
-        // Release the mutex
-        _singleInstanceMutex?.ReleaseMutex();
+        if (_ownsMutex)
+        {
+            _singleInstanceMutex?.ReleaseMutex();
+        }
         _singleInstanceMutex?.Dispose();
 
         base.OnExit(e);


### PR DESCRIPTION
## Summary
- `ReleaseMutex()` in `OnExit` throws `ApplicationException` when called by a thread that doesn't own the mutex
- Tracked via `_ownsMutex` field — only release if we actually acquired ownership
- Fixed in both Dashboard and Lite

## Root Cause
When the app detects a second instance, it creates the mutex but doesn't own it, then calls `Shutdown()`. During `OnExit`, `ReleaseMutex()` throws because the calling thread isn't the owner. This is an unhandled exception during shutdown, so it terminates the process.

Credit to @jaglick for the stack trace on #89.

## Test plan
- [x] Both projects build clean (0 errors, 0 warnings)
- [x] Dashboard and Lite launch and run normally
- [ ] Verify second-instance launch no longer crashes on exit