### PR TITLE
Fix DuckDB file corruption during maintenance (#218)

### DIFF
--- a/Lite/Database/LockedConnection.cs
+++ b/Lite/Database/LockedConnection.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Database;
+
+/// <summary>
+/// Wraps a DuckDBConnection with a read lock that is released when the connection is disposed.
+/// Ensures UI reads hold the lock for their entire duration, preventing CHECKPOINT or compaction
+/// from reorganizing the database file while a reader has stale file offsets.
+/// </summary>
+public sealed class LockedConnection : IDisposable, IAsyncDisposable
+{
+    private readonly DuckDBConnection _connection;
+    private readonly IDisposable _readLock;
+    private bool _disposed;
+
+    public LockedConnection(DuckDBConnection connection, IDisposable readLock)
+    {
+        _connection = connection;
+        _readLock = readLock;
+    }
+
+    /// <summary>
+    /// Creates a command on the underlying connection.
+    /// This is the only method callers need — all 50 call sites use CreateCommand() exclusively.
+    /// </summary>
+    public DuckDBCommand CreateCommand() => _connection.CreateCommand();
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _connection.Dispose();
+        _readLock.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        await _connection.DisposeAsync();
+        _readLock.Dispose();
+    }
+}

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -62,10 +62,10 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
-        // Initialize services
-        _databaseInitializer = new DuckDbInitializer(App.DatabasePath);
+        // Initialize services (with loggers wired to AppLogger)
+        _databaseInitializer = new DuckDbInitializer(App.DatabasePath, new AppLoggerAdapter<DuckDbInitializer>());
         _emailAlertService = new EmailAlertService(_databaseInitializer);
-        _serverManager = new ServerManager(App.ConfigDirectory);
+        _serverManager = new ServerManager(App.ConfigDirectory, logger: new AppLoggerAdapter<ServerManager>());
         _scheduleManager = new ScheduleManager(App.ConfigDirectory);
 
         // Status bar update timer
@@ -96,16 +96,19 @@ public partial class MainWindow : Window
             // Initialize the DuckDB database
             await _databaseInitializer.InitializeAsync();
 
-            // Initialize the collection engine
+            // Initialize the collection engine (with loggers wired to AppLogger)
             _collectorService = new RemoteCollectorService(
                 _databaseInitializer,
                 _serverManager,
-                _scheduleManager);
+                _scheduleManager,
+                new AppLoggerAdapter<RemoteCollectorService>());
 
-            var archiveService = new ArchiveService(_databaseInitializer, App.ArchiveDirectory);
-            var retentionService = new RetentionService(App.ArchiveDirectory);
+            var archiveService = new ArchiveService(_databaseInitializer, App.ArchiveDirectory, new AppLoggerAdapter<ArchiveService>());
+            var retentionService = new RetentionService(App.ArchiveDirectory, new AppLoggerAdapter<RetentionService>());
 
-            _backgroundService = new CollectionBackgroundService(_collectorService, _databaseInitializer, archiveService, retentionService, _serverManager);
+            _backgroundService = new CollectionBackgroundService(
+                _collectorService, _databaseInitializer, archiveService, retentionService, _serverManager,
+                new AppLoggerAdapter<CollectionBackgroundService>());
 
             // Start background collection
             _backgroundCts = new CancellationTokenSource();

--- a/Lite/Services/AppLoggerAdapter.cs
+++ b/Lite/Services/AppLoggerAdapter.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Bridges the static AppLogger to the ILogger&lt;T&gt; interface so services
+/// that accept ILogger&lt;T&gt; can log to the same file as the rest of the app.
+/// </summary>
+public sealed class AppLoggerAdapter<T> : ILogger<T>
+{
+    private readonly string _categoryName = typeof(T).Name;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+
+        var message = formatter(state, exception);
+
+        switch (logLevel)
+        {
+            case LogLevel.Trace:
+            case LogLevel.Debug:
+                AppLogger.Debug(_categoryName, message);
+                break;
+            case LogLevel.Information:
+                AppLogger.Info(_categoryName, message);
+                break;
+            case LogLevel.Warning:
+                AppLogger.Warn(_categoryName, message);
+                break;
+            case LogLevel.Error:
+            case LogLevel.Critical:
+                AppLogger.Error(_categoryName, message, exception);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #218 — Lite app crashes with "Reached the end of the file" DuckDB errors after ~1 hour of uptime.

- **Root cause**: Archival DELETEs + CHECKPOINT reorganized/truncated the DuckDB file while UI connections had stale file offsets
- **Fix**: `ReaderWriterLockSlim` coordinates UI readers (read locks via `LockedConnection` wrapper) with maintenance writers (exclusive write locks on CHECKPOINT and archive DELETEs)
- **Maintenance overhaul**: Replaced compaction cycle (`File.Replace` race condition) with archive-all-and-reset at 512MB threshold
- **Parquet naming**: Per-reset timestamps (`20260221_1925_table.parquet`) — no merge logic, trivial 90-day retention by date prefix
- **Logging**: Wired `AppLoggerAdapter<T>` for all 8 services that had null loggers
- **Removed**: Dead `CompactAsync` method (~140 lines)

## Test plan

- [x] Built clean, zero warnings
- [x] 4 SQL Servers under HammerDB load generating ~500MB/hour
- [x] 3 successful archive+reset cycles (515MB → 19MB in <1s each)
- [x] Archive views correctly query across hot table + multiple parquet file sets (legacy monthly + new timestamped)
- [x] Verified all view queries filter by `server_id` — no cross-server contamination
- [x] RetentionService parses both `yyyyMMdd` and `yyyy-MM` filename formats
- [x] Zero "end of file" errors during extended run

🤖 Generated with [Claude Code](https://claude.com/claude-code)