### PR TITLE
Add right-click Copy Query Text to statements grid

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml
+++ b/Dashboard/Controls/PlanViewerControl.xaml
@@ -140,7 +140,13 @@
                               SelectionChanged="StatementsGrid_SelectionChanged"
                               FontSize="11"
                               Background="{DynamicResource BackgroundDarkBrush}"
-                              BorderThickness="0"/>
+                              BorderThickness="0">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Copy Query Text" Click="CopyStatementText_Click"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
                 </DockPanel>
             </Border>
 

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -1584,6 +1584,16 @@ public partial class PlanViewerControl : UserControl
             RenderStatement(row.Statement);
     }
 
+    private void CopyStatementText_Click(object sender, RoutedEventArgs e)
+    {
+        if (StatementsGrid.SelectedItem is StatementRow row)
+        {
+            var text = row.Statement.StatementText;
+            if (!string.IsNullOrEmpty(text))
+                Clipboard.SetText(text);
+        }
+    }
+
     private void ToggleStatements_Click(object sender, RoutedEventArgs e)
     {
         if (StatementsPanel.Visibility == Visibility.Visible)


### PR DESCRIPTION
## Summary
- Adds a context menu to Dashboard's StatementsGrid with "Copy Query Text" option
- Right-click a statement row to copy full (non-truncated) query text to clipboard
- Synced from plan-b

## Test plan
- [ ] Open a multi-statement plan in Dashboard
- [ ] Show statements panel, right-click a row
- [ ] Verify "Copy Query Text" appears and copies full text to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)