### PR TITLE
Fix settings time range dropdown to match dashboard buttons

### DIFF
--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -58,9 +58,12 @@
                             <TextBlock Text="Show data from last:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                             <ComboBox x:Name="DefaultTimeRangeComboBox" Width="120" SelectionChanged="DefaultTimeRangeComboBox_Changed">
                                 <ComboBoxItem Content="1 hour" Tag="1"/>
-                                <ComboBoxItem Content="6 hours" Tag="6"/>
+                                <ComboBoxItem Content="4 hours" Tag="4"/>
+                                <ComboBoxItem Content="8 hours" Tag="8"/>
+                                <ComboBoxItem Content="12 hours" Tag="12"/>
                                 <ComboBoxItem Content="24 hours" Tag="24"/>
                                 <ComboBoxItem Content="7 days" Tag="168"/>
+                                <ComboBoxItem Content="30 days" Tag="720"/>
                             </ComboBox>
                         </StackPanel>
 

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -83,7 +83,7 @@ namespace PerformanceMonitorDashboard
             // Default to 24 hours if no match
             if (DefaultTimeRangeComboBox.SelectedItem == null)
             {
-                DefaultTimeRangeComboBox.SelectedIndex = 2; // 24 hours
+                DefaultTimeRangeComboBox.SelectedIndex = 4; // 24 hours
             }
 
             // Navigation settings


### PR DESCRIPTION
## Summary
- Settings > Default Time Range dropdown had `1h / 6h / 24h / 7d` but the dashboard time range buttons offer `1h / 4h / 8h / 12h / 24h / 7d / 30d`
- Aligned dropdown to match the dashboard buttons exactly
- Fixed fallback selected index (24 hours moved from index 2 to index 4)

Closes #210

## Test plan
- [ ] Open Settings > General > Default Time Range — verify dropdown shows: 1 hour, 4 hours, 8 hours, 12 hours, 24 hours, 7 days, 30 days
- [ ] Select a value, click OK, reopen Settings — verify selection persisted
- [ ] Verify dashboard time range buttons match the dropdown options

🤖 Generated with [Claude Code](https://claude.com/claude-code)