### PR TITLE
Fix GUI installer: publish as single-file self-contained exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
 
       - name: Publish GUI Installer
-        run: dotnet publish InstallerGui/InstallerGui.csproj -c Release -r win-x64 --self-contained
+        run: dotnet publish InstallerGui/InstallerGui.csproj -c Release
 
       - name: Package release artifacts
         if: github.event_name == 'release'

--- a/InstallerGui/InstallerGui.csproj
+++ b/InstallerGui/InstallerGui.csproj
@@ -12,6 +12,12 @@
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <NoWarn>CA1849;CA2007;CA1508;CA1031;CA1001;CA1822;CA1305;CA2100;CA1002;CA1845;CA1861;CA2234;CA1062;CA1823</NoWarn>


### PR DESCRIPTION
## Summary
- The GUI installer was missing from the v1.3.0 release because `dotnet publish` produced 280 loose files but only the exe was copied to the release zip (with `-ErrorAction SilentlyContinue` hiding the problem)
- Add `PublishSingleFile`, `SelfContained`, `IncludeNativeLibrariesForSelfExtract`, `EnableCompressionInSingleFile`, and `PublishTrimmed=false` to the GUI csproj — matching the CLI installer exactly
- Remove now-redundant `-r win-x64 --self-contained` flags from `build.yml` (properties are in the csproj)

## Test plan
- [x] `dotnet publish -c Release` produces single 75MB exe
- [x] Published exe launches and runs correctly
- [x] Build path matches what `build.yml` line 72 expects (`InstallerGui/bin/Release/net8.0-windows/win-x64/publish/PerformanceMonitorInstallerGui.exe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)