### PR TITLE
Issue #280: Add Current Waits charts to Blocking tab

### DIFF
--- a/Dashboard/Models/BlockedSessionTrendItem.cs
+++ b/Dashboard/Models/BlockedSessionTrendItem.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class BlockedSessionTrendItem
+    {
+        public DateTime CollectionTime { get; set; }
+        public string DatabaseName { get; set; } = string.Empty;
+        public int BlockedCount { get; set; }
+    }
+}

--- a/Dashboard/Models/WaitingTaskTrendItem.cs
+++ b/Dashboard/Models/WaitingTaskTrendItem.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public class WaitingTaskTrendItem
+    {
+        public DateTime CollectionTime { get; set; }
+        public string WaitType { get; set; } = string.Empty;
+        public long TotalWaitMs { get; set; }
+    }
+}

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -550,6 +550,38 @@
                         </Grid>
                     </TabItem>
 
+                    <!-- Current Waits Sub-Tab -->
+                    <TabItem Header="Current Waits">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <Border Grid.Row="0" BorderBrush="LightGray" BorderThickness="1" Margin="5,5,5,2">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Text="Wait Duration by Wait Type" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                    <ScottPlot:WpfPlot Grid.Row="1" x:Name="CurrentWaitsDurationChart"/>
+                                </Grid>
+                            </Border>
+
+                            <Border Grid.Row="1" BorderBrush="LightGray" BorderThickness="1" Margin="5,2,5,5">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Text="Blocked Sessions by Database" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,5"/>
+                                    <ScottPlot:WpfPlot Grid.Row="1" x:Name="CurrentWaitsBlockedChart"/>
+                                </Grid>
+                            </Border>
+                        </Grid>
+                    </TabItem>
+
                     <!-- Blocking Sub-Tab -->
                     <TabItem Header="Blocking">
                         <Grid>

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -771,6 +771,20 @@
                                 </Border>
                             </Grid>
                         </TabItem>
+                        <TabItem Header="Current Waits">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <Border Grid.Row="0" Margin="0,0,0,4">
+                                    <ScottPlot:WpfPlot x:Name="CurrentWaitsDurationChart"/>
+                                </Border>
+                                <Border Grid.Row="1" Margin="0,4,0,0">
+                                    <ScottPlot:WpfPlot x:Name="CurrentWaitsBlockedChart"/>
+                                </Border>
+                            </Grid>
+                        </TabItem>
                         <TabItem Header="Blocked Process Reports">
                             <DataGrid x:Name="BlockedProcessReportGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -60,6 +60,8 @@ public partial class ServerTab : UserControl
     private Helpers.ChartHoverHelper? _memoryClerksHover;
     private Helpers.ChartHoverHelper? _memoryGrantSizingHover;
     private Helpers.ChartHoverHelper? _memoryGrantActivityHover;
+    private Helpers.ChartHoverHelper? _currentWaitsDurationHover;
+    private Helpers.ChartHoverHelper? _currentWaitsBlockedHover;
 
     /* Memory clerks picker */
     private List<SelectableItem> _memoryClerkItems = new();
@@ -174,6 +176,8 @@ public partial class ServerTab : UserControl
         _memoryClerksHover = new Helpers.ChartHoverHelper(MemoryClerksChart, "MB");
         _memoryGrantSizingHover = new Helpers.ChartHoverHelper(MemoryGrantSizingChart, "MB");
         _memoryGrantActivityHover = new Helpers.ChartHoverHelper(MemoryGrantActivityChart, "");
+        _currentWaitsDurationHover = new Helpers.ChartHoverHelper(CurrentWaitsDurationChart, "ms");
+        _currentWaitsBlockedHover = new Helpers.ChartHoverHelper(CurrentWaitsBlockedChart, "sessions");
 
         /* Initial load is triggered by MainWindow.ConnectToServer calling RefreshData()
            after collectors finish - no Loaded handler needed */
@@ -510,10 +514,13 @@ public partial class ServerTab : UserControl
             var procDurationTrendTask = SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate));
             var queryStoreDurationTrendTask = SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate));
             var executionCountTrendTask = SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var currentWaitsDurationTask = SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var currentWaitsBlockedTask = SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate));
 
             await System.Threading.Tasks.Task.WhenAll(
                 lockWaitTrendTask, blockingTrendTask, deadlockTrendTask,
-                queryDurationTrendTask, procDurationTrendTask, queryStoreDurationTrendTask, executionCountTrendTask);
+                queryDurationTrendTask, procDurationTrendTask, queryStoreDurationTrendTask, executionCountTrendTask,
+                currentWaitsDurationTask, currentWaitsBlockedTask);
 
             loadSw.Stop();
 
@@ -563,6 +570,8 @@ public partial class ServerTab : UserControl
             UpdateLockWaitTrendChart(lockWaitTrendTask.Result, hoursBack, fromDate, toDate);
             UpdateBlockingTrendChart(blockingTrendTask.Result, hoursBack, fromDate, toDate);
             UpdateDeadlockTrendChart(deadlockTrendTask.Result, hoursBack, fromDate, toDate);
+            UpdateCurrentWaitsDurationChart(currentWaitsDurationTask.Result, hoursBack, fromDate, toDate);
+            UpdateCurrentWaitsBlockedChart(currentWaitsBlockedTask.Result, hoursBack, fromDate, toDate);
             UpdateQueryDurationTrendChart(queryDurationTrendTask.Result);
             UpdateProcDurationTrendChart(procDurationTrendTask.Result);
             UpdateQueryStoreDurationTrendChart(queryStoreDurationTrendTask.Result);
@@ -1190,6 +1199,138 @@ public partial class ServerTab : UserControl
         SetChartYLimitsWithLegendPadding(DeadlockTrendChart, 0, data.Max(d => d.Count));
         ShowChartLegend(DeadlockTrendChart);
         DeadlockTrendChart.Refresh();
+    }
+
+    /* ========== Current Waits Charts ========== */
+
+    private void UpdateCurrentWaitsDurationChart(List<WaitingTaskTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
+    {
+        ClearChart(CurrentWaitsDurationChart);
+        ApplyDarkTheme(CurrentWaitsDurationChart);
+
+        DateTime rangeStart, rangeEnd;
+        if (fromDate.HasValue && toDate.HasValue)
+        {
+            rangeStart = fromDate.Value;
+            rangeEnd = toDate.Value;
+        }
+        else
+        {
+            rangeEnd = DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+            rangeStart = rangeEnd.AddHours(-hoursBack);
+        }
+
+        _currentWaitsDurationHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = CurrentWaitsDurationChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Current Waits";
+            zeroLine.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            zeroLine.MarkerSize = 0;
+            CurrentWaitsDurationChart.Plot.Axes.DateTimeTicksBottom();
+            CurrentWaitsDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(CurrentWaitsDurationChart);
+            CurrentWaitsDurationChart.Plot.YLabel("Total Wait Duration (ms)");
+            SetChartYLimitsWithLegendPadding(CurrentWaitsDurationChart, 0, 1);
+            ShowChartLegend(CurrentWaitsDurationChart);
+            CurrentWaitsDurationChart.Refresh();
+            return;
+        }
+
+        var grouped = data.GroupBy(d => d.WaitType).OrderBy(g => g.Key).ToList();
+        double globalMax = 0;
+
+        for (int i = 0; i < grouped.Count; i++)
+        {
+            var group = grouped[i];
+            var ordered = group.OrderBy(t => t.CollectionTime).ToList();
+            var times = ordered.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
+            var values = ordered.Select(t => (double)t.TotalWaitMs).ToArray();
+
+            var plot = CurrentWaitsDurationChart.Plot.Add.Scatter(times, values);
+            plot.LegendText = group.Key;
+            plot.LineWidth = 2;
+            plot.MarkerSize = 5;
+            plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+            _currentWaitsDurationHover?.Add(plot, group.Key);
+
+            if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
+        }
+
+        CurrentWaitsDurationChart.Plot.Axes.DateTimeTicksBottom();
+        CurrentWaitsDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(CurrentWaitsDurationChart);
+        CurrentWaitsDurationChart.Plot.YLabel("Total Wait Duration (ms)");
+        SetChartYLimitsWithLegendPadding(CurrentWaitsDurationChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(CurrentWaitsDurationChart);
+        CurrentWaitsDurationChart.Refresh();
+    }
+
+    private void UpdateCurrentWaitsBlockedChart(List<BlockedSessionTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
+    {
+        ClearChart(CurrentWaitsBlockedChart);
+        ApplyDarkTheme(CurrentWaitsBlockedChart);
+
+        DateTime rangeStart, rangeEnd;
+        if (fromDate.HasValue && toDate.HasValue)
+        {
+            rangeStart = fromDate.Value;
+            rangeEnd = toDate.Value;
+        }
+        else
+        {
+            rangeEnd = DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+            rangeStart = rangeEnd.AddHours(-hoursBack);
+        }
+
+        _currentWaitsBlockedHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = CurrentWaitsBlockedChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Blocked Sessions";
+            zeroLine.Color = ScottPlot.Color.FromHex("#E57373");
+            zeroLine.MarkerSize = 0;
+            CurrentWaitsBlockedChart.Plot.Axes.DateTimeTicksBottom();
+            CurrentWaitsBlockedChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(CurrentWaitsBlockedChart);
+            CurrentWaitsBlockedChart.Plot.YLabel("Blocked Sessions");
+            SetChartYLimitsWithLegendPadding(CurrentWaitsBlockedChart, 0, 1);
+            ShowChartLegend(CurrentWaitsBlockedChart);
+            CurrentWaitsBlockedChart.Refresh();
+            return;
+        }
+
+        var grouped = data.GroupBy(d => d.DatabaseName).OrderBy(g => g.Key).ToList();
+        double globalMax = 0;
+
+        for (int i = 0; i < grouped.Count; i++)
+        {
+            var group = grouped[i];
+            var ordered = group.OrderBy(t => t.CollectionTime).ToList();
+            var times = ordered.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
+            var values = ordered.Select(t => (double)t.BlockedCount).ToArray();
+
+            var plot = CurrentWaitsBlockedChart.Plot.Add.Scatter(times, values);
+            plot.LegendText = group.Key;
+            plot.LineWidth = 2;
+            plot.MarkerSize = 5;
+            plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+            _currentWaitsBlockedHover?.Add(plot, group.Key);
+
+            if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
+        }
+
+        CurrentWaitsBlockedChart.Plot.Axes.DateTimeTicksBottom();
+        CurrentWaitsBlockedChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(CurrentWaitsBlockedChart);
+        CurrentWaitsBlockedChart.Plot.YLabel("Blocked Sessions");
+        SetChartYLimitsWithLegendPadding(CurrentWaitsBlockedChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(CurrentWaitsBlockedChart);
+        CurrentWaitsBlockedChart.Refresh();
     }
 
     /* ========== Performance Trend Charts ========== */

--- a/Lite/Services/LocalDataService.WaitingTasks.cs
+++ b/Lite/Services/LocalDataService.WaitingTasks.cs
@@ -57,6 +57,97 @@ ORDER BY collection_time DESC, wait_duration_ms DESC";
 
         return items;
     }
+
+    /// <summary>
+    /// Gets waiting task duration trend grouped by wait type for charting.
+    /// </summary>
+    public async Task<List<WaitingTaskTrendPoint>> GetWaitingTaskTrendAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    collection_time,
+    wait_type,
+    SUM(wait_duration_ms) AS total_wait_ms
+FROM waiting_tasks
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   wait_type IS NOT NULL
+GROUP BY
+    collection_time,
+    wait_type
+ORDER BY
+    collection_time,
+    wait_type";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<WaitingTaskTrendPoint>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new WaitingTaskTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(0),
+                WaitType = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TotalWaitMs = reader.IsDBNull(2) ? 0 : ToInt64(reader.GetValue(2))
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Gets blocked session count trend grouped by database for charting.
+    /// </summary>
+    public async Task<List<BlockedSessionTrendPoint>> GetBlockedSessionTrendAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    collection_time,
+    database_name,
+    COUNT(*) AS blocked_count
+FROM waiting_tasks
+WHERE server_id = $1
+AND   blocking_session_id > 0
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   database_name IS NOT NULL
+GROUP BY
+    collection_time,
+    database_name
+ORDER BY
+    collection_time,
+    database_name";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<BlockedSessionTrendPoint>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new BlockedSessionTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                BlockedCount = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2))
+            });
+        }
+        return items;
+    }
 }
 
 public class WaitingTaskRow
@@ -74,4 +165,18 @@ public class WaitingTaskRow
         : WaitDurationMs < 60000
             ? $"{WaitDurationMs / 1000.0:F1} s"
             : $"{WaitDurationMs / 60000.0:F1} min";
+}
+
+public class WaitingTaskTrendPoint
+{
+    public DateTime CollectionTime { get; set; }
+    public string WaitType { get; set; } = "";
+    public long TotalWaitMs { get; set; }
+}
+
+public class BlockedSessionTrendPoint
+{
+    public DateTime CollectionTime { get; set; }
+    public string DatabaseName { get; set; } = "";
+    public int BlockedCount { get; set; }
 }

--- a/Lite/Services/RemoteCollectorService.WaitingTasks.cs
+++ b/Lite/Services/RemoteCollectorService.WaitingTasks.cs
@@ -32,7 +32,6 @@ SELECT /* PerformanceMonitorLite */
     wait_type = wt.wait_type,
     wait_duration_ms = wt.wait_duration_ms,
     blocking_session_id = wt.blocking_session_id,
-    resource_description = wt.resource_description,
     database_name = DB_NAME(er.database_id)
 FROM sys.dm_os_waiting_tasks AS wt
 LEFT JOIN sys.dm_exec_requests AS er
@@ -73,8 +72,7 @@ OPTION(RECOMPILE);";
                     var waitType = reader.IsDBNull(1) ? null : reader.GetString(1);
                     var waitDurationMs = reader.IsDBNull(2) ? 0L : reader.GetInt64(2);
                     var blockingSessionId = reader.IsDBNull(3) ? (short?)null : reader.GetInt16(3);
-                    var resourceDescription = reader.IsDBNull(4) ? null : reader.GetString(4);
-                    var databaseName = reader.IsDBNull(5) ? null : reader.GetString(5);
+                    var databaseName = reader.IsDBNull(4) ? null : reader.GetString(4);
 
                     var row = appender.CreateRow();
                     row.AppendValue(GenerateCollectionId())
@@ -85,7 +83,7 @@ OPTION(RECOMPILE);";
                        .AppendValue(waitType)
                        .AppendValue(waitDurationMs)
                        .AppendValue(blockingSessionId.HasValue ? (int?)blockingSessionId.Value : null)
-                       .AppendValue(resourceDescription)
+                       .AppendValue((string?)null) /* resource_description — no longer collected */
                        .AppendValue(databaseName)
                        .EndRow();
 


### PR DESCRIPTION
## Summary
- Adds a new **Current Waits** tab to the Blocking section in both Dashboard and Lite, positioned next to the existing Blocking/Deadlock Trends tab
- Two charts per app: **Wait Duration by Wait Type** (multi-series line, total wait_duration_ms per wait type over time) and **Blocked Sessions by Database** (multi-series line, count of sessions with blocking_session_id > 0 per database over time)
- Uses raw point-in-time `wait_duration_ms` values — no delta calculation needed since `waiting_tasks` snapshots the current wait state, not cumulative counters
- Aligns Lite collector with the SQL Server collector trimmed in #281 — stops collecting `resource_description` (now NULL)

## Test plan
- [ ] Connect both apps to a server with active blocking
- [ ] Verify Current Waits tab appears second in tab order (after Trends/Blocking/Deadlock Trends)
- [ ] Wait ~1 min for collection, verify wait duration chart shows lines per wait type
- [ ] Verify blocked sessions chart shows lines per database when blocking is present
- [ ] Verify empty state (flat zero line / no data message) when no waiting tasks collected
- [ ] No regressions on existing Blocking/Deadlock Trends, Blocking, Deadlocks tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)