### PR TITLE
Show Trends tab first in Locking section

### DIFF
--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -701,6 +701,84 @@
                     </StackPanel>
                 </TabItem.Header>
                 <TabControl>
+                    <!-- Blocking/Deadlock Stats Sub-Tab (default tab) -->
+                    <TabItem Header="Blocking/Deadlock Trends">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- Lock Wait Stats Chart - Full Width -->
+                            <Border Grid.Row="0" BorderBrush="LightGray" BorderThickness="1" Margin="5,5,5,2">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Text="Lock Wait Stats (LCK%)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                    <ScottPlot:WpfPlot Grid.Row="1" x:Name="LockWaitStatsChart"/>
+                                </Grid>
+                            </Border>
+
+                            <!-- Trend Charts - 2x2 Grid -->
+                            <Grid Grid.Row="1" Margin="5,2,5,5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <Border Grid.Row="0" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Margin="2">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="Blocking Events" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsBlockingEventsChart"/>
+                                    </Grid>
+                                </Border>
+
+                                <Border Grid.Row="0" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="2">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="Blocking Duration (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDurationChart"/>
+                                    </Grid>
+                                </Border>
+
+                                <Border Grid.Row="1" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Margin="2">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="Deadlock Count" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlocksChart"/>
+                                    </Grid>
+                                </Border>
+
+                                <Border Grid.Row="1" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="2">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Text="Deadlock Wait Time (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlockWaitTimeChart"/>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </Grid>
+                    </TabItem>
+
                     <!-- Blocking Sub-Tab -->
                     <TabItem Header="Blocking">
                         <Grid>
@@ -1085,83 +1163,6 @@
                         </Grid>
                     </TabItem>
 
-                    <!-- Blocking/Deadlock Stats Sub-Tab -->
-                    <TabItem Header="Blocking/Deadlock Trends">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-
-                            <!-- Lock Wait Stats Chart - Full Width -->
-                            <Border Grid.Row="0" BorderBrush="LightGray" BorderThickness="1" Margin="5,5,5,2">
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="*"/>
-                                    </Grid.RowDefinitions>
-                                    <TextBlock Grid.Row="0" Text="Lock Wait Stats (LCK%)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
-                                    <ScottPlot:WpfPlot Grid.Row="1" x:Name="LockWaitStatsChart"/>
-                                </Grid>
-                            </Border>
-
-                            <!-- Trend Charts - 2x2 Grid -->
-                            <Grid Grid.Row="1" Margin="5,2,5,5">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="*"/>
-                                    <RowDefinition Height="*"/>
-                                </Grid.RowDefinitions>
-
-                                <Border Grid.Row="0" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Margin="2">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Blocking Events" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
-                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsBlockingEventsChart"/>
-                                    </Grid>
-                                </Border>
-
-                                <Border Grid.Row="0" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="2">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Blocking Duration (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
-                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDurationChart"/>
-                                    </Grid>
-                                </Border>
-
-                                <Border Grid.Row="1" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Margin="2">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Deadlock Count" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
-                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlocksChart"/>
-                                    </Grid>
-                                </Border>
-
-                                <Border Grid.Row="1" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Margin="2">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Text="Deadlock Wait Time (ms)" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
-                                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="BlockingStatsDeadlockWaitTimeChart"/>
-                                    </Grid>
-                                </Border>
-                            </Grid>
-                        </Grid>
-                    </TabItem>
                 </TabControl>
             </TabItem>
 


### PR DESCRIPTION
## Summary
- Moved the Blocking/Deadlock Trends sub-tab to first position in the Locking section so it's the default view

Closes #171

## Test plan
- [ ] Open Dashboard, navigate to Locking — Trends tab should be shown first

🤖 Generated with [Claude Code](https://claude.com/claude-code)