### PR TITLE
Add time display mode toggle (Issue #17)

### DIFF
--- a/Dashboard/App.xaml
+++ b/Dashboard/App.xaml
@@ -1,12 +1,14 @@
 <Application x:Class="PerformanceMonitorDashboard.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:helpers="clr-namespace:PerformanceMonitorDashboard.Helpers"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/DarkTheme.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            <helpers:ServerTimeConverter x:Key="ServerTimeConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Dashboard/CollectionLogWindow.xaml
+++ b/Dashboard/CollectionLogWindow.xaml
@@ -48,7 +48,7 @@
                   Margin="10"
                   ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button x:Name="CollectionTimeFilterButton" Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="LogFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/ConfigChangesContent.xaml
+++ b/Dashboard/Controls/ConfigChangesContent.xaml
@@ -24,7 +24,7 @@
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding ChangeTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTime" Click="ServerConfigChangesFilter_Click" Margin="0,0,4,0"/>
@@ -141,7 +141,7 @@
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding ChangeTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTime" Click="DbConfigChangesFilter_Click" Margin="0,0,4,0"/>
@@ -211,7 +211,7 @@
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       ContextMenu="{StaticResource DataGridContextMenu}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding ChangeTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding ChangeTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTime" Click="TraceFlagChangesFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/CriticalIssuesContent.xaml
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml
@@ -46,7 +46,7 @@
                     </StackPanel>
                 </DataGridTextColumn.Header>
             </DataGridTextColumn>
-            <DataGridTextColumn Binding="{Binding LogDate, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="160">
+            <DataGridTextColumn Binding="{Binding LogDate, Converter={StaticResource ServerTimeConverter}}" Width="160">
                 <DataGridTextColumn.Header>
                     <StackPanel Orientation="Horizontal">
                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogDate" Click="CriticalIssuesFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/CurrentConfigContent.xaml
+++ b/Dashboard/Controls/CurrentConfigContent.xaml
@@ -80,7 +80,7 @@
                             </StackPanel>
                         </DataGridCheckBoxColumn.Header>
                     </DataGridCheckBoxColumn>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastChanged, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="ServerConfigFilter_Click" Margin="0,0,4,0"/>
@@ -142,7 +142,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastChanged, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="DatabaseConfigFilter_Click" Margin="0,0,4,0"/>
@@ -196,7 +196,7 @@
                             </StackPanel>
                         </DataGridCheckBoxColumn.Header>
                     </DataGridCheckBoxColumn>
-                    <DataGridTextColumn Binding="{Binding LastChanged, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastChanged, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastChanged" Click="TraceFlagsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -34,7 +34,7 @@
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding EventTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="DefaultTraceFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -81,7 +81,7 @@
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -225,7 +225,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding StartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding StartTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -233,7 +233,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TranStartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding TranStartTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranStartTime" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -567,7 +567,7 @@
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStatsDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -607,7 +607,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CreationTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CreationTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -615,7 +615,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
@@ -861,7 +861,7 @@
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="ProcStatsDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -909,7 +909,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding CachedTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CachedTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -917,7 +917,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
@@ -1124,7 +1124,7 @@
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStoreDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1172,7 +1172,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding FirstExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding FirstExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FirstExecutionTime" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1180,7 +1180,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="QueryStoreFilter_Click" Margin="0,0,4,0"/>
@@ -1528,7 +1528,7 @@
                       RowStyle="{DynamicResource DefaultRowStyle}"
                       MouseDoubleClick="QueryStoreRegressionsDataGrid_MouseDoubleClick">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="QsRegressionsFilter_Click" Margin="0,0,4,0"/>
@@ -1777,7 +1777,7 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTextColumn Binding="{Binding LastExecution, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                    <DataGridTextColumn Binding="{Binding LastExecution, Converter={StaticResource ServerTimeConverter}}" Width="150">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecution" Click="LrqPatternsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/SystemEventsContent.xaml
+++ b/Dashboard/Controls/SystemEventsContent.xaml
@@ -182,7 +182,7 @@
                           CanUserSortColumns="True" CanUserResizeColumns="True"
                           GridLinesVisibility="All" RowStyle="{StaticResource DefaultRowStyle}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="160">
+                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="160">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="SevereErrorsFilter_Click" Margin="0,0,4,0"/>
@@ -190,7 +190,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="160">
+                    <DataGridTextColumn Binding="{Binding EventTime, Converter={StaticResource ServerTimeConverter}}" Width="160">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="SevereErrorsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Helpers/ChartHoverHelper.cs
+++ b/Dashboard/Helpers/ChartHoverHelper.cs
@@ -108,7 +108,7 @@ internal sealed class ChartHoverHelper
 
             if (found)
             {
-                var time = DateTime.FromOADate(bestPoint.X);
+                var time = ServerTimeHelper.ConvertForDisplay(DateTime.FromOADate(bestPoint.X), ServerTimeHelper.CurrentDisplayMode);
                 _text.Text = $"{bestLabel}\n{bestPoint.Y:N1} {_unit}\n{time:HH:mm:ss}";
                 _popup.HorizontalOffset = pos.X + 15;
                 _popup.VerticalOffset = pos.Y + 15;

--- a/Dashboard/Helpers/ServerTimeConverter.cs
+++ b/Dashboard/Helpers/ServerTimeConverter.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PerformanceMonitorDashboard.Helpers
+{
+    /// <summary>
+    /// Converts server-time DateTime values for display based on the current TimeDisplayMode setting.
+    /// Used by DataGrid DateTime columns to show timestamps in Server Time, Local Time, or UTC.
+    /// </summary>
+    public class ServerTimeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is DateTime dt)
+            {
+                return ServerTimeHelper.ConvertForDisplay(dt, ServerTimeHelper.CurrentDisplayMode)
+                    .ToString("yyyy-MM-dd HH:mm:ss");
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Dashboard/Helpers/ServerTimeHelper.cs
+++ b/Dashboard/Helpers/ServerTimeHelper.cs
@@ -53,5 +53,31 @@ namespace PerformanceMonitorDashboard.Helpers
             var utcTime = serverTime.AddMinutes(-_utcOffsetMinutes);
             return utcTime.ToLocalTime();
         }
+
+        /// <summary>
+        /// The current display mode preference. Read from UserPreferences at startup,
+        /// updated when the user changes the setting.
+        /// </summary>
+        public static TimeDisplayMode CurrentDisplayMode { get; set; } = TimeDisplayMode.ServerTime;
+
+        /// <summary>
+        /// Converts a server DateTime for display based on the selected display mode.
+        /// </summary>
+        public static DateTime ConvertForDisplay(DateTime serverTime, TimeDisplayMode mode) => mode switch
+        {
+            TimeDisplayMode.LocalTime => ToLocalTime(serverTime),
+            TimeDisplayMode.UTC => serverTime.AddMinutes(-_utcOffsetMinutes),
+            _ => serverTime
+        };
+
+        /// <summary>
+        /// Returns a short timezone label for the current display mode (e.g., "UTC", "PST", "UTC-8:00").
+        /// </summary>
+        public static string GetTimezoneLabel(TimeDisplayMode mode) => mode switch
+        {
+            TimeDisplayMode.LocalTime => TimeZoneInfo.Local.StandardName,
+            TimeDisplayMode.UTC => "UTC",
+            _ => $"UTC{(_utcOffsetMinutes >= 0 ? "+" : "")}{_utcOffsetMinutes / 60}:{Math.Abs(_utcOffsetMinutes % 60):D2}"
+        };
     }
 }

--- a/Dashboard/Helpers/TimeDisplayMode.cs
+++ b/Dashboard/Helpers/TimeDisplayMode.cs
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorDashboard.Helpers
+{
+    public enum TimeDisplayMode
+    {
+        ServerTime,
+        LocalTime,
+        UTC
+    }
+}

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -139,9 +139,11 @@ namespace PerformanceMonitorDashboard
 
         private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            // Sync CSV separator from preferences
+            // Sync preferences
             var startupPrefs = _preferencesService.GetPreferences();
             TabHelpers.CsvSeparator = startupPrefs.CsvSeparator;
+            if (Enum.TryParse<Helpers.TimeDisplayMode>(startupPrefs.TimeDisplayMode, out var tdm))
+                Helpers.ServerTimeHelper.CurrentDisplayMode = tdm;
 
             await LoadServerListAsync();
             InitializeNotificationService();

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -11,6 +11,9 @@ namespace PerformanceMonitorDashboard.Models
 {
     public class UserPreferences
     {
+        // Time display mode: ServerTime, LocalTime, UTC
+        public string TimeDisplayMode { get; set; } = "ServerTime";
+
         // Default date range preferences (hours back)
         public int DefaultHoursBack { get; set; } = 24;
 

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -86,7 +86,7 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -94,7 +94,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -102,7 +102,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CachedTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CachedTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTime" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -88,7 +88,7 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -86,7 +86,7 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -94,7 +94,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LastExecutionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -102,7 +102,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CreationTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding CreationTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTime" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -273,7 +273,7 @@
                                                     </StackPanel>
                                                 </DataGridTextColumn.Header>
                                             </DataGridTextColumn>
-                                            <DataGridTextColumn Binding="{Binding LastSuccessTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                            <DataGridTextColumn Binding="{Binding LastSuccessTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                                 <DataGridTextColumn.Header>
                                                     <StackPanel Orientation="Horizontal">
                                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastSuccessTime" Click="CollectionHealthFilter_Click" Margin="0,0,4,0"/>
@@ -354,7 +354,7 @@
                                             <TextBlock Text="Job Name" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding StartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding StartTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="Start Time" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
@@ -587,7 +587,7 @@
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Binding="{Binding EventTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding EventTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTime" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -744,7 +744,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="BlockingEventsFilter_Click" Margin="0,0,4,0"/>
@@ -776,7 +776,7 @@
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Binding="{Binding EventDate, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding EventDate, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventDate" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>
@@ -944,7 +944,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                                    <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="DeadlocksFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -743,20 +743,24 @@ namespace PerformanceMonitorDashboard
 
         private static string FormatDateRange(string prefix, DateTime from, DateTime to)
         {
-            // Same day: "Feb 7, 2:15 PM – 3:15 PM"
-            if (from.Date == to.Date)
+            var tz = Helpers.ServerTimeHelper.GetTimezoneLabel(Helpers.ServerTimeHelper.CurrentDisplayMode);
+            var displayFrom = Helpers.ServerTimeHelper.ConvertForDisplay(from, Helpers.ServerTimeHelper.CurrentDisplayMode);
+            var displayTo = Helpers.ServerTimeHelper.ConvertForDisplay(to, Helpers.ServerTimeHelper.CurrentDisplayMode);
+
+            // Same day: "Feb 7, 2:15 PM – 3:15 PM (PST)"
+            if (displayFrom.Date == displayTo.Date)
             {
-                return $"{prefix}: {from:MMM d, h:mm tt} – {to:h:mm tt}";
+                return $"{prefix}: {displayFrom:MMM d, h:mm tt} – {displayTo:h:mm tt} ({tz})";
             }
 
-            // Same year, different days: "Feb 6, 3:15 PM – Feb 7, 3:15 PM"
-            if (from.Year == to.Year)
+            // Same year, different days: "Feb 6, 3:15 PM – Feb 7, 3:15 PM (PST)"
+            if (displayFrom.Year == displayTo.Year)
             {
-                return $"{prefix}: {from:MMM d, h:mm tt} – {to:MMM d, h:mm tt}";
+                return $"{prefix}: {displayFrom:MMM d, h:mm tt} – {displayTo:MMM d, h:mm tt} ({tz})";
             }
 
-            // Different years: "Dec 31, 2025, 11:00 PM – Jan 1, 2026, 11:00 PM"
-            return $"{prefix}: {from:MMM d, yyyy, h:mm tt} – {to:MMM d, yyyy, h:mm tt}";
+            // Different years: "Dec 31, 2025, 11:00 PM – Jan 1, 2026, 11:00 PM (PST)"
+            return $"{prefix}: {displayFrom:MMM d, yyyy, h:mm tt} – {displayTo:MMM d, yyyy, h:mm tt} ({tz})";
         }
 
         private void StoreOriginalRangeIfNeeded()

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -87,6 +87,17 @@
                                   Content="Focus server tab when clicking a server card"
                                   Margin="0,0,0,20"/>
 
+                        <!-- Time Display Section -->
+                        <TextBlock Text="Time Display" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+                            <TextBlock Text="Show timestamps in:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <ComboBox x:Name="TimeDisplayModeComboBox" Width="140">
+                                <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                                <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                                <ComboBoxItem Content="UTC" Tag="UTC"/>
+                            </ComboBox>
+                        </StackPanel>
+
                         <!-- Color Theme Section -->
                         <TextBlock Text="Color Theme" FontWeight="Bold" FontSize="13" Margin="0,0,0,10"/>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,0">

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -106,6 +106,18 @@ namespace PerformanceMonitorDashboard
             // Navigation settings
             FocusServerTabCheckBox.IsChecked = prefs.FocusServerTabOnClick;
 
+            // Time display mode
+            foreach (ComboBoxItem item in TimeDisplayModeComboBox.Items)
+            {
+                if (item.Tag?.ToString() == prefs.TimeDisplayMode)
+                {
+                    TimeDisplayModeComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+            if (TimeDisplayModeComboBox.SelectedItem == null)
+                TimeDisplayModeComboBox.SelectedIndex = 0;
+
             // Color theme
             foreach (System.Windows.Controls.ComboBoxItem item in ColorThemeComboBox.Items)
             {
@@ -507,6 +519,14 @@ namespace PerformanceMonitorDashboard
 
             // Save navigation settings
             prefs.FocusServerTabOnClick = FocusServerTabCheckBox.IsChecked == true;
+
+            // Save time display mode
+            if (TimeDisplayModeComboBox.SelectedItem is ComboBoxItem tdmItem && tdmItem.Tag != null)
+            {
+                prefs.TimeDisplayMode = tdmItem.Tag.ToString()!;
+                if (Enum.TryParse<TimeDisplayMode>(prefs.TimeDisplayMode, out var tdm))
+                    ServerTimeHelper.CurrentDisplayMode = tdm;
+            }
 
             // Save color theme
             if (ColorThemeComboBox.SelectedItem is ComboBoxItem themeItem && themeItem.Tag != null)

--- a/Dashboard/TracePatternHistoryWindow.xaml
+++ b/Dashboard/TracePatternHistoryWindow.xaml
@@ -79,7 +79,7 @@
                   ContextMenu="{DynamicResource DataGridContextMenu}"
                   Margin="10">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding EndTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding EndTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EndTime" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -175,7 +175,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding StartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" Width="150">
+                <DataGridTextColumn Binding="{Binding StartTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -84,6 +84,9 @@ public partial class App : Application
     /* System tray settings */
     public static bool MinimizeToTray { get; set; } = true;
 
+    /* Time display mode ("ServerTime", "LocalTime", "UTC") */
+    public static string TimeDisplayMode { get; set; } = "ServerTime";
+
     /* Color theme ("Dark" or "Light") */
     public static string ColorTheme { get; set; } = "Dark";
 
@@ -260,6 +263,18 @@ public partial class App : Application
 
             /* System tray settings */
             if (root.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.GetBoolean();
+
+            /* Time display mode */
+            if (root.TryGetProperty("time_display_mode", out v))
+            {
+                var t = v.GetString();
+                if (t == "ServerTime" || t == "LocalTime" || t == "UTC")
+                {
+                    TimeDisplayMode = t;
+                    if (Enum.TryParse<Helpers.TimeDisplayMode>(t, out var tdm))
+                        Services.ServerTimeHelper.CurrentDisplayMode = tdm;
+                }
+            }
 
             /* Color theme */
             if (root.TryGetProperty("color_theme", out v))

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -662,7 +662,8 @@ public partial class ServerTab : UserControl
             await UpdateMemoryClerksChartFromPickerAsync();
             await UpdatePerfmonChartFromPickerAsync();
 
-            ConnectionStatusText.Text = $"{_server.ServerName} - Last refresh: {DateTime.Now:HH:mm:ss}";
+            var tz = ServerTimeHelper.GetTimezoneLabel(ServerTimeHelper.CurrentDisplayMode);
+            ConnectionStatusText.Text = $"{_server.ServerName} - Last refresh: {DateTime.Now:HH:mm:ss} ({tz})";
 
             /* Notify parent of alert counts for tab badge.
                Include the latest event timestamp so acknowledgement is only

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Helpers;
 
@@ -99,7 +100,7 @@ internal sealed class ChartHoverHelper
 
         if (bestPoint.IsReal && bestDistance < 2500) // ~50px radius
         {
-            var time = DateTime.FromOADate(bestPoint.X);
+            var time = ServerTimeHelper.ConvertForDisplay(DateTime.FromOADate(bestPoint.X), ServerTimeHelper.CurrentDisplayMode);
             _text.Text = $"{bestLabel}\n{bestPoint.Y:N1} {_unit}\n{time:HH:mm:ss}";
             _popup.HorizontalOffset = pos.X + 15;
             _popup.VerticalOffset = pos.Y + 15;

--- a/Lite/Helpers/TimeDisplayMode.cs
+++ b/Lite/Helpers/TimeDisplayMode.cs
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorLite.Helpers
+{
+    public enum TimeDisplayMode
+    {
+        ServerTime,
+        LocalTime,
+        UTC
+    }
+}

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -52,11 +52,36 @@ public static class ServerTimeHelper
         return utcTime.ToLocalTime();
     }
 
+    /// <summary>
+    /// The current display mode preference. Read from App settings at startup.
+    /// </summary>
+    public static Helpers.TimeDisplayMode CurrentDisplayMode { get; set; } = Helpers.TimeDisplayMode.ServerTime;
+
+    /// <summary>
+    /// Converts a server DateTime for display based on the selected display mode.
+    /// </summary>
+    public static DateTime ConvertForDisplay(DateTime serverTime, Helpers.TimeDisplayMode mode) => mode switch
+    {
+        Helpers.TimeDisplayMode.LocalTime => ToLocalTime(serverTime),
+        Helpers.TimeDisplayMode.UTC => serverTime.AddMinutes(-_utcOffsetMinutes),
+        _ => serverTime
+    };
+
+    /// <summary>
+    /// Returns a short timezone label for the current display mode.
+    /// </summary>
+    public static string GetTimezoneLabel(Helpers.TimeDisplayMode mode) => mode switch
+    {
+        Helpers.TimeDisplayMode.LocalTime => TimeZoneInfo.Local.StandardName,
+        Helpers.TimeDisplayMode.UTC => "UTC",
+        _ => $"UTC{(_utcOffsetMinutes >= 0 ? "+" : "")}{_utcOffsetMinutes / 60}:{Math.Abs(_utcOffsetMinutes % 60):D2}"
+    };
+
     public static string FormatServerTime(DateTime utcTime, string format = "yyyy-MM-dd HH:mm:ss")
-        => utcTime.AddMinutes(_utcOffsetMinutes).ToString(format);
+        => ConvertForDisplay(utcTime.AddMinutes(_utcOffsetMinutes), CurrentDisplayMode).ToString(format);
 
     public static string FormatServerTime(DateTime? utcTime, string format = "yyyy-MM-dd HH:mm:ss")
-        => utcTime.HasValue ? utcTime.Value.AddMinutes(_utcOffsetMinutes).ToString(format) : "";
+        => utcTime.HasValue ? ConvertForDisplay(utcTime.Value.AddMinutes(_utcOffsetMinutes), CurrentDisplayMode).ToString(format) : "";
 }
 
 public partial class LocalDataService

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -115,6 +115,15 @@
                                VerticalAlignment="Center" Margin="6,0,0,0" x:Name="CsvSeparatorHint"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Show timestamps in:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="TimeDisplayModeCombo" Width="140" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                        <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                        <ComboBoxItem Content="UTC" Tag="UTC"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                     <TextBlock Text="Color theme:" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
                     <ComboBox x:Name="ColorThemeCombo" Width="140" VerticalAlignment="Center"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -41,6 +41,7 @@ public partial class SettingsWindow : Window
         LoadConnectionTimeout();
         LoadCsvSeparator();
         LoadColorTheme();
+        LoadTimeDisplayMode();
         LoadAlertSettings();
         LoadSmtpSettings();
     }
@@ -115,6 +116,7 @@ public partial class SettingsWindow : Window
         SaveConnectionTimeout();
         SaveCsvSeparator();
         SaveColorTheme();
+        SaveTimeDisplayMode();
         SaveAlertSettings();
         SaveSmtpSettings();
 
@@ -368,6 +370,54 @@ public partial class SettingsWindow : Window
         catch (Exception ex)
         {
             AppLogger.Error("Settings", $"Failed to save color theme: {ex.Message}");
+        }
+    }
+
+    private void LoadTimeDisplayMode()
+    {
+        foreach (ComboBoxItem item in TimeDisplayModeCombo.Items)
+        {
+            if (item.Tag?.ToString() == App.TimeDisplayMode)
+            {
+                TimeDisplayModeCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (TimeDisplayModeCombo.SelectedItem == null)
+            TimeDisplayModeCombo.SelectedIndex = 0;
+    }
+
+    private void SaveTimeDisplayMode()
+    {
+        if (TimeDisplayModeCombo.SelectedItem is ComboBoxItem selected && selected.Tag is string mode)
+        {
+            App.TimeDisplayMode = mode;
+            if (System.Enum.TryParse<Helpers.TimeDisplayMode>(mode, out var tdm))
+                ServerTimeHelper.CurrentDisplayMode = tdm;
+        }
+
+        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
+        try
+        {
+            JsonNode? root;
+            if (File.Exists(settingsPath))
+            {
+                var json = File.ReadAllText(settingsPath);
+                root = JsonNode.Parse(json) ?? new JsonObject();
+            }
+            else
+            {
+                root = new JsonObject();
+            }
+
+            root["time_display_mode"] = App.TimeDisplayMode;
+
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(settingsPath, root.ToJsonString(options));
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Settings", $"Failed to save time display mode: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds **Server Time / Local Time / UTC** toggle to both Dashboard and Lite settings
- All ~44 Dashboard DataGrid DateTime columns now use an `IValueConverter` instead of inline `StringFormat`, converting at display time
- Lite's `FormatServerTime()` routes through `ConvertForDisplay()`, automatically fixing all ~15 computed properties across model classes
- Chart hover tooltips and date range status text also respect the setting
- Timezone label shown in parentheses on status text (e.g. "Showing: Feb 7, 2:15 PM – 3:15 PM (UTC-5:00)")
- Default is **Server Time** — fully backwards compatible, no schema or SQL changes

## Files changed
- **3 new**: `TimeDisplayMode.cs` enum (both apps), `ServerTimeConverter.cs` (Dashboard)
- **26 modified**: Settings UI, ServerTimeHelper, ChartHoverHelper, UserPreferences, App.xaml, 12 XAML DataGrid files, 2 ServerTab files

## Test plan
- [ ] Launch Dashboard — verify default is "Server Time" (no change from current behavior)
- [ ] Open Settings > General > Time Display — switch to "Local Time", verify DataGrid timestamps shift
- [ ] Switch to "UTC" — verify timestamps shift again
- [ ] Hover chart data points — verify tooltip times match selected mode
- [ ] Check date range status text shows timezone label
- [ ] Close and reopen — verify setting persists
- [ ] Repeat all checks in Lite
- [ ] Verify date pickers stay in local time regardless of display mode

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)