### PR TITLE
Fix release workflow to trigger on draft publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, dev]
   release:
-    types: [created]
+    types: [created, published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `published` event type to release trigger so draft-then-publish workflow builds and attaches artifacts
- Currently only `created` is configured, which doesn't fire when publishing a draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)