### PR TITLE
Use user locale for date/time formatting (closes #459)

### DIFF
--- a/Dashboard/App.xaml.cs
+++ b/Dashboard/App.xaml.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Markup;
 using System.Windows.Threading;
 using PerformanceMonitorDashboard.Helpers;
 
@@ -38,6 +39,11 @@ namespace PerformanceMonitorDashboard
             }
 
             base.OnStartup(e);
+
+            // Use the user's locale for date/time formatting in WPF bindings (issue #459)
+            FrameworkElement.LanguageProperty.OverrideMetadata(
+                typeof(FrameworkElement),
+                new FrameworkPropertyMetadata(XmlLanguage.GetLanguage(Thread.CurrentThread.CurrentCulture.IetfLanguageTag)));
 
             // Apply saved color theme before the main window is shown
             var prefs = new Services.UserPreferencesService().GetPreferences();


### PR DESCRIPTION
## Summary
- WPF bindings default to `en-US` culture, ignoring the user's system locale
- One-line fix: `FrameworkElement.LanguageProperty.OverrideMetadata` at app startup to use `CurrentCulture`
- All `StringFormat` bindings (`{0:g}`, etc.) now respect the user's locale — European users see `dd/MM/yyyy` and 24-hour time

Closes #459

## Test plan
- [ ] On a system with non-US locale, open Collector Schedules — Last Run/Next Run should use local date format
- [ ] Verify numbers still format correctly (comma vs period decimal separator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)