### PR TITLE
Move collect_query/collect_plan upgrade to proper upgrade path

### DIFF
--- a/install/01_install_database.sql
+++ b/install/01_install_database.sql
@@ -322,47 +322,6 @@ BEGIN
 END;
 
 /*
-Add collect_query and collect_plan columns for existing installations
-Controls whether collectors store query text and execution plans
-Both default to enabled (1) for backwards compatibility
-*/
-IF NOT EXISTS
-(
-    SELECT
-        1/0
-    FROM sys.columns
-    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
-    AND   name = N'collect_query'
-)
-BEGIN
-    ALTER TABLE
-        config.collection_schedule
-    ADD collect_query bit NOT NULL
-        CONSTRAINT DF_collection_schedule_collect_query
-        DEFAULT CONVERT(bit, 'true');
-
-    PRINT 'Added collect_query column to config.collection_schedule';
-END;
-
-IF NOT EXISTS
-(
-    SELECT
-        1/0
-    FROM sys.columns
-    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
-    AND   name = N'collect_plan'
-)
-BEGIN
-    ALTER TABLE
-        config.collection_schedule
-    ADD collect_plan bit NOT NULL
-        CONSTRAINT DF_collection_schedule_collect_plan
-        DEFAULT CONVERT(bit, 'true');
-
-    PRINT 'Added collect_plan column to config.collection_schedule';
-END;
-
-/*
 Critical issues table
 Logs significant performance problems detected by collectors and analysis procedures
 Provides high-level alerting and triage view for DBAs

--- a/upgrades/2.0.0-to-2.1.0/01_collection_schedule_optional_text.sql
+++ b/upgrades/2.0.0-to-2.1.0/01_collection_schedule_optional_text.sql
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 2.0.0 to 2.1.0
+Adds collect_query and collect_plan columns to config.collection_schedule
+for optional query text and execution plan collection (#337).
+Both default to 1 (enabled) to preserve existing behavior.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+/* Add collect_query column for optional query text collection */
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
+    AND   name = N'collect_query'
+)
+BEGIN
+    ALTER TABLE
+        config.collection_schedule
+    ADD
+        collect_query bit NOT NULL
+            CONSTRAINT DF_collection_schedule_collect_query
+            DEFAULT CONVERT(bit, 'true');
+
+    PRINT 'Added collect_query to config.collection_schedule';
+END;
+GO
+
+/* Add collect_plan column for optional execution plan collection */
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'config.collection_schedule')
+    AND   name = N'collect_plan'
+)
+BEGIN
+    ALTER TABLE
+        config.collection_schedule
+    ADD
+        collect_plan bit NOT NULL
+            CONSTRAINT DF_collection_schedule_collect_plan
+            DEFAULT CONVERT(bit, 'true');
+
+    PRINT 'Added collect_plan to config.collection_schedule';
+END;
+GO

--- a/upgrades/2.0.0-to-2.1.0/upgrade.txt
+++ b/upgrades/2.0.0-to-2.1.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_collection_schedule_optional_text.sql


### PR DESCRIPTION
## Summary
- Remove ALTER TABLE upgrade blocks from `01_install_database.sql` — upgrade logic belongs in `upgrades/` folder, not install scripts
- Create `upgrades/2.0.0-to-2.1.0/` with idempotent upgrade script for `collect_query` and `collect_plan` columns on `config.collection_schedule`
- CREATE TABLE in `01_install_database.sql` already has the columns for fresh installs

## Test plan
- [ ] Fresh install creates columns via CREATE TABLE
- [ ] Upgrade from 2.0.0 adds columns via upgrade script

🤖 Generated with [Claude Code](https://claude.com/claude-code)