### PR TITLE
Add optional query text and plan collection flags (#337)

### DIFF
--- a/install/01_install_database.sql
+++ b/install/01_install_database.sql
@@ -274,6 +274,10 @@ BEGIN
             DEFAULT 5,
         retention_days integer NOT NULL
             DEFAULT 30,
+        collect_query bit NOT NULL
+            DEFAULT CONVERT(bit, 'true'),
+        collect_plan bit NOT NULL
+            DEFAULT CONVERT(bit, 'true'),
         [description] nvarchar(500) NULL,
         created_date datetime2(7) NOT NULL
             DEFAULT SYSDATETIME(),
@@ -315,6 +319,47 @@ BEGIN
             (DATA_COMPRESSION = PAGE);
 
     PRINT 'Created config.collection_schedule table';
+END;
+
+/*
+Add collect_query and collect_plan columns for existing installations
+Controls whether collectors store query text and execution plans
+Both default to enabled (1) for backwards compatibility
+*/
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
+    AND   name = N'collect_query'
+)
+BEGIN
+    ALTER TABLE
+        config.collection_schedule
+    ADD collect_query bit NOT NULL
+        CONSTRAINT DF_collection_schedule_collect_query
+        DEFAULT CONVERT(bit, 'true');
+
+    PRINT 'Added collect_query column to config.collection_schedule';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
+    AND   name = N'collect_plan'
+)
+BEGIN
+    ALTER TABLE
+        config.collection_schedule
+    ADD collect_plan bit NOT NULL
+        CONSTRAINT DF_collection_schedule_collect_plan
+        DEFAULT CONVERT(bit, 'true');
+
+    PRINT 'Added collect_plan column to config.collection_schedule';
 END;
 
 /*


### PR DESCRIPTION
## Summary
- Adds `collect_query` and `collect_plan` bit columns to `config.collection_schedule` (NOT NULL, DEFAULT 1)
- Users can set either flag to 0 per-collector to disable text/plan storage and reduce data volume
- Collectors 08 (query_stats), 09 (query_store), 10 (procedure_stats) read the flags and return NULL when disabled
- Includes idempotent ALTER TABLE with named constraints for existing installations

## Test plan
- [x] Clean install on sql2016 — all 51 scripts pass, 46 collectors succeed
- [x] New columns default to 1 on all schedule rows
- [x] With defaults (1): query_text and query_plan_text populated correctly
- [x] With flags set to 0: query_text and query_plan_text are NULL in new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)