### PR TITLE
Fix NOC deadlock/blocking timestamps showing 'just now' for stale events (fixes #187)

### DIFF
--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -505,7 +505,7 @@ namespace PerformanceMonitorDashboard.Services
 
                 SELECT TOP (1)
                     minutes_ago =
-                        DATEDIFF(MINUTE, bpx.event_time, SYSDATETIME())
+                        DATEDIFF(MINUTE, bpx.event_time, SYSUTCDATETIME())
                 FROM collect.blocked_process_xml AS bpx
                 ORDER BY
                     bpx.id DESC
@@ -530,7 +530,7 @@ namespace PerformanceMonitorDashboard.Services
 
                 SELECT TOP (1)
                     minutes_ago =
-                        DATEDIFF(MINUTE, dx.event_time, SYSDATETIME())
+                        DATEDIFF(MINUTE, dx.event_time, SYSUTCDATETIME())
                 FROM collect.deadlock_xml AS dx
                 ORDER BY
                     dx.id DESC


### PR DESCRIPTION
## Summary
- Extended Events timestamps are UTC, but the NOC queries used `SYSDATETIME()` (local time)
- On a UTC-8 server, `DATEDIFF(MINUTE, utc_event_time, local_sysdatetime)` returned -480 for recent events
- `FormatMinutesAgo` treats anything < 1 as "just now" — so all deadlocks/blocking appeared as "just now"
- Changed `SYSDATETIME()` to `SYSUTCDATETIME()` in both the deadlock and blocking "last event" queries

## Test plan
- [x] Verified sql2022 is UTC-8 (`DATEDIFF(MINUTE, SYSUTCDATETIME(), SYSDATETIME()) = -480`)
- [x] NOC overview now shows correct "Xh ago" / "Xd ago" for last deadlock and blocking events

🤖 Generated with [Claude Code](https://claude.com/claude-code)