### PR TITLE
Add memory summary cards to Memory Overview

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml
+++ b/Dashboard/Controls/MemoryContent.xaml
@@ -49,18 +49,45 @@
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0" Text="Memory Usage Over Time" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
                     <ScottPlot:WpfPlot Grid.Row="1" x:Name="MemoryStatsOverviewChart"/>
-                    <!-- Summary Panel for percentages and pressure status -->
-                    <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,8">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Text="Buffer Pool:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryStatsBPPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-                            <TextBlock Text="Plan Cache:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryStatsPCPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-                            <TextBlock Text="Utilization:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryStatsUtilPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-                            <TextBlock Text="Pressure:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryStatsPressureText" Text="None" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
-                        </StackPanel>
+                    <!-- Summary Panel with absolute GB values and pressure status -->
+                    <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,6">
+                        <WrapPanel HorizontalAlignment="Center">
+                            <!-- Physical Memory -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="Physical Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsPhysicalText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- SQL Server Memory (committed) -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="SQL Server Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsSqlServerText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Target Memory -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="Target Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsTargetText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Buffer Pool -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="Buffer Pool:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsBPPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Plan Cache -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="Plan Cache:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsPCPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Utilization -->
+                            <StackPanel Orientation="Horizontal" Margin="0,0,24,0">
+                                <TextBlock Text="Utilization:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsUtilPercentText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Pressure -->
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Pressure:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryStatsPressureText" Text="None" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </WrapPanel>
                     </Border>
                 </Grid>
             </Border>

--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -333,6 +333,9 @@ namespace PerformanceMonitorDashboard.Controls
         {
             if (dataList == null || dataList.Count == 0)
             {
+                MemoryStatsPhysicalText.Text = "N/A";
+                MemoryStatsSqlServerText.Text = "N/A";
+                MemoryStatsTargetText.Text = "N/A";
                 MemoryStatsBPPercentText.Text = "N/A";
                 MemoryStatsPCPercentText.Text = "N/A";
                 MemoryStatsUtilPercentText.Text = "N/A";
@@ -344,13 +347,25 @@ namespace PerformanceMonitorDashboard.Controls
             // Use the most recent data point
             var latest = dataList.OrderByDescending(d => d.CollectionTime).First();
 
-            MemoryStatsBPPercentText.Text = latest.BufferPoolPercentage.HasValue
-                ? $"{latest.BufferPoolPercentage:F1}%"
+            // Absolute GB values
+            MemoryStatsPhysicalText.Text = latest.TotalPhysicalMemoryMb.HasValue
+                ? $"{latest.TotalPhysicalMemoryMb.Value / 1024.0m:F1} GB"
                 : "N/A";
 
-            MemoryStatsPCPercentText.Text = latest.PlanCachePercentage.HasValue
-                ? $"{latest.PlanCachePercentage:F1}%"
+            MemoryStatsSqlServerText.Text = $"{latest.PhysicalMemoryInUseMb / 1024.0m:F1} GB";
+
+            MemoryStatsTargetText.Text = latest.CommittedTargetMemoryMb.HasValue
+                ? $"{latest.CommittedTargetMemoryMb.Value / 1024.0m:F1} GB"
                 : "N/A";
+
+            // Buffer Pool and Plan Cache with GB and percentage
+            MemoryStatsBPPercentText.Text = latest.BufferPoolPercentage.HasValue
+                ? $"{latest.BufferPoolMb / 1024.0m:F1} GB ({latest.BufferPoolPercentage:F1}%)"
+                : $"{latest.BufferPoolMb / 1024.0m:F1} GB";
+
+            MemoryStatsPCPercentText.Text = latest.PlanCachePercentage.HasValue
+                ? $"{latest.PlanCacheMb / 1024.0m:F1} GB ({latest.PlanCachePercentage:F1}%)"
+                : $"{latest.PlanCacheMb / 1024.0m:F1} GB";
 
             MemoryStatsUtilPercentText.Text = $"{latest.MemoryUtilizationPercentage}%";
 

--- a/Dashboard/Models/MemoryStatsItem.cs
+++ b/Dashboard/Models/MemoryStatsItem.cs
@@ -18,6 +18,10 @@ namespace PerformanceMonitorDashboard.Models
         public decimal AvailablePhysicalMemoryMb { get; set; }
         public int MemoryUtilizationPercentage { get; set; }
 
+        // Server and target memory
+        public decimal? TotalPhysicalMemoryMb { get; set; }
+        public decimal? CommittedTargetMemoryMb { get; set; }
+
         // Pressure warnings
         public bool BufferPoolPressureWarning { get; set; }
         public bool PlanCachePressureWarning { get; set; }

--- a/Dashboard/Services/DatabaseService.Memory.cs
+++ b/Dashboard/Services/DatabaseService.Memory.cs
@@ -46,7 +46,9 @@ namespace PerformanceMonitorDashboard.Services
             ms.available_physical_memory_mb,
             ms.memory_utilization_percentage,
             ms.buffer_pool_pressure_warning,
-            ms.plan_cache_pressure_warning
+            ms.plan_cache_pressure_warning,
+            ms.total_physical_memory_mb,
+            ms.committed_target_memory_mb
         FROM collect.memory_stats AS ms
         {dateFilter}
         ORDER BY
@@ -80,7 +82,9 @@ namespace PerformanceMonitorDashboard.Services
                             AvailablePhysicalMemoryMb = reader.GetDecimal(7),
                             MemoryUtilizationPercentage = reader.GetInt32(8),
                             BufferPoolPressureWarning = reader.GetBoolean(9),
-                            PlanCachePressureWarning = reader.GetBoolean(10)
+                            PlanCachePressureWarning = reader.GetBoolean(10),
+                            TotalPhysicalMemoryMb = reader.IsDBNull(11) ? null : reader.GetDecimal(11),
+                            CommittedTargetMemoryMb = reader.IsDBNull(12) ? null : reader.GetDecimal(12)
                         });
                     }
         

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -194,6 +194,9 @@ BEGIN
         physical_memory_in_use_mb decimal(19,2) NOT NULL,
         available_physical_memory_mb decimal(19,2) NOT NULL,
         memory_utilization_percentage integer NOT NULL,
+        /*Server and target memory*/
+        total_physical_memory_mb decimal(19,2) NULL,
+        committed_target_memory_mb decimal(19,2) NULL,
         /*Pressure warnings*/
         buffer_pool_pressure_warning bit NOT NULL DEFAULT 0,
         plan_cache_pressure_warning bit NOT NULL DEFAULT 0,
@@ -217,6 +220,19 @@ BEGIN
     );
     
     PRINT 'Created collect.memory_stats table';
+END;
+
+/*Add columns for existing installs*/
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'collect.memory_stats') AND name = N'total_physical_memory_mb')
+BEGIN
+    ALTER TABLE collect.memory_stats ADD total_physical_memory_mb decimal(19,2) NULL;
+    PRINT 'Added total_physical_memory_mb to collect.memory_stats';
+END;
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'collect.memory_stats') AND name = N'committed_target_memory_mb')
+BEGIN
+    ALTER TABLE collect.memory_stats ADD committed_target_memory_mb decimal(19,2) NULL;
+    PRINT 'Added committed_target_memory_mb to collect.memory_stats';
 END;
 
 /*

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -294,6 +294,9 @@ BEGIN
         physical_memory_in_use_mb decimal(19,2) NOT NULL,
         available_physical_memory_mb decimal(19,2) NOT NULL,
         memory_utilization_percentage integer NOT NULL,
+        /*Server and target memory*/
+        total_physical_memory_mb decimal(19,2) NULL,
+        committed_target_memory_mb decimal(19,2) NULL,
         /*Pressure warnings*/
         buffer_pool_pressure_warning bit NOT NULL DEFAULT 0,
         plan_cache_pressure_warning bit NOT NULL DEFAULT 0,
@@ -307,12 +310,12 @@ BEGIN
         (
             plan_cache_mb * 100.0 /
               NULLIF(total_memory_mb, 0)
-        ),        
-        CONSTRAINT 
-            PK_memory_stats 
-        PRIMARY KEY CLUSTERED 
-            (collection_time, collection_id) 
-        WITH 
+        ),
+        CONSTRAINT
+            PK_memory_stats
+        PRIMARY KEY CLUSTERED
+            (collection_time, collection_id)
+        WITH
             (DATA_COMPRESSION = PAGE)
     );
         END;


### PR DESCRIPTION
## Summary
- Adds `total_physical_memory_mb` and `committed_target_memory_mb` columns to `collect.memory_stats` table
- Collector now pulls from `sys.dm_os_sys_info` (committed target) and adds total physical from `sys.dm_os_sys_memory`
- Memory Overview summary panel shows absolute GB values: Physical Memory, SQL Server Memory, Target Memory
- Buffer Pool and Plan Cache now show GB alongside percentage (e.g., "21.4 GB (83.2%)")
- Includes `ALTER TABLE` migration for existing installs (NULLable columns)

Closes #140

## Test plan
- [ ] Re-run install scripts (`02_create_tables.sql`, `06_ensure_collection_table.sql`, `14_collect_memory_stats.sql`) on test server
- [ ] Verify new columns exist in `collect.memory_stats` after install
- [ ] Wait for 1-2 collection cycles and verify `total_physical_memory_mb` and `committed_target_memory_mb` are populated
- [ ] Verify Memory Overview summary panel shows Physical Memory, SQL Server Memory, Target Memory in GB
- [ ] Verify Buffer Pool and Plan Cache show GB values with percentages
- [ ] Verify summary gracefully shows "N/A" for rows collected before the schema change

Generated with [Claude Code](https://claude.com/claude-code)