### PR TITLE
Issue #263: Fix empty Query Store drill-down by aligning time filter

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -1443,8 +1443,8 @@ namespace PerformanceMonitorDashboard.Services
                     var connection = tc.Connection;
 
                     var timeFilter = fromDate.HasValue && toDate.HasValue
-                        ? "AND   qsd.collection_time >= @from_date AND qsd.collection_time <= @to_date"
-                        : "AND   qsd.collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
+                        ? "AND   qsd.server_last_execution_time >= @from_date AND qsd.server_last_execution_time <= @to_date"
+                        : "AND   qsd.server_last_execution_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
 
                     string query = $@"
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;


### PR DESCRIPTION
## Summary
- Changes the Query Store drill-down query to filter by `server_last_execution_time` instead of `collection_time`
- Matches the main view's time filter semantics so queries visible in the summary always have execution history in the drill-down

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)