### PR TITLE
Issue #273: Trace pattern drill-down, missing columns, query text tooltips

### DIFF
--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -33,7 +33,7 @@
 
                 <Grid Grid.Row="1">
                 <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                          RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
+                          GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                           ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
                         <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
@@ -103,7 +103,7 @@
         <TabItem Header="Trace Analysis">
             <Grid>
             <DataGrid x:Name="TraceAnalysisDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
@@ -170,14 +170,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding SqlText}" Width="400">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="400">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlText" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="SQL Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding SqlText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding SqlText}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="TraceAnalysisNoDataMessage" Style="{DynamicResource NoDataMessage}"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -77,7 +77,7 @@
         <TabItem Header="Active Queries">
             <Grid>
             <DataGrid x:Name="ActiveQueriesDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}">
                 <DataGrid.Columns>
@@ -281,14 +281,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryText}" Width="400">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="400">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTextColumn Binding="{Binding SqlCommand}" Width="400">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -340,7 +345,7 @@
 
                 <DataGrid Grid.Row="1" x:Name="CurrentActiveQueriesDataGrid"
                           AutoGenerateColumns="False" IsReadOnly="True"
-                          RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                          GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                           ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                           RowStyle="{DynamicResource DefaultRowStyle}">
                     <DataGrid.Columns>
@@ -512,14 +517,19 @@
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding QueryText}" Width="500">
-                            <DataGridTextColumn.Header>
+                        <DataGridTemplateColumn Width="500">
+                            <DataGridTemplateColumn.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>
                                     <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
+                            </DataGridTemplateColumn.Header>
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                         <DataGridTemplateColumn Header="Est Plan" Width="Auto" MinWidth="80">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
@@ -552,7 +562,7 @@
         <TabItem Header="Query Stats">
             <Grid>
             <DataGrid x:Name="QueryStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStatsDataGrid_MouseDoubleClick">
@@ -805,14 +815,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryText}" Width="500">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="500">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="QueryStatsNoDataMessage" Style="{StaticResource EmptyStateMessage}"
@@ -825,7 +840,7 @@
         <TabItem Header="Procedure Stats">
             <Grid>
             <DataGrid x:Name="ProcStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="ProcStatsDataGrid_MouseDoubleClick">
@@ -1088,7 +1103,7 @@
         <TabItem Header="Query Store">
             <Grid>
             <DataGrid x:Name="QueryStoreDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStoreDataGrid_MouseDoubleClick">
@@ -1397,14 +1412,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryText}" Width="500">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="500">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="QueryStoreNoDataMessage" Style="{StaticResource NoDataMessage}"/>
@@ -1415,7 +1435,7 @@
         <TabItem Header="Query Store Regressions">
             <Grid>
             <DataGrid x:Name="QueryStoreRegressionsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStoreRegressionsDataGrid_MouseDoubleClick">
@@ -1564,14 +1584,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryTextSample}" Width="*" MinWidth="300">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="*" MinWidth="300">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryTextSample" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding QueryTextSample}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryTextSample}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="QueryStoreRegressionsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
@@ -1582,9 +1607,10 @@
         <TabItem Header="Query Trace Patterns">
             <Grid>
             <DataGrid x:Name="LongRunningQueryPatternsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                      RowHeight="35" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
-                      RowStyle="{DynamicResource DefaultRowStyle}">
+                      RowStyle="{DynamicResource DefaultRowStyle}"
+                      MouseDoubleClick="LongRunningQueryPatternsDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                         <DataGridTextColumn.Header>
@@ -1634,6 +1660,14 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWrites" Click="LrqPatternsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Avg Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding ConcernLevel}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -1642,6 +1676,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTemplateColumn Width="250">
+                        <DataGridTemplateColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Recommendation" Click="LrqPatternsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Recommendation" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Recommendation}" TextTrimming="CharacterEllipsis" Margin="5,2" ToolTip="{Binding Recommendation}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTextColumn Binding="{Binding LastExecution, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -1650,14 +1697,19 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding QueryPattern}" Width="*" MinWidth="300">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn Width="*" MinWidth="300">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryPattern" Click="LrqPatternsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Query Pattern" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding QueryPattern}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding SampleQueryText}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="LongRunningQueryPatternsNoDataMessage" Style="{StaticResource NoDataMessage}"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1499,6 +1499,37 @@ namespace PerformanceMonitorDashboard.Controls
             LongRunningQueryPatternsDataGrid.ItemsSource = filteredData;
         }
 
+        private void LongRunningQueryPatternsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (!TabHelpers.IsDoubleClickOnRow((DependencyObject)e.OriginalSource)) return;
+            if (_databaseService == null) return;
+
+            if (LongRunningQueryPatternsDataGrid.SelectedItem is LongRunningQueryPatternItem item)
+            {
+                if (string.IsNullOrEmpty(item.DatabaseName) || string.IsNullOrEmpty(item.QueryPattern))
+                {
+                    MessageBox.Show(
+                        "Unable to show history: missing database name or query pattern.",
+                        "Information",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
+                    return;
+                }
+
+                var historyWindow = new TracePatternHistoryWindow(
+                    _databaseService,
+                    item.DatabaseName,
+                    item.QueryPattern,
+                    _lrqPatternsHoursBack,
+                    _lrqPatternsFromDate,
+                    _lrqPatternsToDate
+                );
+                historyWindow.Owner = Window.GetWindow(this);
+                historyWindow.ShowDialog();
+            }
+        }
+
         #endregion
 
         #region Performance Trends

--- a/Dashboard/Models/TracePatternDetailItem.cs
+++ b/Dashboard/Models/TracePatternDetailItem.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Darling Data, LLC
+// Licensed under the MIT License
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class TracePatternDetailItem
+    {
+        public long AnalysisId { get; set; }
+        public DateTime CollectionTime { get; set; }
+        public string EventName { get; set; } = string.Empty;
+        public string? DatabaseName { get; set; }
+        public string? LoginName { get; set; }
+        public string? ApplicationName { get; set; }
+        public string? HostName { get; set; }
+        public int? Spid { get; set; }
+        public long? DurationMs { get; set; }
+        public long? CpuMs { get; set; }
+        public long? Reads { get; set; }
+        public long? Writes { get; set; }
+        public long? RowCounts { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? EndTime { get; set; }
+        public string? SqlText { get; set; }
+        public long? ObjectId { get; set; }
+    }
+}

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -554,7 +554,7 @@
                     <TabItem Header="Blocking">
                         <Grid>
                         <DataGrid x:Name="BlockingEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                                      RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
@@ -670,14 +670,19 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding QueryText}" Width="300">
-                                        <DataGridTextColumn.Header>
+                                    <DataGridTemplateColumn Width="300">
+                                        <DataGridTemplateColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
                                                 <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
                                             </StackPanel>
-                                        </DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
+                                        </DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Binding="{Binding TransactionName}" Width="100">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -1214,6 +1214,10 @@
         <Setter Property="BorderBrush" Value="{StaticResource BorderLightBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="10,8"/>
+        <Setter Property="MaxWidth" Value="600"/>
     </Style>
+
+    <!-- Apply DarkToolTip as the default for all tooltips -->
+    <Style TargetType="ToolTip" BasedOn="{StaticResource DarkToolTip}"/>
 
 </ResourceDictionary>

--- a/Dashboard/TracePatternHistoryWindow.xaml
+++ b/Dashboard/TracePatternHistoryWindow.xaml
@@ -1,0 +1,217 @@
+<Window x:Class="PerformanceMonitorDashboard.TracePatternHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+        Title="Trace Pattern History" Height="900" Width="1600"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <!-- Context Menu for DataGrid Copy/Export -->
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="3*" MinHeight="300"/>
+            <RowDefinition Height="2*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <Border Grid.Row="0" Background="{DynamicResource BackgroundLightBrush}" Padding="10" Margin="10,10,10,0">
+            <StackPanel>
+                <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" TextWrapping="Wrap"/>
+                <TextBlock x:Name="SummaryText" Margin="0,5,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Chart Area -->
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundLightBrush}" Margin="10,10,10,0" Padding="10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Chart Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                    <TextBlock Text="Metric:" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="MetricSelector" Width="200" SelectionChanged="MetricSelector_SelectionChanged">
+                        <ComboBoxItem Content="Duration (ms)" Tag="DurationMs" IsSelected="True"/>
+                        <ComboBoxItem Content="CPU (ms)" Tag="CpuMs"/>
+                        <ComboBoxItem Content="Reads (pages)" Tag="Reads"/>
+                        <ComboBoxItem Content="Writes (pages)" Tag="Writes"/>
+                        <ComboBoxItem Content="Row Counts" Tag="RowCounts"/>
+                    </ComboBox>
+                </StackPanel>
+
+                <!-- Chart -->
+                <ScottPlot:WpfPlot x:Name="HistoryChart" Grid.Row="1"/>
+            </Grid>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="HistoryDataGrid"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  CanUserSortColumns="True"
+                  AlternatingRowBackground="{DynamicResource BackgroundLightBrush}"
+                  Background="{DynamicResource BackgroundBrush}"
+                  Foreground="{DynamicResource ForegroundBrush}"
+                  RowBackground="{DynamicResource BackgroundBrush}"
+                  GridLinesVisibility="All"
+                  ContextMenu="{DynamicResource DataGridContextMenu}"
+                  Margin="10">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding EndTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EndTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="End Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding EventName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Event" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CpuMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RowCounts, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowCounts" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Row Counts" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ApplicationName}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ApplicationName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Application" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding HostName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Spid}" ElementStyle="{StaticResource NumericCell}" Width="60">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding StartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Start Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ObjectId}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectId" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Object ID" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTemplateColumn Width="*" MinWidth="300">
+                    <DataGridTemplateColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlText" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="SQL Text" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding SqlText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding SqlText}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <Border Grid.Row="3" Background="{DynamicResource BackgroundLightBrush}" Padding="10" Margin="10,0,10,10">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Close" Width="100" Height="30" Click="Close_Click"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using ScottPlot;
+
+namespace PerformanceMonitorDashboard
+{
+    public partial class TracePatternHistoryWindow : Window
+    {
+        private readonly DatabaseService _databaseService;
+        private readonly string _databaseName;
+        private readonly string _queryPattern;
+        private readonly int _hoursBack;
+        private readonly DateTime? _fromDate;
+        private readonly DateTime? _toDate;
+        private List<TracePatternDetailItem> _historyData = new();
+        private ChartHoverHelper? _chartHover;
+
+        // Filter state
+        private Dictionary<string, ColumnFilterState> _filters = new();
+        private List<TracePatternDetailItem>? _unfilteredData;
+        private Popup? _filterPopup;
+        private ColumnFilterPopup? _filterPopupContent;
+
+        public TracePatternHistoryWindow(
+            DatabaseService databaseService,
+            string databaseName,
+            string queryPattern,
+            int hoursBack = 24,
+            DateTime? fromDate = null,
+            DateTime? toDate = null)
+        {
+            InitializeComponent();
+
+            _databaseService = databaseService;
+            _databaseName = databaseName;
+            _queryPattern = queryPattern;
+            _hoursBack = hoursBack;
+            _fromDate = fromDate;
+            _toDate = toDate;
+
+            // Collapse newlines/tabs to spaces and truncate for a clean single-line header
+            var displayPattern = System.Text.RegularExpressions.Regex.Replace(queryPattern, @"\s+", " ").Trim();
+            if (displayPattern.Length > 120)
+                displayPattern = displayPattern.Substring(0, 120) + "...";
+            QueryIdentifierText.Text = $"Trace Pattern History: [{databaseName}] — {displayPattern}";
+
+            ApplyDarkModeToChart();
+            Loaded += TracePatternHistoryWindow_Loaded;
+        }
+
+        private void ApplyDarkModeToChart()
+        {
+            Helpers.TabHelpers.ApplyDarkModeToChart(HistoryChart);
+        }
+
+        private async void TracePatternHistoryWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await LoadHistoryAsync();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to load trace pattern history:\n\n{ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+            }
+        }
+
+        private async Task LoadHistoryAsync()
+        {
+            try
+            {
+                _historyData = await _databaseService.GetTracePatternHistoryAsync(_databaseName, _queryPattern, _hoursBack, _fromDate, _toDate);
+
+                _unfilteredData = _historyData;
+                _filters.Clear();
+                HistoryDataGrid.ItemsSource = _historyData;
+                UpdateFilterButtonStyles();
+
+                if (_historyData.Count > 0)
+                {
+                    var avgDuration = _historyData.Where(h => h.DurationMs.HasValue).Select(h => (double)(h.DurationMs ?? 0)).DefaultIfEmpty(0).Average();
+                    var avgCpu = _historyData.Where(h => h.CpuMs.HasValue).Select(h => (double)(h.CpuMs ?? 0)).DefaultIfEmpty(0).Average();
+                    var firstSample = _historyData.Where(h => h.EndTime.HasValue).Min(h => h.EndTime);
+                    var lastSample = _historyData.Where(h => h.EndTime.HasValue).Max(h => h.EndTime);
+
+                    SummaryText.Text = string.Format(CultureInfo.CurrentCulture,
+                        "Executions: {0} | First: {1:yyyy-MM-dd HH:mm} | Last: {2:yyyy-MM-dd HH:mm} | Avg Duration: {3:N0} ms | Avg CPU: {4:N0} ms",
+                        _historyData.Count, firstSample, lastSample, avgDuration, avgCpu);
+
+                    UpdateChart();
+                }
+                else
+                {
+                    SummaryText.Text = "No historical data found for this pattern.";
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to load trace pattern history:\n\n{ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+            }
+        }
+
+        private void MetricSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_historyData.Count > 0)
+            {
+                UpdateChart();
+            }
+        }
+
+        private void UpdateChart()
+        {
+            if (_historyData == null || _historyData.Count == 0)
+                return;
+
+            HistoryChart.Plot.Clear();
+
+            var selectedItem = MetricSelector.SelectedItem as ComboBoxItem;
+            var metricTag = selectedItem?.Tag?.ToString() ?? "DurationMs";
+            var metricLabel = selectedItem?.Content?.ToString() ?? "Duration (ms)";
+
+            var orderedData = _historyData
+                .Where(h => h.EndTime.HasValue)
+                .OrderBy(h => h.EndTime)
+                .ToList();
+
+            if (orderedData.Count == 0) return;
+
+            var dates = orderedData.Select(h => h.EndTime!.Value.ToOADate()).ToArray();
+            var values = orderedData.Select(h => GetMetricValue(h, metricTag)).ToArray();
+
+            var color = ScottPlot.Color.FromHex("#4FC3F7");
+            var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
+            scatter.Color = color;
+
+            // Sparse data: show only markers to avoid misleading interpolated lines
+            if (dates.Length <= 1)
+            {
+                scatter.LineWidth = 0;
+                scatter.MarkerSize = 8;
+            }
+            else
+            {
+                scatter.LineWidth = 2;
+                scatter.MarkerSize = 4;
+            }
+
+            HistoryChart.Plot.Axes.DateTimeTicksBottom();
+            Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);
+            HistoryChart.Plot.YLabel(metricLabel);
+            HistoryChart.Plot.XLabel("End Time");
+
+            // Hover tooltip
+            var unit = metricTag.Contains("Ms") ? "ms" : "";
+            if (_chartHover == null)
+                _chartHover = new ChartHoverHelper(HistoryChart, unit);
+            else
+                _chartHover.Unit = unit;
+            _chartHover.Clear();
+            _chartHover.Add(scatter, metricLabel);
+
+            HistoryChart.Refresh();
+        }
+
+        private static double GetMetricValue(TracePatternDetailItem item, string metricTag)
+        {
+            return metricTag switch
+            {
+                "DurationMs" => (double)(item.DurationMs ?? 0),
+                "CpuMs" => (double)(item.CpuMs ?? 0),
+                "Reads" => (double)(item.Reads ?? 0),
+                "Writes" => (double)(item.Writes ?? 0),
+                "RowCounts" => (double)(item.RowCounts ?? 0),
+                _ => (double)(item.DurationMs ?? 0)
+            };
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        #region Column Filter Popup
+
+        private void Filter_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string columnName) return;
+
+            if (_filterPopup == null)
+            {
+                _filterPopupContent = new ColumnFilterPopup();
+                _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+                _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+                _filterPopup = new Popup
+                {
+                    Child = _filterPopupContent,
+                    StaysOpen = false,
+                    Placement = PlacementMode.Bottom,
+                    AllowsTransparency = true
+                };
+            }
+
+            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterPopupContent!.Initialize(columnName, existingFilter);
+
+            _filterPopup.PlacementTarget = button;
+            _filterPopup.IsOpen = true;
+        }
+
+        private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+
+            if (e.FilterState.IsActive)
+                _filters[e.FilterState.ColumnName] = e.FilterState;
+            else
+                _filters.Remove(e.FilterState.ColumnName);
+
+            ApplyFilters();
+            UpdateFilterButtonStyles();
+        }
+
+        private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+        {
+            if (_filterPopup != null) _filterPopup.IsOpen = false;
+        }
+
+        private void ApplyFilters()
+        {
+            if (_unfilteredData == null) return;
+
+            if (_filters.Count == 0)
+            {
+                HistoryDataGrid.ItemsSource = _unfilteredData;
+                return;
+            }
+
+            var filtered = _unfilteredData.Where(item =>
+            {
+                foreach (var filter in _filters.Values)
+                {
+                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                        return false;
+                }
+                return true;
+            }).ToList();
+
+            HistoryDataGrid.ItemsSource = filtered;
+        }
+
+        private void UpdateFilterButtonStyles()
+        {
+            foreach (var column in HistoryDataGrid.Columns)
+            {
+                if (column.Header is StackPanel stackPanel)
+                {
+                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                    if (filterButton?.Tag is string columnName)
+                    {
+                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+                        filterButton.Content = new System.Windows.Controls.TextBlock
+                        {
+                            Text = "\uE71C",
+                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                            Foreground = hasActive
+                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                        };
+                        filterButton.ToolTip = hasActive && filter != null
+                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                            : "Click to filter";
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu Handlers
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                        Clipboard.SetDataObject(cellContent, false);
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid?.SelectedItem != null)
+                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    var headers = new List<string>();
+                    foreach (var column in dataGrid.Columns)
+                    {
+                        if (column is DataGridBoundColumn)
+                            headers.Add(Helpers.DataGridClipboardBehavior.GetHeaderText(column));
+                    }
+                    sb.AppendLine(string.Join("\t", headers));
+                    foreach (var item in dataGrid.Items)
+                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                    Clipboard.SetDataObject(sb.ToString(), false);
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                if (dataGrid != null && dataGrid.Items.Count > 0)
+                {
+                    var saveFileDialog = new SaveFileDialog
+                    {
+                        FileName = $"trace_pattern_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                        DefaultExt = ".csv",
+                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                    };
+
+                    if (saveFileDialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+                            var headers = new List<string>();
+                            foreach (var column in dataGrid.Columns)
+                            {
+                                if (column is DataGridBoundColumn)
+                                    headers.Add(TabHelpers.EscapeCsvField(Helpers.DataGridClipboardBehavior.GetHeaderText(column)));
+                            }
+                            sb.AppendLine(string.Join(",", headers));
+                            foreach (var item in dataGrid.Items)
+                            {
+                                var values = TabHelpers.GetRowValues(dataGrid, item);
+                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                            }
+                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
+                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary
- Add 3 missing columns to Query Trace Patterns grid (AvgWrites, Recommendation, QueryPattern with tooltip)
- Remove redundant SampleQueryText column (duplicate of QueryPattern)
- Create TracePatternHistoryWindow drill-down (double-click pattern → individual executions over time with chart)
- Deduplicate trace events with ROW_NUMBER (trace file retains events across collection cycles)
- Add hover tooltips to all query text columns across entire Dashboard (matching Lite behavior)
- Apply DarkToolTip as implicit default so all tooltips use dark theme
- Switch query text cells to TextWrapping with MaxHeight=90, remove fixed RowHeight for auto-sizing rows

Closes #273

## Test plan
- [x] Build succeeds with 0 errors/warnings
- [x] Query Trace Patterns grid shows AvgWrites, Recommendation, QueryPattern columns
- [x] SampleQueryText column removed (was redundant)
- [x] Double-click pattern row opens drill-down with chart + detail grid
- [x] Drill-down shows deduplicated rows (no duplicate trace events)
- [x] Header text sanitized (newlines collapsed, truncated to 120 chars)
- [x] Hover tooltips work on all query text columns with dark theme styling
- [x] Query text cells wrap up to ~3-4 lines with auto-sizing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)