### PR TITLE
Add missing poison wait defaults to wait stats picker (fixes #188)

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -1754,6 +1754,19 @@ namespace PerformanceMonitorDashboard.Controls
                     })
                     .ToList();
 
+                // Ensure poison waits are always in the picker even if they have no collected data
+                foreach (var poisonWait in TabHelpers.PoisonWaits)
+                {
+                    if (!waitTypes.Any(w => string.Equals(w.WaitType, poisonWait, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        waitTypes.Add(new WaitTypeSelectionItem
+                        {
+                            WaitType = poisonWait,
+                            IsSelected = previouslySelected.Contains(poisonWait)
+                        });
+                    }
+                }
+
                 // If nothing was previously selected, apply poison waits + usual suspects + top 10
                 if (!waitTypes.Any(w => w.IsSelected))
                 {


### PR DESCRIPTION
## Summary
- RESOURCE_SEMAPHORE and RESOURCE_SEMAPHORE_QUERY_COMPILE were missing from the wait type picker because they had no collected data
- Poison waits are now always injected into the picker list even without data, so they appear and get pre-selected by default
- When those waits occur, data will immediately show on the chart

## Test plan
- [x] Open server tab → Wait Stats Detail — all three poison waits (THREADPOOL, RESOURCE_SEMAPHORE, RESOURCE_SEMAPHORE_QUERY_COMPILE) appear in picker and are pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)