### PR TITLE
Fix installer upgrade bugs and add Agent job cleanup

### DIFF
--- a/Dashboard/RemoveServerDialog.xaml
+++ b/Dashboard/RemoveServerDialog.xaml
@@ -23,9 +23,9 @@
         <!-- Drop database checkbox -->
         <CheckBox Grid.Row="1" x:Name="DropDatabaseCheckBox" Margin="0,0,0,5"
                   Foreground="{DynamicResource ForegroundBrush}">
-            <TextBlock Text="Also drop the PerformanceMonitor database on this server" TextWrapping="Wrap"/>
+            <TextBlock Text="Also drop the PerformanceMonitor database and SQL Agent jobs on this server" TextWrapping="Wrap"/>
         </CheckBox>
-        <TextBlock Grid.Row="2" Text="Warning: all collected monitoring data on the server will be permanently deleted."
+        <TextBlock Grid.Row="2" Text="Warning: all collected monitoring data and scheduled collection jobs on the server will be permanently deleted."
                    FontSize="11" Foreground="{DynamicResource ErrorBrush}" Margin="20,0,0,15"
                    TextWrapping="Wrap" Visibility="{Binding ElementName=DropDatabaseCheckBox, Path=IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
 

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -152,6 +152,17 @@ namespace PerformanceMonitorDashboard.Services
             using var connection = new SqlConnection(builder.ConnectionString);
             await connection.OpenAsync();
 
+            // Remove SQL Agent jobs before dropping the database
+            using var jobCmd = new SqlCommand(@"
+                IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Collection')
+                    EXEC msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Collection', @delete_unused_schedule = 1;
+                IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Data Retention')
+                    EXEC msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Data Retention', @delete_unused_schedule = 1;
+                IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Hung Job Monitor')
+                    EXEC msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Hung Job Monitor', @delete_unused_schedule = 1;", connection);
+            jobCmd.CommandTimeout = 30;
+            await jobCmd.ExecuteNonQueryAsync();
+
             // Close active connections before dropping
             using var killCmd = new SqlCommand(@"
                 IF DB_ID('PerformanceMonitor') IS NOT NULL
@@ -162,7 +173,7 @@ namespace PerformanceMonitorDashboard.Services
             killCmd.CommandTimeout = 30;
             await killCmd.ExecuteNonQueryAsync();
 
-            Logger.Info($"Dropped PerformanceMonitor database on '{server.DisplayName}'");
+            Logger.Info($"Dropped PerformanceMonitor database and Agent jobs on '{server.DisplayName}'");
         }
 
         public void UpdateLastConnected(string id)

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -649,7 +649,7 @@ END";
                         */
                         if (resetSchedule && fileName.StartsWith("04_", StringComparison.Ordinal))
                         {
-                            sqlContent = "TRUNCATE TABLE config.collection_schedule;\nGO\n" + sqlContent;
+                            sqlContent = "TRUNCATE TABLE [PerformanceMonitor].[config].[collection_schedule];\nGO\n" + sqlContent;
                             Console.Write("(resetting schedule) ");
                         }
 
@@ -1155,17 +1155,22 @@ END";
                 return upgradeFolders;
             }
 
-            /*Parse current version - if invalid, skip upgrades*/
-            if (!Version.TryParse(currentVersion, out var current))
+            /*Parse current version - if invalid, skip upgrades
+              Normalize to 3-part (Major.Minor.Build) to avoid Revision mismatch:
+              folder names use 3-part "1.3.0" but DB stores 4-part "1.3.0.0"
+              Version(1,3,0).Revision=-1 which breaks >= comparison with Version(1,3,0,0)*/
+            if (!Version.TryParse(currentVersion, out var currentRaw))
             {
                 return upgradeFolders;
             }
+            var current = new Version(currentRaw.Major, currentRaw.Minor, currentRaw.Build);
 
             /*Parse target version - if invalid, skip upgrades*/
-            if (!Version.TryParse(targetVersion, out var target))
+            if (!Version.TryParse(targetVersion, out var targetRaw))
             {
                 return upgradeFolders;
             }
+            var target = new Version(targetRaw.Major, targetRaw.Minor, targetRaw.Build);
 
             /*
             Find all upgrade folders matching pattern: {from}-to-{to}

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -40,12 +40,18 @@ namespace PerformanceMonitorInstallerGui
         private static readonly SolidColorBrush WarningBrush = new(Color.FromRgb(0xFF, 0xC1, 0x07)); // Yellow
 
         /*
-        Cached version string
+        Cached version strings
+        Display version includes git hash suffix for UI/logs
+        Assembly version is clean (e.g. "2.0.0.0") for upgrade version comparison
         */
         private static readonly string AppVersion =
             Assembly.GetExecutingAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
             ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "Unknown";
+
+        private static readonly string AppAssemblyVersion =
+            Assembly.GetExecutingAssembly().GetName().Version?.ToString()
             ?? "Unknown";
 
         private static readonly char[] NewLineChars = { '\r', '\n' };
@@ -260,7 +266,7 @@ namespace PerformanceMonitorInstallerGui
                             var upgrades = InstallationService.GetApplicableUpgrades(
                                 _monitorRootDirectory,
                                 _installedVersion,
-                                AppVersion);
+                                AppAssemblyVersion);
                             if (upgrades.Count > 0)
                             {
                                 LogMessage($"Found {upgrades.Count} upgrade(s) to apply", "Warning");
@@ -377,7 +383,7 @@ namespace PerformanceMonitorInstallerGui
                         _monitorRootDirectory,
                         _connectionString,
                         _installedVersion,
-                        AppVersion,
+                        AppAssemblyVersion,
                         progress,
                         cancellationToken);
 


### PR DESCRIPTION
## Summary
- Fix TRUNCATE TABLE using three-part name `[PerformanceMonitor].[config].[collection_schedule]` to avoid master context error when `--reset-schedule` is used (both CLI and GUI installers)
- Fix `Version` comparison bug: normalize to 3-part versions to avoid `Revision=-1` vs `Revision=0` mismatch that silently skipped upgrade scripts (both installers)
- Fix GUI installer upgrade detection: use `AppAssemblyVersion` (clean `2.0.0.0`) instead of `AppVersion` (includes `+commithash` suffix that breaks `Version.TryParse`)
- Add SQL Agent job cleanup (all 3 jobs) to Dashboard's `DropMonitorDatabaseAsync` so removing a server doesn't leave orphaned erroring jobs
- Update RemoveServerDialog text to mention Agent job removal

## Test plan
- [x] Fresh install on sql2016 (v1.3.0) — 51/51 scripts, 46 collectors
- [x] Upgrade v1.3.0 → v2.0.0 on sql2016 — upgrade found, 2/2 upgrade scripts + 51/51 install scripts
- [x] Idempotent re-run on sql2016 (already v2.0.0) — no upgrades, 51/51 scripts, 46 collectors
- [x] GUI upgrade on sql2025 — both upgrade paths found and applied
- [x] Agent job cleanup verified — all 3 jobs removed on DB drop
- [x] Dashboard and Lite build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)