### PR TITLE
Fix missing chart context menu on File I/O Throughput charts

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -196,6 +196,8 @@ public partial class ServerTab : UserControl
         Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryGrantActivityChart, "Memory_Grant_Activity");
         Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoReadChart, "File_IO_Read_Latency");
         Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoWriteChart, "File_IO_Write_Latency");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoReadThroughputChart, "File_IO_Read_Throughput");
+        Helpers.ContextMenuHelper.SetupChartContextMenu(FileIoWriteThroughputChart, "File_IO_Write_Throughput");
         Helpers.ContextMenuHelper.SetupChartContextMenu(TempDbChart, "TempDB_Stats");
         Helpers.ContextMenuHelper.SetupChartContextMenu(TempDbFileIoChart, "TempDB_File_IO");
         Helpers.ContextMenuHelper.SetupChartContextMenu(LockWaitTrendChart, "Lock_Wait_Trends");


### PR DESCRIPTION
## Summary
- The two File I/O Throughput charts (`FileIoReadThroughputChart`, `FileIoWriteThroughputChart`) were missed when wiring custom context menus in #284
- They showed ScottPlot's default menu (Save Image, Copy to Clipboard, Autoscale) instead of our custom menu (Copy Image, Save Image As, Open in New Window, Revert, Export CSV)

## Test plan
- [ ] Right-click File I/O Throughput charts → custom 5-item context menu appears
- [ ] File I/O Latency charts still have correct context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)