### PR TITLE
Add configurable connection timeout setting (#236)

### DIFF
--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -65,6 +65,9 @@ public partial class App : Application
     public static bool AlertLongRunningJobEnabled { get; set; } = true;
     public static int AlertLongRunningJobMultiplier { get; set; } = 3;
 
+    /* Connection settings */
+    public static int ConnectionTimeoutSeconds { get; set; } = 5;
+
     /* System tray settings */
     public static bool MinimizeToTray { get; set; } = true;
 
@@ -220,6 +223,13 @@ public partial class App : Application
             if (root.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.GetInt32();
             if (root.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.GetInt32();
+
+            /* Connection settings */
+            if (root.TryGetProperty("connection_timeout_seconds", out v))
+            {
+                var timeout = v.GetInt32();
+                if (timeout >= 5 && timeout <= 60) ConnectionTimeoutSeconds = timeout;
+            }
 
             /* System tray settings */
             if (root.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.GetBoolean();

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -78,9 +78,9 @@ public partial class RemoteCollectorService
     private const int CommandTimeoutSeconds = 30;
 
     /// <summary>
-    /// Connection timeout for SQL Server connections in seconds.
+    /// Connection timeout for SQL Server connections in seconds. Read from App settings each call.
     /// </summary>
-    private const int ConnectionTimeoutSeconds = 5;
+    private static int ConnectionTimeoutSeconds => App.ConnectionTimeoutSeconds;
 
     /// <summary>
     /// Per-call timing fields set by each collector method.

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -31,9 +31,9 @@ public class ServerManager
     private readonly ConcurrentDictionary<string, ServerConnectionStatus> _connectionStatuses;
 
     /// <summary>
-    /// Timeout in seconds for connectivity checks. Kept short to avoid blocking UI.
+    /// Timeout in seconds for connectivity checks. Read from App settings each call.
     /// </summary>
-    private const int ConnectionCheckTimeoutSeconds = 5;
+    private static int ConnectionCheckTimeoutSeconds => App.ConnectionTimeoutSeconds;
 
     public ServerManager(string configDirectory, ILogger<ServerManager>? logger = null)
     {

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -90,6 +90,14 @@
                         <ComboBoxItem Content="Last 7 days"/>
                     </ComboBox>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Connection timeout:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <TextBox x:Name="ConnectionTimeoutBox" Width="50" Text="5" VerticalAlignment="Center"/>
+                    <TextBlock Text="seconds (5–60, increase for VPN/remote connections)"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="6,0,0,0"/>
+                </StackPanel>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Summary
- Connection timeout is now user-configurable in Settings (5–60 seconds, default 5)
- Read live on every connection attempt via property getter — no restart needed
- Fixes VPN users experiencing connection timeouts after v1.2.0 reduced timeout from 15s to 5s

## Files changed
- `App.xaml.cs` — new `ConnectionTimeoutSeconds` property, loaded from `settings.json`
- `ServerManager.cs` — `const` → property getter reading `App.ConnectionTimeoutSeconds`
- `RemoteCollectorService.cs` — same change
- `SettingsWindow.xaml/.cs` — UI field + load/save logic

## Test plan
- [x] Builds with 0 errors
- [x] Verified both `ServerManager` and `RemoteCollectorService` read the value fresh on each connection (no caching)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)