### PR TITLE
Fix incorrect table name in Data Retention README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ ORDER BY collection_time DESC;
 
 ### Data Retention
 
-Default: 30 days (configurable per table in `config.retention_settings`).
+Default: 30 days (configurable per collector via the `retention_days` column in `config.collection_schedule`).
 
 Storage estimates: 5–10 GB per week, 20–40 GB per month.
 


### PR DESCRIPTION
## Summary
- README referenced `config.retention_settings` which doesn't exist — same bug reported in #223 but the fix never landed
- Corrected to `config.collection_schedule` with the `retention_days` column

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)