### PR TITLE
Fix double-click on column header triggering row drill-down (fixes #195)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -761,6 +761,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         private void QueryStoreDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
             if (_databaseService == null) return;
 
             if (QueryStoreDataGrid.SelectedItem is QueryStoreItem item)
@@ -793,6 +794,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         private void ProcStatsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
             if (_databaseService == null) return;
 
             if (ProcStatsDataGrid.SelectedItem is ProcedureStatsItem item)
@@ -825,6 +827,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         private void QueryStatsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
             if (_databaseService == null) return;
 
             if (QueryStatsDataGrid.SelectedItem is QueryStatsItem item)

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -29,6 +29,23 @@ namespace PerformanceMonitorDashboard.Helpers
     public static class TabHelpers
     {
         /// <summary>
+        /// Returns true if a double-click originated from a DataGridRow (not a header).
+        /// Use at the top of MouseDoubleClick handlers to prevent header clicks from
+        /// triggering row actions.
+        /// </summary>
+        public static bool IsDoubleClickOnRow(DependencyObject originalSource)
+        {
+            var dep = originalSource;
+            while (dep != null)
+            {
+                if (dep is DataGridRow) return true;
+                if (dep is DataGridColumnHeader) return false;
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Material Design 300-level color palette for chart data series.
         /// Soft pastels optimized for dark backgrounds, ordered to map 1:1
         /// with common ScottPlot stock colors (Blue→[0], Green→[1], etc.).

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace PerformanceMonitorDashboard
 
         private void ServersDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (!Helpers.TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
             EditSelectedServer();
         }
 

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1356,6 +1356,7 @@ namespace PerformanceMonitorDashboard
 
         private void HealthDataGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            if (!Helpers.TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
             if (HealthDataGrid.SelectedItem is CollectionHealthItem item)
             {
                 var logWindow = new CollectionLogWindow(item.CollectorName, _databaseService);


### PR DESCRIPTION
## Summary
- Double-clicking a column header border to auto-resize was also triggering the row double-click handler, opening unwanted drill-down windows
- Added `TabHelpers.IsDoubleClickOnRow()` helper that walks the visual tree to distinguish `DataGridRow` from `DataGridColumnHeader` clicks
- Applied the guard to all five `MouseDoubleClick` handlers: Query Store, Proc Stats, Query Stats, Collection Health, and Manage Servers

## Test plan
- [x] Double-click column header border to auto-resize — no drill-down opens
- [x] Double-click a data row — drill-down still opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)