### PR TITLE
Add Current Active Queries live snapshot view (#149)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -320,6 +320,231 @@
             </Grid>
         </TabItem>
 
+        <!-- Current Active Queries Sub-Tab (Live DMV Snapshot) -->
+        <TabItem Header="Current Active Queries">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button x:Name="CurrentActiveRefreshButton" Content="Refresh"
+                            Click="CurrentActiveRefresh_Click" Padding="12,4" Margin="0,0,8,0"/>
+                    <TextBlock x:Name="CurrentActiveTimestamp" VerticalAlignment="Center"
+                               Foreground="DarkGoldenrod" FontWeight="SemiBold" FontSize="12"/>
+                </StackPanel>
+
+                <DataGrid Grid.Row="1" x:Name="CurrentActiveQueriesDataGrid"
+                          AutoGenerateColumns="False" IsReadOnly="True"
+                          RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                          ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                          RowStyle="{DynamicResource DefaultRowStyle}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="60">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Status}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding ElapsedTimeFormatted}" Width="120">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ElapsedTimeFormatted" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Elapsed" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding LoginName}" Width="110">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding HostName}" Width="110">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding ProgramName}" Width="140">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ProgramName" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Program" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuTimeMs" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogicalReads" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Writes" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding WaitType}" Width="120">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitType" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Wait Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTimeMs" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Wait (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding WaitResource}" Width="140">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitResource" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Wait Resource" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Dop}" ElementStyle="{StaticResource NumericCell}" Width="50">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Dop" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="DOP" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding ParallelWorkerCount}" ElementStyle="{StaticResource NumericCell}" Width="60">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ParallelWorkerCount" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Workers" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat='{}{0:F2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedQueryMemoryGb" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Memory (GB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionIsolationLevel" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Isolation" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding OpenTransactionCount}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTransactionCount" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Open Tran" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat='{}{0:F1}'}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="% Done" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding QueryText}" Width="500">
+                            <DataGridTextColumn.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTemplateColumn Header="Est Plan" Width="Auto" MinWidth="80">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Download" Click="DownloadCurrentActiveEstPlan_Click"
+                                            IsEnabled="{Binding HasQueryPlan}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            Padding="8,4"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Header="Live Plan" Width="Auto" MinWidth="80">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Download" Click="DownloadCurrentActiveLivePlan_Click"
+                                            IsEnabled="{Binding HasLiveQueryPlan}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            Padding="8,4"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+                <TextBlock x:Name="CurrentActiveNoDataMessage" Style="{StaticResource EmptyStateMessage}"
+                           Text="Click Refresh to load current active queries" Grid.Row="1"/>
+                <local:LoadingOverlay x:Name="CurrentActiveLoading" Grid.Row="1"/>
+            </Grid>
+        </TabItem>
+
         <!-- Query Stats Sub-Tab -->
         <TabItem Header="Query Stats">
             <Grid>

--- a/Dashboard/Models/LiveQueryItem.cs
+++ b/Dashboard/Models/LiveQueryItem.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class LiveQueryItem
+    {
+        public DateTime SnapshotTime { get; set; }
+        public int SessionId { get; set; }
+        public string? DatabaseName { get; set; }
+        public string ElapsedTimeFormatted { get; set; } = string.Empty;
+        public string? QueryText { get; set; }
+        public string? QueryPlan { get; set; }
+        public string? LiveQueryPlan { get; set; }
+        public string? Status { get; set; }
+        public int BlockingSessionId { get; set; }
+        public string? WaitType { get; set; }
+        public long WaitTimeMs { get; set; }
+        public string? WaitResource { get; set; }
+        public long CpuTimeMs { get; set; }
+        public long TotalElapsedTimeMs { get; set; }
+        public long Reads { get; set; }
+        public long Writes { get; set; }
+        public long LogicalReads { get; set; }
+        public decimal GrantedQueryMemoryGb { get; set; }
+        public string? TransactionIsolationLevel { get; set; }
+        public int Dop { get; set; }
+        public int ParallelWorkerCount { get; set; }
+        public string? LoginName { get; set; }
+        public string? HostName { get; set; }
+        public string? ProgramName { get; set; }
+        public int OpenTransactionCount { get; set; }
+        public decimal PercentComplete { get; set; }
+
+        public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlan);
+        public bool HasLiveQueryPlan => !string.IsNullOrEmpty(LiveQueryPlan);
+    }
+}

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -196,7 +196,14 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0" Text="Currently Running Queries" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Currently Running Queries" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <Button x:Name="LiveSnapshotButton" Content="Live Snapshot"
+                                            Click="LiveSnapshot_Click" Padding="12,4" Margin="16,0,8,0"
+                                            VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="LiveSnapshotIndicator" Text="" FontSize="12"
+                                               Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                </StackPanel>
                                 <DataGrid Grid.Row="1" x:Name="QuerySnapshotsGrid"
                                           AutoGenerateColumns="False" IsReadOnly="True"
                                           RowStyle="{StaticResource GridRowStyle}"
@@ -211,6 +218,15 @@
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Binding="{Binding LoginName}" Width="110">
+                                            <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Binding="{Binding HostName}" Width="110">
+                                            <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Binding="{Binding ProgramName}" Width="140">
+                                            <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ProgramName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Program" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding Status}" Width="80">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
@@ -253,6 +269,12 @@
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionIsolationLevel" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Isolation" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Binding="{Binding OpenTransactionCount}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                            <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTransactionCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Open Tran" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat=F1}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                            <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="% Done" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTemplateColumn Width="500">
                                             <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -255,7 +255,12 @@ CREATE TABLE IF NOT EXISTS query_snapshots (
     granted_query_memory_gb DECIMAL(18,2),
     transaction_isolation_level VARCHAR,
     dop INTEGER,
-    parallel_worker_count INTEGER
+    parallel_worker_count INTEGER,
+    login_name VARCHAR,
+    host_name VARCHAR,
+    program_name VARCHAR,
+    open_transaction_count INTEGER,
+    percent_complete DECIMAL(5,2)
 )";
 
     public const string CreateTempdbStatsTable = @"

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -138,7 +138,12 @@ SELECT
     parallel_worker_count,
     query_plan,
     live_query_plan,
-    collection_time
+    collection_time,
+    login_name,
+    host_name,
+    program_name,
+    open_transaction_count,
+    percent_complete
 FROM v_query_snapshots
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -176,7 +181,12 @@ ORDER BY collection_time DESC, cpu_time_ms DESC";
                 ParallelWorkerCount = reader.IsDBNull(17) ? 0 : reader.GetInt32(17),
                 QueryPlan = reader.IsDBNull(18) ? null : reader.GetString(18),
                 LiveQueryPlan = reader.IsDBNull(19) ? null : reader.GetString(19),
-                CollectionTime = reader.IsDBNull(20) ? DateTime.MinValue : reader.GetDateTime(20)
+                CollectionTime = reader.IsDBNull(20) ? DateTime.MinValue : reader.GetDateTime(20),
+                LoginName = reader.IsDBNull(21) ? "" : reader.GetString(21),
+                HostName = reader.IsDBNull(22) ? "" : reader.GetString(22),
+                ProgramName = reader.IsDBNull(23) ? "" : reader.GetString(23),
+                OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
+                PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25))
             });
         }
 
@@ -745,6 +755,11 @@ public class QuerySnapshotRow
     public DateTime CollectionTime { get; set; }
     public string? QueryPlan { get; set; }
     public string? LiveQueryPlan { get; set; }
+    public string LoginName { get; set; } = "";
+    public string HostName { get; set; } = "";
+    public string ProgramName { get; set; } = "";
+    public int OpenTransactionCount { get; set; }
+    public decimal PercentComplete { get; set; }
     public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlan);
     public bool HasLiveQueryPlan => !string.IsNullOrEmpty(LiveQueryPlan);
     public string CollectionTimeLocal => CollectionTime == DateTime.MinValue ? "" : ServerTimeHelper.FormatServerTime(CollectionTime);


### PR DESCRIPTION
## Summary
- **Dashboard**: New "Current Active Queries" sub-tab under Queries — runs `dm_exec_requests` directly for a live view of running queries. Own refresh button, column filtering, query plan download (.sqlplan) from in-memory results.
- **Lite**: "Live Snapshot" button on Active Queries tab queries the server directly, bypassing DuckDB. Gold indicator shows live mode, clears on next auto-refresh.
- **Both**: 5 new columns from `dm_exec_sessions` — login_name, host_name, program_name, open_transaction_count, percent_complete. Lite schema v12 migration.

Closes #149

## Test plan
- [x] Tested on sql2022 and sql2016
- [x] Dashboard: Current Active Queries tab refreshes independently, plan downloads work
- [x] Lite: Live Snapshot populates grid, indicator clears on auto-refresh
- [x] Both build clean (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)