### PR TITLE
Added exclusions for sp_server_diagnostics and WAITFOR wait types to GetLongRunningQueriesAsync() method.

### DIFF
--- a/Dashboard/Controls/LandingPage.xaml.cs
+++ b/Dashboard/Controls/LandingPage.xaml.cs
@@ -7,7 +7,7 @@
  */
 
 using System;
-//using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -603,29 +603,24 @@ namespace PerformanceMonitorDashboard.Services
         /// Gets currently running queries that exceed the duration threshold.
         /// Uses live DMV data (sys.dm_exec_requests) for immediate detection.
         /// </summary>
-        private async Task<List<LongRunningQueryInfo>> GetLongRunningQueriesAsync(SqlConnection connection, int thresholdMinutes, bool excludeSpServerDiagnostics = true, bool excludeWaitFor = true, int maxLongRunningQueryCount = 5, bool excludeBackupWaits = true)
+        private async Task<List<LongRunningQueryInfo>> GetLongRunningQueriesAsync(SqlConnection connection, int thresholdMinutes)
         {
+
             // Exclude internal SP_SERVER_DIAGNOSTICS queries by default, as they often run long and aren't actionable.
-            string spServerDiagnosticsFilter = excludeSpServerDiagnostics ? "AND r.wait_type NOT LIKE N'%SP_SERVER_DIAGNOSTICS%'" : "";
+            string spServerDiagnosticsFilter = "AND r.wait_type NOT LIKE N'%SP_SERVER_DIAGNOSTICS%'";
 
             // Exclude WAITFOR queries by default, as they can run indefinitely and may not indicate a problem.
-            string waitForFilter = excludeWaitFor ? "AND r.wait_type <> N'WAITFOR'" : "";
+            string waitForFilter = "AND r.wait_type NOT IN (N'WAITFOR', N'BROKER_RECEIVE_WAITFOR')";
 
             // Exclude backup waits if specified, as they can run long and aren't typically actionable in this context.
-            string backupsFilter = excludeBackupWaits ? "AND r.wait_type NOT IN (N'BACKUPTHREAD', N'BACKUPIO')" : "";
+            string backupsFilter = "AND r.wait_type NOT IN (N'BACKUPTHREAD', N'BACKUPIO')";
 
-            // Sanity check to prevent SQL syntax errors   
-            if (maxLongRunningQueryCount <= 5)
-            {
-                maxLongRunningQueryCount = 5;
-            };
-
-            // Use TOP to limit the number of long-running queries returned, with a reasonable default of 5.
-            string LongRunningQueryCount = @$"TOP ({maxLongRunningQueryCount})";
+            // Exclude miscellaneous wait type that aren't typically actionable
+            string miscWaitsFilter = "AND r.wait_type NOT IN (N'XE_LIVE_TARGET_TVF')";
 
             string query = @$"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-                SELECT {LongRunningQueryCount}
+                SELECT TOP(5)
                     r.session_id,
                     DB_NAME(r.database_id) AS database_name,
                     SUBSTRING(t.text, 1, 300) AS query_text,
@@ -645,6 +640,7 @@ namespace PerformanceMonitorDashboard.Services
                     {spServerDiagnosticsFilter}
                     {waitForFilter}
                     {backupsFilter}
+                    {miscWaitsFilter}
                 ORDER BY r.total_elapsed_time DESC
                 OPTION(MAXDOP 1, RECOMPILE);";
 


### PR DESCRIPTION
## What does this PR do?

Adds exclusions to `GetLongRunningQueriesAsync()` to exclude `sp_server_diagnostics` and `WAITFOR` wait types.  Adds parameters to `GetLongRunningQueriesAsync()` for future use to allow precise control over exclusion of those wait types, along with an optional parameter to control the maximum number of long running queries returned to the caller.

## Which component(s) does this affect?

- [✔] Full Dashboard

## How was this tested?

Tested against SQL Server 2022 with sp_server_diagnostics wait types caused by Windows Server Failover Cluster monitoring, and via a manual query with `WAITFOR DELAY '00:30:00';`

## Checklist

- [✔] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [✔] My code builds with zero warnings (`dotnet build -c Debug`)
- [✔] I have tested my changes against at least one SQL Server version
- [✔] I have not introduced any hardcoded credentials or server names
