### PR TITLE
Fix schema test: update table count for session_stats

### DIFF
--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -136,8 +136,8 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 26 tables from Schema (schema_version is created separately by DuckDbInitializer) */
-        Assert.Equal(26, tableCount);
+        /* 27 tables from Schema (schema_version is created separately by DuckDbInitializer) */
+        Assert.Equal(27, tableCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Update `SchemaStatements_MatchTableCount` assertion from 26 to 27 after adding `session_stats` table in PR #474

## Test plan

- [x] All 6 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)