### PR TITLE
Fix NOC deadlock severity dot showing green during active deadlocks

### DIFF
--- a/Dashboard/Models/ServerHealthStatus.cs
+++ b/Dashboard/Models/ServerHealthStatus.cs
@@ -433,6 +433,8 @@ namespace PerformanceMonitorDashboard.Models
             get
             {
                 if (DeadlocksSinceLastCheck > 0) return HealthSeverity.Critical;
+                if (_lastDeadlockMinutesAgo.HasValue && _lastDeadlockMinutesAgo.Value <= 10) return HealthSeverity.Critical;
+                if (_lastDeadlockMinutesAgo.HasValue && _lastDeadlockMinutesAgo.Value <= 60) return HealthSeverity.Warning;
                 return HealthSeverity.Healthy;
             }
         }
@@ -447,6 +449,7 @@ namespace PerformanceMonitorDashboard.Models
                 _lastDeadlockMinutesAgo = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(DeadlockDetailText));
+                OnPropertyChanged(nameof(DeadlockSeverity));
             }
         }
 


### PR DESCRIPTION
## Summary
- `DeadlockSeverity` now checks `LastDeadlockMinutesAgo` (from extended events) in addition to the perfmon counter delta
- Deadlock within 10 min = Critical (red), within 60 min = Warning (yellow), older = Healthy (green)
- Added missing `OnPropertyChanged(nameof(DeadlockSeverity))` in the `LastDeadlockMinutesAgo` setter so the dot updates when the XE timestamp arrives

Closes #170

## Test plan
- [ ] Generate a deadlock on sql2022, verify NOC shows red dot within 10 min
- [ ] Wait >10 min, verify dot transitions to yellow
- [ ] Wait >60 min, verify dot transitions to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)