### PR TITLE
Add collection log drill-down and daily summary to Lite (#138)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1130,6 +1130,63 @@
                 </Grid>
             </TabItem>
 
+            <!-- Daily Summary Tab -->
+            <TabItem Header="Daily Summary">
+                <Grid Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Date Selection -->
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="Summary Date:" VerticalAlignment="Center" Margin="0,0,6,0" FontWeight="Bold"/>
+                        <Button x:Name="DailySummaryTodayButton" Content="Today" Click="DailySummaryToday_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource AccentButton}"/>
+                        <DatePicker x:Name="DailySummaryDatePicker" Width="120" Margin="0,0,6,0" SelectedDateChanged="DailySummaryDate_Changed" CalendarOpened="DatePicker_CalendarOpened"/>
+                        <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
+                        <TextBlock x:Name="DailySummaryIndicator" Text="Showing: Today (UTC)" VerticalAlignment="Center"
+                                   FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                    </StackPanel>
+
+                    <!-- Summary Grid -->
+                    <DataGrid Grid.Row="1" x:Name="DailySummaryGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              RowStyle="{StaticResource GridRowStyle}"
+                              HeadersVisibility="Column" GridLinesVisibility="Horizontal">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
+                                <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
+                                <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock Grid.Row="1" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}"/>
+                </Grid>
+            </TabItem>
+
             <!-- Collection Health Tab -->
             <TabItem Header="Collection Health">
                 <Grid Margin="8">
@@ -1138,7 +1195,8 @@
                             <DataGrid x:Name="CollectionHealthGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
-                                      HeadersVisibility="Column" GridLinesVisibility="Horizontal">
+                                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                                      MouseDoubleClick="CollectionHealthGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding CollectorName}" Width="180">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Collector" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    /// <summary>
+    /// Gets daily summary for a specific date (or today if null).
+    /// </summary>
+    public async Task<DailySummaryRow?> GetDailySummaryAsync(int serverId, DateTime? summaryDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var targetDate = summaryDate?.Date ?? DateTime.UtcNow.Date;
+        var dayStart = targetDate;
+        var dayEnd = targetDate.AddDays(1);
+
+        command.CommandText = @"
+SELECT
+    COALESCE(
+        (SELECT SUM(delta_wait_time_ms) / 1000.0
+         FROM v_wait_stats
+         WHERE server_id = $1
+         AND   collection_time >= $2 AND collection_time < $3
+         AND   delta_wait_time_ms > 0), 0
+    ) AS total_wait_sec,
+    (SELECT wait_type
+     FROM v_wait_stats
+     WHERE server_id = $1
+     AND   collection_time >= $2 AND collection_time < $3
+     AND   delta_wait_time_ms > 0
+     ORDER BY delta_wait_time_ms DESC
+     LIMIT 1
+    ) AS top_wait_type,
+    COALESCE(
+        (SELECT COUNT(DISTINCT query_hash)
+         FROM v_query_stats
+         WHERE server_id = $1
+         AND   collection_time >= $2 AND collection_time < $3), 0
+    ) AS unique_queries,
+    COALESCE(
+        (SELECT COUNT(*)
+         FROM v_deadlocks
+         WHERE server_id = $1
+         AND   collection_time >= $2 AND collection_time < $3), 0
+    ) AS deadlock_count,
+    COALESCE(
+        (SELECT COUNT(*)
+         FROM v_blocked_process_reports
+         WHERE server_id = $1
+         AND   collection_time >= $2 AND collection_time < $3), 0
+    ) AS blocking_events,
+    COALESCE(
+        (SELECT COUNT(*)
+         FROM v_cpu_utilization_stats
+         WHERE server_id = $1
+         AND   sqlserver_cpu_utilization >= 80
+         AND   collection_time >= $2 AND collection_time < $3), 0
+    ) AS high_cpu_events,
+    COALESCE(
+        (SELECT COUNT(*)
+         FROM v_collection_log
+         WHERE server_id = $1
+         AND   status = 'ERROR'
+         AND   collection_time >= $2 AND collection_time < $3), 0
+    ) AS collection_errors";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = dayStart });
+        command.Parameters.Add(new DuckDBParameter { Value = dayEnd });
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return null;
+
+        var deadlocks = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3));
+        var blocking = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4));
+        var highCpu = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5));
+
+        var health = "NORMAL";
+        if (deadlocks > 0) health = "DEADLOCKS";
+        else if (highCpu > 5) health = "CPU_CRITICAL";
+        else if (blocking > 10) health = "BLOCKING";
+
+        return new DailySummaryRow
+        {
+            SummaryDate = targetDate,
+            TotalWaitTimeSec = reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
+            TopWaitType = reader.IsDBNull(1) ? "" : reader.GetString(1),
+            UniqueQueries = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2)),
+            DeadlockCount = deadlocks,
+            BlockingEvents = blocking,
+            HighCpuEvents = highCpu,
+            CollectionErrors = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+            OverallHealth = health
+        };
+    }
+}
+
+public class DailySummaryRow
+{
+    public DateTime SummaryDate { get; set; }
+    public decimal TotalWaitTimeSec { get; set; }
+    public string TopWaitType { get; set; } = "";
+    public long UniqueQueries { get; set; }
+    public long DeadlockCount { get; set; }
+    public long BlockingEvents { get; set; }
+    public long HighCpuEvents { get; set; }
+    public long CollectionErrors { get; set; }
+    public string OverallHealth { get; set; } = "";
+
+    public string SummaryDateFormatted => SummaryDate.ToString("yyyy-MM-dd");
+    public string TotalWaitFormatted => TotalWaitTimeSec < 1000
+        ? $"{TotalWaitTimeSec:N1} s"
+        : $"{TotalWaitTimeSec / 60:N1} min";
+}

--- a/Lite/Windows/CollectionLogWindow.xaml
+++ b/Lite/Windows/CollectionLogWindow.xaml
@@ -1,0 +1,81 @@
+<Window x:Class="PerformanceMonitorLite.Windows.CollectionLogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Collection History" Height="600" Width="1100"
+        WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BackgroundBrush}">
+
+    <Window.Resources>
+        <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+    </Window.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <Border Grid.Row="0" Background="{StaticResource BackgroundLightBrush}" Padding="10" Margin="10,10,10,0" CornerRadius="4">
+            <StackPanel>
+                <TextBlock x:Name="CollectorNameText" FontSize="16" FontWeight="Bold"/>
+                <TextBlock x:Name="SummaryText" Margin="0,5,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="1" x:Name="LogDataGrid"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  CanUserSortColumns="True"
+                  HeadersVisibility="Column"
+                  GridLinesVisibility="Horizontal"
+                  Margin="10">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding CollectionTimeFormatted}" Width="140">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="Collection Time" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Status}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="Status" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RowsCollected}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="Rows" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="Duration" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="SQL Duration" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="DuckDB Duration" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ErrorMessage}" Width="*">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="Error Message" FontWeight="Bold"/>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <Border Grid.Row="2" Background="{StaticResource BackgroundLightBrush}" Padding="10" Margin="10,0,10,10" CornerRadius="4">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Close" Width="100" Height="30" Click="Close_Click"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Lite/Windows/CollectionLogWindow.xaml.cs
+++ b/Lite/Windows/CollectionLogWindow.xaml.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Windows
+{
+    public partial class CollectionLogWindow : Window
+    {
+        private readonly string _collectorName;
+        private readonly LocalDataService _dataService;
+        private readonly int _serverId;
+
+        public CollectionLogWindow(LocalDataService dataService, int serverId, string collectorName)
+        {
+            InitializeComponent();
+
+            _dataService = dataService;
+            _serverId = serverId;
+            _collectorName = collectorName;
+
+            CollectorNameText.Text = $"Collection History: {collectorName}";
+
+            Loaded += CollectionLogWindow_Loaded;
+        }
+
+        private async void CollectionLogWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            await LoadCollectionLogAsync();
+        }
+
+        private async Task LoadCollectionLogAsync()
+        {
+            try
+            {
+                var logs = await _dataService.GetCollectionLogByCollectorAsync(_serverId, _collectorName);
+                LogDataGrid.ItemsSource = logs;
+
+                if (logs.Count > 0)
+                {
+                    var successCount = logs.Count(l => l.Status == "SUCCESS");
+                    var errorCount = logs.Count(l => l.Status == "ERROR");
+                    var avgDuration = logs.Where(l => l.Status == "SUCCESS" && l.DurationMs.HasValue)
+                                           .Select(l => (double)l.DurationMs!.Value)
+                                           .DefaultIfEmpty(0)
+                                           .Average();
+
+                    SummaryText.Text = $"Total Runs: {logs.Count} | Success: {successCount} | Errors: {errorCount} | Avg Duration: {avgDuration:F0} ms";
+                }
+                else
+                {
+                    SummaryText.Text = "No collection history found for this collector.";
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to load collection history:\n\n{ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+            }
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Collection log drill-down**: Double-click any collector in Health Summary to open a history window showing all runs, duration breakdown (SQL + DuckDB), and errors
- **Daily summary tab**: New tab with date picker showing aggregated daily metrics — total waits, top wait type, unique queries, deadlocks, blocking events, high CPU events, and collection errors

## Test plan
- [x] Build succeeds with 0 warnings
- [x] Collection log drill-down opens correctly for each collector
- [x] Daily summary shows data for today
- [x] Date picker works and calendar renders in dark mode
- [x] Today button resets to current date

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)