### PR TITLE
Exclude WAITFOR sessions from long-running query alerts

### DIFF
--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -623,6 +623,8 @@ namespace PerformanceMonitorDashboard.Services
                 JOIN sys.dm_exec_sessions AS s ON s.session_id = r.session_id
                 WHERE r.session_id > 50
                 AND r.total_elapsed_time >= @thresholdMs
+                AND t.text NOT LIKE N'%waitfor delay%'
+                AND t.text NOT LIKE N'%waitfor receive%'
                 ORDER BY r.total_elapsed_time DESC
                 OPTION(MAXDOP 1, RECOMPILE);";
 

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -218,6 +218,8 @@ WHERE server_id = $1
 AND collection_time = (SELECT MAX(collection_time) FROM v_query_snapshots WHERE server_id = $1)
 AND session_id > 50
 AND total_elapsed_time_ms >= $2
+AND query_text NOT LIKE '%waitfor delay%'
+AND query_text NOT LIKE '%waitfor receive%'
 ORDER BY total_elapsed_time_ms DESC
 LIMIT 5";
 


### PR DESCRIPTION
## Summary
- CDC capture agents use `waitfor delay @waittime` and run indefinitely by design — these were triggering false long-running query alerts every 5 minutes (#151)
- Service Broker listeners use `waitfor receive` — same pattern, also intentionally long-running
- Adds `NOT LIKE` filters for both patterns in Dashboard (live DMV query) and Lite (DuckDB alert query)

Fixes #151.

## Test plan
- [ ] Build succeeds for both Dashboard and Lite
- [ ] Verify long-running query alerts still fire for actual long-running queries
- [ ] If CDC is available: verify CDC capture agent no longer triggers tray warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)