### PR TITLE
Add 7-day time filter to drill-down queries (#165)

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -1486,6 +1486,7 @@ namespace PerformanceMonitorDashboard.Services
         FROM collect.query_store_data AS qsd
         WHERE qsd.database_name = @database_name
         AND   qsd.query_id = @query_id
+        AND   qsd.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
         ORDER BY
             qsd.collection_time DESC;";
 
@@ -1591,6 +1592,7 @@ namespace PerformanceMonitorDashboard.Services
         FROM collect.procedure_stats AS ps
         WHERE ps.database_name = @database_name
         AND   ps.object_id = @object_id
+        AND   ps.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
         ORDER BY
             ps.collection_time DESC;";
 
@@ -1704,6 +1706,7 @@ namespace PerformanceMonitorDashboard.Services
         FROM collect.query_stats AS qs
         WHERE qs.database_name = @database_name
         AND   qs.query_hash = CONVERT(binary(8), @query_hash, 1)
+        AND   qs.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
         ORDER BY
             qs.collection_time DESC;";
 


### PR DESCRIPTION
## Summary
- All three drill-down windows fetched ALL historical data with no time limit
- Busiest queries had 3776 rows, each carrying ~10KB plan XML (~37MB transfer)
- Added `collection_time >= DATEADD(DAY, -7, SYSDATETIME())` to all three queries
- Reduces result sets to ~672 rows max (~7MB), making drill-down windows responsive

## Test plan
- [ ] Double-click a query in Query Store tab, verify drill-down loads quickly
- [ ] Double-click a procedure in Procedure Stats tab, verify drill-down loads quickly
- [ ] Double-click a query in Query Stats tab, verify drill-down loads quickly
- [ ] Verify chart and grid populate with 7 days of data

🤖 Generated with [Claude Code](https://claude.com/claude-code)