### PR TITLE
Issue #255: Themed perfmon counter packs + 14 new counters

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -250,20 +250,24 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="5,5,5,2">
                             <TextBlock Text="Select Counters" FontWeight="Bold" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="PerfmonCounters_Refresh_Click" Margin="10,0,0,0" Padding="8,2" Style="{StaticResource SuccessButton}" FontSize="11"/>
                         </StackPanel>
-                        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="5,2">
+                        <ComboBox Grid.Row="1" x:Name="PerfmonPackCombo"
+                                  SelectionChanged="PerfmonPack_SelectionChanged"
+                                  Margin="5,2" FontSize="11"/>
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="5,2">
                             <Button Content="Select All" Click="PerfmonCounters_SelectAll_Click" Padding="6,2" FontSize="10" Margin="0,0,5,0"/>
                             <Button Content="Clear All" Click="PerfmonCounters_ClearAll_Click" Padding="6,2" FontSize="10"/>
                         </StackPanel>
-                        <TextBox Grid.Row="2" x:Name="PerfmonCounterSearchBox" Margin="5,2" Height="24" FontSize="11"
+                        <TextBox Grid.Row="3" x:Name="PerfmonCounterSearchBox" Margin="5,2" Height="24" FontSize="11"
                                  TextChanged="PerfmonCounterSearch_TextChanged"
                                  ToolTip="Type to filter counters"/>
-                        <ListBox Grid.Row="3" x:Name="PerfmonCountersList" Margin="5" Background="{DynamicResource BackgroundDarkBrush}" Foreground="{DynamicResource ForegroundBrush}"
+                        <ListBox Grid.Row="4" x:Name="PerfmonCountersList" Margin="5" Background="{DynamicResource BackgroundDarkBrush}" Foreground="{DynamicResource ForegroundBrush}"
                                  SelectionMode="Multiple"
                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                                  SelectionChanged="PerfmonCountersList_SelectionChanged">

--- a/Dashboard/Helpers/PerfmonPacks.cs
+++ b/Dashboard/Helpers/PerfmonPacks.cs
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Dashboard.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitorDashboard.Helpers;
+
+public static class PerfmonPacks
+{
+    public const string AllCounters = "All Counters";
+
+    public static readonly string[] PackNames =
+    [
+        AllCounters,
+        "General Throughput",
+        "Memory Pressure",
+        "CPU / Compilation",
+        "I/O Pressure",
+        "TempDB Pressure",
+        "Lock / Blocking",
+    ];
+
+    public static readonly Dictionary<string, string[]> Packs = new()
+    {
+        ["General Throughput"] =
+        [
+            "Batch Requests/sec",
+            "SQL Compilations/sec",
+            "SQL Re-Compilations/sec",
+            "Query optimizations/sec",
+            "Network IO waits",
+        ],
+        ["Memory Pressure"] =
+        [
+            "Memory Grants Pending",
+            "Granted Workspace Memory (KB)",
+            "Target Server Memory (KB)",
+            "Total Server Memory (KB)",
+            "Stolen Server Memory (KB)",
+            "Lock Memory (KB)",
+            "SQL Cache Memory (KB)",
+            "Lazy writes/sec",
+            "Free list stalls/sec",
+            "Reduced memory grants/sec",
+            "Memory grant queue waits",
+            "Thread-safe memory objects waits",
+            "Page reads/sec",
+            "Readahead pages/sec",
+        ],
+        ["CPU / Compilation"] =
+        [
+            "Batch Requests/sec",
+            "SQL Compilations/sec",
+            "SQL Re-Compilations/sec",
+            "Query optimizations/sec",
+            "Active parallel threads",
+            "Active requests",
+            "Queued requests",
+            "Wait for the worker",
+        ],
+        ["I/O Pressure"] =
+        [
+            "Page reads/sec",
+            "Page writes/sec",
+            "Checkpoint pages/sec",
+            "Page lookups/sec",
+            "Readahead pages/sec",
+            "Background writer pages/sec",
+            "Log Flushes/sec",
+            "Log Bytes Flushed/sec",
+            "Log Flush Write Time (ms)",
+            "Page IO latch waits",
+            "Log buffer waits",
+            "Log write waits",
+            "Full Scans/sec",
+            "Index Searches/sec",
+            "Page Splits/sec",
+        ],
+        ["TempDB Pressure"] =
+        [
+            "Version Store Size (KB)",
+            "Free Space in tempdb (KB)",
+            "Active Temp Tables",
+            "Version Generation rate (KB/s)",
+            "Version Cleanup rate (KB/s)",
+            "Temp Tables Creation Rate",
+            "Workfiles Created/sec",
+            "Worktables Created/sec",
+            "Forwarded Records/sec",
+        ],
+        ["Lock / Blocking"] =
+        [
+            "Lock Requests/sec",
+            "Lock Wait Time (ms)",
+            "Lock Waits/sec",
+            "Number of Deadlocks/sec",
+            "Table Lock Escalations/sec",
+            "Blocked tasks",
+            "Lock waits",
+            "Non-Page latch waits",
+            "Page latch waits",
+            "Processes blocked",
+            "Lock Timeouts/sec",
+        ],
+    };
+}

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -960,16 +960,20 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Text="Select Counters" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,4">
+                            <ComboBox Grid.Row="1" x:Name="PerfmonPackCombo"
+                                      SelectionChanged="PerfmonPack_SelectionChanged"
+                                      Margin="0,0,0,4" FontSize="11"/>
+                            <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,4">
                                 <Button Content="Select All" Click="PerfmonSelectAll_Click" Padding="6,2" Margin="0,0,4,0" FontSize="11"/>
                                 <Button Content="Clear All" Click="PerfmonClearAll_Click" Padding="6,2" FontSize="11"/>
                             </StackPanel>
-                            <TextBox Grid.Row="2" x:Name="PerfmonSearchBox" TextChanged="PerfmonSearch_TextChanged"
+                            <TextBox Grid.Row="3" x:Name="PerfmonSearchBox" TextChanged="PerfmonSearch_TextChanged"
                                      Margin="0,0,0,4" Padding="4,2"/>
-                            <ListBox Grid.Row="3" x:Name="PerfmonCountersList" Background="Transparent" BorderThickness="0">
+                            <ListBox Grid.Row="4" x:Name="PerfmonCountersList" Background="Transparent" BorderThickness="0">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"

--- a/Lite/Helpers/PerfmonPacks.cs
+++ b/Lite/Helpers/PerfmonPacks.cs
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitorLite.Helpers;
+
+public static class PerfmonPacks
+{
+    public const string AllCounters = "All Counters";
+
+    public static readonly string[] PackNames =
+    [
+        AllCounters,
+        "General Throughput",
+        "Memory Pressure",
+        "CPU / Compilation",
+        "I/O Pressure",
+        "TempDB Pressure",
+        "Lock / Blocking",
+    ];
+
+    public static readonly Dictionary<string, string[]> Packs = new()
+    {
+        ["General Throughput"] =
+        [
+            "Batch Requests/sec",
+            "SQL Compilations/sec",
+            "SQL Re-Compilations/sec",
+            "Query optimizations/sec",
+            "Network IO waits",
+        ],
+        ["Memory Pressure"] =
+        [
+            "Memory Grants Pending",
+            "Granted Workspace Memory (KB)",
+            "Target Server Memory (KB)",
+            "Total Server Memory (KB)",
+            "Stolen Server Memory (KB)",
+            "Lock Memory (KB)",
+            "SQL Cache Memory (KB)",
+            "Lazy writes/sec",
+            "Free list stalls/sec",
+            "Reduced memory grants/sec",
+            "Memory grant queue waits",
+            "Thread-safe memory objects waits",
+            "Page reads/sec",
+            "Readahead pages/sec",
+        ],
+        ["CPU / Compilation"] =
+        [
+            "Batch Requests/sec",
+            "SQL Compilations/sec",
+            "SQL Re-Compilations/sec",
+            "Query optimizations/sec",
+            "Active parallel threads",
+            "Active requests",
+            "Queued requests",
+            "Wait for the worker",
+        ],
+        ["I/O Pressure"] =
+        [
+            "Page reads/sec",
+            "Page writes/sec",
+            "Checkpoint pages/sec",
+            "Page lookups/sec",
+            "Readahead pages/sec",
+            "Background writer pages/sec",
+            "Log Flushes/sec",
+            "Log Bytes Flushed/sec",
+            "Log Flush Write Time (ms)",
+            "Page IO latch waits",
+            "Log buffer waits",
+            "Log write waits",
+            "Full Scans/sec",
+            "Index Searches/sec",
+            "Page Splits/sec",
+        ],
+        ["TempDB Pressure"] =
+        [
+            "Version Store Size (KB)",
+            "Free Space in tempdb (KB)",
+            "Active Temp Tables",
+            "Version Generation rate (KB/s)",
+            "Version Cleanup rate (KB/s)",
+            "Temp Tables Creation Rate",
+            "Workfiles Created/sec",
+            "Worktables Created/sec",
+            "Forwarded Records/sec",
+        ],
+        ["Lock / Blocking"] =
+        [
+            "Lock Requests/sec",
+            "Lock Wait Time (ms)",
+            "Lock Waits/sec",
+            "Number of Deadlocks/sec",
+            "Table Lock Escalations/sec",
+            "Blocked tasks",
+            "Lock waits",
+            "Non-Page latch waits",
+            "Page latch waits",
+            "Processes blocked",
+            "Lock Timeouts/sec",
+        ],
+    };
+}

--- a/Lite/Services/RemoteCollectorService.Perfmon.cs
+++ b/Lite/Services/RemoteCollectorService.Perfmon.cs
@@ -34,6 +34,10 @@ public partial class RemoteCollectorService
         "Readahead pages/sec",
         "Background writer pages/sec",
         "Lazy writes/sec",
+        "Full Scans/sec",
+        "Index Searches/sec",
+        "Page Splits/sec",
+        "Free list stalls/sec",
         "Non-Page latch waits",
         "Page IO latch waits",
         "Page latch waits",
@@ -47,6 +51,8 @@ public partial class RemoteCollectorService
         "Lock Waits/sec",
         "Number of Deadlocks/sec",
         "Lock waits",
+        "Processes blocked",
+        "Lock Timeouts/sec",
         /* Memory counters */
         "Granted Workspace Memory (KB)",
         "Lock Memory (KB)",
@@ -75,6 +81,15 @@ public partial class RemoteCollectorService
         "Log Flush Write Time (ms)",
         "Log buffer waits",
         "Log write waits",
+        /* TempDB counters */
+        "Version Store Size (KB)",
+        "Free Space in tempdb (KB)",
+        "Active Temp Tables",
+        "Version Generation rate (KB/s)",
+        "Version Cleanup rate (KB/s)",
+        "Temp Tables Creation Rate",
+        "Workfiles Created/sec",
+        "Worktables Created/sec",
         /* Wait counters */
         "Network IO waits",
         "Wait for the worker"


### PR DESCRIPTION
## Summary
- Adds pack selector ComboBox to perfmon tabs in both Lite and Dashboard with 7 packs: All Counters, General Throughput, Memory Pressure, CPU/Compilation, I/O Pressure, TempDB Pressure, Lock/Blocking
- Adds 14 new counters to Lite's collector (TempDB, I/O, lock categories) for 59 total perfmon counters
- Updates default selection from hardcoded counters to General Throughput pack (Batch Requests/sec, SQL Compilations/sec, SQL Re-Compilations/sec, Query optimizations/sec, Network IO waits)

## Test plan
- [x] Both Lite and Dashboard build with 0 errors, 0 warnings
- [x] Lite: pack ComboBox defaults to General Throughput, switching packs updates counter selection and chart
- [x] Dashboard: same pack ComboBox behavior verified

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)