### PR TITLE
Fix silent plan buttons, add CPU scheduler pressure status

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -699,45 +699,60 @@ namespace PerformanceMonitorDashboard.Controls
 
         private void DownloadCurrentActiveEstPlan_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.DataContext is LiveQueryItem item && !string.IsNullOrEmpty(item.QueryPlan))
+            if (sender is not Button button || button.DataContext is not LiveQueryItem item) return;
+
+            if (string.IsNullOrEmpty(item.QueryPlan))
             {
-                var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
-                var defaultFileName = $"estimated_plan_{item.SessionId}_{timestamp}.sqlplan";
+                MessageBox.Show("No estimated plan is available for this query.", "No Plan Available",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
 
-                var saveFileDialog = new SaveFileDialog
-                {
-                    FileName = defaultFileName,
-                    DefaultExt = ".sqlplan",
-                    Filter = "SQL Plan (*.sqlplan)|*.sqlplan|XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
-                    Title = "Save Query Plan"
-                };
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+            var defaultFileName = $"estimated_plan_{item.SessionId}_{timestamp}.sqlplan";
 
-                if (saveFileDialog.ShowDialog() == true)
-                {
-                    File.WriteAllText(saveFileDialog.FileName, item.QueryPlan);
-                }
+            var saveFileDialog = new SaveFileDialog
+            {
+                FileName = defaultFileName,
+                DefaultExt = ".sqlplan",
+                Filter = "SQL Plan (*.sqlplan)|*.sqlplan|XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
+                Title = "Save Query Plan"
+            };
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                File.WriteAllText(saveFileDialog.FileName, item.QueryPlan);
             }
         }
 
         private void DownloadCurrentActiveLivePlan_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.DataContext is LiveQueryItem item && !string.IsNullOrEmpty(item.LiveQueryPlan))
+            if (sender is not Button button || button.DataContext is not LiveQueryItem item) return;
+
+            if (string.IsNullOrEmpty(item.LiveQueryPlan))
             {
-                var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
-                var defaultFileName = $"live_plan_{item.SessionId}_{timestamp}.sqlplan";
+                MessageBox.Show(
+                    "No live query plan is available for this session. The query may have completed before the plan could be captured.",
+                    "No Plan Available",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
 
-                var saveFileDialog = new SaveFileDialog
-                {
-                    FileName = defaultFileName,
-                    DefaultExt = ".sqlplan",
-                    Filter = "SQL Plan (*.sqlplan)|*.sqlplan|XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
-                    Title = "Save Live Query Plan"
-                };
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+            var defaultFileName = $"live_plan_{item.SessionId}_{timestamp}.sqlplan";
 
-                if (saveFileDialog.ShowDialog() == true)
-                {
-                    File.WriteAllText(saveFileDialog.FileName, item.LiveQueryPlan);
-                }
+            var saveFileDialog = new SaveFileDialog
+            {
+                FileName = defaultFileName,
+                DefaultExt = ".sqlplan",
+                Filter = "SQL Plan (*.sqlplan)|*.sqlplan|XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
+                Title = "Save Live Query Plan"
+            };
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                File.WriteAllText(saveFileDialog.FileName, item.LiveQueryPlan);
             }
         }
 
@@ -798,7 +813,17 @@ namespace PerformanceMonitorDashboard.Controls
             }
 
             if (planXml != null)
+            {
                 ViewPlanRequested?.Invoke(planXml, label, queryText);
+            }
+            else
+            {
+                MessageBox.Show(
+                    "No query plan is available for this row. The plan may have been evicted from the plan cache since it was last collected.",
+                    "No Plan Available",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
         }
 
         private async void GetActualPlan_Click(object sender, RoutedEventArgs e)

--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -44,9 +44,14 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TextBlock Text="CPU Utilization (%)" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
                         <ScottPlot:WpfPlot Grid.Row="1" x:Name="ServerUtilTrendsCpuChart" Margin="5"/>
+                        <TextBlock Grid.Row="2" x:Name="CpuSchedulerStatusText"
+                                   Margin="10,0,10,5" FontSize="11"
+                                   HorizontalAlignment="Center"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
                     </Grid>
                 </Border>
 

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -2649,13 +2649,35 @@ public partial class ServerTab : UserControl
 
     private void DownloadSnapshotPlan_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button btn || btn.DataContext is not QuerySnapshotRow row || row.QueryPlan == null) return;
+        if (sender is not Button btn || btn.DataContext is not QuerySnapshotRow row) return;
+
+        if (row.QueryPlan == null)
+        {
+            MessageBox.Show(
+                "No estimated plan is available for this snapshot. The plan may have been evicted from the plan cache.",
+                "No Plan Available",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
         SavePlanFile(row.QueryPlan, $"EstimatedPlan_Session{row.SessionId}");
     }
 
     private void DownloadSnapshotLivePlan_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button btn || btn.DataContext is not QuerySnapshotRow row || row.LiveQueryPlan == null) return;
+        if (sender is not Button btn || btn.DataContext is not QuerySnapshotRow row) return;
+
+        if (row.LiveQueryPlan == null)
+        {
+            MessageBox.Show(
+                "No live query plan is available for this snapshot. The query may have completed before the plan could be captured.",
+                "No Plan Available",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
         SavePlanFile(row.LiveQueryPlan, $"ActualPlan_Session{row.SessionId}");
     }
 
@@ -2785,6 +2807,14 @@ public partial class ServerTab : UserControl
         {
             OpenPlanTab(planXml, label, queryText);
             PlanViewerTabItem.IsSelected = true;
+        }
+        else
+        {
+            MessageBox.Show(
+                "No query plan is available for this row. The plan may have been evicted from the plan cache since it was last collected.",
+                "No Plan Available",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
         }
     }
 


### PR DESCRIPTION
## Summary
- Plan buttons across both Dashboard and Lite now show a MessageBox when no plan is available instead of silently doing nothing (6 handlers fixed)
- CPU scheduler pressure summary displayed below the CPU chart in Dashboard Resource Metrics (scheduler count, worker utilization, runnable tasks, color-coded pressure level)

## Test plan
- [ ] Click View Plan / Download Plan on rows without cached plans — verify MessageBox appears
- [ ] Check CPU chart in Resource Metrics — verify scheduler status line renders with correct pressure level coloring

🤖 Generated with [Claude Code](https://claude.com/claude-code)