### PR TITLE
Fix query store regressions TVF and context menu icons

### DIFF
--- a/Dashboard/CollectionLogWindow.xaml
+++ b/Dashboard/CollectionLogWindow.xaml
@@ -8,11 +8,19 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <ContextMenu x:Key="DataGridContextMenu">
-            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
             <Separator/>
-            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid>

--- a/Dashboard/CollectorScheduleWindow.xaml
+++ b/Dashboard/CollectorScheduleWindow.xaml
@@ -8,11 +8,19 @@
         Background="{DynamicResource BackgroundBrush}">
     <Window.Resources>
         <ContextMenu x:Key="DataGridContextMenu">
-            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
             <Separator/>
-            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid Margin="16">

--- a/Dashboard/Controls/AlertsHistoryContent.xaml
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml
@@ -13,11 +13,19 @@
 
             <!-- Context Menu for DataGrid Copy/Export -->
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
 
             <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -128,13 +128,23 @@
                     </ListView.ItemTemplate>
                     <ListView.ContextMenu>
                         <ContextMenu Opened="ServerContextMenu_Opened">
-                            <MenuItem Header="Open in New Tab" Click="OpenServerTab_Click"/>
-                            <MenuItem Header="Check Connection" Click="CheckConnection_Click"/>
-                            <MenuItem Header="Edit Server..." Click="EditServer_Click"/>
+                            <MenuItem Header="Open in New Tab" Click="OpenServerTab_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x1F5C2;"/></MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="Check Connection" Click="CheckConnection_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x2705;"/></MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="Edit Server..." Click="EditServer_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x270F;"/></MenuItem.Icon>
+                            </MenuItem>
                             <Separator/>
-                            <MenuItem x:Name="ToggleFavoriteMenuItem" Header="Set as Favorite" Click="ToggleFavorite_Click"/>
+                            <MenuItem x:Name="ToggleFavoriteMenuItem" Header="Set as Favorite" Click="ToggleFavorite_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x2B50;"/></MenuItem.Icon>
+                            </MenuItem>
                             <Separator/>
-                            <MenuItem Header="Remove Server" Click="RemoveServer_Click"/>
+                            <MenuItem Header="Remove Server" Click="RemoveServer_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x1F5D1;"/></MenuItem.Icon>
+                            </MenuItem>
                         </ContextMenu>
                     </ListView.ContextMenu>
                 </ListView>

--- a/Dashboard/ManageServersWindow.xaml
+++ b/Dashboard/ManageServersWindow.xaml
@@ -9,11 +9,19 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
         <ContextMenu x:Key="DataGridContextMenu">
-            <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-            <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
             <Separator/>
-            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid Margin="16">

--- a/Lite/Controls/AlertsHistoryTab.xaml
+++ b/Lite/Controls/AlertsHistoryTab.xaml
@@ -12,11 +12,19 @@
             </ResourceDictionary.MergedDictionaries>
 
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
 
             <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -11,15 +11,29 @@
 
             <!-- Context Menu for DataGrid Copy -->
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
-                <MenuItem Header="Copy Repro Script" Click="CopyReproScript_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Repro Script" Click="CopyReproScript_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4DD;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="View Plan" Click="ViewEstimatedPlan_Click"/>
-                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click"/>
+                <MenuItem Header="View Plan" Click="ViewEstimatedPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
 
             <Style x:Key="GridRowStyle" TargetType="DataGridRow">

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -69,13 +69,23 @@
                                     Background="{DynamicResource BackgroundLightBrush}">
                                 <Border.ContextMenu>
                                     <ContextMenu>
-                                        <MenuItem Header="Connect" Click="ServerContextMenu_Connect_Click"/>
-                                        <MenuItem Header="Disconnect" Click="ServerContextMenu_Disconnect_Click"/>
+                                        <MenuItem Header="Connect" Click="ServerContextMenu_Connect_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x1F517;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="Disconnect" Click="ServerContextMenu_Disconnect_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x274C;"/></MenuItem.Icon>
+                                        </MenuItem>
                                         <Separator/>
-                                        <MenuItem Header="Toggle Favorite" Click="ServerContextMenu_ToggleFavorite_Click"/>
+                                        <MenuItem Header="Toggle Favorite" Click="ServerContextMenu_ToggleFavorite_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x2B50;"/></MenuItem.Icon>
+                                        </MenuItem>
                                         <Separator/>
-                                        <MenuItem Header="Edit..." Click="ServerContextMenu_Edit_Click"/>
-                                        <MenuItem Header="Remove" Click="ServerContextMenu_Remove_Click"/>
+                                        <MenuItem Header="Edit..." Click="ServerContextMenu_Edit_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x270F;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="Remove" Click="ServerContextMenu_Remove_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x1F5D1;"/></MenuItem.Icon>
+                                        </MenuItem>
                                     </ContextMenu>
                                 </Border.ContextMenu>
                                 <Grid>

--- a/Lite/Windows/CollectionLogWindow.xaml
+++ b/Lite/Windows/CollectionLogWindow.xaml
@@ -11,11 +11,19 @@
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/ManageServersWindow.xaml
+++ b/Lite/Windows/ManageServersWindow.xaml
@@ -12,11 +12,19 @@
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/ProcedureHistoryWindow.xaml
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml
@@ -12,11 +12,19 @@
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml
@@ -12,11 +12,19 @@
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml
@@ -12,11 +12,19 @@
                 <ResourceDictionary Source="/Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <ContextMenu x:Key="DataGridContextMenu">
-                <MenuItem Header="Copy Cell" Click="CopyCell_Click"/>
-                <MenuItem Header="Copy Row" Click="CopyRow_Click"/>
-                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
                 <Separator/>
-                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>


### PR DESCRIPTION
## Summary
- Fixes #308: `report.query_store_regressions` TVF was missing 5 columns the Dashboard expects (`additional_duration_ms`, `baseline_exec_count`, `recent_exec_count`, `baseline_plan_count`, `recent_plan_count`)
- Fixes #290: Added emoji icons to all 13 context menus across Dashboard and Lite

## Test plan
- [x] Dashboard builds with 0 warnings, 0 errors
- [x] Lite builds with 0 warnings, 0 errors
- [x] Query Store Regressions tab loads without error on sql2022
- [x] TVF returns 19 columns matching C# model