### PR TITLE
DuckDB checkpoint optimization and timing fix

### DIFF
--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -85,6 +85,10 @@ public class CollectionBackgroundService : BackgroundService
                     IsCollecting = true;
                     await _collectorService.RunDueCollectorsAsync(stoppingToken);
                     LastCollectionTime = DateTime.UtcNow;
+
+                    /* Flush WAL during idle time instead of letting auto-checkpoint
+                       stall collectors mid-write with 2-3s stop-the-world pauses */
+                    await _collectorService.CheckpointAsync();
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -388,26 +388,31 @@ OPTION(RECOMPILE);";
             }
 
             var duckSw = Stopwatch.StartNew();
-            using var duckConnection = _duckDb.CreateConnection();
-            await duckConnection.OpenAsync(cancellationToken);
 
-            using var appender = duckConnection.CreateAppender("deadlocks");
-
-            foreach (var (deadlockTime, victimProcessId, victimSqlText, graphXml) in deadlockRows)
+            using (var duckConnection = _duckDb.CreateConnection())
             {
-                var row = appender.CreateRow();
-                row.AppendValue(GenerateCollectionId())
-                   .AppendValue(collectionTime)
-                   .AppendValue(serverId)
-                   .AppendValue(server.ServerName)
-                   .AppendValue(deadlockTime)
-                   .AppendValue(victimProcessId)
-                   .AppendValue(victimSqlText)
-                   .AppendValue(graphXml)
-                   .EndRow();
+                await duckConnection.OpenAsync(cancellationToken);
 
-                rowsCollected++;
+                using (var appender = duckConnection.CreateAppender("deadlocks"))
+                {
+                    foreach (var (deadlockTime, victimProcessId, victimSqlText, graphXml) in deadlockRows)
+                    {
+                        var row = appender.CreateRow();
+                        row.AppendValue(GenerateCollectionId())
+                           .AppendValue(collectionTime)
+                           .AppendValue(serverId)
+                           .AppendValue(server.ServerName)
+                           .AppendValue(deadlockTime)
+                           .AppendValue(victimProcessId)
+                           .AppendValue(victimSqlText)
+                           .AppendValue(graphXml)
+                           .EndRow();
+
+                        rowsCollected++;
+                    }
+                }
             }
+
             duckSw.Stop();
             _lastDuckDbMs = duckSw.ElapsedMilliseconds;
         }

--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -120,46 +120,50 @@ OPTION(RECOMPILE);";
 
         /* Insert into DuckDB with delta calculations */
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("file_io_stats");
-
-        foreach (var stat in fileStats)
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var deltaKey = $"{stat.DatabaseId}_{stat.FileId}";
-            var deltaReads = _deltaCalculator.CalculateDelta(serverId, "file_io_reads", deltaKey, stat.NumOfReads);
-            var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "file_io_writes", deltaKey, stat.NumOfWrites);
-            var deltaReadBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_read_bytes", deltaKey, stat.ReadBytes);
-            var deltaWriteBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_write_bytes", deltaKey, stat.WriteBytes);
-            var deltaStallReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_read", deltaKey, stat.IoStallReadMs);
-            var deltaStallWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_write", deltaKey, stat.IoStallWriteMs);
+            await duckConnection.OpenAsync(cancellationToken);
 
-            var row = appender.CreateRow();
-            row.AppendValue(GenerateCollectionId())
-               .AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(stat.DatabaseName)
-               .AppendValue(stat.FileName)
-               .AppendValue(stat.FileType)
-               .AppendValue(stat.PhysicalName)
-               .AppendValue(stat.SizeMb)
-               .AppendValue(stat.NumOfReads)
-               .AppendValue(stat.NumOfWrites)
-               .AppendValue(stat.ReadBytes)
-               .AppendValue(stat.WriteBytes)
-               .AppendValue(stat.IoStallReadMs)
-               .AppendValue(stat.IoStallWriteMs)
-               .AppendValue(deltaReads)
-               .AppendValue(deltaWrites)
-               .AppendValue(deltaReadBytes)
-               .AppendValue(deltaWriteBytes)
-               .AppendValue(deltaStallReadMs)
-               .AppendValue(deltaStallWriteMs)
-               .EndRow();
+            using (var appender = duckConnection.CreateAppender("file_io_stats"))
+            {
+                foreach (var stat in fileStats)
+                {
+                    var deltaKey = $"{stat.DatabaseId}_{stat.FileId}";
+                    var deltaReads = _deltaCalculator.CalculateDelta(serverId, "file_io_reads", deltaKey, stat.NumOfReads);
+                    var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "file_io_writes", deltaKey, stat.NumOfWrites);
+                    var deltaReadBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_read_bytes", deltaKey, stat.ReadBytes);
+                    var deltaWriteBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_write_bytes", deltaKey, stat.WriteBytes);
+                    var deltaStallReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_read", deltaKey, stat.IoStallReadMs);
+                    var deltaStallWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_write", deltaKey, stat.IoStallWriteMs);
 
-            rowsCollected++;
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(stat.DatabaseName)
+                       .AppendValue(stat.FileName)
+                       .AppendValue(stat.FileType)
+                       .AppendValue(stat.PhysicalName)
+                       .AppendValue(stat.SizeMb)
+                       .AppendValue(stat.NumOfReads)
+                       .AppendValue(stat.NumOfWrites)
+                       .AppendValue(stat.ReadBytes)
+                       .AppendValue(stat.WriteBytes)
+                       .AppendValue(stat.IoStallReadMs)
+                       .AppendValue(stat.IoStallWriteMs)
+                       .AppendValue(deltaReads)
+                       .AppendValue(deltaWrites)
+                       .AppendValue(deltaReadBytes)
+                       .AppendValue(deltaWriteBytes)
+                       .AppendValue(deltaStallReadMs)
+                       .AppendValue(deltaStallWriteMs)
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.Memory.cs
+++ b/Lite/Services/RemoteCollectorService.Memory.cs
@@ -146,26 +146,31 @@ OPTION(RECOMPILE);";
 
         /* Insert into DuckDB using Appender */
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("memory_stats");
-        var row = appender.CreateRow();
-        row.AppendValue(GenerateCollectionId())
-           .AppendValue(collectionTime)
-           .AppendValue(serverId)
-           .AppendValue(server.ServerName)
-           .AppendValue(totalPhysicalMb)
-           .AppendValue(availablePhysicalMb)
-           .AppendValue(totalPageFileMb)
-           .AppendValue(availablePageFileMb)
-           .AppendValue(systemMemoryState)
-           .AppendValue(sqlMemoryModel)
-           .AppendValue(targetServerMemoryMb)
-           .AppendValue(totalServerMemoryMb)
-           .AppendValue(bufferPoolMb)
-           .AppendValue(planCacheMb)
-           .EndRow();
+        using (var duckConnection = _duckDb.CreateConnection())
+        {
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("memory_stats"))
+            {
+                var row = appender.CreateRow();
+                row.AppendValue(GenerateCollectionId())
+                   .AppendValue(collectionTime)
+                   .AppendValue(serverId)
+                   .AppendValue(server.ServerName)
+                   .AppendValue(totalPhysicalMb)
+                   .AppendValue(availablePhysicalMb)
+                   .AppendValue(totalPageFileMb)
+                   .AppendValue(availablePageFileMb)
+                   .AppendValue(systemMemoryState)
+                   .AppendValue(sqlMemoryModel)
+                   .AppendValue(targetServerMemoryMb)
+                   .AppendValue(totalServerMemoryMb)
+                   .AppendValue(bufferPoolMb)
+                   .AppendValue(planCacheMb)
+                   .EndRow();
+            }
+        }
 
         duckSw.Stop();
         _lastSqlMs = sqlSw.ElapsedMilliseconds;
@@ -211,23 +216,27 @@ OPTION(RECOMPILE);";
 
         /* Insert into DuckDB */
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("memory_clerks");
-
-        while (await reader.ReadAsync(cancellationToken))
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var row = appender.CreateRow();
-            row.AppendValue(GenerateCollectionId())
-               .AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(reader.GetString(0))
-               .AppendValue(reader.GetDecimal(1))
-               .EndRow();
+            await duckConnection.OpenAsync(cancellationToken);
 
-            rowsCollected++;
+            using (var appender = duckConnection.CreateAppender("memory_clerks"))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(reader.GetString(0))
+                       .AppendValue(reader.GetDecimal(1))
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.MemoryGrants.cs
+++ b/Lite/Services/RemoteCollectorService.MemoryGrants.cs
@@ -84,32 +84,37 @@ OPTION(RECOMPILE);";
         sqlSw.Stop();
 
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("memory_grant_stats");
-        foreach (var r in rows)
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var row = appender.CreateRow();
-            row.AppendValue(GenerateCollectionId())
-               .AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(r.SessionId)
-               .AppendValue(r.DatabaseName)
-               .AppendValue(r.QueryText)
-               .AppendValue(r.RequestedMb)
-               .AppendValue(r.GrantedMb)
-               .AppendValue(r.UsedMb)
-               .AppendValue(r.MaxUsedMb)
-               .AppendValue(r.IdealMb)
-               .AppendValue(r.RequiredMb)
-               .AppendValue(r.WaitTimeMs)
-               .AppendValue(r.IsSmall)
-               .AppendValue(r.Dop)
-               .AppendValue(r.QueryCost)
-               .EndRow();
-            rowsCollected++;
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("memory_grant_stats"))
+            {
+                foreach (var r in rows)
+                {
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(r.SessionId)
+                       .AppendValue(r.DatabaseName)
+                       .AppendValue(r.QueryText)
+                       .AppendValue(r.RequestedMb)
+                       .AppendValue(r.GrantedMb)
+                       .AppendValue(r.UsedMb)
+                       .AppendValue(r.MaxUsedMb)
+                       .AppendValue(r.IdealMb)
+                       .AppendValue(r.RequiredMb)
+                       .AppendValue(r.WaitTimeMs)
+                       .AppendValue(r.IsSmall)
+                       .AppendValue(r.Dop)
+                       .AppendValue(r.QueryCost)
+                       .EndRow();
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -199,71 +199,75 @@ OPTION(RECOMPILE);";
         sqlSw.Stop();
 
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("procedure_stats");
-
-        while (await reader.ReadAsync(cancellationToken))
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
-            var schemaName = reader.IsDBNull(1) ? "" : reader.GetString(1);
-            var objectName = reader.IsDBNull(2) ? "" : reader.GetString(2);
-            var objectType = reader.IsDBNull(3) ? "" : reader.GetString(3);
-            var execCount = reader.GetInt64(4);
-            var workerTime = reader.GetInt64(5);
-            var elapsedTime = reader.GetInt64(6);
-            var logicalReads = reader.GetInt64(7);
-            var physicalReads = reader.GetInt64(8);
-            var logicalWrites = reader.GetInt64(9);
-            var minWorkerTime = reader.GetInt64(10);
-            var maxWorkerTime = reader.GetInt64(11);
-            var minElapsedTime = reader.GetInt64(12);
-            var maxElapsedTime = reader.GetInt64(13);
-            var totalSpills = reader.GetInt64(14);
-            var sqlHandle = reader.IsDBNull(15) ? (string?)null : reader.GetString(15);
-            var planHandle = reader.IsDBNull(16) ? (string?)null : reader.GetString(16);
+            await duckConnection.OpenAsync(cancellationToken);
 
-            /* Delta key: database.schema.object */
-            var deltaKey = $"{dbName}.{schemaName}.{objectName}";
-            var deltaExec = _deltaCalculator.CalculateDelta(serverId, "proc_stats_exec", deltaKey, execCount);
-            var deltaWorker = _deltaCalculator.CalculateDelta(serverId, "proc_stats_worker", deltaKey, workerTime);
-            var deltaElapsed = _deltaCalculator.CalculateDelta(serverId, "proc_stats_elapsed", deltaKey, elapsedTime);
-            var deltaReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_reads", deltaKey, logicalReads);
-            var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "proc_stats_writes", deltaKey, logicalWrites);
-            var deltaPhysReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_phys_reads", deltaKey, physicalReads);
+            using (var appender = duckConnection.CreateAppender("procedure_stats"))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                    var schemaName = reader.IsDBNull(1) ? "" : reader.GetString(1);
+                    var objectName = reader.IsDBNull(2) ? "" : reader.GetString(2);
+                    var objectType = reader.IsDBNull(3) ? "" : reader.GetString(3);
+                    var execCount = reader.GetInt64(4);
+                    var workerTime = reader.GetInt64(5);
+                    var elapsedTime = reader.GetInt64(6);
+                    var logicalReads = reader.GetInt64(7);
+                    var physicalReads = reader.GetInt64(8);
+                    var logicalWrites = reader.GetInt64(9);
+                    var minWorkerTime = reader.GetInt64(10);
+                    var maxWorkerTime = reader.GetInt64(11);
+                    var minElapsedTime = reader.GetInt64(12);
+                    var maxElapsedTime = reader.GetInt64(13);
+                    var totalSpills = reader.GetInt64(14);
+                    var sqlHandle = reader.IsDBNull(15) ? (string?)null : reader.GetString(15);
+                    var planHandle = reader.IsDBNull(16) ? (string?)null : reader.GetString(16);
 
-            var row = appender.CreateRow();
-            row.AppendValue(GenerateCollectionId())
-               .AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(dbName)
-               .AppendValue(schemaName)
-               .AppendValue(objectName)
-               .AppendValue(objectType)
-               .AppendValue(execCount)
-               .AppendValue(workerTime)
-               .AppendValue(elapsedTime)
-               .AppendValue(logicalReads)
-               .AppendValue(physicalReads)
-               .AppendValue(logicalWrites)
-               .AppendValue(minWorkerTime)
-               .AppendValue(maxWorkerTime)
-               .AppendValue(minElapsedTime)
-               .AppendValue(maxElapsedTime)
-               .AppendValue(totalSpills)
-               .AppendValue(sqlHandle)
-               .AppendValue(planHandle)
-               .AppendValue(deltaExec)
-               .AppendValue(deltaWorker)
-               .AppendValue(deltaElapsed)
-               .AppendValue(deltaReads)
-               .AppendValue(deltaWrites)
-               .AppendValue(deltaPhysReads)
-               .EndRow();
+                    /* Delta key: database.schema.object */
+                    var deltaKey = $"{dbName}.{schemaName}.{objectName}";
+                    var deltaExec = _deltaCalculator.CalculateDelta(serverId, "proc_stats_exec", deltaKey, execCount);
+                    var deltaWorker = _deltaCalculator.CalculateDelta(serverId, "proc_stats_worker", deltaKey, workerTime);
+                    var deltaElapsed = _deltaCalculator.CalculateDelta(serverId, "proc_stats_elapsed", deltaKey, elapsedTime);
+                    var deltaReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_reads", deltaKey, logicalReads);
+                    var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "proc_stats_writes", deltaKey, logicalWrites);
+                    var deltaPhysReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_phys_reads", deltaKey, physicalReads);
 
-            rowsCollected++;
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(dbName)
+                       .AppendValue(schemaName)
+                       .AppendValue(objectName)
+                       .AppendValue(objectType)
+                       .AppendValue(execCount)
+                       .AppendValue(workerTime)
+                       .AppendValue(elapsedTime)
+                       .AppendValue(logicalReads)
+                       .AppendValue(physicalReads)
+                       .AppendValue(logicalWrites)
+                       .AppendValue(minWorkerTime)
+                       .AppendValue(maxWorkerTime)
+                       .AppendValue(minElapsedTime)
+                       .AppendValue(maxElapsedTime)
+                       .AppendValue(totalSpills)
+                       .AppendValue(sqlHandle)
+                       .AppendValue(planHandle)
+                       .AppendValue(deltaExec)
+                       .AppendValue(deltaWorker)
+                       .AppendValue(deltaElapsed)
+                       .AppendValue(deltaReads)
+                       .AppendValue(deltaWrites)
+                       .AppendValue(deltaPhysReads)
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -103,41 +103,45 @@ OPTION(MAXDOP 1, RECOMPILE);";
         _lastSqlMs = sqlSw.ElapsedMilliseconds;
 
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("query_snapshots");
-
-        while (await reader.ReadAsync(cancellationToken))
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var row = appender.CreateRow();
-            row.AppendValue(GenerateCollectionId())
-               .AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(Convert.ToInt32(reader.GetValue(0)))                                       /* session_id */
-               .AppendValue(reader.IsDBNull(1) ? (string?)null : reader.GetString(1))                  /* database_name */
-               .AppendValue(reader.IsDBNull(2) ? (string?)null : reader.GetString(2))                  /* elapsed_time_formatted */
-               .AppendValue(reader.IsDBNull(3) ? (string?)null : reader.GetString(3))                  /* query_text */
-               .AppendValue(reader.IsDBNull(4) ? (string?)null : reader.GetString(4))                  /* query_plan */
-               .AppendValue(reader.IsDBNull(5) ? (string?)null : reader.GetValue(5)?.ToString())       /* live_query_plan (xml) */
-               .AppendValue(reader.IsDBNull(6) ? (string?)null : reader.GetString(6))                  /* status */
-               .AppendValue(reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)))              /* blocking_session_id */
-               .AppendValue(reader.IsDBNull(8) ? (string?)null : reader.GetString(8))                  /* wait_type */
-               .AppendValue(reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)))             /* wait_time_ms */
-               .AppendValue(reader.IsDBNull(10) ? (string?)null : reader.GetString(10))                /* wait_resource */
-               .AppendValue(reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)))           /* cpu_time_ms */
-               .AppendValue(reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)))           /* total_elapsed_time_ms */
-               .AppendValue(reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)))           /* reads */
-               .AppendValue(reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)))           /* writes */
-               .AppendValue(reader.IsDBNull(15) ? 0L : Convert.ToInt64(reader.GetValue(15)))           /* logical_reads */
-               .AppendValue(reader.IsDBNull(16) ? 0m : reader.GetDecimal(16))                            /* granted_query_memory_gb */
-               .AppendValue(reader.IsDBNull(17) ? (string?)null : reader.GetString(17))                /* transaction_isolation_level */
-               .AppendValue(reader.IsDBNull(18) ? 0 : Convert.ToInt32(reader.GetValue(18)))            /* dop */
-               .AppendValue(reader.IsDBNull(19) ? 0 : Convert.ToInt32(reader.GetValue(19)))            /* parallel_worker_count */
-               .EndRow();
+            await duckConnection.OpenAsync(cancellationToken);
 
-            rowsCollected++;
+            using (var appender = duckConnection.CreateAppender("query_snapshots"))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(Convert.ToInt32(reader.GetValue(0)))                                       /* session_id */
+                       .AppendValue(reader.IsDBNull(1) ? (string?)null : reader.GetString(1))                  /* database_name */
+                       .AppendValue(reader.IsDBNull(2) ? (string?)null : reader.GetString(2))                  /* elapsed_time_formatted */
+                       .AppendValue(reader.IsDBNull(3) ? (string?)null : reader.GetString(3))                  /* query_text */
+                       .AppendValue(reader.IsDBNull(4) ? (string?)null : reader.GetString(4))                  /* query_plan */
+                       .AppendValue(reader.IsDBNull(5) ? (string?)null : reader.GetValue(5)?.ToString())       /* live_query_plan (xml) */
+                       .AppendValue(reader.IsDBNull(6) ? (string?)null : reader.GetString(6))                  /* status */
+                       .AppendValue(reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)))              /* blocking_session_id */
+                       .AppendValue(reader.IsDBNull(8) ? (string?)null : reader.GetString(8))                  /* wait_type */
+                       .AppendValue(reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)))             /* wait_time_ms */
+                       .AppendValue(reader.IsDBNull(10) ? (string?)null : reader.GetString(10))                /* wait_resource */
+                       .AppendValue(reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)))           /* cpu_time_ms */
+                       .AppendValue(reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)))           /* total_elapsed_time_ms */
+                       .AppendValue(reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)))           /* reads */
+                       .AppendValue(reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)))           /* writes */
+                       .AppendValue(reader.IsDBNull(15) ? 0L : Convert.ToInt64(reader.GetValue(15)))           /* logical_reads */
+                       .AppendValue(reader.IsDBNull(16) ? 0m : reader.GetDecimal(16))                            /* granted_query_memory_gb */
+                       .AppendValue(reader.IsDBNull(17) ? (string?)null : reader.GetString(17))                /* transaction_isolation_level */
+                       .AppendValue(reader.IsDBNull(18) ? 0 : Convert.ToInt32(reader.GetValue(18)))            /* dop */
+                       .AppendValue(reader.IsDBNull(19) ? 0 : Convert.ToInt32(reader.GetValue(19)))            /* parallel_worker_count */
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.RunningJobs.cs
+++ b/Lite/Services/RemoteCollectorService.RunningJobs.cs
@@ -153,28 +153,33 @@ OPTION(RECOMPILE);";
         sqlSw.Stop();
 
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("running_jobs");
-        foreach (var r in rows)
+        using (var duckConnection = _duckDb.CreateConnection())
         {
-            var row = appender.CreateRow();
-            row.AppendValue(collectionTime)
-               .AppendValue(serverId)
-               .AppendValue(server.ServerName)
-               .AppendValue(r.JobName)
-               .AppendValue(r.JobId)
-               .AppendValue(r.JobEnabled)
-               .AppendValue(r.StartTime)
-               .AppendValue(r.CurrentDuration)
-               .AppendValue(r.AvgDuration)
-               .AppendValue(r.P95Duration)
-               .AppendValue(r.SuccessfulRunCount)
-               .AppendValue(r.IsRunningLong)
-               .AppendValue(r.PercentOfAverage)
-               .EndRow();
-            rowsCollected++;
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("running_jobs"))
+            {
+                foreach (var r in rows)
+                {
+                    var row = appender.CreateRow();
+                    row.AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(r.JobName)
+                       .AppendValue(r.JobId)
+                       .AppendValue(r.JobEnabled)
+                       .AppendValue(r.StartTime)
+                       .AppendValue(r.CurrentDuration)
+                       .AppendValue(r.AvgDuration)
+                       .AppendValue(r.P95Duration)
+                       .AppendValue(r.SuccessfulRunCount)
+                       .AppendValue(r.IsRunningLong)
+                       .AppendValue(r.PercentOfAverage)
+                       .EndRow();
+                    rowsCollected++;
+                }
+            }
         }
 
         duckSw.Stop();

--- a/Lite/Services/RemoteCollectorService.TempDb.cs
+++ b/Lite/Services/RemoteCollectorService.TempDb.cs
@@ -77,24 +77,29 @@ ORDER BY (ssu.user_objects_alloc_page_count + ssu.internal_objects_alloc_page_co
 
         /* Insert into DuckDB using Appender */
         var duckSw = Stopwatch.StartNew();
-        using var duckConnection = _duckDb.CreateConnection();
-        await duckConnection.OpenAsync(cancellationToken);
 
-        using var appender = duckConnection.CreateAppender("tempdb_stats");
-        var row = appender.CreateRow();
-        row.AppendValue(GenerateCollectionId())
-           .AppendValue(collectionTime)
-           .AppendValue(serverId)
-           .AppendValue(server.ServerName)
-           .AppendValue(userObjMb)
-           .AppendValue(internalObjMb)
-           .AppendValue(versionStoreMb)
-           .AppendValue(totalReservedMb)
-           .AppendValue(unallocatedMb)
-           .AppendValue(totalSessions)
-           .AppendValue(topSessionId)
-           .AppendValue(topSessionMb)
-           .EndRow();
+        using (var duckConnection = _duckDb.CreateConnection())
+        {
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("tempdb_stats"))
+            {
+                var row = appender.CreateRow();
+                row.AppendValue(GenerateCollectionId())
+                   .AppendValue(collectionTime)
+                   .AppendValue(serverId)
+                   .AppendValue(server.ServerName)
+                   .AppendValue(userObjMb)
+                   .AppendValue(internalObjMb)
+                   .AppendValue(versionStoreMb)
+                   .AppendValue(totalReservedMb)
+                   .AppendValue(unallocatedMb)
+                   .AppendValue(totalSessions)
+                   .AppendValue(topSessionId)
+                   .AppendValue(topSessionMb)
+                   .EndRow();
+            }
+        }
 
         duckSw.Stop();
         _lastSqlMs = sqlSw.ElapsedMilliseconds;

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -121,6 +121,11 @@ public partial class RemoteCollectorService
     public Task SeedDeltaCacheAsync() => _deltaCalculator.SeedFromDatabaseAsync(_duckDb);
 
     /// <summary>
+    /// Runs a manual DuckDB WAL checkpoint during idle time between collection cycles.
+    /// </summary>
+    public Task CheckpointAsync() => _duckDb.CheckpointAsync();
+
+    /// <summary>
     /// Gets a summary of collector health. When serverId is provided, filters to that server only.
     /// </summary>
     public CollectorHealthSummary GetHealthSummary(int? serverId = null)
@@ -201,8 +206,8 @@ public partial class RemoteCollectorService
             return;
         }
 
-        var tasks = new List<Task>();
         int skippedOffline = 0;
+        var onlineServers = new List<ServerConnection>();
 
         foreach (var server in enabledServers)
         {
@@ -213,17 +218,25 @@ public partial class RemoteCollectorService
                 _logger?.LogDebug("Skipping offline server '{Server}'", server.DisplayName);
                 continue;
             }
-
-            foreach (var collector in dueCollectors)
-            {
-                tasks.Add(RunCollectorAsync(server, collector.Name, cancellationToken));
-            }
+            onlineServers.Add(server);
         }
 
         _logger?.LogInformation("Running {CollectorCount} collectors for {OnlineCount}/{TotalCount} servers ({SkippedCount} offline, skipped)",
-            dueCollectors.Count, enabledServers.Count - skippedOffline, enabledServers.Count, skippedOffline);
+            dueCollectors.Count, onlineServers.Count, enabledServers.Count, skippedOffline);
 
-        await Task.WhenAll(tasks);
+        /* Run servers in parallel, but collectors within each server sequentially.
+           DuckDB is single-writer; running all collectors in parallel causes spin-wait
+           contention (50%+ CPU, multi-second stalls). Sequential per-server eliminates
+           this while still allowing multi-server parallelism. */
+        var serverTasks = onlineServers.Select(server => Task.Run(async () =>
+        {
+            foreach (var collector in dueCollectors)
+            {
+                await RunCollectorAsync(server, collector.Name, cancellationToken);
+            }
+        }, cancellationToken));
+
+        await Task.WhenAll(serverTasks);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `checkpoint_threshold=1GB` to DuckDB connection string to prevent auto-checkpoint stalls during writes
- Add manual `CHECKPOINT` after each collection cycle during idle time (15-32ms vs 3,920ms mid-write)
- Change collector execution from parallel `Task.WhenAll` to sequential per-server to eliminate DuckDB write contention
- Fix `using var` timing bug across all 16 collector files — appender Dispose (flush + connection close) now captured inside DuckDB stopwatch for accurate `collection_log` timing

## Background
DuckDB's default 16MB WAL auto-checkpoint was triggering 2-3 second stop-the-world pauses mid-write. Combined with database bloat (3.8GB for 35MB of real data), collectors were taking 3-7 seconds each and driving CPU to 50-60%. After these changes + manual database compaction, collectors run in 100-400ms with normal CPU usage.

## Test plan
- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [x] Verified `checkpoint_threshold` reads as 953.6 MiB in DuckDB config
- [x] Collectors run 100-400ms per cycle (was 3-7 seconds)
- [x] CHECKPOINT completes in 15-32ms (was 3,920ms)
- [x] Full collection cycle ~4 seconds for 15 collectors (was 50+ seconds)
- [x] CPU usage returned to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)