### PR TITLE
Support comma-separated values in text column filters (#348)

### DIFF
--- a/Lite/Services/DataGridFilterService.cs
+++ b/Lite/Services/DataGridFilterService.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using PerformanceMonitorLite.Models;
 
 namespace PerformanceMonitorLite.Services;
@@ -40,18 +41,27 @@ public static class DataGridFilterService
         var stringValue = rawValue?.ToString() ?? string.Empty;
         var filterValue = filter.Value ?? string.Empty;
 
-        /* Handle comparison operators */
+        /* Split comma-separated values for text operators (e.g., "db1, db2") */
+        var terms = filterValue.Split(',')
+            .Select(t => t.Trim())
+            .Where(t => !string.IsNullOrEmpty(t))
+            .ToArray();
+
+        if (terms.Length == 0)
+            return true;
+
+        /* Text operators match ANY term, NotEquals excludes ALL terms */
         return filter.Operator switch
         {
-            FilterOperator.Contains => stringValue.Contains(filterValue, StringComparison.OrdinalIgnoreCase),
-            FilterOperator.Equals => CompareValues(rawValue, filterValue, (a, b) => a == b),
-            FilterOperator.NotEquals => CompareValues(rawValue, filterValue, (a, b) => a != b),
+            FilterOperator.Contains => terms.Any(t => stringValue.Contains(t, StringComparison.OrdinalIgnoreCase)),
+            FilterOperator.Equals => terms.Any(t => CompareValues(rawValue, t, (a, b) => a == b)),
+            FilterOperator.NotEquals => terms.All(t => CompareValues(rawValue, t, (a, b) => a != b)),
             FilterOperator.GreaterThan => CompareNumeric(rawValue, filterValue, (a, b) => a > b),
             FilterOperator.GreaterThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a >= b),
             FilterOperator.LessThan => CompareNumeric(rawValue, filterValue, (a, b) => a < b),
             FilterOperator.LessThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a <= b),
-            FilterOperator.StartsWith => stringValue.StartsWith(filterValue, StringComparison.OrdinalIgnoreCase),
-            FilterOperator.EndsWith => stringValue.EndsWith(filterValue, StringComparison.OrdinalIgnoreCase),
+            FilterOperator.StartsWith => terms.Any(t => stringValue.StartsWith(t, StringComparison.OrdinalIgnoreCase)),
+            FilterOperator.EndsWith => terms.Any(t => stringValue.EndsWith(t, StringComparison.OrdinalIgnoreCase)),
             _ => true
         };
     }


### PR DESCRIPTION
## Summary
- Text filter operators (Contains, Equals, NotEquals, StartsWith, EndsWith) now accept comma-separated values
- Contains/Equals/StartsWith/EndsWith match ANY term (OR logic)
- NotEquals excludes ALL terms (AND logic) — e.g., `db1, db2` excludes both
- Numeric operators (>, <, >=, <=) unchanged
- Applied to both Dashboard and Lite popup filters

## Test plan
- [x] Both projects build clean
- [ ] Verify comma-separated Contains shows rows matching any term
- [ ] Verify comma-separated NotEquals excludes all listed values
- [ ] Verify single-value filters still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)