### PR TITLE
Add PlanAnalyzer rules 26-29, exchange spill + RID Lookup fixes

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -712,6 +712,8 @@ public partial class PlanViewerControl : UserControl
         AddPropertyRow("Est. Rows All Execs", $"{node.EstimateRows * Math.Max(1, estExecs):N1}");
         if (node.EstimatedRowsRead > 0)
             AddPropertyRow("Est. Rows to Read", $"{node.EstimatedRowsRead:N1}");
+        if (node.EstimateRowsWithoutRowGoal > 0)
+            AddPropertyRow("Est. Rows (No Row Goal)", $"{node.EstimateRowsWithoutRowGoal:N1}");
         if (node.TableCardinality > 0)
             AddPropertyRow("Table Cardinality", $"{node.TableCardinality:N0}");
         AddPropertyRow("Avg Row Size", $"{node.EstimatedRowSize} B");

--- a/Dashboard/Models/PlanModels.cs
+++ b/Dashboard/Models/PlanModels.cs
@@ -340,6 +340,9 @@ public class PlanNode
 
     // UDX UsedUDXColumns (column references for CLR aggregate operators)
     public string? UdxUsedColumns { get; set; }
+
+    // Row Goal: the optimizer's estimate before TOP/EXISTS reduced it
+    public double EstimateRowsWithoutRowGoal { get; set; }
 }
 
 public class MissingIndex

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -835,8 +835,9 @@ public static class ShowPlanParser
             // Table cardinality and rows to be read (on <RelOp> per XSD)
             node.TableCardinality = ParseDouble(relOpEl.Attribute("TableCardinality")?.Value);
             node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimatedRowsRead")?.Value);
+            node.EstimateRowsWithoutRowGoal = ParseDouble(relOpEl.Attribute("EstimateRowsWithoutRowGoal")?.Value);
             if (node.EstimatedRowsRead == 0)
-                node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimateRowsWithoutRowGoal")?.Value);
+                node.EstimatedRowsRead = node.EstimateRowsWithoutRowGoal;
 
             // TOP operator properties
             var topExprEl = physicalOpEl.Element(Ns + "TopExpression")?.Descendants(Ns + "ScalarOperator").FirstOrDefault();
@@ -1491,7 +1492,7 @@ public static class ShowPlanParser
             result.Add(new PlanWarning
             {
                 WarningType = "Exchange Spill",
-                Message = $"Exchange spill — Writes: {ParseLong(exchSpillEl.Attribute("WritesToTempDb")?.Value):N0}",
+                Message = $"Exchange spill — {ParseLong(exchSpillEl.Attribute("WritesToTempDb")?.Value):N0} writes to TempDB. The parallel exchange operator ran out of memory buffers and spilled rows to disk. This typically means the memory grant was too small for the data volume flowing through this exchange.",
                 Severity = PlanWarningSeverity.Warning,
                 SpillDetails = new SpillDetail
                 {

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -728,6 +728,8 @@ public partial class PlanViewerControl : UserControl
         AddPropertyRow("Est. Rows All Execs", $"{node.EstimateRows * Math.Max(1, estExecs):N1}");
         if (node.EstimatedRowsRead > 0)
             AddPropertyRow("Est. Rows to Read", $"{node.EstimatedRowsRead:N1}");
+        if (node.EstimateRowsWithoutRowGoal > 0)
+            AddPropertyRow("Est. Rows (No Row Goal)", $"{node.EstimateRowsWithoutRowGoal:N1}");
         if (node.TableCardinality > 0)
             AddPropertyRow("Table Cardinality", $"{node.TableCardinality:N0}");
         AddPropertyRow("Avg Row Size", $"{node.EstimatedRowSize} B");

--- a/Lite/Models/PlanModels.cs
+++ b/Lite/Models/PlanModels.cs
@@ -340,6 +340,9 @@ public class PlanNode
 
     // UDX UsedUDXColumns (column references for CLR aggregate operators)
     public string? UdxUsedColumns { get; set; }
+
+    // Row Goal: the optimizer's estimate before TOP/EXISTS reduced it
+    public double EstimateRowsWithoutRowGoal { get; set; }
 }
 
 public class MissingIndex

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -835,8 +835,9 @@ public static class ShowPlanParser
             // Table cardinality and rows to be read (on <RelOp> per XSD)
             node.TableCardinality = ParseDouble(relOpEl.Attribute("TableCardinality")?.Value);
             node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimatedRowsRead")?.Value);
+            node.EstimateRowsWithoutRowGoal = ParseDouble(relOpEl.Attribute("EstimateRowsWithoutRowGoal")?.Value);
             if (node.EstimatedRowsRead == 0)
-                node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimateRowsWithoutRowGoal")?.Value);
+                node.EstimatedRowsRead = node.EstimateRowsWithoutRowGoal;
 
             // TOP operator properties
             var topExprEl = physicalOpEl.Element(Ns + "TopExpression")?.Descendants(Ns + "ScalarOperator").FirstOrDefault();
@@ -1491,7 +1492,7 @@ public static class ShowPlanParser
             result.Add(new PlanWarning
             {
                 WarningType = "Exchange Spill",
-                Message = $"Exchange spill — Writes: {ParseLong(exchSpillEl.Attribute("WritesToTempDb")?.Value):N0}",
+                Message = $"Exchange spill — {ParseLong(exchSpillEl.Attribute("WritesToTempDb")?.Value):N0} writes to TempDB. The parallel exchange operator ran out of memory buffers and spilled rows to disk. This typically means the memory grant was too small for the data volume flowing through this exchange.",
                 Severity = PlanWarningSeverity.Warning,
                 SpillDetails = new SpillDetail
                 {


### PR DESCRIPTION
## Summary
- **Rule 7 enhancement**: Exchange spills get severity from write count (>=1M Critical, >=10K Warning), surface parallel operator time
- **Rule 10 fix**: RID Lookup check before Key Lookup (RID nodes have `Lookup=true`)
- **Rule 26**: Row Goal (informational) — shows estimate reduction from TOP/EXISTS
- **Rule 27**: OPTIMIZE FOR UNKNOWN detection
- **Rule 28**: Row Count Spool / NOT IN pattern with IS NULL predicate
- **Rule 29**: Implicit Convert Seek Plan upgraded to Critical severity
- Parse `EstimateRowsWithoutRowGoal` as dedicated property

## Test plan
- [x] 37/37 tests passing in plan-b
- [x] Dashboard builds clean
- [x] Lite builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)