### PR TITLE
Fixes Missing tooltip on charts (high DPI / multi-monitor DPI issue)

### DIFF
--- a/Dashboard/Helpers/ChartHoverHelper.cs
+++ b/Dashboard/Helpers/ChartHoverHelper.cs
@@ -71,9 +71,10 @@ internal sealed class ChartHoverHelper
         try
         {
             var pos = e.GetPosition(_chart);
+            var dpi = VisualTreeHelper.GetDpi(_chart);
             var pixel = new ScottPlot.Pixel(
-                (float)(pos.X * _chart.DisplayScale),
-                (float)(pos.Y * _chart.DisplayScale));
+                (float)(pos.X * dpi.DpiScaleX),
+                (float)(pos.Y * dpi.DpiScaleY));
             var mouseCoords = _chart.Plot.GetCoordinates(pixel);
 
             /* Use X-axis (time) proximity as the primary filter, Y-axis distance

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -68,9 +68,10 @@ internal sealed class ChartHoverHelper
         _lastUpdate = now;
 
         var pos = e.GetPosition(_chart);
+        var dpi = VisualTreeHelper.GetDpi(_chart);
         var pixel = new ScottPlot.Pixel(
-            (float)(pos.X * _chart.DisplayScale),
-            (float)(pos.Y * _chart.DisplayScale));
+            (float)(pos.X * dpi.DpiScaleX),
+            (float)(pos.Y * dpi.DpiScaleY));
         var mouseCoords = _chart.Plot.GetCoordinates(pixel);
 
         double bestDistance = double.MaxValue;


### PR DESCRIPTION
## What does this PR do?

Fixes #319 

## Which component(s) does this affect?

- [x] Full Dashboard
- [x] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

Before:

https://github.com/user-attachments/assets/8afe8591-efee-470b-bc9b-136174dc9e3e

After:

https://github.com/user-attachments/assets/6c50f0a6-70bb-4827-bc88-91a8024f749b


### Root cause: 
_chart.DisplayScale is captured by ScottPlot at first render and stays fixed at the DPI of the monitor where the window opened. VisualTreeHelper.GetDpi() is a WPF live query that always reflects the DPI of the monitor the visual currently lives on, including after the window is dragged to another screen.

#### What happens without the fix (on a monitor with different DPI):

- e.GetPosition() returns logical pixels scaled by the new monitor's DPI ratio
- _chart.DisplayScale still holds the original monitor's ratio
- The resulting ScottPlot.Pixel is off, dx / dy exceed the proximity threshold, so no tooltip is shown

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
