### PR TITLE
Parquet archive visibility and scheduled compaction

### DIFF
--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -21,11 +21,23 @@ public class DuckDbInitializer
     /// </summary>
     internal const int CurrentSchemaVersion = 10;
 
+    private readonly string _archivePath;
+
     public DuckDbInitializer(string databasePath, ILogger<DuckDbInitializer>? logger = null)
     {
         _databasePath = databasePath;
         _logger = logger;
+        _archivePath = Path.Combine(Path.GetDirectoryName(databasePath) ?? ".", "archive");
     }
+
+    /* Tables that have parquet archives — views are created to UNION hot data with archived parquet files */
+    private static readonly string[] ArchivableTables =
+    [
+        "wait_stats", "query_stats", "procedure_stats", "query_store_stats",
+        "query_snapshots", "cpu_utilization_stats", "file_io_stats", "memory_stats",
+        "memory_clerks", "tempdb_stats", "perfmon_stats", "deadlocks",
+        "blocked_process_reports", "collection_log"
+    ];
 
     /// <summary>
     /// Gets the connection string for the DuckDB database.
@@ -99,6 +111,8 @@ public class DuckDbInitializer
 
             _logger?.LogInformation("Database initialization complete. Schema version: {Version}", CurrentSchemaVersion);
         }
+
+        await CreateArchiveViewsAsync();
     }
 
     /// <summary>
@@ -411,6 +425,58 @@ public class DuckDbInitializer
     }
 
     /// <summary>
+    /// Creates or refreshes views that UNION hot DuckDB tables with archived parquet files.
+    /// Call at startup and after each archive cycle so newly archived data is queryable.
+    /// </summary>
+    public async Task CreateArchiveViewsAsync()
+    {
+        using var connection = CreateConnection();
+        await connection.OpenAsync();
+
+        foreach (var table in ArchivableTables)
+        {
+            try
+            {
+                var parquetGlob = Path.Combine(_archivePath, $"*_{table}.parquet");
+                var hasParquetFiles = Directory.Exists(_archivePath)
+                    && Directory.GetFiles(_archivePath, $"*_{table}.parquet").Length > 0;
+
+                string viewSql;
+                if (hasParquetFiles)
+                {
+                    var globPath = parquetGlob.Replace("\\", "/");
+                    viewSql = $"CREATE OR REPLACE VIEW v_{table} AS SELECT * FROM {table} UNION ALL SELECT * FROM read_parquet('{globPath}', union_by_name=true)";
+                }
+                else
+                {
+                    viewSql = $"CREATE OR REPLACE VIEW v_{table} AS SELECT * FROM {table}";
+                }
+
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = viewSql;
+                await cmd.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                /* Schema mismatch between hot table and old parquet — fall back to table-only view */
+                _logger?.LogWarning(ex, "Failed to create archive view for {Table}, using table-only view", table);
+                try
+                {
+                    using var fallbackCmd = connection.CreateCommand();
+                    fallbackCmd.CommandText = $"CREATE OR REPLACE VIEW v_{table} AS SELECT * FROM {table}";
+                    await fallbackCmd.ExecuteNonQueryAsync();
+                }
+                catch (Exception fallbackEx)
+                {
+                    _logger?.LogError(fallbackEx, "Failed to create fallback view for {Table}", table);
+                }
+            }
+        }
+
+        _logger?.LogDebug("Archive views created/refreshed for {Count} tables", ArchivableTables.Length);
+    }
+
+    /// <summary>
     /// Runs a manual WAL checkpoint. Call this between collection cycles
     /// to flush the WAL during idle time instead of during collector writes.
     /// </summary>
@@ -468,6 +534,129 @@ public class DuckDbInitializer
 
         var fileInfo = new FileInfo(_databasePath);
         return fileInfo.Length / (1024.0 * 1024.0);
+    }
+
+    /// <summary>
+    /// Compacts the database by exporting all tables to a fresh file and swapping.
+    /// DuckDB VACUUM does not reclaim space from append-fragmented files — only
+    /// export/reimport eliminates bloat. Typically takes 2-5 seconds for a 300MB database.
+    /// </summary>
+    /// <returns>True if compaction was performed, false if skipped or failed.</returns>
+    public async Task<bool> CompactAsync()
+    {
+        if (!DatabaseExists())
+        {
+            return false;
+        }
+
+        var sizeBefore = GetDatabaseSizeMb();
+        var tempPath = _databasePath + ".compact";
+        var backupPath = _databasePath + ".precompact";
+
+        _logger?.LogInformation("Starting database compaction ({SizeMb:F0} MB)", sizeBefore);
+
+        try
+        {
+            /* Export all data to a fresh database via ATTACH + CREATE TABLE AS */
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+
+            using (var connection = CreateConnection())
+            {
+                await connection.OpenAsync();
+
+                /* Checkpoint first to flush WAL */
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "CHECKPOINT";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                /* Attach the new database and copy all tables */
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = $"ATTACH '{tempPath.Replace("\\", "/")}' AS compact_db";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                /* Get all table names (exclude views) */
+                var tableNames = new List<string>();
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' AND table_type = 'BASE TABLE'";
+                    using var reader = await cmd.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                        tableNames.Add(reader.GetString(0));
+                    }
+                }
+
+                foreach (var table in tableNames)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = $"CREATE TABLE compact_db.{table} AS SELECT * FROM main.{table}";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "DETACH compact_db";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+
+            /* Swap files: old → backup, compact → primary */
+            if (File.Exists(backupPath)) File.Delete(backupPath);
+            File.Move(_databasePath, backupPath);
+
+            var walPath = _databasePath + ".wal";
+            if (File.Exists(walPath)) File.Delete(walPath);
+
+            File.Move(tempPath, _databasePath);
+
+            /* Recreate indexes and views on the fresh database */
+            using (var connection = CreateConnection())
+            {
+                await connection.OpenAsync();
+
+                foreach (var indexStatement in Schema.GetAllIndexStatements())
+                {
+                    try
+                    {
+                        using var cmd = connection.CreateCommand();
+                        cmd.CommandText = indexStatement;
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                    catch { /* Index may already exist from CREATE TABLE AS */ }
+                }
+            }
+
+            await CreateArchiveViewsAsync();
+
+            /* Clean up backup */
+            File.Delete(backupPath);
+
+            var sizeAfter = GetDatabaseSizeMb();
+            _logger?.LogInformation("Compaction complete: {Before:F0} MB -> {After:F0} MB ({Saved:F0} MB reclaimed)",
+                sizeBefore, sizeAfter, sizeBefore - sizeAfter);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Database compaction failed");
+
+            /* Restore from backup if the primary file was moved */
+            if (!File.Exists(_databasePath) && File.Exists(backupPath))
+            {
+                File.Move(backupPath, _databasePath);
+                _logger?.LogInformation("Restored database from pre-compaction backup");
+            }
+
+            /* Clean up temp file */
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+
+            return false;
+        }
     }
 
 }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -105,7 +105,7 @@ public partial class MainWindow : Window
             var archiveService = new ArchiveService(_databaseInitializer, App.ArchiveDirectory);
             var retentionService = new RetentionService(App.ArchiveDirectory);
 
-            _backgroundService = new CollectionBackgroundService(_collectorService, archiveService, retentionService, _serverManager);
+            _backgroundService = new CollectionBackgroundService(_collectorService, _databaseInitializer, archiveService, retentionService, _serverManager);
 
             // Start background collection
             _backgroundCts = new CancellationTokenSource();

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -128,6 +128,9 @@ COPY (
                 _logger?.LogError(ex, "Failed to archive table {Table}", table);
             }
         }
+
+        /* Refresh archive views so newly archived parquet files are queryable */
+        await _duckDb.CreateArchiveViewsAsync();
         }
         finally
         {

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -78,7 +78,7 @@ SELECT
     victim_process_id,
     victim_sql_text,
     deadlock_graph_xml
-FROM deadlocks
+FROM v_deadlocks
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -139,7 +139,7 @@ SELECT
     query_plan,
     live_query_plan,
     collection_time
-FROM query_snapshots
+FROM v_query_snapshots
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -230,7 +230,7 @@ SELECT
     blocking_last_batch_completed,
     blocked_priority,
     blocking_priority
-FROM blocked_process_reports
+FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -310,7 +310,7 @@ FROM (
     SELECT
         DATE_TRUNC('minute', event_time) AS bucket,
         COUNT(*) AS incident_count
-    FROM blocked_process_reports
+    FROM v_blocked_process_reports
     WHERE server_id = $1
     AND   event_time >= $2
     AND   event_time <= $3
@@ -353,7 +353,7 @@ FROM (
     SELECT
         DATE_TRUNC('hour', deadlock_time) AS bucket,
         COUNT(*) AS deadlock_count
-    FROM deadlocks
+    FROM v_deadlocks
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3

--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -34,7 +34,7 @@ SELECT
     MAX(CASE WHEN status IN ('ERROR', 'PERMISSIONS') THEN error_message END) AS last_error,
     MAX(CASE WHEN status IN ('ERROR', 'PERMISSIONS') THEN collection_time END) AS last_error_time,
     SUM(CASE WHEN status = 'PERMISSIONS' THEN 1 ELSE 0 END) AS permission_denied_count
-FROM collection_log
+FROM v_collection_log
 WHERE server_id = $1
 AND   collection_time >= $2
 GROUP BY collector_name
@@ -83,7 +83,7 @@ SELECT
     status,
     error_message,
     server_name
-FROM collection_log
+FROM v_collection_log
 WHERE server_id = $1
 AND   collection_time >= $2
 ORDER BY collection_time DESC

--- a/Lite/Services/LocalDataService.Cpu.cs
+++ b/Lite/Services/LocalDataService.Cpu.cs
@@ -32,7 +32,7 @@ SELECT
     sample_time,
     sqlserver_cpu_utilization,
     other_process_cpu_utilization
-FROM cpu_utilization_stats
+FROM v_cpu_utilization_stats
 WHERE server_id = $1
 AND   sample_time >= $2
 AND   sample_time <= $3

--- a/Lite/Services/LocalDataService.FileIo.cs
+++ b/Lite/Services/LocalDataService.FileIo.cs
@@ -35,9 +35,9 @@ SELECT
     delta_write_bytes,
     delta_stall_read_ms,
     delta_stall_write_ms
-FROM file_io_stats
+FROM v_file_io_stats
 WHERE server_id = $1
-AND   collection_time = (SELECT MAX(collection_time) FROM file_io_stats WHERE server_id = $1)
+AND   collection_time = (SELECT MAX(collection_time) FROM v_file_io_stats WHERE server_id = $1)
 ORDER BY (delta_stall_read_ms + delta_stall_write_ms) DESC";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -81,7 +81,7 @@ SELECT
     database_name,
     CASE WHEN SUM(delta_reads) > 0 THEN SUM(CAST(delta_stall_read_ms AS DOUBLE)) / SUM(delta_reads) ELSE 0 END AS avg_read_latency_ms,
     CASE WHEN SUM(delta_writes) > 0 THEN SUM(CAST(delta_stall_write_ms AS DOUBLE)) / SUM(delta_writes) ELSE 0 END AS avg_write_latency_ms
-FROM file_io_stats
+FROM v_file_io_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -124,7 +124,7 @@ SELECT
     file_name,
     CASE WHEN SUM(delta_reads) > 0 THEN SUM(CAST(delta_stall_read_ms AS DOUBLE)) / SUM(delta_reads) ELSE 0 END AS avg_read_latency_ms,
     CASE WHEN SUM(delta_writes) > 0 THEN SUM(CAST(delta_stall_write_ms AS DOUBLE)) / SUM(delta_writes) ELSE 0 END AS avg_write_latency_ms
-FROM file_io_stats
+FROM v_file_io_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3

--- a/Lite/Services/LocalDataService.Memory.cs
+++ b/Lite/Services/LocalDataService.Memory.cs
@@ -35,7 +35,7 @@ SELECT
     total_server_memory_mb,
     buffer_pool_mb,
     plan_cache_mb
-FROM memory_stats
+FROM v_memory_stats
 WHERE server_id = $1
 ORDER BY collection_time DESC
 LIMIT 1";
@@ -81,7 +81,7 @@ SELECT
     target_server_memory_mb,
     buffer_pool_mb,
     plan_cache_mb
-FROM memory_stats
+FROM v_memory_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -117,9 +117,9 @@ ORDER BY collection_time";
         using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT clerk_type, memory_mb
-FROM memory_clerks
+FROM v_memory_clerks
 WHERE server_id = $1
-AND   collection_time = (SELECT MAX(collection_time) FROM memory_clerks WHERE server_id = $1)
+AND   collection_time = (SELECT MAX(collection_time) FROM v_memory_clerks WHERE server_id = $1)
 ORDER BY memory_mb DESC";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -34,7 +34,7 @@ public partial class LocalDataService
         {
             cmd.CommandText = @"
 SELECT sqlserver_cpu_utilization, sample_time
-FROM cpu_utilization_stats
+FROM v_cpu_utilization_stats
 WHERE server_id = $1
 ORDER BY sample_time DESC
 LIMIT 1";
@@ -52,7 +52,7 @@ LIMIT 1";
         {
             cmd.CommandText = @"
 SELECT total_server_memory_mb
-FROM memory_stats
+FROM v_memory_stats
 WHERE server_id = $1
 ORDER BY collection_time DESC
 LIMIT 1";
@@ -69,7 +69,7 @@ LIMIT 1";
         {
             cmd.CommandText = @"
 SELECT COUNT(*)
-FROM blocked_process_reports
+FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   event_time >= $2";
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -83,7 +83,7 @@ AND   event_time >= $2";
         {
             cmd.CommandText = @"
 SELECT COUNT(*)
-FROM deadlocks
+FROM v_deadlocks
 WHERE server_id = $1
 AND   deadlock_time >= $2";
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -97,7 +97,7 @@ AND   deadlock_time >= $2";
         {
             cmd.CommandText = @"
 SELECT MAX(collection_time)
-FROM collection_log
+FROM v_collection_log
 WHERE server_id = $1";
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
             var result = await cmd.ExecuteScalarAsync();

--- a/Lite/Services/LocalDataService.Perfmon.cs
+++ b/Lite/Services/LocalDataService.Perfmon.cs
@@ -28,9 +28,9 @@ SELECT
     instance_name,
     cntr_value,
     delta_cntr_value
-FROM perfmon_stats
+FROM v_perfmon_stats
 WHERE server_id = $1
-AND   collection_time = (SELECT MAX(collection_time) FROM perfmon_stats WHERE server_id = $1)
+AND   collection_time = (SELECT MAX(collection_time) FROM v_perfmon_stats WHERE server_id = $1)
 ORDER BY counter_name";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -63,7 +63,7 @@ ORDER BY counter_name";
 
         command.CommandText = @"
 SELECT DISTINCT counter_name
-FROM perfmon_stats
+FROM v_perfmon_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -97,7 +97,7 @@ SELECT
     collection_time,
     cntr_value,
     delta_cntr_value
-FROM perfmon_stats
+FROM v_perfmon_stats
 WHERE server_id = $1
 AND   counter_name = $2
 AND   collection_time >= $3

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -66,7 +66,7 @@ SELECT
     MAX(plan_handle) AS plan_handle,
     MAX(query_text) AS query_text,
     MAX(query_plan_xml) AS query_plan
-FROM query_stats
+FROM v_query_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -139,7 +139,7 @@ SELECT
     max_elapsed_time,
     query_plan_xml,
     query_plan_hash
-FROM query_stats
+FROM v_query_stats
 WHERE server_id = $1
 AND   database_name = $2
 AND   query_hash = $3
@@ -196,7 +196,7 @@ SELECT
     delta_logical_reads,
     delta_logical_writes,
     delta_physical_reads
-FROM procedure_stats
+FROM v_procedure_stats
 WHERE server_id = $1
 AND   database_name = $2
 AND   schema_name = $3
@@ -330,7 +330,7 @@ SELECT
     SUM(total_spills) AS total_spills,
     MAX(sql_handle) AS sql_handle,
     MAX(plan_handle) AS plan_handle
-FROM procedure_stats
+FROM v_procedure_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -389,7 +389,7 @@ WITH raw AS
         SUM(delta_elapsed_time) / 1000.0 AS total_elapsed_ms,
         SUM(delta_execution_count) AS total_executions,
         date_diff('second', LAG(collection_time) OVER (ORDER BY collection_time), collection_time) AS interval_seconds
-    FROM query_stats
+    FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -438,7 +438,7 @@ WITH raw AS
         SUM(delta_elapsed_time) / 1000.0 AS total_elapsed_ms,
         SUM(delta_execution_count) AS total_executions,
         date_diff('second', LAG(collection_time) OVER (ORDER BY collection_time), collection_time) AS interval_seconds
-    FROM procedure_stats
+    FROM v_procedure_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -486,7 +486,7 @@ WITH raw AS
         collection_time,
         SUM(delta_execution_count) AS total_executions,
         date_diff('second', LAG(collection_time) OVER (ORDER BY collection_time), collection_time) AS interval_seconds
-    FROM query_stats
+    FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -44,7 +44,7 @@ SELECT
     AVG(avg_rowcount) AS avg_rowcount,
     MAX(last_execution_time) AS last_execution_time,
     MAX(query_plan_hash) AS query_plan_hash
-FROM query_store_stats
+FROM v_query_store_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -102,7 +102,7 @@ SELECT
     avg_physical_reads,
     avg_rowcount,
     last_execution_time
-FROM query_store_stats
+FROM v_query_store_stats
 WHERE server_id = $1
 AND   database_name = $2
 AND   query_id = $3
@@ -146,7 +146,7 @@ ORDER BY collection_time";
         using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT DISTINCT database_name
-FROM query_store_stats
+FROM v_query_store_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 ORDER BY database_name";
@@ -221,7 +221,7 @@ WITH raw AS
         SUM(execution_count * avg_duration_ms) AS total_duration_ms,
         SUM(execution_count) AS total_executions,
         date_diff('second', LAG(collection_time) OVER (ORDER BY collection_time), collection_time) AS interval_seconds
-    FROM query_store_stats
+    FROM v_query_store_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3

--- a/Lite/Services/LocalDataService.TempDb.cs
+++ b/Lite/Services/LocalDataService.TempDb.cs
@@ -36,7 +36,7 @@ SELECT
     total_sessions_using_tempdb,
     top_session_id,
     top_session_tempdb_mb
-FROM tempdb_stats
+FROM v_tempdb_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -84,7 +84,7 @@ SELECT
     version_store_reserved_mb,
     top_session_tempdb_mb,
     top_session_id
-FROM tempdb_stats
+FROM v_tempdb_stats
 WHERE server_id = $1
 ORDER BY collection_time DESC
 LIMIT 1";


### PR DESCRIPTION
## Summary
- Display queries now read from `v_` views that UNION hot DuckDB tables with archived parquet files via `read_parquet()` glob scans — users can see the full 90-day retention window instead of only the 7-day hot data window (#160)
- Views created at startup and refreshed after each archive cycle; falls back to table-only view if parquet schema doesn't match
- Daily database compaction prevents file bloat from DuckDB's append-only storage — exports all tables to a fresh database via `ATTACH`/`CREATE TABLE AS`, swaps files, recreates indexes and views (#161)
- 1GB size watchdog logs warnings between compaction cycles

Closes #160, closes #161

## Files changed
- `DuckDbInitializer.cs` — `CreateArchiveViewsAsync()`, `CompactAsync()`, archive path + table list
- `CollectionBackgroundService.cs` — daily compaction timer, size watchdog
- `ArchiveService.cs` — refresh views after archival
- `MainWindow.xaml.cs` — pass DuckDbInitializer to background service
- 11 `LocalDataService.*.cs` files — query `v_` views instead of raw tables

## Test plan
- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [x] All 14 `v_` views created successfully
- [x] Archive round-trip: export 73 rows to parquet, delete from hot table, view still returns all 73 rows
- [x] Compaction: 19.3 MB → 5.3 MB (73% reduction), all 1,055 rows across 25 tables preserved
- [x] View fallback: table-only view created when no parquet files exist
- [ ] Launch Lite, verify all tabs populate correctly with views
- [ ] Run for 1+ hour to verify archive cycle refreshes views

🤖 Generated with [Claude Code](https://claude.com/claude-code)