### PR TITLE
Fix newly added servers not appearing on Overview until restart (fixes #199)

### DIFF
--- a/Dashboard/Controls/LandingPage.xaml.cs
+++ b/Dashboard/Controls/LandingPage.xaml.cs
@@ -30,11 +30,11 @@ namespace PerformanceMonitorDashboard.Controls
 
         public event EventHandler<ServerConnection>? ServerCardClicked;
 
-        public LandingPage()
+        public LandingPage(ServerManager? serverManager = null)
         {
             InitializeComponent();
 
-            _serverManager = new ServerManager();
+            _serverManager = serverManager ?? new ServerManager();
             _preferencesService = new UserPreferencesService();
             _credentialService = new CredentialService();
             _serverHealthStatuses = new ObservableCollection<ServerHealthStatus>();

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -554,7 +554,7 @@ namespace PerformanceMonitorDashboard
             }
 
             // Create the landing page
-            _landingPage = new LandingPage();
+            _landingPage = new LandingPage(_serverManager);
             _landingPage.ServerCardClicked += LandingPage_ServerCardClicked;
 
             // Create tab header with close button


### PR DESCRIPTION
## Summary
- LandingPage created its own `ServerManager` instance, separate from MainWindow's
- When a server was added via MainWindow, LandingPage's stale instance didn't see it
- Now MainWindow passes its `_serverManager` to `LandingPage` so they share the same in-memory server list

## Test plan
- [x] Open Overview, add a fake server — card appears immediately without restart
- [x] Existing servers still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)