### PR TITLE
Fix procedure_stats plan query after compression migration

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -2409,7 +2409,7 @@ namespace PerformanceMonitorDashboard.Services
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
         SELECT
-            ps.query_plan
+            CAST(DECOMPRESS(ps.query_plan_text) AS nvarchar(max)) AS query_plan_text
         FROM collect.procedure_stats AS ps
         WHERE ps.collection_id = @collection_id;";
 


### PR DESCRIPTION
## Summary
- PR #433 migrated `collect.procedure_stats` to compressed LOB storage (`COMPRESS()`/`DECOMPRESS()`)
- `GetProcedureStatsPlanXmlByCollectionIdAsync` was missed — still referenced the old `query_plan` column
- Fix: `CAST(DECOMPRESS(ps.query_plan_text) AS nvarchar(max))`
- Without this fix, viewing execution plans for procedure stats rows would fail

## Test plan
- [ ] Open Dashboard, navigate to procedure stats, click to view a plan — should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)