### PR TITLE
Fix UDF timing units: microseconds to milliseconds

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -688,17 +688,17 @@ public partial class PlanViewerControl : UserControl
 
             // Timing
             if (node.ActualElapsedMs > 0 || node.ActualCPUMs > 0
-                || node.UdfCpuTimeUs > 0 || node.UdfElapsedTimeUs > 0)
+                || node.UdfCpuTimeMs > 0 || node.UdfElapsedTimeMs > 0)
             {
                 AddPropertySection("Actual Timing");
                 if (node.ActualElapsedMs > 0)
                     AddPropertyRow("Elapsed Time", $"{node.ActualElapsedMs:N0} ms");
                 if (node.ActualCPUMs > 0)
                     AddPropertyRow("CPU Time", $"{node.ActualCPUMs:N0} ms");
-                if (node.UdfElapsedTimeUs > 0)
-                    AddPropertyRow("UDF Elapsed", $"{node.UdfElapsedTimeUs:N0} us");
-                if (node.UdfCpuTimeUs > 0)
-                    AddPropertyRow("UDF CPU", $"{node.UdfCpuTimeUs:N0} us");
+                if (node.UdfElapsedTimeMs > 0)
+                    AddPropertyRow("UDF Elapsed", $"{node.UdfElapsedTimeMs:N0} ms");
+                if (node.UdfCpuTimeMs > 0)
+                    AddPropertyRow("UDF CPU", $"{node.UdfCpuTimeMs:N0} ms");
             }
 
             // I/O

--- a/Dashboard/Models/PlanModels.cs
+++ b/Dashboard/Models/PlanModels.cs
@@ -272,8 +272,8 @@ public class PlanNode
     public string? ActionColumn { get; set; }
     public long ActualSegmentReads { get; set; }
     public long ActualSegmentSkips { get; set; }
-    public long UdfCpuTimeUs { get; set; }
-    public long UdfElapsedTimeUs { get; set; }
+    public long UdfCpuTimeMs { get; set; }
+    public long UdfElapsedTimeMs { get; set; }
 
     // XSD gap: RelOp-level metadata
     public bool GroupExecuted { get; set; }

--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -221,15 +221,13 @@ public static class PlanAnalyzer
         }
 
         // Rule 4: UDF timing — any node spending time in UDFs (actual plans)
-        if (node.UdfCpuTimeUs > 0 || node.UdfElapsedTimeUs > 0)
+        if (node.UdfCpuTimeMs > 0 || node.UdfElapsedTimeMs > 0)
         {
-            var cpuMs = node.UdfCpuTimeUs / 1000.0;
-            var elapsedMs = node.UdfElapsedTimeUs / 1000.0;
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF executing on this operator. UDF elapsed: {elapsedMs:F1}ms, UDF CPU: {cpuMs:F1}ms",
-                Severity = elapsedMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
+                Message = $"Scalar UDF executing on this operator. UDF elapsed: {node.UdfElapsedTimeMs:N0}ms, UDF CPU: {node.UdfCpuTimeMs:N0}ms",
+                Severity = node.UdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
 

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -1179,8 +1179,8 @@ public static class ShowPlanParser
             node.ActualExecutionMode = actualExecMode;
             node.ActualSegmentReads = totalSegmentReads;
             node.ActualSegmentSkips = totalSegmentSkips;
-            node.UdfCpuTimeUs = totalUdfCpu;
-            node.UdfElapsedTimeUs = maxUdfElapsed;
+            node.UdfCpuTimeMs = totalUdfCpu;
+            node.UdfElapsedTimeMs = maxUdfElapsed;
 
             // Store per-thread data for parallel skew analysis
             foreach (var thread in runtimeEl.Elements(Ns + "RunTimeCountersPerThread"))

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -698,17 +698,17 @@ public partial class PlanViewerControl : UserControl
 
             // Timing
             if (node.ActualElapsedMs > 0 || node.ActualCPUMs > 0
-                || node.UdfCpuTimeUs > 0 || node.UdfElapsedTimeUs > 0)
+                || node.UdfCpuTimeMs > 0 || node.UdfElapsedTimeMs > 0)
             {
                 AddPropertySection("Actual Timing");
                 if (node.ActualElapsedMs > 0)
                     AddPropertyRow("Elapsed Time", $"{node.ActualElapsedMs:N0} ms");
                 if (node.ActualCPUMs > 0)
                     AddPropertyRow("CPU Time", $"{node.ActualCPUMs:N0} ms");
-                if (node.UdfElapsedTimeUs > 0)
-                    AddPropertyRow("UDF Elapsed", $"{node.UdfElapsedTimeUs:N0} us");
-                if (node.UdfCpuTimeUs > 0)
-                    AddPropertyRow("UDF CPU", $"{node.UdfCpuTimeUs:N0} us");
+                if (node.UdfElapsedTimeMs > 0)
+                    AddPropertyRow("UDF Elapsed", $"{node.UdfElapsedTimeMs:N0} ms");
+                if (node.UdfCpuTimeMs > 0)
+                    AddPropertyRow("UDF CPU", $"{node.UdfCpuTimeMs:N0} ms");
             }
 
             // I/O

--- a/Lite/Models/PlanModels.cs
+++ b/Lite/Models/PlanModels.cs
@@ -272,8 +272,8 @@ public class PlanNode
     public string? ActionColumn { get; set; }
     public long ActualSegmentReads { get; set; }
     public long ActualSegmentSkips { get; set; }
-    public long UdfCpuTimeUs { get; set; }
-    public long UdfElapsedTimeUs { get; set; }
+    public long UdfCpuTimeMs { get; set; }
+    public long UdfElapsedTimeMs { get; set; }
 
     // XSD gap: RelOp-level metadata
     public bool GroupExecuted { get; set; }

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -221,15 +221,13 @@ public static class PlanAnalyzer
         }
 
         // Rule 4: UDF timing — any node spending time in UDFs (actual plans)
-        if (node.UdfCpuTimeUs > 0 || node.UdfElapsedTimeUs > 0)
+        if (node.UdfCpuTimeMs > 0 || node.UdfElapsedTimeMs > 0)
         {
-            var cpuMs = node.UdfCpuTimeUs / 1000.0;
-            var elapsedMs = node.UdfElapsedTimeUs / 1000.0;
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF executing on this operator. UDF elapsed: {elapsedMs:F1}ms, UDF CPU: {cpuMs:F1}ms",
-                Severity = elapsedMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
+                Message = $"Scalar UDF executing on this operator. UDF elapsed: {node.UdfElapsedTimeMs:N0}ms, UDF CPU: {node.UdfCpuTimeMs:N0}ms",
+                Severity = node.UdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
 

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -1179,8 +1179,8 @@ public static class ShowPlanParser
             node.ActualExecutionMode = actualExecMode;
             node.ActualSegmentReads = totalSegmentReads;
             node.ActualSegmentSkips = totalSegmentSkips;
-            node.UdfCpuTimeUs = totalUdfCpu;
-            node.UdfElapsedTimeUs = maxUdfElapsed;
+            node.UdfCpuTimeMs = totalUdfCpu;
+            node.UdfElapsedTimeMs = maxUdfElapsed;
 
             // Store per-thread data for parallel skew analysis
             foreach (var thread in runtimeEl.Elements(Ns + "RunTimeCountersPerThread"))


### PR DESCRIPTION
## Summary
- Plan XML `UdfCpuTime`/`UdfElapsedTime` values are milliseconds, not microseconds
- Property names, `/1000` division in PlanAnalyzer Rule 4, and "us" labels in the properties panel were all wrong
- Was showing 1/1000th of real UDF time, and the critical severity threshold (1000ms) was effectively unreachable
- Fixed in both Dashboard and Lite

## Test plan
- [x] Dashboard builds clean
- [x] Lite builds clean
- [x] plan-b 32/32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)