### PR TITLE
Rule 8: Lower parallel skew thresholds, remove 4-thread minimum

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -304,7 +304,8 @@ public static class PlanAnalyzer
             {
                 var maxThread = node.PerThreadStats.OrderByDescending(t => t.ActualRows).First();
                 var skewRatio = (double)maxThread.ActualRows / totalRows;
-                if (skewRatio >= 0.9 && node.PerThreadStats.Count >= 4)
+                var skewThreshold = node.PerThreadStats.Count == 2 ? 0.75 : 0.50;
+                if (skewRatio >= skewThreshold)
                 {
                     node.Warnings.Add(new PlanWarning
                     {

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -304,7 +304,8 @@ public static class PlanAnalyzer
             {
                 var maxThread = node.PerThreadStats.OrderByDescending(t => t.ActualRows).First();
                 var skewRatio = (double)maxThread.ActualRows / totalRows;
-                if (skewRatio >= 0.9 && node.PerThreadStats.Count >= 4)
+                var skewThreshold = node.PerThreadStats.Count == 2 ? 0.75 : 0.50;
+                if (skewRatio >= skewThreshold)
                 {
                     node.Warnings.Add(new PlanWarning
                     {


### PR DESCRIPTION
## Summary
- Removed >= 4 thread requirement — DOP 2 skew is worth flagging
- DOP 2: warn at 75% (one thread doing 3x the other)
- DOP 3+: warn at 50% (one thread doing more than all others combined)
- `threadCount * 1000` minimum rows guard unchanged

## Test plan
- [x] Dashboard and Lite build clean
- [x] plan-b 32/32 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)