### PR TITLE
Rename misleading Total Executions label in drill-down summaries (fixes #194)

### DIFF
--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -97,7 +97,7 @@ namespace PerformanceMonitorDashboard
                     var lastSample = _historyData.Max(h => h.CollectionTime);
 
                     SummaryText.Text = string.Format(CultureInfo.CurrentCulture,
-                        "Samples: {0} | First: {1:yyyy-MM-dd HH:mm} | Last: {2:yyyy-MM-dd HH:mm} | Total Executions: {3:N0} | Avg CPU: {4:N2} ms | Avg Duration: {5:N2} ms",
+                        "Samples: {0} | First: {1:yyyy-MM-dd HH:mm} | Last: {2:yyyy-MM-dd HH:mm} | Executions: {3:N0} | Avg CPU: {4:N2} ms | Avg Duration: {5:N2} ms",
                         _historyData.Count, firstSample, lastSample, totalExecutions, avgCpu, avgDuration);
 
                     UpdateChart();

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -94,7 +94,7 @@ namespace PerformanceMonitorDashboard
                     var lastSample = _historyData.Max(h => h.CollectionTime);
 
                     SummaryText.Text = string.Format(CultureInfo.CurrentCulture,
-                        "Samples: {0} | First: {1:yyyy-MM-dd HH:mm} | Last: {2:yyyy-MM-dd HH:mm} | Total Executions: {3:N0} | Avg CPU: {4:N2} ms | Avg Duration: {5:N2} ms",
+                        "Samples: {0} | First: {1:yyyy-MM-dd HH:mm} | Last: {2:yyyy-MM-dd HH:mm} | Executions: {3:N0} | Avg CPU: {4:N2} ms | Avg Duration: {5:N2} ms",
                         _historyData.Count, firstSample, lastSample, totalExecutions, avgCpu, avgDuration);
 
                     UpdateChart();


### PR DESCRIPTION
## Summary
- Plan cache `execution_count` is a cumulative counter (total since plan was cached), so MAX is the correct aggregation — matching the main grid
- The "Total Executions" label implied a sum, confusing users into thinking it should be an aggregate of all samples
- Renamed to "Executions" in Query Stats History and Procedure History drill-down windows
- Query Store window keeps "Total Executions" since it correctly uses SUM of interval deltas

## Test plan
- [x] Drill-down summary now says "Executions" instead of "Total Executions"
- [x] Value matches the main grid's Executions column

🤖 Generated with [Claude Code](https://claude.com/claude-code)