### PR TITLE
Lite: Add memory clerks tab with picker-driven chart (#145)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -565,6 +565,64 @@
                         </Grid>
                     </TabItem>
 
+                    <!-- Memory Clerks Sub-Tab -->
+                    <TabItem Header="Memory Clerks">
+                        <Grid Margin="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Clerk Type Picker -->
+                            <Border Grid.Column="0" Background="{StaticResource BackgroundDarkBrush}" CornerRadius="4" Padding="8" Margin="0,0,4,0">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Text="Select Memory Clerks" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,4">
+                                        <Button Content="Top Clerks" Click="MemoryClerkSelectTop_Click" Padding="6,2" Margin="0,0,4,0" FontSize="11"/>
+                                        <Button Content="Clear All" Click="MemoryClerkClearAll_Click" Padding="6,2" FontSize="11"/>
+                                        <TextBlock x:Name="MemoryClerkCountText" Text="0 selected" FontSize="10" Foreground="{StaticResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                    </StackPanel>
+                                    <TextBox Grid.Row="2" x:Name="MemoryClerkSearchBox" TextChanged="MemoryClerkSearch_TextChanged"
+                                             Margin="0,0,0,4" Padding="4,2"/>
+                                    <ListBox Grid.Row="3" x:Name="MemoryClerksList" Background="Transparent" BorderThickness="0">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                          Checked="MemoryClerk_CheckChanged" Unchecked="MemoryClerk_CheckChanged"
+                                                          Foreground="{StaticResource ForegroundBrush}" FontSize="11">
+                                                    <TextBlock Text="{Binding DisplayName}"/>
+                                                </CheckBox>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </Grid>
+                            </Border>
+
+                            <!-- Chart + Summary -->
+                            <Grid Grid.Column="1">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <ScottPlot:WpfPlot Grid.Row="0" x:Name="MemoryClerksChart"/>
+                                <Border Grid.Row="1" Background="{StaticResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,8,0,0">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <TextBlock Text="Non-BP Total:" FontWeight="SemiBold" Foreground="{StaticResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                        <TextBlock x:Name="MemoryClerksTotalText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                        <TextBlock Text="Top Non-BP Clerk:" FontWeight="SemiBold" Foreground="{StaticResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                        <TextBlock x:Name="MemoryClerksTopText" Text="--" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Border>
+                            </Grid>
+                        </Grid>
+                    </TabItem>
+
                 </TabControl>
             </TabItem>
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -460,6 +460,9 @@ CREATE INDEX IF NOT EXISTS idx_waiting_tasks_time ON waiting_tasks(server_id, co
     public const string CreateBlockedProcessReportsIndex = @"
 CREATE INDEX IF NOT EXISTS idx_blocked_process_reports_time ON blocked_process_reports(server_id, collection_time)";
 
+    public const string CreateMemoryClerksIndex = @"
+CREATE INDEX IF NOT EXISTS idx_memory_clerks_time ON memory_clerks(server_id, collection_time)";
+
     public const string CreateDatabaseScopedConfigTable = @"
 CREATE TABLE IF NOT EXISTS database_scoped_config (
     config_id BIGINT PRIMARY KEY,
@@ -575,6 +578,7 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
         yield return CreateMemoryGrantStatsIndex;
         yield return CreateWaitingTasksIndex;
         yield return CreateBlockedProcessReportsIndex;
+        yield return CreateMemoryClerksIndex;
         yield return CreateDatabaseScopedConfigIndex;
         yield return CreateTraceFlagsIndex;
         yield return CreateRunningJobsIndex;


### PR DESCRIPTION
## Summary

- Added **Memory Clerks** sub-tab under Memory in Lite, after the Overview tab
- Picker panel (left side) lets you select which clerk types to chart, with search, "Top Clerks" (auto-selects top 5), and "Clear All"
- Trend chart shows MB over time per selected clerk type with hover tooltips
- Summary footer shows Non-BP Total and Top Non-BP Clerk (excludes buffer pool)
- Added missing DuckDB index on `memory_clerks(server_id, collection_time)`

The collector and data service already existed — this was purely UI work plus two new queries (`GetDistinctMemoryClerkTypesAsync`, `GetMemoryClerkTrendAsync`).

Closes #145

## Test plan
- [x] Build succeeds with 0 errors, 0 warnings
- [x] Memory Clerks tab renders with picker and chart
- [x] Selecting/deselecting clerk types updates chart
- [x] Top Clerks and Clear All buttons work
- [x] Search filters clerk type list
- [x] Summary footer shows correct non-BP values
- [x] Hover tooltips show MB values

🤖 Generated with [Claude Code](https://claude.com/claude-code)