### PR TITLE
Add named collection presets (closes #454)

### DIFF
--- a/Dashboard/CollectorScheduleWindow.xaml
+++ b/Dashboard/CollectorScheduleWindow.xaml
@@ -34,8 +34,24 @@
         <!-- Header -->
         <TextBlock Grid.Row="0" Text="Collector Schedules" FontWeight="Bold" FontSize="16"
                    Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
-        <TextBlock Grid.Row="1" Text="Configure collection frequency and data retention for each collector."
-                   Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="12" Margin="0,0,0,12"/>
+        <Grid Grid.Row="1" Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Configure collection frequency and data retention for each collector."
+                       Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="12" VerticalAlignment="Center"/>
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <TextBlock Text="Preset:" Foreground="{DynamicResource ForegroundBrush}" FontSize="12"
+                           VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <ComboBox x:Name="PresetComboBox" Width="140" SelectionChanged="PresetComboBox_SelectionChanged">
+                    <ComboBoxItem Content="Custom" IsEnabled="False"/>
+                    <ComboBoxItem Content="Low-Impact"/>
+                    <ComboBoxItem Content="Balanced"/>
+                    <ComboBoxItem Content="Aggressive"/>
+                </ComboBox>
+            </StackPanel>
+        </Grid>
 
         <!-- Schedule Grid -->
         <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="4">

--- a/Dashboard/CollectorScheduleWindow.xaml.cs
+++ b/Dashboard/CollectorScheduleWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
@@ -20,6 +21,107 @@ namespace PerformanceMonitorDashboard
     {
         private readonly DatabaseService _databaseService;
         private List<CollectorScheduleItem>? _schedules;
+        private bool _suppressPresetChange;
+
+        private static readonly Dictionary<string, Dictionary<string, int>> Presets = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Aggressive"] = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats_collector"] = 1,
+                ["query_stats_collector"] = 1,
+                ["memory_stats_collector"] = 1,
+                ["memory_pressure_events_collector"] = 1,
+                ["system_health_collector"] = 2,
+                ["blocked_process_xml_collector"] = 1,
+                ["deadlock_xml_collector"] = 1,
+                ["process_blocked_process_xml"] = 2,
+                ["blocking_deadlock_analyzer"] = 2,
+                ["process_deadlock_xml"] = 2,
+                ["query_store_collector"] = 2,
+                ["procedure_stats_collector"] = 1,
+                ["query_snapshots_collector"] = 1,
+                ["file_io_stats_collector"] = 1,
+                ["memory_grant_stats_collector"] = 1,
+                ["cpu_scheduler_stats_collector"] = 1,
+                ["memory_clerks_stats_collector"] = 2,
+                ["perfmon_stats_collector"] = 1,
+                ["cpu_utilization_stats_collector"] = 1,
+                ["trace_analysis_collector"] = 1,
+                ["default_trace_collector"] = 2,
+                ["configuration_issues_analyzer"] = 1,
+                ["latch_stats_collector"] = 1,
+                ["spinlock_stats_collector"] = 1,
+                ["tempdb_stats_collector"] = 1,
+                ["plan_cache_stats_collector"] = 2,
+                ["session_stats_collector"] = 1,
+                ["waiting_tasks_collector"] = 1,
+                ["running_jobs_collector"] = 2
+            },
+            ["Balanced"] = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats_collector"] = 1,
+                ["query_stats_collector"] = 2,
+                ["memory_stats_collector"] = 1,
+                ["memory_pressure_events_collector"] = 1,
+                ["system_health_collector"] = 5,
+                ["blocked_process_xml_collector"] = 1,
+                ["deadlock_xml_collector"] = 1,
+                ["process_blocked_process_xml"] = 5,
+                ["blocking_deadlock_analyzer"] = 5,
+                ["process_deadlock_xml"] = 5,
+                ["query_store_collector"] = 2,
+                ["procedure_stats_collector"] = 2,
+                ["query_snapshots_collector"] = 1,
+                ["file_io_stats_collector"] = 1,
+                ["memory_grant_stats_collector"] = 1,
+                ["cpu_scheduler_stats_collector"] = 1,
+                ["memory_clerks_stats_collector"] = 5,
+                ["perfmon_stats_collector"] = 5,
+                ["cpu_utilization_stats_collector"] = 1,
+                ["trace_analysis_collector"] = 2,
+                ["default_trace_collector"] = 5,
+                ["configuration_issues_analyzer"] = 1,
+                ["latch_stats_collector"] = 1,
+                ["spinlock_stats_collector"] = 1,
+                ["tempdb_stats_collector"] = 1,
+                ["plan_cache_stats_collector"] = 5,
+                ["session_stats_collector"] = 1,
+                ["waiting_tasks_collector"] = 1,
+                ["running_jobs_collector"] = 1
+            },
+            ["Low-Impact"] = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats_collector"] = 5,
+                ["query_stats_collector"] = 10,
+                ["memory_stats_collector"] = 10,
+                ["memory_pressure_events_collector"] = 5,
+                ["system_health_collector"] = 15,
+                ["blocked_process_xml_collector"] = 5,
+                ["deadlock_xml_collector"] = 5,
+                ["process_blocked_process_xml"] = 10,
+                ["blocking_deadlock_analyzer"] = 10,
+                ["process_deadlock_xml"] = 10,
+                ["query_store_collector"] = 30,
+                ["procedure_stats_collector"] = 10,
+                ["query_snapshots_collector"] = 5,
+                ["file_io_stats_collector"] = 10,
+                ["memory_grant_stats_collector"] = 5,
+                ["cpu_scheduler_stats_collector"] = 5,
+                ["memory_clerks_stats_collector"] = 30,
+                ["perfmon_stats_collector"] = 5,
+                ["cpu_utilization_stats_collector"] = 5,
+                ["trace_analysis_collector"] = 10,
+                ["default_trace_collector"] = 15,
+                ["configuration_issues_analyzer"] = 5,
+                ["latch_stats_collector"] = 5,
+                ["spinlock_stats_collector"] = 5,
+                ["tempdb_stats_collector"] = 5,
+                ["plan_cache_stats_collector"] = 15,
+                ["session_stats_collector"] = 5,
+                ["waiting_tasks_collector"] = 5,
+                ["running_jobs_collector"] = 30
+            }
+        };
 
         public CollectorScheduleWindow(DatabaseService databaseService)
         {
@@ -59,6 +161,7 @@ namespace PerformanceMonitorDashboard
                 }
 
                 ScheduleDataGrid.ItemsSource = _schedules;
+                DetectActivePreset();
             }
             catch (Exception ex)
             {
@@ -68,6 +171,101 @@ namespace PerformanceMonitorDashboard
                     MessageBoxButton.OK,
                     MessageBoxImage.Error
                 );
+            }
+        }
+
+        private void DetectActivePreset()
+        {
+            if (_schedules == null) return;
+
+            _suppressPresetChange = true;
+            try
+            {
+                var currentIntervals = _schedules
+                    .Where(s => s.FrequencyMinutes < 1440)
+                    .ToDictionary(s => s.CollectorName, s => s.FrequencyMinutes, StringComparer.OrdinalIgnoreCase);
+
+                foreach (var (presetName, presetIntervals) in Presets)
+                {
+                    bool matches = true;
+                    foreach (var (collector, freq) in presetIntervals)
+                    {
+                        if (currentIntervals.TryGetValue(collector, out int current) && current != freq)
+                        {
+                            matches = false;
+                            break;
+                        }
+                    }
+
+                    if (matches)
+                    {
+                        for (int i = 0; i < PresetComboBox.Items.Count; i++)
+                        {
+                            if (PresetComboBox.Items[i] is ComboBoxItem item &&
+                                string.Equals(item.Content?.ToString(), presetName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                PresetComboBox.SelectedIndex = i;
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                /* No preset matched */
+                PresetComboBox.SelectedIndex = 0;
+            }
+            finally
+            {
+                _suppressPresetChange = false;
+            }
+        }
+
+        private async void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressPresetChange) return;
+            if (PresetComboBox.SelectedItem is not ComboBoxItem selected) return;
+
+            string presetName = selected.Content?.ToString() ?? "";
+            if (presetName == "Custom") return;
+
+            var result = MessageBox.Show(
+                $"Apply the \"{presetName}\" preset?\n\nThis will change all collector frequencies. Enabled/disabled state and retention settings are not affected.",
+                "Apply Collection Preset",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question
+            );
+
+            if (result != MessageBoxResult.Yes)
+            {
+                DetectActivePreset();
+                return;
+            }
+
+            try
+            {
+                await _databaseService.ApplyCollectionPresetAsync(presetName);
+
+                /* Unsubscribe, reload, resubscribe */
+                if (_schedules != null)
+                {
+                    foreach (var schedule in _schedules)
+                    {
+                        schedule.PropertyChanged -= Schedule_PropertyChanged;
+                    }
+                }
+
+                await LoadSchedulesAsync();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to apply preset:\n\n{ex.Message}",
+                    "Error Applying Preset",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+
+                DetectActivePreset();
             }
         }
 
@@ -88,6 +286,11 @@ namespace PerformanceMonitorDashboard
                             schedule.FrequencyMinutes,
                             schedule.RetentionDays
                         );
+
+                        if (e.PropertyName == nameof(CollectorScheduleItem.FrequencyMinutes))
+                        {
+                            DetectActivePreset();
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/Dashboard/Services/DatabaseService.cs
+++ b/Dashboard/Services/DatabaseService.cs
@@ -357,5 +357,18 @@ namespace PerformanceMonitorDashboard.Services
 
             await command.ExecuteNonQueryAsync();
         }
+
+        public async Task ApplyCollectionPresetAsync(string presetName)
+        {
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            using var command = new SqlCommand("config.apply_collection_preset", connection);
+            command.CommandType = System.Data.CommandType.StoredProcedure;
+            command.CommandTimeout = 120;
+            command.Parameters.Add(new SqlParameter("@preset_name", SqlDbType.NVarChar, 128) { Value = presetName });
+
+            await command.ExecuteNonQueryAsync();
+        }
     }
 }

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -28,6 +28,39 @@ public class ScheduleManager
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
+    public static readonly string[] PresetNames = ["Low-Impact", "Balanced", "Aggressive"];
+
+    private static readonly Dictionary<string, Dictionary<string, int>> s_presets = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Aggressive"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 1, ["query_stats"] = 1, ["procedure_stats"] = 1,
+            ["query_store"] = 2, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+            ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 2,
+            ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+            ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["blocked_process_report"] = 1, ["running_jobs"] = 2
+        },
+        ["Balanced"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 1, ["query_stats"] = 1, ["procedure_stats"] = 1,
+            ["query_store"] = 5, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+            ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 5,
+            ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+            ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["blocked_process_report"] = 1, ["running_jobs"] = 5
+        },
+        ["Low-Impact"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 5, ["query_stats"] = 10, ["procedure_stats"] = 10,
+            ["query_store"] = 30, ["query_snapshots"] = 5, ["cpu_utilization"] = 5,
+            ["file_io_stats"] = 10, ["memory_stats"] = 10, ["memory_clerks"] = 30,
+            ["tempdb_stats"] = 5, ["perfmon_stats"] = 5, ["deadlocks"] = 5,
+            ["memory_grant_stats"] = 5, ["waiting_tasks"] = 5,
+            ["blocked_process_report"] = 5, ["running_jobs"] = 30
+        }
+    };
+
     private readonly string _schedulePath;
     private readonly ILogger<ScheduleManager>? _logger;
     private List<CollectorSchedule> _schedules;
@@ -157,6 +190,61 @@ public class ScheduleManager
 
             _logger?.LogInformation("Updated schedule for collector '{Name}': Enabled={Enabled}, Frequency={Frequency}m, Retention={Retention}d",
                 collectorName, schedule.Enabled, schedule.FrequencyMinutes, schedule.RetentionDays);
+        }
+    }
+
+    /// <summary>
+    /// Detects which preset matches the current intervals, or returns "Custom".
+    /// </summary>
+    public string GetActivePreset()
+    {
+        lock (_lock)
+        {
+            foreach (var (presetName, intervals) in s_presets)
+            {
+                bool matches = true;
+                foreach (var (collector, freq) in intervals)
+                {
+                    var schedule = _schedules.FirstOrDefault(s =>
+                        s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+                    if (schedule != null && schedule.FrequencyMinutes != freq)
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) return presetName;
+            }
+            return "Custom";
+        }
+    }
+
+    /// <summary>
+    /// Applies a named preset, changing all scheduled collector frequencies.
+    /// Does not modify enabled/disabled state or on-load (frequency=0) collectors.
+    /// </summary>
+    public void ApplyPreset(string presetName)
+    {
+        if (!s_presets.TryGetValue(presetName, out var intervals))
+        {
+            throw new ArgumentException($"Unknown preset: {presetName}");
+        }
+
+        lock (_lock)
+        {
+            foreach (var (collector, freq) in intervals)
+            {
+                var schedule = _schedules.FirstOrDefault(s =>
+                    s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+                if (schedule != null)
+                {
+                    schedule.FrequencyMinutes = freq;
+                }
+            }
+
+            SaveSchedules();
+
+            _logger?.LogInformation("Applied collection preset '{Preset}'", presetName);
         }
     }
 

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -315,8 +315,24 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Text="Collector Schedules" FontSize="14" FontWeight="SemiBold"
-                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8"/>
+            <Grid Grid.Row="0" Margin="0,0,0,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Collector Schedules" FontSize="14" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <TextBlock Text="Preset:" Foreground="{DynamicResource ForegroundBrush}" FontSize="12"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="PresetComboBox" Width="140" SelectionChanged="PresetComboBox_SelectionChanged">
+                        <ComboBoxItem Content="Custom" IsEnabled="False"/>
+                        <ComboBoxItem Content="Low-Impact"/>
+                        <ComboBoxItem Content="Balanced"/>
+                        <ComboBoxItem Content="Aggressive"/>
+                    </ComboBox>
+                </StackPanel>
+            </Grid>
 
             <DataGrid Grid.Row="1" x:Name="ScheduleGrid"
                       AutoGenerateColumns="False" IsReadOnly="False"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -47,9 +47,62 @@ public partial class SettingsWindow : Window
         LoadSmtpSettings();
     }
 
+    private bool _suppressPresetChange;
+
     private void LoadSchedules()
     {
         ScheduleGrid.ItemsSource = _scheduleManager.GetAllSchedules();
+        DetectActivePreset();
+    }
+
+    private void DetectActivePreset()
+    {
+        _suppressPresetChange = true;
+        try
+        {
+            string active = _scheduleManager.GetActivePreset();
+            for (int i = 0; i < PresetComboBox.Items.Count; i++)
+            {
+                if (PresetComboBox.Items[i] is ComboBoxItem item &&
+                    string.Equals(item.Content?.ToString(), active, StringComparison.OrdinalIgnoreCase))
+                {
+                    PresetComboBox.SelectedIndex = i;
+                    return;
+                }
+            }
+            PresetComboBox.SelectedIndex = 0;
+        }
+        finally
+        {
+            _suppressPresetChange = false;
+        }
+    }
+
+    private void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressPresetChange) return;
+        if (PresetComboBox.SelectedItem is not ComboBoxItem selected) return;
+
+        string presetName = selected.Content?.ToString() ?? "";
+        if (presetName == "Custom") return;
+
+        var result = MessageBox.Show(
+            $"Apply the \"{presetName}\" preset?\n\nThis will change all collector frequencies. Enabled/disabled state and retention settings are not affected.",
+            "Apply Collection Preset",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question
+        );
+
+        if (result != MessageBoxResult.Yes)
+        {
+            DetectActivePreset();
+            return;
+        }
+
+        _scheduleManager.ApplyPreset(presetName);
+        ScheduleGrid.ItemsSource = null;
+        ScheduleGrid.ItemsSource = _scheduleManager.GetAllSchedules();
+        DetectActivePreset();
     }
 
     private void UpdateCollectionStatus()

--- a/install/41_schedule_management.sql
+++ b/install/41_schedule_management.sql
@@ -48,7 +48,7 @@ BEGIN
 
     DECLARE
         @rows_updated bigint = 0;
-    
+
     BEGIN TRY
         UPDATE
             config.collection_schedule
@@ -57,24 +57,24 @@ BEGIN
             enabled = ISNULL(@enabled, enabled),
             max_duration_minutes = ISNULL(@max_duration_minutes, max_duration_minutes),
             modified_date = SYSDATETIME(),
-            next_run_time = 
-                CASE 
-                    WHEN ISNULL(@enabled, enabled) = 1 
-                    THEN SYSDATETIME() 
-                    ELSE next_run_time 
+            next_run_time =
+                CASE
+                    WHEN ISNULL(@enabled, enabled) = 1
+                    THEN SYSDATETIME()
+                    ELSE next_run_time
                 END
         WHERE collector_name = @collector_name;
-        
+
         SET @rows_updated = ROWCOUNT_BIG();
-        
+
         IF @rows_updated = 0
         BEGIN
             RAISERROR(N'Collector "%s" not found in schedule', 16, 1, @collector_name);
             RETURN;
         END;
-        
+
         PRINT 'Updated ' + @collector_name + ' frequency to ' + CONVERT(varchar(10), @frequency_minutes) + ' minutes';
-        
+
     END TRY
     BEGIN CATCH
         DECLARE @error_message nvarchar(4000) = ERROR_MESSAGE();
@@ -106,32 +106,32 @@ BEGIN
 
     DECLARE
         @rows_updated bigint = 0;
-    
+
     BEGIN TRY
         UPDATE
             config.collection_schedule
         SET
             enabled = @enabled,
             modified_date = SYSDATETIME(),
-            next_run_time = 
-                CASE 
-                    WHEN @enabled = 1 
-                    THEN SYSDATETIME() 
-                    ELSE NULL 
+            next_run_time =
+                CASE
+                    WHEN @enabled = 1
+                    THEN SYSDATETIME()
+                    ELSE NULL
                 END
         WHERE collector_name = @collector_name;
-        
+
         SET @rows_updated = ROWCOUNT_BIG();
-        
+
         IF @rows_updated = 0
         BEGIN
             RAISERROR(N'Collector "%s" not found in schedule', 16, 1, @collector_name);
             RETURN;
         END;
-        
-        PRINT @collector_name + ' collector ' + 
+
+        PRINT @collector_name + ' collector ' +
               CASE WHEN @enabled = 1 THEN 'enabled' ELSE 'disabled' END;
-        
+
     END TRY
     BEGIN CATCH
         DECLARE @error_message nvarchar(4000) = ERROR_MESSAGE();
@@ -141,157 +141,235 @@ END;
 GO
 
 /*
-Set up real-time monitoring profile (frequent collection)
+Apply a named collection preset
+Changes all scheduled collector frequencies in one operation.
+Does not modify enabled/disabled state or daily/on-load collectors.
+
+Valid preset names: Aggressive, Balanced, Low-Impact
 */
-IF OBJECT_ID(N'config.enable_realtime_monitoring', N'P') IS NULL
+IF OBJECT_ID(N'config.apply_collection_preset', N'P') IS NULL
 BEGIN
-    EXECUTE(N'CREATE PROCEDURE config.enable_realtime_monitoring AS RETURN 138;');
+    EXECUTE(N'CREATE PROCEDURE config.apply_collection_preset AS RETURN 138;');
 END;
 GO
 
 ALTER PROCEDURE
-    config.enable_realtime_monitoring
+    config.apply_collection_preset
+(
+    @preset_name sysname,
+    @debug bit = 0
+)
 WITH RECOMPILE
 AS
 BEGIN
     SET NOCOUNT ON;
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
+    DECLARE
+        @rows_updated bigint = 0;
+
     BEGIN TRY
-        /*High frequency for real-time dashboard*/
-        EXECUTE config.update_collector_frequency N'query_snapshots_collector', 1, 1;
-        EXECUTE config.update_collector_frequency N'wait_stats_collector', 1, 1;
-        EXECUTE config.update_collector_frequency N'query_stats_collector', 1, 1;
-        EXECUTE config.update_collector_frequency N'procedure_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'query_store_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'blocked_process_xml_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'cpu_utilization_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'memory_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'perfmon_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'file_io_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'deadlock_xml_collector', 5, 1;
+        IF @preset_name NOT IN (N'Aggressive', N'Balanced', N'Low-Impact')
+        BEGIN
+            RAISERROR(N'Invalid preset name "%s". Valid presets: Aggressive, Balanced, Low-Impact', 16, 1, @preset_name);
+            RETURN;
+        END;
 
-        /*Medium frequency for context*/
-        EXECUTE config.update_collector_frequency N'memory_grant_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'cpu_scheduler_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'memory_clerks_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'latch_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'spinlock_stats_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'default_trace_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'system_health_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_pressure_events_collector', 2, 1;
-        EXECUTE config.update_collector_frequency N'plan_cache_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'blocking_deadlock_analyzer', 2, 1;
-        EXECUTE config.update_collector_frequency N'process_blocked_process_xml', 2, 1;
-        EXECUTE config.update_collector_frequency N'process_deadlock_xml', 2, 1;
-        EXECUTE config.update_collector_frequency N'trace_analysis_collector', 5, 1;
+        DECLARE
+            @preset TABLE
+            (
+                collector_name sysname NOT NULL,
+                frequency_minutes integer NOT NULL
+            );
 
-        PRINT 'Real-time monitoring profile enabled';
-        PRINT 'Query/procedure stats every 1-2 minutes, everything else 2-5 minutes';
-        
+        IF @preset_name = N'Aggressive'
+        BEGIN
+            INSERT INTO
+                @preset
+            (
+                collector_name,
+                frequency_minutes
+            )
+            VALUES
+                (N'wait_stats_collector', 1),
+                (N'query_stats_collector', 1),
+                (N'memory_stats_collector', 1),
+                (N'memory_pressure_events_collector', 1),
+                (N'system_health_collector', 2),
+                (N'blocked_process_xml_collector', 1),
+                (N'deadlock_xml_collector', 1),
+                (N'process_blocked_process_xml', 2),
+                (N'blocking_deadlock_analyzer', 2),
+                (N'process_deadlock_xml', 2),
+                (N'query_store_collector', 2),
+                (N'procedure_stats_collector', 1),
+                (N'query_snapshots_collector', 1),
+                (N'file_io_stats_collector', 1),
+                (N'memory_grant_stats_collector', 1),
+                (N'cpu_scheduler_stats_collector', 1),
+                (N'memory_clerks_stats_collector', 2),
+                (N'perfmon_stats_collector', 1),
+                (N'cpu_utilization_stats_collector', 1),
+                (N'trace_analysis_collector', 1),
+                (N'default_trace_collector', 2),
+                (N'configuration_issues_analyzer', 1),
+                (N'latch_stats_collector', 1),
+                (N'spinlock_stats_collector', 1),
+                (N'tempdb_stats_collector', 1),
+                (N'plan_cache_stats_collector', 2),
+                (N'session_stats_collector', 1),
+                (N'waiting_tasks_collector', 1),
+                (N'running_jobs_collector', 2);
+        END;
+
+        IF @preset_name = N'Balanced'
+        BEGIN
+            INSERT INTO
+                @preset
+            (
+                collector_name,
+                frequency_minutes
+            )
+            VALUES
+                (N'wait_stats_collector', 1),
+                (N'query_stats_collector', 2),
+                (N'memory_stats_collector', 1),
+                (N'memory_pressure_events_collector', 1),
+                (N'system_health_collector', 5),
+                (N'blocked_process_xml_collector', 1),
+                (N'deadlock_xml_collector', 1),
+                (N'process_blocked_process_xml', 5),
+                (N'blocking_deadlock_analyzer', 5),
+                (N'process_deadlock_xml', 5),
+                (N'query_store_collector', 2),
+                (N'procedure_stats_collector', 2),
+                (N'query_snapshots_collector', 1),
+                (N'file_io_stats_collector', 1),
+                (N'memory_grant_stats_collector', 1),
+                (N'cpu_scheduler_stats_collector', 1),
+                (N'memory_clerks_stats_collector', 5),
+                (N'perfmon_stats_collector', 5),
+                (N'cpu_utilization_stats_collector', 1),
+                (N'trace_analysis_collector', 2),
+                (N'default_trace_collector', 5),
+                (N'configuration_issues_analyzer', 1),
+                (N'latch_stats_collector', 1),
+                (N'spinlock_stats_collector', 1),
+                (N'tempdb_stats_collector', 1),
+                (N'plan_cache_stats_collector', 5),
+                (N'session_stats_collector', 1),
+                (N'waiting_tasks_collector', 1),
+                (N'running_jobs_collector', 1);
+        END;
+
+        IF @preset_name = N'Low-Impact'
+        BEGIN
+            INSERT INTO
+                @preset
+            (
+                collector_name,
+                frequency_minutes
+            )
+            VALUES
+                (N'wait_stats_collector', 5),
+                (N'query_stats_collector', 10),
+                (N'memory_stats_collector', 10),
+                (N'memory_pressure_events_collector', 5),
+                (N'system_health_collector', 15),
+                (N'blocked_process_xml_collector', 5),
+                (N'deadlock_xml_collector', 5),
+                (N'process_blocked_process_xml', 10),
+                (N'blocking_deadlock_analyzer', 10),
+                (N'process_deadlock_xml', 10),
+                (N'query_store_collector', 30),
+                (N'procedure_stats_collector', 10),
+                (N'query_snapshots_collector', 5),
+                (N'file_io_stats_collector', 10),
+                (N'memory_grant_stats_collector', 5),
+                (N'cpu_scheduler_stats_collector', 5),
+                (N'memory_clerks_stats_collector', 30),
+                (N'perfmon_stats_collector', 5),
+                (N'cpu_utilization_stats_collector', 5),
+                (N'trace_analysis_collector', 10),
+                (N'default_trace_collector', 15),
+                (N'configuration_issues_analyzer', 5),
+                (N'latch_stats_collector', 5),
+                (N'spinlock_stats_collector', 5),
+                (N'tempdb_stats_collector', 5),
+                (N'plan_cache_stats_collector', 15),
+                (N'session_stats_collector', 5),
+                (N'waiting_tasks_collector', 5),
+                (N'running_jobs_collector', 30);
+        END;
+
+        /*
+        Apply the preset to all matching collectors.
+        Only updates frequency - does not change enabled/disabled state.
+        Skips daily/on-load collectors not in the preset.
+        */
+        UPDATE
+            cs
+        SET
+            cs.frequency_minutes = p.frequency_minutes,
+            cs.next_run_time =
+                CASE
+                    WHEN cs.enabled = 1
+                    THEN SYSDATETIME()
+                    ELSE cs.next_run_time
+                END,
+            cs.modified_date = SYSDATETIME()
+        FROM config.collection_schedule AS cs
+        JOIN @preset AS p
+          ON p.collector_name = cs.collector_name;
+
+        SET @rows_updated = ROWCOUNT_BIG();
+
+        IF @debug = 1
+        BEGIN
+            RAISERROR(N'Applied "%s" preset to %I64d collectors', 0, 1, @preset_name, @rows_updated) WITH NOWAIT;
+
+            SELECT
+                cs.collector_name,
+                cs.enabled,
+                cs.frequency_minutes,
+                cs.next_run_time,
+                cs.description
+            FROM config.collection_schedule AS cs
+            WHERE cs.frequency_minutes < 1440
+            ORDER BY
+                cs.collector_name;
+        END;
+
+        PRINT 'Applied "' + @preset_name + '" collection preset (' + CONVERT(varchar(10), @rows_updated) + ' collectors updated)';
+
     END TRY
     BEGIN CATCH
-        DECLARE @error_message nvarchar(4000) = ERROR_MESSAGE();
-        RAISERROR(N'Error enabling real-time monitoring: %s', 16, 1, @error_message);
+        DECLARE
+            @error_message nvarchar(4000) = ERROR_MESSAGE();
+
+        RAISERROR(N'Error applying collection preset: %s', 16, 1, @error_message);
     END CATCH;
 END;
 GO
 
 /*
-Set up consulting analysis profile (balanced collection during business hours)
+Drop legacy profile procedures replaced by config.apply_collection_preset
 */
-IF OBJECT_ID(N'config.enable_consulting_analysis', N'P') IS NULL
+IF OBJECT_ID(N'config.enable_realtime_monitoring', N'P') IS NOT NULL
 BEGIN
-    EXECUTE(N'CREATE PROCEDURE config.enable_consulting_analysis AS RETURN 138;');
+    DROP PROCEDURE config.enable_realtime_monitoring;
 END;
 GO
 
-ALTER PROCEDURE
-    config.enable_consulting_analysis
-WITH RECOMPILE
-AS
+IF OBJECT_ID(N'config.enable_consulting_analysis', N'P') IS NOT NULL
 BEGIN
-    SET NOCOUNT ON;
-    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-    BEGIN TRY
-        /*Balanced frequencies for consulting work*/
-        EXECUTE config.update_collector_frequency N'query_snapshots_collector', 1, 1;
-        EXECUTE config.update_collector_frequency N'wait_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'query_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'procedure_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'query_store_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'cpu_utilization_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'blocked_process_xml_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'perfmon_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'file_io_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_grant_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'cpu_scheduler_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_clerks_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'deadlock_xml_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'latch_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'spinlock_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'default_trace_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'system_health_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_pressure_events_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'plan_cache_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'blocking_deadlock_analyzer', 5, 1;
-        EXECUTE config.update_collector_frequency N'process_blocked_process_xml', 5, 1;
-        EXECUTE config.update_collector_frequency N'process_deadlock_xml', 5, 1;
-        EXECUTE config.update_collector_frequency N'trace_analysis_collector', 5, 1;
-
-        PRINT 'Consulting analysis profile enabled';
-        PRINT 'Balanced collection frequencies for comprehensive analysis';
-        
-    END TRY
-    BEGIN CATCH
-        DECLARE @error_message nvarchar(4000) = ERROR_MESSAGE();
-        RAISERROR(N'Error enabling consulting analysis: %s', 16, 1, @error_message);
-    END CATCH;
+    DROP PROCEDURE config.enable_consulting_analysis;
 END;
 GO
 
-/*
-Set up baseline monitoring profile (minimal resource usage)
-*/
-IF OBJECT_ID(N'config.enable_baseline_monitoring', N'P') IS NULL
+IF OBJECT_ID(N'config.enable_baseline_monitoring', N'P') IS NOT NULL
 BEGIN
-    EXECUTE(N'CREATE PROCEDURE config.enable_baseline_monitoring AS RETURN 138;');
-END;
-GO
-
-ALTER PROCEDURE
-    config.enable_baseline_monitoring
-WITH RECOMPILE
-AS
-BEGIN
-    SET NOCOUNT ON;
-    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-    BEGIN TRY
-        /*Baseline: max 5 minutes for everything*/
-        EXECUTE config.update_collector_frequency N'wait_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'query_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'procedure_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'query_store_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'memory_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'cpu_utilization_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'system_health_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'plan_cache_stats_collector', 5, 1;
-        EXECUTE config.update_collector_frequency N'blocking_deadlock_analyzer', 5, 1;
-
-        /*Disable high-frequency collectors*/
-        EXECUTE config.set_collector_enabled N'query_snapshots_collector', 0;
-
-        PRINT 'Baseline monitoring profile enabled';
-        PRINT 'All collectors at 5-minute intervals, snapshots disabled';
-        
-    END TRY
-    BEGIN CATCH
-        DECLARE @error_message nvarchar(4000) = ERROR_MESSAGE();
-        RAISERROR(N'Error enabling baseline monitoring: %s', 16, 1, @error_message);
-    END CATCH;
+    DROP PROCEDURE config.enable_baseline_monitoring;
 END;
 GO
 
@@ -317,11 +395,11 @@ BEGIN
         enabled,
         frequency_minutes,
         next_run_time,
-        minutes_until_next_run = 
-            CASE 
-                WHEN enabled = 1 AND next_run_time IS NOT NULL 
+        minutes_until_next_run =
+            CASE
+                WHEN enabled = 1 AND next_run_time IS NOT NULL
                 THEN DATEDIFF(MINUTE, SYSDATETIME(), next_run_time)
-                ELSE NULL 
+                ELSE NULL
             END,
         last_run_time,
         max_duration_minutes,
@@ -338,8 +416,11 @@ PRINT '';
 PRINT 'Available procedures:';
 PRINT '- config.update_collector_frequency - Change frequency for specific collector';
 PRINT '- config.set_collector_enabled - Enable/disable specific collector';
-PRINT '- config.enable_realtime_monitoring - High frequency for dashboards';
-PRINT '- config.enable_consulting_analysis - Balanced for analysis work';
-PRINT '- config.enable_baseline_monitoring - Minimal overhead monitoring';
+PRINT '- config.apply_collection_preset - Apply a named preset (Aggressive, Balanced, Low-Impact)';
 PRINT '- config.show_collection_schedule - Display current schedule';
+PRINT '';
+PRINT 'Examples:';
+PRINT '  EXECUTE config.apply_collection_preset @preset_name = N''Aggressive'', @debug = 1;';
+PRINT '  EXECUTE config.apply_collection_preset @preset_name = N''Balanced'';';
+PRINT '  EXECUTE config.apply_collection_preset @preset_name = N''Low-Impact'';';
 GO


### PR DESCRIPTION
## Summary
- New `config.apply_collection_preset` stored proc — applies Aggressive, Balanced, or Low-Impact frequency profiles to all 29 scheduled collectors in one operation
- Preset ComboBox added to Dashboard's Collector Schedules window and Lite's Settings window
- Auto-detects active preset by comparing current intervals; shows "Custom" if manually edited
- Drops three legacy profile procs replaced by the unified preset approach

Closes #454

## Preset intervals
| Tier | Core collectors | Heavy collectors | Infrequent |
|---|---|---|---|
| **Aggressive** | 1 min | 1 min | 2 min |
| **Balanced** | 1 min (default) | 2 min | 5 min |
| **Low-Impact** | 5 min | 10 min | 30 min |

## Test plan
- [x] SQL: All three presets tested on sql2022 (29 collectors updated each)
- [x] SQL: Invalid preset name returns proper error
- [x] SQL: Legacy procs confirmed dropped
- [x] Dashboard: Builds clean
- [x] Lite: Builds clean
- [ ] Dashboard: Open schedule window, verify preset detection and apply
- [ ] Lite: Open settings, verify preset detection and apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)