### PR TITLE
Replace TextBox-in-header filters with popup filter buttons

### DIFF
--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -16,34 +16,76 @@
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="220">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Setting" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="210" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ConfigurationName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ConfigurationName" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Setting" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding ValueConfigured}" Width="100">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Configured" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="90" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ValueConfigured"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ValueConfigured" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Configured" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding ValueInUse}" Width="100">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="In Use" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="90" Height="22" FontSize="11" TextChanged="ServerConfigFilterTextBox_TextChanged" Tag="ValueInUse"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ValueInUse" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="In Use" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ValueMinimum}" Width="80" Header="Minimum"/>
-                    <DataGridTextColumn Binding="{Binding ValueMaximum}" Width="80" Header="Maximum"/>
-                    <DataGridCheckBoxColumn Binding="{Binding IsDynamic}" Width="65" Header="Dynamic"/>
-                    <DataGridCheckBoxColumn Binding="{Binding IsAdvanced}" Width="70" Header="Advanced"/>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
-                    <DataGridTextColumn Binding="{Binding Description}" Width="*" MinWidth="200" Header="Description"/>
+                    <DataGridTextColumn Binding="{Binding ValueMinimum}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ValueMinimum" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Minimum" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ValueMaximum}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ValueMaximum" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Maximum" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridCheckBoxColumn Binding="{Binding IsDynamic}" Width="65">
+                        <DataGridCheckBoxColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsDynamic" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Dynamic" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
+                    <DataGridCheckBoxColumn Binding="{Binding IsAdvanced}" Width="70">
+                        <DataGridCheckBoxColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsAdvanced" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Advanced" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Last Changed" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding Description}" Width="*" MinWidth="200">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Description" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Description" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="ServerConfigNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
@@ -59,37 +101,44 @@
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Database" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="140" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="DatabaseName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding SettingType}" Width="160">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Setting Type" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="150" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingType"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SettingType" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Setting Type" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding SettingName}" Width="220">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Setting Name" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="210" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SettingName" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Setting Name" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding SettingValue}" Width="200">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Value" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="190" Height="22" FontSize="11" TextChanged="DatabaseConfigFilterTextBox_TextChanged" Tag="SettingValue"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SettingValue" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Value" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Last Changed" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="DatabaseConfigNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
@@ -103,11 +152,46 @@
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100" Header="Trace Flag"/>
-                    <DataGridCheckBoxColumn Binding="{Binding Status}" Width="70" Header="Enabled"/>
-                    <DataGridCheckBoxColumn Binding="{Binding IsGlobal}" Width="70" Header="Global"/>
-                    <DataGridCheckBoxColumn Binding="{Binding IsSession}" Width="70" Header="Session"/>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150" Header="Last Changed"/>
+                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TraceFlag" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Trace Flag" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridCheckBoxColumn Binding="{Binding Status}" Width="70">
+                        <DataGridCheckBoxColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Enabled" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
+                    <DataGridCheckBoxColumn Binding="{Binding IsGlobal}" Width="70">
+                        <DataGridCheckBoxColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsGlobal" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Global" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
+                    <DataGridCheckBoxColumn Binding="{Binding IsSession}" Width="70">
+                        <DataGridCheckBoxColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsSession" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Session" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
+                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Last Changed" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="TraceFlagsNoDataMessage" Style="{DynamicResource NoDataMessage}"/>

--- a/Dashboard/Controls/CurrentConfigContent.xaml.cs
+++ b/Dashboard/Controls/CurrentConfigContent.xaml.cs
@@ -7,10 +7,14 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -18,6 +22,20 @@ namespace PerformanceMonitorDashboard.Controls
     public partial class CurrentConfigContent : UserControl
     {
         private DatabaseService? _databaseService;
+
+        // Popup filter state (shared popup, per-grid filter dictionaries)
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
+        private string? _activeFilterGrid;
+
+        private readonly Dictionary<string, ColumnFilterState> _serverConfigFilters = new();
+        private List<CurrentServerConfigItem>? _serverConfigUnfilteredData;
+
+        private readonly Dictionary<string, ColumnFilterState> _databaseConfigFilters = new();
+        private List<CurrentDatabaseConfigItem>? _databaseConfigUnfilteredData;
+
+        private readonly Dictionary<string, ColumnFilterState> _traceFlagsFilters = new();
+        private List<CurrentTraceFlagItem>? _traceFlagsUnfilteredData;
 
         public CurrentConfigContent()
         {
@@ -58,18 +76,16 @@ namespace PerformanceMonitorDashboard.Controls
             try
             {
                 var data = await _databaseService.GetCurrentServerConfigAsync();
+                _serverConfigUnfilteredData = data;
+                _serverConfigFilters.Clear();
                 ServerConfigDataGrid.ItemsSource = data;
                 ServerConfigNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(ServerConfigDataGrid, _serverConfigFilters);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading server configuration: {ex.Message}");
             }
-        }
-
-        private void ServerConfigFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(ServerConfigDataGrid, sender as TextBox);
         }
 
         #endregion
@@ -83,18 +99,16 @@ namespace PerformanceMonitorDashboard.Controls
             try
             {
                 var data = await _databaseService.GetCurrentDatabaseConfigAsync();
+                _databaseConfigUnfilteredData = data;
+                _databaseConfigFilters.Clear();
                 DatabaseConfigDataGrid.ItemsSource = data;
                 DatabaseConfigNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(DatabaseConfigDataGrid, _databaseConfigFilters);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading database configuration: {ex.Message}");
             }
-        }
-
-        private void DatabaseConfigFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(DatabaseConfigDataGrid, sender as TextBox);
         }
 
         #endregion
@@ -108,12 +122,158 @@ namespace PerformanceMonitorDashboard.Controls
             try
             {
                 var data = await _databaseService.GetCurrentTraceFlagsAsync();
+                _traceFlagsUnfilteredData = data;
+                _traceFlagsFilters.Clear();
                 TraceFlagsDataGrid.ItemsSource = data;
                 TraceFlagsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(TraceFlagsDataGrid, _traceFlagsFilters);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading trace flags: {ex.Message}");
+            }
+        }
+
+        #endregion
+
+        #region Popup Filter Infrastructure
+
+        private void ServerConfigFilter_Click(object sender, RoutedEventArgs e)
+        {
+            _activeFilterGrid = "ServerConfig";
+            if (sender is Button button && button.Tag is string columnName)
+                ShowFilterPopup(button, columnName, _serverConfigFilters);
+        }
+
+        private void DatabaseConfigFilter_Click(object sender, RoutedEventArgs e)
+        {
+            _activeFilterGrid = "DatabaseConfig";
+            if (sender is Button button && button.Tag is string columnName)
+                ShowFilterPopup(button, columnName, _databaseConfigFilters);
+        }
+
+        private void TraceFlagsFilter_Click(object sender, RoutedEventArgs e)
+        {
+            _activeFilterGrid = "TraceFlags";
+            if (sender is Button button && button.Tag is string columnName)
+                ShowFilterPopup(button, columnName, _traceFlagsFilters);
+        }
+
+        private void ShowFilterPopup(Button button, string columnName, Dictionary<string, ColumnFilterState> filters)
+        {
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+
+            switch (_activeFilterGrid)
+            {
+                case "ServerConfig":
+                    if (e.FilterState.IsActive)
+                        _serverConfigFilters[e.FilterState.ColumnName] = e.FilterState;
+                    else
+                        _serverConfigFilters.Remove(e.FilterState.ColumnName);
+                    ApplyFilters(_serverConfigFilters, _serverConfigUnfilteredData, ServerConfigDataGrid, ServerConfigNoDataMessage);
+                    UpdateFilterButtonStyles(ServerConfigDataGrid, _serverConfigFilters);
+                    break;
+
+                case "DatabaseConfig":
+                    if (e.FilterState.IsActive)
+                        _databaseConfigFilters[e.FilterState.ColumnName] = e.FilterState;
+                    else
+                        _databaseConfigFilters.Remove(e.FilterState.ColumnName);
+                    ApplyFilters(_databaseConfigFilters, _databaseConfigUnfilteredData, DatabaseConfigDataGrid, DatabaseConfigNoDataMessage);
+                    UpdateFilterButtonStyles(DatabaseConfigDataGrid, _databaseConfigFilters);
+                    break;
+
+                case "TraceFlags":
+                    if (e.FilterState.IsActive)
+                        _traceFlagsFilters[e.FilterState.ColumnName] = e.FilterState;
+                    else
+                        _traceFlagsFilters.Remove(e.FilterState.ColumnName);
+                    ApplyFilters(_traceFlagsFilters, _traceFlagsUnfilteredData, TraceFlagsDataGrid, TraceFlagsNoDataMessage);
+                    UpdateFilterButtonStyles(TraceFlagsDataGrid, _traceFlagsFilters);
+                    break;
+            }
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+        }
+
+        private static void ApplyFilters<T>(Dictionary<string, ColumnFilterState> filters, List<T>? unfilteredData, DataGrid grid, TextBlock noDataMessage)
+        {
+            if (unfilteredData == null) return;
+
+            if (filters.Count == 0)
+            {
+                grid.ItemsSource = unfilteredData;
+                noDataMessage.Visibility = unfilteredData.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                return;
+            }
+
+            var filtered = unfilteredData.Where(item =>
+            {
+                foreach (var filter in filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item!, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            grid.ItemsSource = filtered;
+            noDataMessage.Visibility = filtered.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void UpdateFilterButtonStyles(DataGrid grid, Dictionary<string, ColumnFilterState> filters)
+        {
+            foreach (var column in grid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton != null && filterButton.Tag is string columnName)
+                    {
+                        bool hasActiveFilter = filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+
+                        var textBlock = new TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActiveFilter
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.Content = textBlock;
+                        filterButton.ToolTip = hasActiveFilter && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
             }
         }
 

--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -38,57 +38,57 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Event Time" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="140" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="EventTime"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding EventName}" Width="150">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Event Name" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="140" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="EventName"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Event Name" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Database" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="110" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="DatabaseName"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding ObjectName}" Width="150">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Object Name" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="140" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="ObjectName"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Object Name" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Login" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="110" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="LoginName"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding TextData}" Width="300">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Text Data" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="290" Height="22" FontSize="11" TextChanged="DefaultTraceEventsFilterTextBox_TextChanged" Tag="TextData"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TextData" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Text Data" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding Severity}" Width="60">
                             <DataGridTextColumn.Header>
-                                <StackPanel>
-                                    <TextBlock Text="Severity" FontWeight="Bold" Margin="0,0,0,2"/>
-                                    <TextBox Width="50" Height="22" FontSize="11" TextChanged="DefaultTraceEventsNumericFilterTextBox_TextChanged" Tag="Severity"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Severity" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
@@ -108,73 +108,73 @@
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Collected" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="140" Height="22" FontSize="11" TextChanged="TraceAnalysisFilterTextBox_TextChanged" Tag="CollectionTime"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Collected" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding EventName}" Width="150">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Event Name" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="140" Height="22" FontSize="11" TextChanged="TraceAnalysisFilterTextBox_TextChanged" Tag="EventName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Event Name" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Database" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="110" Height="22" FontSize="11" TextChanged="TraceAnalysisFilterTextBox_TextChanged" Tag="DatabaseName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding LoginName}" Width="100">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Login" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="90" Height="22" FontSize="11" TextChanged="TraceAnalysisFilterTextBox_TextChanged" Tag="LoginName"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding DurationMs, StringFormat=N0}" Width="90">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Duration (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="80" Height="22" FontSize="11" TextChanged="TraceAnalysisNumericFilterTextBox_TextChanged" Tag="DurationMs"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding CpuMs, StringFormat=N0}" Width="80">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="CPU (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="70" Height="22" FontSize="11" TextChanged="TraceAnalysisNumericFilterTextBox_TextChanged" Tag="CpuMs"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" Width="90">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Reads (pages)" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="80" Height="22" FontSize="11" TextChanged="TraceAnalysisNumericFilterTextBox_TextChanged" Tag="Reads"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" Width="90">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="Writes (pages)" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="80" Height="22" FontSize="11" TextChanged="TraceAnalysisNumericFilterTextBox_TextChanged" Tag="Writes"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding SqlText}" Width="400">
                         <DataGridTextColumn.Header>
-                            <StackPanel>
-                                <TextBlock Text="SQL Text" FontWeight="Bold" Margin="0,0,0,2"/>
-                                <TextBox Width="390" Height="22" FontSize="11" TextChanged="TraceAnalysisFilterTextBox_TextChanged" Tag="SqlText"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlText" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="SQL Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>

--- a/Dashboard/Controls/DefaultTraceContent.xaml.cs
+++ b/Dashboard/Controls/DefaultTraceContent.xaml.cs
@@ -7,10 +7,14 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -27,6 +31,17 @@ namespace PerformanceMonitorDashboard.Controls
         private int _traceAnalysisHoursBack = 24;
         private DateTime? _traceAnalysisFromDate;
         private DateTime? _traceAnalysisToDate;
+
+        // Popup filter state (shared popup, per-grid filter dictionaries)
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
+        private string? _activeFilterGrid;
+
+        private readonly Dictionary<string, ColumnFilterState> _defaultTraceFilters = new();
+        private List<DefaultTraceEventItem>? _defaultTraceUnfilteredData;
+
+        private readonly Dictionary<string, ColumnFilterState> _traceAnalysisFilters = new();
+        private List<TraceAnalysisItem>? _traceAnalysisUnfilteredData;
 
         public DefaultTraceContent()
         {
@@ -101,23 +116,16 @@ namespace PerformanceMonitorDashboard.Controls
             try
             {
                 var data = await _databaseService.GetDefaultTraceEventsAsync(_defaultTraceEventsHoursBack, _defaultTraceEventsFromDate, _defaultTraceEventsToDate, _defaultTraceEventsFilter);
+                _defaultTraceUnfilteredData = data;
+                _defaultTraceFilters.Clear();
                 DefaultTraceEventsDataGrid.ItemsSource = data;
                 DefaultTraceEventsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(DefaultTraceEventsDataGrid, _defaultTraceFilters);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading default trace events: {ex.Message}");
             }
-        }
-
-        private void DefaultTraceEventsFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(DefaultTraceEventsDataGrid, sender as TextBox);
-        }
-
-        private void DefaultTraceEventsNumericFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(DefaultTraceEventsDataGrid, sender as TextBox);
         }
 
         #endregion
@@ -131,8 +139,11 @@ namespace PerformanceMonitorDashboard.Controls
             try
             {
                 var data = await _databaseService.GetTraceAnalysisAsync(_traceAnalysisHoursBack, _traceAnalysisFromDate, _traceAnalysisToDate);
+                _traceAnalysisUnfilteredData = data;
+                _traceAnalysisFilters.Clear();
                 TraceAnalysisDataGrid.ItemsSource = data;
                 TraceAnalysisNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(TraceAnalysisDataGrid, _traceAnalysisFilters);
             }
             catch (Exception ex)
             {
@@ -140,14 +151,131 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
-        private void TraceAnalysisFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        #endregion
+
+        #region Popup Filter Infrastructure
+
+        private void DefaultTraceFilter_Click(object sender, RoutedEventArgs e)
         {
-            DataGridFilterService.ApplyFilter(TraceAnalysisDataGrid, sender as TextBox);
+            _activeFilterGrid = "DefaultTrace";
+            if (sender is Button button && button.Tag is string columnName)
+                ShowFilterPopup(button, columnName, _defaultTraceFilters);
         }
 
-        private void TraceAnalysisNumericFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        private void TraceAnalysisFilter_Click(object sender, RoutedEventArgs e)
         {
-            DataGridFilterService.ApplyFilter(TraceAnalysisDataGrid, sender as TextBox);
+            _activeFilterGrid = "TraceAnalysis";
+            if (sender is Button button && button.Tag is string columnName)
+                ShowFilterPopup(button, columnName, _traceAnalysisFilters);
+        }
+
+        private void ShowFilterPopup(Button button, string columnName, Dictionary<string, ColumnFilterState> filters)
+        {
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+
+            switch (_activeFilterGrid)
+            {
+                case "DefaultTrace":
+                    if (e.FilterState.IsActive)
+                        _defaultTraceFilters[e.FilterState.ColumnName] = e.FilterState;
+                    else
+                        _defaultTraceFilters.Remove(e.FilterState.ColumnName);
+                    ApplyFilters(_defaultTraceFilters, _defaultTraceUnfilteredData, DefaultTraceEventsDataGrid, DefaultTraceEventsNoDataMessage);
+                    UpdateFilterButtonStyles(DefaultTraceEventsDataGrid, _defaultTraceFilters);
+                    break;
+
+                case "TraceAnalysis":
+                    if (e.FilterState.IsActive)
+                        _traceAnalysisFilters[e.FilterState.ColumnName] = e.FilterState;
+                    else
+                        _traceAnalysisFilters.Remove(e.FilterState.ColumnName);
+                    ApplyFilters(_traceAnalysisFilters, _traceAnalysisUnfilteredData, TraceAnalysisDataGrid, TraceAnalysisNoDataMessage);
+                    UpdateFilterButtonStyles(TraceAnalysisDataGrid, _traceAnalysisFilters);
+                    break;
+            }
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null)
+                _filterPopup.IsOpen = false;
+        }
+
+        private static void ApplyFilters<T>(Dictionary<string, ColumnFilterState> filters, List<T>? unfilteredData, DataGrid grid, TextBlock noDataMessage)
+        {
+            if (unfilteredData == null) return;
+
+            if (filters.Count == 0)
+            {
+                grid.ItemsSource = unfilteredData;
+                noDataMessage.Visibility = unfilteredData.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                return;
+            }
+
+            var filtered = unfilteredData.Where(item =>
+            {
+                foreach (var filter in filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item!, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            grid.ItemsSource = filtered;
+            noDataMessage.Visibility = filtered.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void UpdateFilterButtonStyles(DataGrid grid, Dictionary<string, ColumnFilterState> filters)
+        {
+            foreach (var column in grid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton != null && filterButton.Tag is string columnName)
+                    {
+                        bool hasActiveFilter = filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+
+                        var textBlock = new TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActiveFilter
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.Content = textBlock;
+                        filterButton.ToolTip = hasActiveFilter && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- Migrates 5 DataGrids from the old TextBox-in-header filter style to the standard popup filter pattern
- **DefaultTraceContent**: DefaultTraceEventsDataGrid (7 cols), TraceAnalysisDataGrid (9 cols)
- **CurrentConfigContent**: ServerConfigDataGrid (9 cols), DatabaseConfigDataGrid (5 cols), TraceFlagsDataGrid (5 cols — previously had no filters at all)
- All 35 columns now have consistent popup filter buttons with operator support and gold active-filter indicators

Fixes #200.

## Test plan
- [ ] Build succeeds with zero warnings
- [ ] Default Trace Events: popup filters on all 7 columns, filter/clear works, gold icon when active
- [ ] Trace Analysis: popup filters on all 9 columns
- [ ] Server Configuration: popup filters on all 9 columns (6 previously unfiltered)
- [ ] Database Configuration: popup filters on all 5 columns (1 previously unfiltered)
- [ ] Trace Flags: popup filters on all 5 columns (previously had none)
- [ ] Multi-grid routing: filtering on one grid doesn't interfere with another

🤖 Generated with [Claude Code](https://claude.com/claude-code)