### PR TITLE
Add reserved threads and 10 missing showplan XML attributes

### DIFF
--- a/Dashboard/Models/PlanModels.cs
+++ b/Dashboard/Models/PlanModels.cs
@@ -110,6 +110,12 @@ public class PlanStatement
     public bool ExclusiveProfileTimeActive { get; set; }
     public string? OptimizationReplayScript { get; set; }
 
+    // QueryPlan-level MemoryGrant attribute (unsignedLong)
+    public long QueryPlanMemoryGrantKB { get; set; }
+
+    // StmtUseDb: USE database statement
+    public string? StmtUseDatabaseName { get; set; }
+
     // XSD gap: BaseStmtInfoType
     public int QueryCompilationReplay { get; set; }
 
@@ -317,6 +323,23 @@ public class PlanNode
     public string? RemoteSource { get; set; }
     public string? RemoteObject { get; set; }
     public string? RemoteQuery { get; set; }
+
+    // GuessedSelectivity — optimizer guessed selectivity on predicates
+    public bool GuessedSelectivity { get; set; }
+
+    // ForeignKeyReferenceCheck attributes
+    public int ForeignKeyReferencesCount { get; set; }
+    public int NoMatchingIndexCount { get; set; }
+    public int PartialMatchingIndexCount { get; set; }
+
+    // ConstantScan Values (parsed rows as displayable string)
+    public string? ConstantScanValues { get; set; }
+
+    // SpillOccurred detail flag (node-level, from Warnings element)
+    public bool SpillOccurredDetail { get; set; }
+
+    // UDX UsedUDXColumns (column references for CLR aggregate operators)
+    public string? UdxUsedColumns { get; set; }
 }
 
 public class MissingIndex

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -590,6 +590,8 @@ public partial class PlanViewerControl : UserControl
             AddPropertyRow("Storage", node.StorageType);
         if (node.IsAdaptive)
             AddPropertyRow("Adaptive", "True");
+        if (node.SpillOccurredDetail)
+            AddPropertyRow("Spill Occurred", "True");
 
         // === Object Section ===
         if (!string.IsNullOrEmpty(node.FullObjectName))
@@ -619,7 +621,9 @@ public partial class PlanViewerControl : UserControl
             || node.NLOptimized || node.WithOrderedPrefetch || node.WithUnorderedPrefetch
             || node.WithTies || node.Remoting || node.LocalParallelism
             || node.SpoolStack || node.DMLRequestSort
-            || !string.IsNullOrEmpty(node.OffsetExpression) || node.TopRows > 0;
+            || !string.IsNullOrEmpty(node.OffsetExpression) || node.TopRows > 0
+            || !string.IsNullOrEmpty(node.ConstantScanValues)
+            || !string.IsNullOrEmpty(node.UdxUsedColumns);
 
         if (hasOperatorDetails)
         {
@@ -679,6 +683,22 @@ public partial class PlanViewerControl : UserControl
                 AddPropertyRow("Outer Join Cols", node.OuterSideJoinColumns, isCode: true);
             if (node.ManyToMany)
                 AddPropertyRow("Many to Many", "True");
+            if (!string.IsNullOrEmpty(node.ConstantScanValues))
+                AddPropertyRow("Values", node.ConstantScanValues, isCode: true);
+            if (!string.IsNullOrEmpty(node.UdxUsedColumns))
+                AddPropertyRow("UDX Columns", node.UdxUsedColumns, isCode: true);
+        }
+
+        // === Foreign Key References Section ===
+        if (node.ForeignKeyReferencesCount > 0 || node.NoMatchingIndexCount > 0 || node.PartialMatchingIndexCount > 0)
+        {
+            AddPropertySection("Foreign Key References");
+            if (node.ForeignKeyReferencesCount > 0)
+                AddPropertyRow("FK References", $"{node.ForeignKeyReferencesCount}");
+            if (node.NoMatchingIndexCount > 0)
+                AddPropertyRow("No Matching Index", $"{node.NoMatchingIndexCount}");
+            if (node.PartialMatchingIndexCount > 0)
+                AddPropertyRow("Partial Matching Index", $"{node.PartialMatchingIndexCount}");
         }
 
         // === Adaptive Join Section ===
@@ -790,7 +810,8 @@ public partial class PlanViewerControl : UserControl
             || !string.IsNullOrEmpty(node.HashKeysProbe) || !string.IsNullOrEmpty(node.HashKeysBuild)
             || !string.IsNullOrEmpty(node.BuildResidual) || !string.IsNullOrEmpty(node.ProbeResidual)
             || !string.IsNullOrEmpty(node.MergeResidual) || !string.IsNullOrEmpty(node.PassThru)
-            || !string.IsNullOrEmpty(node.SetPredicate);
+            || !string.IsNullOrEmpty(node.SetPredicate)
+            || node.GuessedSelectivity;
         if (hasPredicates)
         {
             AddPropertySection("Predicates");
@@ -812,6 +833,8 @@ public partial class PlanViewerControl : UserControl
                 AddPropertyRow("Pass Through", node.PassThru, isCode: true);
             if (!string.IsNullOrEmpty(node.SetPredicate))
                 AddPropertyRow("Set Predicate", node.SetPredicate, isCode: true);
+            if (node.GuessedSelectivity)
+                AddPropertyRow("Guessed Selectivity", "True (optimizer guessed, no statistics)");
         }
 
         // === Output Columns ===
@@ -839,12 +862,15 @@ public partial class PlanViewerControl : UserControl
             var s = _currentStatement;
 
             // === Statement Text ===
-            if (!string.IsNullOrEmpty(s.StatementText))
+            if (!string.IsNullOrEmpty(s.StatementText) || !string.IsNullOrEmpty(s.StmtUseDatabaseName))
             {
                 AddPropertySection("Statement");
-                AddPropertyRow("Text", s.StatementText, isCode: true);
+                if (!string.IsNullOrEmpty(s.StatementText))
+                    AddPropertyRow("Text", s.StatementText, isCode: true);
                 if (!string.IsNullOrEmpty(s.ParameterizedText) && s.ParameterizedText != s.StatementText)
                     AddPropertyRow("Parameterized", s.ParameterizedText, isCode: true);
+                if (!string.IsNullOrEmpty(s.StmtUseDatabaseName))
+                    AddPropertyRow("USE Database", s.StmtUseDatabaseName);
             }
 
             // === Cursor Info ===
@@ -899,6 +925,8 @@ public partial class PlanViewerControl : UserControl
                 AddPropertyRow("Non-Parallel Reason", s.NonParallelPlanReason);
             if (s.MaxQueryMemoryKB > 0)
                 AddPropertyRow("Max Query Memory", $"{s.MaxQueryMemoryKB:N0} KB");
+            if (s.QueryPlanMemoryGrantKB > 0)
+                AddPropertyRow("QueryPlan Memory Grant", $"{s.QueryPlanMemoryGrantKB:N0} KB");
             AddPropertyRow("Compile Time", $"{s.CompileTimeMs:N0} ms");
             AddPropertyRow("Compile CPU", $"{s.CompileCPUMs:N0} ms");
             AddPropertyRow("Compile Memory", $"{s.CompileMemoryKB:N0} KB");
@@ -1008,6 +1036,15 @@ public partial class PlanViewerControl : UserControl
                 AddPropertySection("Thread Stats");
                 AddPropertyRow("Branches", $"{s.ThreadStats.Branches}");
                 AddPropertyRow("Used Threads", $"{s.ThreadStats.UsedThreads}");
+                var totalReserved = s.ThreadStats.Reservations.Sum(r => r.ReservedThreads);
+                if (totalReserved > 0)
+                {
+                    AddPropertyRow("Reserved Threads", $"{totalReserved}");
+                    if (totalReserved > s.ThreadStats.UsedThreads)
+                        AddPropertyRow("Inactive Threads", $"{totalReserved - s.ThreadStats.UsedThreads}");
+                }
+                foreach (var res in s.ThreadStats.Reservations)
+                    AddPropertyRow($"  Node {res.NodeId}", $"{res.ReservedThreads} reserved");
             }
 
             // === Wait Stats (actual plans) ===

--- a/Lite/Models/PlanModels.cs
+++ b/Lite/Models/PlanModels.cs
@@ -110,6 +110,12 @@ public class PlanStatement
     public bool ExclusiveProfileTimeActive { get; set; }
     public string? OptimizationReplayScript { get; set; }
 
+    // QueryPlan-level MemoryGrant attribute (unsignedLong)
+    public long QueryPlanMemoryGrantKB { get; set; }
+
+    // StmtUseDb: USE database statement
+    public string? StmtUseDatabaseName { get; set; }
+
     // XSD gap: BaseStmtInfoType
     public int QueryCompilationReplay { get; set; }
 
@@ -317,6 +323,23 @@ public class PlanNode
     public string? RemoteSource { get; set; }
     public string? RemoteObject { get; set; }
     public string? RemoteQuery { get; set; }
+
+    // GuessedSelectivity — optimizer guessed selectivity on predicates
+    public bool GuessedSelectivity { get; set; }
+
+    // ForeignKeyReferenceCheck attributes
+    public int ForeignKeyReferencesCount { get; set; }
+    public int NoMatchingIndexCount { get; set; }
+    public int PartialMatchingIndexCount { get; set; }
+
+    // ConstantScan Values (parsed rows as displayable string)
+    public string? ConstantScanValues { get; set; }
+
+    // SpillOccurred detail flag (node-level, from Warnings element)
+    public bool SpillOccurredDetail { get; set; }
+
+    // UDX UsedUDXColumns (column references for CLR aggregate operators)
+    public string? UdxUsedColumns { get; set; }
 }
 
 public class MissingIndex


### PR DESCRIPTION
## Summary
- Properties panel now shows **Reserved Threads**, **Inactive Threads**, and per-node reservation breakdown in Thread Stats section
- Wait stats bar column uses fixed width (316px) instead of Star for proper duration text alignment
- Added parsing and display for **10 missing showplan XML attributes** identified by XSD audit:
  1. `QueryPlan.MemoryGrant` — top-level memory grant value
  2. `GuessedSelectivity` — flags optimizer selectivity guesses on predicates
  3. `UnmatchedIndexes` — unmatched index detail text
  4. `ForeignKeyReferencesCount` — foreign key reference check count
  5. `NoMatchingIndexCount` — no matching index count
  6. `PartialMatchingIndexCount` — partial matching index count
  7. `ConstantScan.Values` — actual row values in constant scans
  8. `StmtUseDb.Database` — database name from USE statements
  9. `SpillOccurred.Detail` — spill occurred boolean flag
  10. `UDX.UsedUDXColumns` — CLR aggregate columns

Changes synced from plan-b to both Dashboard and Lite (6 files, models + parser + properties display each).

## Test plan
- [ ] Build Dashboard and Lite with 0 errors
- [ ] Open a plan with parallelism — verify Reserved/Inactive Threads appear in Thread Stats
- [ ] Wait stats duration text aligned next to bars (not pushed to far right)
- [ ] Open plans with various operators to verify new attribute display

🤖 Generated with [Claude Code](https://claude.com/claude-code)