### PR TITLE
Fix RID Lookup analyzer rule after Key Lookup parser change

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -459,7 +459,7 @@ public static partial class PlanAnalyzer
 
         // Rule 10: Key Lookup / RID Lookup with residual predicate
         // Check RID Lookup first — it's more specific (PhysicalOp) and also has Lookup=true
-        if (node.PhysicalOp == "RID Lookup")
+        if (node.PhysicalOp.StartsWith("RID Lookup", StringComparison.OrdinalIgnoreCase))
         {
             var message = "RID Lookup — this table is a heap (no clustered index). SQL Server found rows via a nonclustered index but had to follow row identifiers back to unordered heap pages. Heap lookups are more expensive than key lookups because pages are not sorted and may have forwarding pointers. Add a clustered index to the table.";
             if (!string.IsNullOrEmpty(node.Predicate))

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -459,7 +459,7 @@ public static partial class PlanAnalyzer
 
         // Rule 10: Key Lookup / RID Lookup with residual predicate
         // Check RID Lookup first — it's more specific (PhysicalOp) and also has Lookup=true
-        if (node.PhysicalOp == "RID Lookup")
+        if (node.PhysicalOp.StartsWith("RID Lookup", StringComparison.OrdinalIgnoreCase))
         {
             var message = "RID Lookup — this table is a heap (no clustered index). SQL Server found rows via a nonclustered index but had to follow row identifiers back to unordered heap pages. Heap lookups are more expensive than key lookups because pages are not sorted and may have forwarding pointers. Add a clustered index to the table.";
             if (!string.IsNullOrEmpty(node.Predicate))


### PR DESCRIPTION
## Summary
- PR #413 changed PhysicalOp from `"RID Lookup"` to `"RID Lookup (Heap)"` via the Lookup override in ShowPlanParser
- The analyzer Rule 10 used exact equality (`== "RID Lookup"`) which no longer matched
- Changed to `StartsWith("RID Lookup")` so the rule fires for both the old and new label formats

Regression from PR #413. Caught by plan-b test suite.

## Which component(s) does this affect?
- [x] Full Dashboard
- [x] Lite Dashboard

## How was this tested?
plan-b test suite: 37/37 passing after fix (was 36/37 with RID Lookup test failing).

## Checklist
- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names