### PR TITLE
Fix nullable dereference in Lite anomalous job alert

### DIFF
--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1291,7 +1291,7 @@ public partial class MainWindow : Window
                             $"{App.AlertLongRunningJobMultiplier}x historical avg",
                             summary.ServerId,
                             jobContext,
-                            numericCurrentValue: (double)worst.PercentOfAverage,
+                            numericCurrentValue: (double)(worst.PercentOfAverage ?? 0),
                             numericThresholdValue: App.AlertLongRunningJobMultiplier * 100);
                     }
                 }


### PR DESCRIPTION
## Summary

`worst.PercentOfAverage` is `double?` but was cast directly to `(double)` without a null check at `Lite/MainWindow.xaml.cs:1294`. This would throw `InvalidOperationException` if the value were ever null.

**Fix:** `(double)(worst.PercentOfAverage ?? 0)`

Found via CS8629 compiler warning during build review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)