### PR TITLE
[Feature] Adds Warning Status to Lite

### DIFF
--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -108,11 +108,14 @@
                                             <Style TargetType="Ellipse">
                                                 <Setter Property="Fill" Value="{DynamicResource ForegroundMutedBrush}"/>
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsOnline}" Value="True">
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Online">
                                                         <Setter Property="Fill" Value="{DynamicResource SuccessBrush}"/>
                                                     </DataTrigger>
-                                                    <DataTrigger Binding="{Binding IsOnline}" Value="False">
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Offline">
                                                         <Setter Property="Fill" Value="{DynamicResource ErrorBrush}"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Warning">
+                                                        <Setter Property="Fill" Value="{DynamicResource WarningBrush}"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -89,6 +89,30 @@ public class ServerConnection
     public bool? IsOnline { get; set; }
 
     /// <summary>
+    /// Whether one or more collectors are currently failing for this server.
+    /// null = not yet determined; true = some collectors have consecutive errors; false = all healthy.
+    /// </summary>
+    [JsonIgnore]
+    public bool? HasCollectorErrors { get; set; }
+
+    /// <summary>
+    /// Computed dot status for the sidebar indicator. One of: "Unknown", "Online", "Warning", "Offline".
+    /// Drives the Ellipse fill via DataTrigger in MainWindow.xaml.
+    /// </summary>
+    [JsonIgnore]
+    public string DotStatus
+    {
+        get
+        {
+            if (IsOnline == true)
+                return HasCollectorErrors == true ? "Warning" : "Online";
+            if (IsOnline == false)
+                return "Offline";
+            return "Unknown"; // null — not yet checked
+        }
+    }
+
+    /// <summary>
     /// Display-only property for showing status in UI.
     /// </summary>
     [JsonIgnore]

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -127,6 +127,12 @@ public partial class RemoteCollectorService
     public Task CheckpointAsync() => _duckDb.CheckpointAsync();
 
     /// <summary>
+    /// Gets a summary of collector health for a specific server connection.
+    /// </summary>
+    public CollectorHealthSummary GetHealthSummary(ServerConnection server)
+        => GetHealthSummary(GetServerId(server));
+
+    /// <summary>
     /// Gets a summary of collector health. When serverId is provided, filters to that server only.
     /// </summary>
     public CollectorHealthSummary GetHealthSummary(int? serverId = null)


### PR DESCRIPTION
## What does this PR do?

Implements #30

## Which component(s) does this affect?

- [ ] Full Dashboard
- [x] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

If the connection is "online" (we can connect to the server), but we can't collect data (example: lack of permissions), it should be in a warning (🟡) state.

To test, use a login that can connect to the server, but remove/don't give permissions so it fails collect data. It will show a yellow state like the following:
<img width="554" height="589" alt="image" src="https://github.com/user-attachments/assets/9f00bb4a-6f8b-4833-b5d4-8f12972a400c" />


When you have fixed the permissions, on the next attempt to collect data, it will turn green again:
<img width="554" height="589" alt="image" src="https://github.com/user-attachments/assets/276250e3-b8ae-44e9-9af0-251322a6806d" />


## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
