### PR TITLE
Add alert badge count to sidebar Alerts button

### DIFF
--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -148,11 +148,31 @@
                             Height="32"
                             Margin="0,0,0,8"/>
                     <Button x:Name="AlertsHistoryButton"
-                            Content="Alerts"
                             Click="AlertsHistory_Click"
                             Style="{StaticResource AccentButton}"
                             Height="32"
-                            Margin="0,0,0,8"/>
+                            Margin="0,0,0,8">
+                        <Grid>
+                            <TextBlock Text="Alerts" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            <Border x:Name="AlertBadge"
+                                    Background="#FF4444"
+                                    CornerRadius="8"
+                                    MinWidth="16" Height="16"
+                                    Padding="4,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Top"
+                                    Margin="0,-4,-8,0"
+                                    Visibility="Collapsed">
+                                <TextBlock x:Name="AlertBadgeText"
+                                           Text="0"
+                                           FontSize="10"
+                                           FontWeight="Bold"
+                                           Foreground="White"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"/>
+                            </Border>
+                        </Grid>
+                    </Button>
                     <Separator Margin="0,0,0,8"/>
                     <Button x:Name="RefreshAllButton"
                             Content="&#x21BB; Refresh All Status"

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -145,6 +145,7 @@ namespace PerformanceMonitorDashboard
             LoadSidebarState();
             ConfigureConnectionStatusTimer();
             ConfigureAlertCheckTimer();
+            UpdateAlertBadge();
             StartMcpServerIfEnabled();
 
             _displayRefreshTimer.Start();
@@ -970,6 +971,24 @@ namespace PerformanceMonitorDashboard
 
             /* Auto-refresh alert history if the tab is open */
             _alertsHistoryContent?.RefreshAlerts();
+
+            UpdateAlertBadge();
+        }
+
+        private void UpdateAlertBadge()
+        {
+            var alerts = _emailAlertService.GetAlertHistory(hoursBack: 24, limit: 100);
+            var count = alerts.Count;
+
+            if (count > 0)
+            {
+                AlertBadgeText.Text = count > 99 ? "99+" : count.ToString();
+                AlertBadge.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                AlertBadge.Visibility = Visibility.Collapsed;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Red badge on the Alerts sidebar button showing count of active (non-hidden) alerts from the last 24 hours
- Updates on each alert check timer cycle and on app startup
- Caps at "99+" for large counts, collapses when no alerts

Closes #109 (last remaining checklist item)

## Test plan
- [ ] Verify badge appears on Alerts button when there are active alerts
- [ ] Verify badge disappears when all alerts are dismissed
- [ ] Verify badge updates after each alert check cycle
- [ ] Verify badge shows correct count on app startup

Generated with [Claude Code](https://claude.com/claude-code)