### PR TITLE
Some graphs don't get dark mode until they get data

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -82,6 +82,14 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartContextMenus();
             Loaded += OnLoaded;
 
+            // Apply dark theme immediately so charts don't flash white before data loads
+            TabHelpers.ApplyDarkModeToChart(MemoryStatsOverviewChart);
+            TabHelpers.ApplyDarkModeToChart(MemoryGrantSizingChart);
+            TabHelpers.ApplyDarkModeToChart(MemoryGrantActivityChart);
+            TabHelpers.ApplyDarkModeToChart(MemoryClerksChart);
+            TabHelpers.ApplyDarkModeToChart(PlanCacheChart);
+            TabHelpers.ApplyDarkModeToChart(MemoryPressureEventsChart);
+
             _memoryStatsOverviewHover = new Helpers.ChartHoverHelper(MemoryStatsOverviewChart, "MB");
             _memoryGrantSizingHover = new Helpers.ChartHoverHelper(MemoryGrantSizingChart, "MB");
             _memoryGrantActivityHover = new Helpers.ChartHoverHelper(MemoryGrantActivityChart, "count");

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -109,6 +109,23 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartContextMenus();
             Loaded += OnLoaded;
 
+            // Apply dark theme immediately so charts don't flash white before data loads
+            TabHelpers.ApplyDarkModeToChart(LatchStatsChart);
+            TabHelpers.ApplyDarkModeToChart(SpinlockStatsChart);
+            TabHelpers.ApplyDarkModeToChart(TempdbStatsChart);
+            TabHelpers.ApplyDarkModeToChart(TempDbLatencyChart);
+            TabHelpers.ApplyDarkModeToChart(SessionStatsChart);
+            TabHelpers.ApplyDarkModeToChart(UserDbReadLatencyChart);
+            TabHelpers.ApplyDarkModeToChart(UserDbWriteLatencyChart);
+            TabHelpers.ApplyDarkModeToChart(FileIoReadThroughputChart);
+            TabHelpers.ApplyDarkModeToChart(FileIoWriteThroughputChart);
+            TabHelpers.ApplyDarkModeToChart(PerfmonCountersChart);
+            TabHelpers.ApplyDarkModeToChart(WaitStatsDetailChart);
+            TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsCpuChart);
+            TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsTempdbChart);
+            TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsMemoryChart);
+            TabHelpers.ApplyDarkModeToChart(ServerUtilTrendsPerfmonChart);
+
             _sessionStatsHover = new Helpers.ChartHoverHelper(SessionStatsChart, "sessions");
             _latchStatsHover = new Helpers.ChartHoverHelper(LatchStatsChart, "ms/sec");
             _spinlockStatsHover = new Helpers.ChartHoverHelper(SpinlockStatsChart, "collisions/sec");

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -158,6 +158,31 @@ public partial class ServerTab : UserControl
             grid.CopyingRowClipboardContent += Helpers.DataGridClipboardBehavior.FixHeaderCopy;
         }
 
+        /* Apply dark theme immediately so charts don't flash white before data loads */
+        ApplyDarkTheme(WaitStatsChart);
+        ApplyDarkTheme(QueryDurationTrendChart);
+        ApplyDarkTheme(ProcDurationTrendChart);
+        ApplyDarkTheme(QueryStoreDurationTrendChart);
+        ApplyDarkTheme(ExecutionCountTrendChart);
+        ApplyDarkTheme(CpuChart);
+        ApplyDarkTheme(MemoryChart);
+        ApplyDarkTheme(MemoryClerksChart);
+        ApplyDarkTheme(MemoryGrantSizingChart);
+        ApplyDarkTheme(MemoryGrantActivityChart);
+        ApplyDarkTheme(FileIoReadChart);
+        ApplyDarkTheme(FileIoWriteChart);
+        ApplyDarkTheme(FileIoReadThroughputChart);
+        ApplyDarkTheme(FileIoWriteThroughputChart);
+        ApplyDarkTheme(TempDbChart);
+        ApplyDarkTheme(TempDbFileIoChart);
+        ApplyDarkTheme(LockWaitTrendChart);
+        ApplyDarkTheme(BlockingTrendChart);
+        ApplyDarkTheme(DeadlockTrendChart);
+        ApplyDarkTheme(CurrentWaitsDurationChart);
+        ApplyDarkTheme(CurrentWaitsBlockedChart);
+        ApplyDarkTheme(PerfmonChart);
+        ApplyDarkTheme(CollectorDurationChart);
+
         /* Chart hover tooltips */
         _waitStatsHover = new Helpers.ChartHoverHelper(WaitStatsChart, "ms/sec");
         _perfmonHover = new Helpers.ChartHoverHelper(PerfmonChart, "");


### PR DESCRIPTION
## What does this PR do?

Fixes #321 

## Which component(s) does this affect?

- [x] Full Dashboard
- [x] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

Opened the tabs and checked they were in dark mode instead of light mode


### Changes

- ResourceMetricsContent.xaml.cs — all 15 charts now have dark theme applied in the constructor
- MemoryContent.xaml.cs — all 6 charts now have dark theme applied in the constructor

Charts will show the dark background immediately when the tabs are opened, instead of flashing white while waiting for data to load. The existing ApplyDarkModeToChart calls inside the load methods are still needed because chart.Plot.Clear() resets all styling — they correctly reapply the theme after clearing.


The Lite project had the same issue. ServerTab.xaml.cs has 23 charts, all of which only had ApplyDarkTheme() called inside data-loading methods. Added upfront calls to the constructor.


## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
