### PR TITLE
Visual polish: sort arrows, right-aligned numerics, initial sort indicators (#110)

### DIFF
--- a/Dashboard/CollectionLogWindow.xaml
+++ b/Dashboard/CollectionLogWindow.xaml
@@ -46,7 +46,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding RowsCollected}" Width="120">
+                <DataGridTextColumn Binding="{Binding RowsCollected}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button x:Name="RowsCollectedFilterButton" Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowsCollected" Click="LogFilter_Click" Margin="0,0,4,0"/>
@@ -54,7 +54,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DurationMs, StringFormat='{}{0:N0}'}" Width="110">
+                <DataGridTextColumn Binding="{Binding DurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button x:Name="DurationFilterButton" Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="LogFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/ConfigChangesContent.xaml
+++ b/Dashboard/Controls/ConfigChangesContent.xaml
@@ -207,7 +207,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="90">
+                    <DataGridTextColumn Binding="{Binding TraceFlag}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TraceFlag" Click="TraceFlagChangesFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/CriticalIssuesContent.xaml
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml
@@ -42,7 +42,7 @@
               GridLinesVisibility="All" CanUserResizeColumns="True"
               RowStyle="{StaticResource DefaultRowStyle}">
         <DataGrid.Columns>
-            <DataGridTextColumn Binding="{Binding IssueId}" Width="80">
+            <DataGridTextColumn Binding="{Binding IssueId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                 <DataGridTextColumn.Header>
                     <StackPanel Orientation="Horizontal">
                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IssueId" Click="CriticalIssuesFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -152,7 +152,7 @@
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TraceFlag}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TraceFlag" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/DailySummaryContent.xaml
+++ b/Dashboard/Controls/DailySummaryContent.xaml
@@ -79,7 +79,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalWaitTimeSec, StringFormat='{}{0:N2}'}" Width="130">
+                <DataGridTextColumn Binding="{Binding TotalWaitTimeSec, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWaitTimeSec" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -95,7 +95,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ExpensiveQueriesCount, StringFormat='{}{0:N0}'}" Width="130">
+                <DataGridTextColumn Binding="{Binding ExpensiveQueriesCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExpensiveQueriesCount" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -103,7 +103,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat='{}{0:N0}'}" Width="100">
+                <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DeadlockCount" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -111,7 +111,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding BlockingEventsCount, StringFormat='{}{0:N0}'}" Width="130">
+                <DataGridTextColumn Binding="{Binding BlockingEventsCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingEventsCount" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -119,7 +119,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat='{}{0:N0}'}" Width="140">
+                <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="140">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MemoryPressureEvents" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -127,7 +127,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat='{}{0:N0}'}" Width="120">
+                <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HighCpuEvents" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>
@@ -135,7 +135,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CollectorsFailing, StringFormat='{}{0:N0}'}" Width="130">
+                <DataGridTextColumn Binding="{Binding CollectorsFailing, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorsFailing" Click="DailySummaryFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -138,7 +138,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding DurationMs, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn Binding="{Binding DurationMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
@@ -146,7 +146,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CpuMs, StringFormat=N0}" Width="80">
+                    <DataGridTextColumn Binding="{Binding CpuMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
@@ -154,7 +154,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
@@ -162,7 +162,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" Width="90">
+                    <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -86,7 +86,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding SessionId}" Width="60">
+                    <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="60">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -118,7 +118,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding BlockingSessionId}" Width="80">
+                    <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -126,7 +126,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding BlockedSessionCount}" Width="80">
+                    <DataGridTextColumn Binding="{Binding BlockedSessionCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedSessionCount" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -134,7 +134,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Cpu}" Width="80">
+                    <DataGridTextColumn Binding="{Binding Cpu}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Cpu" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -142,7 +142,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -150,7 +150,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -158,7 +158,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding PhysicalReads}" Width="100">
+                    <DataGridTextColumn Binding="{Binding PhysicalReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PhysicalReads" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -166,7 +166,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ContextSwitches}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ContextSwitches}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ContextSwitches" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -174,7 +174,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="UsedMemoryMb" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -182,7 +182,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbCurrentMb" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -190,7 +190,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocations" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -198,7 +198,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TranLogWrites}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogWrites" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -206,7 +206,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding OpenTranCount}" Width="80">
+                    <DataGridTextColumn Binding="{Binding OpenTranCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTranCount" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -214,7 +214,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat='{}{0:N1}%'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat='{}{0:N1}%'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -238,7 +238,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding RequestId}" Width="70">
+                    <DataGridTextColumn Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestId" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -385,7 +385,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -393,7 +393,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -401,7 +401,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -409,7 +409,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinWorkerTime}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MinWorkerTime}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -417,7 +417,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxWorkerTime}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxWorkerTime}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -425,7 +425,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}" Width="120">
+                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -433,7 +433,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat='{}{0:N2}'}" Width="120">
+                    <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -441,7 +441,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinElapsedTime}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MinElapsedTime}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -449,7 +449,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxElapsedTime}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MaxElapsedTime}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -457,7 +457,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -465,7 +465,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -473,7 +473,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat='{}{0:N0}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -481,7 +481,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -489,7 +489,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -497,7 +497,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -505,7 +505,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgRows, StringFormat='{}{0:N2}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding AvgRows, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRows" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -513,7 +513,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinRows, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MinRows, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRows" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -521,7 +521,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxRows, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MaxRows, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRows" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -529,7 +529,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                    <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -537,7 +537,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                    <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -545,7 +545,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -553,7 +553,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -561,7 +561,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinSpills, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MinSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -569,7 +569,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -666,7 +666,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -674,7 +674,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuTimeMs" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -682,7 +682,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -690,7 +690,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinWorkerTime}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MinWorkerTime}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -698,7 +698,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxWorkerTime}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxWorkerTime}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -706,7 +706,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}" Width="120">
+                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -714,7 +714,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat='{}{0:N2}'}" Width="120">
+                    <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -722,7 +722,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinElapsedTime}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MinElapsedTime}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -730,7 +730,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxElapsedTime}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MaxElapsedTime}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -738,7 +738,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -746,7 +746,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -754,7 +754,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -762,7 +762,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -770,7 +770,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat='{}{0:N0}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -778,7 +778,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -786,7 +786,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -794,7 +794,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -802,7 +802,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -810,7 +810,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -818,7 +818,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -826,7 +826,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat='{}{0:N0}'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -834,7 +834,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinSpills, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MinSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -842,7 +842,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -881,7 +881,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryId}" Width="80">
+                    <DataGridTextColumn Binding="{Binding QueryId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryId" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -889,7 +889,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding PlanCount, StringFormat='{}{0:N0}'}" Width="80">
+                    <DataGridTextColumn Binding="{Binding PlanCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanCount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -929,7 +929,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -937,7 +937,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -945,7 +945,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDurationMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -953,7 +953,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDurationMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -961,7 +961,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -969,7 +969,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuTimeMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -977,7 +977,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuTimeMs" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -985,7 +985,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgLogicalIoReads}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgLogicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -993,7 +993,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinLogicalIoReads}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MinLogicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1001,7 +1001,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxLogicalIoReads}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MaxLogicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1009,7 +1009,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgLogicalIoWrites}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgLogicalIoWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalIoWrites" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1017,7 +1017,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinLogicalIoWrites}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MinLogicalIoWrites}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalIoWrites" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1025,7 +1025,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxLogicalIoWrites}" Width="90">
+                    <DataGridTextColumn Binding="{Binding MaxLogicalIoWrites}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalIoWrites" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1033,7 +1033,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgPhysicalIoReads}" Width="110">
+                    <DataGridTextColumn Binding="{Binding AvgPhysicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1041,7 +1041,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinPhysicalIoReads}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MinPhysicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1049,7 +1049,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxPhysicalIoReads}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxPhysicalIoReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalIoReads" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1057,7 +1057,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgRowcount}" Width="90">
+                    <DataGridTextColumn Binding="{Binding AvgRowcount}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1065,7 +1065,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinRowcount}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MinRowcount}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRowcount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1073,7 +1073,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxRowcount}" Width="80">
+                    <DataGridTextColumn Binding="{Binding MaxRowcount}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRowcount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1081,7 +1081,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                    <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1089,7 +1089,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                    <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1097,7 +1097,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgMemoryMb" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1105,7 +1105,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxMemoryMb" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1113,7 +1113,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgTempdbMb" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1121,7 +1121,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxTempdbMb" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1145,7 +1145,7 @@
                             </StackPanel>
                         </DataGridCheckBoxColumn.Header>
                     </DataGridCheckBoxColumn>
-                    <DataGridTextColumn Binding="{Binding ForceFailureCount}" Width="90">
+                    <DataGridTextColumn Binding="{Binding ForceFailureCount}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ForceFailureCount" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1161,7 +1161,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CompatibilityLevel}" Width="80">
+                    <DataGridTextColumn Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompatibilityLevel" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1215,7 +1215,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryId}" Width="80">
+                    <DataGridTextColumn Binding="{Binding QueryId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Query ID" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1223,7 +1223,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding DurationRegressionPercent, StringFormat='{}{0:N2}%'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding DurationRegressionPercent, StringFormat='{}{0:N2}%'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Duration Δ%" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1231,7 +1231,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding BaselineDurationMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding BaselineDurationMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Base Dur (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1239,7 +1239,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding RecentDurationMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding RecentDurationMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Recent Dur (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1247,7 +1247,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CpuRegressionPercent, StringFormat='{}{0:N2}%'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding CpuRegressionPercent, StringFormat='{}{0:N2}%'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="CPU Δ%" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1255,7 +1255,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding BaselineCpuMs, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding BaselineCpuMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Base CPU (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1263,7 +1263,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding RecentCpuMs, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding RecentCpuMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Recent CPU (ms)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1271,7 +1271,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding IoRegressionPercent, StringFormat='{}{0:N2}%'}" Width="90">
+                    <DataGridTextColumn Binding="{Binding IoRegressionPercent, StringFormat='{}{0:N2}%'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="I/O Δ%" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1279,7 +1279,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding BaselineReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding BaselineReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Base Reads (pages)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1287,7 +1287,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding RecentReads, StringFormat='{}{0:N0}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding RecentReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Recent Reads (pages)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1325,7 +1325,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Executions}" Width="100">
+                    <DataGridTextColumn Binding="{Binding Executions}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Executions" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1333,7 +1333,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgDurationSec, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding AvgDurationSec, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Avg Duration (sec)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1341,7 +1341,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding MaxDurationSec, StringFormat='{}{0:N2}'}" Width="110">
+                    <DataGridTextColumn Binding="{Binding MaxDurationSec, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Max Duration (sec)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1349,7 +1349,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgCpuSec, StringFormat='{}{0:N2}'}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgCpuSec, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Avg CPU (sec)" FontWeight="Bold" Margin="0,0,0,2"/>
@@ -1357,7 +1357,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding AvgReads}" Width="100">
+                    <DataGridTextColumn Binding="{Binding AvgReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel>
                                 <TextBlock Text="Avg Reads (pages)" FontWeight="Bold" Margin="0,0,0,2"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -251,14 +252,17 @@ namespace PerformanceMonitorDashboard.Controls
                 var queryStats = await queryStatsTask;
                 QueryStatsDataGrid.ItemsSource = queryStats;
                 QueryStatsNoDataMessage.Visibility = queryStats.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                SetInitialSort(QueryStatsDataGrid, "AvgCpuTimeMs", ListSortDirection.Descending);
 
                 var procStats = await procStatsTask;
                 ProcStatsDataGrid.ItemsSource = procStats;
                 ProcStatsNoDataMessage.Visibility = procStats.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                SetInitialSort(ProcStatsDataGrid, "AvgCpuTimeMs", ListSortDirection.Descending);
 
                 var queryStore = await queryStoreTask;
                 QueryStoreDataGrid.ItemsSource = queryStore;
                 QueryStoreNoDataMessage.Visibility = queryStore.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                SetInitialSort(QueryStoreDataGrid, "AvgCpuTimeMs", ListSortDirection.Descending);
 
                 // Populate charts from time-series data
                 LoadDurationChart(QueryPerfTrendsQueryChart, await queryDurationTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate, "Duration (ms/sec)", TabHelpers.ChartColors[0], _queryDurationHover);
@@ -279,6 +283,20 @@ namespace PerformanceMonitorDashboard.Controls
         private void SetStatus(string message)
         {
             _statusCallback?.Invoke(message);
+        }
+
+        private static void SetInitialSort(DataGrid grid, string bindingPath, ListSortDirection direction)
+        {
+            foreach (var column in grid.Columns)
+            {
+                if (column is DataGridBoundColumn bc &&
+                    bc.Binding is Binding b &&
+                    b.Path.Path == bindingPath)
+                {
+                    column.SortDirection = direction;
+                    return;
+                }
+            }
         }
 
         private void SetupChartSaveMenus()
@@ -872,6 +890,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var data = await _databaseService.GetQueryStoreRegressionsAsync(_qsRegressionsHoursBack, _qsRegressionsFromDate, _qsRegressionsToDate);
                 QueryStoreRegressionsDataGrid.ItemsSource = data;
                 QueryStoreRegressionsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                SetInitialSort(QueryStoreRegressionsDataGrid, "DurationRegressionPercent", ListSortDirection.Descending);
                 SetStatus($"Loaded {data.Count} query store regression records");
             }
             catch (Exception ex)
@@ -908,6 +927,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var data = await _databaseService.GetLongRunningQueryPatternsAsync(_lrqPatternsHoursBack, _lrqPatternsFromDate, _lrqPatternsToDate);
                 LongRunningQueryPatternsDataGrid.ItemsSource = data;
                 LongRunningQueryPatternsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                SetInitialSort(LongRunningQueryPatternsDataGrid, "AvgDurationSec", ListSortDirection.Descending);
                 SetStatus($"Loaded {data.Count} long running query pattern records");
             }
             catch (Exception ex)

--- a/Dashboard/Controls/SystemEventsContent.xaml
+++ b/Dashboard/Controls/SystemEventsContent.xaml
@@ -202,7 +202,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ErrorNumber}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ErrorNumber}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorNumber" Click="SevereErrorsFilter_Click" Margin="0,0,4,0"/>
@@ -210,7 +210,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Severity}" Width="80">
+                    <DataGridTextColumn Binding="{Binding Severity}" ElementStyle="{StaticResource NumericCell}" Width="80">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="SevereErrorsFilter_Click" Margin="0,0,4,0"/>
@@ -218,7 +218,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding State}" Width="70">
+                    <DataGridTextColumn Binding="{Binding State}" ElementStyle="{StaticResource NumericCell}" Width="70">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="State" Click="SevereErrorsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -128,7 +128,7 @@
                 </DataGridTextColumn>
 
                 <!-- Execution Count -->
-                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -136,7 +136,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -146,7 +146,7 @@
                 </DataGridTextColumn>
 
                 <!-- Worker Time (CPU) -->
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110">
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -154,7 +154,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -162,7 +162,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -170,7 +170,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -178,7 +178,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105">
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -188,7 +188,7 @@
                 </DataGridTextColumn>
 
                 <!-- Elapsed Time -->
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -196,7 +196,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -204,7 +204,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -212,7 +212,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -220,7 +220,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -230,7 +230,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -238,7 +238,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -246,7 +246,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -254,7 +254,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -262,7 +262,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95">
+                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -272,7 +272,7 @@
                 </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130">
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -280,7 +280,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120">
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -288,7 +288,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -296,7 +296,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -304,7 +304,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -314,7 +314,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -322,7 +322,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -330,7 +330,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -338,7 +338,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -346,7 +346,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95">
+                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -356,7 +356,7 @@
                 </DataGridTextColumn>
 
                 <!-- Spills -->
-                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -364,7 +364,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat=N2}" Width="85">
+                <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -372,7 +372,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -380,7 +380,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -390,7 +390,7 @@
                 </DataGridTextColumn>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" Width="85">
+                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -96,7 +96,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PlanId}" Width="70">
+                <DataGridTextColumn Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanId" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -104,7 +104,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CountExecutions, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding CountExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CountExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -114,7 +114,7 @@
                 </DataGridTextColumn>
 
                 <!-- Duration (ms) -->
-                <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -122,7 +122,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -130,7 +130,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -140,7 +140,7 @@
                 </DataGridTextColumn>
 
                 <!-- CPU (ms) -->
-                <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -148,7 +148,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -156,7 +156,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -166,7 +166,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -174,7 +174,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -182,7 +182,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -192,7 +192,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -200,7 +200,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -208,7 +208,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -218,7 +218,7 @@
                 </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -226,7 +226,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -234,7 +234,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -244,7 +244,7 @@
                 </DataGridTextColumn>
 
                 <!-- DOP -->
-                <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -252,7 +252,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -262,7 +262,7 @@
                 </DataGridTextColumn>
 
                 <!-- Memory (MB) -->
-                <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -270,7 +270,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinMemoryMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -278,7 +278,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -288,7 +288,7 @@
                 </DataGridTextColumn>
 
                 <!-- Row Count -->
-                <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -296,7 +296,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinRowcount, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding MinRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -304,7 +304,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxRowcount, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding MaxRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -314,7 +314,7 @@
                 </DataGridTextColumn>
 
                 <!-- TempDB (MB) -->
-                <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -322,7 +322,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinTempdbMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -330,7 +330,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -356,7 +356,7 @@
                         </StackPanel>
                     </DataGridCheckBoxColumn.Header>
                 </DataGridCheckBoxColumn>
-                <DataGridTextColumn Binding="{Binding ForceFailureCount}" Width="100">
+                <DataGridTextColumn Binding="{Binding ForceFailureCount}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ForceFailureCount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -380,7 +380,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CompatibilityLevel}" Width="90">
+                <DataGridTextColumn Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompatibilityLevel" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -120,7 +120,7 @@
                 </DataGridTextColumn>
 
                 <!-- Execution Count -->
-                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -128,7 +128,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -138,7 +138,7 @@
                 </DataGridTextColumn>
 
                 <!-- Worker Time (CPU) - Total/Avg/Min/Max -->
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" Width="110">
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -146,7 +146,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -154,7 +154,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -162,7 +162,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" Width="100">
+                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -170,7 +170,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" Width="105">
+                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -180,7 +180,7 @@
                 </DataGridTextColumn>
 
                 <!-- Elapsed Time - Total/Avg/Min/Max -->
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -188,7 +188,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -196,7 +196,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -204,7 +204,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -212,7 +212,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -222,7 +222,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -230,7 +230,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -238,7 +238,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" Width="95">
+                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -248,7 +248,7 @@
                 </DataGridTextColumn>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="130">
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -256,7 +256,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" Width="120">
+                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -264,7 +264,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -272,7 +272,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" Width="120">
+                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -280,7 +280,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" Width="115">
+                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -290,7 +290,7 @@
                 </DataGridTextColumn>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="125">
+                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -298,7 +298,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" Width="115">
+                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -306,7 +306,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" Width="95">
+                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -316,7 +316,7 @@
                 </DataGridTextColumn>
 
                 <!-- Rows -->
-                <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" Width="100">
+                <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -324,7 +324,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgRows, StringFormat=N2}" Width="90">
+                <DataGridTextColumn Binding="{Binding AvgRows, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRows" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -332,7 +332,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinRows, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MinRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRows" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -340,7 +340,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxRows, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MaxRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRows" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -350,7 +350,7 @@
                 </DataGridTextColumn>
 
                 <!-- Parallelism -->
-                <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -358,7 +358,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -368,7 +368,7 @@
                 </DataGridTextColumn>
 
                 <!-- Memory Grants -->
-                <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" Width="105">
+                <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -376,7 +376,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" Width="105">
+                <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -384,7 +384,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" Width="105">
+                <DataGridTextColumn Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -394,7 +394,7 @@
                 </DataGridTextColumn>
 
                 <!-- Thread Usage -->
-                <DataGridTextColumn Binding="{Binding MinUsedThreads}" Width="85">
+                <DataGridTextColumn Binding="{Binding MinUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -402,7 +402,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" Width="85">
+                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -412,7 +412,7 @@
                 </DataGridTextColumn>
 
                 <!-- Spills -->
-                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -420,7 +420,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -428,7 +428,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" Width="85">
+                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -438,7 +438,7 @@
                 </DataGridTextColumn>
 
                 <!-- CLR Time -->
-                <DataGridTextColumn Binding="{Binding TotalClrTime, StringFormat=N0}" Width="100">
+                <DataGridTextColumn Binding="{Binding TotalClrTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -448,7 +448,7 @@
                 </DataGridTextColumn>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" Width="85">
+                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -267,7 +267,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding HoursSinceSuccess}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding HoursSinceSuccess}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HoursSinceSuccess" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -283,7 +283,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat='{}{0:F2}%'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat='{}{0:F2}%'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailureRatePercent" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -291,7 +291,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalRuns7d, StringFormat='{}{0:N0}'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding TotalRuns7d, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRuns7d" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -299,7 +299,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding FailedRuns7d, StringFormat='{}{0:N0}'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding FailedRuns7d, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailedRuns7d" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -307,7 +307,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat='{}{0:N0}'}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -315,7 +315,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalRowsCollected7d, StringFormat='{}{0:N0}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding TotalRowsCollected7d, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRowsCollected7d" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -366,12 +366,12 @@
                                             <TextBlock Text="Avg Duration" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding P95DurationSeconds, StringFormat='{}{0:N0}s'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding P95DurationSeconds, StringFormat='{}{0:N0}s'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="P95 Duration" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding PercentOfAverage, StringFormat='{}{0:N0}%'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding PercentOfAverage, StringFormat='{}{0:N0}%'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="% of Average" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
@@ -381,7 +381,7 @@
                                             <TextBlock Text="Running Long" FontWeight="Bold"/>
                                         </DataGridCheckBoxColumn.Header>
                                     </DataGridCheckBoxColumn>
-                                    <DataGridTextColumn Binding="{Binding SuccessfulRunCount, StringFormat='{}{0:N0}'}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding SuccessfulRunCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="History Runs" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
@@ -543,7 +543,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Spid, StringFormat='{}{0:N0}'}" Width="50">
+                                    <DataGridTextColumn Binding="{Binding Spid, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="50">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -575,7 +575,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTimeMs" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -655,7 +655,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TransactionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding TransactionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionCount" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -663,7 +663,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Priority, StringFormat='{}{0:N0}'}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding Priority, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Priority" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -671,7 +671,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding LogUsed, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding LogUsed, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogUsed" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -735,7 +735,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Spid, StringFormat='{}{0:N0}'}" Width="50">
+                                    <DataGridTextColumn Binding="{Binding Spid, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="50">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>
@@ -751,7 +751,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding WaitTime, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding WaitTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTime" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>
@@ -847,7 +847,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TransactionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding TransactionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionCount" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>
@@ -855,7 +855,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Priority, StringFormat='{}{0:N0}'}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding Priority, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Priority" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>
@@ -863,7 +863,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding LogUsed, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding LogUsed, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogUsed" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -625,6 +625,20 @@
         <Setter Property="HeadersVisibility" Value="Column"/>
     </Style>
 
+    <!-- Column header resize gripper -->
+    <Style x:Key="ColumnHeaderGripperStyle" TargetType="{x:Type Thumb}">
+        <Setter Property="Width" Value="8"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Cursor" Value="SizeWE"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="DataGridColumnHeader">
         <Setter Property="Background" Value="{StaticResource BackgroundLightBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
@@ -633,17 +647,71 @@
         <Setter Property="Padding" Value="8,6"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="DataGridColumnHeader">
+                    <Grid>
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter Grid.Column="0"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="Center"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <Path x:Name="SortArrow"
+                                      Grid.Column="1"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Width="8" Height="6"
+                                      Margin="4,0,2,0"
+                                      Stretch="Fill"
+                                      Opacity="0.7"
+                                      Fill="{StaticResource ForegroundDimBrush}"
+                                      RenderTransformOrigin="0.5,0.5"
+                                      Visibility="Collapsed"
+                                      Data="M 0,0 L 8,0 L 4,6 Z"/>
+                            </Grid>
+                        </Border>
+                        <Thumb x:Name="PART_LeftHeaderGripper"
+                               HorizontalAlignment="Left"
+                               Style="{StaticResource ColumnHeaderGripperStyle}"/>
+                        <Thumb x:Name="PART_RightHeaderGripper"
+                               HorizontalAlignment="Right"
+                               Style="{StaticResource ColumnHeaderGripperStyle}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="SortDirection" Value="Ascending">
+                            <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="SortArrow" Property="RenderTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="180"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="SortDirection" Value="Descending">
+                            <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- Column header style when filter is active - subtle blue highlight -->
-    <Style x:Key="FilteredColumnHeaderStyle" TargetType="DataGridColumnHeader">
+    <Style x:Key="FilteredColumnHeaderStyle" TargetType="DataGridColumnHeader"
+           BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
         <Setter Property="Background" Value="#3D5A80"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
-        <Setter Property="BorderThickness" Value="0,0,1,1"/>
-        <Setter Property="Padding" Value="8,6"/>
-        <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+    </Style>
+
+    <!-- Right-aligned text style for numeric DataGrid columns -->
+    <Style x:Key="NumericCell" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="TextAlignment" Value="Right"/>
     </Style>
 
     <Style TargetType="DataGridCell">

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -203,7 +203,7 @@
                                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                           CanUserSortColumns="True">
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Binding="{Binding SessionId}" Width="55">
+                                        <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding CollectionTimeLocal}" Width="140">
@@ -218,37 +218,37 @@
                                         <DataGridTextColumn Binding="{Binding ElapsedTimeFormatted}" Width="120">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ElapsedTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Elapsed" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat=N0}" Width="80">
+                                        <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat=N0}" Width="95">
+                                        <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" Width="70">
+                                        <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" Width="70">
+                                        <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding WaitType}" Width="120">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitType" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Wait Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat=N0}" Width="80">
+                                        <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Wait (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding WaitResource}" Width="140">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitResource" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Wait Resource" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding BlockingSessionId}" Width="70">
+                                        <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding Dop}" Width="45">
+                                        <DataGridTextColumn Binding="{Binding Dop}" ElementStyle="{StaticResource NumericCell}" Width="45">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Dop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding ParallelWorkerCount}" Width="60">
+                                        <DataGridTextColumn Binding="{Binding ParallelWorkerCount}" ElementStyle="{StaticResource NumericCell}" Width="60">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ParallelWorkerCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Workers" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat=F2}" Width="90">
+                                        <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat=F2}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedQueryMemoryGb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Memory (GB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
@@ -294,55 +294,55 @@
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" Width="110">
+                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalElapsedMs, StringFormat=N1}" Width="130">
+                                    <DataGridTextColumn Binding="{Binding TotalElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="110">
+                                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MinCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MaxCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MinElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MaxElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MinDop}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MaxDop}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding QueryHash}" Width="140">
@@ -389,46 +389,46 @@
                                     <DataGridTextColumn Binding="{Binding ObjectType}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" Width="110">
+                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalElapsedMs, StringFormat=N1}" Width="130">
+                                    <DataGridTextColumn Binding="{Binding TotalElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" Width="110">
+                                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MinCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MaxCpuMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MinElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding MaxElapsedMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding PlanHandle}" Width="140">
@@ -457,37 +457,37 @@
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding QueryId}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding QueryId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query ID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding PlanId}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan ID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalDurationMs, StringFormat=N1}" Width="130">
+                                    <DataGridTextColumn Binding="{Binding TotalDurationMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalDurationMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" Width="110">
+                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N1}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N1}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N1}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N1}" Width="90">
+                                    <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="130">
@@ -697,10 +697,10 @@
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding BlockedSpid}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding BlockedSpid}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedSpid" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocked SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding BlockingSpid}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding BlockingSpid}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSpid" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocking SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding WaitTimeFormatted}" Width="80">
@@ -727,13 +727,13 @@
                                     <DataGridTextColumn Binding="{Binding BlockedTransactionName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedTransactionName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocked Tran" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding BlockedPriority}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding BlockedPriority}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedPriority" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocked Priority" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding BlockedTransactionCount}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding BlockedTransactionCount}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedTransactionCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocked Tran Count" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding BlockedLogUsed}" Width="70">
+                                    <DataGridTextColumn Binding="{Binding BlockedLogUsed}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedLogUsed" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocked Log Used" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding BlockedLoginName}" Width="100">
@@ -799,7 +799,7 @@
                                     <DataGridTextColumn Binding="{Binding VictimDisplay}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="VictimDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Victim" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Spid}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding Spid}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
@@ -832,10 +832,10 @@
                                     <DataGridTextColumn Binding="{Binding TransactionName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Name" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TransactionCount}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding TransactionCount}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Count" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Priority}" Width="55">
+                                    <DataGridTextColumn Binding="{Binding Priority}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Priority" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Priority" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding LoginName}" Width="100">
@@ -955,7 +955,7 @@
                             <DataGridTextColumn Binding="{Binding RunningLongDisplay}" Width="90">
                                 <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RunningLongDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Running Long" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SuccessfulRunCount}" Width="140">
+                            <DataGridTextColumn Binding="{Binding SuccessfulRunCount}" ElementStyle="{StaticResource NumericCell}" Width="140">
                                 <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SuccessfulRunCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Successful Runs (30d)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
@@ -1003,7 +1003,7 @@
                                     <DataGridTextColumn Binding="{Binding StateDesc}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StateDesc" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="State" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding CompatibilityLevel}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompatibilityLevel" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Compat Level" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding CollationName}" Width="180">
@@ -1066,7 +1066,7 @@
                                     <DataGridTextColumn Binding="{Binding PageVerifyOption}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PageVerifyOption" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Page Verify" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TargetRecoveryTimeSeconds}" Width="135">
+                                    <DataGridTextColumn Binding="{Binding TargetRecoveryTimeSeconds}" ElementStyle="{StaticResource NumericCell}" Width="135">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TargetRecoveryTimeSeconds" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Target Recovery (s)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding DelayedDurability}" Width="130">
@@ -1111,7 +1111,7 @@
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Binding="{Binding TraceFlag}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding TraceFlag}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TraceFlag" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Trace Flag" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding StatusDisplay}" Width="100">
@@ -1146,16 +1146,16 @@
                                     <DataGridTextColumn Binding="{Binding HealthStatus}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HealthStatus" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalRuns, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding TotalRuns, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRuns" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Runs" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding SuccessCount, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding SuccessCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SuccessCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Success" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding ErrorCount, StringFormat=N0}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding ErrorCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Errors" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat=N1}" Width="85">
+                                    <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="85">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailureRatePercent" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Fail %" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="100">
@@ -1208,7 +1208,7 @@
                                         <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" Width="100">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DuckDbDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="DuckDB (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding RowsCollected, StringFormat=N0}" Width="80">
+                                        <DataGridTextColumn Binding="{Binding RowsCollected, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowsCollected" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding ErrorMessage}" Width="*">

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -17,6 +17,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Controls.Primitives;
+using System.ComponentModel;
+using System.Windows.Data;
 using System.Windows.Threading;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Database;
@@ -522,10 +524,13 @@ public partial class ServerTab : UserControl
             /* Update grids (via filter managers to preserve active filters) */
             _querySnapshotsFilterMgr!.UpdateData(snapshotsTask.Result);
             _queryStatsFilterMgr!.UpdateData(queryStatsTask.Result);
+            SetInitialSort(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
             _procStatsFilterMgr!.UpdateData(procStatsTask.Result);
+            SetInitialSort(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
             _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
             _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(deadlockTask.Result));
             _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
+            SetInitialSort(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
             _serverConfigFilterMgr!.UpdateData(serverConfigTask.Result);
             _databaseConfigFilterMgr!.UpdateData(databaseConfigTask.Result);
             _dbScopedConfigFilterMgr!.UpdateData(databaseScopedConfigTask.Result);
@@ -2422,5 +2427,19 @@ public partial class ServerTab : UserControl
             current = VisualTreeHelper.GetParent(current);
         }
         return null;
+    }
+
+    private static void SetInitialSort(DataGrid grid, string bindingPath, ListSortDirection direction)
+    {
+        foreach (var column in grid.Columns)
+        {
+            if (column is DataGridBoundColumn bc &&
+                bc.Binding is Binding b &&
+                b.Path.Path == bindingPath)
+            {
+                column.SortDirection = direction;
+                return;
+            }
+        }
     }
 }

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -582,6 +582,20 @@
         <Setter Property="HeadersVisibility" Value="Column"/>
     </Style>
 
+    <!-- Column header resize gripper -->
+    <Style x:Key="ColumnHeaderGripperStyle" TargetType="{x:Type Thumb}">
+        <Setter Property="Width" Value="8"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Cursor" Value="SizeWE"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="DataGridColumnHeader">
         <Setter Property="Background" Value="{StaticResource BackgroundLightBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
@@ -590,17 +604,71 @@
         <Setter Property="Padding" Value="8,6"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="DataGridColumnHeader">
+                    <Grid>
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter Grid.Column="0"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="Center"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <Path x:Name="SortArrow"
+                                      Grid.Column="1"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Width="8" Height="6"
+                                      Margin="4,0,2,0"
+                                      Stretch="Fill"
+                                      Opacity="0.7"
+                                      Fill="{StaticResource ForegroundDimBrush}"
+                                      RenderTransformOrigin="0.5,0.5"
+                                      Visibility="Collapsed"
+                                      Data="M 0,0 L 8,0 L 4,6 Z"/>
+                            </Grid>
+                        </Border>
+                        <Thumb x:Name="PART_LeftHeaderGripper"
+                               HorizontalAlignment="Left"
+                               Style="{StaticResource ColumnHeaderGripperStyle}"/>
+                        <Thumb x:Name="PART_RightHeaderGripper"
+                               HorizontalAlignment="Right"
+                               Style="{StaticResource ColumnHeaderGripperStyle}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="SortDirection" Value="Ascending">
+                            <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="SortArrow" Property="RenderTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="180"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="SortDirection" Value="Descending">
+                            <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- Column header style when filter is active - subtle blue highlight -->
-    <Style x:Key="FilteredColumnHeaderStyle" TargetType="DataGridColumnHeader">
+    <Style x:Key="FilteredColumnHeaderStyle" TargetType="DataGridColumnHeader"
+           BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
         <Setter Property="Background" Value="#3D5A80"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
-        <Setter Property="BorderThickness" Value="0,0,1,1"/>
-        <Setter Property="Padding" Value="8,6"/>
-        <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+    </Style>
+
+    <!-- Right-aligned text style for numeric DataGrid columns -->
+    <Style x:Key="NumericCell" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="TextAlignment" Value="Right"/>
     </Style>
 
     <Style TargetType="DataGridCell">

--- a/Lite/Windows/ProcedureHistoryWindow.xaml
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml
@@ -51,15 +51,15 @@
                   HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
-                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" Width="110"/>
-                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" Width="130"/>
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" Width="100"/>
-                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" Width="90"/>
-                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" Width="80"/>
-                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" Width="100"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
                 <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml
@@ -52,21 +52,21 @@
                   HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
-                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" Width="110"/>
-                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" Width="130"/>
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" Width="100"/>
-                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" Width="90"/>
-                <DataGridTextColumn Header="Rows" Binding="{Binding DeltaRows, StringFormat=N0}" Width="80"/>
-                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" Width="80"/>
-                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" Width="100"/>
-                <DataGridTextColumn Header="Spills" Binding="{Binding DeltaSpills, StringFormat=N0}" Width="70"/>
-                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedMs, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" Width="120"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Rows" Binding="{Binding DeltaRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Spills" Binding="{Binding DeltaSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
                 <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" Width="70"/>
                 <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" Width="70"/>
                 <DataGridTextColumn Header="Plan Hash" Binding="{Binding QueryPlanHash}" Width="140"/>

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml
@@ -52,15 +52,15 @@
                   HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
-                <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat=N0}" Width="90"/>
-                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat=N1}" Width="130"/>
-                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" Width="120"/>
-                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" Width="110"/>
-                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" Width="100"/>
-                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgLogicalReads, StringFormat=N1}" Width="90"/>
-                <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N1}" Width="90"/>
-                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" Width="120"/>
-                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N1}" Width="90"/>
+                <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgLogicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
                 <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
                 <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
                     <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- Add sort direction arrows to DataGrid column headers via custom ControlTemplate with Path geometry and SortDirection triggers (both Dashboard and Lite themes)
- Right-align ~321 numeric columns across both projects using `NumericCell` ElementStyle
- Show initial sort arrow on pre-sorted grids (Query Stats, Proc Stats, Query Store, Regressions, Long Running Patterns) so users see current sort order before clicking

## Test plan
- [x] Both projects build clean (0 warnings, 0 errors)
- [x] Sort arrows appear when clicking column headers (ascending/descending toggle)
- [x] Pre-sorted columns show descending arrow on initial load
- [x] All numeric columns right-aligned across all DataGrids
- [x] Filtered column headers (golden yellow) still display correctly with arrows
- [x] Column resize grippers still work

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)