### PR TITLE
Rule 9: Raise memory grant warning floor to 1GB

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -75,7 +75,7 @@ public static class PlanAnalyzer
             if (grant.GrantedMemoryKB > 0 && grant.MaxUsedMemoryKB > 0)
             {
                 var wasteRatio = (double)grant.GrantedMemoryKB / grant.MaxUsedMemoryKB;
-                if (wasteRatio >= 10 && grant.GrantedMemoryKB > 1024)
+                if (wasteRatio >= 10 && grant.GrantedMemoryKB >= 1048576)
                 {
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
@@ -98,7 +98,7 @@ public static class PlanAnalyzer
             }
 
             // Large memory grant with sort/hash guidance
-            if (grant.GrantedMemoryKB > 102400 && stmt.RootNode != null)
+            if (grant.GrantedMemoryKB >= 1048576 && stmt.RootNode != null)
             {
                 var consumers = new List<string>();
                 FindMemoryConsumers(stmt.RootNode, consumers);
@@ -112,7 +112,7 @@ public static class PlanAnalyzer
                 {
                     WarningType = "Large Memory Grant",
                     Message = $"Query granted {grantMB:F0} MB of memory.{guidance}",
-                    Severity = grantMB >= 512 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
+                    Severity = grantMB >= 4096 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                 });
             }
         }

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -75,7 +75,7 @@ public static class PlanAnalyzer
             if (grant.GrantedMemoryKB > 0 && grant.MaxUsedMemoryKB > 0)
             {
                 var wasteRatio = (double)grant.GrantedMemoryKB / grant.MaxUsedMemoryKB;
-                if (wasteRatio >= 10 && grant.GrantedMemoryKB > 1024)
+                if (wasteRatio >= 10 && grant.GrantedMemoryKB >= 1048576)
                 {
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
@@ -98,7 +98,7 @@ public static class PlanAnalyzer
             }
 
             // Large memory grant with sort/hash guidance
-            if (grant.GrantedMemoryKB > 102400 && stmt.RootNode != null)
+            if (grant.GrantedMemoryKB >= 1048576 && stmt.RootNode != null)
             {
                 var consumers = new List<string>();
                 FindMemoryConsumers(stmt.RootNode, consumers);
@@ -112,7 +112,7 @@ public static class PlanAnalyzer
                 {
                     WarningType = "Large Memory Grant",
                     Message = $"Query granted {grantMB:F0} MB of memory.{guidance}",
-                    Severity = grantMB >= 512 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
+                    Severity = grantMB >= 4096 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Excessive grant (9a): floor raised from 1MB to 1GB
- Large grant (9c): floor raised from 100MB to 1GB, Critical from 512MB to 4GB
- Grant wait (9b) unchanged — any wait for memory is still worth flagging

## Test plan
- [x] Dashboard and Lite build clean
- [x] plan-b 32/32 tests passing (already had these thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)