### PR TITLE
Fix squished drill-down charts (#166)

### DIFF
--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -14,8 +14,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="250"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="2*" MinHeight="250"/>
+            <RowDefinition Height="3*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -14,8 +14,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="250"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="2*" MinHeight="250"/>
+            <RowDefinition Height="3*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -14,8 +14,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="250"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="2*" MinHeight="250"/>
+            <RowDefinition Height="3*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 


### PR DESCRIPTION
## Summary
- Charts in all 3 drill-down windows (Query Execution History, Query Stats History, Procedure History) were fixed at 250px height
- Changed to proportional layout: 2* for chart, 3* for grid, with MinHeight=250 on the chart row
- Charts now scale with window size — ~40% chart / ~60% grid

## Test plan
- [ ] Open a query drill-down, verify chart is readable
- [ ] Resize the window, verify chart and grid scale proportionally
- [ ] Test at minimum size, verify chart maintains 250px minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)