### PR TITLE
Add missing perfmon counters to SQL collector, fix TempDB Pressure pack

### DIFF
--- a/Dashboard/Helpers/PerfmonPacks.cs
+++ b/Dashboard/Helpers/PerfmonPacks.cs
@@ -91,7 +91,6 @@ public static class PerfmonPacks
             "Temp Tables Creation Rate",
             "Workfiles Created/sec",
             "Worktables Created/sec",
-            "Forwarded Records/sec",
         ],
         ["Lock / Blocking"] =
         [

--- a/Lite/Helpers/PerfmonPacks.cs
+++ b/Lite/Helpers/PerfmonPacks.cs
@@ -91,7 +91,6 @@ public static class PerfmonPacks
             "Temp Tables Creation Rate",
             "Workfiles Created/sec",
             "Worktables Created/sec",
-            "Forwarded Records/sec",
         ],
         ["Lock / Blocking"] =
         [

--- a/install/19_collect_perfmon_stats.sql
+++ b/install/19_collect_perfmon_stats.sql
@@ -157,6 +157,9 @@ BEGIN
         (
             /*I/O counters*/
             N'Forwarded Records/sec',
+            N'Full Scans/sec',
+            N'Index Searches/sec',
+            N'Page Splits/sec',
             N'Page reads/sec',
             N'Page writes/sec',
             N'Checkpoint pages/sec',
@@ -177,6 +180,8 @@ BEGIN
             N'Lock Waits/sec',
             N'Number of Deadlocks/sec',
             N'Lock waits',
+            N'Lock Timeouts/sec',
+            N'Processes blocked',
             /*Memory counters*/
             N'Granted Workspace Memory (KB)',
             N'Lock Memory (KB)',
@@ -187,6 +192,7 @@ BEGIN
             N'Total Server Memory (KB)',
             N'Memory grant queue waits',
             N'Thread-safe memory objects waits',
+            N'Free list stalls/sec',
             /*Compilation counters*/
             N'SQL Compilations/sec',
             N'SQL Re-Compilations/sec',
@@ -205,6 +211,15 @@ BEGIN
             N'Log Flush Write Time (ms)',
             N'Log buffer waits',
             N'Log write waits',
+            /*TempDB counters*/
+            N'Version Store Size (KB)',
+            N'Free Space in tempdb (KB)',
+            N'Active Temp Tables',
+            N'Version Generation rate (KB/s)',
+            N'Version Cleanup rate (KB/s)',
+            N'Temp Tables Creation Rate',
+            N'Workfiles Created/sec',
+            N'Worktables Created/sec',
             /*Wait counters*/
             N'Network IO waits',
             N'Wait for the worker'


### PR DESCRIPTION
## Summary
- SQL collector was missing 14 counters that sp_PressureDetector collects and the UI packs reference
- TempDB Pressure pack showed only "Forwarded Records/sec" (not a tempdb counter) because the 8 real tempdb counters were never collected
- Also missing from I/O and Lock packs: Full Scans/sec, Index Searches/sec, Page Splits/sec, Free list stalls/sec, Processes blocked, Lock Timeouts/sec
- Removed "Forwarded Records/sec" from TempDB Pressure pack in both apps
- SQL collector now matches sp_PressureDetector's counter list exactly

## Test plan
- [x] All 14 new counter names verified in `sys.dm_os_performance_counters` on sql2022
- [x] Collector deployed and run — all counters collecting
- [x] Dashboard and Lite build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)