### PR TITLE
Fix execution count mismatches between main views and drill-downs

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1226,7 +1226,9 @@ namespace PerformanceMonitorDashboard.Controls
                     item.FullObjectName ?? item.ObjectName ?? $"ObjectId_{item.ObjectId}",
                     _procStatsHoursBack,
                     _procStatsFromDate,
-                    _procStatsToDate
+                    _procStatsToDate,
+                    item.SchemaName,
+                    item.ProcedureName
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();

--- a/Dashboard/Models/ProcedureExecutionHistoryItem.cs
+++ b/Dashboard/Models/ProcedureExecutionHistoryItem.cs
@@ -22,6 +22,7 @@ namespace PerformanceMonitorDashboard.Models
 
         // Cumulative values
         public long ExecutionCount { get; set; }
+        public long IntervalExecutions { get; set; }
         public long TotalWorkerTime { get; set; }
         public long MinWorkerTime { get; set; }
         public long MaxWorkerTime { get; set; }

--- a/Dashboard/Models/QueryStatsHistoryItem.cs
+++ b/Dashboard/Models/QueryStatsHistoryItem.cs
@@ -22,6 +22,7 @@ namespace PerformanceMonitorDashboard.Models
         // Execution count
         public long ExecutionCount { get; set; }
         public long? ExecutionCountDelta { get; set; }
+        public long IntervalExecutions { get; set; }
 
         // Worker time (CPU) - microseconds in database
         public long TotalWorkerTime { get; set; }

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -62,7 +62,7 @@
                         <ComboBoxItem Content="Avg Logical Writes" Tag="AvgLogicalWrites"/>
                         <ComboBoxItem Content="Avg Physical Reads" Tag="AvgPhysicalReads"/>
                         <ComboBoxItem Content="Avg Spills" Tag="AvgSpills"/>
-                        <ComboBoxItem Content="Execution Count Delta" Tag="ExecutionCountDelta"/>
+                        <ComboBoxItem Content="Executions Per Interval" Tag="IntervalExecutions"/>
                     </ComboBox>
                 </StackPanel>
 
@@ -127,11 +127,11 @@
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
 
-                <!-- Execution Count -->
-                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                <!-- Execution Count (per-interval, computed from cumulative counter) -->
+                <DataGridTextColumn Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IntervalExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
                             <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -62,7 +62,7 @@
                         <ComboBoxItem Content="Avg Logical Writes" Tag="AvgLogicalWrites"/>
                         <ComboBoxItem Content="Avg Physical Reads" Tag="AvgPhysicalReads"/>
                         <ComboBoxItem Content="Avg Rows" Tag="AvgRows"/>
-                        <ComboBoxItem Content="Execution Count Delta" Tag="ExecutionCountDelta"/>
+                        <ComboBoxItem Content="Executions Per Interval" Tag="IntervalExecutions"/>
                     </ComboBox>
                 </StackPanel>
 
@@ -119,11 +119,11 @@
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
 
-                <!-- Execution Count -->
-                <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                <!-- Execution Count (per-interval, computed from cumulative counter) -->
+                <DataGridTextColumn Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IntervalExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
                             <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>


### PR DESCRIPTION
## Summary
- **Query Store / Query Stats / Procedure Stats** main view queries now aggregate inline with time filter BEFORE GROUP BY, so execution counts reflect only the selected time range
- **Query Stats / Procedure Stats** drill-down grids now show computed per-interval execution counts instead of raw cumulative DMV counters (which were confusing — showing 7,6,5,4,3,2,1 instead of 1,1,1,1,1,1,1)
- **Procedure Stats** drill-down now queries by schema_name + object_name instead of object_id, fixing missing rows when objects are dropped/recreated (different object_id each time)

## Test plan
- [x] Query Store: main view execution counts match drill-down SUM (verified with TSQLV5 query 1162: 139 = 139)
- [x] Query Stats: plan eviction case shows correct total (0x847EDDE9D7BE9DDC: 2 executions from 2 lifetimes, not 1)
- [x] Query Stats: per-interval Exec Count column sums to header total (0xC5658DEBEEC48DBE: 9 = 2+1+1+1+1+1+1+1)
- [x] Procedure Stats: trigger with 5 different object_ids shows all 6 rows in drill-down
- [x] All three tabs load correctly at 1h, 24h, 7d, 30d time ranges
- [x] Build: 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)