### PR TITLE
Add wait stats query drill-down (#372)

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -199,7 +199,8 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.SetupChartContextMenu(PerfmonCountersChart, "Perfmon_Counters", "collect.perfmon_stats");
 
             // Wait Stats Detail chart
-            TabHelpers.SetupChartContextMenu(WaitStatsDetailChart, "Wait_Stats_Detail", "collect.wait_stats");
+            var waitStatsMenu = TabHelpers.SetupChartContextMenu(WaitStatsDetailChart, "Wait_Stats_Detail", "collect.wait_stats");
+            AddWaitDrillDownMenuItem(WaitStatsDetailChart, waitStatsMenu);
         }
 
         /// <summary>
@@ -1811,6 +1812,48 @@ namespace PerformanceMonitorDashboard.Controls
             if (_isUpdatingWaitTypeSelection) return;
             RefreshWaitTypeListOrder();
             await UpdateWaitStatsDetailChartAsync();
+        }
+
+        private void AddWaitDrillDownMenuItem(ScottPlot.WPF.WpfPlot chart, ContextMenu contextMenu)
+        {
+            contextMenu.Items.Insert(0, new Separator());
+            var drillDownItem = new MenuItem { Header = "Show Queries With This Wait" };
+            drillDownItem.Click += ShowQueriesForWaitType_Click;
+            contextMenu.Items.Insert(0, drillDownItem);
+
+            contextMenu.Opened += (s, _) =>
+            {
+                var pos = System.Windows.Input.Mouse.GetPosition(chart);
+                var nearest = _waitStatsHover?.GetNearestSeries(pos);
+                if (nearest.HasValue)
+                {
+                    drillDownItem.Tag = (nearest.Value.Label, nearest.Value.Time);
+                    drillDownItem.Header = $"Show Queries With {nearest.Value.Label.Replace("_", "__")}";
+                    drillDownItem.IsEnabled = true;
+                }
+                else
+                {
+                    drillDownItem.Tag = null;
+                    drillDownItem.Header = "Show Queries With This Wait";
+                    drillDownItem.IsEnabled = false;
+                }
+            };
+        }
+
+        private void ShowQueriesForWaitType_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem) return;
+            if (menuItem.Tag is not ValueTuple<string, DateTime> tag) return;
+            if (_databaseService == null) return;
+
+            // ±15 minute window around the clicked point
+            var fromDate = tag.Item2.AddMinutes(-15);
+            var toDate = tag.Item2.AddMinutes(15);
+
+            var window = new WaitDrillDownWindow(
+                _databaseService, tag.Item1, 1, fromDate, toDate);
+            window.Owner = Window.GetWindow(this);
+            window.ShowDialog();
         }
 
         private void WaitStatsMetric_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Dashboard/Helpers/ChartHoverHelper.cs
+++ b/Dashboard/Helpers/ChartHoverHelper.cs
@@ -61,6 +61,50 @@ internal sealed class ChartHoverHelper
     public void Add(ScottPlot.Plottables.Scatter scatter, string label) =>
         _scatters.Add((scatter, label));
 
+    /// <summary>
+    /// Returns the nearest series label and data-point time for the given mouse position,
+    /// or null if no series is close enough.
+    /// </summary>
+    public (string Label, DateTime Time)? GetNearestSeries(Point mousePos)
+    {
+        if (_scatters.Count == 0) return null;
+        try
+        {
+            var dpi = VisualTreeHelper.GetDpi(_chart);
+            var pixel = new ScottPlot.Pixel(
+                (float)(mousePos.X * dpi.DpiScaleX),
+                (float)(mousePos.Y * dpi.DpiScaleY));
+            var mouseCoords = _chart.Plot.GetCoordinates(pixel);
+
+            double bestYDistance = double.MaxValue;
+            ScottPlot.DataPoint bestPoint = default;
+            string bestLabel = "";
+            bool found = false;
+
+            foreach (var (scatter, label) in _scatters)
+            {
+                var nearest = scatter.Data.GetNearest(mouseCoords, _chart.Plot.LastRender);
+                if (!nearest.IsReal) continue;
+                var nearestPixel = _chart.Plot.GetPixel(
+                    new ScottPlot.Coordinates(nearest.X, nearest.Y));
+                double dx = Math.Abs(nearestPixel.X - pixel.X);
+                double dy = Math.Abs(nearestPixel.Y - pixel.Y);
+                if (dx < 80 && dy < bestYDistance)
+                {
+                    bestYDistance = dy;
+                    bestPoint = nearest;
+                    bestLabel = label;
+                    found = true;
+                }
+            }
+
+            if (found)
+                return (bestLabel, DateTime.FromOADate(bestPoint.X));
+        }
+        catch { }
+        return null;
+    }
+
     private void OnMouseMove(object sender, MouseEventArgs e)
     {
         if (_scatters.Count == 0) return;

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -603,7 +603,7 @@ namespace PerformanceMonitorDashboard.Helpers
         /// <param name="chart">The WpfPlot chart control</param>
         /// <param name="chartName">A descriptive name for the chart (used in filenames)</param>
         /// <param name="dataSource">Optional SQL view/table name that populates this chart</param>
-        public static void SetupChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
+        public static ContextMenu SetupChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
         {
             var contextMenu = new ContextMenu();
 
@@ -786,6 +786,8 @@ namespace PerformanceMonitorDashboard.Helpers
                 chart.Plot.Axes.AutoScale();
                 chart.Refresh();
             };
+
+            return contextMenu;
         }
 
         /// <summary>

--- a/Dashboard/Helpers/WaitDrillDownHelper.cs
+++ b/Dashboard/Helpers/WaitDrillDownHelper.cs
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitorDashboard.Helpers;
+
+/// <summary>
+/// Classifies wait types for drill-down behavior and walks blocking chains
+/// to find head blockers. Used by WaitDrillDownWindow.
+/// </summary>
+public static class WaitDrillDownHelper
+{
+    public enum WaitCategory
+    {
+        /// <summary>Wait is too brief to appear in snapshots. Show all queries sorted by correlated metric.</summary>
+        Correlated,
+        /// <summary>Walk blocking chain to find head blockers (LCK_M_*).</summary>
+        Chain,
+        /// <summary>Sessions may lack worker threads, unlikely to appear in snapshots.</summary>
+        Uncapturable,
+        /// <summary>Attempt direct wait_type filter; may return empty for brief waits.</summary>
+        Filtered
+    }
+
+    public sealed record WaitClassification(
+        WaitCategory Category,
+        string SortProperty,
+        string Description
+    );
+
+    /// <summary>
+    /// Lightweight result from the chain walker — just the head blocker identity and blocked count.
+    /// Callers look up the original full row by (CollectionTime, SessionId).
+    /// </summary>
+    public sealed record HeadBlockerInfo(
+        DateTime CollectionTime,
+        int SessionId,
+        int BlockedSessionCount,
+        string BlockingPath
+    );
+
+    public sealed record SnapshotInfo
+    {
+        public int SessionId { get; init; }
+        public int BlockingSessionId { get; init; }
+        public DateTime CollectionTime { get; init; }
+        public string DatabaseName { get; init; } = "";
+        public string Status { get; init; } = "";
+        public string QueryText { get; init; } = "";
+        public string? WaitType { get; init; }
+        public long WaitTimeMs { get; init; }
+        public long CpuTimeMs { get; init; }
+        public long Reads { get; init; }
+        public long Writes { get; init; }
+        public long LogicalReads { get; init; }
+    }
+
+    private const int MaxChainDepth = 20;
+
+    public static WaitClassification Classify(string waitType)
+    {
+        if (string.IsNullOrEmpty(waitType))
+            return new WaitClassification(WaitCategory.Filtered, "WaitTimeMs", "Unknown");
+
+        return waitType switch
+        {
+            "SOS_SCHEDULER_YIELD" =>
+                new(WaitCategory.Correlated, "CpuTimeMs", "CPU pressure — showing high-CPU queries active during this period"),
+            "WRITELOG" =>
+                new(WaitCategory.Correlated, "Writes", "Transaction log writes — showing high-write queries active during this period"),
+            "CXPACKET" or "CXCONSUMER" =>
+                new(WaitCategory.Correlated, "Dop", "Parallelism — showing parallel queries active during this period"),
+            "RESOURCE_SEMAPHORE" or "RESOURCE_SEMAPHORE_QUERY_COMPILE" =>
+                new(WaitCategory.Correlated, "GrantedQueryMemoryGb", "Memory grant pressure — showing high-memory queries active during this period"),
+            "THREADPOOL" =>
+                new(WaitCategory.Uncapturable, "CpuTimeMs", "Thread pool starvation — sessions may not appear in snapshots"),
+            "LATCH_EX" or "LATCH_UP" =>
+                new(WaitCategory.Correlated, "CpuTimeMs", "Latch contention — showing high-CPU queries active during this period"),
+            _ when waitType.StartsWith("PAGEIOLATCH_", StringComparison.OrdinalIgnoreCase) =>
+                new(WaitCategory.Correlated, "Reads", "Disk I/O — showing high-read queries active during this period"),
+            _ when waitType.StartsWith("LCK_M_", StringComparison.OrdinalIgnoreCase) =>
+                new(WaitCategory.Chain, "", "Lock contention — showing head blockers"),
+            _ =>
+                new(WaitCategory.Filtered, "WaitTimeMs", "Filtered by wait type")
+        };
+    }
+
+    /// <summary>
+    /// Walks blocking chains to find head blockers.
+    /// Returns lightweight HeadBlockerInfo records — callers look up original full rows
+    /// by (CollectionTime, SessionId) to preserve all columns.
+    /// </summary>
+    public static List<HeadBlockerInfo> WalkBlockingChains(
+        IEnumerable<SnapshotInfo> waiters,
+        IEnumerable<SnapshotInfo> allSnapshots)
+    {
+        var byTime = allSnapshots
+            .GroupBy(s => s.CollectionTime)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToDictionary(s => s.SessionId));
+
+        var headBlockers = new Dictionary<(DateTime, int), (SnapshotInfo Info, HashSet<int> BlockedSessions)>();
+
+        foreach (var waiter in waiters)
+        {
+            if (!byTime.TryGetValue(waiter.CollectionTime, out var sessionsAtTime))
+                continue;
+
+            var head = FindHeadBlocker(waiter, sessionsAtTime);
+            if (head == null)
+                continue;
+
+            var key = (waiter.CollectionTime, head.SessionId);
+            if (!headBlockers.TryGetValue(key, out var existing))
+            {
+                existing = (head, new HashSet<int>());
+                headBlockers[key] = existing;
+            }
+
+            existing.BlockedSessions.Add(waiter.SessionId);
+        }
+
+        return headBlockers.Values
+            .Select(hb => new HeadBlockerInfo(
+                hb.Info.CollectionTime,
+                hb.Info.SessionId,
+                hb.BlockedSessions.Count,
+                $"Head SPID {hb.Info.SessionId} blocking {hb.BlockedSessions.Count} session(s)"))
+            .OrderByDescending(r => r.BlockedSessionCount)
+            .ThenByDescending(r => r.CollectionTime)
+            .ToList();
+    }
+
+    private static SnapshotInfo? FindHeadBlocker(
+        SnapshotInfo waiter,
+        Dictionary<int, SnapshotInfo> sessionsAtTime)
+    {
+        var visited = new HashSet<int>();
+        var current = waiter;
+
+        for (int depth = 0; depth < MaxChainDepth; depth++)
+        {
+            if (!visited.Add(current.SessionId))
+                return current; // cycle detected — treat current as head
+
+            var blockerId = current.BlockingSessionId;
+
+            // Head blocker: not blocked by anyone, or blocked by self, or blocker not found
+            if (blockerId <= 0 || blockerId == current.SessionId)
+                return current;
+
+            if (!sessionsAtTime.TryGetValue(blockerId, out var blocker))
+                return current; // blocker not in snapshot — treat current as head
+
+            current = blocker;
+        }
+
+        return current; // max depth — treat current as head
+    }
+}

--- a/Dashboard/Models/QuerySnapshotItem.cs
+++ b/Dashboard/Models/QuerySnapshotItem.cs
@@ -45,5 +45,8 @@ namespace PerformanceMonitorDashboard.Models
 
         // Property alias for XAML binding compatibility
         public string? QueryText => SqlText;
+
+        // Chain mode — set by WaitDrillDownWindow when showing head blockers
+        public string ChainBlockingPath { get; set; } = "";
     }
 }

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -690,6 +690,163 @@ namespace PerformanceMonitorDashboard.Services
                     return result == DBNull.Value ? null : result as string;
                 }
 
+                /// <summary>
+                /// Gets query snapshots filtered by wait type for the wait drill-down feature.
+                /// Uses LIKE on wait_info to match sp_WhoIsActive's formatted wait string.
+                /// </summary>
+                public async Task<List<QuerySnapshotItem>> GetQuerySnapshotsByWaitTypeAsync(
+                    string waitType, int hoursBack = 1,
+                    DateTime? fromDate = null, DateTime? toDate = null)
+                {
+                    var items = new List<QuerySnapshotItem>();
+
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    // Check if the view exists
+                    string checkViewQuery = @"
+                        SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                        SELECT 1 FROM sys.views
+                        WHERE name = 'query_snapshots'
+                        AND schema_id = SCHEMA_ID('report')";
+
+                    using var checkCommand = new SqlCommand(checkViewQuery, connection);
+                    var viewExists = await checkCommand.ExecuteScalarAsync();
+
+                    if (viewExists == null)
+                        return items;
+
+                    bool useCustomDates = fromDate.HasValue && toDate.HasValue;
+
+                    // sp_WhoIsActive formats wait_info as "(1x: 349ms)LCK_M_X, (1x: 12ms)..."
+                    // The ')' always precedes the wait type name, so we use '%)WAIT_TYPE%'
+                    // to avoid false positives (e.g., LCK_M_X matching LCK_M_IX)
+                    string query = useCustomDates
+                        ? @"
+                            SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                            SELECT TOP (500)
+                                qs.collection_time,
+                                qs.[dd hh:mm:ss.mss],
+                                qs.session_id,
+                                qs.status,
+                                qs.wait_info,
+                                qs.blocking_session_id,
+                                qs.blocked_session_count,
+                                qs.database_name,
+                                qs.login_name,
+                                qs.host_name,
+                                qs.program_name,
+                                sql_text = CONVERT(nvarchar(max), qs.sql_text),
+                                sql_command = CONVERT(nvarchar(max), qs.sql_command),
+                                qs.CPU,
+                                qs.reads,
+                                qs.writes,
+                                qs.physical_reads,
+                                qs.context_switches,
+                                qs.used_memory,
+                                qs.tempdb_current,
+                                qs.tempdb_allocations,
+                                qs.tran_log_writes,
+                                qs.open_tran_count,
+                                qs.percent_complete,
+                                qs.start_time,
+                                qs.tran_start_time,
+                                qs.request_id,
+                                additional_info = CONVERT(nvarchar(max), qs.additional_info)
+                            FROM report.query_snapshots AS qs
+                            WHERE qs.collection_time >= @from_date
+                            AND   qs.collection_time <= @to_date
+                            AND   CONVERT(nvarchar(max), qs.wait_info) LIKE N'%)' + @wait_type + N'%'
+                            ORDER BY
+                                qs.collection_time DESC,
+                                qs.session_id;"
+                        : @"
+                            SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                            SELECT TOP (500)
+                                qs.collection_time,
+                                qs.[dd hh:mm:ss.mss],
+                                qs.session_id,
+                                qs.status,
+                                qs.wait_info,
+                                qs.blocking_session_id,
+                                qs.blocked_session_count,
+                                qs.database_name,
+                                qs.login_name,
+                                qs.host_name,
+                                qs.program_name,
+                                sql_text = CONVERT(nvarchar(max), qs.sql_text),
+                                sql_command = CONVERT(nvarchar(max), qs.sql_command),
+                                qs.CPU,
+                                qs.reads,
+                                qs.writes,
+                                qs.physical_reads,
+                                qs.context_switches,
+                                qs.used_memory,
+                                qs.tempdb_current,
+                                qs.tempdb_allocations,
+                                qs.tran_log_writes,
+                                qs.open_tran_count,
+                                qs.percent_complete,
+                                qs.start_time,
+                                qs.tran_start_time,
+                                qs.request_id,
+                                additional_info = CONVERT(nvarchar(max), qs.additional_info)
+                            FROM report.query_snapshots AS qs
+                            WHERE qs.collection_time >= DATEADD(HOUR, @hours_back, SYSDATETIME())
+                            AND   CONVERT(nvarchar(max), qs.wait_info) LIKE N'%)' + @wait_type + N'%'
+                            ORDER BY
+                                qs.collection_time DESC,
+                                qs.session_id;";
+
+                    using var command = new SqlCommand(query, connection);
+                    command.CommandTimeout = 120;
+                    command.Parameters.Add(new SqlParameter("@wait_type", SqlDbType.NVarChar, 200) { Value = waitType });
+                    command.Parameters.Add(new SqlParameter("@hours_back", SqlDbType.Int) { Value = -hoursBack });
+                    if (fromDate.HasValue) command.Parameters.Add(new SqlParameter("@from_date", SqlDbType.DateTime2) { Value = fromDate.Value });
+                    if (toDate.HasValue) command.Parameters.Add(new SqlParameter("@to_date", SqlDbType.DateTime2) { Value = toDate.Value });
+
+                    using var reader = await command.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                        items.Add(new QuerySnapshotItem
+                        {
+                            CollectionTime = reader.GetDateTime(0),
+                            Duration = reader.IsDBNull(1) ? string.Empty : reader.GetValue(1)?.ToString() ?? string.Empty,
+                            SessionId = SafeToInt16(reader.GetValue(2), "session_id") ?? 0,
+                            Status = reader.IsDBNull(3) ? null : reader.GetValue(3)?.ToString(),
+                            WaitInfo = reader.IsDBNull(4) ? null : reader.GetValue(4)?.ToString(),
+                            BlockingSessionId = SafeToInt16(reader.GetValue(5), "blocking_session_id"),
+                            BlockedSessionCount = SafeToInt16(reader.GetValue(6), "blocked_session_count"),
+                            DatabaseName = reader.IsDBNull(7) ? null : reader.GetValue(7)?.ToString(),
+                            LoginName = reader.IsDBNull(8) ? null : reader.GetValue(8)?.ToString(),
+                            HostName = reader.IsDBNull(9) ? null : reader.GetValue(9)?.ToString(),
+                            ProgramName = reader.IsDBNull(10) ? null : reader.GetValue(10)?.ToString(),
+                            SqlText = reader.IsDBNull(11) ? null : reader.GetValue(11)?.ToString(),
+                            SqlCommand = reader.IsDBNull(12) ? null : reader.GetValue(12)?.ToString(),
+                            Cpu = SafeToInt64(reader.GetValue(13), "CPU"),
+                            Reads = SafeToInt64(reader.GetValue(14), "reads"),
+                            Writes = SafeToInt64(reader.GetValue(15), "writes"),
+                            PhysicalReads = SafeToInt64(reader.GetValue(16), "physical_reads"),
+                            ContextSwitches = SafeToInt64(reader.GetValue(17), "context_switches"),
+                            UsedMemoryMb = SafeToDecimal(reader.GetValue(18), "used_memory"),
+                            TempdbCurrentMb = SafeToDecimal(reader.GetValue(19), "tempdb_current"),
+                            TempdbAllocations = SafeToDecimal(reader.GetValue(20), "tempdb_allocations"),
+                            TranLogWrites = reader.IsDBNull(21) ? null : reader.GetValue(21)?.ToString(),
+                            OpenTranCount = SafeToInt16(reader.GetValue(22), "open_tran_count"),
+                            PercentComplete = SafeToDecimal(reader.GetValue(23), "percent_complete"),
+                            StartTime = reader.IsDBNull(24) ? null : reader.GetDateTime(24),
+                            TranStartTime = reader.IsDBNull(25) ? null : reader.GetDateTime(25),
+                            RequestId = SafeToInt16(reader.GetValue(26), "request_id"),
+                            AdditionalInfo = reader.IsDBNull(27) ? null : reader.GetValue(27)?.ToString()
+                        });
+                    }
+
+                    return items;
+                }
+
                 public async Task<List<QueryStatsItem>> GetQueryStatsAsync(int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
                 {
                     var items = new List<QueryStatsItem>();

--- a/Dashboard/WaitDrillDownWindow.xaml
+++ b/Dashboard/WaitDrillDownWindow.xaml
@@ -1,0 +1,301 @@
+<Window x:Class="PerformanceMonitorDashboard.WaitDrillDownWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Wait Drill-Down" Width="1500" Height="700"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,6">
+            <TextBlock x:Name="HeaderText" FontSize="16" FontWeight="Bold"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0"
+                       Foreground="{DynamicResource ForegroundDimBrush}"/>
+        </StackPanel>
+
+        <!-- Warning banner (hidden by default) -->
+        <Border x:Name="WarningBanner" Grid.Row="1" Background="#3D332200"
+                BorderBrush="#665C3300" BorderThickness="1" CornerRadius="3"
+                Padding="8,4" Margin="0,0,0,6" Visibility="Collapsed">
+            <TextBlock x:Name="WarningText" FontSize="11"
+                       Foreground="#FFCC66" TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="ResultsDataGrid"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserSortColumns="True" CanUserReorderColumns="True" CanUserResizeColumns="True"
+                  GridLinesVisibility="Horizontal"
+                  ScrollViewer.CanContentScroll="True"
+                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                  RowStyle="{DynamicResource DefaultRowStyle}"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Collected" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="60">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Duration}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Duration" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Duration" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Status}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding WaitInfo}" Width="180">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitInfo" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Wait Info" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding BlockedSessionCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedSessionCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Blocked" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Cpu}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Cpu" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding PhysicalReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ContextSwitches}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ContextSwitches" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Ctx Switches" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="UsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbCurrentMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="TempDB Cur (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocations" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="TempDB Alloc" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogWrites" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Tran Log" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding OpenTranCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTranCount" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Open Tran" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat='{}{0:N1}%'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="% Complete" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding StartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Start Time" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranStartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranStartTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Tran Start" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestId" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Req ID" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding HostName}" Width="120">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ProgramName}" Width="140">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ProgramName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Program" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTemplateColumn Width="500">
+                    <DataGridTemplateColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
+                                       ToolTip="{Binding QueryText}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Width="300">
+                    <DataGridTemplateColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlCommand" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="SQL Command" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding SqlCommand}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
+                                       ToolTip="{Binding SqlCommand}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <Border Grid.Row="3" Background="{DynamicResource BackgroundLightBrush}" Padding="10" Margin="0,10,0,0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Close" Width="100" Height="30" Click="Close_Click"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Dashboard/WaitDrillDownWindow.xaml.cs
+++ b/Dashboard/WaitDrillDownWindow.xaml.cs
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using static PerformanceMonitorDashboard.Helpers.WaitDrillDownHelper;
+
+namespace PerformanceMonitorDashboard;
+
+public partial class WaitDrillDownWindow : Window
+{
+    private readonly DatabaseService _databaseService;
+    private readonly string _waitType;
+    private readonly int _hoursBack;
+    private readonly DateTime? _fromDate;
+    private readonly DateTime? _toDate;
+
+    // Filter state
+    private Dictionary<string, ColumnFilterState> _filters = new();
+    private List<QuerySnapshotItem>? _unfilteredData;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public WaitDrillDownWindow(
+        DatabaseService databaseService,
+        string waitType,
+        int hoursBack,
+        DateTime? fromDate = null,
+        DateTime? toDate = null)
+    {
+        InitializeComponent();
+        _databaseService = databaseService;
+        _waitType = waitType;
+        _hoursBack = hoursBack;
+        _fromDate = fromDate;
+        _toDate = toDate;
+
+        Title = $"Wait Drill-Down: {waitType}";
+
+        var classification = Classify(waitType);
+        HeaderText.Text = classification.Category == WaitCategory.Correlated
+            ? $"Queries active during {waitType} spike"
+            : $"Queries experiencing {waitType}";
+
+        Loaded += async (_, _) => await LoadDataAsync();
+        ThemeManager.ThemeChanged += OnThemeChanged;
+        Closed += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private async System.Threading.Tasks.Task LoadDataAsync()
+    {
+        SummaryText.Text = "Loading...";
+
+        try
+        {
+            var classification = Classify(_waitType);
+            SetWarningBanner(classification);
+
+            List<QuerySnapshotItem> data;
+            if (classification.Category == WaitCategory.Correlated || classification.Category == WaitCategory.Uncapturable)
+            {
+                // Fetch ALL queries in time range (no wait type filter)
+                data = await _databaseService.GetQuerySnapshotsAsync(_hoursBack, _fromDate, _toDate);
+            }
+            else
+            {
+                data = await _databaseService.GetQuerySnapshotsByWaitTypeAsync(
+                    _waitType, _hoursBack, _fromDate, _toDate);
+            }
+
+            if (data.Count == 0)
+            {
+                SummaryText.Text = classification.Category == WaitCategory.Correlated
+                    ? "No query snapshots found in the selected time range."
+                    : $"No query-level data found for {_waitType} in the selected time range.";
+                return;
+            }
+
+            if (classification.Category == WaitCategory.Chain)
+            {
+                LoadChainData(data, classification);
+            }
+            else
+            {
+                LoadDirectData(data, classification);
+            }
+        }
+        catch (Exception ex)
+        {
+            SummaryText.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private void LoadDirectData(List<QuerySnapshotItem> data, WaitClassification classification)
+    {
+        data = SortByProperty(data, classification.SortProperty);
+        _unfilteredData = data;
+        _filters.Clear();
+        ResultsDataGrid.ItemsSource = data;
+        UpdateFilterButtonStyles();
+
+        var timeRange = GetTimeRangeDescription(data);
+        var truncated = data.Count >= 500 ? " (limited to 500 rows)" : "";
+        SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange}{truncated}";
+
+        ApplyInitialSort(classification.SortProperty);
+    }
+
+    private void LoadChainData(List<QuerySnapshotItem> data, WaitClassification classification)
+    {
+        // Map QuerySnapshotItem to SnapshotInfo for chain walker
+        var allInfos = data.Select(ToSnapshotInfo).ToList();
+
+        // For Dashboard, all returned rows already have the target wait type (filtered server-side)
+        // so they're all "waiters" — use all of them for chain walking
+        var headBlockerInfos = WalkBlockingChains(allInfos, allInfos);
+
+        if (headBlockerInfos.Count == 0)
+        {
+            // No chain found — fall back to showing direct data
+            _unfilteredData = data;
+            _filters.Clear();
+            ResultsDataGrid.ItemsSource = data;
+            UpdateFilterButtonStyles();
+            var timeRange = GetTimeRangeDescription(data);
+            SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange} | No blocking chains found, showing waiters";
+            return;
+        }
+
+        // Look up original full rows for each head blocker and set chain metadata
+        var snapshotLookup = data
+            .GroupBy(s => (s.CollectionTime, (int)s.SessionId))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var headBlockerRows = new List<QuerySnapshotItem>();
+        foreach (var hb in headBlockerInfos)
+        {
+            if (snapshotLookup.TryGetValue((hb.CollectionTime, hb.SessionId), out var row))
+            {
+                row.ChainBlockingPath = hb.BlockingPath;
+                // Overwrite BlockedSessionCount with chain walker's count
+                row.BlockedSessionCount = (short)Math.Min(hb.BlockedSessionCount, short.MaxValue);
+                headBlockerRows.Add(row);
+            }
+        }
+
+        if (headBlockerRows.Count == 0)
+        {
+            // Head blockers not in data — show original data
+            _unfilteredData = data;
+            _filters.Clear();
+            ResultsDataGrid.ItemsSource = data;
+            UpdateFilterButtonStyles();
+            var timeRange = GetTimeRangeDescription(data);
+            SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange} | Head blockers not in snapshots, showing waiters";
+            return;
+        }
+
+        // Insert chain-specific columns into the existing XAML columns
+        InsertChainColumns();
+
+        _unfilteredData = headBlockerRows;
+        _filters.Clear();
+        ResultsDataGrid.ItemsSource = headBlockerRows;
+        UpdateFilterButtonStyles();
+
+        var timeRangeDesc = GetTimeRangeDescription(headBlockerRows);
+        SummaryText.Text = $"{headBlockerRows.Count} head blocker(s) from {data.Count} waiting session(s) | " +
+                           $"{classification.Description} | {timeRangeDesc}";
+    }
+
+    private void InsertChainColumns()
+    {
+        // Insert "Blocking Path" column at the beginning — BlockedSessionCount already exists in the XAML columns
+        var blockingPathCol = CreateFilterColumn("Blocking Path", "ChainBlockingPath", 250);
+        ResultsDataGrid.Columns.Insert(0, blockingPathCol);
+    }
+
+    private DataGridTextColumn CreateFilterColumn(string headerText, string bindingPath, int width,
+        bool isNumeric = false, string? stringFormat = null)
+    {
+        var filterButton = new Button { Tag = bindingPath, Margin = new Thickness(0, 0, 4, 0) };
+        filterButton.SetResourceReference(StyleProperty, "ColumnFilterButtonStyle");
+        filterButton.Click += Filter_Click;
+
+        var header = new StackPanel { Orientation = Orientation.Horizontal };
+        header.Children.Add(filterButton);
+        header.Children.Add(new System.Windows.Controls.TextBlock
+        {
+            Text = headerText,
+            FontWeight = FontWeights.Bold,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+
+        var binding = new System.Windows.Data.Binding(bindingPath);
+        if (stringFormat != null) binding.StringFormat = stringFormat;
+
+        var column = new DataGridTextColumn
+        {
+            Header = header,
+            Binding = binding,
+            Width = new DataGridLength(width)
+        };
+
+        if (isNumeric)
+        {
+            var numericStyle = (Style?)FindResource("NumericCell");
+            if (numericStyle != null) column.ElementStyle = numericStyle;
+        }
+
+        return column;
+    }
+
+    private void SetWarningBanner(WaitClassification classification)
+    {
+        if (classification.Category == WaitCategory.Uncapturable)
+        {
+            WarningText.Text = $"Sessions experiencing {_waitType} waits may not be captured in query snapshots " +
+                               "because they may lack assigned worker threads. Showing all queries in this time range.";
+            WarningBanner.Visibility = Visibility.Visible;
+        }
+        else if (classification.Category == WaitCategory.Correlated)
+        {
+            WarningText.Text = $"{_waitType} waits are too brief to appear in query snapshots. " +
+                               "Showing all queries active during this period, sorted by the most correlated metric.";
+            WarningBanner.Visibility = Visibility.Visible;
+            WarningBanner.Background = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x3D, 0x00, 0x33, 0x66));
+            WarningBanner.BorderBrush = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x66, 0x00, 0x55, 0x99));
+            WarningText.Foreground = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromRgb(0x66, 0xBB, 0xFF));
+        }
+        else if (classification.Category == WaitCategory.Chain)
+        {
+            WarningText.Text = $"Showing head blockers (the cause of {_waitType} waits), not the waiting sessions themselves.";
+            WarningBanner.Visibility = Visibility.Visible;
+            WarningBanner.Background = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x3D, 0x00, 0x33, 0x66));
+            WarningBanner.BorderBrush = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x66, 0x00, 0x55, 0x99));
+            WarningText.Foreground = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromRgb(0x66, 0xBB, 0xFF));
+        }
+    }
+
+    private static SnapshotInfo ToSnapshotInfo(QuerySnapshotItem item) => new()
+    {
+        SessionId = item.SessionId,
+        BlockingSessionId = item.BlockingSessionId ?? 0,
+        CollectionTime = item.CollectionTime,
+        DatabaseName = item.DatabaseName ?? "",
+        Status = item.Status ?? "",
+        QueryText = item.SqlText ?? "",
+        WaitType = item.WaitInfo,
+        WaitTimeMs = 0, // Dashboard wait_info is formatted text, no separate ms column
+        CpuTimeMs = item.Cpu ?? 0,
+        Reads = item.Reads ?? 0,
+        Writes = item.Writes ?? 0,
+        LogicalReads = 0 // Not available in Dashboard snapshot model
+    };
+
+    private static List<QuerySnapshotItem> SortByProperty(List<QuerySnapshotItem> data, string property) =>
+        property switch
+        {
+            "CpuTimeMs" => data.OrderByDescending(r => r.Cpu ?? 0).ToList(),
+            "Reads" => data.OrderByDescending(r => r.Reads ?? 0).ToList(),
+            "Writes" => data.OrderByDescending(r => r.Writes ?? 0).ToList(),
+            "Dop" => data, // Dashboard snapshots don't have a DOP column
+            "GrantedQueryMemoryGb" => data.OrderByDescending(r => r.UsedMemoryMb ?? 0).ToList(),
+            "WaitTimeMs" => data, // wait_info is text, can't sort numerically
+            _ => data
+        };
+
+    private void ApplyInitialSort(string property)
+    {
+        var columnHeader = property switch
+        {
+            "CpuTimeMs" => "CPU (ms)",
+            "Reads" => "Reads (pages)",
+            "Writes" => "Writes (pages)",
+            "GrantedQueryMemoryGb" => "Used Mem (MB)",
+            _ => null
+        };
+
+        if (columnHeader == null) return;
+
+        foreach (var column in ResultsDataGrid.Columns)
+        {
+            if (column.Header is StackPanel sp)
+            {
+                var textBlock = sp.Children.OfType<System.Windows.Controls.TextBlock>().FirstOrDefault();
+                if (textBlock?.Text == columnHeader)
+                {
+                    column.SortDirection = ListSortDirection.Descending;
+                    break;
+                }
+            }
+        }
+    }
+
+    private static string GetTimeRangeDescription(List<QuerySnapshotItem> data)
+    {
+        if (data.Count == 0) return "";
+        var first = data.Min(r => r.CollectionTime);
+        var last = data.Max(r => r.CollectionTime);
+        return $"{ServerTimeHelper.ConvertForDisplay(first, ServerTimeHelper.CurrentDisplayMode):MM/dd HH:mm} to " +
+               $"{ServerTimeHelper.ConvertForDisplay(last, ServerTimeHelper.CurrentDisplayMode):MM/dd HH:mm}";
+    }
+
+    private void OnThemeChanged(string _)
+    {
+        UpdateFilterButtonStyles();
+    }
+
+    #region Column Filter Popup
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+            _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+
+        _filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent!.Initialize(columnName, existingFilter);
+
+        _filterPopup.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+
+        if (e.FilterState.IsActive)
+            _filters[e.FilterState.ColumnName] = e.FilterState;
+        else
+            _filters.Remove(e.FilterState.ColumnName);
+
+        ApplyFilters();
+        UpdateFilterButtonStyles();
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+    }
+
+    private void ApplyFilters()
+    {
+        if (_unfilteredData == null) return;
+
+        if (_filters.Count == 0)
+        {
+            ResultsDataGrid.ItemsSource = _unfilteredData;
+            return;
+        }
+
+        var filtered = _unfilteredData.Where(item =>
+        {
+            foreach (var filter in _filters.Values)
+            {
+                if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
+                    return false;
+            }
+            return true;
+        }).ToList();
+
+        ResultsDataGrid.ItemsSource = filtered;
+    }
+
+    private void UpdateFilterButtonStyles()
+    {
+        foreach (var column in ResultsDataGrid.Columns)
+        {
+            if (column.Header is StackPanel stackPanel)
+            {
+                var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
+                if (filterButton?.Tag is string columnName)
+                {
+                    bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
+                    filterButton.Content = new System.Windows.Controls.TextBlock
+                    {
+                        Text = "\uE71C",
+                        FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+                        Foreground = hasActive
+                            ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
+                            : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
+                    };
+                    filterButton.ToolTip = hasActive && filter != null
+                        ? $"Filter: {filter.DisplayText}\n(Click to modify)"
+                        : "Click to filter";
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region Context Menu Handlers
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+            if (dataGrid != null && dataGrid.CurrentCell.Item != null)
+            {
+                var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
+                if (!string.IsNullOrEmpty(cellContent))
+                    Clipboard.SetDataObject(cellContent, false);
+            }
+        }
+    }
+
+    private void CopyRow_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+            if (dataGrid?.SelectedItem != null)
+                Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
+        }
+    }
+
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+            if (dataGrid != null && dataGrid.Items.Count > 0)
+            {
+                var sb = new StringBuilder();
+                var headers = new List<string>();
+                foreach (var column in dataGrid.Columns)
+                {
+                    if (column is DataGridBoundColumn)
+                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
+                }
+                sb.AppendLine(string.Join("\t", headers));
+                foreach (var item in dataGrid.Items)
+                    sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
+                Clipboard.SetDataObject(sb.ToString(), false);
+            }
+        }
+    }
+
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+            if (dataGrid != null && dataGrid.Items.Count > 0)
+            {
+                var dialog = new SaveFileDialog
+                {
+                    FileName = $"wait_drill_down_{_waitType}_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+                    DefaultExt = ".csv",
+                    Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
+                };
+
+                if (dialog.ShowDialog() == true)
+                {
+                    try
+                    {
+                        var sb = new StringBuilder();
+                        var headers = new List<string>();
+                        foreach (var column in dataGrid.Columns)
+                        {
+                            if (column is DataGridBoundColumn)
+                                headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
+                        }
+                        sb.AppendLine(string.Join(",", headers));
+                        foreach (var item in dataGrid.Items)
+                        {
+                            var values = TabHelpers.GetRowValues(dataGrid, item);
+                            sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
+                        }
+                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Export failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -209,7 +209,8 @@ public partial class ServerTab : UserControl
         _currentWaitsBlockedHover = new Helpers.ChartHoverHelper(CurrentWaitsBlockedChart, "sessions");
 
         /* Chart context menus (right-click save/export) */
-        Helpers.ContextMenuHelper.SetupChartContextMenu(WaitStatsChart, "Wait_Stats");
+        var waitStatsMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(WaitStatsChart, "Wait_Stats");
+        AddWaitDrillDownMenuItem(WaitStatsChart, waitStatsMenu);
         Helpers.ContextMenuHelper.SetupChartContextMenu(QueryDurationTrendChart, "Query_Duration_Trends");
         Helpers.ContextMenuHelper.SetupChartContextMenu(ProcDurationTrendChart, "Procedure_Duration_Trends");
         Helpers.ContextMenuHelper.SetupChartContextMenu(QueryStoreDurationTrendChart, "QueryStore_Duration_Trends");
@@ -1733,6 +1734,48 @@ public partial class ServerTab : UserControl
         if (_isUpdatingWaitTypeSelection) return;
         RefreshWaitTypeListOrder();
         _ = UpdateWaitStatsChartFromPickerAsync();
+    }
+
+    private void AddWaitDrillDownMenuItem(ScottPlot.WPF.WpfPlot chart, ContextMenu contextMenu)
+    {
+        contextMenu.Items.Insert(0, new Separator());
+        var drillDownItem = new MenuItem { Header = "Show Queries With This Wait" };
+        drillDownItem.Click += ShowQueriesForWaitType_Click;
+        contextMenu.Items.Insert(0, drillDownItem);
+
+        contextMenu.Opened += (s, _) =>
+        {
+            if (s is not ContextMenu cm) return;
+            var pos = System.Windows.Input.Mouse.GetPosition(chart);
+            var nearest = _waitStatsHover?.GetNearestSeries(pos);
+            if (nearest.HasValue)
+            {
+                drillDownItem.Tag = (nearest.Value.Label, nearest.Value.Time);
+                drillDownItem.Header = $"Show Queries With {nearest.Value.Label.Replace("_", "__")}";
+                drillDownItem.IsEnabled = true;
+            }
+            else
+            {
+                drillDownItem.Tag = null;
+                drillDownItem.Header = "Show Queries With This Wait";
+                drillDownItem.IsEnabled = false;
+            }
+        };
+    }
+
+    private void ShowQueriesForWaitType_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        if (menuItem.Tag is not (string waitType, DateTime time)) return;
+
+        // ±15 minute window around the clicked point (already in server local time from chart)
+        var fromDate = time.AddMinutes(-15);
+        var toDate = time.AddMinutes(15);
+
+        var window = new Windows.WaitDrillDownWindow(
+            _dataService, _serverId, waitType, 1, fromDate, toDate);
+        window.Owner = Window.GetWindow(this);
+        window.ShowDialog();
     }
 
     private async System.Threading.Tasks.Task UpdateWaitStatsChartFromPickerAsync()

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -61,6 +61,45 @@ internal sealed class ChartHoverHelper
     public void Add(ScottPlot.Plottables.Scatter scatter, string label) =>
         _scatters.Add((scatter, label));
 
+    /// <summary>
+    /// Returns the nearest series label and data-point time for the given mouse position,
+    /// or null if no series is close enough.
+    /// </summary>
+    public (string Label, DateTime Time)? GetNearestSeries(Point mousePos)
+    {
+        if (_scatters.Count == 0) return null;
+        var dpi = VisualTreeHelper.GetDpi(_chart);
+        var pixel = new ScottPlot.Pixel(
+            (float)(mousePos.X * dpi.DpiScaleX),
+            (float)(mousePos.Y * dpi.DpiScaleY));
+        var mouseCoords = _chart.Plot.GetCoordinates(pixel);
+
+        double bestDistance = double.MaxValue;
+        ScottPlot.DataPoint bestPoint = default;
+        string bestLabel = "";
+
+        foreach (var (scatter, label) in _scatters)
+        {
+            var nearest = scatter.Data.GetNearest(mouseCoords, _chart.Plot.LastRender);
+            if (!nearest.IsReal) continue;
+            var nearestPixel = _chart.Plot.GetPixel(
+                new ScottPlot.Coordinates(nearest.X, nearest.Y));
+            double dx = nearestPixel.X - pixel.X;
+            double dy = nearestPixel.Y - pixel.Y;
+            double dist = dx * dx + dy * dy;
+            if (dist < bestDistance)
+            {
+                bestDistance = dist;
+                bestPoint = nearest;
+                bestLabel = label;
+            }
+        }
+
+        if (bestPoint.IsReal && bestDistance < 2500) // ~50px radius
+            return (bestLabel, DateTime.FromOADate(bestPoint.X));
+        return null;
+    }
+
     private void OnMouseMove(object sender, MouseEventArgs e)
     {
         if (_scatters.Count == 0) return;

--- a/Lite/Helpers/ContextMenuHelper.cs
+++ b/Lite/Helpers/ContextMenuHelper.cs
@@ -181,7 +181,7 @@ public static class ContextMenuHelper
     /// Sets up a context menu for a ScottPlot chart with standard options:
     /// Copy Image, Save Image As, Open in New Window, Revert, Export Data to CSV.
     /// </summary>
-    public static void SetupChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
+    public static ContextMenu SetupChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
     {
         var contextMenu = new ContextMenu();
 
@@ -369,5 +369,7 @@ public static class ContextMenuHelper
             chart.Plot.Axes.AutoScale();
             chart.Refresh();
         };
+
+        return contextMenu;
     }
 }

--- a/Lite/Helpers/WaitDrillDownHelper.cs
+++ b/Lite/Helpers/WaitDrillDownHelper.cs
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Classifies wait types for drill-down behavior and walks blocking chains
+/// to find head blockers. Used by WaitDrillDownWindow.
+/// </summary>
+public static class WaitDrillDownHelper
+{
+    public enum WaitCategory
+    {
+        /// <summary>Wait is too brief to appear in snapshots. Show all queries sorted by correlated metric.</summary>
+        Correlated,
+        /// <summary>Walk blocking chain to find head blockers (LCK_M_*).</summary>
+        Chain,
+        /// <summary>Sessions may lack worker threads, unlikely to appear in snapshots.</summary>
+        Uncapturable,
+        /// <summary>Attempt direct wait_type filter; may return empty for brief waits.</summary>
+        Filtered
+    }
+
+    public sealed record WaitClassification(
+        WaitCategory Category,
+        string SortProperty,
+        string Description
+    );
+
+    /// <summary>
+    /// Lightweight result from the chain walker — just the head blocker identity and blocked count.
+    /// Callers look up the original full row by (CollectionTime, SessionId).
+    /// </summary>
+    public sealed record HeadBlockerInfo(
+        DateTime CollectionTime,
+        int SessionId,
+        int BlockedSessionCount,
+        string BlockingPath
+    );
+
+    public sealed record SnapshotInfo
+    {
+        public int SessionId { get; init; }
+        public int BlockingSessionId { get; init; }
+        public DateTime CollectionTime { get; init; }
+        public string DatabaseName { get; init; } = "";
+        public string Status { get; init; } = "";
+        public string QueryText { get; init; } = "";
+        public string? WaitType { get; init; }
+        public long WaitTimeMs { get; init; }
+        public long CpuTimeMs { get; init; }
+        public long Reads { get; init; }
+        public long Writes { get; init; }
+        public long LogicalReads { get; init; }
+    }
+
+    private const int MaxChainDepth = 20;
+
+    public static WaitClassification Classify(string waitType)
+    {
+        if (string.IsNullOrEmpty(waitType))
+            return new WaitClassification(WaitCategory.Filtered, "WaitTimeMs", "Unknown");
+
+        return waitType switch
+        {
+            "SOS_SCHEDULER_YIELD" =>
+                new(WaitCategory.Correlated, "CpuTimeMs", "CPU pressure — showing high-CPU queries active during this period"),
+            "WRITELOG" =>
+                new(WaitCategory.Correlated, "Writes", "Transaction log writes — showing high-write queries active during this period"),
+            "CXPACKET" or "CXCONSUMER" =>
+                new(WaitCategory.Correlated, "Dop", "Parallelism — showing parallel queries active during this period"),
+            "RESOURCE_SEMAPHORE" or "RESOURCE_SEMAPHORE_QUERY_COMPILE" =>
+                new(WaitCategory.Correlated, "GrantedQueryMemoryGb", "Memory grant pressure — showing high-memory queries active during this period"),
+            "THREADPOOL" =>
+                new(WaitCategory.Uncapturable, "CpuTimeMs", "Thread pool starvation — sessions may not appear in snapshots"),
+            "LATCH_EX" or "LATCH_UP" =>
+                new(WaitCategory.Correlated, "CpuTimeMs", "Latch contention — showing high-CPU queries active during this period"),
+            _ when waitType.StartsWith("PAGEIOLATCH_", StringComparison.OrdinalIgnoreCase) =>
+                new(WaitCategory.Correlated, "Reads", "Disk I/O — showing high-read queries active during this period"),
+            _ when waitType.StartsWith("LCK_M_", StringComparison.OrdinalIgnoreCase) =>
+                new(WaitCategory.Chain, "", "Lock contention — showing head blockers"),
+            _ =>
+                new(WaitCategory.Filtered, "WaitTimeMs", "Filtered by wait type")
+        };
+    }
+
+    /// <summary>
+    /// Walks blocking chains to find head blockers.
+    /// Returns lightweight HeadBlockerInfo records — callers look up original full rows
+    /// by (CollectionTime, SessionId) to preserve all columns.
+    /// </summary>
+    public static List<HeadBlockerInfo> WalkBlockingChains(
+        IEnumerable<SnapshotInfo> waiters,
+        IEnumerable<SnapshotInfo> allSnapshots)
+    {
+        var byTime = allSnapshots
+            .GroupBy(s => s.CollectionTime)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToDictionary(s => s.SessionId));
+
+        var headBlockers = new Dictionary<(DateTime, int), (SnapshotInfo Info, HashSet<int> BlockedSessions)>();
+
+        foreach (var waiter in waiters)
+        {
+            if (!byTime.TryGetValue(waiter.CollectionTime, out var sessionsAtTime))
+                continue;
+
+            var head = FindHeadBlocker(waiter, sessionsAtTime);
+            if (head == null)
+                continue;
+
+            var key = (waiter.CollectionTime, head.SessionId);
+            if (!headBlockers.TryGetValue(key, out var existing))
+            {
+                existing = (head, new HashSet<int>());
+                headBlockers[key] = existing;
+            }
+
+            existing.BlockedSessions.Add(waiter.SessionId);
+        }
+
+        return headBlockers.Values
+            .Select(hb => new HeadBlockerInfo(
+                hb.Info.CollectionTime,
+                hb.Info.SessionId,
+                hb.BlockedSessions.Count,
+                $"Head SPID {hb.Info.SessionId} blocking {hb.BlockedSessions.Count} session(s)"))
+            .OrderByDescending(r => r.BlockedSessionCount)
+            .ThenByDescending(r => r.CollectionTime)
+            .ToList();
+    }
+
+    private static SnapshotInfo? FindHeadBlocker(
+        SnapshotInfo waiter,
+        Dictionary<int, SnapshotInfo> sessionsAtTime)
+    {
+        var visited = new HashSet<int>();
+        var current = waiter;
+
+        for (int depth = 0; depth < MaxChainDepth; depth++)
+        {
+            if (!visited.Add(current.SessionId))
+                return current; // cycle detected — treat current as head
+
+            var blockerId = current.BlockingSessionId;
+
+            // Head blocker: not blocked by anyone, or blocked by self, or blocker not found
+            if (blockerId <= 0 || blockerId == current.SessionId)
+                return current;
+
+            if (!sessionsAtTime.TryGetValue(blockerId, out var blocker))
+                return current; // blocker not in snapshot — treat current as head
+
+            current = blocker;
+        }
+
+        return current; // max depth — treat current as head
+    }
+}

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -788,4 +788,8 @@ public class QuerySnapshotRow
     public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlan);
     public bool HasLiveQueryPlan => !string.IsNullOrEmpty(LiveQueryPlan);
     public string CollectionTimeLocal => CollectionTime == DateTime.MinValue ? "" : ServerTimeHelper.FormatServerTime(CollectionTime);
+
+    // Chain mode — set by WaitDrillDownWindow when showing head blockers
+    public int ChainBlockedCount { get; set; }
+    public string ChainBlockingPath { get; set; } = "";
 }

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -192,6 +192,188 @@ LIMIT 3";
     }
 
     /// <summary>
+    /// Gets query snapshots filtered by wait type, for the wait drill-down feature.
+    /// Returns sessions that were experiencing the specified wait type during the time range.
+    /// </summary>
+    public async Task<List<QuerySnapshotRow>> GetQuerySnapshotsByWaitTypeAsync(
+        int serverId, string waitType, int hoursBack = 24,
+        DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    session_id,
+    database_name,
+    elapsed_time_formatted,
+    query_text,
+    status,
+    blocking_session_id,
+    wait_type,
+    wait_time_ms,
+    wait_resource,
+    cpu_time_ms,
+    total_elapsed_time_ms,
+    reads,
+    writes,
+    logical_reads,
+    granted_query_memory_gb,
+    transaction_isolation_level,
+    dop,
+    parallel_worker_count,
+    query_plan,
+    live_query_plan,
+    collection_time,
+    login_name,
+    host_name,
+    program_name,
+    open_transaction_count,
+    percent_complete
+FROM v_query_snapshots
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   wait_type = $4
+ORDER BY wait_time_ms DESC
+LIMIT 500";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+        command.Parameters.Add(new DuckDBParameter { Value = waitType });
+
+        var items = new List<QuerySnapshotRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new QuerySnapshotRow
+            {
+                SessionId = reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                ElapsedTimeFormatted = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                QueryText = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                Status = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                BlockingSessionId = reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+                WaitType = reader.IsDBNull(6) ? "" : reader.GetString(6),
+                WaitTimeMs = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                WaitResource = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                CpuTimeMs = reader.IsDBNull(9) ? 0 : reader.GetInt64(9),
+                TotalElapsedTimeMs = reader.IsDBNull(10) ? 0 : reader.GetInt64(10),
+                Reads = reader.IsDBNull(11) ? 0 : reader.GetInt64(11),
+                Writes = reader.IsDBNull(12) ? 0 : reader.GetInt64(12),
+                LogicalReads = reader.IsDBNull(13) ? 0 : reader.GetInt64(13),
+                GrantedQueryMemoryGb = reader.IsDBNull(14) ? 0 : ToDouble(reader.GetValue(14)),
+                TransactionIsolationLevel = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                Dop = reader.IsDBNull(16) ? 0 : reader.GetInt32(16),
+                ParallelWorkerCount = reader.IsDBNull(17) ? 0 : reader.GetInt32(17),
+                QueryPlan = reader.IsDBNull(18) ? null : reader.GetString(18),
+                LiveQueryPlan = reader.IsDBNull(19) ? null : reader.GetString(19),
+                CollectionTime = reader.IsDBNull(20) ? DateTime.MinValue : reader.GetDateTime(20),
+                LoginName = reader.IsDBNull(21) ? "" : reader.GetString(21),
+                HostName = reader.IsDBNull(22) ? "" : reader.GetString(22),
+                ProgramName = reader.IsDBNull(23) ? "" : reader.GetString(23),
+                OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
+                PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25))
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets ALL query snapshots in a time range (for chain walking).
+    /// Used when a chain wait type (LCK_M_*, LATCH_EX/UP) needs blocking chain traversal.
+    /// </summary>
+    public async Task<List<QuerySnapshotRow>> GetAllQuerySnapshotsInRangeAsync(
+        int serverId, int hoursBack = 24,
+        DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    session_id,
+    database_name,
+    elapsed_time_formatted,
+    query_text,
+    status,
+    blocking_session_id,
+    wait_type,
+    wait_time_ms,
+    wait_resource,
+    cpu_time_ms,
+    total_elapsed_time_ms,
+    reads,
+    writes,
+    logical_reads,
+    granted_query_memory_gb,
+    transaction_isolation_level,
+    dop,
+    parallel_worker_count,
+    query_plan,
+    live_query_plan,
+    collection_time,
+    login_name,
+    host_name,
+    program_name,
+    open_transaction_count,
+    percent_complete
+FROM v_query_snapshots
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+ORDER BY collection_time DESC
+LIMIT 2000";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<QuerySnapshotRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new QuerySnapshotRow
+            {
+                SessionId = reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                ElapsedTimeFormatted = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                QueryText = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                Status = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                BlockingSessionId = reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+                WaitType = reader.IsDBNull(6) ? "" : reader.GetString(6),
+                WaitTimeMs = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                WaitResource = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                CpuTimeMs = reader.IsDBNull(9) ? 0 : reader.GetInt64(9),
+                TotalElapsedTimeMs = reader.IsDBNull(10) ? 0 : reader.GetInt64(10),
+                Reads = reader.IsDBNull(11) ? 0 : reader.GetInt64(11),
+                Writes = reader.IsDBNull(12) ? 0 : reader.GetInt64(12),
+                LogicalReads = reader.IsDBNull(13) ? 0 : reader.GetInt64(13),
+                GrantedQueryMemoryGb = reader.IsDBNull(14) ? 0 : ToDouble(reader.GetValue(14)),
+                TransactionIsolationLevel = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                Dop = reader.IsDBNull(16) ? 0 : reader.GetInt32(16),
+                ParallelWorkerCount = reader.IsDBNull(17) ? 0 : reader.GetInt32(17),
+                QueryPlan = reader.IsDBNull(18) ? null : reader.GetString(18),
+                LiveQueryPlan = reader.IsDBNull(19) ? null : reader.GetString(19),
+                CollectionTime = reader.IsDBNull(20) ? DateTime.MinValue : reader.GetDateTime(20),
+                LoginName = reader.IsDBNull(21) ? "" : reader.GetString(21),
+                HostName = reader.IsDBNull(22) ? "" : reader.GetString(22),
+                ProgramName = reader.IsDBNull(23) ? "" : reader.GetString(23),
+                OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
+                PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25))
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
     /// Gets long-running queries from the latest collection snapshot.
     /// Returns sessions whose total elapsed time exceeds the given threshold.
     /// </summary>

--- a/Lite/Windows/WaitDrillDownWindow.xaml
+++ b/Lite/Windows/WaitDrillDownWindow.xaml
@@ -1,0 +1,145 @@
+<Window x:Class="PerformanceMonitorLite.Windows.WaitDrillDownWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Wait Drill-Down" Width="1400" Height="700"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,6">
+            <TextBlock x:Name="HeaderText" FontSize="16" FontWeight="Bold"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0"
+                       Foreground="{DynamicResource ForegroundDimBrush}"/>
+        </StackPanel>
+
+        <!-- Warning banner (hidden by default) -->
+        <Border x:Name="WarningBanner" Grid.Row="1" Background="#3D332200"
+                BorderBrush="#665C3300" BorderThickness="1" CornerRadius="3"
+                Padding="8,4" Margin="0,0,0,6" Visibility="Collapsed">
+            <TextBlock x:Name="WarningText" FontSize="11"
+                       Foreground="#FFCC66" TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="ResultsDataGrid"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                  CanUserSortColumns="True" CanUserReorderColumns="True" CanUserResizeColumns="True"
+                  ScrollViewer.CanContentScroll="True"
+                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="55">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CollectionTimeLocal}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTimeLocal" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Collected" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LoginName}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding HostName}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ProgramName}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ProgramName" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Program" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Status}" Width="80">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ElapsedTimeFormatted}" Width="120">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ElapsedTimeFormatted" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Elapsed" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LogicalReads" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Reads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Writes, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding WaitType}" Width="120">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitType" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Wait Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTimeMs" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Wait (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding WaitResource}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitResource" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Wait Resource" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding Dop}" ElementStyle="{StaticResource NumericCell}" Width="45">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Dop" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ParallelWorkerCount}" ElementStyle="{StaticResource NumericCell}" Width="60">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ParallelWorkerCount" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Workers" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat=F2}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedQueryMemoryGb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Memory (GB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionIsolationLevel" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Isolation" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding OpenTransactionCount}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTransactionCount" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Open Tran" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat=F1}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="% Done" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTemplateColumn Width="500">
+                    <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
+                                       ToolTip="{Binding QueryText}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Close" Padding="20,6" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Lite/Windows/WaitDrillDownWindow.xaml.cs
+++ b/Lite/Windows/WaitDrillDownWindow.xaml.cs
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using PerformanceMonitorLite.Controls;
+using PerformanceMonitorLite.Helpers;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using static PerformanceMonitorLite.Helpers.WaitDrillDownHelper;
+
+namespace PerformanceMonitorLite.Windows;
+
+public partial class WaitDrillDownWindow : Window
+{
+    private readonly LocalDataService _dataService;
+    private readonly int _serverId;
+    private readonly string _waitType;
+    private readonly int _hoursBack;
+    private readonly DateTime? _fromDate;
+    private readonly DateTime? _toDate;
+
+    // Filter state
+    private DataGridFilterManager<QuerySnapshotRow>? _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public WaitDrillDownWindow(
+        LocalDataService dataService,
+        int serverId,
+        string waitType,
+        int hoursBack,
+        DateTime? fromDate = null,
+        DateTime? toDate = null)
+    {
+        InitializeComponent();
+        _dataService = dataService;
+        _serverId = serverId;
+        _waitType = waitType;
+        _hoursBack = hoursBack;
+        _fromDate = fromDate;
+        _toDate = toDate;
+
+        _filterManager = new DataGridFilterManager<QuerySnapshotRow>(ResultsDataGrid);
+
+        Title = $"Wait Drill-Down: {waitType}";
+
+        var classification = Classify(waitType);
+        HeaderText.Text = classification.Category == WaitCategory.Correlated
+            ? $"Queries active during {waitType} spike"
+            : $"Queries experiencing {waitType}";
+
+        Loaded += async (_, _) => await LoadDataAsync();
+        ThemeManager.ThemeChanged += OnThemeChanged;
+        Closed += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private async System.Threading.Tasks.Task LoadDataAsync()
+    {
+        SummaryText.Text = "Loading...";
+
+        try
+        {
+            var classification = Classify(_waitType);
+            SetWarningBanner(classification);
+
+            if (classification.Category == WaitCategory.Chain)
+            {
+                await LoadChainDataAsync(classification);
+            }
+            else if (classification.Category == WaitCategory.Correlated || classification.Category == WaitCategory.Uncapturable)
+            {
+                await LoadCorrelatedDataAsync(classification);
+            }
+            else
+            {
+                await LoadDirectDataAsync(classification);
+            }
+        }
+        catch (Exception ex)
+        {
+            SummaryText.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadDirectDataAsync(WaitClassification classification)
+    {
+        var data = await _dataService.GetQuerySnapshotsByWaitTypeAsync(
+            _serverId, _waitType, _hoursBack, _fromDate, _toDate);
+
+        if (data.Count == 0)
+        {
+            SummaryText.Text = $"No query-level data found for {_waitType} in the selected time range.";
+            return;
+        }
+
+        // Sort by the classified column
+        data = SortByProperty(data, classification.SortProperty);
+
+        _filterManager!.UpdateData(data);
+
+        var timeRange = GetTimeRangeDescription(data);
+        var truncated = data.Count >= 500 ? " (limited to 500 rows)" : "";
+        SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange}{truncated}";
+
+        // Set initial sort on the DataGrid
+        ApplyInitialSort(classification.SortProperty);
+    }
+
+    private async System.Threading.Tasks.Task LoadCorrelatedDataAsync(WaitClassification classification)
+    {
+        // Fetch ALL queries in the time range (no wait type filter)
+        var data = await _dataService.GetAllQuerySnapshotsInRangeAsync(
+            _serverId, _hoursBack, _fromDate, _toDate);
+
+        if (data.Count == 0)
+        {
+            SummaryText.Text = $"No query snapshots found in the selected time range.";
+            return;
+        }
+
+        data = SortByProperty(data, classification.SortProperty);
+        _filterManager!.UpdateData(data);
+
+        var timeRange = GetTimeRangeDescription(data);
+        var truncated = data.Count >= 500 ? " (limited to 500 rows)" : "";
+        SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange}{truncated}";
+
+        ApplyInitialSort(classification.SortProperty);
+    }
+
+    private async System.Threading.Tasks.Task LoadChainDataAsync(WaitClassification classification)
+    {
+        // Get waiters with the target wait type
+        var waiters = await _dataService.GetQuerySnapshotsByWaitTypeAsync(
+            _serverId, _waitType, _hoursBack, _fromDate, _toDate);
+
+        if (waiters.Count == 0)
+        {
+            SummaryText.Text = $"No query-level data found for {_waitType} in the selected time range.";
+            return;
+        }
+
+        // Get all snapshots in range for chain walking
+        var allSnapshots = await _dataService.GetAllQuerySnapshotsInRangeAsync(
+            _serverId, _hoursBack, _fromDate, _toDate);
+
+        // Map to SnapshotInfo for the chain walker
+        var waiterInfos = waiters.Select(ToSnapshotInfo).ToList();
+        var allInfos = allSnapshots.Select(ToSnapshotInfo).ToList();
+
+        var headBlockerInfos = WalkBlockingChains(waiterInfos, allInfos);
+
+        if (headBlockerInfos.Count == 0)
+        {
+            // No chain found — fall back to showing the waiters directly
+            _filterManager!.UpdateData(waiters);
+            var timeRange = GetTimeRangeDescription(waiters);
+            SummaryText.Text = $"{waiters.Count} snapshot(s) | {classification.Description} | {timeRange} | No blocking chains found, showing waiters";
+            return;
+        }
+
+        // Look up original full rows for each head blocker and set chain metadata
+        var snapshotLookup = allSnapshots
+            .GroupBy(s => (s.CollectionTime, s.SessionId))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var headBlockerRows = new List<QuerySnapshotRow>();
+        foreach (var hb in headBlockerInfos)
+        {
+            if (snapshotLookup.TryGetValue((hb.CollectionTime, hb.SessionId), out var row))
+            {
+                row.ChainBlockedCount = hb.BlockedSessionCount;
+                row.ChainBlockingPath = hb.BlockingPath;
+                headBlockerRows.Add(row);
+            }
+        }
+
+        if (headBlockerRows.Count == 0)
+        {
+            // Head blockers not found in snapshots — show waiters instead
+            _filterManager!.UpdateData(waiters);
+            var timeRange = GetTimeRangeDescription(waiters);
+            SummaryText.Text = $"{waiters.Count} snapshot(s) | {classification.Description} | {timeRange} | Head blockers not in snapshots, showing waiters";
+            return;
+        }
+
+        // Add chain columns to the existing XAML-defined columns
+        InsertChainColumns();
+
+        _filterManager!.UpdateData(headBlockerRows);
+
+        var timeRangeDesc = GetTimeRangeDescription(headBlockerRows);
+        SummaryText.Text = $"{headBlockerRows.Count} head blocker(s) from {waiters.Count} waiting session(s) | " +
+                           $"{classification.Description} | {timeRangeDesc}";
+    }
+
+    private void InsertChainColumns()
+    {
+        // Insert "Blocked Sessions" and "Blocking Path" columns at the beginning of the grid
+        var blockedCountCol = CreateFilterColumn("Blocked Sessions", "ChainBlockedCount", 105, isNumeric: true);
+        var blockingPathCol = CreateFilterColumn("Blocking Path", "ChainBlockingPath", 250);
+
+        ResultsDataGrid.Columns.Insert(0, blockedCountCol);
+        ResultsDataGrid.Columns.Insert(1, blockingPathCol);
+    }
+
+    private DataGridTextColumn CreateFilterColumn(string headerText, string bindingPath, int width,
+        bool isNumeric = false, string? stringFormat = null)
+    {
+        var filterButton = new Button { Tag = bindingPath, Margin = new Thickness(0, 0, 4, 0) };
+        filterButton.SetResourceReference(StyleProperty, "ColumnFilterButtonStyle");
+        filterButton.Click += Filter_Click;
+
+        var header = new StackPanel { Orientation = Orientation.Horizontal };
+        header.Children.Add(filterButton);
+        header.Children.Add(new System.Windows.Controls.TextBlock
+        {
+            Text = headerText,
+            FontWeight = FontWeights.Bold,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+
+        var binding = new System.Windows.Data.Binding(bindingPath);
+        if (stringFormat != null) binding.StringFormat = stringFormat;
+
+        var column = new DataGridTextColumn
+        {
+            Header = header,
+            Binding = binding,
+            Width = new DataGridLength(width)
+        };
+
+        if (isNumeric)
+        {
+            var numericStyle = (Style?)FindResource("NumericCell");
+            if (numericStyle != null) column.ElementStyle = numericStyle;
+        }
+
+        return column;
+    }
+
+    private void SetWarningBanner(WaitClassification classification)
+    {
+        if (classification.Category == WaitCategory.Uncapturable)
+        {
+            WarningText.Text = $"Sessions experiencing {_waitType} waits may not be captured in query snapshots " +
+                               "because they may lack assigned worker threads. Showing all queries in this time range.";
+            WarningBanner.Visibility = Visibility.Visible;
+        }
+        else if (classification.Category == WaitCategory.Correlated)
+        {
+            WarningText.Text = $"{_waitType} waits are too brief to appear in query snapshots. " +
+                               "Showing all queries active during this period, sorted by the most correlated metric.";
+            WarningBanner.Visibility = Visibility.Visible;
+            WarningBanner.Background = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x3D, 0x00, 0x33, 0x66));
+            WarningBanner.BorderBrush = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x66, 0x00, 0x55, 0x99));
+            WarningText.Foreground = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromRgb(0x66, 0xBB, 0xFF));
+        }
+        else if (classification.Category == WaitCategory.Chain)
+        {
+            WarningText.Text = $"Showing head blockers (the cause of {_waitType} waits), not the waiting sessions themselves.";
+            WarningBanner.Visibility = Visibility.Visible;
+            WarningBanner.Background = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x3D, 0x00, 0x33, 0x66));
+            WarningBanner.BorderBrush = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromArgb(0x66, 0x00, 0x55, 0x99));
+            WarningText.Foreground = new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Color.FromRgb(0x66, 0xBB, 0xFF));
+        }
+    }
+
+    private static SnapshotInfo ToSnapshotInfo(QuerySnapshotRow row) => new()
+    {
+        SessionId = row.SessionId,
+        BlockingSessionId = row.BlockingSessionId,
+        CollectionTime = row.CollectionTime,
+        DatabaseName = row.DatabaseName,
+        Status = row.Status,
+        QueryText = row.QueryText,
+        WaitType = row.WaitType,
+        WaitTimeMs = row.WaitTimeMs,
+        CpuTimeMs = row.CpuTimeMs,
+        Reads = row.Reads,
+        Writes = row.Writes,
+        LogicalReads = row.LogicalReads
+    };
+
+    private static List<QuerySnapshotRow> SortByProperty(List<QuerySnapshotRow> data, string property) =>
+        property switch
+        {
+            "CpuTimeMs" => data.OrderByDescending(r => r.CpuTimeMs).ToList(),
+            "Reads" => data.OrderByDescending(r => r.Reads).ToList(),
+            "Writes" => data.OrderByDescending(r => r.Writes).ToList(),
+            "Dop" => data.OrderByDescending(r => r.Dop).ToList(),
+            "GrantedQueryMemoryGb" => data.OrderByDescending(r => r.GrantedQueryMemoryGb).ToList(),
+            "WaitTimeMs" => data.OrderByDescending(r => r.WaitTimeMs).ToList(),
+            _ => data
+        };
+
+    private void ApplyInitialSort(string property)
+    {
+        var columnHeader = property switch
+        {
+            "CpuTimeMs" => "CPU (ms)",
+            "Reads" => "Reads",
+            "Writes" => "Writes",
+            "Dop" => "DOP",
+            "GrantedQueryMemoryGb" => "Memory (GB)",
+            "WaitTimeMs" => "Wait (ms)",
+            _ => null
+        };
+
+        if (columnHeader == null) return;
+
+        foreach (var column in ResultsDataGrid.Columns)
+        {
+            if (column.Header is StackPanel sp)
+            {
+                var textBlock = sp.Children.OfType<System.Windows.Controls.TextBlock>().FirstOrDefault();
+                if (textBlock?.Text == columnHeader)
+                {
+                    column.SortDirection = ListSortDirection.Descending;
+                    break;
+                }
+            }
+        }
+    }
+
+    private static string GetTimeRangeDescription(List<QuerySnapshotRow> data)
+    {
+        if (data.Count == 0) return "";
+        var first = data.Min(r => r.CollectionTime);
+        var last = data.Max(r => r.CollectionTime);
+        return $"{ServerTimeHelper.FormatServerTime(first)} to {ServerTimeHelper.FormatServerTime(last)}";
+    }
+
+
+    private void OnThemeChanged(string _)
+    {
+        _filterManager?.UpdateFilterButtonStyles();
+    }
+
+    #region Column Filter Popup
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+        if (_filterManager == null) return;
+
+        EnsureFilterPopup();
+
+        // Detach/reattach to avoid double-fire
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+
+        _filterManager?.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+    }
+
+    #endregion
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.ExportToCsv(sender, "wait_drill_down");
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+}


### PR DESCRIPTION
## Summary
- Right-click any wait type in the chart legend → "Show Queries With This Wait" opens a drill-down modal
- Classifies waits into categories: correlated (SOS_SCHEDULER_YIELD, PAGEIOLATCH_*, etc.), chain (LCK_M_*), uncapturable (THREADPOOL), and filtered (everything else)
- Correlated waits show all queries sorted by the most relevant metric (CPU for scheduler yield, reads for I/O, etc.)
- Chain waits walk blocking chains to find head blockers, then show them with the **same full column set** plus "Blocked Sessions" and "Blocking Path" prepended
- Both Dashboard and Lite, no new collectors needed

## Test plan
- [x] Build both apps — 0 errors
- [x] Right-click SOS_SCHEDULER_YIELD → shows queries sorted by CPU with info banner
- [x] Right-click LCK_M_X → shows head blockers with full columns + chain info
- [x] Right-click a rare/absent wait → shows "No data found" message
- [x] Column filters work in all modes (chain and non-chain)
- [x] Context menu (copy cell/row/all, export CSV) works
- [x] Theme changes update filter button styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)