### PR TITLE
Sync plan-b fixes: temp table names, Rule 28, memory grants

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -145,7 +145,7 @@ public partial class PlanViewerControl : UserControl
 
         // Update banners
         ShowMissingIndexes(statement.MissingIndexes);
-        ShowWaitStats(statement.WaitStats);
+        ShowWaitStats(statement.WaitStats, statement.QueryTimeStats != null);
         ShowRuntimeSummary(statement);
         UpdateInsightsHeader();
 
@@ -1501,13 +1501,16 @@ public partial class PlanViewerControl : UserControl
             CollectWarnings(child, warnings);
     }
 
-    private void ShowWaitStats(List<WaitStatInfo> waits)
+    private void ShowWaitStats(List<WaitStatInfo> waits, bool isActualPlan)
     {
         WaitStatsContent.Children.Clear();
 
         if (waits.Count == 0)
         {
             WaitStatsHeader.Text = "Wait Stats";
+            WaitStatsEmpty.Text = isActualPlan
+                ? "No wait stats recorded"
+                : "No wait stats (estimated plan)";
             WaitStatsEmpty.Visibility = Visibility.Visible;
             return;
         }

--- a/Dashboard/Models/PlanModels.cs
+++ b/Dashboard/Models/PlanModels.cs
@@ -280,6 +280,9 @@ public class PlanNode
     public long ActualSegmentSkips { get; set; }
     public long UdfCpuTimeMs { get; set; }
     public long UdfElapsedTimeMs { get; set; }
+    public long InputMemoryGrantKB { get; set; }
+    public long OutputMemoryGrantKB { get; set; }
+    public long UsedMemoryGrantKB { get; set; }
 
     // XSD gap: RelOp-level metadata
     public bool GroupExecuted { get; set; }

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -161,7 +161,7 @@ public partial class PlanViewerControl : UserControl
 
         // Update insights panel
         ShowMissingIndexes(statement.MissingIndexes);
-        ShowWaitStats(statement.WaitStats);
+        ShowWaitStats(statement.WaitStats, statement.QueryTimeStats != null);
         ShowRuntimeSummary(statement);
         UpdateInsightsHeader();
 
@@ -1512,13 +1512,16 @@ public partial class PlanViewerControl : UserControl
             CollectWarnings(child, warnings);
     }
 
-    private void ShowWaitStats(List<WaitStatInfo> waits)
+    private void ShowWaitStats(List<WaitStatInfo> waits, bool isActualPlan)
     {
         WaitStatsContent.Children.Clear();
 
         if (waits.Count == 0)
         {
             WaitStatsHeader.Text = "Wait Stats";
+            WaitStatsEmpty.Text = isActualPlan
+                ? "No wait stats recorded"
+                : "No wait stats (estimated plan)";
             WaitStatsEmpty.Visibility = Visibility.Visible;
             return;
         }

--- a/Lite/Models/PlanModels.cs
+++ b/Lite/Models/PlanModels.cs
@@ -280,6 +280,9 @@ public class PlanNode
     public long ActualSegmentSkips { get; set; }
     public long UdfCpuTimeMs { get; set; }
     public long UdfElapsedTimeMs { get; set; }
+    public long InputMemoryGrantKB { get; set; }
+    public long OutputMemoryGrantKB { get; set; }
+    public long UsedMemoryGrantKB { get; set; }
 
     // XSD gap: RelOp-level metadata
     public bool GroupExecuted { get; set; }


### PR DESCRIPTION
## Summary
- **CleanTempTableName**: Strip internal SQL Server padding/hex suffix from #temp table names in node objects and missing index suggestions
- **Rule 28 fix**: Check sibling Anti Semi Join nodes for IS NULL predicate (not just direct parents), rename warning to "NOT IN with Nullable Column"
- **Per-operator memory grants**: Roll up InputMemoryGrant/OutputMemoryGrant/UsedMemoryGrant from RunTimeCountersPerThread to node-level
- **Wait stats message**: "No wait stats recorded" for actual plans vs "No wait stats (estimated plan)" for estimated

## Test plan
- [ ] Build Dashboard and Lite — 0 errors
- [ ] Open plan with #temp table — name should show clean (no underscores/hex suffix)
- [ ] Open nullable-columns plan — Rule 28 should fire on Row Count Spool
- [ ] Open actual plan with no waits — should say "No wait stats recorded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)