### PR TITLE
Fix FinOps CI: sql_variant CONCAT and test table count

### DIFF
--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -136,8 +136,8 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 24 tables from Schema (schema_version is created separately by DuckDbInitializer) */
-        Assert.Equal(24, tableCount);
+        /* 26 tables from Schema (schema_version is created separately by DuckDbInitializer) */
+        Assert.Equal(26, tableCount);
     }
 
     [Fact]

--- a/install/53_collect_server_properties.sql
+++ b/install/53_collect_server_properties.sql
@@ -212,9 +212,9 @@ BEGIN
                     N'SHA2_256',
                     CONCAT
                     (
-                        SERVERPROPERTY(N'Edition'), N'|',
-                        SERVERPROPERTY(N'ProductVersion'), N'|',
-                        SERVERPROPERTY(N'ProductLevel'), N'|',
+                        CONVERT(nvarchar(128), SERVERPROPERTY(N'Edition')), N'|',
+                        CONVERT(nvarchar(128), SERVERPROPERTY(N'ProductVersion')), N'|',
+                        CONVERT(nvarchar(128), SERVERPROPERTY(N'ProductLevel')), N'|',
                         @engine_edition, N'|',
                         (SELECT osi.cpu_count FROM sys.dm_os_sys_info AS osi), N'|',
                         (SELECT osi.physical_memory_kb FROM sys.dm_os_sys_info AS osi), N'|',


### PR DESCRIPTION
## Summary
- Fix `Msg 257` in server_properties_collector: SERVERPROPERTY returns `sql_variant` which can't be used in CONCAT implicitly — added explicit CONVERT to `nvarchar(128)`
- Update `SchemaStatements_MatchTableCount` test assertion from 24 to 26 for the two new FinOps tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)