### PR TITLE
Issue #269: Make plan viewer properties copyable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$instDir/upgrades"
 
           Copy-Item 'Installer/bin/Release/net8.0/win-x64/publish/PerformanceMonitorInstaller.exe' $instDir
-          Copy-Item 'InstallerGui/bin/Release/net8.0-windows/win-x64/publish/InstallerGui.exe' $instDir -ErrorAction SilentlyContinue
+          Copy-Item 'InstallerGui/bin/Release/net8.0-windows/win-x64/publish/PerformanceMonitorInstallerGui.exe' $instDir -ErrorAction SilentlyContinue
           Copy-Item 'install/*.sql' "$instDir/install/"
           if (Test-Path 'upgrades') { Copy-Item 'upgrades/*' "$instDir/upgrades/" -Recurse -ErrorAction SilentlyContinue }
           if (Test-Path 'README.md') { Copy-Item 'README.md' $instDir }

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -1115,16 +1115,21 @@ public partial class PlanViewerControl : UserControl
         Grid.SetColumn(labelBlock, 0);
         grid.Children.Add(labelBlock);
 
-        var valueBlock = new TextBlock
+        var valueBox = new TextBox
         {
             Text = value,
             FontSize = 11,
             Foreground = TooltipFgBrush,
-            TextWrapping = TextWrapping.Wrap
+            TextWrapping = TextWrapping.Wrap,
+            IsReadOnly = true,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalAlignment = VerticalAlignment.Top
         };
-        if (isCode) valueBlock.FontFamily = new FontFamily("Consolas");
-        Grid.SetColumn(valueBlock, 1);
-        grid.Children.Add(valueBlock);
+        if (isCode) valueBox.FontFamily = new FontFamily("Consolas");
+        Grid.SetColumn(valueBox, 1);
+        grid.Children.Add(valueBox);
 
         var target = _currentPropertySection ?? PropertiesContent;
         target.Children.Add(grid);


### PR DESCRIPTION
## Summary
- Switch property values from TextBlock to TextBox (IsReadOnly) for text selection and Ctrl+C
- TextBox's built-in context menu (Copy, Select All) replaces the parent alert context menu that was incorrectly appearing in the properties panel

## Test plan
- [x] Dashboard builds cleanly
- [x] Property values are selectable with click-drag
- [x] Ctrl+C copies selected text
- [x] Right-click shows Copy/Select All instead of Acknowledge Alerts

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)