### PR TITLE
Fix drill-down windows: inline plan XML, time range, aggregation

### DIFF
--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -11,7 +11,7 @@
         <TabItem Header="Server Configuration">
             <Grid>
             <DataGrid x:Name="ServerConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="220">
@@ -46,7 +46,7 @@
                     <DataGridTextColumn Binding="{Binding Description}" Width="*" MinWidth="200" Header="Description"/>
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock x:Name="ServerConfigNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            <TextBlock x:Name="ServerConfigNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
             </Grid>
         </TabItem>
 
@@ -54,7 +54,7 @@
         <TabItem Header="Database Configuration">
             <Grid>
             <DataGrid x:Name="DatabaseConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
@@ -92,7 +92,7 @@
                     <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock x:Name="DatabaseConfigNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            <TextBlock x:Name="DatabaseConfigNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
             </Grid>
         </TabItem>
 
@@ -100,7 +100,7 @@
         <TabItem Header="Trace Flags">
             <Grid>
             <DataGrid x:Name="TraceFlagsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100" Header="Trace Flag"/>
@@ -110,7 +110,7 @@
                     <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock x:Name="TraceFlagsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            <TextBlock x:Name="TraceFlagsNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
             </Grid>
         </TabItem>
     </TabControl>

--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -28,12 +28,12 @@
                         <ComboBoxItem Content="Security%" Tag="Security%"/>
                     </ComboBox>
                     <Separator Margin="10,0" Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"/>
-                    <Button Content="Refresh" Click="DefaultTraceEvents_Refresh_Click" Margin="5,0" Padding="10,4" Style="{StaticResource SuccessButton}"/>
+                    <Button Content="Refresh" Click="DefaultTraceEvents_Refresh_Click" Margin="5,0" Padding="10,4" Style="{DynamicResource SuccessButton}"/>
                 </StackPanel>
 
                 <Grid Grid.Row="1">
                 <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                          RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                          RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                           ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
@@ -94,7 +94,7 @@
                         </DataGridTextColumn>
                     </DataGrid.Columns>
                 </DataGrid>
-                <TextBlock x:Name="DefaultTraceEventsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+                <TextBlock x:Name="DefaultTraceEventsNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
                 </Grid>
             </Grid>
         </TabItem>
@@ -103,7 +103,7 @@
         <TabItem Header="Trace Analysis">
             <Grid>
             <DataGrid x:Name="TraceAnalysisDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{StaticResource DataGridContextMenu}"
+                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
@@ -180,7 +180,7 @@
                     </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock x:Name="TraceAnalysisNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+            <TextBlock x:Name="TraceAnalysisNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
             </Grid>
         </TabItem>
     </TabControl>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -781,7 +781,10 @@ namespace PerformanceMonitorDashboard.Controls
                     _databaseService,
                     item.DatabaseName,
                     item.QueryId,
-                    "Query Store"
+                    "Query Store",
+                    _queryStoreHoursBack,
+                    _queryStoreFromDate,
+                    _queryStoreToDate
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();
@@ -810,7 +813,10 @@ namespace PerformanceMonitorDashboard.Controls
                     _databaseService,
                     item.DatabaseName,
                     item.ObjectId,
-                    item.FullObjectName ?? item.ObjectName ?? $"ObjectId_{item.ObjectId}"
+                    item.FullObjectName ?? item.ObjectName ?? $"ObjectId_{item.ObjectId}",
+                    _procStatsHoursBack,
+                    _procStatsFromDate,
+                    _procStatsToDate
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();
@@ -838,7 +844,10 @@ namespace PerformanceMonitorDashboard.Controls
                 var historyWindow = new QueryStatsHistoryWindow(
                     _databaseService,
                     item.DatabaseName,
-                    item.QueryHash
+                    item.QueryHash,
+                    _queryStatsHoursBack,
+                    _queryStatsFromDate,
+                    _queryStatsToDate
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -64,7 +64,7 @@
                   Foreground="{DynamicResource ForegroundBrush}"
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
-                  RowHeight="30"
+                  RowHeight="35"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
@@ -127,9 +127,8 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Button Content="Download" Click="DownloadPlan_Click"
-                                    IsEnabled="{Binding QueryPlanXml, Converter={StaticResource NullToBooleanConverter}}"
                                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                                    Padding="8,4"/>
+                                    Padding="8,2"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -27,13 +27,19 @@ namespace PerformanceMonitorDashboard
         private readonly string _databaseName;
         private readonly int _objectId;
         private readonly string _objectName;
+        private readonly int _hoursBack;
+        private readonly DateTime? _fromDate;
+        private readonly DateTime? _toDate;
         private List<ProcedureExecutionHistoryItem> _historyData = new();
 
         public ProcedureHistoryWindow(
             DatabaseService databaseService,
             string databaseName,
             int objectId,
-            string objectName)
+            string objectName,
+            int hoursBack = 24,
+            DateTime? fromDate = null,
+            DateTime? toDate = null)
         {
             InitializeComponent();
 
@@ -41,6 +47,9 @@ namespace PerformanceMonitorDashboard
             _databaseName = databaseName;
             _objectId = objectId;
             _objectName = objectName;
+            _hoursBack = hoursBack;
+            _fromDate = fromDate;
+            _toDate = toDate;
 
             ProcedureIdentifierText.Text = $"Procedure Execution History: {objectName} in [{databaseName}]";
 
@@ -74,7 +83,7 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                _historyData = await _databaseService.GetProcedureStatsHistoryAsync(_databaseName, _objectId);
+                _historyData = await _databaseService.GetProcedureStatsHistoryAsync(_databaseName, _objectId, _hoursBack, _fromDate, _toDate);
 
                 HistoryDataGrid.ItemsSource = _historyData;
 
@@ -167,38 +176,48 @@ namespace PerformanceMonitorDashboard
             Close();
         }
 
-        private void DownloadPlan_Click(object sender, RoutedEventArgs e)
+        private async void DownloadPlan_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && button.DataContext is ProcedureExecutionHistoryItem item)
             {
-                if (string.IsNullOrWhiteSpace(item.QueryPlanXml))
+                try
                 {
-                    MessageBox.Show("No query plan available for this collection.", "No Plan", MessageBoxButton.OK, MessageBoxImage.Information);
-                    return;
-                }
+                    button.IsEnabled = false;
+                    button.Content = "Loading...";
 
-                var timestamp = item.CollectionTime.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
-                var safeObjectName = string.Join("_", _objectName.Split(Path.GetInvalidFileNameChars()));
-                var defaultFileName = $"procedure_history_{safeObjectName}_{timestamp}.sqlplan";
+                    var planXml = await _databaseService.GetProcedureStatsPlanXmlByCollectionIdAsync(item.CollectionId);
 
-                var saveFileDialog = new SaveFileDialog
-                {
-                    FileName = defaultFileName,
-                    Filter = "SQL Plan files (*.sqlplan)|*.sqlplan|XML files (*.xml)|*.xml|All files (*.*)|*.*",
-                    DefaultExt = ".sqlplan"
-                };
-
-                if (saveFileDialog.ShowDialog() == true)
-                {
-                    try
+                    if (string.IsNullOrWhiteSpace(planXml))
                     {
-                        File.WriteAllText(saveFileDialog.FileName, item.QueryPlanXml);
+                        MessageBox.Show("No query plan available for this collection.", "No Plan", MessageBoxButton.OK, MessageBoxImage.Information);
+                        return;
+                    }
+
+                    var timestamp = item.CollectionTime.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+                    var safeObjectName = string.Join("_", _objectName.Split(Path.GetInvalidFileNameChars()));
+                    var defaultFileName = $"procedure_history_{safeObjectName}_{timestamp}.sqlplan";
+
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = defaultFileName,
+                        Filter = "SQL Plan files (*.sqlplan)|*.sqlplan|XML files (*.xml)|*.xml|All files (*.*)|*.*",
+                        DefaultExt = ".sqlplan"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        File.WriteAllText(saveFileDialog.FileName, planXml);
                         MessageBox.Show($"Query plan saved to:\n{saveFileDialog.FileName}", "Plan Saved", MessageBoxButton.OK, MessageBoxImage.Information);
                     }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show($"Failed to save query plan:\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Failed to download query plan:\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+                finally
+                {
+                    button.IsEnabled = true;
+                    button.Content = "Download Plan";
                 }
             }
         }

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -66,7 +66,7 @@
                   Foreground="{DynamicResource ForegroundBrush}"
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
-                  RowHeight="30"
+                  RowHeight="35"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
@@ -131,9 +131,8 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Button Content="Download" Click="DownloadPlan_Click"
-                                    IsEnabled="{Binding QueryPlanXml, Converter={StaticResource NullToBooleanConverter}}"
                                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                                    Padding="8,4"/>
+                                    Padding="8,2"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -64,7 +64,7 @@
                   Foreground="{DynamicResource ForegroundBrush}"
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
-                  RowHeight="30"
+                  RowHeight="35"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
@@ -143,9 +143,8 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Button Content="Download" Click="DownloadPlan_Click"
-                                    IsEnabled="{Binding QueryPlanXml, Converter={StaticResource NullToBooleanConverter}}"
                                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                                    Padding="8,4"/>
+                                    Padding="8,2"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/upgrades/1.2.0-to-1.3.0/01_add_memory_stats_columns.sql
+++ b/upgrades/1.2.0-to-1.3.0/01_add_memory_stats_columns.sql
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 1.2.0 to 1.3.0
+Adds total_physical_memory_mb and committed_target_memory_mb to collect.memory_stats
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'collect.memory_stats')
+    AND   name = N'total_physical_memory_mb'
+)
+BEGIN
+    ALTER TABLE
+        collect.memory_stats
+    ADD
+        total_physical_memory_mb decimal(19,2) NULL;
+
+    PRINT 'Added total_physical_memory_mb to collect.memory_stats';
+END;
+GO
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'collect.memory_stats')
+    AND   name = N'committed_target_memory_mb'
+)
+BEGIN
+    ALTER TABLE
+        collect.memory_stats
+    ADD
+        committed_target_memory_mb decimal(19,2) NULL;
+
+    PRINT 'Added committed_target_memory_mb to collect.memory_stats';
+END;
+GO

--- a/upgrades/1.2.0-to-1.3.0/upgrade.txt
+++ b/upgrades/1.2.0-to-1.3.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_add_memory_stats_columns.sql

--- a/upgrades/README.md
+++ b/upgrades/README.md
@@ -70,5 +70,7 @@ GO
 
 - **1.0.0**: Initial release
 - **1.1.0**: Remove invalid query_hash column from trace_analysis table; fix trace_analysis_collector to properly query sys.traces for file paths; add PerformanceMonitor database exclusion filter to trace; make trace START action idempotent
+- **1.2.0**: Current Configuration tabs, Default Trace DynamicResource fix, alert badge, chart tooltips, drill-down sizing
+- **1.3.0**: Add total_physical_memory_mb and committed_target_memory_mb to memory_stats collector
 
 Future upgrade folders will be added here as new versions are released.


### PR DESCRIPTION
## Summary

- Remove query_plan_text/query_plan from drill-down SELECTs (was loading 122 MB inline, hanging the app)
- Add on-demand plan fetch via Download button for all three drill-down types
- Pass parent view's time range through to drill-down queries so they respect the selected hour/date filter
- Aggregate query_stats drill-down by collection_time with MAX for cumulative counters (matches report.query_stats_summary)
- Aggregate query_store drill-down by collection_time + plan_id with weighted averages
- Remove broken 7-day DATEADD filter from PR #179 that prevented drill-downs from returning data
- Fix Download button: RowHeight 30->35, remove stale IsEnabled binding
- Fix DefaultTraceContent/CurrentConfigContent StaticResource -> DynamicResource
- Add upgrade script for memory_stats columns (1.2.0 -> 1.3.0)

## Test plan

- [ ] Open Query Stats tab, double-click a row — drill-down loads, respects time range
- [ ] Open Query Store tab, double-click a row — drill-down loads with per-plan chart lines
- [ ] Open Procedure Stats tab, double-click a row — drill-down loads
- [ ] Click Download button in any drill-down — fetches plan on demand, save dialog works
- [ ] Switch time range buttons (1h, 8h, 7d) and verify drill-down row counts change accordingly
- [ ] Verify execution counts in drill-down are consistent with main view

🤖 Generated with [Claude Code](https://claude.com/claude-code)