### PR TITLE
Sync plan viewer: spool labels + unmatched index detail

### DIFF
--- a/Dashboard/Services/PlanIconMapper.cs
+++ b/Dashboard/Services/PlanIconMapper.cs
@@ -30,6 +30,8 @@ public static class PlanIconMapper
         ["Index Scan"] = "index_scan",
         ["Index Seek"] = "index_seek",
         ["Index Spool"] = "index_spool",
+        ["Eager Index Spool"] = "index_spool",
+        ["Lazy Index Spool"] = "index_spool",
         ["Index Update"] = "index_update",
 
         // Columnstore
@@ -74,7 +76,11 @@ public static class PlanIconMapper
 
         // Spool
         ["Table Spool"] = "table_spool",
+        ["Eager Table Spool"] = "table_spool",
+        ["Lazy Table Spool"] = "table_spool",
         ["Row Count Spool"] = "row_count_spool",
+        ["Eager Row Count Spool"] = "row_count_spool",
+        ["Lazy Row Count Spool"] = "row_count_spool",
         ["Window Spool"] = "table_spool",
         ["Eager Spool"] = "table_spool",
         ["Lazy Spool"] = "table_spool",

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -631,6 +631,19 @@ public static class ShowPlanParser
             StatsCollectionId = ParseLong(relOpEl.Attribute("StatsCollectionId")?.Value)
         };
 
+        // Spool operators: prepend Eager/Lazy from LogicalOp to PhysicalOp
+        // XML has PhysicalOp="Index Spool" but LogicalOp="Eager Spool" — show "Eager Index Spool"
+        if (node.PhysicalOp.EndsWith("Spool", StringComparison.OrdinalIgnoreCase)
+            && node.LogicalOp.StartsWith("Eager", StringComparison.OrdinalIgnoreCase))
+        {
+            node.PhysicalOp = "Eager " + node.PhysicalOp;
+        }
+        else if (node.PhysicalOp.EndsWith("Spool", StringComparison.OrdinalIgnoreCase)
+            && node.LogicalOp.StartsWith("Lazy", StringComparison.OrdinalIgnoreCase))
+        {
+            node.PhysicalOp = "Lazy " + node.PhysicalOp;
+        }
+
         // Map to icon
         node.IconName = PlanIconMapper.GetIconName(node.PhysicalOp);
 
@@ -1429,10 +1442,32 @@ public static class ShowPlanParser
 
         if (warningsEl.Attribute("UnmatchedIndexes")?.Value is "true" or "1")
         {
+            var unmatchedMsg = "Indexes could not be matched due to parameterization";
+            var unmatchedEl = warningsEl.Element(Ns + "UnmatchedIndexes");
+            if (unmatchedEl != null)
+            {
+                var unmatchedDetails = new List<string>();
+                foreach (var paramEl in unmatchedEl.Elements(Ns + "Parameterization"))
+                {
+                    var db = paramEl.Attribute("Database")?.Value?.Replace("[", "").Replace("]", "");
+                    var schema = paramEl.Attribute("Schema")?.Value?.Replace("[", "").Replace("]", "");
+                    var table = paramEl.Attribute("Table")?.Value?.Replace("[", "").Replace("]", "");
+                    var index = paramEl.Attribute("Index")?.Value?.Replace("[", "").Replace("]", "");
+                    var parts = new List<string>();
+                    if (!string.IsNullOrEmpty(db)) parts.Add(db);
+                    if (!string.IsNullOrEmpty(schema)) parts.Add(schema);
+                    if (!string.IsNullOrEmpty(table)) parts.Add(table);
+                    if (!string.IsNullOrEmpty(index)) parts.Add(index);
+                    if (parts.Count > 0)
+                        unmatchedDetails.Add(string.Join(".", parts));
+                }
+                if (unmatchedDetails.Count > 0)
+                    unmatchedMsg += ": " + string.Join(", ", unmatchedDetails);
+            }
             result.Add(new PlanWarning
             {
                 WarningType = "Unmatched Indexes",
-                Message = "Indexes could not be matched due to parameterization",
+                Message = unmatchedMsg,
                 Severity = PlanWarningSeverity.Warning
             });
         }

--- a/Lite/Services/PlanIconMapper.cs
+++ b/Lite/Services/PlanIconMapper.cs
@@ -30,6 +30,8 @@ public static class PlanIconMapper
         ["Index Scan"] = "index_scan",
         ["Index Seek"] = "index_seek",
         ["Index Spool"] = "index_spool",
+        ["Eager Index Spool"] = "index_spool",
+        ["Lazy Index Spool"] = "index_spool",
         ["Index Update"] = "index_update",
 
         // Columnstore
@@ -74,7 +76,11 @@ public static class PlanIconMapper
 
         // Spool
         ["Table Spool"] = "table_spool",
+        ["Eager Table Spool"] = "table_spool",
+        ["Lazy Table Spool"] = "table_spool",
         ["Row Count Spool"] = "row_count_spool",
+        ["Eager Row Count Spool"] = "row_count_spool",
+        ["Lazy Row Count Spool"] = "row_count_spool",
         ["Window Spool"] = "table_spool",
         ["Eager Spool"] = "table_spool",
         ["Lazy Spool"] = "table_spool",

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -631,6 +631,19 @@ public static class ShowPlanParser
             StatsCollectionId = ParseLong(relOpEl.Attribute("StatsCollectionId")?.Value)
         };
 
+        // Spool operators: prepend Eager/Lazy from LogicalOp to PhysicalOp
+        // XML has PhysicalOp="Index Spool" but LogicalOp="Eager Spool" — show "Eager Index Spool"
+        if (node.PhysicalOp.EndsWith("Spool", StringComparison.OrdinalIgnoreCase)
+            && node.LogicalOp.StartsWith("Eager", StringComparison.OrdinalIgnoreCase))
+        {
+            node.PhysicalOp = "Eager " + node.PhysicalOp;
+        }
+        else if (node.PhysicalOp.EndsWith("Spool", StringComparison.OrdinalIgnoreCase)
+            && node.LogicalOp.StartsWith("Lazy", StringComparison.OrdinalIgnoreCase))
+        {
+            node.PhysicalOp = "Lazy " + node.PhysicalOp;
+        }
+
         // Map to icon
         node.IconName = PlanIconMapper.GetIconName(node.PhysicalOp);
 
@@ -1429,10 +1442,32 @@ public static class ShowPlanParser
 
         if (warningsEl.Attribute("UnmatchedIndexes")?.Value is "true" or "1")
         {
+            var unmatchedMsg = "Indexes could not be matched due to parameterization";
+            var unmatchedEl = warningsEl.Element(Ns + "UnmatchedIndexes");
+            if (unmatchedEl != null)
+            {
+                var unmatchedDetails = new List<string>();
+                foreach (var paramEl in unmatchedEl.Elements(Ns + "Parameterization"))
+                {
+                    var db = paramEl.Attribute("Database")?.Value?.Replace("[", "").Replace("]", "");
+                    var schema = paramEl.Attribute("Schema")?.Value?.Replace("[", "").Replace("]", "");
+                    var table = paramEl.Attribute("Table")?.Value?.Replace("[", "").Replace("]", "");
+                    var index = paramEl.Attribute("Index")?.Value?.Replace("[", "").Replace("]", "");
+                    var parts = new List<string>();
+                    if (!string.IsNullOrEmpty(db)) parts.Add(db);
+                    if (!string.IsNullOrEmpty(schema)) parts.Add(schema);
+                    if (!string.IsNullOrEmpty(table)) parts.Add(table);
+                    if (!string.IsNullOrEmpty(index)) parts.Add(index);
+                    if (parts.Count > 0)
+                        unmatchedDetails.Add(string.Join(".", parts));
+                }
+                if (unmatchedDetails.Count > 0)
+                    unmatchedMsg += ": " + string.Join(", ", unmatchedDetails);
+            }
             result.Add(new PlanWarning
             {
                 WarningType = "Unmatched Indexes",
-                Message = "Indexes could not be matched due to parameterization",
+                Message = unmatchedMsg,
                 Severity = PlanWarningSeverity.Warning
             });
         }


### PR DESCRIPTION
## Summary
- Spool operators now show Eager/Lazy prefix (e.g., "Eager Index Spool" instead of just "Index Spool") by prepending qualifier from LogicalOp to PhysicalOp
- PlanIconMapper entries added for all 6 Eager/Lazy spool variants so icons resolve correctly
- UnmatchedIndexes warning now parses child `<Parameterization>` elements to show specific database.schema.table.index names instead of generic message

Synced from plan-b where these were developed and tested.

## Which component(s) does this affect?
- [x] Full Dashboard
- [x] Lite Dashboard

## How was this tested?
Built both Dashboard and Lite (`dotnet build -c Debug`). Spool label fix verified against plan-b eager-index-spool.sqlplan example.

## Checklist
- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>