### PR TITLE
Issue #284: Standardize chart save/export filenames

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -179,6 +179,29 @@ public partial class ServerTab : UserControl
         _currentWaitsDurationHover = new Helpers.ChartHoverHelper(CurrentWaitsDurationChart, "ms");
         _currentWaitsBlockedHover = new Helpers.ChartHoverHelper(CurrentWaitsBlockedChart, "sessions");
 
+        /* Chart context menus (right-click save/export) */
+        Helpers.ContextMenuHelper.SetupChartContextMenu(WaitStatsChart, "Wait_Stats");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(QueryDurationTrendChart, "Query_Duration_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(ProcDurationTrendChart, "Procedure_Duration_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(QueryStoreDurationTrendChart, "QueryStore_Duration_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(ExecutionCountTrendChart, "Execution_Count_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(CpuChart, "CPU_Usage");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryChart, "Memory_Usage");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryClerksChart, "Memory_Clerks");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryGrantSizingChart, "Memory_Grant_Sizing");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryGrantActivityChart, "Memory_Grant_Activity");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoReadChart, "File_IO_Read_Latency");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoWriteChart, "File_IO_Write_Latency");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(TempDbChart, "TempDB_Stats");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(TempDbFileIoChart, "TempDB_File_IO");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(LockWaitTrendChart, "Lock_Wait_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(BlockingTrendChart, "Blocking_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(DeadlockTrendChart, "Deadlock_Trends");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(CurrentWaitsDurationChart, "Current_Waits_Duration");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(CurrentWaitsBlockedChart, "Current_Waits_Blocked");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(PerfmonChart, "Perfmon_Counters");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(CollectorDurationChart, "Collector_Duration");
+
         /* Initial load is triggered by MainWindow.ConnectToServer calling RefreshData()
            after collectors finish - no Loaded handler needed */
     }

--- a/Lite/Helpers/ContextMenuHelper.cs
+++ b/Lite/Helpers/ContextMenuHelper.cs
@@ -13,16 +13,18 @@ using System.IO;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.Win32;
+using ScottPlot.WPF;
 
 namespace PerformanceMonitorLite.Helpers;
 
 /// <summary>
-/// Shared context menu helpers for DataGrid copy/export operations.
+/// Shared context menu helpers for DataGrid copy/export and chart save/export operations.
 /// Used by standalone windows (history, collection log, manage servers, settings)
-/// that don't have the full ServerTab context menu infrastructure.
+/// and all ScottPlot chart controls.
 /// </summary>
 public static class ContextMenuHelper
 {
@@ -173,5 +175,199 @@ public static class ContextMenuHelper
             return "\"" + value.Replace("\"", "\"\"") + "\"";
         }
         return value;
+    }
+
+    /// <summary>
+    /// Sets up a context menu for a ScottPlot chart with standard options:
+    /// Copy Image, Save Image As, Open in New Window, Revert, Export Data to CSV.
+    /// </summary>
+    public static void SetupChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
+    {
+        var contextMenu = new ContextMenu();
+
+        // Copy Image
+        var copyItem = new MenuItem { Header = "Copy Image", Icon = new TextBlock { Text = "\U0001f4cb" } };
+        copyItem.Click += (s, e) =>
+        {
+            var tempFile = Path.Combine(Path.GetTempPath(), $"chart_copy_{Guid.NewGuid()}.png");
+            try
+            {
+                chart.Plot.SavePng(tempFile, (int)chart.ActualWidth, (int)chart.ActualHeight);
+                var bitmap = new System.Windows.Media.Imaging.BitmapImage();
+                bitmap.BeginInit();
+                bitmap.CacheOption = System.Windows.Media.Imaging.BitmapCacheOption.OnLoad;
+                bitmap.UriSource = new Uri(tempFile);
+                bitmap.EndInit();
+                bitmap.Freeze();
+                Clipboard.SetDataObject(new DataObject(DataFormats.Bitmap, bitmap), false);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        };
+        contextMenu.Items.Add(copyItem);
+
+        // Save Image As
+        var saveItem = new MenuItem { Header = "Save Image As...", Icon = new TextBlock { Text = "\U0001f4be" } };
+        saveItem.Click += (s, e) =>
+        {
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+            var defaultFileName = $"{chartName}_{timestamp}.png";
+            var saveDialog = new SaveFileDialog
+            {
+                Filter = "PNG Image|*.png|JPEG Image|*.jpg|BMP Image|*.bmp",
+                FileName = defaultFileName,
+                DefaultExt = ".png"
+            };
+            if (saveDialog.ShowDialog() == true)
+            {
+                chart.Plot.SavePng(saveDialog.FileName, (int)chart.ActualWidth, (int)chart.ActualHeight);
+            }
+        };
+        contextMenu.Items.Add(saveItem);
+
+        // Open in New Window
+        var openWindowItem = new MenuItem { Header = "Open in New Window", Icon = new TextBlock { Text = "\U0001f5d7" } };
+        openWindowItem.Click += (s, e) =>
+        {
+            var newWindow = new Window
+            {
+                Title = chartName.Replace("_", " ", StringComparison.Ordinal),
+                Width = 800,
+                Height = 600
+            };
+            var tempFile = Path.Combine(Path.GetTempPath(), $"chart_temp_{Guid.NewGuid()}.png");
+            try
+            {
+                chart.Plot.SavePng(tempFile, 800, 600);
+                var image = new System.Windows.Controls.Image();
+                var bitmap = new System.Windows.Media.Imaging.BitmapImage();
+                bitmap.BeginInit();
+                bitmap.CacheOption = System.Windows.Media.Imaging.BitmapCacheOption.OnLoad;
+                bitmap.UriSource = new Uri(tempFile);
+                bitmap.EndInit();
+                bitmap.Freeze();
+                image.Source = bitmap;
+                newWindow.Content = image;
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+            newWindow.Show();
+        };
+        contextMenu.Items.Add(openWindowItem);
+
+        contextMenu.Items.Add(new Separator());
+
+        // Revert (Autoscale)
+        var autoscaleItem = new MenuItem { Header = "Revert (or double-click)", Icon = new TextBlock { Text = "\u21a9" } };
+        autoscaleItem.Click += (s, e) =>
+        {
+            chart.Plot.Axes.AutoScale();
+            chart.Refresh();
+        };
+        contextMenu.Items.Add(autoscaleItem);
+
+        contextMenu.Items.Add(new Separator());
+
+        // Export Data to CSV
+        var exportCsvItem = new MenuItem { Header = "Export Data to CSV...", Icon = new TextBlock { Text = "\U0001f4ca" } };
+        exportCsvItem.Click += (s, e) =>
+        {
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+            var defaultFileName = $"{chartName}_data_{timestamp}.csv";
+            var saveDialog = new SaveFileDialog
+            {
+                Filter = "CSV Files|*.csv|All Files|*.*",
+                FileName = defaultFileName,
+                DefaultExt = ".csv"
+            };
+            if (saveDialog.ShowDialog() == true)
+            {
+                try
+                {
+                    var sb = new StringBuilder();
+                    var sep = App.CsvSeparator;
+                    sb.AppendLine(string.Join(sep, new[] { "DateTime", "Series", "Value" }));
+
+                    var plottables = chart.Plot.GetPlottables();
+                    int seriesIndex = 1;
+                    foreach (var plottable in plottables)
+                    {
+                        if (plottable is ScottPlot.Plottables.Scatter scatter)
+                        {
+                            var seriesName = scatter.LegendText ?? $"Series{seriesIndex}";
+                            var points = scatter.Data.GetScatterPoints();
+
+                            foreach (var point in points)
+                            {
+                                var dateTime = DateTime.FromOADate(point.X);
+                                sb.AppendLine(string.Join(sep, new[]
+                                {
+                                    dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                                    CsvEscape(seriesName, sep),
+                                    point.Y.ToString(CultureInfo.InvariantCulture)
+                                }));
+                            }
+                            seriesIndex++;
+                        }
+                    }
+
+                    File.WriteAllText(saveDialog.FileName, sb.ToString(), Encoding.UTF8);
+                    MessageBox.Show($"Data exported to:\n{saveDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        };
+        contextMenu.Items.Add(exportCsvItem);
+
+        // Show Data Source (if provided)
+        if (!string.IsNullOrEmpty(dataSource))
+        {
+            contextMenu.Items.Add(new Separator());
+
+            var dataSourceItem = new MenuItem { Header = "Show Data Source", Icon = new TextBlock { Text = "\u2139" } };
+            dataSourceItem.Click += (s, e) =>
+            {
+                MessageBox.Show(
+                    $"Data Source:\n\n{dataSource}",
+                    "Chart Data Source",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            };
+            contextMenu.Items.Add(dataSourceItem);
+        }
+
+        // Disable ScottPlot's default right-click context menu handling
+        chart.UserInputProcessor.UserActionResponses.RemoveAll(r =>
+            r.GetType().Name.Contains("Context", StringComparison.Ordinal) ||
+            r.GetType().Name.Contains("RightClick", StringComparison.Ordinal) ||
+            r.GetType().Name.Contains("Menu", StringComparison.Ordinal));
+
+        // Use PreviewMouseRightButtonDown to show context menu before ScottPlot handles it
+        chart.PreviewMouseRightButtonDown += (s, e) =>
+        {
+            e.Handled = true;
+            contextMenu.PlacementTarget = chart;
+            contextMenu.Placement = PlacementMode.MousePoint;
+            contextMenu.IsOpen = true;
+        };
+
+        // Disable ScottPlot's default double-click behaviors
+        chart.UserInputProcessor.UserActionResponses.RemoveAll(r =>
+            r.GetType().Name.Contains("DoubleClick", StringComparison.Ordinal));
+
+        // Use PreviewMouseDoubleClick for revert/autoscale
+        chart.PreviewMouseDoubleClick += (s, e) =>
+        {
+            e.Handled = true;
+            chart.Plot.Axes.AutoScale();
+            chart.Refresh();
+        };
     }
 }


### PR DESCRIPTION
## Summary
- Add chart right-click context menu (Copy Image, Save Image As, Open in New Window, Revert, Export CSV) to all 21 Lite charts — previously Lite had no chart export and defaulted to ScottPlot's `ScottPlot.png`
- Standardize on `yyyy-MM-dd_HH-mm-ss` timestamp format for all chart filenames across both apps
- Consolidate Dashboard's duplicate `SetupChartSaveMenu` instance method (~200 lines) into the shared `TabHelpers.SetupChartContextMenu`
- Add context menus to 2 Current Waits charts that had none

Closes #284

## Test plan
- [x] Both apps build with 0 errors
- [x] Lite: right-click any chart shows 5-item context menu
- [x] Lite: Save Image As defaults to `{ChartName}_{yyyy-MM-dd_HH-mm-ss}.png`
- [x] Dashboard: all ServerTab charts use `TabHelpers.SetupChartContextMenu`
- [x] Dashboard: Current Waits charts now have context menu
- [x] Double-click any chart to autoscale/revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)