### PR TITLE
Restore commercial support tiers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,14 +577,27 @@ dotnet publish InstallerGui/InstallerGui.csproj -c Release -r win-x64 --self-con
 
 ## Support & Sponsorship
 
-**This project is free and open source.** If you find it valuable, consider supporting continued development:
+**This project is free and open source under the MIT License.** The software is fully functional with no features withheld — every user gets the same tool, same collectors, same MCP integration.
+
+However, some organizations have procurement or compliance policies that require a formal vendor relationship, a support agreement, or an invoice on file before software can be deployed to production. If that sounds familiar, two commercial support tiers are available:
+
+| Tier | Annual Cost | What You Get |
+|------|-------------|--------------|
+| **Supported** | $500/year | Email support (2-business-day response), compatibility guarantees for new SQL Server versions, vendor agreement and invoices for compliance, unlimited instances |
+| **Priority** | $2,500/year | Next-business-day email response, quarterly live Q&A sessions, early access to new features, roadmap input, unlimited instances |
+
+Both tiers cover unlimited SQL Server instances. The software itself is identical — commercial support is about the relationship, not a feature gate.
+
+**[Read more about the free tool and commercial options](https://erikdarling.com/free-sql-server-performance-monitoring/)** | **[Purchase a support subscription](https://training.erikdarling.com/sql-monitoring)**
+
+If you find the project valuable, you can also support continued development:
 
 | | |
 |---|---|
 | **Sponsor on GitHub** | [Become a sponsor](https://github.com/sponsors/erikdarlingdata) to fund new features, ongoing maintenance, and SQL Server version support. |
 | **Consulting Services** | [Hire me](https://training.erikdarling.com/sqlconsulting) for hands-on consulting if you need help analyzing the data this tool collects? Want expert assistance fixing the issues it uncovers?  |
 
-Neither is required — use the tool freely. Sponsorship and consulting keep this project alive.
+Neither sponsorship nor consulting is required — use the tool freely.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #436. Restores the commercial support tiers (Supported $500/yr, Priority $2,500/yr) that were accidentally removed during the README restructure in PR #377.

## Test plan

- [ ] Verify support tiers table renders correctly
- [ ] Verify links to erikdarling.com and training.erikdarling.com work

🤖 Generated with [Claude Code](https://claude.com/claude-code)