### PR TITLE
Issues #245-248: scrollbars, self-filtering, missing columns, context menus

### DIFF
--- a/Dashboard/CollectionLogWindow.xaml
+++ b/Dashboard/CollectionLogWindow.xaml
@@ -6,6 +6,15 @@
         Title="Collection History" Height="600" Width="1000"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+        </ContextMenu>
+    </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -28,7 +37,8 @@
                   CanUserSortColumns="True"
                   AlternatingRowBackground="{DynamicResource BackgroundLightBrush}"
                   GridLinesVisibility="All"
-                  Margin="10">
+                  Margin="10"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                     <DataGridTextColumn.Header>

--- a/Dashboard/CollectionLogWindow.xaml.cs
+++ b/Dashboard/CollectionLogWindow.xaml.cs
@@ -189,6 +189,80 @@ namespace PerformanceMonitorDashboard
             }
         }
 
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = Helpers.TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(Helpers.TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                        headers.Add(Helpers.DataGridClipboardBehavior.GetHeaderText(column));
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(Helpers.TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var dialog = new Microsoft.Win32.SaveFileDialog
+                    {
+                        FileName = $"collection_log_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+                    if (dialog.ShowDialog() == true)
+                    {
+                        var sb = new System.Text.StringBuilder();
+                        var headers = new List<string>();
+                        foreach (var column in dataGrid.Columns)
+                            headers.Add(Helpers.TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                        sb.AppendLine(string.Join(",", headers));
+                        foreach (var item in dataGrid.Items)
+                        {
+                            var values = Helpers.TabHelpers.GetRowValues(dataGrid, item);
+                            sb.AppendLine(string.Join(",", values.Select(v => Helpers.TabHelpers.EscapeCsvField(v))));
+                        }
+                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
+                    }
+                }
+            }
+        }
+
         private void Close_Click(object sender, RoutedEventArgs e)
         {
             Close();

--- a/Dashboard/CollectorScheduleWindow.xaml
+++ b/Dashboard/CollectorScheduleWindow.xaml
@@ -6,6 +6,15 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+        </ContextMenu>
+    </Window.Resources>
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -34,7 +43,8 @@
                       Background="{DynamicResource BackgroundBrush}"
                       RowBackground="{DynamicResource BackgroundBrush}"
                       AlternatingRowBackground="{DynamicResource BackgroundLightBrush}"
-                      BorderThickness="0">
+                      BorderThickness="0"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="65"/>
                     <DataGridTextColumn Header="Collector" Binding="{Binding DisplayName}" Width="180" IsReadOnly="True"/>

--- a/Dashboard/Controls/ConfigChangesContent.xaml
+++ b/Dashboard/Controls/ConfigChangesContent.xaml
@@ -6,13 +6,23 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
              Loaded="OnLoaded">
+    <UserControl.Resources>
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+        </ContextMenu>
+    </UserControl.Resources>
     <TabControl>
         <!-- Server Configuration Changes Sub-Tab -->
         <TabItem Header="Server Config Changes">
             <Grid>
             <DataGrid x:Name="ServerConfigChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
@@ -128,7 +138,8 @@
             <Grid>
             <DataGrid x:Name="DatabaseConfigChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
@@ -197,7 +208,8 @@
             <Grid>
             <DataGrid x:Name="TraceFlagChangesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>

--- a/Dashboard/Controls/ConfigChangesContent.xaml.cs
+++ b/Dashboard/Controls/ConfigChangesContent.xaml.cs
@@ -380,5 +380,83 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var dialog = new Microsoft.Win32.SaveFileDialog
+                    {
+                        FileName = $"config_changes_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+                    if (dialog.ShowDialog() == true)
+                    {
+                        var sb = new System.Text.StringBuilder();
+                        var headers = new List<string>();
+                        foreach (var column in dataGrid.Columns)
+                            headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
+                        sb.AppendLine(string.Join(",", headers));
+                        foreach (var item in dataGrid.Items)
+                        {
+                            var values = TabHelpers.GetRowValues(dataGrid, item);
+                            sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                        }
+                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -6,13 +6,23 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
              Loaded="OnLoaded">
+    <UserControl.Resources>
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+        </ContextMenu>
+    </UserControl.Resources>
     <TabControl>
         <!-- Current Server Configuration Sub-Tab -->
         <TabItem Header="Server Configuration">
             <Grid>
             <DataGrid x:Name="ServerConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="220">
                         <DataGridTextColumn.Header>
@@ -97,7 +107,8 @@
             <Grid>
             <DataGrid x:Name="DatabaseConfigDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
                         <DataGridTextColumn.Header>
@@ -150,7 +161,8 @@
             <Grid>
             <DataGrid x:Name="TraceFlagsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
-                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding TraceFlag}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -513,10 +513,10 @@ namespace PerformanceMonitorDashboard.Helpers
         /// </summary>
         public static DataGrid? FindDataGridFromContextMenu(ContextMenu contextMenu)
         {
+            if (contextMenu.PlacementTarget is DataGrid grid)
+                return grid;
             if (contextMenu.PlacementTarget is DataGridRow row)
-            {
                 return FindParent<DataGrid>(row);
-            }
             return null;
         }
 

--- a/Dashboard/ManageServersWindow.xaml
+++ b/Dashboard/ManageServersWindow.xaml
@@ -8,6 +8,13 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+        </ContextMenu>
     </Window.Resources>
     <Grid Margin="16">
         <Grid.RowDefinitions>
@@ -36,7 +43,8 @@
                       RowBackground="{DynamicResource BackgroundBrush}"
                       AlternatingRowBackground="{DynamicResource BackgroundLightBrush}"
                       BorderThickness="0"
-                      MouseDoubleClick="ServersDataGrid_MouseDoubleClick">
+                      MouseDoubleClick="ServersDataGrid_MouseDoubleClick"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="" Width="30" CanUserSort="False">
                         <DataGridTemplateColumn.CellTemplate>

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
@@ -185,6 +187,80 @@ namespace PerformanceMonitorDashboard
                     MessageBoxButton.OK,
                     MessageBoxImage.Information
                 );
+            }
+        }
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = Helpers.TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(Helpers.TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    var headers = new System.Collections.Generic.List<string>();
+                    foreach (var column in dataGrid.Columns)
+                        headers.Add(Helpers.DataGridClipboardBehavior.GetHeaderText(column));
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(Helpers.TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var dialog = new Microsoft.Win32.SaveFileDialog
+                    {
+                        FileName = $"servers_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+                    if (dialog.ShowDialog() == true)
+                    {
+                        var sb = new System.Text.StringBuilder();
+                        var headers = new System.Collections.Generic.List<string>();
+                        foreach (var column in dataGrid.Columns)
+                            headers.Add(Helpers.TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                        sb.AppendLine(string.Join(",", headers));
+                        foreach (var item in dataGrid.Items)
+                        {
+                            var values = Helpers.TabHelpers.GetRowValues(dataGrid, item);
+                            sb.AppendLine(string.Join(",", values.Select(v => Helpers.TabHelpers.EscapeCsvField(v))));
+                        }
+                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
+                    }
+                }
             }
         }
 

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -623,6 +623,8 @@
         <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="VerticalGridLinesBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="HeadersVisibility" Value="Column"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Visible"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Visible"/>
     </Style>
 
     <!-- Column header resize gripper -->

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -377,6 +377,12 @@
                                     <DataGridTextColumn Binding="{Binding QueryPlanHash}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryPlanHash" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Hash" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding SqlHandle}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlHandle" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SQL Handle" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding PlanHandle}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanHandle" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Handle" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTemplateColumn Width="500">
                                         <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
                                                                                 <DataGridTemplateColumn.CellTemplate>
@@ -519,8 +525,26 @@
                                     <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ModuleName}" Width="120">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ModuleName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Module" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding QueryHash}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryHash" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Hash" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding QueryPlanHash}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryPlanHash" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Hash" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridCheckBoxColumn Binding="{Binding IsForcedPlan, Mode=OneWay}" Width="80" IsReadOnly="True">
+                                        <DataGridCheckBoxColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsForcedPlan" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Forced" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridCheckBoxColumn.Header>
+                                    </DataGridCheckBoxColumn>
+                                    <DataGridTextColumn Binding="{Binding PlanForcingType}" Width="100">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanForcingType" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Force Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTemplateColumn Width="500">
                                         <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>

--- a/Lite/Helpers/ContextMenuHelper.cs
+++ b/Lite/Helpers/ContextMenuHelper.cs
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Microsoft.Win32;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Shared context menu helpers for DataGrid copy/export operations.
+/// Used by standalone windows (history, collection log, manage servers, settings)
+/// that don't have the full ServerTab context menu infrastructure.
+/// </summary>
+public static class ContextMenuHelper
+{
+    public static DataGrid? FindParentDataGrid(object sender)
+    {
+        if (sender is not MenuItem menuItem) return null;
+        var contextMenu = menuItem.Parent as ContextMenu;
+        var target = contextMenu?.PlacementTarget as FrameworkElement;
+        while (target != null && target is not DataGrid)
+        {
+            target = VisualTreeHelper.GetParent(target) as FrameworkElement;
+        }
+        return target as DataGrid;
+    }
+
+    public static string GetCellValue(DataGridColumn col, object item)
+    {
+        if (col is DataGridBoundColumn boundCol
+            && boundCol.Binding is Binding binding)
+        {
+            var prop = item.GetType().GetProperty(binding.Path.Path);
+            return FormatForExport(prop?.GetValue(item));
+        }
+
+        if (col is DataGridTemplateColumn templateCol && templateCol.CellTemplate != null)
+        {
+            var content = templateCol.CellTemplate.LoadContent();
+            if (content is TextBlock textBlock)
+            {
+                var textBinding = BindingOperations.GetBinding(textBlock, TextBlock.TextProperty);
+                if (textBinding != null)
+                {
+                    var prop = item.GetType().GetProperty(textBinding.Path.Path);
+                    return FormatForExport(prop?.GetValue(item));
+                }
+            }
+        }
+
+        return "";
+    }
+
+    public static void CopyCell(object sender)
+    {
+        var grid = FindParentDataGrid(sender);
+        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
+
+        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
+        if (value.Length > 0) Clipboard.SetDataObject(value, false);
+    }
+
+    public static void CopyRow(object sender)
+    {
+        var grid = FindParentDataGrid(sender);
+        if (grid?.CurrentItem == null) return;
+
+        var sb = new StringBuilder();
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(GetCellValue(col, grid.CurrentItem));
+            sb.Append('\t');
+        }
+        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
+    }
+
+    public static void CopyAllRows(object sender)
+    {
+        var grid = FindParentDataGrid(sender);
+        if (grid?.Items == null) return;
+
+        var sb = new StringBuilder();
+
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
+            sb.Append('\t');
+        }
+        sb.AppendLine();
+
+        foreach (var item in grid.Items)
+        {
+            foreach (var col in grid.Columns)
+            {
+                sb.Append(GetCellValue(col, item));
+                sb.Append('\t');
+            }
+            sb.AppendLine();
+        }
+
+        Clipboard.SetDataObject(sb.ToString(), false);
+    }
+
+    public static void ExportToCsv(object sender, string defaultFilePrefix)
+    {
+        var grid = FindParentDataGrid(sender);
+        if (grid?.Items == null || grid.Items.Count == 0) return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            DefaultExt = ".csv",
+            FileName = $"{defaultFilePrefix}_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        var sb = new StringBuilder();
+        var sep = App.CsvSeparator;
+
+        var headers = new List<string>();
+        foreach (var col in grid.Columns)
+        {
+            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col), sep));
+        }
+        sb.AppendLine(string.Join(sep, headers));
+
+        foreach (var item in grid.Items)
+        {
+            var values = new List<string>();
+            foreach (var col in grid.Columns)
+            {
+                values.Add(CsvEscape(GetCellValue(col, item), sep));
+            }
+            sb.AppendLine(string.Join(sep, values));
+        }
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private static string FormatForExport(object? value)
+    {
+        if (value == null) return "";
+        if (value is IFormattable formattable)
+            return formattable.ToString(null, CultureInfo.InvariantCulture);
+        return value.ToString() ?? "";
+    }
+
+    private static string CsvEscape(string value, string separator)
+    {
+        if (value.Contains(separator, StringComparison.Ordinal) || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+}

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -119,7 +119,7 @@ SELECT @threshold;", connection);
         using (var cmd = new SqlCommand(@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     is_running = CASE WHEN dxs.name IS NOT NULL THEN 1 ELSE 0 END
 FROM sys.server_event_sessions AS ses
 LEFT JOIN sys.dm_xe_sessions AS dxs
@@ -200,7 +200,7 @@ ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON SERVER STATE = START;", c
         using (var cmd = new SqlCommand(@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     session_state = des.name
 FROM sys.database_event_sessions AS des
 WHERE des.name = @session_name;", connection))
@@ -285,7 +285,7 @@ INSERT
 (
     ring_buffer
 )
-SELECT
+SELECT /* PerformanceMonitorLite */
     ring_xml = TRY_CAST(xet.target_data AS xml)
 FROM sys.dm_xe_database_session_targets AS xet
 JOIN sys.dm_xe_database_sessions AS xes
@@ -325,7 +325,7 @@ INSERT
 (
     ring_buffer
 )
-SELECT
+SELECT /* PerformanceMonitorLite */
     ring_xml = TRY_CAST(xet.target_data AS xml)
 FROM sys.dm_xe_session_targets AS xet
 JOIN sys.dm_xe_sessions AS xes

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -72,7 +72,7 @@ public partial class RemoteCollectorService
         using (var cmd = new SqlCommand(@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     is_running = CASE WHEN dxs.name IS NOT NULL THEN 1 ELSE 0 END
 FROM sys.server_event_sessions AS ses
 LEFT JOIN sys.dm_xe_sessions AS dxs
@@ -156,7 +156,7 @@ ALTER EVENT SESSION [{DeadlockXeSessionName}] ON SERVER STATE = START;", connect
         using (var cmd = new SqlCommand(@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     has_correct_event = CASE
         WHEN EXISTS
         (
@@ -282,7 +282,7 @@ INSERT
 (
     ring_buffer
 )
-SELECT
+SELECT /* PerformanceMonitorLite */
     ring_xml = TRY_CAST(xet.target_data AS xml)
 FROM sys.dm_xe_database_session_targets AS xet
 JOIN sys.dm_xe_database_sessions AS xes
@@ -323,7 +323,7 @@ INSERT
 (
     ring_buffer
 )
-SELECT
+SELECT /* PerformanceMonitorLite */
     ring_xml = TRY_CAST(xet.target_data AS xml)
 FROM sys.dm_xe_session_targets AS xet
 JOIN sys.dm_xe_sessions AS xes

--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -41,7 +41,7 @@ DECLARE
     @sql nvarchar(max);
 
 SET @sql = CAST(N'
-SELECT TOP (150) * FROM (
+SELECT /* PerformanceMonitorLite */ TOP (150) * FROM (
 SELECT
     database_name = d.name,
     schema_name = OBJECT_SCHEMA_NAME(s.object_id, s.database_id),
@@ -186,7 +186,7 @@ EXECUTE sys.sp_executesql @sql;";
         const string azureSqlDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP (150)
+SELECT /* PerformanceMonitorLite */ TOP (150)
     database_name = DB_NAME(),
     schema_name = OBJECT_SCHEMA_NAME(s.object_id, s.database_id),
     object_name = OBJECT_NAME(s.object_id, s.database_id),

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -23,7 +23,7 @@ public partial class RemoteCollectorService
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LOCK_TIMEOUT 1000;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     der.session_id,
     database_name = DB_NAME(der.database_id),
     elapsed_time_formatted =

--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -34,7 +34,7 @@ public partial class RemoteCollectorService
         const string standardQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP (200)
+SELECT /* PerformanceMonitorLite */ TOP (200)
     database_name = d.name,
     query_hash = CONVERT(varchar(64), qs.query_hash, 1),
     query_plan_hash = CONVERT(varchar(64), qs.query_plan_hash, 1),
@@ -104,6 +104,7 @@ CROSS APPLY
 INNER JOIN sys.databases AS d
   ON pa.dbid = d.database_id
 WHERE pa.dbid NOT IN (1, 2, 3, 4, 32761, 32767, ISNULL(DB_ID(N'PerformanceMonitor'), 0))
+AND   st.text NOT LIKE N'%PerformanceMonitorLite%'
 AND   qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ORDER BY
     qs.total_elapsed_time DESC
@@ -113,7 +114,7 @@ OPTION(RECOMPILE);";
         const string azureSqlDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP (200)
+SELECT /* PerformanceMonitorLite */ TOP (200)
     database_name = DB_NAME(),
     query_hash = CONVERT(varchar(64), qs.query_hash, 1),
     query_plan_hash = CONVERT(varchar(64), qs.query_plan_hash, 1),
@@ -173,7 +174,8 @@ SELECT TOP (200)
         END
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
-WHERE qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+WHERE st.text NOT LIKE N'%PerformanceMonitorLite%'
+AND   qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ORDER BY
     qs.total_elapsed_time DESC
 OPTION(RECOMPILE);";

--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -30,7 +30,7 @@ public partial class RemoteCollectorService
         const string dbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     d.name
 FROM sys.databases AS d
 WHERE d.is_query_store_on = 1
@@ -137,7 +137,7 @@ OPTION(RECOMPILE);";
 EXECUTE [{escapedDbName}].sys.sp_executesql
     N'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-     SELECT
+     SELECT /* PerformanceMonitorLite */
          query_id = qsq.query_id,
          plan_id = qsp.plan_id,
          execution_type_desc = qsrs.execution_type_desc,
@@ -199,6 +199,7 @@ EXECUTE [{escapedDbName}].sys.sp_executesql
      JOIN sys.query_store_query_text AS qst
        ON qst.query_text_id = qsq.query_text_id
      WHERE qsrs.last_execution_time > @cutoff_time
+     AND   qst.query_sql_text NOT LIKE N''%PerformanceMonitorLite%''
      OPTION(RECOMPILE);',
     N'@cutoff_time datetime2(7)',
     @cutoff_time;";

--- a/Lite/Services/RemoteCollectorService.TempDb.cs
+++ b/Lite/Services/RemoteCollectorService.TempDb.cs
@@ -27,20 +27,22 @@ public partial class RemoteCollectorService
         const string query = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     user_object_reserved_mb = CONVERT(decimal(18,2), SUM(dsu.user_object_reserved_page_count) * 8 / 1024.0),
     internal_object_reserved_mb = CONVERT(decimal(18,2), SUM(dsu.internal_object_reserved_page_count) * 8 / 1024.0),
     version_store_reserved_mb = CONVERT(decimal(18,2), SUM(dsu.version_store_reserved_page_count) * 8 / 1024.0),
     total_reserved_mb = CONVERT(decimal(18,2), SUM(dsu.user_object_reserved_page_count + dsu.internal_object_reserved_page_count + dsu.version_store_reserved_page_count) * 8 / 1024.0),
     unallocated_mb = CONVERT(decimal(18,2), SUM(dsu.unallocated_extent_page_count) * 8 / 1024.0)
-FROM tempdb.sys.dm_db_file_space_usage AS dsu;
+FROM tempdb.sys.dm_db_file_space_usage AS dsu
+OPTION(RECOMPILE);
 
-SELECT TOP (1)
+SELECT /* PerformanceMonitorLite */ TOP (1)
     session_id = ssu.session_id,
     tempdb_mb = CONVERT(decimal(18,2), (ssu.user_objects_alloc_page_count + ssu.internal_objects_alloc_page_count) * 8 / 1024.0),
     total_sessions = (SELECT COUNT_BIG(*) FROM sys.dm_db_session_space_usage WHERE user_objects_alloc_page_count + internal_objects_alloc_page_count > 0)
 FROM sys.dm_db_session_space_usage AS ssu
-ORDER BY (ssu.user_objects_alloc_page_count + ssu.internal_objects_alloc_page_count) DESC;";
+ORDER BY (ssu.user_objects_alloc_page_count + ssu.internal_objects_alloc_page_count) DESC
+OPTION(RECOMPILE);";
 
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;

--- a/Lite/Services/RemoteCollectorService.WaitingTasks.cs
+++ b/Lite/Services/RemoteCollectorService.WaitingTasks.cs
@@ -27,7 +27,7 @@ public partial class RemoteCollectorService
         const string query = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
+SELECT /* PerformanceMonitorLite */
     session_id = wt.session_id,
     wait_type = wt.wait_type,
     wait_duration_ms = wt.wait_duration_ms,

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -580,6 +580,8 @@
         <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="VerticalGridLinesBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="HeadersVisibility" Value="Column"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Visible"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Visible"/>
     </Style>
 
     <!-- Column header resize gripper -->

--- a/Lite/Windows/CollectionLogWindow.xaml
+++ b/Lite/Windows/CollectionLogWindow.xaml
@@ -6,7 +6,18 @@
         Background="{StaticResource BackgroundBrush}">
 
     <Window.Resources>
-        <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+        </ResourceDictionary>
     </Window.Resources>
 
     <Grid>
@@ -31,7 +42,8 @@
                   CanUserSortColumns="True"
                   HeadersVisibility="Column"
                   GridLinesVisibility="Horizontal"
-                  Margin="10">
+                  Margin="10"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding CollectionTimeFormatted}" Width="140">
                     <DataGridTextColumn.Header>

--- a/Lite/Windows/CollectionLogWindow.xaml.cs
+++ b/Lite/Windows/CollectionLogWindow.xaml.cs
@@ -72,6 +72,11 @@ namespace PerformanceMonitorLite.Windows
             }
         }
 
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "collection_log");
+
         private void Close_Click(object sender, RoutedEventArgs e)
         {
             Close();

--- a/Lite/Windows/ManageServersWindow.xaml
+++ b/Lite/Windows/ManageServersWindow.xaml
@@ -11,6 +11,13 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>
     <Grid Margin="16">
@@ -32,7 +39,8 @@
                   SelectionMode="Single"
                   Background="Transparent" BorderThickness="0"
                   HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                  MouseDoubleClick="ServersGrid_MouseDoubleClick">
+                  MouseDoubleClick="ServersGrid_MouseDoubleClick"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayName}" Width="150"/>
                 <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="200"/>

--- a/Lite/Windows/ManageServersWindow.xaml.cs
+++ b/Lite/Windows/ManageServersWindow.xaml.cs
@@ -91,6 +91,11 @@ public partial class ManageServersWindow : Window
         }
     }
 
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "servers");
+
     private void CloseButton_Click(object sender, RoutedEventArgs e)
     {
         Close();

--- a/Lite/Windows/ProcedureHistoryWindow.xaml
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml
@@ -7,7 +7,18 @@
         Background="{StaticResource BackgroundBrush}">
 
     <Window.Resources>
-        <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+        </ResourceDictionary>
     </Window.Resources>
 
     <Grid Margin="10">
@@ -49,7 +60,8 @@
         <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
                   AutoGenerateColumns="False" IsReadOnly="True"
                   CanUserSortColumns="True" CanUserReorderColumns="True"
-                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
                 <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -171,5 +171,10 @@ public partial class ProcedureHistoryWindow : Window
         }
     }
 
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "procedure_history");
+
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml
@@ -7,7 +7,18 @@
         Background="{StaticResource BackgroundBrush}">
 
     <Window.Resources>
-        <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+        </ResourceDictionary>
     </Window.Resources>
 
     <Grid Margin="10">
@@ -49,7 +60,8 @@
         <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
                   AutoGenerateColumns="False" IsReadOnly="True"
                   CanUserSortColumns="True" CanUserReorderColumns="True"
-                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
                 <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -191,5 +191,10 @@ public partial class QueryStatsHistoryWindow : Window
         chart.Plot.Axes.Left.TickLabelStyle.ForeColor = text;
     }
 
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_stats_history");
+
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml
@@ -7,7 +7,18 @@
         Background="{StaticResource BackgroundBrush}">
 
     <Window.Resources>
-        <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
+        </ResourceDictionary>
     </Window.Resources>
 
     <Grid Margin="10">
@@ -49,7 +60,8 @@
         <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
                   AutoGenerateColumns="False" IsReadOnly="True"
                   CanUserSortColumns="True" CanUserReorderColumns="True"
-                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
                 <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -172,5 +172,10 @@ public partial class QueryStoreHistoryWindow : Window
         chart.Plot.Axes.Left.TickLabelStyle.ForeColor = text;
     }
 
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_store_history");
+
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -13,6 +13,13 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
@@ -257,7 +264,8 @@
                       CanUserAddRows="False" CanUserDeleteRows="False"
                       SelectionMode="Single"
                       Background="Transparent" BorderThickness="0"
-                      HeadersVisibility="Column" GridLinesVisibility="Horizontal">
+                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                      ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
                     <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="65"/>
                     <DataGridTextColumn Header="Collector" Binding="{Binding Name}" Width="160" IsReadOnly="True"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -613,6 +613,11 @@ public partial class SettingsWindow : Window
         }
     }
 
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "schedules");
+
     private void CloseButton_Click(object sender, RoutedEventArgs e)
     {
         Close();


### PR DESCRIPTION
## Summary
- **#247**: Always-visible scrollbars on all DataGrids in both apps
- **#246**: Inline `/* PerformanceMonitorLite */` marker in collector SELECT statements, filtered at collection time so own queries never enter DuckDB. TempDb also gets `OPTION(RECOMPILE)` for consistency.
- **#248**: Missing columns added to Lite grids — QueryStore gets MinDop, MaxDop, ModuleName, QueryPlanHash, IsForcedPlan, PlanForcingType; QueryStats gets SqlHandle, PlanHandle. Fixed pre-existing XAML tag mismatch.
- **#245**: Right-click context menus (Copy Cell/Row/All, Export CSV) on 15 DataGrids across Lite (6 windows) and Dashboard (9 grids).

## Test plan
- [x] Both apps build clean (0 errors, 0 warnings)
- [x] Self-filtering verified: new collections show 0 marked rows in DuckDB
- [ ] Context menus work on all 15 grids
- [ ] New columns display correctly in QueryStore and QueryStats grids
- [ ] Scrollbars visible on empty DataGrids

Closes #245, closes #246, closes #247, closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)