### PR TITLE
Plan Viewer "Key Lookup" not showing right icon/text

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -534,7 +534,8 @@ public partial class PlanViewerControl : UserControl
 
         // Header
         var headerText = node.PhysicalOp;
-        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp))
+        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp)
+            && !node.PhysicalOp.Contains(node.LogicalOp, StringComparison.OrdinalIgnoreCase))
             headerText += $" ({node.LogicalOp})";
         PropertiesHeader.Text = headerText;
         PropertiesSubHeader.Text = $"Node ID: {node.NodeId}";
@@ -1481,7 +1482,8 @@ public partial class PlanViewerControl : UserControl
 
         // Header
         var headerText = node.PhysicalOp;
-        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp))
+        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp)
+            && !node.PhysicalOp.Contains(node.LogicalOp, StringComparison.OrdinalIgnoreCase))
             headerText += $" ({node.LogicalOp})";
         stack.Children.Add(new TextBlock
         {

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -832,6 +832,19 @@ public static class ShowPlanParser
             node.Lookup = physicalOpEl.Attribute("Lookup")?.Value is "true" or "1";
             node.DynamicSeek = physicalOpEl.Attribute("DynamicSeek")?.Value is "true" or "1";
 
+            // Override PhysicalOp, LogicalOp, and icon when Lookup=true.
+            // SQL Server's XML emits PhysicalOp="Clustered Index Seek" with <IndexScan Lookup="1">
+            // rather than "Key Lookup (Clustered)" — correct the label here so all display
+            // paths (node card, tooltip, properties panel) show the right operator name.
+            if (node.Lookup)
+            {
+                var isHeap = node.IndexKind?.Equals("Heap", StringComparison.OrdinalIgnoreCase) == true
+                             || node.PhysicalOp.StartsWith("RID Lookup", StringComparison.OrdinalIgnoreCase);
+                node.PhysicalOp = isHeap ? "RID Lookup (Heap)" : "Key Lookup (Clustered)";
+                node.LogicalOp  = isHeap ? "RID Lookup" : "Key Lookup";
+                node.IconName   = isHeap ? "rid_lookup" : "bookmark_lookup";
+            }
+
             // Table cardinality and rows to be read (on <RelOp> per XSD)
             node.TableCardinality = ParseDouble(relOpEl.Attribute("TableCardinality")?.Value);
             node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimatedRowsRead")?.Value);

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -550,7 +550,8 @@ public partial class PlanViewerControl : UserControl
 
         // Header
         var headerText = node.PhysicalOp;
-        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp))
+        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp)
+            && !node.PhysicalOp.Contains(node.LogicalOp, StringComparison.OrdinalIgnoreCase))
             headerText += $" ({node.LogicalOp})";
         PropertiesHeader.Text = headerText;
         PropertiesSubHeader.Text = $"Node ID: {node.NodeId}";
@@ -1492,7 +1493,8 @@ public partial class PlanViewerControl : UserControl
 
         // Header
         var headerText = node.PhysicalOp;
-        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp))
+        if (node.LogicalOp != node.PhysicalOp && !string.IsNullOrEmpty(node.LogicalOp)
+            && !node.PhysicalOp.Contains(node.LogicalOp, StringComparison.OrdinalIgnoreCase))
             headerText += $" ({node.LogicalOp})";
         stack.Children.Add(new TextBlock
         {

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -832,6 +832,19 @@ public static class ShowPlanParser
             node.Lookup = physicalOpEl.Attribute("Lookup")?.Value is "true" or "1";
             node.DynamicSeek = physicalOpEl.Attribute("DynamicSeek")?.Value is "true" or "1";
 
+            // Override PhysicalOp, LogicalOp, and icon when Lookup=true.
+            // SQL Server's XML emits PhysicalOp="Clustered Index Seek" with <IndexScan Lookup="1">
+            // rather than "Key Lookup (Clustered)" — correct the label here so all display
+            // paths (node card, tooltip, properties panel) show the right operator name.
+            if (node.Lookup)
+            {
+                var isHeap = node.IndexKind?.Equals("Heap", StringComparison.OrdinalIgnoreCase) == true
+                             || node.PhysicalOp.StartsWith("RID Lookup", StringComparison.OrdinalIgnoreCase);
+                node.PhysicalOp = isHeap ? "RID Lookup (Heap)" : "Key Lookup (Clustered)";
+                node.LogicalOp  = isHeap ? "RID Lookup" : "Key Lookup";
+                node.IconName   = isHeap ? "rid_lookup" : "bookmark_lookup";
+            }
+
             // Table cardinality and rows to be read (on <RelOp> per XSD)
             node.TableCardinality = ParseDouble(relOpEl.Attribute("TableCardinality")?.Value);
             node.EstimatedRowsRead = ParseDouble(relOpEl.Attribute("EstimatedRowsRead")?.Value);


### PR DESCRIPTION
## What does this PR do?

Fix #412

## Which component(s) does this affect?

- [x] Full Dashboard
- [X] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

Check #412 

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
