### PR TITLE
Fix SQL dumps on mirroring passive servers

### DIFF
--- a/install/08_collect_query_stats.sql
+++ b/install/08_collect_query_stats.sql
@@ -312,6 +312,7 @@ BEGIN
         INNER JOIN sys.databases AS d
           ON pa.dbid = d.database_id
         WHERE qs.last_execution_time >= @cutoff_time
+        AND   d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
         AND   pa.dbid NOT IN
         (
             1, 2, 3, 4, 32761, 32767,

--- a/install/10_collect_procedure_stats.sql
+++ b/install/10_collect_procedure_stats.sql
@@ -255,9 +255,10 @@ BEGIN
             FROM sys.dm_exec_plan_attributes(ps.plan_handle) AS pa
             WHERE pa.attribute = N'dbid'
         ) AS pa
-        LEFT JOIN sys.databases AS d
+        INNER JOIN sys.databases AS d
           ON pa.dbid = d.database_id
         WHERE ps.last_execution_time >= @cutoff_time
+        AND   d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
         AND   pa.dbid NOT IN
         (
             1, 3, 4, 32761, 32767,
@@ -423,9 +424,10 @@ BEGIN
             FROM sys.dm_exec_plan_attributes(ts.plan_handle) AS pa
             WHERE pa.attribute = N'dbid'
         ) AS pa
-        LEFT JOIN sys.databases AS d
+        INNER JOIN sys.databases AS d
           ON pa.dbid = d.database_id
         WHERE ts.last_execution_time >= @cutoff_time
+        AND   d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
         AND   pa.dbid NOT IN
         (
             1, 3, 4, 32761, 32767,
@@ -486,9 +488,10 @@ BEGIN
             FROM sys.dm_exec_plan_attributes(fs.plan_handle) AS pa
             WHERE pa.attribute = N'dbid'
         ) AS pa
-        LEFT JOIN sys.databases AS d
+        INNER JOIN sys.databases AS d
           ON pa.dbid = d.database_id
         WHERE fs.last_execution_time >= @cutoff_time
+        AND   d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
         AND   pa.dbid NOT IN
         (
             1, 3, 4, 32761, 32767,

--- a/install/20_collect_file_io_stats.sql
+++ b/install/20_collect_file_io_stats.sql
@@ -133,7 +133,7 @@ BEGIN
             database_name =
                 ISNULL
                 (
-                    DB_NAME(vfs.database_id),
+                    d.name,
                     N'UNKNOWN'
                 ),
             file_id = vfs.file_id,
@@ -162,6 +162,8 @@ BEGIN
             io_stall_queued_write_ms = vfs.io_stall_queued_write_ms,
             sample_ms = vfs.sample_ms
         FROM sys.dm_io_virtual_file_stats(NULL, NULL) AS vfs
+        LEFT JOIN sys.databases AS d
+          ON  d.database_id = vfs.database_id
         LEFT JOIN sys.master_files AS mf
           ON  mf.database_id = vfs.database_id
           AND mf.file_id = vfs.file_id

--- a/install/37_collect_waiting_tasks.sql
+++ b/install/37_collect_waiting_tasks.sql
@@ -146,7 +146,7 @@ BEGIN
             blocking_session_id = ISNULL(wt.blocking_session_id, 0),
             resource_description = NULL,
             database_id = NULL,
-            database_name = DB_NAME(der.database_id),
+            database_name = d.name,
             query_text = NULL,
             statement_text = NULL,
             query_plan = NULL,
@@ -162,6 +162,8 @@ BEGIN
         FROM sys.dm_os_waiting_tasks AS wt
         LEFT JOIN sys.dm_exec_requests AS der
           ON der.session_id = wt.session_id
+        LEFT JOIN sys.databases AS d
+          ON d.database_id = der.database_id
         OUTER APPLY sys.dm_exec_sql_text(der.sql_handle) AS dest
         OUTER APPLY sys.dm_exec_text_query_plan
         (


### PR DESCRIPTION
## Summary

- `OBJECT_NAME()` and `OBJECT_SCHEMA_NAME()` with a `database_id` referencing a RESTORING database open the target database's metadata catalog — on mirroring passive servers this causes severity 22 engine crashes and SQL dumps
- **procedure_stats**: Change `LEFT JOIN` to `INNER JOIN sys.databases` with `d.state = 0` on all 3 sub-queries (procedures, triggers, functions) — structurally excludes RESTORING database rows
- **query_stats**: Add `d.state = 0` to WHERE clause (defensive filter)
- **file_io_stats** + **waiting_tasks**: Replace `DB_NAME(database_id)` function call with `LEFT JOIN sys.databases` / `d.name`

## Test plan

- [x] Deployed all 4 fixed collectors to sql2022
- [x] `procedure_stats_collector @debug = 1` — SUCCESS
- [x] `query_stats_collector @debug = 1` — SUCCESS
- [x] `file_io_stats_collector @debug = 1` — SUCCESS, 35 rows with deltas
- [x] `waiting_tasks_collector @debug = 1` — SUCCESS
- [x] Zero errors in `config.collection_log`

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)