### PR TITLE
Fix Regression - The tooltip for data points doesn't appear

### DIFF
--- a/Dashboard/Helpers/ChartHoverHelper.cs
+++ b/Dashboard/Helpers/ChartHoverHelper.cs
@@ -71,9 +71,10 @@ internal sealed class ChartHoverHelper
         try
         {
             var pos = e.GetPosition(_chart);
+            var dpi = VisualTreeHelper.GetDpi(_chart);
             var pixel = new ScottPlot.Pixel(
-                (float)(pos.X * _chart.DisplayScale),
-                (float)(pos.Y * _chart.DisplayScale));
+                (float)(pos.X * dpi.DpiScaleX),
+                (float)(pos.Y * dpi.DpiScaleY));
             var mouseCoords = _chart.Plot.GetCoordinates(pixel);
 
             /* Use X-axis (time) proximity as the primary filter, Y-axis distance

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -69,9 +69,10 @@ internal sealed class ChartHoverHelper
         _lastUpdate = now;
 
         var pos = e.GetPosition(_chart);
+        var dpi = VisualTreeHelper.GetDpi(_chart);
         var pixel = new ScottPlot.Pixel(
-            (float)(pos.X * _chart.DisplayScale),
-            (float)(pos.Y * _chart.DisplayScale));
+            (float)(pos.X * dpi.DpiScaleX),
+            (float)(pos.Y * dpi.DpiScaleY));
         var mouseCoords = _chart.Plot.GetCoordinates(pixel);
 
         double bestDistance = double.MaxValue;


### PR DESCRIPTION
## What does this PR do?

fixes #410 

### Regression Timeline
The fix was lost in commit 842dc68 on 2026-03-03

### What Happened:
2026-02-26 - Commit 98694ba / PR #320: Fixed tooltips by replacing _chart.DisplayScale with VisualTreeHelper.GetDpi(_chart) — merged to dev branch

- 2026-02-27 - Commit 4202ad7 / PR #352: Merged dev → main (would have brought the fix to main)
- 2026-02-27 - Commit 7d8130a / PR #353: Reverted PR #352 (main rejected the merge, so the fix never made it to main)
- 2026-03-03 - Commit 842dc68: Merged origin/main → dev

This overwrote the fix in dev with the old broken code from main
Changed back from VisualTreeHelper.GetDpi(_chart) to _chart.DisplayScale
This is where the regression occurred

### Root Cause:
PR #320 was only in the dev branch. When PR #352 tried to merge dev to main, it was reverted via PR #353. Later, when main was merged back into dev (commit 842dc68), the old code from main overwrote the fix that existed in dev, causing the regression.

## Which component(s) does this affect?

- [x] Full Dashboard
- [x] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

Describe the testing you've done. Include:
- SQL Server version(s) tested against
- Steps to verify the change works

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
