### PR TITLE
Sync Rule 5 message format and seek predicate parsing from plan-b

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -388,12 +388,12 @@ public static partial class PlanAnalyzer
                         var direction = ratio >= 10.0 ? "underestimated" : "overestimated";
                         var factor = ratio >= 10.0 ? ratio : 1.0 / ratio;
                         var actualDisplay = executions > 1
-                            ? $"actual {actualPerExec:N0}/exec ({node.ActualRows:N0} total across {executions:N0} executions)"
-                            : $"actual {node.ActualRows:N0}";
+                            ? $"Actual {node.ActualRows:N0} ({actualPerExec:N0} rows x {executions:N0} executions)"
+                            : $"Actual {node.ActualRows:N0}";
                         node.Warnings.Add(new PlanWarning
                         {
                             WarningType = "Row Estimate Mismatch",
-                            Message = $"Estimated {node.EstimateRows:N0} rows, {actualDisplay} ({factor:F0}x {direction}). {harm}",
+                            Message = $"Estimated {node.EstimateRows:N0} vs {actualDisplay} — {factor:F0}x {direction}. {harm}",
                             Severity = factor >= 100 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                         });
                     }

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -712,16 +712,35 @@ public static class ShowPlanParser
             var seekParts = new List<string>();
             foreach (var sp in seekPreds)
             {
-                var scalarOps = sp.Descendants(Ns + "ScalarOperator");
-                foreach (var so in scalarOps)
+                foreach (var seekKeys in sp.Elements(Ns + "SeekKeys"))
                 {
-                    var val = so.Attribute("ScalarString")?.Value;
-                    if (!string.IsNullOrEmpty(val))
-                        seekParts.Add(val);
+                    foreach (var range in seekKeys.Elements())
+                    {
+                        var scanType = range.Attribute("ScanType")?.Value;
+                        var cols = range.Element(Ns + "RangeColumns")?
+                            .Elements(Ns + "ColumnReference")
+                            .Select(FormatColumnRef)
+                            .ToList();
+                        var exprs = range.Element(Ns + "RangeExpressions")?
+                            .Elements(Ns + "ScalarOperator")
+                            .Select(so => so.Attribute("ScalarString")?.Value ?? "?")
+                            .ToList();
+
+                        if (cols != null && exprs != null)
+                        {
+                            var op = scanType switch
+                            {
+                                "EQ" => "=", "GT" => ">", "GE" => ">=",
+                                "LT" => "<", "LE" => "<=", _ => scanType ?? "="
+                            };
+                            for (int ci = 0; ci < cols.Count && ci < exprs.Count; ci++)
+                                seekParts.Add($"{cols[ci]} {op} {exprs[ci]}");
+                        }
+                    }
                 }
             }
             if (seekParts.Count > 0)
-                node.SeekPredicates = string.Join(" AND ", seekParts);
+                node.SeekPredicates = string.Join(", ", seekParts);
 
             // GuessedSelectivity — check if optimizer guessed selectivity on predicates
             if (ScopedDescendants(physicalOpEl, Ns + "GuessedSelectivity").Any())

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -388,12 +388,12 @@ public static partial class PlanAnalyzer
                         var direction = ratio >= 10.0 ? "underestimated" : "overestimated";
                         var factor = ratio >= 10.0 ? ratio : 1.0 / ratio;
                         var actualDisplay = executions > 1
-                            ? $"actual {actualPerExec:N0}/exec ({node.ActualRows:N0} total across {executions:N0} executions)"
-                            : $"actual {node.ActualRows:N0}";
+                            ? $"Actual {node.ActualRows:N0} ({actualPerExec:N0} rows x {executions:N0} executions)"
+                            : $"Actual {node.ActualRows:N0}";
                         node.Warnings.Add(new PlanWarning
                         {
                             WarningType = "Row Estimate Mismatch",
-                            Message = $"Estimated {node.EstimateRows:N0} rows, {actualDisplay} ({factor:F0}x {direction}). {harm}",
+                            Message = $"Estimated {node.EstimateRows:N0} vs {actualDisplay} — {factor:F0}x {direction}. {harm}",
                             Severity = factor >= 100 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                         });
                     }

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -712,16 +712,35 @@ public static class ShowPlanParser
             var seekParts = new List<string>();
             foreach (var sp in seekPreds)
             {
-                var scalarOps = sp.Descendants(Ns + "ScalarOperator");
-                foreach (var so in scalarOps)
+                foreach (var seekKeys in sp.Elements(Ns + "SeekKeys"))
                 {
-                    var val = so.Attribute("ScalarString")?.Value;
-                    if (!string.IsNullOrEmpty(val))
-                        seekParts.Add(val);
+                    foreach (var range in seekKeys.Elements())
+                    {
+                        var scanType = range.Attribute("ScanType")?.Value;
+                        var cols = range.Element(Ns + "RangeColumns")?
+                            .Elements(Ns + "ColumnReference")
+                            .Select(FormatColumnRef)
+                            .ToList();
+                        var exprs = range.Element(Ns + "RangeExpressions")?
+                            .Elements(Ns + "ScalarOperator")
+                            .Select(so => so.Attribute("ScalarString")?.Value ?? "?")
+                            .ToList();
+
+                        if (cols != null && exprs != null)
+                        {
+                            var op = scanType switch
+                            {
+                                "EQ" => "=", "GT" => ">", "GE" => ">=",
+                                "LT" => "<", "LE" => "<=", _ => scanType ?? "="
+                            };
+                            for (int ci = 0; ci < cols.Count && ci < exprs.Count; ci++)
+                                seekParts.Add($"{cols[ci]} {op} {exprs[ci]}");
+                        }
+                    }
                 }
             }
             if (seekParts.Count > 0)
-                node.SeekPredicates = string.Join(" AND ", seekParts);
+                node.SeekPredicates = string.Join(", ", seekParts);
 
             // GuessedSelectivity — check if optimizer guessed selectivity on predicates
             if (ScopedDescendants(physicalOpEl, Ns + "GuessedSelectivity").Any())


### PR DESCRIPTION
## Summary
- **Rule 5** (Row Estimate Mismatch): Updated message format to match plan-b — cleaner `"Estimated X vs Actual Y — Nx direction"` instead of older `"Estimated X rows, actual Y/exec"` format
- **Seek predicates**: Proper `Column = Value` format with scan type operators (=, >, >=, <, <=) instead of bare scalar values like `(2) AND (0)`

Both Dashboard and Lite updated identically.

## Test plan
- [ ] Verify seek predicate display in plan viewer tooltips
- [ ] Verify Row Estimate Mismatch warning message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)