### PR TITLE
Sync plan-b v0.3.0 Plan Insights to Dashboard and Lite

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml
+++ b/Dashboard/Controls/PlanViewerControl.xaml
@@ -7,8 +7,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -39,51 +37,87 @@
             </DockPanel>
         </Border>
 
-        <!-- Missing Index Banner -->
-        <Border x:Name="MissingIndexBanner" Grid.Row="1" Padding="10,8"
-                Background="#3D2A0E" Visibility="Collapsed"
-                BorderBrush="#7A5A1E" BorderThickness="0,0,0,1">
-            <StackPanel>
-                <TextBlock Text="Missing Index Suggestions" FontWeight="SemiBold"
-                           Foreground="#FFB347" Margin="0,0,0,4"/>
-                <ItemsControl x:Name="MissingIndexList">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,2">
-                                <TextBlock Foreground="#E4E6EB" FontSize="11" TextWrapping="Wrap">
-                                    <Run Text="{Binding Table, Mode=OneWay}" FontWeight="SemiBold"/>
-                                    <Run Text=" — Impact: "/>
-                                    <Run Text="{Binding Impact, StringFormat={}{0:F1}%, Mode=OneWay}" Foreground="#FFB347"/>
-                                </TextBlock>
-                                <TextBlock Text="{Binding CreateStatement, Mode=OneWay}" FontFamily="Consolas" FontSize="10"
-                                           Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap"
-                                           Margin="12,2,0,0"/>
+        <!-- Insights Panel: Runtime Summary + Missing Indexes + Wait Stats (collapsible) -->
+        <Border x:Name="InsightsPanel" Grid.Row="1" Visibility="Collapsed"
+                Background="{DynamicResource BackgroundDarkBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+            <Expander x:Name="InsightsExpander" IsExpanded="True"
+                      Foreground="{DynamicResource ForegroundBrush}"
+                      Background="Transparent"
+                      BorderThickness="0"
+                      Padding="0">
+                <Expander.Header>
+                    <TextBlock x:Name="InsightsHeader" Text="  Plan Insights"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </Expander.Header>
+                <Grid MaxHeight="220">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" MinWidth="180"/>
+                        <ColumnDefinition Width="Auto" MinWidth="200"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Runtime Summary (left) -->
+                    <Border Grid.Column="0" Padding="10,4,10,8"
+                            Background="{DynamicResource BackgroundDarkBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,1,0">
+                        <StackPanel>
+                            <TextBlock Text="Runtime Summary"
+                                       FontSize="13"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource ForegroundBrush}"
+                                       Margin="0,0,0,4"/>
+                            <StackPanel x:Name="RuntimeSummaryContent"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Missing Indexes (center) -->
+                    <Border Grid.Column="1" Padding="10,4,10,8"
+                            Background="#3D2A0E"
+                            BorderBrush="#7A5A1E" BorderThickness="0,0,1,0">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <TextBlock x:Name="MissingIndexHeader"
+                                           Text="Missing Index Suggestions"
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#FFB347"
+                                           Margin="0,0,0,6"/>
+                                <StackPanel x:Name="MissingIndexContent"/>
+                                <TextBlock x:Name="MissingIndexEmpty"
+                                           Text="No missing index suggestions"
+                                           FontSize="12" Visibility="Collapsed"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
                             </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-        </Border>
+                        </ScrollViewer>
+                    </Border>
 
-        <!-- Warnings Banner -->
-        <Border x:Name="WarningsBanner" Grid.Row="2" Padding="10,6"
-                Background="#3D1A1A" Visibility="Collapsed"
-                BorderBrush="#7A2A2A" BorderThickness="0,0,0,1">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#x26A0;" Foreground="#E57373" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                <TextBlock x:Name="WarningsSummaryText" Foreground="#E57373" VerticalAlignment="Center" FontSize="12"/>
-            </StackPanel>
-        </Border>
-
-        <!-- Wait Stats Banner (actual plans only) -->
-        <Border x:Name="WaitStatsBanner" Grid.Row="3" Padding="10,8"
-                Background="#1A2A3D" Visibility="Collapsed"
-                BorderBrush="#2A4A6A" BorderThickness="0,0,0,1">
-            <StackPanel x:Name="WaitStatsContent"/>
+                    <!-- Wait Stats (right, fills remaining space) -->
+                    <Border Grid.Column="2" Padding="10,4,10,8"
+                            Background="#1A2A3D">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <TextBlock x:Name="WaitStatsHeader"
+                                           Text="Wait Stats"
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#4FA3FF"
+                                           Margin="0,0,0,6"/>
+                                <StackPanel x:Name="WaitStatsContent"/>
+                                <TextBlock x:Name="WaitStatsEmpty"
+                                           Text="No wait stats (estimated plan)"
+                                           FontSize="12" Visibility="Collapsed"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Expander>
         </Border>
 
         <!-- Query Text (collapsible) -->
-        <Expander Grid.Row="4" x:Name="QueryTextExpander" Header="  Query Text"
+        <Expander Grid.Row="2" x:Name="QueryTextExpander" Header="  Query Text"
                   IsExpanded="False" Visibility="Collapsed"
                   Foreground="{DynamicResource ForegroundBrush}"
                   Background="{DynamicResource BackgroundDarkBrush}"
@@ -98,7 +132,7 @@
         </Expander>
 
         <!-- Statements Panel + Plan Canvas + Properties Panel -->
-        <Grid Grid.Row="5">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <!-- Col 0: Statements Panel (hidden by default) -->
                 <ColumnDefinition x:Name="StatementsColumn" Width="0"/>

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -41,6 +41,7 @@ public partial class PlanViewerControl : UserControl
     private static readonly SolidColorBrush EdgeBrush = new(Color.FromRgb(0x6B, 0x72, 0x80));
     private static readonly SolidColorBrush SectionHeaderBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));
     private static readonly SolidColorBrush PropSeparatorBrush = new(Color.FromRgb(0x2A, 0x2D, 0x35));
+    private static readonly SolidColorBrush OrangeBrush = new(Color.FromRgb(0xFF, 0xB3, 0x47));
 
     // Current property section for collapsible groups
     private StackPanel? _currentPropertySection;
@@ -112,9 +113,7 @@ public partial class PlanViewerControl : UserControl
         _selectedNodeBorder = null;
         EmptyState.Visibility = Visibility.Visible;
         PlanScrollViewer.Visibility = Visibility.Collapsed;
-        MissingIndexBanner.Visibility = Visibility.Collapsed;
-        WarningsBanner.Visibility = Visibility.Collapsed;
-        WaitStatsBanner.Visibility = Visibility.Collapsed;
+        InsightsPanel.Visibility = Visibility.Collapsed;
         CloseStatementsPanel();
         CostText.Text = "";
         CostText.Visibility = Visibility.Collapsed;
@@ -140,12 +139,15 @@ public partial class PlanViewerControl : UserControl
         RenderEdges(statement.RootNode);
 
         // Render nodes
-        RenderNodes(statement.RootNode);
+        var allWarnings = new List<PlanWarning>();
+        CollectWarnings(statement.RootNode, allWarnings);
+        RenderNodes(statement.RootNode, allWarnings.Count);
 
         // Update banners
         ShowMissingIndexes(statement.MissingIndexes);
-        ShowWarnings(statement.RootNode);
         ShowWaitStats(statement.WaitStats);
+        ShowRuntimeSummary(statement);
+        UpdateInsightsHeader();
 
         // Update cost text
         CostText.Text = $"Statement Cost: {statement.StatementSubTreeCost:F4}";
@@ -153,9 +155,9 @@ public partial class PlanViewerControl : UserControl
 
     #region Node Rendering
 
-    private void RenderNodes(PlanNode node)
+    private void RenderNodes(PlanNode node, int totalWarningCount = -1)
     {
-        var visual = CreateNodeVisual(node);
+        var visual = CreateNodeVisual(node, totalWarningCount);
         Canvas.SetLeft(visual, node.X);
         Canvas.SetTop(visual, node.Y);
         PlanCanvas.Children.Add(visual);
@@ -164,7 +166,7 @@ public partial class PlanViewerControl : UserControl
             RenderNodes(child);
     }
 
-    private Border CreateNodeVisual(PlanNode node)
+    private Border CreateNodeVisual(PlanNode node, int totalWarningCount = -1)
     {
         var isExpensive = node.IsExpensive;
 
@@ -356,6 +358,34 @@ public partial class PlanViewerControl : UserControl
                 HorizontalAlignment = HorizontalAlignment.Center,
                 ToolTip = node.FullObjectName ?? node.ObjectName
             });
+        }
+
+        // Total warning count badge on root node
+        if (totalWarningCount > 0)
+        {
+            var badgeRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 2, 0, 0)
+            };
+            badgeRow.Children.Add(new TextBlock
+            {
+                Text = "\u26A0",
+                FontSize = 13,
+                Foreground = OrangeBrush,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 4, 0)
+            });
+            badgeRow.Children.Add(new TextBlock
+            {
+                Text = $"{totalWarningCount} warning{(totalWarningCount == 1 ? "" : "s")}",
+                FontSize = 12,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = OrangeBrush,
+                VerticalAlignment = VerticalAlignment.Center
+            });
+            stack.Children.Add(badgeRow);
         }
 
         border.Child = stack;
@@ -1365,35 +1395,63 @@ public partial class PlanViewerControl : UserControl
 
     private void ShowMissingIndexes(List<MissingIndex> indexes)
     {
+        MissingIndexContent.Children.Clear();
+
         if (indexes.Count > 0)
         {
-            MissingIndexList.ItemsSource = indexes;
-            MissingIndexBanner.Visibility = Visibility.Visible;
+            MissingIndexHeader.Text = $"  Missing Index Suggestions ({indexes.Count})";
+
+            foreach (var mi in indexes)
+            {
+                var itemPanel = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
+
+                var headerRow = new StackPanel { Orientation = Orientation.Horizontal };
+                headerRow.Children.Add(new TextBlock
+                {
+                    Text = mi.Table,
+                    FontWeight = FontWeights.SemiBold,
+                    Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")),
+                    FontSize = 12
+                });
+                headerRow.Children.Add(new TextBlock
+                {
+                    Text = $" \u2014 Impact: ",
+                    Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")),
+                    FontSize = 12
+                });
+                headerRow.Children.Add(new TextBlock
+                {
+                    Text = $"{mi.Impact:F1}%",
+                    Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFB347")),
+                    FontSize = 12
+                });
+                itemPanel.Children.Add(headerRow);
+
+                if (!string.IsNullOrEmpty(mi.CreateStatement))
+                {
+                    itemPanel.Children.Add(new TextBox
+                    {
+                        Text = mi.CreateStatement,
+                        FontFamily = new FontFamily("Consolas"),
+                        FontSize = 11,
+                        Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")),
+                        Background = Brushes.Transparent,
+                        BorderThickness = new Thickness(0),
+                        IsReadOnly = true,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(12, 2, 0, 0)
+                    });
+                }
+
+                MissingIndexContent.Children.Add(itemPanel);
+            }
+
+            MissingIndexEmpty.Visibility = Visibility.Collapsed;
         }
         else
         {
-            MissingIndexBanner.Visibility = Visibility.Collapsed;
-        }
-    }
-
-    private void ShowWarnings(PlanNode root)
-    {
-        var allWarnings = new List<PlanWarning>();
-        CollectWarnings(root, allWarnings);
-
-        if (allWarnings.Count > 0)
-        {
-            var criticalCount = allWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical);
-            var warningCount = allWarnings.Count(w => w.Severity == PlanWarningSeverity.Warning);
-            var parts = new List<string>();
-            if (criticalCount > 0) parts.Add($"{criticalCount} critical");
-            if (warningCount > 0) parts.Add($"{warningCount} warning(s)");
-            WarningsSummaryText.Text = $"Plan has {string.Join(", ", parts)} — hover over nodes with \u26A0 for details";
-            WarningsBanner.Visibility = Visibility.Visible;
-        }
-        else
-        {
-            WarningsBanner.Visibility = Visibility.Collapsed;
+            MissingIndexHeader.Text = "Missing Index Suggestions";
+            MissingIndexEmpty.Visibility = Visibility.Visible;
         }
     }
 
@@ -1410,106 +1468,78 @@ public partial class PlanViewerControl : UserControl
 
         if (waits.Count == 0)
         {
-            WaitStatsBanner.Visibility = Visibility.Collapsed;
+            WaitStatsHeader.Text = "Wait Stats";
+            WaitStatsEmpty.Visibility = Visibility.Visible;
             return;
         }
+
+        WaitStatsEmpty.Visibility = Visibility.Collapsed;
 
         var sorted = waits.OrderByDescending(w => w.WaitTimeMs).ToList();
         var maxWait = sorted[0].WaitTimeMs;
         var totalWait = sorted.Sum(w => w.WaitTimeMs);
 
-        // Header
-        WaitStatsContent.Children.Add(new TextBlock
+        WaitStatsHeader.Text = $"  Wait Stats \u2014 {totalWait:N0}ms total";
+
+        var longestName = sorted.Max(w => w.WaitType.Length);
+        var nameColWidth = longestName * 6.5 + 10;
+
+        var maxBarWidth = 300;
+
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(nameColWidth) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(maxBarWidth + 16) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        for (int i = 0; i < sorted.Count; i++)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        for (int i = 0; i < sorted.Count; i++)
         {
-            Text = $"Wait Stats \u2014 {totalWait:N0}ms total",
-            FontWeight = FontWeights.SemiBold,
-            Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#4FA3FF")),
-            Margin = new Thickness(0, 0, 0, 6)
-        });
-
-        // Stacked summary bar showing category breakdown
-        if (sorted.Count > 1)
-        {
-            var summaryBar = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Height = 8,
-                Margin = new Thickness(0, 0, 0, 8)
-            };
-
-            var categories = sorted
-                .GroupBy(w => GetWaitCategory(w.WaitType))
-                .OrderByDescending(g => g.Sum(w => w.WaitTimeMs))
-                .ToList();
-
-            foreach (var cat in categories)
-            {
-                var catMs = cat.Sum(w => w.WaitTimeMs);
-                var fraction = totalWait > 0 ? (double)catMs / totalWait : 0;
-                summaryBar.Children.Add(new Border
-                {
-                    Width = Math.Max(2, fraction * 500),
-                    Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString(GetWaitCategoryColor(cat.Key))),
-                    CornerRadius = new CornerRadius(2),
-                    Margin = new Thickness(0, 0, 1, 0)
-                });
-            }
-
-            WaitStatsContent.Children.Add(summaryBar);
-        }
-
-        // Per-wait-type rows with horizontal bars
-        foreach (var w in sorted)
-        {
+            var w = sorted[i];
             var barFraction = maxWait > 0 ? (double)w.WaitTimeMs / maxWait : 0;
             var color = GetWaitCategoryColor(GetWaitCategory(w.WaitType));
 
-            var row = new Grid { Margin = new Thickness(0, 1, 0, 1) };
-            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(140) });
-            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-            // Wait type name
             var nameText = new TextBlock
             {
                 Text = w.WaitType,
-                FontSize = 11,
+                FontSize = 12,
                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")),
                 VerticalAlignment = VerticalAlignment.Center,
-                Margin = new Thickness(0, 0, 8, 0)
+                Margin = new Thickness(0, 2, 10, 2)
             };
+            Grid.SetRow(nameText, i);
             Grid.SetColumn(nameText, 0);
-            row.Children.Add(nameText);
+            grid.Children.Add(nameText);
 
-            // Bar
-            var bar = new Border
+            var colorBar = new Border
             {
+                Width = Math.Max(4, barFraction * maxBarWidth),
                 Height = 14,
-                Width = Math.Max(4, barFraction * 300),
-                HorizontalAlignment = HorizontalAlignment.Left,
                 Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color)),
                 CornerRadius = new CornerRadius(2),
-                Margin = new Thickness(0, 0, 8, 0)
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 2, 8, 2)
             };
-            Grid.SetColumn(bar, 1);
-            row.Children.Add(bar);
+            Grid.SetRow(colorBar, i);
+            Grid.SetColumn(colorBar, 1);
+            grid.Children.Add(colorBar);
 
-            // Duration text
             var durationText = new TextBlock
             {
                 Text = $"{w.WaitTimeMs:N0}ms ({w.WaitCount:N0} waits)",
-                FontSize = 11,
-                Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#B0B6C0")),
+                FontSize = 12,
+                Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")),
                 VerticalAlignment = VerticalAlignment.Center,
-                MinWidth = 120
+                Margin = new Thickness(0, 2, 0, 2)
             };
+            Grid.SetRow(durationText, i);
             Grid.SetColumn(durationText, 2);
-            row.Children.Add(durationText);
-
-            WaitStatsContent.Children.Add(row);
+            grid.Children.Add(durationText);
         }
 
-        WaitStatsBanner.Visibility = Visibility.Visible;
+        WaitStatsContent.Children.Add(grid);
     }
 
     private static string GetWaitCategory(string waitType)
@@ -1550,6 +1580,107 @@ public partial class PlanViewerControl : UserControl
             "Network" => "#2ECC71",
             _ => "#6BB5FF"
         };
+    }
+
+    private void ShowRuntimeSummary(PlanStatement statement)
+    {
+        RuntimeSummaryContent.Children.Clear();
+
+        var labelColor = "#E4E6EB";
+        var valueColor = "#E4E6EB";
+
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        int rowIndex = 0;
+
+        void AddRow(string label, string value)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var labelText = new TextBlock
+            {
+                Text = label,
+                FontSize = 11,
+                Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(labelColor)),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Margin = new Thickness(0, 1, 8, 1)
+            };
+            Grid.SetRow(labelText, rowIndex);
+            Grid.SetColumn(labelText, 0);
+            grid.Children.Add(labelText);
+
+            var valueText = new TextBlock
+            {
+                Text = value,
+                FontSize = 11,
+                Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(valueColor)),
+                Margin = new Thickness(0, 1, 0, 1)
+            };
+            Grid.SetRow(valueText, rowIndex);
+            Grid.SetColumn(valueText, 1);
+            grid.Children.Add(valueText);
+
+            rowIndex++;
+        }
+
+        if (statement.QueryTimeStats != null)
+        {
+            AddRow("Elapsed", $"{statement.QueryTimeStats.ElapsedTimeMs:N0}ms");
+            AddRow("CPU", $"{statement.QueryTimeStats.CpuTimeMs:N0}ms");
+        }
+
+        if (statement.MemoryGrant != null)
+        {
+            var mg = statement.MemoryGrant;
+            AddRow("Memory grant", $"{mg.GrantedMemoryKB:N0} KB granted, {mg.MaxUsedMemoryKB:N0} KB used");
+            if (mg.GrantWaitTimeMs > 0)
+                AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms");
+        }
+
+        if (statement.DegreeOfParallelism > 0)
+            AddRow("DOP", statement.DegreeOfParallelism.ToString());
+        else if (statement.NonParallelPlanReason != null)
+            AddRow("Serial", statement.NonParallelPlanReason);
+
+        if (statement.ThreadStats != null)
+        {
+            var ts = statement.ThreadStats;
+            AddRow("Branches", ts.Branches.ToString());
+            var totalReserved = ts.Reservations.Sum(r => r.ReservedThreads);
+            if (totalReserved > 0)
+            {
+                var threadText = ts.UsedThreads == totalReserved
+                    ? $"{ts.UsedThreads} used ({totalReserved} reserved)"
+                    : $"{ts.UsedThreads} used of {totalReserved} reserved ({totalReserved - ts.UsedThreads} inactive)";
+                AddRow("Threads", threadText);
+            }
+            else
+            {
+                AddRow("Threads", $"{ts.UsedThreads} used");
+            }
+        }
+
+        if (statement.CardinalityEstimationModelVersion > 0)
+            AddRow("CE model", statement.CardinalityEstimationModelVersion.ToString());
+
+        if (statement.CompileTimeMs > 0)
+            AddRow("Compile time", $"{statement.CompileTimeMs:N0}ms");
+        if (statement.CachedPlanSizeKB > 0)
+            AddRow("Cached plan size", $"{statement.CachedPlanSizeKB:N0} KB");
+
+        if (!string.IsNullOrEmpty(statement.StatementOptmLevel))
+            AddRow("Optimization", statement.StatementOptmLevel);
+        if (!string.IsNullOrEmpty(statement.StatementOptmEarlyAbortReason))
+            AddRow("Early abort", statement.StatementOptmEarlyAbortReason);
+
+        RuntimeSummaryContent.Children.Add(grid);
+    }
+
+    private void UpdateInsightsHeader()
+    {
+        InsightsPanel.Visibility = Visibility.Visible;
+        InsightsHeader.Text = "  Plan Insights";
     }
 
     #endregion
@@ -1682,17 +1813,17 @@ public partial class PlanViewerControl : UserControl
 
         StatementsGrid.Columns.Add(new DataGridTextColumn
         {
-            Header = "\u26A0 Crit",
+            Header = "Critical",
             Binding = new System.Windows.Data.Binding("Critical"),
-            Width = new DataGridLength(55),
+            Width = new DataGridLength(60),
             IsReadOnly = true
         });
 
         StatementsGrid.Columns.Add(new DataGridTextColumn
         {
-            Header = "\u26A0 Warn",
+            Header = "Warnings",
             Binding = new System.Windows.Data.Binding("Warnings"),
-            Width = new DataGridLength(60),
+            Width = new DataGridLength(70),
             IsReadOnly = true
         });
 
@@ -1781,6 +1912,10 @@ public partial class PlanViewerControl : UserControl
 
     private void PlanScrollViewer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
+        // Don't intercept scrollbar interactions
+        if (IsScrollBarAtPoint(e))
+            return;
+
         // Don't pan if clicking on a node
         if (IsNodeAtPoint(e))
             return;
@@ -1814,6 +1949,19 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.Cursor = Cursors.Arrow;
         PlanScrollViewer.ReleaseMouseCapture();
         e.Handled = true;
+    }
+
+    /// <summary>Check if the mouse event originated from a ScrollBar.</summary>
+    private static bool IsScrollBarAtPoint(MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        while (source != null)
+        {
+            if (source is System.Windows.Controls.Primitives.ScrollBar)
+                return true;
+            source = VisualTreeHelper.GetParent(source);
+        }
+        return false;
     }
 
     /// <summary>Check if the mouse event originated from a node Border (has PlanNode in Tag).</summary>

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -1295,9 +1295,13 @@ public static class ShowPlanParser
                 var keyCols = mi.EqualityColumns.Concat(mi.InequalityColumns).ToList();
                 if (keyCols.Count > 0)
                 {
-                    var create = $"CREATE NONCLUSTERED INDEX [{mi.Table}_{string.Join("_", keyCols.Take(3))}]\nON {mi.Schema}.{mi.Table} ({string.Join(", ", keyCols)})";
+                    var quotedKeyCols = keyCols.Select(c => $"[{c}]");
+                    var create = $"CREATE NONCLUSTERED INDEX [{mi.Table}_{string.Join("_", keyCols.Take(3))}]\nON [{mi.Schema}].[{mi.Table}] ({string.Join(", ", quotedKeyCols)})";
                     if (mi.IncludeColumns.Count > 0)
-                        create += $"\nINCLUDE ({string.Join(", ", mi.IncludeColumns)})";
+                    {
+                        var quotedIncludes = mi.IncludeColumns.Select(c => $"[{c}]");
+                        create += $"\nINCLUDE ({string.Join(", ", quotedIncludes)})";
+                    }
                     create += ";";
                     mi.CreateStatement = create;
                 }

--- a/Lite/Controls/PlanViewerControl.xaml
+++ b/Lite/Controls/PlanViewerControl.xaml
@@ -7,8 +7,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -42,51 +40,87 @@
             </DockPanel>
         </Border>
 
-        <!-- Missing Index Banner -->
-        <Border x:Name="MissingIndexBanner" Grid.Row="1" Padding="10,8"
-                Background="#3D2A0E" Visibility="Collapsed"
-                BorderBrush="#7A5A1E" BorderThickness="0,0,0,1">
-            <StackPanel>
-                <TextBlock Text="Missing Index Suggestions" FontWeight="SemiBold"
-                           Foreground="#FFB347" Margin="0,0,0,4"/>
-                <ItemsControl x:Name="MissingIndexList">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,2">
-                                <TextBlock Foreground="#E4E6EB" FontSize="11" TextWrapping="Wrap">
-                                    <Run Text="{Binding Table, Mode=OneWay}" FontWeight="SemiBold"/>
-                                    <Run Text=" — Impact: "/>
-                                    <Run Text="{Binding Impact, StringFormat={}{0:F1}%, Mode=OneWay}" Foreground="#FFB347"/>
-                                </TextBlock>
-                                <TextBlock Text="{Binding CreateStatement, Mode=OneWay}" FontFamily="Consolas" FontSize="10"
-                                           Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap"
-                                           Margin="12,2,0,0"/>
+        <!-- Insights Panel: Runtime Summary + Missing Indexes + Wait Stats (collapsible) -->
+        <Border x:Name="InsightsPanel" Grid.Row="1" Visibility="Collapsed"
+                Background="{DynamicResource BackgroundDarkBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+            <Expander x:Name="InsightsExpander" IsExpanded="True"
+                      Foreground="{DynamicResource ForegroundBrush}"
+                      Background="Transparent"
+                      BorderThickness="0"
+                      Padding="0">
+                <Expander.Header>
+                    <TextBlock x:Name="InsightsHeader" Text="  Plan Insights"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </Expander.Header>
+                <Grid MaxHeight="220">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" MinWidth="180"/>
+                        <ColumnDefinition Width="Auto" MinWidth="200"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Runtime Summary (left) -->
+                    <Border Grid.Column="0" Padding="10,4,10,8"
+                            Background="{DynamicResource BackgroundDarkBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,1,0">
+                        <StackPanel>
+                            <TextBlock Text="Runtime Summary"
+                                       FontSize="13"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource ForegroundBrush}"
+                                       Margin="0,0,0,4"/>
+                            <StackPanel x:Name="RuntimeSummaryContent"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Missing Indexes (center) -->
+                    <Border Grid.Column="1" Padding="10,4,10,8"
+                            Background="#3D2A0E"
+                            BorderBrush="#7A5A1E" BorderThickness="0,0,1,0">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <TextBlock x:Name="MissingIndexHeader"
+                                           Text="Missing Index Suggestions"
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#FFB347"
+                                           Margin="0,0,0,6"/>
+                                <StackPanel x:Name="MissingIndexContent"/>
+                                <TextBlock x:Name="MissingIndexEmpty"
+                                           Text="No missing index suggestions"
+                                           FontSize="12" Visibility="Collapsed"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
                             </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-        </Border>
+                        </ScrollViewer>
+                    </Border>
 
-        <!-- Warnings Banner -->
-        <Border x:Name="WarningsBanner" Grid.Row="2" Padding="10,6"
-                Background="#3D1A1A" Visibility="Collapsed"
-                BorderBrush="#7A2A2A" BorderThickness="0,0,0,1">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="&#x26A0;" Foreground="#E57373" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                <TextBlock x:Name="WarningsSummaryText" Foreground="#E57373" VerticalAlignment="Center" FontSize="12"/>
-            </StackPanel>
-        </Border>
-
-        <!-- Wait Stats Banner (actual plans only) -->
-        <Border x:Name="WaitStatsBanner" Grid.Row="3" Padding="10,8"
-                Background="#1A2A3D" Visibility="Collapsed"
-                BorderBrush="#2A4A6A" BorderThickness="0,0,0,1">
-            <StackPanel x:Name="WaitStatsContent"/>
+                    <!-- Wait Stats (right, fills remaining space) -->
+                    <Border Grid.Column="2" Padding="10,4,10,8"
+                            Background="#1A2A3D">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel>
+                                <TextBlock x:Name="WaitStatsHeader"
+                                           Text="Wait Stats"
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#4FA3FF"
+                                           Margin="0,0,0,6"/>
+                                <StackPanel x:Name="WaitStatsContent"/>
+                                <TextBlock x:Name="WaitStatsEmpty"
+                                           Text="No wait stats (estimated plan)"
+                                           FontSize="12" Visibility="Collapsed"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Expander>
         </Border>
 
         <!-- Query Text (collapsible) -->
-        <Expander Grid.Row="4" x:Name="QueryTextExpander" Header="  Query Text"
+        <Expander Grid.Row="2" x:Name="QueryTextExpander" Header="  Query Text"
                   IsExpanded="False" Visibility="Collapsed"
                   Foreground="{DynamicResource ForegroundBrush}"
                   Background="{DynamicResource BackgroundDarkBrush}"
@@ -101,7 +135,7 @@
         </Expander>
 
         <!-- Plan Canvas + Properties Panel -->
-        <Grid Grid.Row="5">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
@@ -113,7 +147,10 @@
                           HorizontalScrollBarVisibility="Auto"
                           VerticalScrollBarVisibility="Auto"
                           Background="{DynamicResource BackgroundBrush}"
-                          PreviewMouseWheel="PlanScrollViewer_PreviewMouseWheel">
+                          PreviewMouseWheel="PlanScrollViewer_PreviewMouseWheel"
+                          PreviewMouseLeftButtonDown="PlanScrollViewer_PreviewMouseLeftButtonDown"
+                          PreviewMouseMove="PlanScrollViewer_PreviewMouseMove"
+                          PreviewMouseLeftButtonUp="PlanScrollViewer_PreviewMouseLeftButtonUp">
                 <Canvas x:Name="PlanCanvas" ClipToBounds="False"
                         HorizontalAlignment="Left" VerticalAlignment="Top">
                     <Canvas.LayoutTransform>

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -1295,9 +1295,13 @@ public static class ShowPlanParser
                 var keyCols = mi.EqualityColumns.Concat(mi.InequalityColumns).ToList();
                 if (keyCols.Count > 0)
                 {
-                    var create = $"CREATE NONCLUSTERED INDEX [{mi.Table}_{string.Join("_", keyCols.Take(3))}]\nON {mi.Schema}.{mi.Table} ({string.Join(", ", keyCols)})";
+                    var quotedKeyCols = keyCols.Select(c => $"[{c}]");
+                    var create = $"CREATE NONCLUSTERED INDEX [{mi.Table}_{string.Join("_", keyCols.Take(3))}]\nON [{mi.Schema}].[{mi.Table}] ({string.Join(", ", quotedKeyCols)})";
                     if (mi.IncludeColumns.Count > 0)
-                        create += $"\nINCLUDE ({string.Join(", ", mi.IncludeColumns)})";
+                    {
+                        var quotedIncludes = mi.IncludeColumns.Select(c => $"[{c}]");
+                        create += $"\nINCLUDE ({string.Join(", ", quotedIncludes)})";
+                    }
                     create += ";";
                     mi.CreateStatement = create;
                 }


### PR DESCRIPTION
## Summary
- Replace three separate banners (missing indexes, warnings, wait stats) with unified **Plan Insights** panel — three-column layout: Runtime Summary, Missing Indexes, Wait Stats
- Add **Rule 25** (Ineffective Parallelism) to PlanAnalyzer in both apps
- Fix **QUOTENAME**: bracket schema/table/column names in CREATE INDEX statements
- Add **warning count badge** on root operator node (replaces red warnings banner)
- Grid-based **wait stats bar chart** with color-coded categories and proper column sizing
- **Runtime summary** as two-column grid (elapsed, CPU, memory grant, DOP, threads, CE model, etc.)
- Copyable CREATE INDEX statements via `TextBox IsReadOnly`
- Add **canvas panning** to Lite (was missing entirely)
- Add **scrollbar click detection** to prevent pan interference (both apps)

## Test plan
- [ ] Dashboard: Open actual plan — Insights panel shows all three columns
- [ ] Dashboard: Open estimated plan — Runtime Summary present, "No wait stats" shown
- [ ] Lite: Same checks as Dashboard
- [ ] Lite: Canvas panning works (click + drag on empty canvas area)
- [ ] Both: Scrollbar drag still works (not intercepted by panning)
- [ ] Both: Warning badge shows on root node with correct count
- [ ] Both: Missing index CREATE statements have bracketed names

🤖 Generated with [Claude Code](https://claude.com/claude-code)