### PR TITLE
Fix sidebar alert badge not syncing with sub-tab dismissals

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -445,6 +445,12 @@ namespace PerformanceMonitorDashboard
             Helpers.ServerTimeHelper.UtcOffsetMinutes = utcOffset;
 
             var serverTab = new ServerTab(server, utcOffset);
+            serverTab.AlertAcknowledged += (_, _) =>
+            {
+                _emailAlertService.HideAllAlerts(8760, server.DisplayName);
+                UpdateAlertBadge();
+                _alertsHistoryContent?.RefreshAlerts();
+            };
 
             var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };
             var headerText = new TextBlock

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -29,6 +29,12 @@ namespace PerformanceMonitorDashboard
         private ServerHealthStatus? _lastKnownStatus;
 
         /// <summary>
+        /// Raised when the user acknowledges a sub-tab alert (Locking, Memory, etc.)
+        /// so the sidebar badge can be updated.
+        /// </summary>
+        public event EventHandler? AlertAcknowledged;
+
+        /// <summary>
         /// This server's UTC offset in minutes, used to restore the global
         /// ServerTimeHelper when this tab becomes active.
         /// </summary>
@@ -3097,6 +3103,8 @@ namespace PerformanceMonitorDashboard
                     {
                         badge.Visibility = Visibility.Collapsed;
                     }
+
+                    AlertAcknowledged?.Invoke(this, EventArgs.Empty);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Sidebar "Alerts" badge wasn't updating when alerts were dismissed from inside a server tab (Locking, Memory, etc.)
- Root cause: ServerTab only called `AlertStateService.AcknowledgeAlert` (tab badges) but never touched `EmailAlertService` (sidebar badge source)
- Added `AlertAcknowledged` event on ServerTab; MainWindow subscribes and hides email alerts + refreshes sidebar badge

## Note
The sidebar badge re-notification follows a 5-minute cooldown per alert type per server. If an alert condition persists after dismissal, the badge reappears after cooldown expires. This is by design to avoid notification spam.

## Test plan
- [x] Connect to server generating blocking/deadlock alerts
- [x] Verify sidebar badge shows count
- [x] Right-click Locking sub-tab → Acknowledge → sidebar badge clears
- [x] Wait for new alerts → sidebar badge reappears after cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)