### PR TITLE
Skip non-readable AG secondary databases in collectors

### DIFF
--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -48,6 +48,23 @@ DECLARE db_check CURSOR LOCAL FAST_FORWARD FOR
     AND   d.database_id < 32761
     AND   d.state_desc = N'ONLINE'
     AND   d.name <> N'PerformanceMonitor'
+    AND   d.database_id NOT IN
+          (
+              SELECT
+                  d2.database_id
+              FROM sys.databases AS d2
+              JOIN sys.availability_replicas AS r
+                ON d2.replica_id = r.replica_id
+              WHERE NOT EXISTS
+                    (
+                        SELECT
+                            1/0
+                        FROM sys.dm_hadr_availability_group_states AS s
+                        WHERE s.primary_replica = r.replica_server_name
+                    )
+              AND   r.secondary_role_allow_connections_desc = N'READ_ONLY'
+              AND   r.replica_server_name = @@SERVERNAME
+          )
     OPTION(RECOMPILE);
 
 OPEN db_check;

--- a/Lite/Services/RemoteCollectorService.ServerConfig.cs
+++ b/Lite/Services/RemoteCollectorService.ServerConfig.cs
@@ -336,6 +336,23 @@ WHERE (d.database_id > 4 OR d.database_id = 2)
 AND   d.database_id < 32761
 AND   d.name <> N'PerformanceMonitor'
 AND   d.state_desc = N'ONLINE'
+AND   d.database_id NOT IN
+      (
+          SELECT
+              d2.database_id
+          FROM sys.databases AS d2
+          JOIN sys.availability_replicas AS r
+            ON d2.replica_id = r.replica_id
+          WHERE NOT EXISTS
+                (
+                    SELECT
+                        1/0
+                    FROM sys.dm_hadr_availability_group_states AS s
+                    WHERE s.primary_replica = r.replica_server_name
+                )
+          AND   r.secondary_role_allow_connections_desc = N'READ_ONLY'
+          AND   r.replica_server_name = @@SERVERNAME
+      )
 ORDER BY d.name
 OPTION(RECOMPILE);";
 

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -291,6 +291,23 @@ BEGIN
             AND   d.is_read_only = 0
             AND   d.name <> N'PerformanceMonitor'
             AND   d.database_id < 32761 /*exclude contained AG system databases*/
+            AND   d.database_id NOT IN
+                  (
+                      SELECT
+                          d2.database_id
+                      FROM sys.databases AS d2
+                      JOIN sys.availability_replicas AS r
+                        ON d2.replica_id = r.replica_id
+                      WHERE NOT EXISTS
+                            (
+                                SELECT
+                                    1/0
+                                FROM sys.dm_hadr_availability_group_states AS s
+                                WHERE s.primary_replica = r.replica_server_name
+                            )
+                      AND   r.secondary_role_allow_connections_desc = N'READ_ONLY'
+                      AND   r.replica_server_name = @@SERVERNAME
+                  )
             OPTION(RECOMPILE);
 
         OPEN @db_check_cursor;

--- a/install/39_collect_database_configuration.sql
+++ b/install/39_collect_database_configuration.sql
@@ -165,6 +165,23 @@ BEGIN
             AND   d.name != DB_NAME()
             AND   d.state_desc = N'ONLINE'
             AND   d.database_id < 32761 /*exclude contained AG system databases*/
+            AND   d.database_id NOT IN
+                  (
+                      SELECT
+                          d2.database_id
+                      FROM sys.databases AS d2
+                      JOIN sys.availability_replicas AS r
+                        ON d2.replica_id = r.replica_id
+                      WHERE NOT EXISTS
+                            (
+                                SELECT
+                                    1/0
+                                FROM sys.dm_hadr_availability_group_states AS s
+                                WHERE s.primary_replica = r.replica_server_name
+                            )
+                      AND   r.secondary_role_allow_connections_desc = N'READ_ONLY'
+                      AND   r.replica_server_name = @@SERVERNAME
+                  )
             ORDER BY
                 d.name
             OPTION (RECOMPILE);


### PR DESCRIPTION
## Summary
- Fixes #325 — collectors that do cross-database queries (`USE [db]` or 3-part naming) now skip AG secondary replicas that reject non-read-intent sessions
- Adds `NOT IN` filter using `sys.availability_replicas.secondary_role_allow_connections_desc` to exclude secondaries configured as `READ_ONLY`
- Databases on primaries, non-AG databases, and secondaries with `ALL` connections are unaffected

## Changed locations
| Location | What it does |
|----------|-------------|
| `install/39_collect_database_configuration.sql` | Scoped config cursor |
| `install/09_collect_query_store.sql` | Query Store discovery cursor |
| `Lite/RemoteCollectorService.ServerConfig.cs` | Scoped config database list |
| `Lite/RemoteCollectorService.QueryStore.cs` | Query Store discovery cursor |

## Test plan
- [x] Clean install on sql2016 — all 51 scripts pass, zero errors
- [x] Lite builds clean
- [ ] Needs validation on an actual AG environment (reporter volunteered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)