### PR TITLE
Fix drill-down chart UX: sparse data, tooltips, window sizing (#271)

### DIFF
--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:converters="clr-namespace:PerformanceMonitorDashboard.Converters"
         xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
-        Title="Procedure Execution History" Height="900" Width="1400"
+        Title="Procedure Execution History" Height="900" Width="1600"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -36,6 +36,7 @@ namespace PerformanceMonitorDashboard
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
         private List<ProcedureExecutionHistoryItem> _historyData = new();
+        private ChartHoverHelper? _chartHover;
 
         // Filter state
         private Dictionary<string, ColumnFilterState> _filters = new();
@@ -188,13 +189,32 @@ namespace PerformanceMonitorDashboard
             var color = ScottPlot.Color.FromHex("#4FC3F7");
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
-            scatter.LineWidth = 2;
-            scatter.MarkerSize = 6;
+
+            // Sparse data: show only markers to avoid misleading interpolated lines
+            if (dates.Length <= 10)
+            {
+                scatter.LineWidth = 0;
+                scatter.MarkerSize = 8;
+            }
+            else
+            {
+                scatter.LineWidth = 2;
+                scatter.MarkerSize = 4;
+            }
 
             HistoryChart.Plot.Axes.DateTimeTicksBottom();
             Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);
             HistoryChart.Plot.YLabel(metricLabel);
             HistoryChart.Plot.XLabel("Collection Time");
+
+            // Hover tooltip
+            var unit = metricTag.Contains("Ms") ? "ms" : "";
+            if (_chartHover == null)
+                _chartHover = new ChartHoverHelper(HistoryChart, unit);
+            else
+                _chartHover.Unit = unit;
+            _chartHover.Clear();
+            _chartHover.Add(scatter, metricLabel);
 
             HistoryChart.Refresh();
         }

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:converters="clr-namespace:PerformanceMonitorDashboard.Converters"
         xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
-        Title="Query Execution History" Height="900" Width="1400"
+        Title="Query Execution History" Height="900" Width="1600"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace PerformanceMonitorDashboard
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
         private List<QueryStatsHistoryItem> _historyData = new();
+        private ChartHoverHelper? _chartHover;
 
         // Filter state
         private Dictionary<string, ColumnFilterState> _filters = new();
@@ -180,13 +181,32 @@ namespace PerformanceMonitorDashboard
             var color = ScottPlot.Color.FromHex("#4FC3F7");
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
-            scatter.LineWidth = 2;
-            scatter.MarkerSize = 6;
+
+            // Sparse data: show only markers to avoid misleading interpolated lines
+            if (dates.Length <= 10)
+            {
+                scatter.LineWidth = 0;
+                scatter.MarkerSize = 8;
+            }
+            else
+            {
+                scatter.LineWidth = 2;
+                scatter.MarkerSize = 4;
+            }
 
             HistoryChart.Plot.Axes.DateTimeTicksBottom();
             Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);
             HistoryChart.Plot.YLabel(metricLabel);
             HistoryChart.Plot.XLabel("Collection Time");
+
+            // Hover tooltip
+            var unit = metricTag.Contains("Ms") ? "ms" : "";
+            if (_chartHover == null)
+                _chartHover = new ChartHoverHelper(HistoryChart, unit);
+            else
+                _chartHover.Unit = unit;
+            _chartHover.Clear();
+            _chartHover.Add(scatter, metricLabel);
 
             HistoryChart.Refresh();
         }


### PR DESCRIPTION
## Summary
- Show markers-only (no interpolated lines) when <=10 data points across all 3 drill-down chart windows
- Add `ChartHoverHelper` tooltips to QueryStats, ProcedureHistory, and QueryExecutionHistory drill-down charts with dynamic unit display (ms for time metrics, empty for counts)
- Align Procedure and QueryExecution drill-down window width from 1400px to 1600px to match QueryStats

Closes #271

## Test plan
- [ ] Open Query Stats drill-down with sparse data (<10 points) — verify markers only, no lines
- [ ] Open Query Stats drill-down with dense data (>10 points) — verify lines + small markers
- [ ] Hover over chart data points in all 3 drill-down windows — verify tooltip shows metric, value, timestamp
- [ ] Switch metric selector — verify tooltip unit updates (ms for duration/CPU, empty for reads/executions)
- [ ] Verify Procedure and QueryExecution windows open at same width as QueryStats (1600px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)