### PR TITLE
Fix numeric filter negative range parsing and MCP shutdown deadlock risk

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -234,7 +234,7 @@ namespace PerformanceMonitorDashboard
                 try
                 {
                     _mcpCts?.Cancel();
-                    _mcpHostService.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5));
+                    Task.Run(() => _mcpHostService.StopAsync(CancellationToken.None)).Wait(TimeSpan.FromSeconds(5));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- **NumericFilterHelper** (#113): Replace naive `Split('-')` range parsing with `TryParseRange` that finds the separator dash by looking for a `-` preceded by a digit. Correctly handles `-100-200`, `-100--50`, and `..` syntax. Previously, negative-start ranges were silently ignored.
- **MainWindow** (#112): Wrap MCP `StopAsync` in `Task.Run` to avoid sync-over-async deadlock on the WPF UI thread during app close.

## Test plan
- [ ] Build succeeds with zero warnings
- [ ] Numeric grid filters still work for positive ranges (e.g., `100-500`)
- [ ] App closes cleanly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)