### PR TITLE
Show UDF CPU and elapsed in Runtime Summary pane

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -1914,6 +1914,10 @@ public partial class PlanViewerControl : UserControl
         {
             AddRow("Elapsed", $"{statement.QueryTimeStats.ElapsedTimeMs:N0}ms");
             AddRow("CPU", $"{statement.QueryTimeStats.CpuTimeMs:N0}ms");
+            if (statement.QueryUdfCpuTimeMs > 0)
+                AddRow("UDF CPU", $"{statement.QueryUdfCpuTimeMs:N0}ms");
+            if (statement.QueryUdfElapsedTimeMs > 0)
+                AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
         }
 
         if (statement.MemoryGrant != null)

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -1925,6 +1925,10 @@ public partial class PlanViewerControl : UserControl
         {
             AddRow("Elapsed", $"{statement.QueryTimeStats.ElapsedTimeMs:N0}ms");
             AddRow("CPU", $"{statement.QueryTimeStats.CpuTimeMs:N0}ms");
+            if (statement.QueryUdfCpuTimeMs > 0)
+                AddRow("UDF CPU", $"{statement.QueryUdfCpuTimeMs:N0}ms");
+            if (statement.QueryUdfElapsedTimeMs > 0)
+                AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
         }
 
         if (statement.MemoryGrant != null)


### PR DESCRIPTION
## Summary
- Display UDF CPU and UDF elapsed time in the Runtime Summary pane when values are > 0
- Applied to both Dashboard and Lite PlanViewerControl
- Shows immediately below the main CPU/Elapsed rows for plans with scalar UDF overhead

## Test plan
- [x] Dashboard and Lite build with 0 errors
- [x] plan-b 37/37 tests passing
- [x] Verified with udf.sqlplan (2,296ms UDF CPU out of 2,899ms total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)