### PR TITLE
Fix query/procedure stats collectors ignoring recent queries

### DIFF
--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -70,6 +70,7 @@ CROSS APPLY
 LEFT JOIN sys.databases AS d
   ON pa.dbid = d.database_id
 WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 
 UNION ALL
 
@@ -115,6 +116,7 @@ CROSS APPLY
 LEFT JOIN sys.databases AS d
   ON pa.dbid = d.database_id
 WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 
 UNION ALL
 
@@ -147,6 +149,7 @@ CROSS APPLY
 LEFT JOIN sys.databases AS d
   ON pa.dbid = d.database_id
 WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ) AS combined
 ORDER BY total_elapsed_time DESC
 OPTION(RECOMPILE);' AS nvarchar(max));
@@ -178,6 +181,7 @@ SELECT TOP (150)
     plan_handle = CONVERT(varchar(64), s.plan_handle, 1)
 FROM sys.dm_exec_procedure_stats AS s
 WHERE s.database_id = DB_ID()
+AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ORDER BY s.total_elapsed_time DESC
 OPTION(RECOMPILE);";
 

--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -34,7 +34,7 @@ public partial class RemoteCollectorService
         const string standardQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP (50)
+SELECT TOP (200)
     database_name = d.name,
     query_hash = CONVERT(varchar(64), qs.query_hash, 1),
     query_plan_hash = CONVERT(varchar(64), qs.query_plan_hash, 1),
@@ -85,6 +85,7 @@ CROSS APPLY
 INNER JOIN sys.databases AS d
   ON pa.dbid = d.database_id
 WHERE pa.dbid NOT IN (1, 2, 3, 4, 32761, 32767, ISNULL(DB_ID(N'PerformanceMonitor'), 0))
+AND   qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ORDER BY
     qs.total_elapsed_time DESC
 OPTION(RECOMPILE);";
@@ -93,7 +94,7 @@ OPTION(RECOMPILE);";
         const string azureSqlDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP (50)
+SELECT TOP (200)
     database_name = DB_NAME(),
     query_hash = CONVERT(varchar(64), qs.query_hash, 1),
     query_plan_hash = CONVERT(varchar(64), qs.query_plan_hash, 1),
@@ -134,6 +135,7 @@ SELECT TOP (50)
         END
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
+WHERE qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ORDER BY
     qs.total_elapsed_time DESC
 OPTION(RECOMPILE);";


### PR DESCRIPTION
## Summary
- Both `query_stats` and `procedure_stats` collectors used `TOP N ORDER BY total_elapsed_time DESC` with no time filter, so long-running cached plans (e.g. HammerDB TPC-H) permanently occupied all slots and recently-executed queries were never collected
- Added `last_execution_time >= DATEADD(MINUTE, -10, GETDATE())` filter to both collectors (all query variants including Azure SQL DB)
- Bumped `query_stats` TOP from 50 to 200 to capture more active queries per sweep

## Test plan
- [x] Verified fixed SQL runs clean on SQL2022 — returns only recently-executed queries
- [x] Verified HammerDB queries (last executed 8+ hours ago) are correctly excluded
- [x] Verified new queries show up immediately after execution
- [x] Lite builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)