### PR TITLE
Fix CSV export for non-US locales (#240)

### DIFF
--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -404,16 +404,17 @@ namespace PerformanceMonitorDashboard.Controls
                         try
                         {
                             var sb = new StringBuilder();
+                            var sep = TabHelpers.CsvSeparator;
                             var headers = dataGrid.Columns
                                 .OfType<DataGridBoundColumn>()
-                                .Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c)))
+                                .Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c), sep))
                                 .ToList();
-                            sb.AppendLine(string.Join(",", headers));
+                            sb.AppendLine(string.Join(sep, headers));
 
                             foreach (var item in dataGrid.Items)
                             {
                                 var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                                sb.AppendLine(string.Join(sep, values.Select(v => TabHelpers.EscapeCsvField(v, sep))));
                             }
 
                             File.WriteAllText(saveFileDialog.FileName, sb.ToString());

--- a/Dashboard/Controls/CriticalIssuesContent.xaml.cs
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml.cs
@@ -351,16 +351,16 @@ namespace PerformanceMonitorDashboard.Controls
                             {
                                 if (column is DataGridBoundColumn)
                                 {
-                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
                                 }
                             }
-                            sb.AppendLine(string.Join(",", headers));
+                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
 
                             // Add all rows
                             foreach (var item in dataGrid.Items)
                             {
                                 var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
                             }
 
                             File.WriteAllText(saveFileDialog.FileName, sb.ToString());

--- a/Dashboard/Controls/DailySummaryContent.xaml.cs
+++ b/Dashboard/Controls/DailySummaryContent.xaml.cs
@@ -428,16 +428,16 @@ namespace PerformanceMonitorDashboard.Controls
                             {
                                 if (column is DataGridBoundColumn)
                                 {
-                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
                                 }
                             }
-                            sb.AppendLine(string.Join(",", headers));
+                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
 
                             // Add all rows
                             foreach (var item in dataGrid.Items)
                             {
                                 var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
                             }
 
                             File.WriteAllText(saveFileDialog.FileName, sb.ToString());

--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -974,16 +974,16 @@ namespace PerformanceMonitorDashboard.Controls
                             {
                                 if (column is DataGridBoundColumn)
                                 {
-                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
                                 }
                             }
-                            sb.AppendLine(string.Join(",", headers));
+                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
 
                             // Add all rows
                             foreach (var item in dataGrid.Items)
                             {
                                 var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
                             }
 
                             File.WriteAllText(saveFileDialog.FileName, sb.ToString());

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1561,15 +1561,15 @@ namespace PerformanceMonitorDashboard.Controls
                             {
                                 if (column is DataGridBoundColumn)
                                 {
-                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
                                 }
                             }
-                            sb.AppendLine(string.Join(",", headers));
+                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
 
                             foreach (var item in dataGrid.Items)
                             {
                                 var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
                             }
 
                             File.WriteAllText(saveFileDialog.FileName, sb.ToString());

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -1336,8 +1336,9 @@ namespace PerformanceMonitorDashboard.Controls
                         {
                             var sb = new StringBuilder();
 
-                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c)));
-                            sb.AppendLine(string.Join(",", headers));
+                            var sep = TabHelpers.CsvSeparator;
+                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c), sep));
+                            sb.AppendLine(string.Join(sep, headers));
 
                             foreach (var item in grid.Items)
                             {
@@ -1348,11 +1349,10 @@ namespace PerformanceMonitorDashboard.Controls
                                     if (binding != null)
                                     {
                                         var prop = item.GetType().GetProperty(binding.Path.Path);
-                                        var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
-                                        values.Add(TabHelpers.EscapeCsvField(value));
+                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
                                     }
                                 }
-                                sb.AppendLine(string.Join(",", values));
+                                sb.AppendLine(string.Join(sep, values));
                             }
 
                             File.WriteAllText(dialog.FileName, sb.ToString());

--- a/Dashboard/Controls/SystemEventsContent.xaml.cs
+++ b/Dashboard/Controls/SystemEventsContent.xaml.cs
@@ -2169,8 +2169,9 @@ namespace PerformanceMonitorDashboard.Controls
                             var sb = new StringBuilder();
 
                             // Header row
-                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c)));
-                            sb.AppendLine(string.Join(",", headers));
+                            var sep = TabHelpers.CsvSeparator;
+                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(c), sep));
+                            sb.AppendLine(string.Join(sep, headers));
 
                             // Data rows
                             foreach (var item in grid.Items)
@@ -2182,11 +2183,10 @@ namespace PerformanceMonitorDashboard.Controls
                                     if (binding != null)
                                     {
                                         var prop = item.GetType().GetProperty(binding.Path.Path);
-                                        var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
-                                        values.Add(TabHelpers.EscapeCsvField(value));
+                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
                                     }
                                 }
-                                sb.AppendLine(string.Join(",", values));
+                                sb.AppendLine(string.Join(sep, values));
                             }
 
                             File.WriteAllText(dialog.FileName, sb.ToString());

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -29,6 +29,12 @@ namespace PerformanceMonitorDashboard.Helpers
     public static class TabHelpers
     {
         /// <summary>
+        /// CSV separator character used for exports. Auto-detected from locale by default;
+        /// updated from user preferences when settings are loaded.
+        /// </summary>
+        public static string CsvSeparator { get; set; } =
+            CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator == "," ? ";" : ",";
+        /// <summary>
         /// Returns true if a double-click originated from a DataGridRow (not a header).
         /// Use at the top of MouseDoubleClick handlers to prevent header clicks from
         /// triggering row actions.
@@ -307,12 +313,12 @@ namespace PerformanceMonitorDashboard.Helpers
         /// <summary>
         /// Escapes a field value for proper CSV formatting.
         /// </summary>
-        public static string EscapeCsvField(string field)
+        public static string EscapeCsvField(string field, string separator = ",")
         {
             if (string.IsNullOrEmpty(field))
                 return string.Empty;
 
-            if (field.Contains(',', StringComparison.Ordinal) || field.Contains('"', StringComparison.Ordinal) || field.Contains('\n', StringComparison.Ordinal))
+            if (field.Contains(separator, StringComparison.Ordinal) || field.Contains('"', StringComparison.Ordinal) || field.Contains('\n', StringComparison.Ordinal))
             {
                 return "\"" + field.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
             }
@@ -414,8 +420,7 @@ namespace PerformanceMonitorDashboard.Helpers
                 var property = cellInfo.Item.GetType().GetProperty(propertyName);
                 if (property != null)
                 {
-                    var value = property.GetValue(cellInfo.Item);
-                    return value?.ToString() ?? string.Empty;
+                    return FormatForExport(property.GetValue(cellInfo.Item));
                 }
             }
 
@@ -429,7 +434,7 @@ namespace PerformanceMonitorDashboard.Helpers
                     if (textBinding != null)
                     {
                         var prop = cellInfo.Item.GetType().GetProperty(textBinding.Path.Path);
-                        return prop?.GetValue(cellInfo.Item)?.ToString() ?? string.Empty;
+                        return FormatForExport(prop?.GetValue(cellInfo.Item));
                     }
                 }
             }
@@ -463,7 +468,7 @@ namespace PerformanceMonitorDashboard.Helpers
                     if (property != null)
                     {
                         var value = property.GetValue(item);
-                        values.Add(value?.ToString() ?? string.Empty);
+                        values.Add(FormatForExport(value));
                     }
                 }
                 /* DataGridTemplateColumn — instantiate the template and find a TextBlock binding */
@@ -476,7 +481,7 @@ namespace PerformanceMonitorDashboard.Helpers
                         if (textBinding != null)
                         {
                             var prop = item.GetType().GetProperty(textBinding.Path.Path);
-                            values.Add(prop?.GetValue(item)?.ToString() ?? string.Empty);
+                            values.Add(FormatForExport(prop?.GetValue(item)));
                         }
                         else
                         {
@@ -490,6 +495,17 @@ namespace PerformanceMonitorDashboard.Helpers
                 }
             }
             return values;
+        }
+
+        /// <summary>
+        /// Formats a value for CSV/clipboard export using invariant culture.
+        /// </summary>
+        public static string FormatForExport(object? value)
+        {
+            if (value == null) return string.Empty;
+            if (value is IFormattable formattable)
+                return formattable.ToString(null, CultureInfo.InvariantCulture);
+            return value.ToString() ?? string.Empty;
         }
 
         /// <summary>

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -137,6 +137,10 @@ namespace PerformanceMonitorDashboard
 
         private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            // Sync CSV separator from preferences
+            var startupPrefs = _preferencesService.GetPreferences();
+            TabHelpers.CsvSeparator = startupPrefs.CsvSeparator;
+
             LoadServerList();
             InitializeNotificationService();
             OpenNocTab();

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -100,6 +100,14 @@ namespace PerformanceMonitorDashboard.Models
         public bool McpEnabled { get; set; } = false;
         public int McpPort { get; set; } = 5150;
 
+        // CSV export settings
+        public string CsvSeparator { get; set; } = GetDefaultCsvSeparator();
+
+        private static string GetDefaultCsvSeparator()
+        {
+            return System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator == "," ? ";" : ",";
+        }
+
         // Navigation settings
         public bool FocusServerTabOnClick { get; set; } = true;
 

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -67,6 +67,20 @@
                             </ComboBox>
                         </StackPanel>
 
+                        <!-- CSV Export Section -->
+                        <TextBlock Text="CSV Export" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+                            <TextBlock Text="Separator:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <ComboBox x:Name="CsvSeparatorComboBox" Width="140">
+                                <ComboBoxItem Content="Comma (,)" Tag=","/>
+                                <ComboBoxItem Content="Semicolon (;)" Tag=";"/>
+                                <ComboBoxItem Content="Tab" Tag="&#x9;"/>
+                            </ComboBox>
+                            <TextBlock Text="auto-detected from locale" FontSize="11" FontStyle="Italic"
+                                       Foreground="Gray" VerticalAlignment="Center" Margin="8,0,0,0"
+                                       x:Name="CsvSeparatorHint"/>
+                        </StackPanel>
+
                         <!-- Navigation Section -->
                         <TextBlock Text="Navigation" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
                         <CheckBox x:Name="FocusServerTabCheckBox"

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -86,6 +86,21 @@ namespace PerformanceMonitorDashboard
                 DefaultTimeRangeComboBox.SelectedIndex = 4; // 24 hours
             }
 
+            // CSV separator
+            foreach (ComboBoxItem item in CsvSeparatorComboBox.Items)
+            {
+                if (item.Tag != null && item.Tag.ToString() == prefs.CsvSeparator)
+                {
+                    CsvSeparatorComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+
+            if (CsvSeparatorComboBox.SelectedItem == null)
+            {
+                CsvSeparatorComboBox.SelectedIndex = 0; // Comma
+            }
+
             // Navigation settings
             FocusServerTabCheckBox.IsChecked = prefs.FocusServerTabOnClick;
 
@@ -458,6 +473,13 @@ namespace PerformanceMonitorDashboard
             if (DefaultTimeRangeComboBox.SelectedItem is ComboBoxItem rangeItem && rangeItem.Tag != null)
             {
                 prefs.DefaultHoursBack = int.Parse(rangeItem.Tag.ToString()!, CultureInfo.InvariantCulture);
+            }
+
+            // Save CSV separator
+            if (CsvSeparatorComboBox.SelectedItem is ComboBoxItem csvItem && csvItem.Tag != null)
+            {
+                prefs.CsvSeparator = csvItem.Tag.ToString()!;
+                TabHelpers.CsvSeparator = prefs.CsvSeparator;
             }
 
             // Save navigation settings

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -68,6 +68,15 @@ public partial class App : Application
     /* Connection settings */
     public static int ConnectionTimeoutSeconds { get; set; } = 5;
 
+    /* CSV export settings */
+    public static string CsvSeparator { get; set; } = GetDefaultCsvSeparator();
+
+    private static string GetDefaultCsvSeparator()
+    {
+        /* Auto-detect: use semicolon when the locale's decimal separator is a comma (Italian, German, French, etc.) */
+        return System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator == "," ? ";" : ",";
+    }
+
     /* System tray settings */
     public static bool MinimizeToTray { get; set; } = true;
 
@@ -229,6 +238,13 @@ public partial class App : Application
             {
                 var timeout = v.GetInt32();
                 if (timeout >= 5 && timeout <= 60) ConnectionTimeoutSeconds = timeout;
+            }
+
+            /* CSV export settings */
+            if (root.TryGetProperty("csv_separator", out v))
+            {
+                var sep = v.GetString();
+                if (sep == "," || sep == ";" || sep == "\t") CsvSeparator = sep;
             }
 
             /* System tray settings */

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -98,6 +98,18 @@
                                FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
                                VerticalAlignment="Center" Margin="6,0,0,0"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="CSV separator:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="CsvSeparatorCombo" Width="140" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Comma (,)" Tag=","/>
+                        <ComboBoxItem Content="Semicolon (;)" Tag=";"/>
+                        <ComboBoxItem Content="Tab" Tag="&#x9;"/>
+                    </ComboBox>
+                    <TextBlock Text="auto-detected from locale"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="6,0,0,0" x:Name="CsvSeparatorHint"/>
+                </StackPanel>
             </StackPanel>
         </Border>
 

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Windows;
+using System.Windows.Controls;
 using PerformanceMonitorLite.Mcp;
 using PerformanceMonitorLite.Services;
 
@@ -38,6 +39,7 @@ public partial class SettingsWindow : Window
         UpdateMcpStatus();
         LoadDefaultTimeRange();
         LoadConnectionTimeout();
+        LoadCsvSeparator();
         LoadAlertSettings();
         LoadSmtpSettings();
     }
@@ -110,6 +112,7 @@ public partial class SettingsWindow : Window
         bool mcpChanged = SaveMcpSettings();
         SaveDefaultTimeRange();
         SaveConnectionTimeout();
+        SaveCsvSeparator();
         SaveAlertSettings();
         SaveSmtpSettings();
 
@@ -255,6 +258,52 @@ public partial class SettingsWindow : Window
         catch (Exception ex)
         {
             AppLogger.Error("Settings", $"Failed to save connection timeout: {ex.Message}");
+        }
+    }
+
+    private void LoadCsvSeparator()
+    {
+        foreach (ComboBoxItem item in CsvSeparatorCombo.Items)
+        {
+            if (item.Tag?.ToString() == App.CsvSeparator)
+            {
+                CsvSeparatorCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (CsvSeparatorCombo.SelectedItem == null)
+            CsvSeparatorCombo.SelectedIndex = 0;
+    }
+
+    private void SaveCsvSeparator()
+    {
+        if (CsvSeparatorCombo.SelectedItem is ComboBoxItem selected && selected.Tag is string sep)
+        {
+            App.CsvSeparator = sep;
+        }
+
+        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
+        try
+        {
+            JsonNode? root;
+            if (File.Exists(settingsPath))
+            {
+                var json = File.ReadAllText(settingsPath);
+                root = JsonNode.Parse(json) ?? new JsonObject();
+            }
+            else
+            {
+                root = new JsonObject();
+            }
+
+            root["csv_separator"] = App.CsvSeparator;
+
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(settingsPath, root.ToJsonString(options));
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Settings", $"Failed to save CSV separator: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Force `InvariantCulture` on all exported numeric values so decimals always use `.` regardless of thread culture
- Add configurable CSV separator (comma, semicolon, tab) to Settings in both Dashboard and Lite
- Auto-detect default separator from locale (semicolon when decimal separator is comma)

Closes #240

## Test plan
- [ ] Verify CSV export produces `.` decimal separators on all grids
- [ ] Verify Settings shows CSV separator combo with correct default
- [ ] Verify changing separator persists across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)