### PR TITLE
Fix poison wait false positives and alert log parsing (#445)

### DIFF
--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1099,7 +1099,9 @@ public partial class MainWindow : Window
                             allWaitNames,
                             $"{App.AlertPoisonWaitThresholdMs}ms avg",
                             summary.ServerId,
-                            poisonContext);
+                            poisonContext,
+                            numericCurrentValue: worst.AvgMsPerWait,
+                            numericThresholdValue: App.AlertPoisonWaitThresholdMs);
                     }
                 }
                 else if (_activePoisonWaitAlert.TryGetValue(key, out var wasPoisonWait) && wasPoisonWait)
@@ -1147,7 +1149,9 @@ public partial class MainWindow : Window
                             $"{longRunning.Count} query(s), longest {elapsedMinutes}m",
                             $"{App.AlertLongRunningQueryThresholdMinutes}m",
                             summary.ServerId,
-                            lrqContext);
+                            lrqContext,
+                            numericCurrentValue: elapsedMinutes,
+                            numericThresholdValue: App.AlertLongRunningQueryThresholdMinutes);
                     }
                 }
                 else if (_activeLongRunningQueryAlert.TryGetValue(key, out var wasLongRunning) && wasLongRunning)
@@ -1191,7 +1195,9 @@ public partial class MainWindow : Window
                             $"{tempDb.UsedPercent:F0}% used ({tempDb.TotalReservedMb:F0} MB)",
                             $"{App.AlertTempDbSpaceThresholdPercent}%",
                             summary.ServerId,
-                            tempDbContext);
+                            tempDbContext,
+                            numericCurrentValue: tempDb.UsedPercent,
+                            numericThresholdValue: App.AlertTempDbSpaceThresholdPercent);
                     }
                 }
                 else if (_activeTempDbSpaceAlert.TryGetValue(key, out var wasTempDb) && wasTempDb)
@@ -1240,7 +1246,9 @@ public partial class MainWindow : Window
                             $"{anomalousJobs.Count} job(s) exceeding {App.AlertLongRunningJobMultiplier}x average",
                             $"{App.AlertLongRunningJobMultiplier}x historical avg",
                             summary.ServerId,
-                            jobContext);
+                            jobContext,
+                            numericCurrentValue: (double)worst.PercentOfAverage,
+                            numericThresholdValue: App.AlertLongRunningJobMultiplier * 100);
                     }
                 }
                 else if (_activeLongRunningJobAlert.TryGetValue(key, out var wasJob) && wasJob)

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -48,7 +48,9 @@ public class EmailAlertService
         string currentValue,
         string thresholdValue,
         int serverId = 0,
-        AlertContext? context = null)
+        AlertContext? context = null,
+        double? numericCurrentValue = null,
+        double? numericThresholdValue = null)
     {
         try
         {
@@ -108,10 +110,12 @@ public class EmailAlertService
             }
 
             /* Always log the alert to DuckDB, regardless of email status */
+            var logCurrent = numericCurrentValue
+                ?? (double.TryParse(currentValue.TrimEnd('%'), out var cv) ? cv : 0);
+            var logThreshold = numericThresholdValue
+                ?? (double.TryParse(thresholdValue.TrimEnd('%'), out var tv) ? tv : 0);
             await LogAlertAsync(serverId, serverName, metricName,
-                double.TryParse(currentValue.TrimEnd('%'), out var cv) ? cv : 0,
-                double.TryParse(thresholdValue.TrimEnd('%'), out var tv) ? tv : 0,
-                sent, notificationType, sendError);
+                logCurrent, logThreshold, sent, notificationType, sendError);
         }
         catch (Exception ex)
         {

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -170,6 +170,7 @@ FROM v_wait_stats
 WHERE server_id = $1
 AND wait_type IN ('THREADPOOL', 'RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE')
 AND delta_waiting_tasks > 0
+AND collection_time >= NOW() - INTERVAL '10 minutes'
 ORDER BY collection_time DESC
 LIMIT 3";
 


### PR DESCRIPTION
## Summary
Cherry-pick of 564bab0 which was accidentally merged to main via PR #447 (should have targeted dev).

- Fixes #445 — Lite poison wait query had no time filter, so stale data kept triggering false alerts. Added 10-minute window matching Dashboard.
- Fixed alert history logging: non-numeric display strings logged as 0/0. Added numeric parameters to `TrySendAlertEmailAsync`.

## Test plan
- [ ] Verify poison wait alerts only fire for recent activity
- [ ] Verify alert history shows correct numeric values

🤖 Generated with [Claude Code](https://claude.com/claude-code)