### PR TITLE
Raise wait stats cap so poison waits are never dropped

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -112,7 +112,7 @@
                         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="5,2">
                             <Button Content="Top Waits" Click="WaitTypes_SelectAll_Click" Padding="6,2" FontSize="10" Margin="0,0,5,0"/>
                             <Button Content="Clear All" Click="WaitTypes_ClearAll_Click" Padding="6,2" FontSize="10"/>
-                            <TextBlock x:Name="WaitTypeCountText" Text="0 / 20 selected" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                            <TextBlock x:Name="WaitTypeCountText" Text="0 / 30 selected" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
                         </StackPanel>
                         <TextBox Grid.Row="2" x:Name="WaitTypeSearchBox" Margin="5,2" Height="24" FontSize="11"
                                  TextChanged="WaitTypeSearch_TextChanged"

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -1923,8 +1923,8 @@ namespace PerformanceMonitorDashboard.Controls
         {
             if (_waitTypeItems == null || WaitTypeCountText == null) return;
             int count = _waitTypeItems.Count(x => x.IsSelected);
-            WaitTypeCountText.Text = $"{count} / 20 selected";
-            WaitTypeCountText.Foreground = count >= 20
+            WaitTypeCountText.Text = $"{count} / 30 selected";
+            WaitTypeCountText.Foreground = count >= 30
                 ? new System.Windows.Media.SolidColorBrush((System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString("#E57373")!)
                 : (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush");
         }

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -87,7 +87,7 @@ namespace PerformanceMonitorDashboard.Helpers
 
         /// <summary>
         /// Returns the set of wait types that should be selected by default:
-        /// poison waits + usual suspects + top 10 by total wait time (deduped), capped at 20.
+        /// poison waits + usual suspects + top 10 by total wait time (deduped), capped at 30.
         /// The availableWaitTypes list must be sorted by total wait time descending.
         /// </summary>
         public static HashSet<string> GetDefaultWaitTypes(IList<string> availableWaitTypes)
@@ -108,11 +108,11 @@ namespace PerformanceMonitorDashboard.Helpers
                     if (w.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                         defaults.Add(w);
 
-            // 4. Top 10 by total wait time (items not already in the set), hard cap at 20 total
+            // 4. Top 10 by total wait time (items not already in the set), hard cap at 30 total
             int added = 0;
             foreach (var w in availableWaitTypes)
             {
-                if (defaults.Count >= 20) break;
+                if (defaults.Count >= 30) break;
                 if (added >= 10) break;
                 if (defaults.Add(w))
                 {

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -127,7 +127,7 @@
                             <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,4">
                                 <Button Content="Top Waits" Click="WaitTypeSelectAll_Click" Padding="6,2" Margin="0,0,4,0" FontSize="11"/>
                                 <Button Content="Clear All" Click="WaitTypeClearAll_Click" Padding="6,2" FontSize="11"/>
-                                <TextBlock x:Name="WaitTypeCountText" Text="0 / 20 selected" FontSize="10" Foreground="{StaticResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                <TextBlock x:Name="WaitTypeCountText" Text="0 / 30 selected" FontSize="10" Foreground="{StaticResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
                             </StackPanel>
                             <TextBox Grid.Row="2" x:Name="WaitTypeSearchBox" TextChanged="WaitTypeSearch_TextChanged"
                                      Margin="0,0,0,4" Padding="4,2"/>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -1119,7 +1119,7 @@ public partial class ServerTab : UserControl
         int added = 0;
         foreach (var w in availableWaitTypes)
         {
-            if (defaults.Count >= 20) break;
+            if (defaults.Count >= 30) break;
             if (added >= 10) break;
             if (defaults.Add(w)) { added++; }
         }
@@ -1156,8 +1156,8 @@ public partial class ServerTab : UserControl
     {
         if (_waitTypeItems == null || WaitTypeCountText == null) return;
         int count = _waitTypeItems.Count(x => x.IsSelected);
-        WaitTypeCountText.Text = $"{count} / 20 selected";
-        WaitTypeCountText.Foreground = count >= 20
+        WaitTypeCountText.Text = $"{count} / 30 selected";
+        WaitTypeCountText.Foreground = count >= 30
             ? new SolidColorBrush((System.Windows.Media.Color)ColorConverter.ConvertFromString("#E57373")!)
             : (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush");
     }

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -144,7 +144,7 @@ WITH
     WHERE ws.collection_time >= DATEADD(HOUR, -1, SYSDATETIME())
     AND   ws.wait_time_ms_delta > 0
 )
-SELECT TOP (20)
+SELECT TOP (50)
     wait_type = rw.wait_type,
     wait_time_ms = rw.wait_time_ms_delta,
     wait_time_sec = rw.wait_time_ms_delta / 1000.0,


### PR DESCRIPTION
## Summary
- SQL view `report.top_waits_last_hour`: `TOP (20)` → `TOP (50)` so low-volume poison waits (THREADPOOL, RESOURCE_SEMAPHORE) always reach the client
- UI default selection cap raised from 20 to 30 in both Dashboard and Lite, giving room for poison waits + usual suspects + top 10 without squeezing
- Lite `LIMIT 50` in `GetWaitStatsAsync` was already sufficient, no change needed

Closes #139

## Test plan
- [ ] Dashboard: verify wait type picker shows "X / 30 selected" and can select up to 30
- [ ] Lite: same verification
- [ ] Deploy updated view to a test server, confirm poison waits appear even when low-volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)