### PR TITLE
Plan canvas top-left alignment and scroll reset

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml
+++ b/Dashboard/Controls/PlanViewerControl.xaml
@@ -159,7 +159,8 @@
                           PreviewMouseLeftButtonDown="PlanScrollViewer_PreviewMouseLeftButtonDown"
                           PreviewMouseMove="PlanScrollViewer_PreviewMouseMove"
                           PreviewMouseLeftButtonUp="PlanScrollViewer_PreviewMouseLeftButtonUp">
-                <Canvas x:Name="PlanCanvas" ClipToBounds="False">
+                <Canvas x:Name="PlanCanvas" ClipToBounds="False"
+                        HorizontalAlignment="Left" VerticalAlignment="Top">
                     <Canvas.LayoutTransform>
                         <ScaleTransform x:Name="ZoomTransform" ScaleX="1" ScaleY="1"/>
                     </Canvas.LayoutTransform>

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -125,6 +125,7 @@ public partial class PlanViewerControl : UserControl
         _currentStatement = statement;
         PlanCanvas.Children.Clear();
         _selectedNodeBorder = null;
+        PlanScrollViewer.ScrollToHome();
 
         if (statement.RootNode == null) return;
 

--- a/Lite/Controls/PlanViewerControl.xaml
+++ b/Lite/Controls/PlanViewerControl.xaml
@@ -106,7 +106,8 @@
                           VerticalScrollBarVisibility="Auto"
                           Background="{DynamicResource BackgroundBrush}"
                           PreviewMouseWheel="PlanScrollViewer_PreviewMouseWheel">
-                <Canvas x:Name="PlanCanvas" ClipToBounds="False">
+                <Canvas x:Name="PlanCanvas" ClipToBounds="False"
+                        HorizontalAlignment="Left" VerticalAlignment="Top">
                     <Canvas.LayoutTransform>
                         <ScaleTransform x:Name="ZoomTransform" ScaleX="1" ScaleY="1"/>
                     </Canvas.LayoutTransform>

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -135,6 +135,7 @@ public partial class PlanViewerControl : UserControl
         _currentStatement = statement;
         PlanCanvas.Children.Clear();
         _selectedNodeBorder = null;
+        PlanScrollViewer.ScrollToHome();
 
         if (statement.RootNode == null) return;
 


### PR DESCRIPTION
## Summary
- Anchor plan canvas to top-left instead of centered so more of large plans are immediately visible
- Reset scroll position to origin when switching between statements

Synced from plan-b.

## Test plan
- [ ] Open a large plan — verify it starts at top-left, not centered in space
- [ ] Switch between statements — verify scroll resets to top-left each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)