### PR TITLE
Use per-collector retention from collection_schedule (#237)

### DIFF
--- a/install/45_create_agent_jobs.sql
+++ b/install/45_create_agent_jobs.sql
@@ -164,7 +164,7 @@ EXECUTE msdb.dbo.sp_add_jobstep
     @step_name = N'Run Data Retention',
     @subsystem = N'TSQL',
     @database_name = N'PerformanceMonitor',
-    @command = N'EXECUTE config.data_retention @retention_days = 30, @debug = 1;',
+    @command = N'EXECUTE config.data_retention @debug = 1;',
     @retry_attempts = 0,
     @on_success_action = 1; /*Quit with success*/
 


### PR DESCRIPTION
## Summary
- `config.data_retention` now reads `retention_days` from `config.collection_schedule` per collector instead of using a hardcoded 30-day value
- Direct name matching (strip `_collector`/`_analyzer` suffix) handles most tables; special mappings cover HealthParser, blocking_BlockedProcessReport, and deadlocks
- `@retention_days` parameter remains as fallback for any unmatched tables
- SQL Agent job step no longer passes `@retention_days = 30`

## Test plan
- [x] Tested mapping logic: all 53 collect tables matched to their collector, zero false positives
- [x] Deployed and ran on sql2022 with `@debug = 1` — query_snapshots used 10-day, running_jobs used 7-day retention
- [x] Batch deletion verified with `@batch_size = 1000`: 29 batches of 1000 + final batch of 5 for wait_stats

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)