### PR TITLE
Add CLI --help flag and fix Lite status bar text (#111)

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -82,6 +82,36 @@ namespace PerformanceMonitorInstaller
               --encrypt=X       Connection encryption: mandatory (default), optional, strict
               --trust-cert      Trust server certificate without validation (default: require valid cert)
             */
+            if (args.Any(a => a.Equals("--help", StringComparison.OrdinalIgnoreCase)
+                              || a.Equals("-h", StringComparison.OrdinalIgnoreCase)))
+            {
+                Console.WriteLine("Usage:");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe                                   Interactive mode");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> [options]                 Windows Auth");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username> <password>     SQL Auth");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username>                SQL Auth (password via env var)");
+                Console.WriteLine();
+                Console.WriteLine("Options:");
+                Console.WriteLine("  -h, --help           Show this help message");
+                Console.WriteLine("  --reinstall          Drop existing database and perform clean install");
+                Console.WriteLine("  --reset-schedule     Reset collection schedule to recommended defaults");
+                Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
+                Console.WriteLine("  --trust-cert         Trust server certificate without validation");
+                Console.WriteLine();
+                Console.WriteLine("Environment Variables:");
+                Console.WriteLine("  PM_SQL_PASSWORD      SQL Auth password (avoids passing on command line)");
+                Console.WriteLine();
+                Console.WriteLine("Exit Codes:");
+                Console.WriteLine("  0  Success");
+                Console.WriteLine("  1  Invalid arguments");
+                Console.WriteLine("  2  Connection failed");
+                Console.WriteLine("  3  Critical file failed");
+                Console.WriteLine("  4  Partial installation (non-critical failures)");
+                Console.WriteLine("  5  Version check failed");
+                Console.WriteLine("  6  SQL files not found");
+                return 0;
+            }
+
             bool automatedMode = args.Length > 0;
             bool reinstallMode = args.Any(a => a.Equals("--reinstall", StringComparison.OrdinalIgnoreCase));
             bool resetSchedule = args.Any(a => a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase));

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -275,11 +275,11 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Column="0" x:Name="StatusText" Text="Ready" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
-                    <TextBlock Grid.Column="1" x:Name="CollectorHealthText" Text="" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-                    <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-                    <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: Stopped" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-                    <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="0" x:Name="StatusText" Text="Ready" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="1" x:Name="CollectorHealthText" Text="" Foreground="{DynamicResource ForegroundBrush}" Margin="16,0" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" Foreground="{DynamicResource ForegroundBrush}" Margin="16,0" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: Stopped" Foreground="{DynamicResource ForegroundBrush}" Margin="16,0" VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
                 </Grid>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- **CLI `--help`/`-h` flag**: Installer now prints comprehensive usage info (modes, options, environment variables, exit codes) and exits cleanly
- **Lite status bar text color**: Changed from `ForegroundMutedBrush` (#6B7280 gray) to `ForegroundBrush` (#E4E6EB white) for readability on dark background

Partial fix for #111 — the two quick-win items selected from the larger onboarding issue.

## Test plan
- [x] `PerformanceMonitorInstaller.exe --help` prints usage and returns exit code 0
- [x] `PerformanceMonitorInstaller.exe -h` same behavior
- [x] Lite status bar text is readable (white on dark background)
- [x] Both projects build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)