### PR TITLE
Add version bump check for PRs to main

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,48 @@
+name: Check version bump
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-version:
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Get PR version
+        id: pr
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content Dashboard/Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "PR version: $version"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main-branch
+
+      - name: Get main version
+        id: main
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content main-branch/Dashboard/Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Main version: $version"
+
+      - name: Compare versions
+        env:
+          PR_VERSION: ${{ steps.pr.outputs.VERSION }}
+          MAIN_VERSION: ${{ steps.main.outputs.VERSION }}
+        run: |
+          echo "Main version: $MAIN_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$PR_VERSION" == "$MAIN_VERSION" ]; then
+            echo "::error::Version in Dashboard.csproj ($PR_VERSION) has not changed from main. Bump the version before merging to main."
+            exit 1
+          fi
+          echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"


### PR DESCRIPTION
## Summary

Adds a CI workflow that blocks merging dev → main if the version in `Dashboard.csproj` hasn't been bumped. Adapted from the PerformanceStudio repo.

- Only triggers on PRs targeting `main` from `dev`
- Compares `<Version>` in `Dashboard/Dashboard.csproj` between PR and main
- Fails with a clear error if versions match

## Test plan

- [ ] Workflow file is valid YAML
- [ ] Will trigger on next dev → main PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)