### PR TITLE
Issue #261: Fix View Plan for Query Store and Regressions tabs

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -741,7 +741,7 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
-        private void ViewEstimatedPlan_Click(object sender, RoutedEventArgs e)
+        private async void ViewEstimatedPlan_Click(object sender, RoutedEventArgs e)
         {
             var item = GetContextMenuDataItem(sender);
             if (item == null) return;
@@ -777,10 +777,23 @@ namespace PerformanceMonitorDashboard.Controls
                     queryText = proc.ObjectName;
                     label = $"Est Plan - {proc.ProcedureName}";
                     break;
-                case QueryStoreItem qs when !string.IsNullOrEmpty(qs.QueryPlanXml):
+                case QueryStoreItem qs:
+                    if (string.IsNullOrEmpty(qs.QueryPlanXml) && _databaseService != null)
+                    {
+                        qs.QueryPlanXml = await _databaseService.GetQueryStorePlanXmlAsync(qs.DatabaseName, qs.QueryId);
+                    }
                     planXml = qs.QueryPlanXml;
                     queryText = qs.QueryText;
                     label = $"Est Plan - QS {qs.QueryId}";
+                    break;
+                case QueryStoreRegressionItem reg:
+                    if (string.IsNullOrEmpty(reg.QueryPlanXml) && _databaseService != null)
+                    {
+                        reg.QueryPlanXml = await _databaseService.GetQueryStorePlanXmlAsync(reg.DatabaseName, reg.QueryId);
+                    }
+                    planXml = reg.QueryPlanXml;
+                    queryText = reg.QueryTextSample;
+                    label = $"Est Plan - QS {reg.QueryId}";
                     break;
             }
 
@@ -824,8 +837,18 @@ namespace PerformanceMonitorDashboard.Controls
                 case QueryStoreItem qs:
                     queryText = qs.QueryText;
                     databaseName = qs.DatabaseName;
+                    if (string.IsNullOrEmpty(qs.QueryPlanXml))
+                        qs.QueryPlanXml = await _databaseService.GetQueryStorePlanXmlAsync(qs.DatabaseName, qs.QueryId);
                     planXml = qs.QueryPlanXml;
                     label = $"Actual Plan - QS {qs.QueryId}";
+                    break;
+                case QueryStoreRegressionItem reg:
+                    queryText = reg.QueryTextSample;
+                    databaseName = reg.DatabaseName;
+                    if (string.IsNullOrEmpty(reg.QueryPlanXml))
+                        reg.QueryPlanXml = await _databaseService.GetQueryStorePlanXmlAsync(reg.DatabaseName, reg.QueryId);
+                    planXml = reg.QueryPlanXml;
+                    label = $"Actual Plan - QS {reg.QueryId}";
                     break;
             }
 

--- a/Dashboard/Models/QueryStoreRegressionItem.cs
+++ b/Dashboard/Models/QueryStoreRegressionItem.cs
@@ -21,5 +21,6 @@ namespace PerformanceMonitorDashboard.Models
         public string Severity { get; set; } = string.Empty;
         public string QueryTextSample { get; set; } = string.Empty;
         public DateTime? LastExecutionTime { get; set; }
+        public string? QueryPlanXml { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Fix View Plan button for Query Store tab — plan XML was never fetched (skipped for performance), now loaded on demand via `GetQueryStorePlanXmlAsync` when user clicks View Plan
- Add View Plan and Get Actual Plan support for Query Store Regressions tab — adds `QueryPlanXml` property to model and switch cases in both handlers
- Fetched plans are cached on the row item to avoid repeat queries

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)