### PR TITLE
Add --preserve-jobs flag to CLI and GUI installers

### DIFF
--- a/InstallerGui/MainWindow.xaml
+++ b/InstallerGui/MainWindow.xaml
@@ -186,6 +186,12 @@
                           Margin="0,0,0,10"
                           Foreground="{DynamicResource ForegroundBrush}"/>
 
+                <!-- Preserve Jobs Checkbox -->
+                <CheckBox x:Name="PreserveJobsCheckBox"
+                          Content="Keep existing SQL Agent jobs (owner, schedule, notifications)"
+                          Margin="0,0,0,10"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
+
                 <!-- Validation Checkbox -->
                 <CheckBox x:Name="ValidationCheckBox"
                           Content="Run validation after install (recommended)"

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -401,11 +401,13 @@ namespace PerformanceMonitorInstallerGui
                 Community dependencies install automatically before validation (98_validate)
                 */
                 bool resetSchedule = ResetScheduleCheckBox.IsChecked == true;
+                bool preserveJobs = PreserveJobsCheckBox.IsChecked == true;
                 _installationResult = await InstallationService.ExecuteInstallationAsync(
                     _connectionString,
                     _sqlFiles,
                     isCleanInstall,
                     resetSchedule,
+                    preserveJobs,
                     progress,
                     preValidationAction: async () =>
                     {

--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -325,6 +325,7 @@ END;";
             List<string> sqlFiles,
             bool cleanInstall,
             bool resetSchedule = false,
+            bool preserveJobs = false,
             IProgress<InstallationProgress>? progress = null,
             Func<Task>? preValidationAction = null,
             CancellationToken cancellationToken = default)
@@ -418,6 +419,17 @@ END;";
                         progress?.Report(new InstallationProgress
                         {
                             Message = "Resetting schedule to recommended defaults...",
+                            Status = "Info"
+                        });
+                    }
+
+                    /*Preserve existing SQL Agent jobs if requested*/
+                    if (preserveJobs && fileName.StartsWith("45_", StringComparison.Ordinal))
+                    {
+                        sqlContent = sqlContent.Replace("@preserve_jobs bit = 0", "@preserve_jobs bit = 1");
+                        progress?.Report(new InstallationProgress
+                        {
+                            Message = "Preserving existing SQL Agent jobs...",
                             Status = "Info"
                         });
                     }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A GUI installer (`PerformanceMonitorInstallerGui.exe`) is also included in the r
 | `USERNAME PASSWORD` | SQL Authentication credentials (positional, optional) |
 | `--reinstall` | Drop existing database and perform clean install |
 | `--reset-schedule` | Reset collection schedule to recommended defaults during upgrade |
+| `--preserve-jobs` | Keep existing SQL Agent jobs unchanged (owner, schedule, notifications) |
 | `--encrypt=optional\|mandatory\|strict` | Connection encryption level (default: mandatory) |
 | `--trust-cert` | Trust server certificate without validation (default: require valid cert) |
 


### PR DESCRIPTION
## Summary
- Adds `--preserve-jobs` CLI flag and GUI checkbox to keep existing SQL Agent jobs untouched during upgrades
- Existing jobs (owner, schedule, notifications) are preserved; only missing jobs are created
- Uses a `@preserve_jobs` T-SQL variable — C# flips `0` to `1` via string replace

Fixes #324

## Test plan
- [x] Default install drops+recreates jobs (verified via `date_created` change on sql2022)
- [x] `--preserve-jobs` preserves existing jobs (verified `date_created` unchanged on sql2022)
- [x] Both installers build with zero errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)