### PR TITLE
Fix sidebar alert badge not clearing on acknowledge (fixes #186)

### DIFF
--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -23,6 +23,8 @@ namespace PerformanceMonitorDashboard.Controls
 {
     public partial class AlertsHistoryContent : UserControl
     {
+        public event EventHandler? AlertsDismissed;
+
         private List<AlertHistoryDisplayItem> _allAlerts = new();
 
         /* Column filter state */
@@ -219,6 +221,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             service.HideAlerts(keys);
             LoadAlerts();
+            AlertsDismissed?.Invoke(this, EventArgs.Empty);
         }
 
         private void DismissAll_Click(object sender, RoutedEventArgs e)
@@ -247,6 +250,7 @@ namespace PerformanceMonitorDashboard.Controls
 
             service.HideAllAlerts(hoursBack > 0 ? hoursBack : 8760, serverName);
             LoadAlerts();
+            AlertsDismissed?.Invoke(this, EventArgs.Empty);
         }
 
         #endregion

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -606,6 +606,7 @@ namespace PerformanceMonitorDashboard
             }
 
             _alertsHistoryContent = new AlertsHistoryContent();
+            _alertsHistoryContent.AlertsDismissed += (_, _) => UpdateAlertBadge();
 
             var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };
             var headerText = new TextBlock
@@ -1567,6 +1568,15 @@ namespace PerformanceMonitorDashboard
                 if (_openTabs.TryGetValue(serverId, out var tabItem) && tabItem.Content is ServerTab serverTab)
                 {
                     serverTab.UpdateBadges(null, _alertStateService);
+                }
+
+                // Hide alerts in the email alert log so the sidebar badge updates
+                var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == serverId);
+                if (server != null)
+                {
+                    _emailAlertService.HideAllAlerts(8760, server.DisplayName);
+                    UpdateAlertBadge();
+                    _alertsHistoryContent?.RefreshAlerts();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Acknowledging server alerts now also hides those alerts in the email alert log, so the sidebar Alerts button badge count immediately drops
- Dismissing alerts in the Alert History tab now immediately updates the sidebar badge via an `AlertsDismissed` event

**Root cause:** `AcknowledgeServerAlerts_Click` only updated `AlertStateService` (per-tab badges) but never called `EmailAlertService.HideAllAlerts()`, leaving the sidebar badge unchanged until the next timer tick — which then re-counted the same unhidden alerts.

## Test plan
- [x] Generate deadlocks on sql2022, wait for sidebar badge count to appear
- [x] Right-click server tab → Acknowledge Alerts → sidebar badge clears immediately
- [x] Open Alert History tab → Dismiss Selected / Dismiss All → sidebar badge updates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)