### PR TITLE
Add current configuration view to Dashboard Overview

### DIFF
--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -1,0 +1,117 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.CurrentConfigContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800"
+             Loaded="OnLoaded">
+    <TabControl>
+        <!-- Current Server Configuration Sub-Tab -->
+        <TabItem Header="Server Configuration">
+            <Grid>
+            <DataGrid x:Name="ServerConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="220">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Setting" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="210" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ConfigurationName"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ValueConfigured}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Configured" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="90" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ValueConfigured"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ValueInUse}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="In Use" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="90" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ValueInUse"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ValueMinimum}" Width="80" Header="Minimum"/>
+                    <DataGridTextColumn Binding="{Binding ValueMaximum}" Width="80" Header="Maximum"/>
+                    <DataGridCheckBoxColumn Binding="{Binding IsDynamic}" Width="65" Header="Dynamic"/>
+                    <DataGridCheckBoxColumn Binding="{Binding IsAdvanced}" Width="70" Header="Advanced"/>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
+                    <DataGridTextColumn Binding="{Binding Description}" Width="*" MinWidth="200" Header="Description"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock x:Name="ServerConfigNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            </Grid>
+        </TabItem>
+
+        <!-- Current Database Configuration Sub-Tab -->
+        <TabItem Header="Database Configuration">
+            <Grid>
+            <DataGrid x:Name="DatabaseConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Database" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="140" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="DatabaseName"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding SettingType}" Width="160">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Setting Type" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="150" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingType"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding SettingName}" Width="220">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Setting Name" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="210" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingName"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding SettingValue}" Width="200">
+                        <DataGridTextColumn.Header>
+                            <StackPanel>
+                                <TextBlock Text="Value" FontWeight="Bold" Margin="0,0,0,2"/>
+                                <TextBox Width="190" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingValue"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock x:Name="DatabaseConfigNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            </Grid>
+        </TabItem>
+
+        <!-- Current Trace Flags Sub-Tab -->
+        <TabItem Header="Trace Flags">
+            <Grid>
+            <DataGrid x:Name="TraceFlagsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100" Header="Trace Flag"/>
+                    <DataGridCheckBoxColumn Binding="{Binding Status}" Width="70" Header="Enabled"/>
+                    <DataGridCheckBoxColumn Binding="{Binding IsGlobal}" Width="70" Header="Global"/>
+                    <DataGridCheckBoxColumn Binding="{Binding IsSession}" Width="70" Header="Session"/>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <TextBlock x:Name="TraceFlagsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            </Grid>
+        </TabItem>
+    </TabControl>
+</UserControl>

--- a/Dashboard/Controls/CurrentConfigContent.xaml.cs
+++ b/Dashboard/Controls/CurrentConfigContent.xaml.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Services;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    public partial class CurrentConfigContent : UserControl
+    {
+        private DatabaseService? _databaseService;
+
+        public CurrentConfigContent()
+        {
+            InitializeComponent();
+        }
+
+        public void Initialize(DatabaseService databaseService)
+        {
+            _databaseService = databaseService;
+        }
+
+        public async Task RefreshAllDataAsync()
+        {
+            if (_databaseService == null) return;
+
+            await Task.WhenAll(
+                RefreshServerConfigAsync(),
+                RefreshDatabaseConfigAsync(),
+                RefreshTraceFlagsAsync()
+            );
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            TabHelpers.AutoSizeColumnMinWidths(ServerConfigDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(DatabaseConfigDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(TraceFlagsDataGrid);
+            TabHelpers.FreezeColumns(ServerConfigDataGrid, 1);
+            TabHelpers.FreezeColumns(DatabaseConfigDataGrid, 1);
+        }
+
+        #region Server Configuration
+
+        private async Task RefreshServerConfigAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var data = await _databaseService.GetCurrentServerConfigAsync();
+                ServerConfigDataGrid.ItemsSource = data;
+                ServerConfigNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading server configuration: {ex.Message}");
+            }
+        }
+
+        private void ServerConfigFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            DataGridFilterService.ApplyFilter(ServerConfigDataGrid, sender as TextBox);
+        }
+
+        #endregion
+
+        #region Database Configuration
+
+        private async Task RefreshDatabaseConfigAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var data = await _databaseService.GetCurrentDatabaseConfigAsync();
+                DatabaseConfigDataGrid.ItemsSource = data;
+                DatabaseConfigNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading database configuration: {ex.Message}");
+            }
+        }
+
+        private void DatabaseConfigFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            DataGridFilterService.ApplyFilter(DatabaseConfigDataGrid, sender as TextBox);
+        }
+
+        #endregion
+
+        #region Trace Flags
+
+        private async Task RefreshTraceFlagsAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var data = await _databaseService.GetCurrentTraceFlagsAsync();
+                TraceFlagsDataGrid.ItemsSource = data;
+                TraceFlagsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading trace flags: {ex.Message}");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Dashboard/Models/CurrentServerConfigItem.cs
+++ b/Dashboard/Models/CurrentServerConfigItem.cs
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class CurrentServerConfigItem
+    {
+        public string ConfigurationName { get; set; } = string.Empty;
+        public string ValueConfigured { get; set; } = string.Empty;
+        public string ValueInUse { get; set; } = string.Empty;
+        public string ValueMinimum { get; set; } = string.Empty;
+        public string ValueMaximum { get; set; } = string.Empty;
+        public bool IsDynamic { get; set; }
+        public bool IsAdvanced { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public DateTime LastChanged { get; set; }
+    }
+
+    public class CurrentDatabaseConfigItem
+    {
+        public string DatabaseName { get; set; } = string.Empty;
+        public string SettingType { get; set; } = string.Empty;
+        public string SettingName { get; set; } = string.Empty;
+        public string SettingValue { get; set; } = string.Empty;
+        public DateTime LastChanged { get; set; }
+    }
+
+    public class CurrentTraceFlagItem
+    {
+        public int TraceFlag { get; set; }
+        public bool Status { get; set; }
+        public bool IsGlobal { get; set; }
+        public bool IsSession { get; set; }
+        public DateTime LastChanged { get; set; }
+    }
+}

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -229,6 +229,11 @@
                         <controls:DefaultTraceContent x:Name="DefaultTraceTab" />
                     </TabItem>
 
+                    <!-- Current Configuration Sub-Tab -->
+                    <TabItem Header="Current Configuration">
+                        <controls:CurrentConfigContent x:Name="CurrentConfigTab" />
+                    </TabItem>
+
                     <!-- Server Configuration Changes Sub-Tab -->
                     <TabItem Header="Server Config Changes">
                         <Grid>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -115,6 +115,7 @@ namespace PerformanceMonitorDashboard
             DailySummaryTab.Initialize(_databaseService);
             CriticalIssuesTab.Initialize(_databaseService);
             DefaultTraceTab.Initialize(_databaseService);
+            CurrentConfigTab.Initialize(_databaseService);
             MemoryTab.Initialize(_databaseService);
             PerformanceTab.Initialize(_databaseService, s => StatusText.Text = s);
             SystemEventsContent.Initialize(_databaseService);
@@ -1169,6 +1170,7 @@ namespace PerformanceMonitorDashboard
                         CollectionHealth_Refresh_Click(null, new RoutedEventArgs());
                         await CriticalIssuesTab.RefreshDataAsync();
                         await DefaultTraceTab.RefreshAllDataAsync();
+                        await CurrentConfigTab.RefreshAllDataAsync();
                         await RefreshResourceOverviewAsync();
                         break;
 
@@ -1278,13 +1280,14 @@ namespace PerformanceMonitorDashboard
                 var dailySummaryTask = DailySummaryTab.RefreshDataAsync();
                 var criticalIssuesTask = CriticalIssuesTab.RefreshDataAsync();
                 var defaultTraceTask = DefaultTraceTab.RefreshAllDataAsync();
+                var currentConfigTask = CurrentConfigTab.RefreshAllDataAsync();
                 var systemEventsTask = SystemEventsContent.RefreshAllDataAsync();
 
                 // Wait for everything to complete before _isRefreshing resets
                 await Task.WhenAll(
                     healthTask, blockingEventsTask, deadlocksTask, blockingStatsTask, lockWaitStatsTask,
                     performanceTask, memoryTask, resourceOverviewTask, runningJobsTask,
-                    resourceMetricsTask, dailySummaryTask, criticalIssuesTask, defaultTraceTask, systemEventsTask);
+                    resourceMetricsTask, dailySummaryTask, criticalIssuesTask, defaultTraceTask, currentConfigTask, systemEventsTask);
 
                 // Populate grids with fetched data
                 var healthData = await healthTask;


### PR DESCRIPTION
## Summary
- Adds a "Current Configuration" tab to the Overview section showing latest server settings, database settings, and trace flags
- Uses `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY collection_time DESC)` to derive current state from the change history tables
- Three sub-tabs with inline column filters for quick searching

Closes #143

## Test plan
- [ ] Verify "Current Configuration" tab appears in Overview after Default Trace
- [ ] Server Configuration sub-tab shows all `sys.configurations` settings with latest values
- [ ] Database Configuration sub-tab shows database-level settings grouped by type
- [ ] Trace Flags sub-tab shows enabled/disabled trace flags
- [ ] Inline column filters work on all filterable columns
- [ ] Empty state message appears when no data is available

Generated with [Claude Code](https://claude.com/claude-code)