### PR TITLE
Fix Lite collectors for mirroring/RESTORING database crash

### DIFF
--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -59,7 +59,7 @@ OPTION(RECOMPILE);"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    database_name = DB_NAME(vfs.database_id),
+    database_name = ISNULL(d.name, N'Unknown'),
     file_name = mf.name,
     file_type = mf.type_desc,
     physical_name = mf.physical_name,
@@ -78,6 +78,8 @@ FROM sys.dm_io_virtual_file_stats(NULL, NULL) AS vfs
 LEFT JOIN sys.master_files AS mf
   ON  mf.database_id = vfs.database_id
   AND mf.file_id = vfs.file_id
+LEFT JOIN sys.databases AS d
+  ON  d.database_id = vfs.database_id
 WHERE (vfs.database_id > 4 OR vfs.database_id = 2)
 AND   vfs.database_id < 32761
 AND   vfs.database_id <> ISNULL(DB_ID(N'PerformanceMonitor'), 0)

--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -76,9 +76,10 @@ CROSS APPLY
     FROM sys.dm_exec_plan_attributes(s.plan_handle) AS pa
     WHERE pa.attribute = N''dbid''
 ) AS pa
-LEFT JOIN sys.databases AS d
+INNER JOIN sys.databases AS d
   ON pa.dbid = d.database_id
-WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+WHERE d.state = 0
+AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 
 UNION ALL
@@ -130,9 +131,10 @@ CROSS APPLY
     FROM sys.dm_exec_plan_attributes(s.plan_handle) AS pa
     WHERE pa.attribute = N''dbid''
 ) AS pa
-LEFT JOIN sys.databases AS d
+INNER JOIN sys.databases AS d
   ON pa.dbid = d.database_id
-WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+WHERE d.state = 0
+AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 
 UNION ALL
@@ -171,9 +173,10 @@ CROSS APPLY
     FROM sys.dm_exec_plan_attributes(s.plan_handle) AS pa
     WHERE pa.attribute = N''dbid''
 ) AS pa
-LEFT JOIN sys.databases AS d
+INNER JOIN sys.databases AS d
   ON pa.dbid = d.database_id
-WHERE pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
+WHERE d.state = 0
+AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
 ) AS combined
 ORDER BY total_elapsed_time DESC

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -25,7 +25,7 @@ SET LOCK_TIMEOUT 1000;
 
 SELECT /* PerformanceMonitorLite */
     der.session_id,
-    database_name = DB_NAME(der.database_id),
+    database_name = d.name,
     elapsed_time_formatted =
         CASE
             WHEN der.total_elapsed_time < 0
@@ -72,6 +72,8 @@ JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
 OUTER APPLY sys.dm_exec_sql_text(COALESCE(der.sql_handle, der.plan_handle)) AS dest
 OUTER APPLY sys.dm_exec_text_query_plan(der.plan_handle, der.statement_start_offset, der.statement_end_offset) AS deqp
+LEFT JOIN sys.databases AS d
+  ON d.database_id = der.database_id
 {1}
 WHERE der.session_id <> @@SPID
 AND   der.session_id >= 50

--- a/Lite/Services/RemoteCollectorService.WaitingTasks.cs
+++ b/Lite/Services/RemoteCollectorService.WaitingTasks.cs
@@ -32,10 +32,12 @@ SELECT /* PerformanceMonitorLite */
     wait_type = wt.wait_type,
     wait_duration_ms = wt.wait_duration_ms,
     blocking_session_id = wt.blocking_session_id,
-    database_name = DB_NAME(er.database_id)
+    database_name = d.name
 FROM sys.dm_os_waiting_tasks AS wt
 LEFT JOIN sys.dm_exec_requests AS er
   ON er.session_id = wt.session_id
+LEFT JOIN sys.databases AS d
+  ON d.database_id = er.database_id
 WHERE wt.session_id >= 50
 AND   wt.session_id <> @@SPID
 AND   wt.wait_type IS NOT NULL


### PR DESCRIPTION
## Summary
- Applies same fixes as PR #385 to Lite's embedded SQL queries (#384)
- ProcedureStats: `LEFT JOIN` → `INNER JOIN` sys.databases + `d.state = 0` (3 sub-queries)
- FileIo, WaitingTasks, QuerySnapshots: `DB_NAME(database_id)` → `LEFT JOIN sys.databases` + `d.name`

## Test plan
- [x] Build clean (0 errors, 0 warnings)
- [x] All 16 collectors SUCCESS across 168+ collections after relaunch
- [x] All 4 modified collectors (file_io_stats, procedure_stats, query_snapshots, waiting_tasks) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)