### PR TITLE
Fix Int16 cast and DuckDB migration ordering

### DIFF
--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -641,7 +641,7 @@ namespace PerformanceMonitorDashboard.Services
                 {
                     results.Add(new LongRunningQueryInfo
                     {
-                        SessionId = reader.GetInt32(0),
+                        SessionId = Convert.ToInt32(reader.GetValue(0)),
                         DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
                         QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
                         ProgramName = reader.IsDBNull(3) ? "" : reader.GetString(3),


### PR DESCRIPTION
## Summary
- Fix `Unable to cast System.Int16 to System.Int32` in long-running query alert polling (`session_id` is `smallint` in DMVs)
- Fix DuckDB `ALTER TABLE ... Table does not exist` errors after archive-and-reset by running CREATE TABLE before migrations

## Test plan
- [x] Dashboard: 0 errors after 3 minutes (only SMTP config failure, not code)
- [x] Lite: 0 errors after 3 minutes
- [x] Both build with 0 errors