### PR TITLE
Default trace overhaul, memory clerks picker, query trace plan support

### DIFF
--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -6,118 +6,46 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
              Loaded="OnLoaded">
-    <TabControl>
-        <!-- Default Trace Events Sub-Tab -->
-        <TabItem Header="Default Trace Events">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10" Background="{DynamicResource BackgroundLightBrush}">
-                    <TextBlock Text="Event Filter:" VerticalAlignment="Center" Margin="5,0" FontWeight="Bold"/>
-                    <ComboBox x:Name="DefaultTraceEventsFilterCombo" Width="200" Margin="2,0" SelectionChanged="DefaultTraceEventsFilter_Changed">
-                        <ComboBoxItem Content="All Events" Tag="" IsSelected="True"/>
-                        <ComboBoxItem Content="Object:Altered" Tag="%Object:Altered%"/>
-                        <ComboBoxItem Content="Object:Created" Tag="%Object:Created%"/>
-                        <ComboBoxItem Content="Object:Deleted" Tag="%Object:Deleted%"/>
-                        <ComboBoxItem Content="Audit%" Tag="Audit%"/>
-                        <ComboBoxItem Content="Database%" Tag="Database%"/>
-                        <ComboBoxItem Content="ErrorLog" Tag="%ErrorLog%"/>
-                        <ComboBoxItem Content="Security%" Tag="Security%"/>
-                    </ComboBox>
-                    <Separator Margin="10,0" Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"/>
-                    <Button Content="Refresh" Click="DefaultTraceEvents_Refresh_Click" Margin="5,0" Padding="10,4" Style="{DynamicResource SuccessButton}"/>
-                </StackPanel>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10" Background="{DynamicResource BackgroundLightBrush}">
+            <TextBlock Text="Event Filter:" VerticalAlignment="Center" Margin="5,0" FontWeight="Bold"/>
+            <ComboBox x:Name="DefaultTraceEventsFilterCombo" Width="200" Margin="2,0" SelectionChanged="DefaultTraceEventsFilter_Changed">
+                <ComboBoxItem Content="All Events" Tag="" IsSelected="True"/>
+                <ComboBoxItem Content="Auto Grow/Shrink" Tag="%Auto %"/>
+                <ComboBoxItem Content="Audit Events" Tag="Audit%"/>
+                <ComboBoxItem Content="Config Changes" Tag="%Configuration Change%"/>
+                <ComboBoxItem Content="ErrorLog" Tag="%ErrorLog%"/>
+                <ComboBoxItem Content="Memory Changes" Tag="%Memory Change%"/>
+                <ComboBoxItem Content="Object:Altered" Tag="%Object:Altered%"/>
+                <ComboBoxItem Content="Object:Created" Tag="%Object:Created%"/>
+                <ComboBoxItem Content="Object:Deleted" Tag="%Object:Deleted%"/>
+            </ComboBox>
+            <Separator Margin="10,0" Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"/>
+            <Button Content="Refresh" Click="DefaultTraceEvents_Refresh_Click" Margin="5,0" Padding="10,4" Style="{DynamicResource SuccessButton}"/>
+        </StackPanel>
 
-                <Grid Grid.Row="1">
-                <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
-                          GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
-                          ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding EventName}" Width="150">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Event Name" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding ObjectName}" Width="150">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Object Name" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding TextData}" Width="300">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TextData" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Text Data" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Severity}" Width="60">
-                            <DataGridTextColumn.Header>
-                                <StackPanel Orientation="Horizontal">
-                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
-                                    <TextBlock Text="Severity" FontWeight="Bold" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <TextBlock x:Name="DefaultTraceEventsNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
-                </Grid>
-            </Grid>
-        </TabItem>
-
-        <!-- Trace Analysis Sub-Tab -->
-        <TabItem Header="Trace Analysis">
-            <Grid>
-            <DataGrid x:Name="TraceAnalysisDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+        <Grid Grid.Row="1">
+            <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="Collected" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding EventName}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Event Name" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
@@ -125,68 +53,86 @@
                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LoginName}" Width="100">
+                    <DataGridTextColumn Binding="{Binding ObjectName}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Object Name" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding DurationMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn Binding="{Binding HostName}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ApplicationName}" Width="150">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ApplicationName" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Application" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DurationMs, StringFormat='{}{0:N1}'}" Width="90">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CpuMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn Binding="{Binding GrowthMb, StringFormat='{}{0:N2}'}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuMs" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrowthMb" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Growth (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn Binding="{Binding TextData}" Width="300">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TextData" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Text Data" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn Binding="{Binding Severity}" Width="60">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Severity" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTemplateColumn Width="400">
-                        <DataGridTemplateColumn.Header>
+                    <DataGridTextColumn Binding="{Binding Spid}" Width="60">
+                        <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlText" Click="TraceAnalysisFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="SQL Text" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTemplateColumn.Header>
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding SqlText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding SqlText}"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
-            <TextBlock x:Name="TraceAnalysisNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
-            </Grid>
-        </TabItem>
-    </TabControl>
+            <TextBlock x:Name="DefaultTraceEventsNoDataMessage" Style="{DynamicResource NoDataMessage}"/>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/Dashboard/Controls/MemoryContent.xaml
+++ b/Dashboard/Controls/MemoryContent.xaml
@@ -133,28 +133,66 @@
 
         <!-- Memory Clerks Sub-Tab -->
         <TabItem Header="Memory Clerks">
-            <!-- Chart + Summary Panel (grid removed) -->
             <Border BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="5">
                 <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0" Text="Top Memory Clerks Over Time" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
-                    <ScottPlot:WpfPlot Grid.Row="1" x:Name="MemoryClerksChart"/>
-                    <!-- Summary Panel (excludes buffer pool) -->
-                    <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,8">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Text="Non-BP Total:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryClerksTotalText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-                            <TextBlock Text="Top Non-BP Clerk:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBlock x:Name="MemoryClerksTopText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
-                        </StackPanel>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="220"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Clerk Type Picker -->
+                    <Border Grid.Column="0" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,1,0" Padding="8">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="Select Memory Clerks" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,4">
+                                <Button Content="Top Clerks" Click="MemoryClerkSelectTop_Click" Padding="6,2" Margin="0,0,4,0" FontSize="11"/>
+                                <Button Content="Clear All" Click="MemoryClerkClearAll_Click" Padding="6,2" FontSize="11"/>
+                                <TextBlock x:Name="MemoryClerkCountText" Text="0 selected" FontSize="10" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                            </StackPanel>
+                            <TextBox Grid.Row="2" x:Name="MemoryClerkSearchBox" TextChanged="MemoryClerkSearch_TextChanged"
+                                     Margin="0,0,0,4" Padding="4,2"/>
+                            <ListBox Grid.Row="3" x:Name="MemoryClerksList" Background="Transparent" BorderThickness="0">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                  Checked="MemoryClerk_CheckChanged" Unchecked="MemoryClerk_CheckChanged"
+                                                  Foreground="{DynamicResource ForegroundBrush}" FontSize="11">
+                                            <TextBlock Text="{Binding DisplayName}"/>
+                                        </CheckBox>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Grid>
                     </Border>
-                    <TextBlock x:Name="MemoryClerksNoDataMessage" Grid.Row="1" Style="{StaticResource EmptyStateMessage}"
-                               Text="No memory clerk data in selected time range"/>
-                    <controls:LoadingOverlay x:Name="MemoryClerksLoading" Grid.Row="1"/>
+
+                    <!-- Chart + Summary -->
+                    <Grid Grid.Column="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Grid.Row="0" Text="Memory Clerks Over Time" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="MemoryClerksChart"/>
+                        <!-- Summary Panel (excludes buffer pool) -->
+                        <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,8">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="Non-BP Total:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryClerksTotalText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                <TextBlock Text="Top Non-BP Clerk:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="MemoryClerksTopText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
+                        <TextBlock x:Name="MemoryClerksNoDataMessage" Grid.Row="1" Style="{StaticResource EmptyStateMessage}"
+                                   Text="No memory clerk data in selected time range"/>
+                        <controls:LoadingOverlay x:Name="MemoryClerksLoading" Grid.Row="1"/>
+                    </Grid>
                 </Grid>
             </Border>
         </TabItem>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -812,6 +812,16 @@ namespace PerformanceMonitorDashboard.Controls
                     break;
             }
 
+            if (planXml == null && item is LongRunningQueryPatternItem)
+            {
+                MessageBox.Show(
+                    "Query trace patterns are aggregated data with no cached plan. Use 'Get Actual Plan' to generate one.",
+                    "No Cached Plan",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
             if (planXml != null)
             {
                 ViewPlanRequested?.Invoke(planXml, label, queryText);
@@ -874,6 +884,11 @@ namespace PerformanceMonitorDashboard.Controls
                         reg.QueryPlanXml = await _databaseService.GetQueryStorePlanXmlAsync(reg.DatabaseName, reg.QueryId);
                     planXml = reg.QueryPlanXml;
                     label = $"Actual Plan - QS {reg.QueryId}";
+                    break;
+                case LongRunningQueryPatternItem lrq:
+                    queryText = lrq.SampleQueryText;
+                    databaseName = lrq.DatabaseName;
+                    label = $"Actual Plan - Pattern";
                     break;
             }
 

--- a/Dashboard/Models/DefaultTraceEventItem.cs
+++ b/Dashboard/Models/DefaultTraceEventItem.cs
@@ -28,5 +28,11 @@ namespace PerformanceMonitorDashboard.Models
         public long? EventSequence { get; set; }
         public bool? IsSystem { get; set; }
         public int? RequestId { get; set; }
+        public long? DurationUs { get; set; }
+        public DateTime? EndTime { get; set; }
+
+        // Display helpers
+        public decimal? DurationMs => DurationUs.HasValue ? DurationUs.Value / 1000.0m : null;
+        public decimal? GrowthMb => IntegerData.HasValue ? IntegerData.Value * 8.0m / 1024.0m : null;
     }
 }

--- a/Dashboard/Models/SelectableItem.cs
+++ b/Dashboard/Models/SelectableItem.cs
@@ -1,0 +1,8 @@
+namespace PerformanceMonitorDashboard.Models
+{
+    public class SelectableItem
+    {
+        public string DisplayName { get; set; } = "";
+        public bool IsSelected { get; set; }
+    }
+}

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -1455,7 +1455,7 @@ namespace PerformanceMonitorDashboard.Services
                     WHEN avg_writes > 100000 THEN N'High write volume - review update/delete patterns'
                     ELSE N'Review execution plan for optimization opportunities'
                 END,
-            sample_query_text = CONVERT(nvarchar(500), sample_query_text),
+            sample_query_text,
             last_execution
         FROM query_patterns
         WHERE executions > 1

--- a/Dashboard/Services/DatabaseService.SystemEvents.cs
+++ b/Dashboard/Services/DatabaseService.SystemEvents.cs
@@ -64,7 +64,9 @@ namespace PerformanceMonitorDashboard.Services
             dte.state,
             dte.event_sequence,
             dte.is_system,
-            dte.request_id
+            dte.request_id,
+            dte.duration_us,
+            dte.end_time
         FROM collect.default_trace_events AS dte
         {dateFilter}{eventFilter}
         ORDER BY
@@ -116,7 +118,9 @@ namespace PerformanceMonitorDashboard.Services
                             State = reader.IsDBNull(20) ? null : reader.GetInt32(20),
                             EventSequence = reader.IsDBNull(21) ? null : reader.GetInt64(21),
                             IsSystem = reader.IsDBNull(22) ? null : reader.GetBoolean(22),
-                            RequestId = reader.IsDBNull(23) ? null : reader.GetInt32(23)
+                            RequestId = reader.IsDBNull(23) ? null : reader.GetInt32(23),
+                            DurationUs = reader.IsDBNull(24) ? null : reader.GetInt64(24),
+                            EndTime = reader.IsDBNull(25) ? null : reader.GetDateTime(25)
                         });
                     }
         

--- a/Lite/Services/LocalDataService.MemoryGrants.cs
+++ b/Lite/Services/LocalDataService.MemoryGrants.cs
@@ -82,7 +82,6 @@ FROM memory_grant_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
-AND   granted_memory_mb > 0
 GROUP BY collection_time, pool_id
 ORDER BY collection_time, pool_id";
 

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -619,11 +619,13 @@ BEGIN
         event_sequence bigint NULL,
         is_system bit NULL,
         request_id integer NULL,
-        CONSTRAINT 
-            PK_default_trace_events 
+        duration_us bigint NULL,
+        end_time datetime2(7) NULL,
+        CONSTRAINT
+            PK_default_trace_events
         PRIMARY KEY
-            (collection_time, event_id) 
-        WITH 
+            (collection_time, event_id)
+        WITH
             (DATA_COMPRESSION = PAGE)
     );
 

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -620,7 +620,9 @@ BEGIN
         event_sequence bigint NULL,
         is_system bit NULL,
         request_id integer NULL,
-        CONSTRAINT PK_default_trace_events 
+        duration_us bigint NULL,
+        end_time datetime2(7) NULL,
+        CONSTRAINT PK_default_trace_events
         PRIMARY KEY CLUSTERED
         (collection_time, event_id) WITH (DATA_COMPRESSION = PAGE)
     );

--- a/upgrades/1.3.0-to-2.0.0/03_default_trace_schema.sql
+++ b/upgrades/1.3.0-to-2.0.0/03_default_trace_schema.sql
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 1.3.0 to 2.0.0
+Adds duration_us and end_time columns to collect.default_trace_events
+for autogrow duration tracking and event completion times.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+/* Add duration_us for autogrow/shrink I/O stall duration (microseconds) */
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'collect.default_trace_events')
+    AND   name = N'duration_us'
+)
+BEGIN
+    ALTER TABLE
+        collect.default_trace_events
+    ADD
+        duration_us bigint NULL;
+
+    PRINT 'Added duration_us to collect.default_trace_events';
+END;
+GO
+
+/* Add end_time for event completion timestamp */
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'collect.default_trace_events')
+    AND   name = N'end_time'
+)
+BEGIN
+    ALTER TABLE
+        collect.default_trace_events
+    ADD
+        end_time datetime2(7) NULL;
+
+    PRINT 'Added end_time to collect.default_trace_events';
+END;
+GO

--- a/upgrades/1.3.0-to-2.0.0/upgrade.txt
+++ b/upgrades/1.3.0-to-2.0.0/upgrade.txt
@@ -1,2 +1,3 @@
 01_memory_grant_stats_schema.sql
 02_session_wait_stats_cleanup.sql
+03_default_trace_schema.sql


### PR DESCRIPTION
## Summary

- **Default trace collector**: Added ErrorLog, Object DDL, and Security Audit event types. Added `duration_us` and `end_time` columns for autogrow I/O stall tracking. Filter autogrow events to > 1s duration only. Exclude tempdb Object DDL and auto-stats (`_WA_%`) noise.
- **Removed Trace Analysis tab**: Redundant with the improved Query Trace Patterns tab under Queries.
- **Memory clerks picker**: Added type picker with search, top-N selection, and clear-all to Dashboard (parity with Lite).
- **Memory grants fix**: Removed `granted_memory_mb > 0` filter in both Dashboard and Lite that hid chart data when no active grants existed.
- **Query Trace Patterns plans**: Wired up Get Actual Plan using full `SampleQueryText` (removed artificial 500-char truncation). View Estimated Plan shows redirect message.
- **Upgrade script**: Added `03_default_trace_schema.sql` to 1.3.0-to-2.0.0 upgrade path.

## Test plan

- [x] Built Dashboard with zero errors/warnings
- [x] Deployed collector to sql2022, verified event filtering (tempdb excluded, auto-stats excluded, autogrow > 1s threshold)
- [x] Verified Default Trace tab shows clean data with Duration (ms) and Growth (MB) columns
- [x] Verified memory clerks picker works with top-5 default selection
- [x] Verified Get Actual Plan works on Query Trace Patterns rows
- [x] Upgrade script tested on sql2022 (idempotent column adds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)