### PR TITLE
Add RESTORING database filter to waiting_tasks collector (#430)

### DIFF
--- a/install/37_collect_waiting_tasks.sql
+++ b/install/37_collect_waiting_tasks.sql
@@ -163,7 +163,8 @@ BEGIN
         LEFT JOIN sys.dm_exec_requests AS der
           ON der.session_id = wt.session_id
         LEFT JOIN sys.databases AS d
-          ON d.database_id = der.database_id
+          ON  d.database_id = der.database_id
+          AND d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
         OUTER APPLY sys.dm_exec_sql_text(der.sql_handle) AS dest
         OUTER APPLY sys.dm_exec_text_query_plan
         (


### PR DESCRIPTION
## Summary

- Add `d.state = 0` filter to the `sys.databases` join in the waiting_tasks collector
- Prevents sessions in RESTORING databases (mirroring passive / AG secondary) from being passed to `sys.dm_exec_sql_text` and `sys.dm_exec_text_query_plan`
- Matches the pattern already applied to query_stats, procedure_stats, query_store, and file_io_stats collectors in PR #385

## Context

Issue #430 reported SQL dumps on a mirroring passive server. WinDbg analysis of the dumps showed the crashes are from an internal SQL Server 2016 background thread (spid 40, `m_fBackground=1`), not from our collectors. However, the waiting_tasks collector was the only one still missing the RESTORING database guard — this closes that gap.

## Test plan

- [x] One-line change: adds `AND d.state = 0` to the LEFT JOIN condition
- [x] Pattern matches existing guards in other collectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)