### PR TITLE
Fix database_size_stats tinyint cast error

### DIFF
--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -61,7 +61,7 @@ SELECT
     recovery_model_desc =
         d.recovery_model_desc,
     compatibility_level =
-        d.compatibility_level,
+        CONVERT(int, d.compatibility_level),
     state_desc =
         d.state_desc
 FROM sys.master_files AS mf


### PR DESCRIPTION
## Summary
- `database_size_stats` collector failing every cycle with `InvalidCastException: Unable to cast object of type 'System.Byte' to type 'System.Int32'`
- `sys.databases.compatibility_level` is `tinyint` (System.Byte) but C# reader called `GetInt32()`
- Fix: `CONVERT(int, d.compatibility_level)` in the on-prem SQL query

## Test plan
- [x] Build clean
- [ ] Launch Lite, verify `database_size_stats` collector runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)