### PR TITLE
Fix row clipping in Default Trace and Current Configuration grids (fixes #183, #184)

### DIFF
--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -11,7 +11,7 @@
         <TabItem Header="Server Configuration">
             <Grid>
             <DataGrid x:Name="ServerConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="220">
@@ -54,7 +54,7 @@
         <TabItem Header="Database Configuration">
             <Grid>
             <DataGrid x:Name="DatabaseConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
@@ -100,7 +100,7 @@
         <TabItem Header="Trace Flags">
             <Grid>
             <DataGrid x:Name="TraceFlagsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100" Header="Trace Flag"/>

--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -33,7 +33,7 @@
 
                 <Grid Grid.Row="1">
                 <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                          RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
+                          RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                           ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
@@ -103,7 +103,7 @@
         <TabItem Header="Trace Analysis">
             <Grid>
             <DataGrid x:Name="TraceAnalysisDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="25" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
+                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">


### PR DESCRIPTION
## Summary

- RowHeight 25 -> 28 in DefaultTraceContent.xaml (2 grids) and CurrentConfigContent.xaml (3 grids)
- Matches all other Dashboard DataGrids set in PR #78

## Test plan

- [x] Default Trace grids — text no longer clipped
- [x] Current Configuration grids — text no longer clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)