### PR TITLE
Add uninstall option to CLI and GUI installers

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -21,6 +21,69 @@ namespace PerformanceMonitorInstaller
 {
     partial class Program
     {
+        /// <summary>
+        /// Complete uninstall SQL: stops traces, deletes all 3 Agent jobs,
+        /// drops both XE sessions, and drops the database.
+        /// </summary>
+        private const string UninstallSql = @"
+/*
+Remove SQL Agent jobs
+*/
+USE msdb;
+
+IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Collection')
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Collection', @delete_unused_schedule = 1;
+    PRINT 'Deleted job: PerformanceMonitor - Collection';
+END;
+
+IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Data Retention')
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Data Retention', @delete_unused_schedule = 1;
+    PRINT 'Deleted job: PerformanceMonitor - Data Retention';
+END;
+
+IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Hung Job Monitor')
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Hung Job Monitor', @delete_unused_schedule = 1;
+    PRINT 'Deleted job: PerformanceMonitor - Hung Job Monitor';
+END;
+
+/*
+Drop Extended Events sessions
+*/
+USE master;
+
+IF EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'PerformanceMonitor_BlockedProcess')
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'PerformanceMonitor_BlockedProcess')
+        ALTER EVENT SESSION [PerformanceMonitor_BlockedProcess] ON SERVER STATE = STOP;
+    DROP EVENT SESSION [PerformanceMonitor_BlockedProcess] ON SERVER;
+    PRINT 'Dropped XE session: PerformanceMonitor_BlockedProcess';
+END;
+
+IF EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'PerformanceMonitor_Deadlock')
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'PerformanceMonitor_Deadlock')
+        ALTER EVENT SESSION [PerformanceMonitor_Deadlock] ON SERVER STATE = STOP;
+    DROP EVENT SESSION [PerformanceMonitor_Deadlock] ON SERVER;
+    PRINT 'Dropped XE session: PerformanceMonitor_Deadlock';
+END;
+
+/*
+Drop the database
+*/
+IF EXISTS (SELECT 1 FROM sys.databases WHERE name = N'PerformanceMonitor')
+BEGIN
+    ALTER DATABASE PerformanceMonitor SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE PerformanceMonitor;
+    PRINT 'PerformanceMonitor database dropped';
+END
+ELSE
+BEGIN
+    PRINT 'PerformanceMonitor database does not exist';
+END;";
+
         /*
         Pre-compiled regex patterns for performance
         */
@@ -53,6 +116,7 @@ namespace PerformanceMonitorInstaller
             public const int PartialInstallation = 4;
             public const int VersionCheckFailed = 5;
             public const int SqlFilesNotFound = 6;
+            public const int UninstallFailed = 7;
         }
 
         static async Task<int> Main(string[] args)
@@ -92,6 +156,7 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("Options:");
                 Console.WriteLine("  -h, --help           Show this help message");
                 Console.WriteLine("  --reinstall          Drop existing database and perform clean install");
+                Console.WriteLine("  --uninstall          Remove database, Agent jobs, and XE sessions");
                 Console.WriteLine("  --reset-schedule     Reset collection schedule to recommended defaults");
                 Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                 Console.WriteLine("  --trust-cert         Trust server certificate without validation");
@@ -107,11 +172,13 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  4  Partial installation (non-critical failures)");
                 Console.WriteLine("  5  Version check failed");
                 Console.WriteLine("  6  SQL files not found");
+                Console.WriteLine("  7  Uninstall failed");
                 return 0;
             }
 
             bool automatedMode = args.Length > 0;
             bool reinstallMode = args.Any(a => a.Equals("--reinstall", StringComparison.OrdinalIgnoreCase));
+            bool uninstallMode = args.Any(a => a.Equals("--uninstall", StringComparison.OrdinalIgnoreCase));
             bool resetSchedule = args.Any(a => a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase));
             bool trustCert = args.Any(a => a.Equals("--trust-cert", StringComparison.OrdinalIgnoreCase));
 
@@ -132,6 +199,7 @@ namespace PerformanceMonitorInstaller
             /*Filter out option flags to get positional arguments*/
             var filteredArgs = args
                 .Where(a => !a.Equals("--reinstall", StringComparison.OrdinalIgnoreCase))
+                .Where(a => !a.Equals("--uninstall", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.Equals("--trust-cert", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.StartsWith("--encrypt=", StringComparison.OrdinalIgnoreCase))
@@ -309,6 +377,14 @@ namespace PerformanceMonitorInstaller
             }
 
             /*
+            Handle --uninstall mode (no SQL files needed)
+            */
+            if (uninstallMode)
+            {
+                return await PerformUninstallAsync(builder.ConnectionString, automatedMode);
+            }
+
+            /*
             Find SQL files to execute (do this once before the installation loop)
             Search current directory and up to 5 parent directories
             Prefer install/ subfolder if it exists (new structure)
@@ -466,41 +542,7 @@ namespace PerformanceMonitorInstaller
                             /*Database or procedure doesn't exist - no traces to clean*/
                         }
 
-                        string cleanupSql = @"
-/*
-Remove any existing Agent jobs
-*/
-USE msdb;
-
-IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Collection')
-BEGIN
-    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Collection';
-    PRINT 'Dropped PerformanceMonitor - Collection job';
-END;
-
-IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Data Retention')
-BEGIN
-    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Data Retention';
-    PRINT 'Dropped PerformanceMonitor - Data Retention job';
-END;
-
-/*
-Drop the database
-*/
-USE master;
-
-IF EXISTS (SELECT 1 FROM sys.databases WHERE name = N'PerformanceMonitor')
-BEGIN
-    ALTER DATABASE PerformanceMonitor SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-    DROP DATABASE PerformanceMonitor;
-    PRINT 'PerformanceMonitor database dropped successfully';
-END
-ELSE
-BEGIN
-    PRINT 'PerformanceMonitor database does not exist';
-END";
-
-                        using (var command = new SqlCommand(cleanupSql, connection))
+                        using (var command = new SqlCommand(UninstallSql, connection))
                         {
                             command.CommandTimeout = ShortTimeoutSeconds;
                             await command.ExecuteNonQueryAsync().ConfigureAwait(false);
@@ -1085,6 +1127,86 @@ END";
         Log installation history to database
         Tracks version, duration, success/failure, and upgrade detection
         */
+
+        /// <summary>
+        /// Performs a complete uninstall: stops traces, removes jobs, XE sessions, and database.
+        /// </summary>
+        private static async Task<int> PerformUninstallAsync(string connectionString, bool automatedMode)
+        {
+            Console.WriteLine();
+            Console.WriteLine("================================================================================");
+            Console.WriteLine("UNINSTALL MODE");
+            Console.WriteLine("================================================================================");
+            Console.WriteLine();
+
+            if (!automatedMode)
+            {
+                Console.WriteLine("This will remove:");
+                Console.WriteLine("  - SQL Agent jobs (Collection, Data Retention, Hung Job Monitor)");
+                Console.WriteLine("  - Extended Events sessions (BlockedProcess, Deadlock)");
+                Console.WriteLine("  - Server-side traces");
+                Console.WriteLine("  - PerformanceMonitor database and ALL collected data");
+                Console.WriteLine();
+                Console.Write("Are you sure you want to continue? (Y/N, default N): ");
+                string? confirm = Console.ReadLine();
+                if (!confirm?.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase) ?? true)
+                {
+                    Console.WriteLine("Uninstall cancelled.");
+                    WaitForExit();
+                    return ExitCodes.Success;
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Uninstalling Performance Monitor...");
+
+            try
+            {
+                using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync().ConfigureAwait(false);
+
+                /*Stop traces first (procedure lives in the database)*/
+                try
+                {
+                    using var traceCmd = new SqlCommand(
+                        "EXECUTE PerformanceMonitor.collect.trace_management_collector @action = 'STOP';",
+                        connection);
+                    traceCmd.CommandTimeout = ShortTimeoutSeconds;
+                    await traceCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+                    Console.WriteLine("✓ Stopped server-side traces");
+                }
+                catch (SqlException)
+                {
+                    Console.WriteLine("  No traces to stop (database or procedure not found)");
+                }
+
+                /*Remove jobs, XE sessions, and database*/
+                using var command = new SqlCommand(UninstallSql, connection);
+                command.CommandTimeout = ShortTimeoutSeconds;
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+                Console.WriteLine();
+                Console.WriteLine("✓ Uninstall completed successfully");
+                Console.WriteLine();
+                Console.WriteLine("Note: blocked process threshold (s) was NOT reset.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Uninstall failed: {ex.Message}");
+                if (!automatedMode)
+                {
+                    WaitForExit();
+                }
+                return ExitCodes.UninstallFailed;
+            }
+
+            if (!automatedMode)
+            {
+                WaitForExit();
+            }
+            return ExitCodes.Success;
+        }
 
         /*
         Get currently installed version from database

--- a/InstallerGui/MainWindow.xaml
+++ b/InstallerGui/MainWindow.xaml
@@ -258,6 +258,15 @@
                     Margin="0,0,10,0"
                     Click="ViewReport_Click"
                     IsEnabled="False"/>
+            <Button x:Name="UninstallButton"
+                    Content="Uninstall"
+                    Width="100" Height="32"
+                    Margin="0,0,10,0"
+                    Click="Uninstall_Click"
+                    IsEnabled="False"
+                    Foreground="White"
+                    Background="#C62828"
+                    ToolTip="Remove database, Agent jobs, and XE sessions"/>
             <Button x:Name="CloseButton"
                     Content="Close"
                     Width="100" Height="32"

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -171,6 +171,7 @@ namespace PerformanceMonitorInstallerGui
             _serverInfo = null;
             _installedVersion = null;
             InstallButton.IsEnabled = false;
+            UninstallButton.IsEnabled = false;
         }
 
         /// <summary>
@@ -283,6 +284,7 @@ namespace PerformanceMonitorInstallerGui
                     }
 
                     InstallButton.IsEnabled = _sqlFiles != null && _sqlFiles.Count > 0;
+                    UninstallButton.IsEnabled = _installedVersion != null;
 
                     /*Show confirmation MessageBox*/
                     string installedVersionText = _installedVersion != null
@@ -547,6 +549,98 @@ namespace PerformanceMonitorInstallerGui
         }
 
         /// <summary>
+        /// Uninstall button click
+        /// </summary>
+        private async void Uninstall_Click(object sender, RoutedEventArgs e)
+        {
+            if (_connectionString == null || _installedVersion == null)
+            {
+                MessageBox.Show(this, "No installation detected.", "Info",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var result = MessageBox.Show(this,
+                "WARNING: This will permanently remove the PerformanceMonitor database,\n" +
+                "all SQL Agent jobs, Extended Events sessions, and ALL collected data.\n\n" +
+                "This action CANNOT be undone!\n\n" +
+                $"Installed version: {_installedVersion}\n\n" +
+                "Are you sure you want to continue?",
+                "Confirm Uninstall",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning,
+                MessageBoxResult.No);
+
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = _cancellationTokenSource.Token;
+
+            SetUIState(installing: true);
+            ClearLog();
+
+            LogMessage($"Performance Monitor Uninstaller v{AppVersion}", "Info");
+            LogMessage("", "Info");
+
+            var progress = new Progress<InstallationProgress>(ReportProgress);
+
+            try
+            {
+                bool success = await InstallationService.ExecuteUninstallAsync(
+                    _connectionString,
+                    progress,
+                    cancellationToken);
+
+                if (success)
+                {
+                    LogMessage("", "Info");
+                    LogMessage("================================================================================", "Info");
+                    LogMessage("Uninstall completed successfully!", "Success");
+                    LogMessage("================================================================================", "Info");
+                    LogMessage("", "Info");
+                    LogMessage("Note: blocked process threshold (s) was NOT reset.", "Info");
+
+                    _installedVersion = null;
+                    ProgressBar.Value = 100;
+                    ProgressText.Text = "100%";
+
+                    MessageBox.Show(this,
+                        "Uninstall completed successfully!\n\n" +
+                        "Database, Agent jobs, and XE sessions have been removed.",
+                        "Uninstall Complete",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                LogMessage("", "Info");
+                LogMessage("Uninstall cancelled by user.", "Warning");
+            }
+            catch (Exception ex)
+            {
+                LogMessage("", "Info");
+                LogMessage($"Uninstall failed: {ex.Message}", "Error");
+
+                MessageBox.Show(this,
+                    $"Uninstall failed:\n\n{ex.Message}",
+                    "Uninstall Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            finally
+            {
+                SetUIState(installing: false);
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+            }
+        }
+
+        /// <summary>
         /// Troubleshoot button click - runs 99_troubleshooting.sql
         /// </summary>
         private async void Troubleshoot_Click(object sender, RoutedEventArgs e)
@@ -720,6 +814,7 @@ namespace PerformanceMonitorInstallerGui
 
             TroubleshootButton.IsEnabled = !installing && _installationResult?.Success == true;
             ViewReportButton.IsEnabled = !installing && _installationResult?.ReportPath != null;
+            UninstallButton.IsEnabled = !installing && _installedVersion != null;
 
             if (!installing)
             {

--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -282,22 +282,41 @@ namespace PerformanceMonitorInstallerGui.Services
             }
 
             /*
-            Remove Agent jobs and database
+            Remove Agent jobs, XE sessions, and database
             */
             string cleanupSql = @"
 USE msdb;
 
 IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Collection')
 BEGIN
-    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Collection';
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Collection', @delete_unused_schedule = 1;
 END;
 
 IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Data Retention')
 BEGIN
-    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Data Retention';
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Data Retention', @delete_unused_schedule = 1;
+END;
+
+IF EXISTS (SELECT 1 FROM msdb.dbo.sysjobs WHERE name = N'PerformanceMonitor - Hung Job Monitor')
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job @job_name = N'PerformanceMonitor - Hung Job Monitor', @delete_unused_schedule = 1;
 END;
 
 USE master;
+
+IF EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'PerformanceMonitor_BlockedProcess')
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'PerformanceMonitor_BlockedProcess')
+        ALTER EVENT SESSION [PerformanceMonitor_BlockedProcess] ON SERVER STATE = STOP;
+    DROP EVENT SESSION [PerformanceMonitor_BlockedProcess] ON SERVER;
+END;
+
+IF EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'PerformanceMonitor_Deadlock')
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'PerformanceMonitor_Deadlock')
+        ALTER EVENT SESSION [PerformanceMonitor_Deadlock] ON SERVER STATE = STOP;
+    DROP EVENT SESSION [PerformanceMonitor_Deadlock] ON SERVER;
+END;
 
 IF EXISTS (SELECT 1 FROM sys.databases WHERE name = N'PerformanceMonitor')
 BEGIN
@@ -311,9 +330,68 @@ END;";
 
             progress?.Report(new InstallationProgress
             {
-                Message = "Clean install completed (jobs and database removed)",
+                Message = "Clean install completed (jobs, XE sessions, and database removed)",
                 Status = "Success"
             });
+        }
+
+        /// <summary>
+        /// Perform complete uninstall (remove database, jobs, XE sessions, and traces)
+        /// </summary>
+        public static async Task<bool> ExecuteUninstallAsync(
+            string connectionString,
+            IProgress<InstallationProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            progress?.Report(new InstallationProgress
+            {
+                Message = "Uninstalling Performance Monitor...",
+                Status = "Info"
+            });
+
+            using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            /*
+            Stop existing traces before dropping database
+            */
+            try
+            {
+                using var traceCmd = new SqlCommand(
+                    "EXECUTE PerformanceMonitor.collect.trace_management_collector @action = 'STOP';",
+                    connection);
+                traceCmd.CommandTimeout = 60;
+                await traceCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+                progress?.Report(new InstallationProgress
+                {
+                    Message = "Stopped server-side traces",
+                    Status = "Success"
+                });
+            }
+            catch (SqlException)
+            {
+                progress?.Report(new InstallationProgress
+                {
+                    Message = "No traces to stop (database or procedure not found)",
+                    Status = "Info"
+                });
+            }
+
+            /*
+            Remove Agent jobs, XE sessions, and database
+            */
+            await CleanInstallAsync(connectionString, progress, cancellationToken)
+                .ConfigureAwait(false);
+
+            progress?.Report(new InstallationProgress
+            {
+                Message = "Uninstall completed successfully",
+                Status = "Success",
+                ProgressPercent = 100
+            });
+
+            return true;
         }
 
         /// <summary>

--- a/install/00_uninstall.sql
+++ b/install/00_uninstall.sql
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ *
+ * Uninstall script - removes all Performance Monitor objects from SQL Server.
+ *
+ * Removes:
+ *   - Server-side traces (must happen before database drop)
+ *   - SQL Agent jobs (3 jobs in msdb)
+ *   - Extended Events sessions (2 server-level sessions)
+ *   - PerformanceMonitor database
+ *
+ * Does NOT reset:
+ *   - blocked process threshold (s) sp_configure setting
+ *     (other monitoring tools may depend on it)
+ *
+ * Safe to run multiple times (all operations are idempotent).
+ */
+
+USE master;
+GO
+
+SET NOCOUNT ON;
+GO
+
+PRINT '================================================================================';
+PRINT 'Performance Monitor Uninstaller';
+PRINT '================================================================================';
+PRINT '';
+GO
+
+/*
+Stop server-side traces before dropping database.
+The trace_management_collector procedure lives in the PerformanceMonitor database,
+so this must happen first.
+*/
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.databases AS d
+    WHERE d.name = N'PerformanceMonitor'
+)
+AND OBJECT_ID(N'PerformanceMonitor.collect.trace_management_collector', N'P') IS NOT NULL
+BEGIN
+    PRINT 'Stopping server-side traces...';
+
+    BEGIN TRY
+        EXECUTE PerformanceMonitor.collect.trace_management_collector
+            @action = 'STOP';
+
+        PRINT 'Server-side traces stopped';
+    END TRY
+    BEGIN CATCH
+        PRINT 'Note: Could not stop traces (may not be running)';
+    END CATCH;
+END;
+ELSE
+BEGIN
+    PRINT 'No traces to stop (database or procedure not found)';
+END;
+GO
+
+PRINT '';
+GO
+
+/*
+Delete SQL Agent jobs from msdb.
+*/
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM msdb.dbo.sysjobs AS sj
+    WHERE sj.name = N'PerformanceMonitor - Collection'
+)
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job
+        @job_name = N'PerformanceMonitor - Collection',
+        @delete_unused_schedule = 1;
+
+    PRINT 'Deleted job: PerformanceMonitor - Collection';
+END;
+ELSE
+BEGIN
+    PRINT 'Job not found: PerformanceMonitor - Collection';
+END;
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM msdb.dbo.sysjobs AS sj
+    WHERE sj.name = N'PerformanceMonitor - Data Retention'
+)
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job
+        @job_name = N'PerformanceMonitor - Data Retention',
+        @delete_unused_schedule = 1;
+
+    PRINT 'Deleted job: PerformanceMonitor - Data Retention';
+END;
+ELSE
+BEGIN
+    PRINT 'Job not found: PerformanceMonitor - Data Retention';
+END;
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM msdb.dbo.sysjobs AS sj
+    WHERE sj.name = N'PerformanceMonitor - Hung Job Monitor'
+)
+BEGIN
+    EXECUTE msdb.dbo.sp_delete_job
+        @job_name = N'PerformanceMonitor - Hung Job Monitor',
+        @delete_unused_schedule = 1;
+
+    PRINT 'Deleted job: PerformanceMonitor - Hung Job Monitor';
+END;
+ELSE
+BEGIN
+    PRINT 'Job not found: PerformanceMonitor - Hung Job Monitor';
+END;
+GO
+
+PRINT '';
+GO
+
+/*
+Drop Extended Events sessions.
+Stop running sessions before dropping.
+*/
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.server_event_sessions AS ses
+    WHERE ses.name = N'PerformanceMonitor_BlockedProcess'
+)
+BEGIN
+    IF EXISTS
+    (
+        SELECT
+            1/0
+        FROM sys.dm_xe_sessions AS dxs
+        WHERE dxs.name = N'PerformanceMonitor_BlockedProcess'
+    )
+    BEGIN
+        ALTER EVENT SESSION
+            [PerformanceMonitor_BlockedProcess]
+        ON SERVER
+            STATE = STOP;
+    END;
+
+    DROP EVENT SESSION
+        [PerformanceMonitor_BlockedProcess]
+    ON SERVER;
+
+    PRINT 'Dropped Extended Events session: PerformanceMonitor_BlockedProcess';
+END;
+ELSE
+BEGIN
+    PRINT 'XE session not found: PerformanceMonitor_BlockedProcess';
+END;
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.server_event_sessions AS ses
+    WHERE ses.name = N'PerformanceMonitor_Deadlock'
+)
+BEGIN
+    IF EXISTS
+    (
+        SELECT
+            1/0
+        FROM sys.dm_xe_sessions AS dxs
+        WHERE dxs.name = N'PerformanceMonitor_Deadlock'
+    )
+    BEGIN
+        ALTER EVENT SESSION
+            [PerformanceMonitor_Deadlock]
+        ON SERVER
+            STATE = STOP;
+    END;
+
+    DROP EVENT SESSION
+        [PerformanceMonitor_Deadlock]
+    ON SERVER;
+
+    PRINT 'Dropped Extended Events session: PerformanceMonitor_Deadlock';
+END;
+ELSE
+BEGIN
+    PRINT 'XE session not found: PerformanceMonitor_Deadlock';
+END;
+GO
+
+PRINT '';
+GO
+
+/*
+Drop the PerformanceMonitor database.
+SET SINGLE_USER forces all connections closed.
+*/
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.databases AS d
+    WHERE d.name = N'PerformanceMonitor'
+)
+BEGIN
+    PRINT 'Dropping PerformanceMonitor database...';
+
+    ALTER DATABASE [PerformanceMonitor]
+        SET SINGLE_USER
+        WITH ROLLBACK IMMEDIATE;
+
+    DROP DATABASE [PerformanceMonitor];
+
+    PRINT 'PerformanceMonitor database dropped';
+END;
+ELSE
+BEGIN
+    PRINT 'PerformanceMonitor database not found';
+END;
+GO
+
+PRINT '';
+PRINT '================================================================================';
+PRINT 'Uninstall complete';
+PRINT '================================================================================';
+PRINT '';
+PRINT 'Note: blocked process threshold (s) was NOT reset.';
+PRINT 'If no other tools use it, you can reset it manually:';
+PRINT '  EXECUTE sp_configure ''show advanced options'', 1; RECONFIGURE;';
+PRINT '  EXECUTE sp_configure ''blocked process threshold (s)'', 0; RECONFIGURE;';
+PRINT '  EXECUTE sp_configure ''show advanced options'', 0; RECONFIGURE;';
+GO


### PR DESCRIPTION
## Summary

Closes #431. Adds complete uninstall capability to both installers plus a standalone SQL script.

- **`install/00_uninstall.sql`** — standalone script for SSMS users, fully idempotent
- **CLI `--uninstall` flag** — with interactive confirmation prompt
- **GUI Uninstall button** — red styled, only enabled when installed version is detected
- **Bug fix**: existing clean install path now removes all 3 Agent jobs + both XE sessions (previously missed Hung Job Monitor and XE sessions)

### What gets cleaned up
| Object | Type |
|--------|------|
| PerformanceMonitor - Collection | Agent Job |
| PerformanceMonitor - Data Retention | Agent Job |
| PerformanceMonitor - Hung Job Monitor | Agent Job |
| PerformanceMonitor_BlockedProcess | XE Session |
| PerformanceMonitor_Deadlock | XE Session |
| Server-side trace (LongQueries) | Trace |
| PerformanceMonitor database | Database |

`blocked process threshold (s)` is intentionally NOT reset (other tools may depend on it).

## Test plan

- [ ] CLI: `PerformanceMonitorInstaller.exe <server> <user> <pass> --uninstall`
- [ ] CLI: verify all 3 jobs removed, both XE sessions removed, database dropped
- [ ] CLI: run `--uninstall` a second time (idempotent — no errors)
- [ ] CLI: reinstall after uninstall — clean slate
- [ ] GUI: connect → verify Uninstall button enabled when installed
- [ ] GUI: click Uninstall → confirm dialog → verify removal
- [ ] SSMS: run `00_uninstall.sql` directly
- [ ] Verify `--reinstall` also removes 3rd job + XE sessions (bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)