### PR TITLE
Reduce first-run lookback to 1 hour for all collectors

### DIFF
--- a/install/08_collect_query_stats.sql
+++ b/install/08_collect_query_stats.sql
@@ -107,16 +107,16 @@ BEGIN
         END;
 
         /*
-        First run detection - collect all queries if this is the first execution
+        First run detection - collect last 1 hour of queries if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.query_stats)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'query_stats_collector')
         BEGIN
-            SET @cutoff_time = CONVERT(datetime2(7), '19000101');
+            SET @cutoff_time = DATEADD(HOUR, -1, SYSDATETIME());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting all queries from sys.dm_exec_query_stats', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of query stats', 0, 1) WITH NOWAIT;
             END;
         END;
         ELSE

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -145,16 +145,16 @@ BEGIN
         END;
 
         /*
-        First run detection - collect 3 days of history if this is the first execution
+        First run detection - collect last 1 hour of history if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.query_store_data)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'query_store_collector')
         BEGIN
-            SET @cutoff_time = TODATETIMEOFFSET(DATEADD(DAY, -3, SYSUTCDATETIME()), 0);
+            SET @cutoff_time = TODATETIMEOFFSET(DATEADD(HOUR, -1, SYSUTCDATETIME()), 0);
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting last 3 days of Query Store data', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of Query Store data', 0, 1) WITH NOWAIT;
             END;
         END;
         ELSE

--- a/install/10_collect_procedure_stats.sql
+++ b/install/10_collect_procedure_stats.sql
@@ -107,16 +107,16 @@ BEGIN
         END;
 
         /*
-        First run detection - collect all procedures if this is the first execution
+        First run detection - collect last 1 hour of procedures if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.procedure_stats)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'procedure_stats_collector')
         BEGIN
-            SET @cutoff_time = CONVERT(datetime2(7), '19000101');
+            SET @cutoff_time = DATEADD(HOUR, -1, SYSDATETIME());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting all procedures from sys.dm_exec_procedure_stats', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of procedure stats', 0, 1) WITH NOWAIT;
             END;
         END;
         ELSE

--- a/install/18_collect_cpu_utilization_stats.sql
+++ b/install/18_collect_cpu_utilization_stats.sql
@@ -112,7 +112,7 @@ BEGIN
         /*
         Collect CPU utilization data from ring buffers
         Only collects samples newer than the most recent sample we have
-        On first run (NULL max_sample_time), looks back 7 days to populate initial data
+        On first run (NULL max_sample_time), looks back 1 hour to populate initial data
         Avoids duplicate collection of same ring buffer events
         */
         INSERT INTO
@@ -156,7 +156,7 @@ BEGIN
             SECOND,
             -((@current_ms_ticks - t.timestamp) / 1000),
             @start_time
-        ) > ISNULL(@max_sample_time, DATEADD(DAY, -7, @start_time))
+        ) > ISNULL(@max_sample_time, DATEADD(HOUR, -1, @start_time))
         ORDER BY
             t.timestamp DESC
         OPTION(RECOMPILE);

--- a/install/22_collect_blocked_processes.sql
+++ b/install/22_collect_blocked_processes.sql
@@ -140,17 +140,17 @@ BEGIN
         END;
 
         /*
-        First run detection - collect 3 days of history if this is the first execution
+        First run detection - collect last 1 hour of history if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.blocked_process_xml)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'blocked_process_xml_collector')
         BEGIN
-            SET @minutes_back = 4320; /*3 days*/
+            SET @minutes_back = 60; /*1 hour*/
             SET @cutoff_time = DATEADD(MINUTE, -@minutes_back, SYSUTCDATETIME());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting last 3 days of blocked process events', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of blocked process events', 0, 1) WITH NOWAIT;
             END;
         END;
 

--- a/install/24_collect_deadlock_xml.sql
+++ b/install/24_collect_deadlock_xml.sql
@@ -101,17 +101,17 @@ BEGIN
         END;
 
         /*
-        First run detection - collect 3 days of history if this is the first execution
+        First run detection - collect last 1 hour of history if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.deadlock_xml)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'deadlock_xml_collector')
         BEGIN
-            SET @minutes_back = 4320; /*3 days*/
+            SET @minutes_back = 60; /*1 hour*/
             SET @cutoff_time = DATEADD(MINUTE, -@minutes_back, SYSUTCDATETIME());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting last 3 days of deadlock events', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of deadlock events', 0, 1) WITH NOWAIT;
             END;
         END;
 

--- a/install/28_collect_system_health_wrapper.sql
+++ b/install/28_collect_system_health_wrapper.sql
@@ -101,16 +101,16 @@ BEGIN
         END;
 
         /*
-        First run detection - collect 3 days of history if this is the first execution
+        First run detection - collect last 1 hour of history if this is the first execution
         */
         IF NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'system_health_collector')
         BEGIN
-            SET @hours_back = 72; /*3 days*/
+            SET @hours_back = 1; /*1 hour*/
             SET @start_date = DATEADD(HOUR, -@hours_back, SYSDATETIMEOFFSET());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting last 3 days of system health data', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of system health data', 0, 1) WITH NOWAIT;
             END;
         END;
 

--- a/install/29_collect_default_trace.sql
+++ b/install/29_collect_default_trace.sql
@@ -110,17 +110,17 @@ BEGIN
         END;
 
         /*
-        First run detection - collect all available trace data if this is the first execution
+        First run detection - collect last 1 hour of trace data if this is the first execution
         Ignore CONFIG_CHANGE entries when checking for first run (those are just from enabling the trace)
         */
         IF NOT EXISTS (SELECT 1/0 FROM collect.default_trace_events)
         AND NOT EXISTS (SELECT 1/0 FROM config.collection_log WHERE collector_name = N'default_trace_collector' AND collection_status = N'SUCCESS')
         BEGIN
-            SET @cutoff_time = CONVERT(datetime2(7), '19000101');
+            SET @cutoff_time = DATEADD(HOUR, -1, SYSDATETIME());
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'First run detected - collecting all available default trace events', 0, 1) WITH NOWAIT;
+                RAISERROR(N'First run detected - collecting last 1 hour of default trace events', 0, 1) WITH NOWAIT;
             END;
         END;
 


### PR DESCRIPTION
## Summary
- Reduces first-run lookback from 3-7 days (or unlimited) to 1 hour for all 8 collectors with backfill logic
- Fixes #335 — the aggressive lookback was a development convenience that causes catastrophic resource consumption on large environments (particularly query_store_collector with XML plan decompression on multi-GB Query Store databases)
- The timeout→rollback→retry loop on first run is eliminated because 1 hour of data is bounded and completes quickly

## Collectors changed
| Collector | Before | After |
|-----------|--------|-------|
| `query_stats` | All DMV data | 1 hour |
| `query_store` | 3 days | 1 hour |
| `procedure_stats` | All DMV data | 1 hour |
| `cpu_utilization_stats` | 7 days | 1 hour |
| `blocked_processes` | 3 days | 1 hour |
| `deadlock_xml` | 3 days | 1 hour |
| `system_health_wrapper` | 3 days | 1 hour |
| `default_trace` | All available | 1 hour |

## Test plan
- [x] Clean install on sql2016 — all 51 scripts pass, zero errors
- [x] All 48 collectors run successfully after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)