### PR TITLE
Issue #257: Fix truncated status text in Add Server dialog

### DIFF
--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -96,7 +96,7 @@
 
         <!-- Status -->
         <TextBlock Grid.Row="9" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
-                   VerticalAlignment="Bottom" Margin="0,0,0,8"/>
+                   TextWrapping="Wrap" VerticalAlignment="Bottom" Margin="0,0,0,8"/>
 
         <!-- Buttons -->
         <StackPanel Grid.Row="10" Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary
- Adds `TextWrapping="Wrap"` to the StatusText TextBlock in the Add Server dialog
- Long success messages now wrap instead of being clipped at the dialog edge
- Dialog already uses `SizeToContent="Height"` so it grows to fit wrapped text

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)