### PR TITLE
FinOps estate-level tabs, session_stats collector, archive reconciliation

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1,0 +1,390 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.FinOpsContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+             xmlns:controls="clr-namespace:PerformanceMonitorDashboard.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="600" d:DesignWidth="1200">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <!-- Context Menu for DataGrid Copy/Export -->
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+
+            <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Server Selector -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,6,10,0">
+            <TextBlock Text="Server:" VerticalAlignment="Center" Margin="0,0,6,0"
+                       FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+            <ComboBox x:Name="ServerSelector" Width="300" DisplayMemberPath="DisplayName"
+                      SelectionChanged="ServerSelector_SelectionChanged"/>
+        </StackPanel>
+
+    <TabControl Grid.Row="1" TabStripPlacement="Top" Margin="0,5,0,0">
+
+        <!-- Utilization Sub-Tab -->
+        <TabItem Header="Utilization">
+            <Grid Margin="10,5,10,10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Refresh Button -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="Refresh" Click="UtilizationRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                    <controls:LoadingOverlay x:Name="UtilizationLoading" Width="24" Height="24" Margin="10,0,0,0"/>
+                </StackPanel>
+
+                <!-- Provisioning Status Summary Panel -->
+                <Border Grid.Row="1" Background="{DynamicResource BackgroundLightBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Padding="12,10" Margin="0,0,0,8">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Row 1: Provisioning Status + CPU Metrics -->
+                        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="Provisioning:" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <Border x:Name="ProvisioningStatusBorder" CornerRadius="3" Padding="8,2" Margin="0,0,20,0">
+                                <TextBlock x:Name="ProvisioningStatusText" Text="--" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </Border>
+
+                            <TextBlock Text="CPU Count:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="CpuCountText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Avg CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="AvgCpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="P95 CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="P95CpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Max CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="MaxCpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Samples:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="CpuSamplesText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                        </StackPanel>
+
+                        <!-- Row 2: Memory + Thread Metrics -->
+                        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
+                            <TextBlock Text="Physical Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="PhysicalMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Target Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="TargetMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Total Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="TotalMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Memory Util:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="MemoryUtilText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Worker Threads:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="WorkerThreadsText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                            <TextBlock Text="Thread Ratio:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="ThreadRatioText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Peak Utilization Chart -->
+                <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="Peak Utilization by Hour" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="PeakUtilizationChart" Margin="5"/>
+                    </Grid>
+                </Border>
+            </Grid>
+        </TabItem>
+
+        <!-- Database Resources Sub-Tab -->
+        <TabItem Header="Database Resources">
+            <Grid Margin="10,5,10,10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Refresh Button -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="Refresh" Click="DatabaseResourcesRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1">
+                    <DataGrid x:Name="DatabaseResourcesDataGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" CanUserResizeColumns="True"
+                              GridLinesVisibility="All"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="180">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Database" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding PctCpuShare, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="CPU %" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding PctIoShare, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="I/O %" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="CPU Time (ms)" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Executions" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Logical Reads" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding PhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Physical Reads" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding LogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Logical Writes" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IoReadMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="I/O Read MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IoWriteMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="I/O Write MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IoStallMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="I/O Stall (ms)" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="DatabaseResourcesNoDataMessage" Style="{DynamicResource NoDataMessage}"
+                               Text="No database resource usage data available."/>
+                    <controls:LoadingOverlay x:Name="DatabaseResourcesLoading"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Database Sizes Sub-Tab -->
+        <TabItem Header="Database Sizes">
+            <Grid Margin="10,5,10,10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Refresh Button -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="Refresh" Click="DatabaseSizesRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1">
+                    <DataGrid x:Name="DatabaseSizesDataGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" CanUserResizeColumns="True"
+                              GridLinesVisibility="All"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="160">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Database" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FileTypeDesc}" Width="80">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="File Type" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FileName}" Width="160">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="File Name" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TotalSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Total MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding UsedSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Used MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FreeSpaceMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Free MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding UsedPct, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Used %" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding AutoGrowthMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Auto Growth" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding MaxSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Max Size MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding RecoveryModelDesc}" Width="100">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Recovery" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding StateDesc}" Width="80">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="State" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding VolumeMountPoint}" Width="80">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Volume" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding VolumeTotalMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Vol Total MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding VolumeFreeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Vol Free MB" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding PhysicalName}" Width="400">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Physical Path" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="DatabaseSizesNoDataMessage" Style="{DynamicResource NoDataMessage}"
+                               Text="No database size data available."/>
+                    <controls:LoadingOverlay x:Name="DatabaseSizesLoading"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Application Connections Sub-Tab -->
+        <TabItem Header="Application Connections">
+            <Grid Margin="10,5,10,10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Refresh Button -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="Refresh" Click="ApplicationConnectionsRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1">
+                    <DataGrid x:Name="ApplicationConnectionsDataGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" CanUserResizeColumns="True"
+                              GridLinesVisibility="All"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding ApplicationName}" Width="300">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Application" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding AvgConnections, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Avg Connections" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding MaxConnections, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Max Connections" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Sample Count" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FirstSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="160">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="First Seen" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="160">
+                                <DataGridTextColumn.Header>
+                                    <TextBlock Text="Last Seen" FontWeight="Bold"/>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="ApplicationConnectionsNoDataMessage" Style="{DynamicResource NoDataMessage}"
+                               Text="No application connection data available."/>
+                    <controls:LoadingOverlay x:Name="ApplicationConnectionsLoading"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+    </TabControl>
+    </Grid>
+</UserControl>

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Microsoft.Win32;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    /// <summary>
+    /// UserControl for the FinOps tab content.
+    /// Displays utilization efficiency, database resource usage,
+    /// database sizes, and application connection metrics.
+    /// </summary>
+    public partial class FinOpsContent : UserControl
+    {
+        private DatabaseService? _databaseService;
+        private ServerManager? _serverManager;
+        private CredentialService? _credentialService;
+
+        public FinOpsContent()
+        {
+            InitializeComponent();
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
+            Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
+
+            // Apply dark theme immediately so charts don't flash white
+            TabHelpers.ApplyThemeToChart(PeakUtilizationChart);
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
+        }
+
+        private void OnThemeChanged(string _)
+        {
+            TabHelpers.ApplyThemeToChart(PeakUtilizationChart);
+            PeakUtilizationChart.Refresh();
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            TabHelpers.AutoSizeColumnMinWidths(DatabaseResourcesDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(DatabaseSizesDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(ApplicationConnectionsDataGrid);
+
+            TabHelpers.FreezeColumns(DatabaseResourcesDataGrid, 1);
+            TabHelpers.FreezeColumns(DatabaseSizesDataGrid, 1);
+            TabHelpers.FreezeColumns(ApplicationConnectionsDataGrid, 1);
+        }
+
+        /// <summary>
+        /// Initializes the control with required dependencies.
+        /// </summary>
+        public void Initialize(ServerManager serverManager, CredentialService credentialService)
+        {
+            _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
+            _credentialService = credentialService ?? throw new ArgumentNullException(nameof(credentialService));
+
+            var servers = _serverManager.GetAllServers();
+            ServerSelector.ItemsSource = servers;
+            if (servers.Count > 0)
+                ServerSelector.SelectedIndex = 0;
+        }
+
+        private async void ServerSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ServerSelector.SelectedItem is ServerConnection server && _credentialService != null)
+            {
+                var connectionString = server.GetConnectionString(_credentialService);
+                _databaseService = new DatabaseService(connectionString);
+                await RefreshDataAsync();
+            }
+        }
+
+        /// <summary>
+        /// Refreshes all FinOps data. Can be called from parent control.
+        /// </summary>
+        public async Task RefreshDataAsync()
+        {
+            try
+            {
+                await Task.WhenAll(
+                    LoadUtilizationAsync(),
+                    LoadDatabaseResourcesAsync(),
+                    LoadDatabaseSizesAsync(),
+                    LoadApplicationConnectionsAsync()
+                );
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error refreshing FinOps data: {ex.Message}", ex);
+            }
+        }
+
+        // ============================================
+        // Utilization Tab
+        // ============================================
+
+        private async Task LoadUtilizationAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                UtilizationLoading.IsLoading = true;
+
+                var efficiencyTask = _databaseService.GetFinOpsUtilizationEfficiencyAsync();
+                var peakTask = _databaseService.GetFinOpsPeakUtilizationAsync();
+
+                await Task.WhenAll(efficiencyTask, peakTask);
+
+                var efficiency = await efficiencyTask;
+                var peakData = await peakTask;
+
+                UpdateUtilizationSummary(efficiency);
+                RenderPeakUtilizationChart(peakData);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading utilization data: {ex.Message}", ex);
+            }
+            finally
+            {
+                UtilizationLoading.IsLoading = false;
+            }
+        }
+
+        private void UpdateUtilizationSummary(FinOpsUtilizationEfficiency? efficiency)
+        {
+            if (efficiency == null)
+            {
+                ProvisioningStatusText.Text = "No Data";
+                ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
+                return;
+            }
+
+            // Provisioning status with color coding
+            ProvisioningStatusText.Text = efficiency.ProvisioningStatus.Replace("_", " ");
+
+            switch (efficiency.ProvisioningStatus)
+            {
+                case "RIGHT_SIZED":
+                    ProvisioningStatusBorder.Background = (Brush)FindResource("SuccessBrush");
+                    ProvisioningStatusText.Foreground = Brushes.White;
+                    break;
+                case "OVER_PROVISIONED":
+                    ProvisioningStatusBorder.Background = (Brush)FindResource("WarningBrush");
+                    ProvisioningStatusText.Foreground = Brushes.Black;
+                    break;
+                case "UNDER_PROVISIONED":
+                    ProvisioningStatusBorder.Background = (Brush)FindResource("ErrorBrush");
+                    ProvisioningStatusText.Foreground = Brushes.White;
+                    break;
+                default:
+                    ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
+                    ProvisioningStatusText.Foreground = Brushes.White;
+                    break;
+            }
+
+            // CPU metrics
+            CpuCountText.Text = efficiency.CpuCount.ToString("N0");
+            AvgCpuText.Text = $"{efficiency.AvgCpuPct:N2}%";
+            P95CpuText.Text = $"{efficiency.P95CpuPct:N2}%";
+            MaxCpuText.Text = $"{efficiency.MaxCpuPct}%";
+            CpuSamplesText.Text = efficiency.CpuSamples.ToString("N0");
+
+            // Memory metrics
+            PhysicalMemoryText.Text = $"{efficiency.PhysicalMemoryMb:N0} MB";
+            TargetMemoryText.Text = $"{efficiency.TargetMemoryMb:N0} MB";
+            TotalMemoryText.Text = $"{efficiency.TotalMemoryMb:N0} MB";
+            MemoryUtilText.Text = $"{efficiency.MemoryUtilizationPct}%";
+
+            // Thread metrics
+            WorkerThreadsText.Text = $"{efficiency.WorkerThreadsCurrent:N0} / {efficiency.WorkerThreadsMax:N0}";
+            ThreadRatioText.Text = $"{efficiency.WorkerThreadRatio:N2}";
+        }
+
+        private void RenderPeakUtilizationChart(List<FinOpsPeakUtilization> data)
+        {
+            PeakUtilizationChart.Plot.Clear();
+
+            if (data.Count == 0)
+            {
+                var noDataText = PeakUtilizationChart.Plot.Add.Text("No peak utilization data available", 12, 50);
+                noDataText.LabelFontSize = 14;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex("#888888");
+                PeakUtilizationChart.Refresh();
+                return;
+            }
+
+            // Build bars for avg CPU by hour, colored by classification
+            var bars = new List<ScottPlot.Bar>();
+
+            foreach (var item in data)
+            {
+                var color = item.HourClassification switch
+                {
+                    "PEAK" => ScottPlot.Color.FromHex("#E74C3C"),   // Red
+                    "IDLE" => ScottPlot.Color.FromHex("#27AE60"),   // Green
+                    "NORMAL" => ScottPlot.Color.FromHex("#3498DB"), // Blue
+                    _ => ScottPlot.Color.FromHex("#95A5A6")         // Gray
+                };
+
+                bars.Add(new ScottPlot.Bar
+                {
+                    Position = item.HourOfDay,
+                    Value = (double)item.AvgCpuPct,
+                    FillColor = color,
+                    Size = 0.8
+                });
+            }
+
+            var barPlot = PeakUtilizationChart.Plot.Add.Bars(bars.ToArray());
+            barPlot.Horizontal = false;
+
+            PeakUtilizationChart.Plot.Axes.Bottom.Label.Text = "Hour of Day";
+            PeakUtilizationChart.Plot.Axes.Left.Label.Text = "Avg CPU %";
+
+            // Set x-axis ticks to show each hour
+            var ticks = data.Select(d => new ScottPlot.Tick(d.HourOfDay, $"{d.HourOfDay:D2}:00")).ToArray();
+            PeakUtilizationChart.Plot.Axes.Bottom.TickGenerator = new ScottPlot.TickGenerators.NumericManual(ticks);
+            PeakUtilizationChart.Plot.Axes.Bottom.TickLabelStyle.Rotation = 45;
+
+            // Add a legend for classifications
+            PeakUtilizationChart.Plot.Legend.IsVisible = true;
+            PeakUtilizationChart.Plot.Legend.Alignment = ScottPlot.Alignment.UpperRight;
+
+            PeakUtilizationChart.Refresh();
+        }
+
+        // ============================================
+        // Database Resources Tab
+        // ============================================
+
+        private async Task LoadDatabaseResourcesAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                if (DatabaseResourcesDataGrid.ItemsSource == null)
+                {
+                    DatabaseResourcesLoading.IsLoading = true;
+                    DatabaseResourcesNoDataMessage.Visibility = Visibility.Collapsed;
+                }
+
+                var data = await _databaseService.GetFinOpsDatabaseResourceUsageAsync();
+                DatabaseResourcesDataGrid.ItemsSource = data;
+                DatabaseResourcesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading database resources: {ex.Message}", ex);
+            }
+            finally
+            {
+                DatabaseResourcesLoading.IsLoading = false;
+            }
+        }
+
+        // ============================================
+        // Database Sizes Tab
+        // ============================================
+
+        private async Task LoadDatabaseSizesAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                if (DatabaseSizesDataGrid.ItemsSource == null)
+                {
+                    DatabaseSizesLoading.IsLoading = true;
+                    DatabaseSizesNoDataMessage.Visibility = Visibility.Collapsed;
+                }
+
+                var data = await _databaseService.GetFinOpsDatabaseSizeStatsAsync();
+                DatabaseSizesDataGrid.ItemsSource = data;
+                DatabaseSizesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading database sizes: {ex.Message}", ex);
+            }
+            finally
+            {
+                DatabaseSizesLoading.IsLoading = false;
+            }
+        }
+
+        // ============================================
+        // Application Connections Tab
+        // ============================================
+
+        private async Task LoadApplicationConnectionsAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                if (ApplicationConnectionsDataGrid.ItemsSource == null)
+                {
+                    ApplicationConnectionsLoading.IsLoading = true;
+                    ApplicationConnectionsNoDataMessage.Visibility = Visibility.Collapsed;
+                }
+
+                var data = await _databaseService.GetFinOpsApplicationResourceUsageAsync();
+                ApplicationConnectionsDataGrid.ItemsSource = data;
+                ApplicationConnectionsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading application connections: {ex.Message}", ex);
+            }
+            finally
+            {
+                ApplicationConnectionsLoading.IsLoading = false;
+            }
+        }
+
+        // ============================================
+        // Refresh Button Handlers
+        // ============================================
+
+        private async void UtilizationRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadUtilizationAsync();
+        }
+
+        private async void DatabaseResourcesRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadDatabaseResourcesAsync();
+        }
+
+        private async void DatabaseSizesRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadDatabaseSizesAsync();
+        }
+
+        private async void ApplicationConnectionsRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadApplicationConnectionsAsync();
+        }
+
+        // ============================================
+        // Copy / Export Context Menu Handlers
+        // ============================================
+
+        private void CopyCell_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                if (contextMenu.PlacementTarget is DataGrid grid && grid.CurrentCell.Column != null)
+                {
+                    var cellContent = TabHelpers.GetCellContent(grid, grid.CurrentCell);
+                    if (!string.IsNullOrEmpty(cellContent))
+                    {
+                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
+                        Clipboard.SetDataObject(cellContent, false);
+                    }
+                }
+            }
+        }
+
+        private void CopyRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                if (contextMenu.PlacementTarget is DataGrid grid && grid.SelectedItem != null)
+                {
+                    var rowText = TabHelpers.GetRowAsText(grid, grid.SelectedItem);
+                    if (!string.IsNullOrEmpty(rowText))
+                    {
+                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
+                        Clipboard.SetDataObject(rowText, false);
+                    }
+                }
+            }
+        }
+
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                if (contextMenu.PlacementTarget is DataGrid grid)
+                {
+                    var sb = new StringBuilder();
+
+                    // Header row
+                    var headers = grid.Columns.Select(c => DataGridClipboardBehavior.GetHeaderText(c));
+                    sb.AppendLine(string.Join("\t", headers));
+
+                    // Data rows
+                    foreach (var item in grid.Items)
+                    {
+                        var values = new List<string>();
+                        foreach (var column in grid.Columns)
+                        {
+                            var binding = (column as DataGridBoundColumn)?.Binding as Binding;
+                            if (binding != null)
+                            {
+                                var prop = item.GetType().GetProperty(binding.Path.Path);
+                                var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
+                                values.Add(value);
+                            }
+                        }
+                        sb.AppendLine(string.Join("\t", values));
+                    }
+
+                    if (sb.Length > 0)
+                    {
+                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
+                        Clipboard.SetDataObject(sb.ToString(), false);
+                    }
+                }
+            }
+        }
+
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                if (contextMenu.PlacementTarget is DataGrid grid)
+                {
+                    var dialog = new SaveFileDialog
+                    {
+                        Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+                        DefaultExt = ".csv",
+                        FileName = $"FinOps_Export_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
+                    };
+
+                    if (dialog.ShowDialog() == true)
+                    {
+                        try
+                        {
+                            var sb = new StringBuilder();
+
+                            // Header row
+                            var sep = TabHelpers.CsvSeparator;
+                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(c), sep));
+                            sb.AppendLine(string.Join(sep, headers));
+
+                            // Data rows
+                            foreach (var item in grid.Items)
+                            {
+                                var values = new List<string>();
+                                foreach (var column in grid.Columns)
+                                {
+                                    var binding = (column as DataGridBoundColumn)?.Binding as Binding;
+                                    if (binding != null)
+                                    {
+                                        var prop = item.GetType().GetProperty(binding.Path.Path);
+                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
+                                    }
+                                }
+                                sb.AppendLine(string.Join(sep, values));
+                            }
+
+                            File.WriteAllText(dialog.FileName, sb.ToString());
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error($"Error exporting to CSV: {ex.Message}", ex);
+                            MessageBox.Show($"Error exporting to CSV: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -193,6 +193,12 @@
                             <TextBlock Text="Open Plan Viewer" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
+                    <Button x:Name="FinOpsButton"
+                            Content="FinOps"
+                            Click="FinOps_Click"
+                            Style="{StaticResource AccentButton}"
+                            Height="32"
+                            Margin="0,0,0,8"/>
                     <Separator Margin="0,0,0,8"/>
                     <Button x:Name="RefreshAllButton"
                             Content="&#x21BB; Refresh All Status"

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -49,6 +49,8 @@ namespace PerformanceMonitorDashboard
         private LandingPage? _landingPage;
         private TabItem? _alertsTab;
         private TabItem? _planViewerTab;
+        private TabItem? _finOpsTab;
+        private Controls.FinOpsContent? _finOpsContent;
         private AlertsHistoryContent? _alertsHistoryContent;
 
         private McpHostService? _mcpHostService;
@@ -79,6 +81,7 @@ namespace PerformanceMonitorDashboard
         private const string NocTabId = "__NOC_OVERVIEW__";
         private const string AlertsTabId = "__ALERTS_HISTORY__";
         private const string PlanViewerTabId = "__PLAN_VIEWER__";
+        private const string FinOpsTabId = "__FINOPS__";
 
         public MainWindow()
         {
@@ -627,6 +630,11 @@ namespace PerformanceMonitorDashboard
             OpenAlertsTab();
         }
 
+        private void FinOps_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFinOpsTab();
+        }
+
         private void OpenAlertsTab()
         {
             if (_alertsTab != null && ServerTabControl.Items.Contains(_alertsTab))
@@ -670,6 +678,61 @@ namespace PerformanceMonitorDashboard
             _alertsHistoryContent.RefreshAlerts();
         }
 
+        private void OpenFinOpsTab()
+        {
+            if (_finOpsTab != null && ServerTabControl.Items.Contains(_finOpsTab))
+            {
+                ServerTabControl.SelectedItem = _finOpsTab;
+                _ = _finOpsContent?.RefreshDataAsync();
+                return;
+            }
+
+            // Ensure at least one server is configured
+            var servers = _serverManager.GetAllServers();
+            if (servers.Count == 0)
+            {
+                MessageBox.Show("Add at least one server before opening FinOps.", "No Servers",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            _finOpsContent = new Controls.FinOpsContent();
+            _finOpsContent.Initialize(_serverManager, _credentialService);
+
+            var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };
+            var headerText = new TextBlock
+            {
+                Text = "FinOps",
+                VerticalAlignment = VerticalAlignment.Center,
+                FontWeight = FontWeights.SemiBold
+            };
+            var closeButton = new Button
+            {
+                Style = (Style)FindResource("TabCloseButton"),
+                Tag = FinOpsTabId
+            };
+            closeButton.Click += CloseTab_Click;
+            headerPanel.Children.Add(headerText);
+            headerPanel.Children.Add(closeButton);
+
+            _finOpsTab = new TabItem
+            {
+                Header = headerPanel,
+                Content = _finOpsContent,
+                Tag = FinOpsTabId
+            };
+
+            /* Insert after Alerts tab if present, else after NOC, else at 0 */
+            var insertIndex = 0;
+            if (_alertsTab != null && ServerTabControl.Items.Contains(_alertsTab))
+                insertIndex = ServerTabControl.Items.IndexOf(_alertsTab) + 1;
+            else if (_nocTab != null && ServerTabControl.Items.Contains(_nocTab))
+                insertIndex = ServerTabControl.Items.IndexOf(_nocTab) + 1;
+
+            ServerTabControl.Items.Insert(insertIndex, _finOpsTab);
+            ServerTabControl.SelectedItem = _finOpsTab;
+        }
+
         private void CloseTab_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && button.Tag is string tabId)
@@ -691,6 +754,15 @@ namespace PerformanceMonitorDashboard
                         ServerTabControl.Items.Remove(_alertsTab);
                         _alertsTab = null;
                         _alertsHistoryContent = null;
+                    }
+                }
+                else if (tabId == FinOpsTabId)
+                {
+                    if (_finOpsTab != null)
+                    {
+                        ServerTabControl.Items.Remove(_finOpsTab);
+                        _finOpsTab = null;
+                        _finOpsContent = null;
                     }
                 }
                 else if (tabId == PlanViewerTabId)

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitorDashboard.Helpers;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    public partial class DatabaseService
+    {
+        // ============================================
+        // FinOps Tab Data Access
+        // ============================================
+
+        /// <summary>
+        /// Fetches per-database resource usage from report.finops_database_resource_usage.
+        /// </summary>
+        public async Task<List<FinOpsDatabaseResourceUsage>> GetFinOpsDatabaseResourceUsageAsync()
+        {
+            var items = new List<FinOpsDatabaseResourceUsage>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    database_name,
+                    cpu_time_ms,
+                    logical_reads,
+                    physical_reads,
+                    logical_writes,
+                    execution_count,
+                    io_read_mb,
+                    io_write_mb,
+                    io_stall_ms,
+                    pct_cpu_share,
+                    pct_io_share
+                FROM report.finops_database_resource_usage
+                ORDER BY
+                    pct_cpu_share DESC
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_DatabaseResourceUsage", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsDatabaseResourceUsage
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        CpuTimeMs = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                        LogicalReads = reader.IsDBNull(2) ? 0 : Convert.ToInt64(reader.GetValue(2)),
+                        PhysicalReads = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
+                        LogicalWrites = reader.IsDBNull(4) ? 0 : Convert.ToInt64(reader.GetValue(4)),
+                        ExecutionCount = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
+                        IoReadMb = reader.IsDBNull(6) ? 0m : Convert.ToDecimal(reader.GetValue(6)),
+                        IoWriteMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                        IoStallMs = reader.IsDBNull(8) ? 0 : Convert.ToInt64(reader.GetValue(8)),
+                        PctCpuShare = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                        PctIoShare = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10))
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Fetches utilization efficiency metrics from report.finops_utilization_efficiency.
+        /// </summary>
+        public async Task<FinOpsUtilizationEfficiency?> GetFinOpsUtilizationEfficiencyAsync()
+        {
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    avg_cpu_pct,
+                    max_cpu_pct,
+                    p95_cpu_pct,
+                    cpu_samples,
+                    total_memory_mb,
+                    target_memory_mb,
+                    physical_memory_mb,
+                    memory_ratio,
+                    memory_utilization_pct,
+                    worker_threads_current,
+                    worker_threads_max,
+                    worker_thread_ratio,
+                    cpu_count,
+                    provisioning_status
+                FROM report.finops_utilization_efficiency
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_UtilizationEfficiency", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    return new FinOpsUtilizationEfficiency
+                    {
+                        AvgCpuPct = reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
+                        MaxCpuPct = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1)),
+                        P95CpuPct = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2)),
+                        CpuSamples = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
+                        TotalMemoryMb = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                        TargetMemoryMb = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                        PhysicalMemoryMb = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
+                        MemoryRatio = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                        MemoryUtilizationPct = reader.IsDBNull(8) ? 0 : Convert.ToInt32(reader.GetValue(8)),
+                        WorkerThreadsCurrent = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
+                        WorkerThreadsMax = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
+                        WorkerThreadRatio = reader.IsDBNull(11) ? 0m : Convert.ToDecimal(reader.GetValue(11)),
+                        CpuCount = reader.IsDBNull(12) ? 0 : Convert.ToInt32(reader.GetValue(12)),
+                        ProvisioningStatus = reader.IsDBNull(13) ? "" : reader.GetString(13)
+                    };
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Fetches peak utilization by hour from report.finops_peak_utilization.
+        /// </summary>
+        public async Task<List<FinOpsPeakUtilization>> GetFinOpsPeakUtilizationAsync()
+        {
+            var items = new List<FinOpsPeakUtilization>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    hour_of_day,
+                    avg_cpu_pct,
+                    max_cpu_pct,
+                    avg_memory_pct,
+                    max_memory_pct,
+                    cpu_samples,
+                    hour_classification
+                FROM report.finops_peak_utilization
+                ORDER BY
+                    hour_of_day ASC
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_PeakUtilization", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsPeakUtilization
+                    {
+                        HourOfDay = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0)),
+                        AvgCpuPct = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                        MaxCpuPct = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                        AvgMemoryPct = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        MaxMemoryPct = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                        CpuSamples = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
+                        HourClassification = reader.IsDBNull(6) ? "" : reader.GetString(6)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Fetches per-application resource usage from report.finops_application_resource_usage.
+        /// </summary>
+        public async Task<List<FinOpsApplicationResourceUsage>> GetFinOpsApplicationResourceUsageAsync()
+        {
+            var items = new List<FinOpsApplicationResourceUsage>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    application_name,
+                    avg_connections,
+                    max_connections,
+                    sample_count,
+                    first_seen,
+                    last_seen
+                FROM report.finops_application_resource_usage
+                ORDER BY
+                    max_connections DESC
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_ApplicationResourceUsage", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsApplicationResourceUsage
+                    {
+                        ApplicationName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        AvgConnections = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1)),
+                        MaxConnections = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                        SampleCount = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
+                        FirstSeen = reader.IsDBNull(4) ? DateTime.MinValue : reader.GetDateTime(4),
+                        LastSeen = reader.IsDBNull(5) ? DateTime.MinValue : reader.GetDateTime(5)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Fetches latest database size stats from collect.database_size_stats.
+        /// </summary>
+        public async Task<List<FinOpsDatabaseSizeStats>> GetFinOpsDatabaseSizeStatsAsync()
+        {
+            var items = new List<FinOpsDatabaseSizeStats>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    collection_time,
+                    database_name,
+                    database_id,
+                    file_id,
+                    file_type_desc,
+                    file_name,
+                    physical_name,
+                    total_size_mb,
+                    used_size_mb,
+                    free_space_mb,
+                    used_pct,
+                    auto_growth_mb,
+                    max_size_mb,
+                    recovery_model_desc,
+                    compatibility_level,
+                    state_desc,
+                    volume_mount_point,
+                    volume_total_mb,
+                    volume_free_mb
+                FROM collect.database_size_stats
+                WHERE collection_time =
+                (
+                    SELECT
+                        MAX(collection_time)
+                    FROM collect.database_size_stats
+                )
+                ORDER BY
+                    database_name,
+                    file_type_desc,
+                    file_id
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_DatabaseSizeStats", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsDatabaseSizeStats
+                    {
+                        CollectionTime = reader.IsDBNull(0) ? DateTime.MinValue : reader.GetDateTime(0),
+                        DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        DatabaseId = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                        FileId = reader.IsDBNull(3) ? 0 : Convert.ToInt32(reader.GetValue(3)),
+                        FileTypeDesc = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                        FileName = reader.IsDBNull(5) ? "" : reader.GetString(5),
+                        PhysicalName = reader.IsDBNull(6) ? "" : reader.GetString(6),
+                        TotalSizeMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                        UsedSizeMb = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                        FreeSpaceMb = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                        UsedPct = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10)),
+                        AutoGrowthMb = reader.IsDBNull(11) ? 0m : Convert.ToDecimal(reader.GetValue(11)),
+                        MaxSizeMb = reader.IsDBNull(12) ? 0m : Convert.ToDecimal(reader.GetValue(12)),
+                        RecoveryModelDesc = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                        CompatibilityLevel = reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14)),
+                        StateDesc = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                        VolumeMountPoint = reader.IsDBNull(16) ? "" : reader.GetString(16),
+                        VolumeTotalMb = reader.IsDBNull(17) ? 0m : Convert.ToDecimal(reader.GetValue(17)),
+                        VolumeFreeMb = reader.IsDBNull(18) ? 0m : Convert.ToDecimal(reader.GetValue(18))
+                    });
+                }
+            }
+
+            return items;
+        }
+    }
+
+    // ============================================
+    // FinOps Model Classes
+    // ============================================
+
+    public class FinOpsDatabaseResourceUsage
+    {
+        public string DatabaseName { get; set; } = "";
+        public long CpuTimeMs { get; set; }
+        public long LogicalReads { get; set; }
+        public long PhysicalReads { get; set; }
+        public long LogicalWrites { get; set; }
+        public long ExecutionCount { get; set; }
+        public decimal IoReadMb { get; set; }
+        public decimal IoWriteMb { get; set; }
+        public long IoStallMs { get; set; }
+        public decimal PctCpuShare { get; set; }
+        public decimal PctIoShare { get; set; }
+    }
+
+    public class FinOpsUtilizationEfficiency
+    {
+        public decimal AvgCpuPct { get; set; }
+        public int MaxCpuPct { get; set; }
+        public decimal P95CpuPct { get; set; }
+        public long CpuSamples { get; set; }
+        public int TotalMemoryMb { get; set; }
+        public int TargetMemoryMb { get; set; }
+        public int PhysicalMemoryMb { get; set; }
+        public decimal MemoryRatio { get; set; }
+        public int MemoryUtilizationPct { get; set; }
+        public int WorkerThreadsCurrent { get; set; }
+        public int WorkerThreadsMax { get; set; }
+        public decimal WorkerThreadRatio { get; set; }
+        public int CpuCount { get; set; }
+        public string ProvisioningStatus { get; set; } = "";
+    }
+
+    public class FinOpsPeakUtilization
+    {
+        public int HourOfDay { get; set; }
+        public decimal AvgCpuPct { get; set; }
+        public int MaxCpuPct { get; set; }
+        public decimal AvgMemoryPct { get; set; }
+        public int MaxMemoryPct { get; set; }
+        public long CpuSamples { get; set; }
+        public string HourClassification { get; set; } = "";
+    }
+
+    public class FinOpsApplicationResourceUsage
+    {
+        public string ApplicationName { get; set; } = "";
+        public int AvgConnections { get; set; }
+        public int MaxConnections { get; set; }
+        public long SampleCount { get; set; }
+        public DateTime FirstSeen { get; set; }
+        public DateTime LastSeen { get; set; }
+    }
+
+    public class FinOpsDatabaseSizeStats
+    {
+        public DateTime CollectionTime { get; set; }
+        public string DatabaseName { get; set; } = "";
+        public int DatabaseId { get; set; }
+        public int FileId { get; set; }
+        public string FileTypeDesc { get; set; } = "";
+        public string FileName { get; set; } = "";
+        public string PhysicalName { get; set; } = "";
+        public decimal TotalSizeMb { get; set; }
+        public decimal UsedSizeMb { get; set; }
+        public decimal FreeSpaceMb { get; set; }
+        public decimal UsedPct { get; set; }
+        public decimal AutoGrowthMb { get; set; }
+        public decimal MaxSizeMb { get; set; }
+        public string RecoveryModelDesc { get; set; } = "";
+        public int CompatibilityLevel { get; set; }
+        public string StateDesc { get; set; } = "";
+        public string VolumeMountPoint { get; set; } = "";
+        public decimal VolumeTotalMb { get; set; }
+        public decimal VolumeFreeMb { get; set; }
+    }
+}

--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -765,7 +765,10 @@ public static partial class PlanAnalyzer
         }
 
         // Rule 26: Row Goal (informational) — optimizer reduced estimate due to TOP/EXISTS/IN
-        if (node.EstimateRowsWithoutRowGoal > 0 && node.EstimateRows > 0 &&
+        // Only surface on data access operators (seeks/scans) where the row goal actually matters
+        var isDataAccess = node.PhysicalOp != null &&
+            (node.PhysicalOp.Contains("Scan") || node.PhysicalOp.Contains("Seek"));
+        if (isDataAccess && node.EstimateRowsWithoutRowGoal > 0 && node.EstimateRows > 0 &&
             node.EstimateRowsWithoutRowGoal > node.EstimateRows)
         {
             var reduction = node.EstimateRowsWithoutRowGoal / node.EstimateRows;

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -1,0 +1,511 @@
+<UserControl x:Class="PerformanceMonitorLite.Controls.FinOpsTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+
+            <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Server Selector (for per-server sub-tabs) -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,6,10,0">
+            <TextBlock Text="Server:" VerticalAlignment="Center" Margin="0,0,6,0"
+                       FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+            <ComboBox x:Name="ServerSelector" Width="260" DisplayMemberPath="DisplayName"
+                      SelectionChanged="ServerSelector_SelectionChanged"/>
+        </StackPanel>
+
+        <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0">
+
+        <!-- Utilization Sub-Tab -->
+        <TabItem Header="Utilization">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Utilization Efficiency" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshUtilization_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <Border x:Name="ProvisioningStatusBorder" CornerRadius="4" Padding="8,2" Margin="12,0,0,0"
+                            VerticalAlignment="Center" Background="Gray">
+                        <TextBlock x:Name="ProvisioningStatusText" Text="No Data"
+                                   FontWeight="Bold" Foreground="White"/>
+                    </Border>
+                </StackPanel>
+
+                <!-- Utilization Summary -->
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="10,0,10,10">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- CPU Metrics -->
+                        <GroupBox Grid.Column="0" Header="CPU" Margin="0,0,5,0"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <StackPanel Margin="8">
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}">
+                                    <Run Text="Avg CPU: " FontWeight="SemiBold"/>
+                                    <Run x:Name="AvgCpuText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="P95 CPU: " FontWeight="SemiBold"/>
+                                    <Run x:Name="P95CpuText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Max CPU: " FontWeight="SemiBold"/>
+                                    <Run x:Name="MaxCpuText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Samples: " FontWeight="SemiBold"/>
+                                    <Run x:Name="CpuSamplesText" Text="-"/>
+                                </TextBlock>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Memory Metrics -->
+                        <GroupBox Grid.Column="1" Header="Memory" Margin="5,0"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <StackPanel Margin="8">
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}">
+                                    <Run Text="Physical: " FontWeight="SemiBold"/>
+                                    <Run x:Name="PhysicalMemoryText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Target: " FontWeight="SemiBold"/>
+                                    <Run x:Name="TargetMemoryText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Total: " FontWeight="SemiBold"/>
+                                    <Run x:Name="TotalMemoryText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Buffer Pool: " FontWeight="SemiBold"/>
+                                    <Run x:Name="BufferPoolText" Text="-"/>
+                                </TextBlock>
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
+                                    <Run Text="Memory Ratio: " FontWeight="SemiBold"/>
+                                    <Run x:Name="MemoryRatioText" Text="-"/>
+                                </TextBlock>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Classification Info -->
+                        <GroupBox Grid.Column="2" Header="Classification" Margin="5,0,0,0"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <StackPanel Margin="8">
+                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12">
+                                    <Run FontWeight="SemiBold" Foreground="#27AE60">RIGHT SIZED</Run>
+                                    <Run Text=" — balanced resource usage"/>
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12" Margin="0,6,0,0">
+                                    <Run FontWeight="SemiBold" Foreground="#F39C12">OVER PROVISIONED</Run>
+                                    <Run Text=" — avg CPU &lt;15%, max &lt;40%, memory ratio &lt;0.5"/>
+                                </TextBlock>
+                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12" Margin="0,6,0,0">
+                                    <Run FontWeight="SemiBold" Foreground="#E74C3C">UNDER PROVISIONED</Run>
+                                    <Run Text=" — p95 CPU >85% or memory ratio >0.95"/>
+                                </TextBlock>
+                            </StackPanel>
+                        </GroupBox>
+                    </Grid>
+                </ScrollViewer>
+
+                <!-- Empty State -->
+                <TextBlock x:Name="NoUtilizationMessage"
+                           Grid.Row="1"
+                           Text="No utilization data collected yet. Select a server above."
+                           FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Visibility="Collapsed"/>
+            </Grid>
+        </TabItem>
+
+        <!-- Database Resources Sub-Tab -->
+        <TabItem Header="Database Resources">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Database Resource Usage (24h)" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshDatabaseResources_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="DbResourcesCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="DatabaseResourcesDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="180"/>
+                            <DataGridTextColumn Header="CPU Time (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="CPU %" Binding="{Binding PctCpuShare, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Logical Reads" Binding="{Binding LogicalReads, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Physical Reads" Binding="{Binding PhysicalReads, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Logical Writes" Binding="{Binding LogicalWrites, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="IO Read MB" Binding="{Binding IoReadMb, StringFormat='{}{0:N2}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="IO Write MB" Binding="{Binding IoWriteMb, StringFormat='{}{0:N2}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="IO %" Binding="{Binding PctIoShare, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="IO Stall (ms)" Binding="{Binding IoStallMs, StringFormat='{}{0:N0}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="NoDatabaseResourcesMessage"
+                               Text="No database resource data collected yet. Select a server above."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Application Connections Sub-Tab -->
+        <TabItem Header="Application Connections">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Application Connections (24h)" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshApplicationConnections_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="AppConnectionsCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="ApplicationConnectionsDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Application" Binding="{Binding ApplicationName}" Width="300"/>
+                            <DataGridTextColumn Header="Max Connections" Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="First Seen" Binding="{Binding FirstSeenLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                            <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeenLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="NoAppConnectionsMessage"
+                               Text="No application connection data collected yet. Select a server above."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Database Sizes Sub-Tab -->
+        <TabItem Header="Database Sizes">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Database Sizes (All Servers)" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshDatabaseSizes_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="DbSizeCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="DatabaseSizesDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="140"/>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="160"/>
+                            <DataGridTextColumn Header="File Type" Binding="{Binding FileTypeDesc}" Width="80"/>
+                            <DataGridTextColumn Header="File Name" Binding="{Binding FileName}" Width="160"/>
+                            <DataGridTextColumn Header="Total Size MB" Binding="{Binding TotalSizeMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Used Size MB" Binding="{Binding UsedSizeMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Free Space MB" Binding="{Binding FreeSpaceMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Used %" Binding="{Binding UsedPct, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Volume" Binding="{Binding VolumeMountPoint}" Width="80"/>
+                            <DataGridTextColumn Header="Volume Total MB" Binding="{Binding VolumeTotalMb, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Volume Free MB" Binding="{Binding VolumeFreeMb, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Recovery Model" Binding="{Binding RecoveryModel}" Width="120"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="NoDbSizesMessage"
+                               Text="No database size data collected yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Server Inventory Sub-Tab -->
+        <TabItem Header="Server Inventory">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Server Inventory (All Servers)" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshServerInventory_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="ServerInventoryCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="ServerInventoryDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="160"/>
+                            <DataGridTextColumn Header="Edition" Binding="{Binding Edition}" Width="200"/>
+                            <DataGridTextColumn Header="Version" Binding="{Binding ProductVersion}" Width="110"/>
+                            <DataGridTextColumn Header="Update Level" Binding="{Binding ProductUpdateLevel}" Width="100"/>
+                            <DataGridTextColumn Header="Engine Edition" Binding="{Binding EngineEdition}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="CPUs" Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Memory MB" Binding="{Binding PhysicalMemoryMb, StringFormat='{}{0:N0}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Sockets" Binding="{Binding SocketCount}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Cores/Socket" Binding="{Binding CoresPerSocket}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="HADR" Binding="{Binding HadrDisplay}" Width="60"/>
+                            <DataGridTextColumn Header="Clustered" Binding="{Binding ClusteredDisplay}" Width="80"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="NoServerInventoryMessage"
+                               Text="No server property data collected yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+    </TabControl>
+    </Grid>
+</UserControl>

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Microsoft.Win32;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Controls;
+
+public partial class FinOpsTab : UserControl
+{
+    private LocalDataService? _dataService;
+    private ServerManager? _serverManager;
+
+    public FinOpsTab()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Initializes the control with required dependencies.
+    /// </summary>
+    public void Initialize(LocalDataService dataService, ServerManager serverManager)
+    {
+        _dataService = dataService;
+        _serverManager = serverManager;
+
+        PopulateServerSelector();
+        RefreshData();
+    }
+
+    private void PopulateServerSelector()
+    {
+        if (_serverManager == null) return;
+
+        var servers = _serverManager.GetAllServers();
+        ServerSelector.ItemsSource = servers;
+        if (servers.Count > 0)
+            ServerSelector.SelectedIndex = 0;
+    }
+
+    private int GetSelectedServerId()
+    {
+        if (ServerSelector.SelectedItem is ServerConnection server)
+            return RemoteCollectorService.GetDeterministicHashCode(server.ServerName);
+        return 0;
+    }
+
+    /// <summary>
+    /// Refreshes all FinOps data.
+    /// </summary>
+    public async void RefreshData()
+    {
+        await LoadDatabaseSizesAsync();
+        await LoadServerInventoryAsync();
+        await LoadPerServerDataAsync();
+    }
+
+    #region Data Loading
+
+    private async System.Threading.Tasks.Task LoadPerServerDataAsync()
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId == 0 || _dataService == null) return;
+
+        await LoadUtilizationAsync(serverId);
+        await LoadDatabaseResourcesAsync(serverId);
+        await LoadApplicationConnectionsAsync(serverId);
+    }
+
+    private async System.Threading.Tasks.Task LoadUtilizationAsync(int serverId)
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetUtilizationEfficiencyAsync(serverId);
+            UpdateUtilizationSummary(data);
+            NoUtilizationMessage.Visibility = data == null ? Visibility.Visible : Visibility.Collapsed;
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load utilization: {ex.Message}");
+        }
+    }
+
+    private void UpdateUtilizationSummary(UtilizationEfficiencyRow? data)
+    {
+        if (data == null)
+        {
+            ProvisioningStatusText.Text = "No Data";
+            ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
+            AvgCpuText.Text = P95CpuText.Text = MaxCpuText.Text = CpuSamplesText.Text = "-";
+            PhysicalMemoryText.Text = TargetMemoryText.Text = TotalMemoryText.Text = BufferPoolText.Text = MemoryRatioText.Text = "-";
+            return;
+        }
+
+        ProvisioningStatusText.Text = data.ProvisioningStatus.Replace("_", " ");
+        switch (data.ProvisioningStatus)
+        {
+            case "RIGHT_SIZED":
+                ProvisioningStatusBorder.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#27AE60"));
+                ProvisioningStatusText.Foreground = Brushes.White;
+                break;
+            case "OVER_PROVISIONED":
+                ProvisioningStatusBorder.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#F39C12"));
+                ProvisioningStatusText.Foreground = Brushes.Black;
+                break;
+            case "UNDER_PROVISIONED":
+                ProvisioningStatusBorder.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E74C3C"));
+                ProvisioningStatusText.Foreground = Brushes.White;
+                break;
+            default:
+                ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
+                ProvisioningStatusText.Foreground = Brushes.White;
+                break;
+        }
+
+        AvgCpuText.Text = $"{data.AvgCpuPct:N2}%";
+        P95CpuText.Text = $"{data.P95CpuPct:N2}%";
+        MaxCpuText.Text = $"{data.MaxCpuPct}%";
+        CpuSamplesText.Text = data.CpuSamples.ToString("N0");
+
+        PhysicalMemoryText.Text = $"{data.PhysicalMemoryMb:N0} MB";
+        TargetMemoryText.Text = $"{data.TargetMemoryMb:N0} MB";
+        TotalMemoryText.Text = $"{data.TotalMemoryMb:N0} MB";
+        BufferPoolText.Text = $"{data.BufferPoolMb:N0} MB";
+        MemoryRatioText.Text = $"{data.MemoryRatio:N2}";
+    }
+
+    private async System.Threading.Tasks.Task LoadDatabaseResourcesAsync(int serverId)
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetDatabaseResourceUsageAsync(serverId);
+            DatabaseResourcesDataGrid.ItemsSource = data;
+            NoDatabaseResourcesMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            DbResourcesCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load database resources: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadApplicationConnectionsAsync(int serverId)
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetApplicationConnectionsAsync(serverId);
+            ApplicationConnectionsDataGrid.ItemsSource = data;
+            NoAppConnectionsMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            AppConnectionsCountIndicator.Text = data.Count > 0 ? $"{data.Count} application(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load application connections: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadDatabaseSizesAsync()
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetDatabaseSizeLatestAsync();
+            DatabaseSizesDataGrid.ItemsSource = data;
+
+            NoDbSizesMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            DbSizeCountIndicator.Text = data.Count > 0 ? $"{data.Count} file(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load database sizes: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadServerInventoryAsync()
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetServerPropertiesLatestAsync();
+            ServerInventoryDataGrid.ItemsSource = data;
+
+            NoServerInventoryMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            ServerInventoryCountIndicator.Text = data.Count > 0 ? $"{data.Count} server(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load server inventory: {ex.Message}");
+        }
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private async void ServerSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        await LoadPerServerDataAsync();
+    }
+
+    private async void RefreshUtilization_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadUtilizationAsync(serverId);
+    }
+
+    private async void RefreshDatabaseResources_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadDatabaseResourcesAsync(serverId);
+    }
+
+    private async void RefreshApplicationConnections_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadApplicationConnectionsAsync(serverId);
+    }
+
+    private async void RefreshDatabaseSizes_Click(object sender, RoutedEventArgs e)
+    {
+        await LoadDatabaseSizesAsync();
+    }
+
+    private async void RefreshServerInventory_Click(object sender, RoutedEventArgs e)
+    {
+        await LoadServerInventoryAsync();
+    }
+
+    #endregion
+
+    #region Context Menu Handlers
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
+
+        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
+        if (value.Length > 0) Clipboard.SetDataObject(value, false);
+    }
+
+    private void CopyRow_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem == null) return;
+
+        var sb = new StringBuilder();
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(GetCellValue(col, grid.CurrentItem));
+            sb.Append('\t');
+        }
+        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
+    }
+
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.Items == null) return;
+
+        var sb = new StringBuilder();
+
+        foreach (var col in grid.Columns)
+        {
+            sb.Append(col.Header?.ToString() ?? "");
+            sb.Append('\t');
+        }
+        sb.AppendLine();
+
+        foreach (var item in grid.Items)
+        {
+            foreach (var col in grid.Columns)
+            {
+                sb.Append(GetCellValue(col, item));
+                sb.Append('\t');
+            }
+            sb.AppendLine();
+        }
+
+        Clipboard.SetDataObject(sb.ToString(), false);
+    }
+
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.Items == null || grid.Items.Count == 0) return;
+
+        var prefix = grid.Name switch
+        {
+            nameof(DatabaseSizesDataGrid) => "database_sizes",
+            nameof(ServerInventoryDataGrid) => "server_inventory",
+            nameof(DatabaseResourcesDataGrid) => "database_resources",
+            nameof(ApplicationConnectionsDataGrid) => "application_connections",
+            _ => "finops_export"
+        };
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            DefaultExt = ".csv",
+            FileName = $"{prefix}_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        var sb = new StringBuilder();
+
+        var headers = new List<string>();
+        foreach (var col in grid.Columns)
+            headers.Add(CsvEscape(col.Header?.ToString() ?? ""));
+        sb.AppendLine(string.Join(",", headers));
+
+        foreach (var item in grid.Items)
+        {
+            var values = new List<string>();
+            foreach (var col in grid.Columns)
+                values.Add(CsvEscape(GetCellValue(col, item)));
+            sb.AppendLine(string.Join(",", values));
+        }
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static DataGrid? FindParentDataGrid(MenuItem menuItem)
+    {
+        var contextMenu = menuItem.Parent as ContextMenu;
+        var target = contextMenu?.PlacementTarget as FrameworkElement;
+        while (target != null && target is not DataGrid)
+            target = VisualTreeHelper.GetParent(target) as FrameworkElement;
+        return target as DataGrid;
+    }
+
+    private static string GetCellValue(DataGridColumn col, object item)
+    {
+        if (col is DataGridBoundColumn boundCol && boundCol.Binding is Binding binding)
+        {
+            var prop = item.GetType().GetProperty(binding.Path.Path);
+            return prop?.GetValue(item)?.ToString() ?? "";
+        }
+        return "";
+    }
+
+    private static string CsvEscape(string value)
+    {
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        return value;
+    }
+
+    #endregion
+}

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -86,7 +86,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 17;
+    internal const int CurrentSchemaVersion = 18;
 
     private readonly string _archivePath;
 
@@ -97,13 +97,18 @@ public class DuckDbInitializer
         _archivePath = Path.Combine(Path.GetDirectoryName(databasePath) ?? ".", "archive");
     }
 
-    /* Tables that have parquet archives — views are created to UNION hot data with archived parquet files */
+    /* Tables that have parquet archives — views are created to UNION hot data with archived parquet files.
+       IMPORTANT: Must match ArchiveService.ArchivableTables — every archived table needs an archive view. */
     private static readonly string[] ArchivableTables =
     [
         "wait_stats", "query_stats", "procedure_stats", "query_store_stats",
         "query_snapshots", "cpu_utilization_stats", "file_io_stats", "memory_stats",
         "memory_clerks", "tempdb_stats", "perfmon_stats", "deadlocks",
-        "blocked_process_reports", "collection_log"
+        "blocked_process_reports", "memory_grant_stats", "waiting_tasks",
+        "running_jobs", "database_size_stats", "server_properties",
+        "session_stats", "server_config", "database_config",
+        "database_scoped_config", "trace_flags", "config_alert_log",
+        "collection_log"
     ];
 
     /// <summary>
@@ -317,6 +322,12 @@ public class DuckDbInitializer
     /// <summary>
     /// Runs schema migrations from the given version up to CurrentSchemaVersion.
     /// Each migration drops and recreates affected tables.
+    ///
+    /// IMPORTANT: When adding a new data collection table, you must also register it in:
+    ///   1. Schema.cs — GetAllTableStatements() and GetAllIndexStatements()
+    ///   2. DuckDbInitializer.cs — ArchivableTables (archive view creation)
+    ///   3. ArchiveService.cs — ArchivableTables (parquet export + purge)
+    /// Forgetting any of these causes unbounded growth and 512 MB reset loops.
     /// </summary>
     private async Task RunMigrationsAsync(DuckDBConnection connection, int fromVersion)
     {
@@ -521,6 +532,13 @@ public class DuckDbInitializer
             {
                 /* Table doesn't exist yet — will be created with correct schema below */
             }
+        }
+
+        if (fromVersion < 18)
+        {
+            /* v18: Added session_stats table for per-application connection tracking
+                    from sys.dm_exec_sessions. New table only — created by GetAllTableStatements(). */
+            _logger?.LogInformation("Running migration to v18: adding session_stats table for application connections");
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -643,6 +643,26 @@ CREATE TABLE IF NOT EXISTS server_properties (
     public const string CreateServerPropertiesIndex = @"
 CREATE INDEX IF NOT EXISTS idx_server_properties_time ON server_properties(server_id, collection_time)";
 
+    public const string CreateSessionStatsTable = @"
+CREATE TABLE IF NOT EXISTS session_stats (
+    collection_id BIGINT PRIMARY KEY,
+    collection_time TIMESTAMP NOT NULL,
+    server_id INTEGER NOT NULL,
+    server_name VARCHAR NOT NULL,
+    program_name VARCHAR NOT NULL,
+    connection_count INTEGER NOT NULL,
+    running_count INTEGER NOT NULL,
+    sleeping_count INTEGER NOT NULL,
+    dormant_count INTEGER NOT NULL,
+    total_cpu_time_ms BIGINT,
+    total_reads BIGINT,
+    total_writes BIGINT,
+    total_logical_reads BIGINT
+)";
+
+    public const string CreateSessionStatsIndex = @"
+CREATE INDEX IF NOT EXISTS idx_session_stats_time ON session_stats(server_id, collection_time)";
+
     public const string CreateAlertLogTable = @"
 CREATE TABLE IF NOT EXISTS config_alert_log (
     alert_time TIMESTAMP NOT NULL,
@@ -687,6 +707,7 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
         yield return CreateRunningJobsTable;
         yield return CreateDatabaseSizeStatsTable;
         yield return CreateServerPropertiesTable;
+        yield return CreateSessionStatsTable;
         yield return CreateAlertLogTable;
     }
 
@@ -716,5 +737,6 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
         yield return CreateRunningJobsIndex;
         yield return CreateDatabaseSizeStatsIndex;
         yield return CreateServerPropertiesIndex;
+        yield return CreateSessionStatsIndex;
     }
 }

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -279,6 +279,9 @@
                     <TabItem Header="Alert History" x:Name="AlertsTab">
                         <controls:AlertsHistoryTab x:Name="AlertsHistoryContent"/>
                     </TabItem>
+                    <TabItem Header="FinOps" x:Name="FinOpsTab">
+                        <controls:FinOpsTab x:Name="FinOpsContent"/>
+                    </TabItem>
                     <TabItem x:Name="MainWindowPlanViewerTab" Visibility="Collapsed">
                         <TabItem.Header>
                             <StackPanel Orientation="Horizontal">

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -125,6 +125,9 @@ public partial class MainWindow : Window
             // Initialize alerts history tab
             AlertsHistoryContent.Initialize(_dataService);
 
+            // Initialize FinOps tab
+            FinOpsContent.Initialize(_dataService, _serverManager);
+
             // Start MCP server if enabled
             var mcpSettings = McpSettings.Load(App.ConfigDirectory);
             if (mcpSettings.Enabled)

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -26,7 +26,9 @@ public class ArchiveService
     private readonly ILogger<ArchiveService>? _logger;
     private static readonly SemaphoreSlim s_archiveLock = new(1, 1);
 
-    /* Tables eligible for archival with their time column */
+    /* Tables eligible for archival with their time column.
+       IMPORTANT: Every table with time-series data must be listed here,
+       or it will grow unbounded and push the DB past the 512 MB reset threshold. */
     private static readonly (string Table, string TimeColumn)[] ArchivableTables =
     [
         ("wait_stats", "collection_time"),
@@ -42,6 +44,17 @@ public class ArchiveService
         ("perfmon_stats", "collection_time"),
         ("deadlocks", "collection_time"),
         ("blocked_process_reports", "collection_time"),
+        ("memory_grant_stats", "collection_time"),
+        ("waiting_tasks", "collection_time"),
+        ("running_jobs", "collection_time"),
+        ("database_size_stats", "collection_time"),
+        ("server_properties", "collection_time"),
+        ("session_stats", "collection_time"),
+        ("server_config", "capture_time"),
+        ("database_config", "capture_time"),
+        ("database_scoped_config", "capture_time"),
+        ("trace_flags", "capture_time"),
+        ("config_alert_log", "alert_time"),
         ("collection_log", "collection_time")
     ];
 

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    /// <summary>
+    /// Gets the latest database size snapshot per server per file (cross-server).
+    /// </summary>
+    public async Task<List<DatabaseSizeRow>> GetDatabaseSizeLatestAsync()
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT
+    server_name,
+    database_name,
+    file_type_desc,
+    file_name,
+    total_size_mb,
+    used_size_mb,
+    volume_mount_point,
+    volume_total_mb,
+    volume_free_mb,
+    recovery_model_desc
+FROM database_size_stats
+WHERE (server_id, collection_time) IN (
+    SELECT server_id, MAX(collection_time)
+    FROM database_size_stats
+    GROUP BY server_id
+)
+ORDER BY server_name, database_name, file_type_desc, file_name";
+
+        var items = new List<DatabaseSizeRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new DatabaseSizeRow
+            {
+                ServerName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                FileTypeDesc = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                FileName = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                TotalSizeMb = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                UsedSizeMb = reader.IsDBNull(5) ? null : Convert.ToDecimal(reader.GetValue(5)),
+                VolumeMountPoint = reader.IsDBNull(6) ? null : reader.GetString(6),
+                VolumeTotalMb = reader.IsDBNull(7) ? null : Convert.ToDecimal(reader.GetValue(7)),
+                VolumeFreeMb = reader.IsDBNull(8) ? null : Convert.ToDecimal(reader.GetValue(8)),
+                RecoveryModel = reader.IsDBNull(9) ? null : reader.GetString(9)
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets the latest server properties snapshot per server (cross-server).
+    /// </summary>
+    public async Task<List<ServerPropertyRow>> GetServerPropertiesLatestAsync()
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT
+    server_name,
+    edition,
+    product_version,
+    product_level,
+    product_update_level,
+    engine_edition,
+    cpu_count,
+    physical_memory_mb,
+    socket_count,
+    cores_per_socket,
+    is_hadr_enabled,
+    is_clustered
+FROM server_properties
+WHERE (server_id, collection_time) IN (
+    SELECT server_id, MAX(collection_time)
+    FROM server_properties
+    GROUP BY server_id
+)
+ORDER BY server_name";
+
+        var items = new List<ServerPropertyRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new ServerPropertyRow
+            {
+                ServerName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                Edition = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                ProductVersion = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ProductLevel = reader.IsDBNull(3) ? null : reader.GetString(3),
+                ProductUpdateLevel = reader.IsDBNull(4) ? null : reader.GetString(4),
+                EngineEdition = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                CpuCount = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
+                PhysicalMemoryMb = reader.IsDBNull(7) ? 0L : ToInt64(reader.GetValue(7)),
+                SocketCount = reader.IsDBNull(8) ? null : Convert.ToInt32(reader.GetValue(8)),
+                CoresPerSocket = reader.IsDBNull(9) ? null : Convert.ToInt32(reader.GetValue(9)),
+                IsHadrEnabled = reader.IsDBNull(10) ? null : reader.GetBoolean(10),
+                IsClustered = reader.IsDBNull(11) ? null : reader.GetBoolean(11)
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets database size trend (total_size_mb per database per collection) for a specific server.
+    /// </summary>
+    public async Task<List<DatabaseSizeTrendPoint>> GetDatabaseSizeTrendAsync(int serverId, int daysBack = 30)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddDays(-daysBack);
+
+        command.CommandText = @"
+SELECT
+    collection_time,
+    database_name,
+    SUM(total_size_mb) AS total_size_mb
+FROM database_size_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+GROUP BY collection_time, database_name
+ORDER BY collection_time, database_name";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        var items = new List<DatabaseSizeTrendPoint>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new DatabaseSizeTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TotalSizeMb = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2))
+            });
+        }
+
+        return items;
+    }
+    /// <summary>
+    /// Computes utilization efficiency from cpu_utilization_stats + memory_stats (last 24 hours).
+    /// </summary>
+    public async Task<UtilizationEfficiencyRow?> GetUtilizationEfficiencyAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-24);
+
+        command.CommandText = @"
+WITH cpu_stats AS (
+    SELECT
+        AVG(CAST(sqlserver_cpu_utilization AS DECIMAL(5,2))) AS avg_cpu_pct,
+        MAX(sqlserver_cpu_utilization) AS max_cpu_pct,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu_pct,
+        COUNT(*) AS cpu_samples
+    FROM cpu_utilization_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+),
+mem_latest AS (
+    SELECT
+        total_server_memory_mb,
+        target_server_memory_mb,
+        total_physical_memory_mb,
+        buffer_pool_mb,
+        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
+    FROM memory_stats
+    WHERE server_id = $1
+    ORDER BY collection_time DESC
+    LIMIT 1
+)
+SELECT
+    c.avg_cpu_pct,
+    c.max_cpu_pct,
+    c.p95_cpu_pct,
+    c.cpu_samples,
+    m.total_server_memory_mb,
+    m.target_server_memory_mb,
+    m.total_physical_memory_mb,
+    m.buffer_pool_mb,
+    m.memory_ratio
+FROM cpu_stats c
+CROSS JOIN mem_latest m";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return null;
+
+        var avgCpu = reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0));
+        var maxCpu = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
+        var p95Cpu = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2));
+        var memRatio = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8));
+
+        var status = "RIGHT_SIZED";
+        if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
+            status = "OVER_PROVISIONED";
+        else if (p95Cpu > 85 || memRatio > 0.95m)
+            status = "UNDER_PROVISIONED";
+
+        return new UtilizationEfficiencyRow
+        {
+            AvgCpuPct = avgCpu,
+            MaxCpuPct = maxCpu,
+            P95CpuPct = p95Cpu,
+            CpuSamples = reader.IsDBNull(3) ? 0L : ToInt64(reader.GetValue(3)),
+            TotalMemoryMb = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+            TargetMemoryMb = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+            PhysicalMemoryMb = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
+            BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
+            MemoryRatio = memRatio,
+            ProvisioningStatus = status
+        };
+    }
+
+    /// <summary>
+    /// Computes per-database resource usage from query_stats + file_io_stats deltas (last 24 hours).
+    /// </summary>
+    public async Task<List<DatabaseResourceUsageRow>> GetDatabaseResourceUsageAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-24);
+
+        command.CommandText = @"
+WITH workload AS (
+    SELECT
+        database_name,
+        SUM(delta_worker_time) / 1000 AS cpu_time_ms,
+        SUM(delta_logical_reads) AS logical_reads,
+        SUM(delta_physical_reads) AS physical_reads,
+        SUM(delta_logical_writes) AS logical_writes,
+        SUM(delta_execution_count) AS execution_count
+    FROM query_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_worker_time IS NOT NULL
+    GROUP BY database_name
+),
+io AS (
+    SELECT
+        database_name,
+        SUM(delta_read_bytes) / 1048576.0 AS io_read_mb,
+        SUM(delta_write_bytes) / 1048576.0 AS io_write_mb,
+        SUM(delta_stall_read_ms + delta_stall_write_ms) AS io_stall_ms
+    FROM file_io_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_read_bytes IS NOT NULL
+    GROUP BY database_name
+),
+combined AS (
+    SELECT
+        COALESCE(w.database_name, i.database_name) AS database_name,
+        COALESCE(w.cpu_time_ms, 0) AS cpu_time_ms,
+        COALESCE(w.logical_reads, 0) AS logical_reads,
+        COALESCE(w.physical_reads, 0) AS physical_reads,
+        COALESCE(w.logical_writes, 0) AS logical_writes,
+        COALESCE(w.execution_count, 0) AS execution_count,
+        COALESCE(i.io_read_mb, 0) AS io_read_mb,
+        COALESCE(i.io_write_mb, 0) AS io_write_mb,
+        COALESCE(i.io_stall_ms, 0) AS io_stall_ms
+    FROM workload w
+    FULL JOIN io i ON i.database_name = w.database_name
+),
+totals AS (
+    SELECT
+        NULLIF(SUM(cpu_time_ms), 0) AS total_cpu,
+        NULLIF(SUM(io_read_mb + io_write_mb), 0) AS total_io
+    FROM combined
+)
+SELECT
+    c.database_name,
+    c.cpu_time_ms,
+    c.logical_reads,
+    c.physical_reads,
+    c.logical_writes,
+    c.execution_count,
+    CAST(c.io_read_mb AS DECIMAL(19,2)),
+    CAST(c.io_write_mb AS DECIMAL(19,2)),
+    c.io_stall_ms,
+    CAST(c.cpu_time_ms * 100.0 / t.total_cpu AS DECIMAL(5,2)) AS pct_cpu_share,
+    CAST((c.io_read_mb + c.io_write_mb) * 100.0 / t.total_io AS DECIMAL(5,2)) AS pct_io_share
+FROM combined c
+CROSS JOIN totals t
+WHERE c.database_name IS NOT NULL
+ORDER BY c.cpu_time_ms DESC";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        var items = new List<DatabaseResourceUsageRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new DatabaseResourceUsageRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                CpuTimeMs = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1)),
+                LogicalReads = reader.IsDBNull(2) ? 0L : ToInt64(reader.GetValue(2)),
+                PhysicalReads = reader.IsDBNull(3) ? 0L : ToInt64(reader.GetValue(3)),
+                LogicalWrites = reader.IsDBNull(4) ? 0L : ToInt64(reader.GetValue(4)),
+                ExecutionCount = reader.IsDBNull(5) ? 0L : ToInt64(reader.GetValue(5)),
+                IoReadMb = reader.IsDBNull(6) ? 0m : Convert.ToDecimal(reader.GetValue(6)),
+                IoWriteMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                IoStallMs = reader.IsDBNull(8) ? 0L : ToInt64(reader.GetValue(8)),
+                PctCpuShare = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                PctIoShare = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10))
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets per-application connection counts from session_stats (last 24 hours).
+    /// Aggregates snapshots of sys.dm_exec_sessions grouped by program_name.
+    /// </summary>
+    public async Task<List<ApplicationConnectionRow>> GetApplicationConnectionsAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-24);
+
+        command.CommandText = @"
+SELECT
+    program_name,
+    MAX(connection_count) AS max_connections,
+    MIN(collection_time) AS first_seen,
+    MAX(collection_time) AS last_seen
+FROM session_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+GROUP BY program_name
+ORDER BY max_connections DESC";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        var items = new List<ApplicationConnectionRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new ApplicationConnectionRow
+            {
+                ApplicationName = reader.GetString(0),
+                SampleCount = ToInt64(reader.GetValue(1)),
+                FirstSeen = reader.GetDateTime(2),
+                LastSeen = reader.GetDateTime(3)
+            });
+        }
+
+        return items;
+    }
+}
+
+public class UtilizationEfficiencyRow
+{
+    public decimal AvgCpuPct { get; set; }
+    public int MaxCpuPct { get; set; }
+    public decimal P95CpuPct { get; set; }
+    public long CpuSamples { get; set; }
+    public int TotalMemoryMb { get; set; }
+    public int TargetMemoryMb { get; set; }
+    public int PhysicalMemoryMb { get; set; }
+    public int BufferPoolMb { get; set; }
+    public decimal MemoryRatio { get; set; }
+    public string ProvisioningStatus { get; set; } = "";
+}
+
+public class DatabaseResourceUsageRow
+{
+    public string DatabaseName { get; set; } = "";
+    public long CpuTimeMs { get; set; }
+    public long LogicalReads { get; set; }
+    public long PhysicalReads { get; set; }
+    public long LogicalWrites { get; set; }
+    public long ExecutionCount { get; set; }
+    public decimal IoReadMb { get; set; }
+    public decimal IoWriteMb { get; set; }
+    public long IoStallMs { get; set; }
+    public decimal PctCpuShare { get; set; }
+    public decimal PctIoShare { get; set; }
+}
+
+public class ApplicationConnectionRow
+{
+    public string ApplicationName { get; set; } = "";
+    public long SampleCount { get; set; }
+    public DateTime FirstSeen { get; set; }
+    public DateTime LastSeen { get; set; }
+    public DateTime FirstSeenLocal => FirstSeen.ToLocalTime();
+    public DateTime LastSeenLocal => LastSeen.ToLocalTime();
+}
+
+public class DatabaseSizeRow
+{
+    public string ServerName { get; set; } = "";
+    public string DatabaseName { get; set; } = "";
+    public string FileTypeDesc { get; set; } = "";
+    public string FileName { get; set; } = "";
+    public decimal TotalSizeMb { get; set; }
+    public decimal? UsedSizeMb { get; set; }
+    public decimal? FreeSpaceMb => UsedSizeMb.HasValue ? TotalSizeMb - UsedSizeMb.Value : null;
+    public decimal? UsedPct => UsedSizeMb.HasValue && TotalSizeMb > 0 ? Math.Round(UsedSizeMb.Value * 100m / TotalSizeMb, 1) : null;
+    public string? VolumeMountPoint { get; set; }
+    public decimal? VolumeTotalMb { get; set; }
+    public decimal? VolumeFreeMb { get; set; }
+    public string? RecoveryModel { get; set; }
+}
+
+public class ServerPropertyRow
+{
+    public string ServerName { get; set; } = "";
+    public string Edition { get; set; } = "";
+    public string ProductVersion { get; set; } = "";
+    public string? ProductLevel { get; set; }
+    public string? ProductUpdateLevel { get; set; }
+    public int EngineEdition { get; set; }
+    public int CpuCount { get; set; }
+    public long PhysicalMemoryMb { get; set; }
+    public int? SocketCount { get; set; }
+    public int? CoresPerSocket { get; set; }
+    public bool? IsHadrEnabled { get; set; }
+    public bool? IsClustered { get; set; }
+
+    public string HadrDisplay => IsHadrEnabled.HasValue ? (IsHadrEnabled.Value ? "Yes" : "No") : "";
+    public string ClusteredDisplay => IsClustered.HasValue ? (IsClustered.Value ? "Yes" : "No") : "";
+}
+
+public class DatabaseSizeTrendPoint
+{
+    public DateTime CollectionTime { get; set; }
+    public string DatabaseName { get; set; } = "";
+    public decimal TotalSizeMb { get; set; }
+}

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -765,7 +765,10 @@ public static partial class PlanAnalyzer
         }
 
         // Rule 26: Row Goal (informational) — optimizer reduced estimate due to TOP/EXISTS/IN
-        if (node.EstimateRowsWithoutRowGoal > 0 && node.EstimateRows > 0 &&
+        // Only surface on data access operators (seeks/scans) where the row goal actually matters
+        var isDataAccess = node.PhysicalOp != null &&
+            (node.PhysicalOp.Contains("Scan") || node.PhysicalOp.Contains("Seek"));
+        if (isDataAccess && node.EstimateRowsWithoutRowGoal > 0 && node.EstimateRows > 0 &&
             node.EstimateRowsWithoutRowGoal > node.EstimateRows)
         {
             var reduction = node.EstimateRowsWithoutRowGoal / node.EstimateRows;

--- a/Lite/Services/RemoteCollectorService.SessionStats.cs
+++ b/Lite/Services/RemoteCollectorService.SessionStats.cs
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class RemoteCollectorService
+{
+    /// <summary>
+    /// Collects per-application session statistics from sys.dm_exec_sessions.
+    /// Groups by program_name to track connection counts, status breakdown,
+    /// and cumulative resource usage per application.
+    /// </summary>
+    private async Task<int> CollectSessionStatsAsync(ServerConnection server, CancellationToken cancellationToken)
+    {
+        const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    program_name =
+        ISNULL(des.program_name, N''),
+    connection_count =
+        COUNT_BIG(*),
+    running_count =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'running'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    sleeping_count =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'sleeping'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    dormant_count =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'dormant'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    total_cpu_time_ms =
+        SUM(des.cpu_time),
+    total_reads =
+        SUM(des.reads),
+    total_writes =
+        SUM(des.writes),
+    total_logical_reads =
+        SUM(des.logical_reads)
+FROM sys.dm_exec_sessions AS des
+WHERE des.session_id > 50
+AND   des.is_user_process = 1
+AND   des.program_name IS NOT NULL
+AND   des.program_name <> N''
+AND   des.program_name NOT LIKE N'PerformanceMonitor%'
+GROUP BY
+    des.program_name
+ORDER BY
+    COUNT_BIG(*) DESC
+OPTION(RECOMPILE);";
+
+        var serverId = GetServerId(server);
+        var collectionTime = DateTime.UtcNow;
+        var rowsCollected = 0;
+        _lastSqlMs = 0;
+        _lastDuckDbMs = 0;
+
+        var sqlSw = Stopwatch.StartNew();
+        using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+        using var command = new SqlCommand(query, sqlConnection);
+        command.CommandTimeout = CommandTimeoutSeconds;
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        sqlSw.Stop();
+        _lastSqlMs = sqlSw.ElapsedMilliseconds;
+
+        var duckSw = Stopwatch.StartNew();
+
+        using (var duckConnection = _duckDb.CreateConnection())
+        {
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("session_stats"))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var programName = reader.GetString(0);
+                    var connectionCount = Convert.ToInt32(reader.GetValue(1));
+                    var runningCount = Convert.ToInt32(reader.GetValue(2));
+                    var sleepingCount = Convert.ToInt32(reader.GetValue(3));
+                    var dormantCount = Convert.ToInt32(reader.GetValue(4));
+                    long? totalCpuTimeMs = reader.IsDBNull(5) ? null : Convert.ToInt64(reader.GetValue(5));
+                    long? totalReads = reader.IsDBNull(6) ? null : Convert.ToInt64(reader.GetValue(6));
+                    long? totalWrites = reader.IsDBNull(7) ? null : Convert.ToInt64(reader.GetValue(7));
+                    long? totalLogicalReads = reader.IsDBNull(8) ? null : Convert.ToInt64(reader.GetValue(8));
+
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(server.ServerName)
+                       .AppendValue(programName)
+                       .AppendValue(connectionCount)
+                       .AppendValue(runningCount)
+                       .AppendValue(sleepingCount)
+                       .AppendValue(dormantCount)
+                       .AppendValue(totalCpuTimeMs)
+                       .AppendValue(totalReads)
+                       .AppendValue(totalWrites)
+                       .AppendValue(totalLogicalReads)
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
+        }
+
+        duckSw.Stop();
+        _lastDuckDbMs = duckSw.ElapsedMilliseconds;
+
+        _logger?.LogDebug("Collected {RowCount} session stats rows for server '{Server}'", rowsCollected, server.DisplayName);
+        return rowsCollected;
+    }
+}

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -358,6 +358,7 @@ public partial class RemoteCollectorService
                 "running_jobs" => await CollectRunningJobsAsync(server, cancellationToken),
                 "database_size_stats" => await CollectDatabaseSizeStatsAsync(server, cancellationToken),
                 "server_properties" => await CollectServerPropertiesAsync(server, cancellationToken),
+                "session_stats" => await CollectSessionStatsAsync(server, cancellationToken),
                 _ => throw new ArgumentException($"Unknown collector: {collectorName}")
             };
 

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -388,7 +388,8 @@ public class ScheduleManager
             new() { Name = "trace_flags", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Active trace flags via DBCC TRACESTATUS (on-load only)" },
             new() { Name = "running_jobs", Enabled = true, FrequencyMinutes = 5, RetentionDays = 7, Description = "Currently running SQL Agent jobs with duration comparison" },
             new() { Name = "database_size_stats", Enabled = true, FrequencyMinutes = 60, RetentionDays = 90, Description = "Database file sizes for growth trending and capacity planning" },
-            new() { Name = "server_properties", Enabled = true, FrequencyMinutes = 0, RetentionDays = 365, Description = "Server edition, licensing, CPU/memory hardware metadata (on-load only)" }
+            new() { Name = "server_properties", Enabled = true, FrequencyMinutes = 0, RetentionDays = 365, Description = "Server edition, licensing, CPU/memory hardware metadata (on-load only)" },
+            new() { Name = "session_stats", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Per-application session counts from sys.dm_exec_sessions" }
         };
     }
 


### PR DESCRIPTION
## Summary

- **Estate-level FinOps**: Moved Dashboard FinOps from per-server ServerTab to estate-level MainWindow tab with server selector, consistent with Lite
- **Lite FinOps parity**: Added Utilization, Database Resources, and Application Connections sub-tabs to Lite
- **session_stats collector**: New Lite collector querying `sys.dm_exec_sessions` grouped by `program_name` every 5 min (filters out own connections). Fixes empty Application Connections tab which was incorrectly reading from `query_snapshots`
- **Archive reconciliation**: Fixed 10 tables missing from archive/view lists (`memory_grant_stats`, `waiting_tasks`, `running_jobs`, `database_size_stats`, `server_properties`, `server_config`, `database_config`, `database_scoped_config`, `trace_flags`, `config_alert_log`) — these were growing unbounded and could trigger infinite 512MB reset loops
- **PlanAnalyzer**: Rule 26 row goal warning limited to data access operators

## Test plan

- [x] Lite builds clean, session_stats collector runs successfully (9→7 rows after self-filter)
- [x] Dashboard builds clean, estate-level FinOps tab opens with server selector
- [x] Schema migration v17→v18 runs cleanly
- [x] All 25 time-series tables now in both archive lists (only `servers` and `collection_schedule` excluded as config-only)
- [ ] Verify Application Connections tab populates in Lite after ~5 min of collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)