### PR TITLE
Lite - fixed sort on columns that are formatted for seconds or milliseconds

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1459,7 +1459,7 @@
                                     <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="85">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailureRatePercent" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Fail %" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="100">
+                                    <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="120" SortMemberPath="AvgDurationMs">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding LastSuccessFormatted}" Width="140">
@@ -1500,13 +1500,13 @@
                                         <DataGridTextColumn Binding="{Binding Status}" Width="80">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding DurationFormatted}" Width="90">
+                                        <DataGridTextColumn Binding="{Binding DurationFormatted}" Width="90" SortMemberPath="DurationMs">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" Width="90">
+                                        <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" Width="90" SortMemberPath="SqlDurationMs">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SQL (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
-                                        <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" Width="100">
+                                        <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" Width="120" SortMemberPath="DuckDbDurationMs">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DuckDbDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="DuckDB (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Binding="{Binding RowsCollected, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">

--- a/Lite/Windows/CollectionLogWindow.xaml
+++ b/Lite/Windows/CollectionLogWindow.xaml
@@ -65,17 +65,17 @@
                         <TextBlock Text="Rows" FontWeight="Bold"/>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                <DataGridTextColumn Binding="{Binding DurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="DurationMs">
                     <DataGridTextColumn.Header>
                         <TextBlock Text="Duration" FontWeight="Bold"/>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="SqlDurationMs">
                     <DataGridTextColumn.Header>
                         <TextBlock Text="SQL Duration" FontWeight="Bold"/>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="DuckDbDurationMs">
                     <DataGridTextColumn.Header>
                         <TextBlock Text="DuckDB Duration" FontWeight="Bold"/>
                     </DataGridTextColumn.Header>


### PR DESCRIPTION
## What does this PR do?

This PR fixes bug/issue #450.
- Used the SortMemberPath property to point to the numeric value for the sorting of the columns that are formatted for seconds or milliseconds under the Server Tab -> Collection Health tabs.
- Increased some column widths to ensure complete header is shown.

## Which component(s) does this affect?

- [ ] Full Dashboard
- [X] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

Describe the testing you've done. Include:
- SQL Server version(s) tested against:
  - SQL Server 2022
- Steps to verify the change works:
  - Complied and ran the PerformanceMonitorLite project
  - Waited for Collection to finish
  - Browsed to the affected data grids under Server Tab -> Collection Health tabs.
  - Clicked on the affected columns to verify visually that sorting was applied correctly. Also specifically where the output could be a mix of "s" and "ms".

## Checklist

- [X] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [X] My code builds with zero warnings (`dotnet build -c Debug`)
- [X] I have tested my changes against at least one SQL Server version
- [X] I have not introduced any hardcoded credentials or server names
