### PR TITLE
Widen SQL Validation path filter to include .github/sql changes

### DIFF
--- a/.github/workflows/sql-validation.yml
+++ b/.github/workflows/sql-validation.yml
@@ -3,10 +3,10 @@ name: SQL Validation
 on:
   push:
     branches: [dev]
-    paths: ['install/**']
+    paths: ['install/**', '.github/sql/**', '.github/workflows/sql-validation.yml']
   pull_request:
     branches: [dev]
-    paths: ['install/**']
+    paths: ['install/**', '.github/sql/**', '.github/workflows/sql-validation.yml']
 
 jobs:
   validate-sql:


### PR DESCRIPTION
## Summary
- Add `.github/sql/**` and `.github/workflows/sql-validation.yml` to the SQL Validation workflow path filter
- Previously only `install/**` changes triggered the workflow, so validation script updates didn't get verified

## Test plan
- [ ] This PR itself should trigger SQL Validation (since the workflow file changed)
- [ ] SQL Validation passes on all 4 SQL Server versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)