### PR TITLE
Issue #274: Query Store Regressions drill-down + TVF rewrite

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -1417,7 +1417,8 @@
             <DataGrid x:Name="QueryStoreRegressionsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
-                      RowStyle="{DynamicResource DefaultRowStyle}">
+                      RowStyle="{DynamicResource DefaultRowStyle}"
+                      MouseDoubleClick="QueryStoreRegressionsDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
@@ -1448,6 +1449,46 @@
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryId" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query ID" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AdditionalDurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AdditionalDurationMs" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Total Impact (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineExecCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BaselineExecCount" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Base Execs" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding RecentExecCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RecentExecCount" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Recent Execs" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselinePlanCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BaselinePlanCount" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Base Plans" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding RecentPlanCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RecentPlanCount" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Recent Plans" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1200,6 +1200,38 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
+        private void QueryStoreRegressionsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
+            if (_databaseService == null) return;
+
+            if (QueryStoreRegressionsDataGrid.SelectedItem is QueryStoreRegressionItem item)
+            {
+                if (string.IsNullOrEmpty(item.DatabaseName) || item.QueryId <= 0)
+                {
+                    MessageBox.Show(
+                        "Unable to show history: missing database name or query ID.",
+                        "Information",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
+                    return;
+                }
+
+                var historyWindow = new QueryExecutionHistoryWindow(
+                    _databaseService,
+                    item.DatabaseName,
+                    item.QueryId,
+                    "Query Store",
+                    _queryStoreHoursBack,
+                    _queryStoreFromDate,
+                    _queryStoreToDate
+                );
+                historyWindow.Owner = Window.GetWindow(this);
+                historyWindow.ShowDialog();
+            }
+        }
+
         private void ProcStatsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;

--- a/Dashboard/Models/QueryStoreRegressionItem.cs
+++ b/Dashboard/Models/QueryStoreRegressionItem.cs
@@ -18,6 +18,11 @@ namespace PerformanceMonitorDashboard.Models
         public decimal BaselineReads { get; set; }
         public decimal RecentReads { get; set; }
         public decimal IoRegressionPercent { get; set; }
+        public decimal AdditionalDurationMs { get; set; }
+        public long BaselineExecCount { get; set; }
+        public long RecentExecCount { get; set; }
+        public int BaselinePlanCount { get; set; }
+        public int RecentPlanCount { get; set; }
         public string Severity { get; set; } = string.Empty;
         public string QueryTextSample { get; set; } = string.Empty;
         public DateTime? LastExecutionTime { get; set; }

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -31,8 +31,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="2*" MinHeight="250"/>
-            <RowDefinition Height="3*"/>
+            <RowDefinition Height="3*" MinHeight="300"/>
+            <RowDefinition Height="2*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -191,7 +191,7 @@ namespace PerformanceMonitorDashboard
             scatter.Color = color;
 
             // Sparse data: show only markers to avoid misleading interpolated lines
-            if (dates.Length <= 10)
+            if (dates.Length <= 1)
             {
                 scatter.LineWidth = 0;
                 scatter.MarkerSize = 8;

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -31,8 +31,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="2*" MinHeight="250"/>
-            <RowDefinition Height="3*"/>
+            <RowDefinition Height="3*" MinHeight="300"/>
+            <RowDefinition Height="2*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -183,6 +183,7 @@ namespace PerformanceMonitorDashboard
             };
 
             int colorIndex = 0;
+            var scatterSeries = new List<(ScottPlot.Plottables.Scatter Scatter, string Label)>();
 
             foreach (var planGroup in planGroups)
             {
@@ -197,10 +198,12 @@ namespace PerformanceMonitorDashboard
                 var color = colors[colorIndex % colors.Length];
                 var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
                 scatter.Color = color;
-                scatter.LegendText = $"Plan {planGroup.Key}";
+                var label = $"Plan {planGroup.Key}";
+                scatter.LegendText = label;
 
-                // Sparse data: show only markers to avoid misleading interpolated lines
-                if (dates.Length <= 10)
+                // Sparse data: use total dataset size, not per-plan size, since
+                // data is split across plan groups
+                if (_historyData.Count <= 1)
                 {
                     scatter.LineWidth = 0;
                     scatter.MarkerSize = 8;
@@ -211,6 +214,7 @@ namespace PerformanceMonitorDashboard
                     scatter.MarkerSize = 4;
                 }
 
+                scatterSeries.Add((scatter, label));
                 colorIndex++;
             }
 
@@ -228,8 +232,8 @@ namespace PerformanceMonitorDashboard
             else
                 _chartHover.Unit = unit;
             _chartHover.Clear();
-            foreach (var p in HistoryChart.Plot.GetPlottables().OfType<ScottPlot.Plottables.Scatter>())
-                _chartHover.Add(p, p.LegendText ?? "");
+            foreach (var (s, l) in scatterSeries)
+                _chartHover.Add(s, l);
 
             // Update legend text
             ChartLegendText.Text = planGroups.Count > 1

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -31,8 +31,8 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="2*" MinHeight="250"/>
-            <RowDefinition Height="3*"/>
+            <RowDefinition Height="3*" MinHeight="300"/>
+            <RowDefinition Height="2*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -183,7 +183,7 @@ namespace PerformanceMonitorDashboard
             scatter.Color = color;
 
             // Sparse data: show only markers to avoid misleading interpolated lines
-            if (dates.Length <= 10)
+            if (dates.Length <= 1)
             {
                 scatter.LineWidth = 0;
                 scatter.MarkerSize = 8;


### PR DESCRIPTION
## Summary
- Rewrite `report.query_store_regressions` TVF: bounded baseline (mirror window), weighted averages, multi-metric detection (duration/CPU/reads), absolute minimum thresholds, total impact ranking (`additional_duration_ms`)
- Add double-click drill-down from regressions grid to QueryExecutionHistoryWindow
- Add new grid columns: Total Impact (ms), Base/Recent Exec Counts, Base/Recent Plan Counts
- Fix chart:grid ratio to 3\*:2\* with MinHeight 300 across all drill-down windows
- Lower sparse data threshold to 1 (lines always connect with 2+ points)
- Fix QueryExecutionHistoryWindow sparse threshold and tooltip registration

## Test plan
- [x] TVF deployed and tested on sql2017, sql2019, sql2022, sql2025
- [x] Dashboard builds cleanly (0 errors, 0 warnings)
- [ ] Query Store Regressions tab shows new columns (Total Impact, exec counts, plan counts)
- [ ] Double-click regression row opens QueryExecutionHistoryWindow
- [ ] All 4 drill-down charts show connected lines with 2+ data points
- [ ] Chart:grid ratio is 3:2 across all drill-down windows

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)