### PR TITLE
Add column filters and context menus to drill-down history windows

### DIFF
--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -10,6 +10,23 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <converters:NullToBooleanConverter x:Key="NullToBooleanConverter"/>
+
+        <!-- Context Menu for DataGrid Copy/Export -->
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -65,62 +82,322 @@
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
                   RowHeight="35"
+                  ContextMenu="{DynamicResource DataGridContextMenu}"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Cached Time" Binding="{Binding CachedTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Object Type" Binding="{Binding ObjectType}" Width="90"/>
-                <DataGridTextColumn Header="Type Desc" Binding="{Binding TypeDesc}" Width="120"/>
+                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CachedTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Cached Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ObjectType}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Object Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TypeDesc}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TypeDesc" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Type Desc" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Execution Count -->
-                <DataGridTextColumn Header="Exec Count" Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Exec Delta" Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Exec Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
-                <!-- Worker Time (CPU) - Total/Avg/Min/Max -->
-                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110"/>
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105"/>
+                <!-- Worker Time (CPU) -->
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="CPU Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
-                <!-- Elapsed Time - Total/Avg/Min/Max -->
-                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125"/>
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125"/>
+                <!-- Elapsed Time -->
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Duration Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125"/>
-                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Logical Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Max Logical Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Reads Delta" Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95"/>
+                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Header="Total Physical Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130"/>
-                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Phys Reads Delta" Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Phys Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Header="Total Logical Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125"/>
-                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Logical Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Max Logical Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Writes Delta" Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95"/>
+                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Writes Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Spills -->
-                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Avg Spills" Binding="{Binding AvgSpills, StringFormat=N2}" Width="85"/>
-                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" Width="85"/>
-                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat=N2}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Interval (sec)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -11,10 +11,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using ScottPlot;
@@ -31,6 +34,12 @@ namespace PerformanceMonitorDashboard
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
         private List<ProcedureExecutionHistoryItem> _historyData = new();
+
+        // Filter state
+        private Dictionary<string, ColumnFilterState> _filters = new();
+        private List<ProcedureExecutionHistoryItem>? _unfilteredData;
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
 
         public ProcedureHistoryWindow(
             DatabaseService databaseService,
@@ -85,7 +94,10 @@ namespace PerformanceMonitorDashboard
             {
                 _historyData = await _databaseService.GetProcedureStatsHistoryAsync(_databaseName, _objectId, _hoursBack, _fromDate, _toDate);
 
+                _unfilteredData = _historyData;
+                _filters.Clear();
                 HistoryDataGrid.ItemsSource = _historyData;
+                UpdateFilterButtonStyles();
 
                 if (_historyData.Count > 0)
                 {
@@ -221,5 +233,195 @@ namespace PerformanceMonitorDashboard
                 }
             }
         }
+
+        #region Column Filter Popup
+
+        private void Filter_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string columnName) return;
+
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+
+            if (e.FilterState.IsActive)
+                _filters[e.FilterState.ColumnName] = e.FilterState;
+            else
+                _filters.Remove(e.FilterState.ColumnName);
+
+            ApplyFilters();
+            UpdateFilterButtonStyles();
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+        }
+
+        private void ApplyFilters()
+        {
+            if (_unfilteredData == null) return;
+
+            if (_filters.Count == 0)
+            {
+                HistoryDataGrid.ItemsSource = _unfilteredData;
+                return;
+            }
+
+            var filtered = _unfilteredData.Where(item =>
+            {
+                foreach (var filter in _filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            HistoryDataGrid.ItemsSource = filtered;
+        }
+
+        private void UpdateFilterButtonStyles()
+        {
+            foreach (var column in HistoryDataGrid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton?.Tag is string columnName)
+                    {
+                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+                        filterButton.Content = new System.Windows.Controls.TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActive
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.ToolTip = hasActive && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                    {
+                        if (column is DataGridBoundColumn)
+                            headers.Add(TabHelpers.GetColumnHeader(column));
+                    }
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = $"procedure_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+                            var headers = new List<string>();
+                            foreach (var column in dataGrid.Columns)
+                            {
+                                if (column is DataGridBoundColumn)
+                                    headers.Add(TabHelpers.EscapeCsvField(TabHelpers.GetColumnHeader(column)));
+                            }
+                            sb.AppendLine(string.Join(",", headers));
+                            foreach (var item in dataGrid.Items)
+                            {
+                                var values = TabHelpers.GetRowValues(dataGrid, item);
+                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                            }
+                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
+                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -10,6 +10,23 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <converters:NullToBooleanConverter x:Key="NullToBooleanConverter"/>
+
+        <!-- Context Menu for DataGrid Copy/Export -->
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -67,64 +84,310 @@
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
                   RowHeight="35"
+                  ContextMenu="{DynamicResource DataGridContextMenu}"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Plan ID" Binding="{Binding PlanId}" Width="70"/>
-                <DataGridTextColumn Header="Executions" Binding="{Binding CountExecutions, StringFormat=N0}" Width="90"/>
+                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding PlanId}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanId" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Plan ID" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CountExecutions, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CountExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Duration (ms) -->
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinDurationMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxDurationMs, StringFormat=N2}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- CPU (ms) -->
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" Width="100"/>
+                <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Min Logical Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Max Logical Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Min Logical Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115"/>
-                <DataGridTextColumn Header="Max Logical Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120"/>
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- DOP -->
-                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" Width="70"/>
-                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" Width="70"/>
+                <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Memory (MB) -->
-                <DataGridTextColumn Header="Avg Memory (MB)" Binding="{Binding AvgMemoryMb, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Memory (MB)" Binding="{Binding MinMemoryMb, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Max Memory (MB)" Binding="{Binding MaxMemoryMb, StringFormat=N2}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinMemoryMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Row Count -->
-                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRowcount, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRowcount, StringFormat=N0}" Width="90"/>
+                <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinRowcount, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxRowcount, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- TempDB (MB) -->
-                <DataGridTextColumn Header="Avg TempDB (MB)" Binding="{Binding AvgTempdbMb, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min TempDB (MB)" Binding="{Binding MinTempdbMb, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Max TempDB (MB)" Binding="{Binding MaxTempdbMb, StringFormat=N2}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg TempDB (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinTempdbMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min TempDB (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max TempDB (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Plan Info -->
-                <DataGridTextColumn Header="Plan Type" Binding="{Binding PlanType}" Width="100"/>
-                <DataGridCheckBoxColumn Header="Forced" Binding="{Binding IsForcedPlan}" Width="60"/>
-                <DataGridTextColumn Header="Force Failures" Binding="{Binding ForceFailureCount}" Width="100"/>
-                <DataGridTextColumn Header="Last Failure Reason" Binding="{Binding LastForceFailureReasonDesc}" Width="150"/>
-                <DataGridTextColumn Header="Forcing Type" Binding="{Binding PlanForcingType}" Width="100"/>
-                <DataGridTextColumn Header="Compat Level" Binding="{Binding CompatibilityLevel}" Width="90"/>
+                <DataGridTextColumn Binding="{Binding PlanType}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanType" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Plan Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridCheckBoxColumn Binding="{Binding IsForcedPlan}" Width="60">
+                    <DataGridCheckBoxColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsForcedPlan" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Forced" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridCheckBoxColumn.Header>
+                </DataGridCheckBoxColumn>
+                <DataGridTextColumn Binding="{Binding ForceFailureCount}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ForceFailureCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Force Failures" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LastForceFailureReasonDesc}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastForceFailureReasonDesc" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Last Failure Reason" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding PlanForcingType}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanForcingType" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Forcing Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CompatibilityLevel}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompatibilityLevel" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Compat Level" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -11,10 +11,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using ScottPlot;
@@ -32,6 +35,12 @@ namespace PerformanceMonitorDashboard
         private readonly DateTime? _toDate;
         private List<QueryExecutionHistoryItem> _historyData = new();
         private ScottPlot.IPanel? _legendPanel;
+
+        // Filter state
+        private Dictionary<string, ColumnFilterState> _filters = new();
+        private List<QueryExecutionHistoryItem>? _unfilteredData;
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
 
         public QueryExecutionHistoryWindow(
             DatabaseService databaseService,
@@ -60,7 +69,6 @@ namespace PerformanceMonitorDashboard
 
         private void ApplyDarkModeToChart()
         {
-            // Use TabHelpers pattern for consistency with other charts
             Helpers.TabHelpers.ApplyDarkModeToChart(HistoryChart);
         }
 
@@ -94,7 +102,10 @@ namespace PerformanceMonitorDashboard
                     _historyData = new List<QueryExecutionHistoryItem>();
                 }
 
+                _unfilteredData = _historyData;
+                _filters.Clear();
                 HistoryDataGrid.ItemsSource = _historyData;
+                UpdateFilterButtonStyles();
 
                 if (_historyData.Count > 0)
                 {
@@ -274,5 +285,195 @@ namespace PerformanceMonitorDashboard
                 }
             }
         }
+
+        #region Column Filter Popup
+
+        private void Filter_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string columnName) return;
+
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+
+            if (e.FilterState.IsActive)
+                _filters[e.FilterState.ColumnName] = e.FilterState;
+            else
+                _filters.Remove(e.FilterState.ColumnName);
+
+            ApplyFilters();
+            UpdateFilterButtonStyles();
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+        }
+
+        private void ApplyFilters()
+        {
+            if (_unfilteredData == null) return;
+
+            if (_filters.Count == 0)
+            {
+                HistoryDataGrid.ItemsSource = _unfilteredData;
+                return;
+            }
+
+            var filtered = _unfilteredData.Where(item =>
+            {
+                foreach (var filter in _filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            HistoryDataGrid.ItemsSource = filtered;
+        }
+
+        private void UpdateFilterButtonStyles()
+        {
+            foreach (var column in HistoryDataGrid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton?.Tag is string columnName)
+                    {
+                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+                        filterButton.Content = new System.Windows.Controls.TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActive
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.ToolTip = hasActive && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                    {
+                        if (column is DataGridBoundColumn)
+                            headers.Add(TabHelpers.GetColumnHeader(column));
+                    }
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = $"query_execution_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+                            var headers = new List<string>();
+                            foreach (var column in dataGrid.Columns)
+                            {
+                                if (column is DataGridBoundColumn)
+                                    headers.Add(TabHelpers.EscapeCsvField(TabHelpers.GetColumnHeader(column)));
+                            }
+                            sb.AppendLine(string.Join(",", headers));
+                            foreach (var item in dataGrid.Items)
+                            {
+                                var values = TabHelpers.GetRowValues(dataGrid, item);
+                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                            }
+                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
+                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -10,6 +10,23 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <converters:NullToBooleanConverter x:Key="NullToBooleanConverter"/>
+
+        <!-- Context Menu for DataGrid Copy/Export -->
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -65,78 +82,380 @@
                   RowBackground="{DynamicResource BackgroundBrush}"
                   GridLinesVisibility="All"
                   RowHeight="35"
+                  ContextMenu="{DynamicResource DataGridContextMenu}"
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Creation Time" Binding="{Binding CreationTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150"/>
-                <DataGridTextColumn Header="Object Type" Binding="{Binding ObjectType}" Width="90"/>
+                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CreationTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Creation Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ObjectType}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Object Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Execution Count -->
-                <DataGridTextColumn Header="Exec Count" Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Exec Delta" Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Exec Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Worker Time (CPU) - Total/Avg/Min/Max -->
-                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110"/>
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105"/>
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="CPU Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Elapsed Time - Total/Avg/Min/Max -->
-                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125"/>
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125"/>
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Duration Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125"/>
-                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Reads Delta" Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95"/>
+                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Header="Total Physical Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130"/>
-                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120"/>
-                <DataGridTextColumn Header="Phys Reads Delta" Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115"/>
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Phys Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Header="Total Logical Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125"/>
-                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115"/>
-                <DataGridTextColumn Header="Writes Delta" Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95"/>
+                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Writes Delta" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Rows -->
-                <DataGridTextColumn Header="Total Rows" Binding="{Binding TotalRows, StringFormat=N0}" Width="100"/>
-                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRows, StringFormat=N2}" Width="90"/>
-                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRows, StringFormat=N0}" Width="85"/>
-                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRows, StringFormat=N0}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding AvgRows, StringFormat=N2}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRows" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinRows, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRows" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxRows, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRows" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Rows" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Parallelism -->
-                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" Width="70"/>
-                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" Width="70"/>
+                <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Memory Grants -->
-                <DataGridTextColumn Header="Max Grant (MB)" Binding="{Binding MaxGrantMb, StringFormat=N2}" Width="105"/>
-                <DataGridTextColumn Header="Max Used (MB)" Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" Width="105"/>
-                <DataGridTextColumn Header="Max Ideal (MB)" Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" Width="105"/>
+                <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Used (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Ideal (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Thread Usage -->
-                <DataGridTextColumn Header="Min Threads" Binding="{Binding MinUsedThreads}" Width="85"/>
-                <DataGridTextColumn Header="Max Threads" Binding="{Binding MaxUsedThreads}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding MinUsedThreads}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Spills -->
-                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" Width="85"/>
-                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- CLR Time -->
-                <DataGridTextColumn Header="Total CLR Time" Binding="{Binding TotalClrTime, StringFormat=N0}" Width="100"/>
+                <DataGridTextColumn Binding="{Binding TotalClrTime, StringFormat=N0}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Total CLR Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" Width="85"/>
+                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" Width="85">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Interval (sec)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -11,10 +11,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using ScottPlot;
@@ -30,6 +33,12 @@ namespace PerformanceMonitorDashboard
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
         private List<QueryStatsHistoryItem> _historyData = new();
+
+        // Filter state
+        private Dictionary<string, ColumnFilterState> _filters = new();
+        private List<QueryStatsHistoryItem>? _unfilteredData;
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
 
         public QueryStatsHistoryWindow(
             DatabaseService databaseService,
@@ -82,7 +91,10 @@ namespace PerformanceMonitorDashboard
             {
                 _historyData = await _databaseService.GetQueryStatsHistoryAsync(_databaseName, _queryHash, _hoursBack, _fromDate, _toDate);
 
+                _unfilteredData = _historyData;
+                _filters.Clear();
                 HistoryDataGrid.ItemsSource = _historyData;
+                UpdateFilterButtonStyles();
 
                 if (_historyData.Count > 0)
                 {
@@ -218,5 +230,195 @@ namespace PerformanceMonitorDashboard
                 }
             }
         }
+
+        #region Column Filter Popup
+
+        private void Filter_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string columnName) return;
+
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+
+            if (e.FilterState.IsActive)
+                _filters[e.FilterState.ColumnName] = e.FilterState;
+            else
+                _filters.Remove(e.FilterState.ColumnName);
+
+            ApplyFilters();
+            UpdateFilterButtonStyles();
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+        }
+
+        private void ApplyFilters()
+        {
+            if (_unfilteredData == null) return;
+
+            if (_filters.Count == 0)
+            {
+                HistoryDataGrid.ItemsSource = _unfilteredData;
+                return;
+            }
+
+            var filtered = _unfilteredData.Where(item =>
+            {
+                foreach (var filter in _filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            HistoryDataGrid.ItemsSource = filtered;
+        }
+
+        private void UpdateFilterButtonStyles()
+        {
+            foreach (var column in HistoryDataGrid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton?.Tag is string columnName)
+                    {
+                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+                        filterButton.Content = new System.Windows.Controls.TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActive
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.ToolTip = hasActive && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                    {
+                        if (column is DataGridBoundColumn)
+                            headers.Add(TabHelpers.GetColumnHeader(column));
+                    }
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = $"query_stats_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+                            var headers = new List<string>();
+                            foreach (var column in dataGrid.Columns)
+                            {
+                                if (column is DataGridBoundColumn)
+                                    headers.Add(TabHelpers.EscapeCsvField(TabHelpers.GetColumnHeader(column)));
+                            }
+                            sb.AppendLine(string.Join(",", headers));
+                            foreach (var item in dataGrid.Items)
+                            {
+                                var values = TabHelpers.GetRowValues(dataGrid, item);
+                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                            }
+                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
+                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary
- Added popup column filter buttons to all columns in all 3 drill-down history windows (QueryStatsHistory, QueryExecutionHistory, ProcedureHistory)
- Added right-click context menus (Copy Cell, Copy Row, Copy All Rows, Export to CSV) — these were missing entirely from drill-down windows
- Every DataGrid in the application now has consistent filtering and context menu behavior

Closes #206

## Test plan
- [ ] Query Stats tab — double-click row, verify filter buttons + context menu in history window
- [ ] Query Store tab — double-click row, verify filter buttons + context menu in history window
- [ ] Procedure Stats tab — double-click row, verify filter buttons + context menu in history window
- [ ] Apply a filter, confirm button turns gold, data filters correctly
- [ ] Right-click — Copy Cell, Copy Row, Copy All Rows, Export to CSV all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)