### PR TITLE
Port Utilization tab redesign to Dashboard, align metrics between apps

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -3,8 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
-             xmlns:controls="clr-namespace:PerformanceMonitorDashboard.Controls"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="1200">
     <UserControl.Resources>
@@ -42,345 +40,706 @@
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,6,10,0">
             <TextBlock Text="Server:" VerticalAlignment="Center" Margin="0,0,6,0"
                        FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
-            <ComboBox x:Name="ServerSelector" Width="300" DisplayMemberPath="DisplayName"
+            <ComboBox x:Name="ServerSelector" Width="260" DisplayMemberPath="DisplayName"
                       SelectionChanged="ServerSelector_SelectionChanged"/>
         </StackPanel>
 
-    <TabControl Grid.Row="1" TabStripPlacement="Top" Margin="0,5,0,0">
+        <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0">
 
         <!-- Utilization Sub-Tab -->
         <TabItem Header="Utilization">
-            <Grid Margin="10,5,10,10">
+            <Grid>
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <!-- Refresh Button -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="Refresh" Click="UtilizationRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
-                    <controls:LoadingOverlay x:Name="UtilizationLoading" Width="24" Height="24" Margin="10,0,0,0"/>
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Utilization Efficiency" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="UtilizationRefresh_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <Border x:Name="ProvisioningStatusBorder" CornerRadius="4" Padding="8,2" Margin="12,0,0,0"
+                            VerticalAlignment="Center" Background="Gray">
+                        <TextBlock x:Name="ProvisioningStatusText" Text="No Data"
+                                   FontWeight="Bold" Foreground="White"/>
+                    </Border>
                 </StackPanel>
 
-                <!-- Provisioning Status Summary Panel -->
-                <Border Grid.Row="1" Background="{DynamicResource BackgroundLightBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Padding="12,10" Margin="0,0,0,8">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
+                <!-- Utilization Summary — compact, top-aligned -->
+                <Grid Grid.Row="1" Margin="10,0,10,0" x:Name="UtilizationContent">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- CPU Metrics -->
+                    <GroupBox Grid.Column="0" Header="CPU" Margin="0,0,5,0" VerticalAlignment="Top"
+                              Foreground="{DynamicResource ForegroundBrush}">
+                        <StackPanel Margin="10">
+                            <!-- Avg CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Avg CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="AvgCpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="AvgCpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="AvgCpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="AvgCpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- P95 CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="P95 CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="P95CpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="P95CpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="P95CpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="P95CpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Max CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Max CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MaxCpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MaxCpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MaxCpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MaxCpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- CPU Details -->
+                            <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                <Run x:Name="CpuCountText" Text="-"/>
+                                <Run Text=" CPUs,"/>
+                                <Run x:Name="WorkerThreadsText" Text="-"/>
+                                <Run Text=" workers,"/>
+                                <Run x:Name="CpuSamplesText" Text="-"/>
+                                <Run Text=" samples (24h)"/>
+                            </TextBlock>
+                        </StackPanel>
+                    </GroupBox>
+
+                    <!-- Memory Metrics -->
+                    <GroupBox Grid.Column="1" Header="Memory" Margin="5,0,0,0" VerticalAlignment="Top"
+                              Foreground="{DynamicResource ForegroundBrush}">
+                        <StackPanel Margin="10">
+                            <!-- Committed vs Target -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Stolen Mem %" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"
+                                           ToolTip="(Total Server Memory - Buffer Pool) / Total Server Memory — memory used by plan cache, locks, grants, CLR, etc."/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MemUtilFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MemUtilEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MemoryUtilBar" Background="#3498DB"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MemoryUtilText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Buffer Pool vs Physical -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Buffer Pool %" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"
+                                           ToolTip="Buffer Pool / Physical Memory — how much of physical RAM is used by the buffer pool"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MemRatioFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MemRatioEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MemoryRatioBar" Background="#3498DB"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MemoryRatioText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Memory Details -->
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5">
+                                        <Run Text="Physical: " FontWeight="SemiBold"/>
+                                        <Run x:Name="PhysicalMemoryText" Text="-"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                        <Run Text="Target: " FontWeight="SemiBold"/>
+                                        <Run x:Name="TargetMemoryText" Text="-"/>
+                                    </TextBlock>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1">
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5">
+                                        <Run Text="Total: " FontWeight="SemiBold"/>
+                                        <Run x:Name="TotalMemoryText" Text="-"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                        <Run Text="Buffer Pool: " FontWeight="SemiBold"/>
+                                        <Run x:Name="BufferPoolText" Text="-"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Grid>
+                        </StackPanel>
+                    </GroupBox>
+                </Grid>
+
+                <!-- Classification Explanation -->
+                <TextBlock x:Name="ClassificationExplanation" Grid.Row="2" Margin="12,8,10,4"
+                           VerticalAlignment="Top" TextWrapping="Wrap" FontSize="12"
+                           Foreground="{DynamicResource ForegroundMutedBrush}"/>
+
+                <!-- Resource Summaries -->
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
+                    <Grid x:Name="SummaryContent">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <!-- Row 1: Provisioning Status + CPU Metrics -->
-                        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,6">
-                            <TextBlock Text="Provisioning:" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                            <Border x:Name="ProvisioningStatusBorder" CornerRadius="3" Padding="8,2" Margin="0,0,20,0">
-                                <TextBlock x:Name="ProvisioningStatusText" Text="--" FontWeight="Bold" VerticalAlignment="Center"/>
-                            </Border>
+                        <!-- Top Resource Consumers — Total + Avg side by side -->
+                        <Grid Grid.Row="0" Margin="10,4,10,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
 
-                            <TextBlock Text="CPU Count:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="CpuCountText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                            <!-- Top 5 by Total CPU -->
+                            <GroupBox Grid.Column="0" Header="Top Databases by Total CPU" Margin="0,0,5,0"
+                                      Foreground="{DynamicResource ForegroundBrush}">
+                                <DataGrid x:Name="TopTotalGrid"
+                                          AutoGenerateColumns="False" IsReadOnly="True"
+                                          CanUserSortColumns="True" HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal" SelectionMode="Single"
+                                          MinHeight="40" MaxHeight="200"
+                                          RowStyle="{StaticResource DefaultRowStyle}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="*"/>
+                                        <DataGridTextColumn Header="CPU %" Binding="{Binding PctCpu, StringFormat='{}{0:N1}'}" Width="60">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="IO %" Binding="{Binding PctIo, StringFormat='{}{0:N1}'}" Width="55">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="CPU (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" Width="80">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Execs" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </GroupBox>
 
-                            <TextBlock Text="Avg CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="AvgCpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                            <!-- Top 5 by Avg CPU per Execution -->
+                            <GroupBox Grid.Column="1" Header="Top Databases by Avg CPU / Execution" Margin="5,0,0,0"
+                                      Foreground="{DynamicResource ForegroundBrush}">
+                                <DataGrid x:Name="TopAvgGrid"
+                                          AutoGenerateColumns="False" IsReadOnly="True"
+                                          CanUserSortColumns="True" HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal" SelectionMode="Single"
+                                          MinHeight="40" MaxHeight="200"
+                                          RowStyle="{StaticResource DefaultRowStyle}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="*"/>
+                                        <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N2}'}" Width="95">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Avg IO (MB)" Binding="{Binding AvgIoMb, StringFormat='{}{0:N2}'}" Width="90">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Execs" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </GroupBox>
+                        </Grid>
 
-                            <TextBlock Text="P95 CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="P95CpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Max CPU:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="MaxCpuText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Samples:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="CpuSamplesText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
-                        </StackPanel>
-
-                        <!-- Row 2: Memory + Thread Metrics -->
-                        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
-                            <TextBlock Text="Physical Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="PhysicalMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Target Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="TargetMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Total Memory:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="TotalMemoryText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Memory Util:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="MemoryUtilText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Worker Threads:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="WorkerThreadsText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
-
-                            <TextBlock Text="Thread Ratio:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock x:Name="ThreadRatioText" Text="--" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
-                        </StackPanel>
+                        <!-- Database Size Chart -->
+                        <GroupBox Grid.Row="1" Header="Database Sizes — Allocated vs Used" Margin="10,8,10,10"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <ItemsControl x:Name="DbSizeChart" Margin="8,4,8,4">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="0,2" Height="22">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="160"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="90"/>
+                                            </Grid.ColumnDefinitions>
+                                            <!-- Database name -->
+                                            <TextBlock Grid.Column="0" Text="{Binding DatabaseName}"
+                                                       VerticalAlignment="Center" FontSize="11.5"
+                                                       Foreground="{DynamicResource ForegroundBrush}"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <!-- Stacked bar: used (accent) + free (dim) -->
+                                            <Grid Grid.Column="1" Margin="4,2">
+                                                <Border CornerRadius="3" Background="#1AFFFFFF"/>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="{Binding UsedStarWidth}"/>
+                                                        <ColumnDefinition Width="{Binding FreeStarWidth}"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Border Grid.Column="0" CornerRadius="3" Background="#3498DB"/>
+                                                </Grid>
+                                            </Grid>
+                                            <!-- Size label -->
+                                            <TextBlock Grid.Column="2" VerticalAlignment="Center"
+                                                       HorizontalAlignment="Right" FontSize="11.5"
+                                                       Foreground="{DynamicResource ForegroundBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0:N0} / {1:N0} MB">
+                                                        <Binding Path="UsedMb"/>
+                                                        <Binding Path="TotalMb"/>
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </GroupBox>
                     </Grid>
-                </Border>
+                </ScrollViewer>
 
-                <!-- Peak Utilization Chart -->
-                <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock Text="Peak Utilization by Hour" FontWeight="Bold" FontSize="14" Margin="10,5" Foreground="{DynamicResource ForegroundBrush}"/>
-                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="PeakUtilizationChart" Margin="5"/>
-                    </Grid>
-                </Border>
+                <!-- Empty State -->
+                <TextBlock x:Name="NoUtilizationMessage"
+                           Grid.Row="1" Grid.RowSpan="3"
+                           Text="No utilization data collected yet. Select a server above."
+                           FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Visibility="Collapsed"/>
             </Grid>
         </TabItem>
 
         <!-- Database Resources Sub-Tab -->
         <TabItem Header="Database Resources">
-            <Grid Margin="10,5,10,10">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <!-- Refresh Button -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="Refresh" Click="DatabaseResourcesRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Database Resource Usage" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="ResourceUsageTimeRangeCombo" SelectedIndex="3" Width="120" Margin="0,0,8,0"
+                              SelectionChanged="ResourceUsageTimeRange_Changed">
+                        <ComboBoxItem Content="Last 1 hour"/>
+                        <ComboBoxItem Content="Last 4 hours"/>
+                        <ComboBoxItem Content="Last 12 hours"/>
+                        <ComboBoxItem Content="Last 24 hours"/>
+                        <ComboBoxItem Content="Last 7 days"/>
+                    </ComboBox>
+                    <Button Content="Refresh" Click="DatabaseResourcesRefresh_Click"
+                            Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="DbResourcesCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                 </StackPanel>
 
                 <!-- DataGrid -->
-                <Grid Grid.Row="1">
+                <Grid Grid.Row="1" Margin="10,0,10,10">
                     <DataGrid x:Name="DatabaseResourcesDataGrid"
-                              AutoGenerateColumns="False" IsReadOnly="True"
-                              CanUserSortColumns="True" CanUserResizeColumns="True"
-                              GridLinesVisibility="All"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="180">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Database" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="180"/>
+                            <DataGridTextColumn Header="CPU Time (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PctCpuShare, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="CPU %" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="CPU %" Binding="{Binding PctCpuShare, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PctIoShare, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="I/O %" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Logical Reads" Binding="{Binding LogicalReads, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="CPU Time (ms)" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Physical Reads" Binding="{Binding PhysicalReads, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Executions" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Logical Writes" Binding="{Binding LogicalWrites, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Logical Reads" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PhysicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Physical Reads" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="IO Read MB" Binding="{Binding IoReadMb, StringFormat='{}{0:N2}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LogicalWrites, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Logical Writes" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="IO Write MB" Binding="{Binding IoWriteMb, StringFormat='{}{0:N2}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IoReadMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="I/O Read MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="IO %" Binding="{Binding PctIoShare, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IoWriteMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="I/O Write MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IoStallMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="I/O Stall (ms)" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="IO Stall (ms)" Binding="{Binding IoStallMs, StringFormat='{}{0:N0}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <TextBlock x:Name="DatabaseResourcesNoDataMessage" Style="{DynamicResource NoDataMessage}"
-                               Text="No database resource usage data available."/>
-                    <controls:LoadingOverlay x:Name="DatabaseResourcesLoading"/>
-                </Grid>
-            </Grid>
-        </TabItem>
 
-        <!-- Database Sizes Sub-Tab -->
-        <TabItem Header="Database Sizes">
-            <Grid Margin="10,5,10,10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-
-                <!-- Refresh Button -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="Refresh" Click="DatabaseSizesRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
-                </StackPanel>
-
-                <!-- DataGrid -->
-                <Grid Grid.Row="1">
-                    <DataGrid x:Name="DatabaseSizesDataGrid"
-                              AutoGenerateColumns="False" IsReadOnly="True"
-                              CanUserSortColumns="True" CanUserResizeColumns="True"
-                              GridLinesVisibility="All"
-                              RowStyle="{StaticResource DefaultRowStyle}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="160">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Database" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding FileTypeDesc}" Width="80">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="File Type" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding FileName}" Width="160">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="File Name" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TotalSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Total MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding UsedSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Used MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding FreeSpaceMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Free MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding UsedPct, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Used %" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AutoGrowthMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Auto Growth" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding MaxSizeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Max Size MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding RecoveryModelDesc}" Width="100">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Recovery" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding StateDesc}" Width="80">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="State" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding VolumeMountPoint}" Width="80">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Volume" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding VolumeTotalMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Vol Total MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding VolumeFreeMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Vol Free MB" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PhysicalName}" Width="400">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Physical Path" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    <TextBlock x:Name="DatabaseSizesNoDataMessage" Style="{DynamicResource NoDataMessage}"
-                               Text="No database size data available."/>
-                    <controls:LoadingOverlay x:Name="DatabaseSizesLoading"/>
+                    <!-- Empty State -->
+                    <TextBlock x:Name="DatabaseResourcesNoDataMessage"
+                               Text="No database resource data collected yet. Select a server above."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
                 </Grid>
             </Grid>
         </TabItem>
 
         <!-- Application Connections Sub-Tab -->
         <TabItem Header="Application Connections">
-            <Grid Margin="10,5,10,10">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <!-- Refresh Button -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="Refresh" Click="ApplicationConnectionsRefresh_Click" Padding="10,4" MinWidth="70" Style="{DynamicResource SuccessButton}"/>
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Application Connections (24h)" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="ApplicationConnectionsRefresh_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="AppConnectionsCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                 </StackPanel>
 
                 <!-- DataGrid -->
-                <Grid Grid.Row="1">
+                <Grid Grid.Row="1" Margin="10,0,10,10">
                     <DataGrid x:Name="ApplicationConnectionsDataGrid"
-                              AutoGenerateColumns="False" IsReadOnly="True"
-                              CanUserSortColumns="True" CanUserResizeColumns="True"
-                              GridLinesVisibility="All"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding ApplicationName}" Width="300">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Application" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Application" Binding="{Binding ApplicationName}" Width="300"/>
+                            <DataGridTextColumn Header="Avg Connections" Binding="{Binding AvgConnections, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AvgConnections, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Avg Connections" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Max Connections" Binding="{Binding MaxConnections, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding MaxConnections, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Max Connections" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
+                            <DataGridTextColumn Header="Samples" Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Sample Count" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding FirstSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="160">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="First Seen" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="160">
-                                <DataGridTextColumn.Header>
-                                    <TextBlock Text="Last Seen" FontWeight="Bold"/>
-                                </DataGridTextColumn.Header>
-                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="First Seen" Binding="{Binding FirstSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                            <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <TextBlock x:Name="ApplicationConnectionsNoDataMessage" Style="{DynamicResource NoDataMessage}"
-                               Text="No application connection data available."/>
-                    <controls:LoadingOverlay x:Name="ApplicationConnectionsLoading"/>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="ApplicationConnectionsNoDataMessage"
+                               Text="No application connection data collected yet. Select a server above."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Database Sizes Sub-Tab -->
+        <TabItem Header="Database Sizes">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Database Sizes" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="DatabaseSizesRefresh_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="DbSizeCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="DatabaseSizesDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="160"/>
+                            <DataGridTextColumn Header="File Type" Binding="{Binding FileTypeDesc}" Width="80"/>
+                            <DataGridTextColumn Header="File Name" Binding="{Binding FileName}" Width="160"/>
+                            <DataGridTextColumn Header="Total Size MB" Binding="{Binding TotalSizeMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Used Size MB" Binding="{Binding UsedSizeMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Free Space MB" Binding="{Binding FreeSpaceMb, StringFormat='{}{0:N2}'}" Width="110">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Used %" Binding="{Binding UsedPct, StringFormat='{}{0:N1}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Volume" Binding="{Binding VolumeMountPoint}" Width="80"/>
+                            <DataGridTextColumn Header="Volume Total MB" Binding="{Binding VolumeTotalMb, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Volume Free MB" Binding="{Binding VolumeFreeMb, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Recovery Model" Binding="{Binding RecoveryModelDesc}" Width="120"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="DatabaseSizesNoDataMessage"
+                               Text="No database size data collected yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Server Inventory Sub-Tab -->
+        <TabItem Header="Server Inventory">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header Controls -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Server Inventory" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="ServerInventoryRefresh_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="ServerInventoryCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- DataGrid -->
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="ServerInventoryDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal"
+                              CanUserResizeColumns="True"
+                              HeadersVisibility="Column"
+                              SelectionMode="Extended"
+                              RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="160"/>
+                            <DataGridTextColumn Header="Edition" Binding="{Binding Edition}" Width="200"/>
+                            <DataGridTextColumn Header="Version" Binding="{Binding SqlVersion}" Width="140"/>
+                            <DataGridTextColumn Header="Environment" Binding="{Binding EnvironmentType}" Width="100"/>
+                            <DataGridTextColumn Header="CPUs" Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Memory MB" Binding="{Binding PhysicalMemoryMb, StringFormat='{}{0:N0}'}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Uptime" Binding="{Binding UptimeDisplay}" Width="90"/>
+                            <DataGridTextColumn Header="Start Time" Binding="{Binding SqlServerStartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                            <DataGridTextColumn Header="Last Updated" Binding="{Binding LastUpdated, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- Empty State -->
+                    <TextBlock x:Name="ServerInventoryNoDataMessage"
+                               Text="No server inventory data collected yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
                 </Grid>
             </Grid>
         </TabItem>

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -23,11 +23,6 @@ using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard.Controls
 {
-    /// <summary>
-    /// UserControl for the FinOps tab content.
-    /// Displays utilization efficiency, database resource usage,
-    /// database sizes, and application connection metrics.
-    /// </summary>
     public partial class FinOpsContent : UserControl
     {
         private DatabaseService? _databaseService;
@@ -38,22 +33,6 @@ namespace PerformanceMonitorDashboard.Controls
         {
             InitializeComponent();
             Loaded += OnLoaded;
-            Unloaded += OnUnloaded;
-            Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
-
-            // Apply dark theme immediately so charts don't flash white
-            TabHelpers.ApplyThemeToChart(PeakUtilizationChart);
-        }
-
-        private void OnUnloaded(object sender, RoutedEventArgs e)
-        {
-            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
-        }
-
-        private void OnThemeChanged(string _)
-        {
-            TabHelpers.ApplyThemeToChart(PeakUtilizationChart);
-            PeakUtilizationChart.Refresh();
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -61,10 +40,16 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.AutoSizeColumnMinWidths(DatabaseResourcesDataGrid);
             TabHelpers.AutoSizeColumnMinWidths(DatabaseSizesDataGrid);
             TabHelpers.AutoSizeColumnMinWidths(ApplicationConnectionsDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(ServerInventoryDataGrid);
+            TabHelpers.AutoSizeColumnMinWidths(TopTotalGrid);
+            TabHelpers.AutoSizeColumnMinWidths(TopAvgGrid);
 
             TabHelpers.FreezeColumns(DatabaseResourcesDataGrid, 1);
             TabHelpers.FreezeColumns(DatabaseSizesDataGrid, 1);
             TabHelpers.FreezeColumns(ApplicationConnectionsDataGrid, 1);
+            TabHelpers.FreezeColumns(ServerInventoryDataGrid, 1);
+            TabHelpers.FreezeColumns(TopTotalGrid, 1);
+            TabHelpers.FreezeColumns(TopAvgGrid, 1);
         }
 
         /// <summary>
@@ -102,7 +87,8 @@ namespace PerformanceMonitorDashboard.Controls
                     LoadUtilizationAsync(),
                     LoadDatabaseResourcesAsync(),
                     LoadDatabaseSizesAsync(),
-                    LoadApplicationConnectionsAsync()
+                    LoadApplicationConnectionsAsync(),
+                    LoadServerInventoryAsync()
                 );
             }
             catch (Exception ex)
@@ -121,26 +107,26 @@ namespace PerformanceMonitorDashboard.Controls
 
             try
             {
-                UtilizationLoading.IsLoading = true;
-
-                var efficiencyTask = _databaseService.GetFinOpsUtilizationEfficiencyAsync();
-                var peakTask = _databaseService.GetFinOpsPeakUtilizationAsync();
-
-                await Task.WhenAll(efficiencyTask, peakTask);
-
-                var efficiency = await efficiencyTask;
-                var peakData = await peakTask;
-
+                var efficiency = await _databaseService.GetFinOpsUtilizationEfficiencyAsync();
                 UpdateUtilizationSummary(efficiency);
-                RenderPeakUtilizationChart(peakData);
+                NoUtilizationMessage.Visibility = efficiency == null ? Visibility.Visible : Visibility.Collapsed;
+                SummaryContent.Visibility = efficiency == null ? Visibility.Collapsed : Visibility.Visible;
+
+                if (efficiency != null)
+                {
+                    var topTotal = await _databaseService.GetFinOpsTopResourceConsumersByTotalAsync();
+                    TopTotalGrid.ItemsSource = topTotal;
+
+                    var topAvg = await _databaseService.GetFinOpsTopResourceConsumersByAvgAsync();
+                    TopAvgGrid.ItemsSource = topAvg;
+
+                    var sizes = await _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
+                    DbSizeChart.ItemsSource = sizes;
+                }
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading utilization data: {ex.Message}", ex);
-            }
-            finally
-            {
-                UtilizationLoading.IsLoading = false;
             }
         }
 
@@ -150,8 +136,20 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 ProvisioningStatusText.Text = "No Data";
                 ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
+                AvgCpuText.Text = P95CpuText.Text = MaxCpuText.Text = CpuSamplesText.Text = "-";
+                AvgCpuBar.Width = P95CpuBar.Width = MaxCpuBar.Width = 0;
+                MemoryUtilBar.Width = MemoryRatioBar.Width = 0;
+                MemoryUtilText.Text = MemoryRatioText.Text = "-";
+                PhysicalMemoryText.Text = TargetMemoryText.Text = TotalMemoryText.Text = BufferPoolText.Text = "-";
+                WorkerThreadsText.Text = "-";
+                CpuCountText.Text = "-";
+                CpuSamplesText.Text = "-";
+                ClassificationExplanation.Text = "";
+                UtilizationContent.Visibility = Visibility.Collapsed;
                 return;
             }
+
+            UtilizationContent.Visibility = Visibility.Visible;
 
             // Provisioning status with color coding
             ProvisioningStatusText.Text = efficiency.ProvisioningStatus.Replace("_", " ");
@@ -176,80 +174,91 @@ namespace PerformanceMonitorDashboard.Controls
                     break;
             }
 
-            // CPU metrics
-            CpuCountText.Text = efficiency.CpuCount.ToString("N0");
+            /* CPU text + bars */
             AvgCpuText.Text = $"{efficiency.AvgCpuPct:N2}%";
             P95CpuText.Text = $"{efficiency.P95CpuPct:N2}%";
             MaxCpuText.Text = $"{efficiency.MaxCpuPct}%";
             CpuSamplesText.Text = efficiency.CpuSamples.ToString("N0");
+            CpuCountText.Text = efficiency.CpuCount.ToString("N0");
 
-            // Memory metrics
+            SetBar(AvgCpuBar, AvgCpuFilled, AvgCpuEmpty, (double)efficiency.AvgCpuPct);
+            SetBar(P95CpuBar, P95CpuFilled, P95CpuEmpty, (double)efficiency.P95CpuPct);
+            SetBar(MaxCpuBar, MaxCpuFilled, MaxCpuEmpty, efficiency.MaxCpuPct);
+
+            /* Stolen Memory % = (Total Server Memory - Buffer Pool) / Total Server Memory
+               Uses perfmon counter value (TotalServerMemoryMb) for parity with Lite */
+            var tsm = efficiency.TotalServerMemoryMb > 0 ? efficiency.TotalServerMemoryMb : efficiency.TotalMemoryMb;
+            var stolenPct = tsm > 0
+                ? (double)(tsm - efficiency.BufferPoolMb) / tsm * 100.0
+                : 0;
+            MemoryUtilText.Text = $"{stolenPct:N0}%";
+            SetBar(MemoryUtilBar, MemUtilFilled, MemUtilEmpty, stolenPct);
+
+            /* Buffer Pool % = Buffer Pool / Physical Memory */
+            var bpPct = efficiency.PhysicalMemoryMb > 0
+                ? (double)efficiency.BufferPoolMb / efficiency.PhysicalMemoryMb * 100.0
+                : 0;
+            MemoryRatioText.Text = $"{bpPct:N0}%";
+            SetBar(MemoryRatioBar, MemRatioFilled, MemRatioEmpty, bpPct);
+
             PhysicalMemoryText.Text = $"{efficiency.PhysicalMemoryMb:N0} MB";
             TargetMemoryText.Text = $"{efficiency.TargetMemoryMb:N0} MB";
-            TotalMemoryText.Text = $"{efficiency.TotalMemoryMb:N0} MB";
-            MemoryUtilText.Text = $"{efficiency.MemoryUtilizationPct}%";
-
-            // Thread metrics
+            TotalMemoryText.Text = $"{tsm:N0} MB";
+            BufferPoolText.Text = $"{efficiency.BufferPoolMb:N0} MB";
             WorkerThreadsText.Text = $"{efficiency.WorkerThreadsCurrent:N0} / {efficiency.WorkerThreadsMax:N0}";
-            ThreadRatioText.Text = $"{efficiency.WorkerThreadRatio:N2}";
+
+            /* Contextual explanation — one sentence describing WHY this classification */
+            ClassificationExplanation.Text = efficiency.ProvisioningStatus switch
+            {
+                "RIGHT_SIZED" => $"CPU is moderately loaded (avg {efficiency.AvgCpuPct:N1}%, p95 {efficiency.P95CpuPct:N1}%) and memory is well-utilized (buffer pool uses {bpPct:N0}% of physical RAM). No action needed.",
+                "OVER_PROVISIONED" => $"CPU is lightly loaded (avg {efficiency.AvgCpuPct:N1}%, max {efficiency.MaxCpuPct}%) and buffer pool uses only {bpPct:N0}% of physical RAM. This server may have more resources than it needs.",
+                "UNDER_PROVISIONED" => efficiency.P95CpuPct > 85
+                    ? $"CPU p95 is {efficiency.P95CpuPct:N1}% (threshold: 85%). This server may need more CPU capacity."
+                    : $"Buffer pool uses {bpPct:N0}% of physical RAM and memory ratio is {efficiency.MemoryRatio:N2} (threshold: 0.95). Memory pressure is high.",
+                _ => ""
+            };
         }
 
-        private void RenderPeakUtilizationChart(List<FinOpsPeakUtilization> data)
+        private static void SetBar(Border bar, ColumnDefinition filled, ColumnDefinition empty, double pct)
         {
-            PeakUtilizationChart.Plot.Clear();
+            var clamped = Math.Max(0, Math.Min(100, pct));
 
-            if (data.Count == 0)
+            /* Color thresholds: green < 60, orange 60-85, red > 85 */
+            var color = clamped switch
             {
-                var noDataText = PeakUtilizationChart.Plot.Add.Text("No peak utilization data available", 12, 50);
-                noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Color.FromHex("#888888");
-                PeakUtilizationChart.Refresh();
-                return;
-            }
+                > 85 => "#E74C3C",
+                > 60 => "#F39C12",
+                _ => "#27AE60"
+            };
+            bar.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color));
 
-            // Build bars for avg CPU by hour, colored by classification
-            var bars = new List<ScottPlot.Bar>();
-
-            foreach (var item in data)
-            {
-                var color = item.HourClassification switch
-                {
-                    "PEAK" => ScottPlot.Color.FromHex("#E74C3C"),   // Red
-                    "IDLE" => ScottPlot.Color.FromHex("#27AE60"),   // Green
-                    "NORMAL" => ScottPlot.Color.FromHex("#3498DB"), // Blue
-                    _ => ScottPlot.Color.FromHex("#95A5A6")         // Gray
-                };
-
-                bars.Add(new ScottPlot.Bar
-                {
-                    Position = item.HourOfDay,
-                    Value = (double)item.AvgCpuPct,
-                    FillColor = color,
-                    Size = 0.8
-                });
-            }
-
-            var barPlot = PeakUtilizationChart.Plot.Add.Bars(bars.ToArray());
-            barPlot.Horizontal = false;
-
-            PeakUtilizationChart.Plot.Axes.Bottom.Label.Text = "Hour of Day";
-            PeakUtilizationChart.Plot.Axes.Left.Label.Text = "Avg CPU %";
-
-            // Set x-axis ticks to show each hour
-            var ticks = data.Select(d => new ScottPlot.Tick(d.HourOfDay, $"{d.HourOfDay:D2}:00")).ToArray();
-            PeakUtilizationChart.Plot.Axes.Bottom.TickGenerator = new ScottPlot.TickGenerators.NumericManual(ticks);
-            PeakUtilizationChart.Plot.Axes.Bottom.TickLabelStyle.Rotation = 45;
-
-            // Add a legend for classifications
-            PeakUtilizationChart.Plot.Legend.IsVisible = true;
-            PeakUtilizationChart.Plot.Legend.Alignment = ScottPlot.Alignment.UpperRight;
-
-            PeakUtilizationChart.Refresh();
+            /* Use star-width proportions — the layout engine handles sizing natively */
+            filled.Width = new GridLength(Math.Max(clamped, 0.1), GridUnitType.Star);
+            empty.Width = new GridLength(Math.Max(100 - clamped, 0.1), GridUnitType.Star);
         }
 
         // ============================================
         // Database Resources Tab
         // ============================================
+
+        private int GetResourceUsageHoursBack()
+        {
+            return ResourceUsageTimeRangeCombo.SelectedIndex switch
+            {
+                0 => 1,
+                1 => 4,
+                2 => 12,
+                3 => 24,
+                4 => 168,
+                _ => 24
+            };
+        }
+
+        private async void ResourceUsageTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _databaseService == null) return;
+            await LoadDatabaseResourcesAsync();
+        }
 
         private async Task LoadDatabaseResourcesAsync()
         {
@@ -257,23 +266,15 @@ namespace PerformanceMonitorDashboard.Controls
 
             try
             {
-                if (DatabaseResourcesDataGrid.ItemsSource == null)
-                {
-                    DatabaseResourcesLoading.IsLoading = true;
-                    DatabaseResourcesNoDataMessage.Visibility = Visibility.Collapsed;
-                }
-
-                var data = await _databaseService.GetFinOpsDatabaseResourceUsageAsync();
+                var hoursBack = GetResourceUsageHoursBack();
+                var data = await _databaseService.GetFinOpsDatabaseResourceUsageAsync(hoursBack);
                 DatabaseResourcesDataGrid.ItemsSource = data;
                 DatabaseResourcesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                DbResourcesCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading database resources: {ex.Message}", ex);
-            }
-            finally
-            {
-                DatabaseResourcesLoading.IsLoading = false;
             }
         }
 
@@ -287,23 +288,14 @@ namespace PerformanceMonitorDashboard.Controls
 
             try
             {
-                if (DatabaseSizesDataGrid.ItemsSource == null)
-                {
-                    DatabaseSizesLoading.IsLoading = true;
-                    DatabaseSizesNoDataMessage.Visibility = Visibility.Collapsed;
-                }
-
                 var data = await _databaseService.GetFinOpsDatabaseSizeStatsAsync();
                 DatabaseSizesDataGrid.ItemsSource = data;
                 DatabaseSizesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                DbSizeCountIndicator.Text = data.Count > 0 ? $"{data.Count} file(s)" : "";
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading database sizes: {ex.Message}", ex);
-            }
-            finally
-            {
-                DatabaseSizesLoading.IsLoading = false;
             }
         }
 
@@ -317,23 +309,35 @@ namespace PerformanceMonitorDashboard.Controls
 
             try
             {
-                if (ApplicationConnectionsDataGrid.ItemsSource == null)
-                {
-                    ApplicationConnectionsLoading.IsLoading = true;
-                    ApplicationConnectionsNoDataMessage.Visibility = Visibility.Collapsed;
-                }
-
                 var data = await _databaseService.GetFinOpsApplicationResourceUsageAsync();
                 ApplicationConnectionsDataGrid.ItemsSource = data;
                 ApplicationConnectionsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                AppConnectionsCountIndicator.Text = data.Count > 0 ? $"{data.Count} application(s)" : "";
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading application connections: {ex.Message}", ex);
             }
-            finally
+        }
+
+        // ============================================
+        // Server Inventory Tab
+        // ============================================
+
+        private async Task LoadServerInventoryAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
             {
-                ApplicationConnectionsLoading.IsLoading = false;
+                var data = await _databaseService.GetFinOpsServerInventoryAsync();
+                ServerInventoryDataGrid.ItemsSource = data;
+                ServerInventoryNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                ServerInventoryCountIndicator.Text = data.Count > 0 ? $"{data.Count} server(s)" : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading server inventory: {ex.Message}", ex);
             }
         }
 
@@ -359,6 +363,11 @@ namespace PerformanceMonitorDashboard.Controls
         private async void ApplicationConnectionsRefresh_Click(object sender, RoutedEventArgs e)
         {
             await LoadApplicationConnectionsAsync();
+        }
+
+        private async void ServerInventoryRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadServerInventoryAsync();
         }
 
         // ============================================

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -23,33 +23,120 @@ namespace PerformanceMonitorDashboard.Services
         /// <summary>
         /// Fetches per-database resource usage from report.finops_database_resource_usage.
         /// </summary>
-        public async Task<List<FinOpsDatabaseResourceUsage>> GetFinOpsDatabaseResourceUsageAsync()
+        public async Task<List<FinOpsDatabaseResourceUsage>> GetFinOpsDatabaseResourceUsageAsync(int hoursBack = 24)
         {
             var items = new List<FinOpsDatabaseResourceUsage>();
 
             await using var tc = await OpenThrottledConnectionAsync();
             var connection = tc.Connection;
 
-            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-                SELECT
-                    database_name,
-                    cpu_time_ms,
-                    logical_reads,
-                    physical_reads,
-                    logical_writes,
-                    execution_count,
-                    io_read_mb,
-                    io_write_mb,
-                    io_stall_ms,
-                    pct_cpu_share,
-                    pct_io_share
-                FROM report.finops_database_resource_usage
-                ORDER BY
-                    pct_cpu_share DESC
-                OPTION(MAXDOP 1, RECOMPILE);";
+WITH
+    workload_stats AS
+    (
+        SELECT
+            database_name = qs.database_name,
+            cpu_time_ms =
+                SUM(qs.total_worker_time_delta) / 1000,
+            logical_reads =
+                SUM(qs.total_logical_reads_delta),
+            physical_reads =
+                SUM(qs.total_physical_reads_delta),
+            logical_writes =
+                SUM(qs.total_logical_writes_delta),
+            execution_count =
+                SUM(qs.execution_count_delta)
+        FROM collect.query_stats AS qs
+        WHERE qs.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   qs.total_worker_time_delta IS NOT NULL
+        GROUP BY
+            qs.database_name
+    ),
+    io_stats AS
+    (
+        SELECT
+            database_name = fio.database_name,
+            io_read_bytes =
+                SUM(fio.num_of_bytes_read_delta),
+            io_write_bytes =
+                SUM(fio.num_of_bytes_written_delta),
+            io_stall_ms =
+                SUM(fio.io_stall_ms_delta)
+        FROM collect.file_io_stats AS fio
+        WHERE fio.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   fio.num_of_bytes_read_delta IS NOT NULL
+        GROUP BY
+            fio.database_name
+    ),
+    totals AS
+    (
+        SELECT
+            total_cpu_ms =
+                NULLIF(SUM(ws.cpu_time_ms), 0),
+            total_io_bytes =
+                NULLIF
+                (
+                    SUM(ios.io_read_bytes) +
+                    SUM(ios.io_write_bytes),
+                    0
+                )
+        FROM workload_stats AS ws
+        FULL JOIN io_stats AS ios
+          ON ios.database_name = ws.database_name
+    )
+SELECT
+    database_name =
+        COALESCE(ws.database_name, ios.database_name),
+    cpu_time_ms =
+        ISNULL(ws.cpu_time_ms, 0),
+    logical_reads =
+        ISNULL(ws.logical_reads, 0),
+    physical_reads =
+        ISNULL(ws.physical_reads, 0),
+    logical_writes =
+        ISNULL(ws.logical_writes, 0),
+    execution_count =
+        ISNULL(ws.execution_count, 0),
+    io_read_mb =
+        CONVERT
+        (
+            decimal(19,2),
+            ISNULL(ios.io_read_bytes, 0) / 1048576.0
+        ),
+    io_write_mb =
+        CONVERT
+        (
+            decimal(19,2),
+            ISNULL(ios.io_write_bytes, 0) / 1048576.0
+        ),
+    io_stall_ms =
+        ISNULL(ios.io_stall_ms, 0),
+    pct_cpu_share =
+        CONVERT
+        (
+            decimal(5,2),
+            ISNULL(ws.cpu_time_ms, 0) * 100.0 /
+              t.total_cpu_ms
+        ),
+    pct_io_share =
+        CONVERT
+        (
+            decimal(5,2),
+            (ISNULL(ios.io_read_bytes, 0) + ISNULL(ios.io_write_bytes, 0)) * 100.0 /
+              t.total_io_bytes
+        )
+FROM workload_stats AS ws
+FULL JOIN io_stats AS ios
+  ON ios.database_name = ws.database_name
+CROSS JOIN totals AS t
+ORDER BY
+    ISNULL(ws.cpu_time_ms, 0) DESC
+OPTION(MAXDOP 1, RECOMPILE);";
 
             using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
             command.CommandTimeout = 120;
 
             using (StartQueryTiming("FinOps_DatabaseResourceUsage", query, connection))
@@ -88,21 +175,39 @@ namespace PerformanceMonitorDashboard.Services
             const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
                 SELECT
-                    avg_cpu_pct,
-                    max_cpu_pct,
-                    p95_cpu_pct,
-                    cpu_samples,
-                    total_memory_mb,
-                    target_memory_mb,
-                    physical_memory_mb,
-                    memory_ratio,
-                    memory_utilization_pct,
-                    worker_threads_current,
-                    worker_threads_max,
-                    worker_thread_ratio,
-                    cpu_count,
-                    provisioning_status
-                FROM report.finops_utilization_efficiency
+                    v.avg_cpu_pct,
+                    v.max_cpu_pct,
+                    v.p95_cpu_pct,
+                    v.cpu_samples,
+                    v.total_memory_mb,
+                    v.target_memory_mb,
+                    v.physical_memory_mb,
+                    v.memory_ratio,
+                    v.memory_utilization_pct,
+                    v.worker_threads_current,
+                    v.worker_threads_max,
+                    v.worker_thread_ratio,
+                    v.cpu_count,
+                    v.provisioning_status,
+                    m.buffer_pool_mb,
+                    tsm.total_server_memory_mb
+                FROM report.finops_utilization_efficiency AS v
+                OUTER APPLY
+                (
+                    SELECT TOP (1)
+                        ms.buffer_pool_mb
+                    FROM collect.memory_stats AS ms
+                    ORDER BY
+                        ms.collection_time DESC
+                ) AS m
+                OUTER APPLY
+                (
+                    SELECT
+                        total_server_memory_mb =
+                            pc.cntr_value / 1024
+                    FROM sys.dm_os_performance_counters AS pc
+                    WHERE pc.counter_name = N'Total Server Memory (KB)'
+                ) AS tsm
                 OPTION(MAXDOP 1, RECOMPILE);";
 
             using var command = new SqlCommand(query, connection);
@@ -128,61 +233,14 @@ namespace PerformanceMonitorDashboard.Services
                         WorkerThreadsMax = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
                         WorkerThreadRatio = reader.IsDBNull(11) ? 0m : Convert.ToDecimal(reader.GetValue(11)),
                         CpuCount = reader.IsDBNull(12) ? 0 : Convert.ToInt32(reader.GetValue(12)),
-                        ProvisioningStatus = reader.IsDBNull(13) ? "" : reader.GetString(13)
+                        ProvisioningStatus = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                        BufferPoolMb = reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14)),
+                        TotalServerMemoryMb = reader.IsDBNull(15) ? 0 : Convert.ToInt32(reader.GetValue(15))
                     };
                 }
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Fetches peak utilization by hour from report.finops_peak_utilization.
-        /// </summary>
-        public async Task<List<FinOpsPeakUtilization>> GetFinOpsPeakUtilizationAsync()
-        {
-            var items = new List<FinOpsPeakUtilization>();
-
-            await using var tc = await OpenThrottledConnectionAsync();
-            var connection = tc.Connection;
-
-            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-                SELECT
-                    hour_of_day,
-                    avg_cpu_pct,
-                    max_cpu_pct,
-                    avg_memory_pct,
-                    max_memory_pct,
-                    cpu_samples,
-                    hour_classification
-                FROM report.finops_peak_utilization
-                ORDER BY
-                    hour_of_day ASC
-                OPTION(MAXDOP 1, RECOMPILE);";
-
-            using var command = new SqlCommand(query, connection);
-            command.CommandTimeout = 120;
-
-            using (StartQueryTiming("FinOps_PeakUtilization", query, connection))
-            {
-                using var reader = await command.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
-                {
-                    items.Add(new FinOpsPeakUtilization
-                    {
-                        HourOfDay = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0)),
-                        AvgCpuPct = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
-                        MaxCpuPct = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
-                        AvgMemoryPct = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
-                        MaxMemoryPct = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                        CpuSamples = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
-                        HourClassification = reader.IsDBNull(6) ? "" : reader.GetString(6)
-                    });
-                }
-            }
-
-            return items;
         }
 
         /// <summary>
@@ -312,6 +370,301 @@ namespace PerformanceMonitorDashboard.Services
 
             return items;
         }
+
+        /// <summary>
+        /// Fetches server inventory from config.server_info.
+        /// </summary>
+        public async Task<List<FinOpsServerInventory>> GetFinOpsServerInventoryAsync()
+        {
+            var items = new List<FinOpsServerInventory>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    server_name,
+                    edition,
+                    sql_version,
+                    environment_type,
+                    cpu_count,
+                    physical_memory_mb,
+                    sqlserver_start_time,
+                    uptime_days,
+                    uptime_hours,
+                    last_updated
+                FROM config.server_info
+                ORDER BY
+                    server_name
+                OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_ServerInventory", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsServerInventory
+                    {
+                        ServerName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        Edition = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        SqlVersion = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        EnvironmentType = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                        CpuCount = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                        PhysicalMemoryMb = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                        SqlServerStartTime = reader.IsDBNull(6) ? null : reader.GetDateTime(6),
+                        UptimeDays = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
+                        UptimeHours = reader.IsDBNull(8) ? 0 : Convert.ToInt32(reader.GetValue(8)),
+                        LastUpdated = reader.IsDBNull(9) ? null : reader.GetDateTime(9)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets top N databases by total CPU for the utilization summary.
+        /// </summary>
+        public async Task<List<FinOpsTopResourceConsumer>> GetFinOpsTopResourceConsumersByTotalAsync(int hoursBack = 24, int topN = 5)
+        {
+            var items = new List<FinOpsTopResourceConsumer>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH
+    workload AS
+    (
+        SELECT
+            database_name,
+            cpu_time_ms =
+                SUM(qs.total_worker_time_delta) / 1000,
+            execution_count =
+                SUM(qs.execution_count_delta)
+        FROM collect.query_stats AS qs
+        WHERE qs.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   qs.total_worker_time_delta IS NOT NULL
+        GROUP BY
+            qs.database_name
+    ),
+    io AS
+    (
+        SELECT
+            database_name,
+            io_total_bytes =
+                SUM(fio.num_of_bytes_read_delta + fio.num_of_bytes_written_delta)
+        FROM collect.file_io_stats AS fio
+        WHERE fio.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   fio.num_of_bytes_read_delta IS NOT NULL
+        GROUP BY
+            fio.database_name
+    ),
+    combined AS
+    (
+        SELECT
+            database_name =
+                COALESCE(w.database_name, i.database_name),
+            cpu_time_ms =
+                ISNULL(w.cpu_time_ms, 0),
+            execution_count =
+                ISNULL(w.execution_count, 0),
+            io_total_mb =
+                CONVERT(decimal(19,2), ISNULL(i.io_total_bytes, 0) / 1048576.0)
+        FROM workload AS w
+        FULL JOIN io AS i
+          ON i.database_name = w.database_name
+    ),
+    totals AS
+    (
+        SELECT
+            total_cpu =
+                NULLIF(SUM(cpu_time_ms), 0),
+            total_io =
+                NULLIF(SUM(io_total_mb), 0)
+        FROM combined
+    )
+SELECT TOP(@topN)
+    c.database_name,
+    c.cpu_time_ms,
+    c.execution_count,
+    c.io_total_mb,
+    pct_cpu =
+        CONVERT(decimal(5,2), c.cpu_time_ms * 100.0 / t.total_cpu),
+    pct_io =
+        CONVERT(decimal(5,2), c.io_total_mb * 100.0 / t.total_io)
+FROM combined AS c
+CROSS JOIN totals AS t
+ORDER BY
+    c.cpu_time_ms DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_TopResourceByTotal", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsTopResourceConsumer
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        CpuTimeMs = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                        ExecutionCount = reader.IsDBNull(2) ? 0 : Convert.ToInt64(reader.GetValue(2)),
+                        IoTotalMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        PctCpu = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                        PctIo = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5))
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets top N databases by average CPU per execution for the utilization summary.
+        /// </summary>
+        public async Task<List<FinOpsTopResourceConsumer>> GetFinOpsTopResourceConsumersByAvgAsync(int hoursBack = 24, int topN = 5)
+        {
+            var items = new List<FinOpsTopResourceConsumer>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH
+    workload AS
+    (
+        SELECT
+            database_name,
+            cpu_time_ms =
+                SUM(qs.total_worker_time_delta) / 1000,
+            execution_count =
+                SUM(qs.execution_count_delta)
+        FROM collect.query_stats AS qs
+        WHERE qs.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   qs.total_worker_time_delta IS NOT NULL
+        GROUP BY
+            qs.database_name
+        HAVING
+            SUM(qs.execution_count_delta) > 0
+    ),
+    io AS
+    (
+        SELECT
+            database_name,
+            io_total_mb =
+                SUM(fio.num_of_bytes_read_delta + fio.num_of_bytes_written_delta) / 1048576.0
+        FROM collect.file_io_stats AS fio
+        WHERE fio.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+        AND   fio.num_of_bytes_read_delta IS NOT NULL
+        GROUP BY
+            fio.database_name
+    )
+SELECT TOP(@topN)
+    w.database_name,
+    avg_cpu_ms =
+        CONVERT(decimal(19,2), w.cpu_time_ms * 1.0 / w.execution_count),
+    w.execution_count,
+    io_total_mb =
+        CONVERT(decimal(19,2), ISNULL(i.io_total_mb, 0)),
+    w.cpu_time_ms,
+    avg_io_mb =
+        CONVERT(decimal(19,4), ISNULL(i.io_total_mb, 0) * 1.0 / w.execution_count)
+FROM workload AS w
+LEFT JOIN io AS i
+  ON i.database_name = w.database_name
+ORDER BY
+    avg_cpu_ms DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_TopResourceByAvg", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsTopResourceConsumer
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        CpuTimeMs = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                        ExecutionCount = reader.IsDBNull(2) ? 0 : Convert.ToInt64(reader.GetValue(2)),
+                        IoTotalMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        TotalCpuTimeMs = reader.IsDBNull(4) ? 0 : Convert.ToInt64(reader.GetValue(4)),
+                        AvgIoMb = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5))
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets per-database total allocated and used space for the utilization size chart.
+        /// </summary>
+        public async Task<List<FinOpsDatabaseSizeSummary>> GetFinOpsDatabaseSizeSummaryAsync(int topN = 10)
+        {
+            var items = new List<FinOpsDatabaseSizeSummary>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP(@topN)
+    database_name,
+    total_mb =
+        SUM(total_size_mb),
+    used_mb =
+        SUM(used_size_mb)
+FROM collect.database_size_stats
+WHERE collection_time =
+(
+    SELECT MAX(collection_time)
+    FROM collect.database_size_stats
+)
+GROUP BY
+    database_name
+ORDER BY
+    SUM(total_size_mb) DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_DatabaseSizeSummary", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsDatabaseSizeSummary
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        TotalMb = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                        UsedMb = reader.IsDBNull(2) ? null : Convert.ToDecimal(reader.GetValue(2))
+                    });
+                }
+            }
+
+            return items;
+        }
     }
 
     // ============================================
@@ -348,18 +701,9 @@ namespace PerformanceMonitorDashboard.Services
         public int WorkerThreadsMax { get; set; }
         public decimal WorkerThreadRatio { get; set; }
         public int CpuCount { get; set; }
+        public int BufferPoolMb { get; set; }
+        public int TotalServerMemoryMb { get; set; }
         public string ProvisioningStatus { get; set; } = "";
-    }
-
-    public class FinOpsPeakUtilization
-    {
-        public int HourOfDay { get; set; }
-        public decimal AvgCpuPct { get; set; }
-        public int MaxCpuPct { get; set; }
-        public decimal AvgMemoryPct { get; set; }
-        public int MaxMemoryPct { get; set; }
-        public long CpuSamples { get; set; }
-        public string HourClassification { get; set; } = "";
     }
 
     public class FinOpsApplicationResourceUsage
@@ -370,6 +714,21 @@ namespace PerformanceMonitorDashboard.Services
         public long SampleCount { get; set; }
         public DateTime FirstSeen { get; set; }
         public DateTime LastSeen { get; set; }
+    }
+
+    public class FinOpsServerInventory
+    {
+        public string ServerName { get; set; } = "";
+        public string Edition { get; set; } = "";
+        public string SqlVersion { get; set; } = "";
+        public string EnvironmentType { get; set; } = "";
+        public int CpuCount { get; set; }
+        public long PhysicalMemoryMb { get; set; }
+        public DateTime? SqlServerStartTime { get; set; }
+        public int UptimeDays { get; set; }
+        public int UptimeHours { get; set; }
+        public DateTime? LastUpdated { get; set; }
+        public string UptimeDisplay => $"{UptimeDays}d {UptimeHours}h";
     }
 
     public class FinOpsDatabaseSizeStats
@@ -393,5 +752,32 @@ namespace PerformanceMonitorDashboard.Services
         public string VolumeMountPoint { get; set; } = "";
         public decimal VolumeTotalMb { get; set; }
         public decimal VolumeFreeMb { get; set; }
+    }
+
+    public class FinOpsTopResourceConsumer
+    {
+        public string DatabaseName { get; set; } = "";
+        public long CpuTimeMs { get; set; }
+        public long ExecutionCount { get; set; }
+        public decimal IoTotalMb { get; set; }
+        public decimal PctCpu { get; set; }
+        public decimal PctIo { get; set; }
+        public long TotalCpuTimeMs { get; set; }
+        public decimal AvgIoMb { get; set; }
+    }
+
+    public class FinOpsDatabaseSizeSummary
+    {
+        public string DatabaseName { get; set; } = "";
+        public decimal TotalMb { get; set; }
+        public decimal? UsedMb { get; set; }
+        public decimal FreeMb => UsedMb.HasValue ? TotalMb - UsedMb.Value : TotalMb;
+        public decimal UsedPct => TotalMb > 0 && UsedMb.HasValue ? Math.Round(UsedMb.Value * 100m / TotalMb, 1) : 0;
+
+        /* Star-width GridLength for XAML binding — drives the stacked bar proportions */
+        public System.Windows.GridLength UsedStarWidth =>
+            new(Math.Max((double)(UsedMb ?? 0m), 0.1), System.Windows.GridUnitType.Star);
+        public System.Windows.GridLength FreeStarWidth =>
+            new(Math.Max((double)FreeMb, 0.1), System.Windows.GridUnitType.Star);
     }
 }

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -50,6 +50,8 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
@@ -67,89 +69,320 @@
                     </Border>
                 </StackPanel>
 
-                <!-- Utilization Summary -->
-                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="10,0,10,10">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
+                <!-- Utilization Summary — compact, top-aligned -->
+                <Grid Grid.Row="1" Margin="10,0,10,0" x:Name="UtilizationContent">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-                        <!-- CPU Metrics -->
-                        <GroupBox Grid.Column="0" Header="CPU" Margin="0,0,5,0"
-                                  Foreground="{DynamicResource ForegroundBrush}">
-                            <StackPanel Margin="8">
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}">
-                                    <Run Text="Avg CPU: " FontWeight="SemiBold"/>
-                                    <Run x:Name="AvgCpuText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="P95 CPU: " FontWeight="SemiBold"/>
-                                    <Run x:Name="P95CpuText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Max CPU: " FontWeight="SemiBold"/>
-                                    <Run x:Name="MaxCpuText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Samples: " FontWeight="SemiBold"/>
-                                    <Run x:Name="CpuSamplesText" Text="-"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </GroupBox>
+                    <!-- CPU Metrics -->
+                    <GroupBox Grid.Column="0" Header="CPU" Margin="0,0,5,0" VerticalAlignment="Top"
+                              Foreground="{DynamicResource ForegroundBrush}">
+                        <StackPanel Margin="10">
+                            <!-- Avg CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Avg CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="AvgCpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="AvgCpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="AvgCpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="AvgCpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- P95 CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="P95 CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="P95CpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="P95CpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="P95CpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="P95CpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Max CPU -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Max CPU" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MaxCpuFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MaxCpuEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MaxCpuBar" Background="#27AE60"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MaxCpuText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- CPU Details -->
+                            <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                <Run x:Name="WorkerThreadsText" Text="-"/>
+                                <Run Text=" workers,"/>
+                                <Run x:Name="CpuSamplesText" Text="-"/>
+                                <Run Text=" samples (24h)"/>
+                            </TextBlock>
+                        </StackPanel>
+                    </GroupBox>
 
-                        <!-- Memory Metrics -->
-                        <GroupBox Grid.Column="1" Header="Memory" Margin="5,0"
-                                  Foreground="{DynamicResource ForegroundBrush}">
-                            <StackPanel Margin="8">
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}">
-                                    <Run Text="Physical: " FontWeight="SemiBold"/>
-                                    <Run x:Name="PhysicalMemoryText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Target: " FontWeight="SemiBold"/>
-                                    <Run x:Name="TargetMemoryText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Total: " FontWeight="SemiBold"/>
-                                    <Run x:Name="TotalMemoryText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Buffer Pool: " FontWeight="SemiBold"/>
-                                    <Run x:Name="BufferPoolText" Text="-"/>
-                                </TextBlock>
-                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" Margin="0,4,0,0">
-                                    <Run Text="Memory Ratio: " FontWeight="SemiBold"/>
-                                    <Run x:Name="MemoryRatioText" Text="-"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </GroupBox>
+                    <!-- Memory Metrics -->
+                    <GroupBox Grid.Column="1" Header="Memory" Margin="5,0,0,0" VerticalAlignment="Top"
+                              Foreground="{DynamicResource ForegroundBrush}">
+                        <StackPanel Margin="10">
+                            <!-- Committed vs Target -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Stolen Mem %" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"
+                                           ToolTip="(Total Server Memory - Buffer Pool) / Total Server Memory — memory used by plan cache, locks, grants, CLR, etc."/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MemUtilFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MemUtilEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MemoryUtilBar" Background="#3498DB"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MemoryUtilText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Buffer Pool vs Physical -->
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="60"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Buffer Pool %" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"
+                                           ToolTip="Buffer Pool / Physical Memory — how much of physical RAM is used by the buffer pool"/>
+                                <Grid Grid.Column="1" Margin="0,0,8,0">
+                                    <Border Height="16" CornerRadius="3" Background="#1AFFFFFF"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="MemRatioFilled" Width="0*"/>
+                                            <ColumnDefinition x:Name="MemRatioEmpty" Width="100*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Height="16" CornerRadius="3"
+                                                x:Name="MemoryRatioBar" Background="#3498DB"/>
+                                    </Grid>
+                                </Grid>
+                                <TextBlock x:Name="MemoryRatioText" Grid.Column="2" Text="-"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Memory Details -->
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5">
+                                        <Run Text="Physical: " FontWeight="SemiBold"/>
+                                        <Run x:Name="PhysicalMemoryText" Text="-"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                        <Run Text="Target: " FontWeight="SemiBold"/>
+                                        <Run x:Name="TargetMemoryText" Text="-"/>
+                                    </TextBlock>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1">
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5">
+                                        <Run Text="Total: " FontWeight="SemiBold"/>
+                                        <Run x:Name="TotalMemoryText" Text="-"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11.5" Margin="0,2,0,0">
+                                        <Run Text="Buffer Pool: " FontWeight="SemiBold"/>
+                                        <Run x:Name="BufferPoolText" Text="-"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Grid>
+                        </StackPanel>
+                    </GroupBox>
+                </Grid>
 
-                        <!-- Classification Info -->
-                        <GroupBox Grid.Column="2" Header="Classification" Margin="5,0,0,0"
+                <!-- Classification Explanation -->
+                <TextBlock x:Name="ClassificationExplanation" Grid.Row="2" Margin="12,8,10,4"
+                           VerticalAlignment="Top" TextWrapping="Wrap" FontSize="12"
+                           Foreground="{DynamicResource ForegroundMutedBrush}"/>
+
+                <!-- Resource Summaries -->
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
+                    <Grid x:Name="SummaryContent">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Top Resource Consumers — Total + Avg side by side -->
+                        <Grid Grid.Row="0" Margin="10,4,10,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Top 5 by Total CPU -->
+                            <GroupBox Grid.Column="0" Header="Top Databases by Total CPU" Margin="0,0,5,0"
+                                      Foreground="{DynamicResource ForegroundBrush}">
+                                <DataGrid x:Name="TopTotalGrid"
+                                          AutoGenerateColumns="False" IsReadOnly="True"
+                                          CanUserSortColumns="True" HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal" SelectionMode="Single"
+                                          MinHeight="40" MaxHeight="200"
+                                          RowStyle="{StaticResource DefaultRowStyle}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="*"/>
+                                        <DataGridTextColumn Header="CPU %" Binding="{Binding PctCpu, StringFormat='{}{0:N1}'}" Width="60">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="IO %" Binding="{Binding PctIo, StringFormat='{}{0:N1}'}" Width="55">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="CPU (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N0}'}" Width="80">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Execs" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </GroupBox>
+
+                            <!-- Top 5 by Avg CPU per Execution -->
+                            <GroupBox Grid.Column="1" Header="Top Databases by Avg CPU / Execution" Margin="5,0,0,0"
+                                      Foreground="{DynamicResource ForegroundBrush}">
+                                <DataGrid x:Name="TopAvgGrid"
+                                          AutoGenerateColumns="False" IsReadOnly="True"
+                                          CanUserSortColumns="True" HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal" SelectionMode="Single"
+                                          MinHeight="40" MaxHeight="200"
+                                          RowStyle="{StaticResource DefaultRowStyle}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="*"/>
+                                        <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding CpuTimeMs, StringFormat='{}{0:N2}'}" Width="95">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Avg IO (MB)" Binding="{Binding AvgIoMb, StringFormat='{}{0:N2}'}" Width="90">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Execs" Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </GroupBox>
+                        </Grid>
+
+                        <!-- Database Size Chart -->
+                        <GroupBox Grid.Row="1" Header="Database Sizes — Allocated vs Used" Margin="10,8,10,10"
                                   Foreground="{DynamicResource ForegroundBrush}">
-                            <StackPanel Margin="8">
-                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12">
-                                    <Run FontWeight="SemiBold" Foreground="#27AE60">RIGHT SIZED</Run>
-                                    <Run Text=" — balanced resource usage"/>
-                                </TextBlock>
-                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12" Margin="0,6,0,0">
-                                    <Run FontWeight="SemiBold" Foreground="#F39C12">OVER PROVISIONED</Run>
-                                    <Run Text=" — avg CPU &lt;15%, max &lt;40%, memory ratio &lt;0.5"/>
-                                </TextBlock>
-                                <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" FontSize="12" Margin="0,6,0,0">
-                                    <Run FontWeight="SemiBold" Foreground="#E74C3C">UNDER PROVISIONED</Run>
-                                    <Run Text=" — p95 CPU >85% or memory ratio >0.95"/>
-                                </TextBlock>
-                            </StackPanel>
+                            <ItemsControl x:Name="DbSizeChart" Margin="8,4,8,4">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="0,2" Height="22">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="160"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="90"/>
+                                            </Grid.ColumnDefinitions>
+                                            <!-- Database name -->
+                                            <TextBlock Grid.Column="0" Text="{Binding DatabaseName}"
+                                                       VerticalAlignment="Center" FontSize="11.5"
+                                                       Foreground="{DynamicResource ForegroundBrush}"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <!-- Stacked bar: used (accent) + free (dim) -->
+                                            <Grid Grid.Column="1" Margin="4,2">
+                                                <Border CornerRadius="3" Background="#1AFFFFFF"/>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="{Binding UsedStarWidth}"/>
+                                                        <ColumnDefinition Width="{Binding FreeStarWidth}"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Border Grid.Column="0" CornerRadius="3" Background="#3498DB"/>
+                                                </Grid>
+                                            </Grid>
+                                            <!-- Size label -->
+                                            <TextBlock Grid.Column="2" VerticalAlignment="Center"
+                                                       HorizontalAlignment="Right" FontSize="11.5"
+                                                       Foreground="{DynamicResource ForegroundBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0:N0} / {1:N0} MB">
+                                                        <Binding Path="UsedMb"/>
+                                                        <Binding Path="TotalMb"/>
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                         </GroupBox>
                     </Grid>
                 </ScrollViewer>
 
                 <!-- Empty State -->
                 <TextBlock x:Name="NoUtilizationMessage"
-                           Grid.Row="1"
+                           Grid.Row="1" Grid.RowSpan="3"
                            Text="No utilization data collected yet. Select a server above."
                            FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
                            HorizontalAlignment="Center" VerticalAlignment="Center"
@@ -167,11 +400,19 @@
 
                 <!-- Header Controls -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                    <TextBlock Text="Database Resource Usage (24h)" VerticalAlignment="Center" Margin="0,0,10,0"
+                    <TextBlock Text="Database Resource Usage" VerticalAlignment="Center" Margin="0,0,10,0"
                                FontWeight="Bold" FontSize="14"
                                Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="ResourceUsageTimeRangeCombo" SelectedIndex="3" Width="120" Margin="0,0,8,0"
+                              SelectionChanged="ResourceUsageTimeRange_Changed">
+                        <ComboBoxItem Content="Last 1 hour"/>
+                        <ComboBoxItem Content="Last 4 hours"/>
+                        <ComboBoxItem Content="Last 12 hours"/>
+                        <ComboBoxItem Content="Last 24 hours"/>
+                        <ComboBoxItem Content="Last 7 days"/>
+                    </ComboBox>
                     <Button Content="Refresh" Click="RefreshDatabaseResources_Click"
-                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                            Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
                     <TextBlock x:Name="DbResourcesCountIndicator" Text="" Margin="12,0,0,0"
                                VerticalAlignment="Center" FontStyle="Italic"
                                Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
@@ -306,7 +547,21 @@
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Application" Binding="{Binding ApplicationName}" Width="300"/>
-                            <DataGridTextColumn Header="Max Connections" Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" Width="120">
+                            <DataGridTextColumn Header="Avg Connections" Binding="{Binding AvgConnections, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Max Connections" Binding="{Binding MaxConnections, StringFormat='{}{0:N0}'}" Width="120">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Samples" Binding="{Binding SampleCount, StringFormat='{}{0:N0}'}" Width="100">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="HorizontalAlignment" Value="Right"/>

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -91,6 +91,19 @@ public partial class FinOpsTab : UserControl
             var data = await _dataService.GetUtilizationEfficiencyAsync(serverId);
             UpdateUtilizationSummary(data);
             NoUtilizationMessage.Visibility = data == null ? Visibility.Visible : Visibility.Collapsed;
+            SummaryContent.Visibility = data == null ? Visibility.Collapsed : Visibility.Visible;
+
+            if (data != null)
+            {
+                var topTotal = await _dataService.GetTopResourceConsumersByTotalAsync(serverId);
+                TopTotalGrid.ItemsSource = topTotal;
+
+                var topAvg = await _dataService.GetTopResourceConsumersByAvgAsync(serverId);
+                TopAvgGrid.ItemsSource = topAvg;
+
+                var sizes = await _dataService.GetDatabaseSizeSummaryAsync(serverId);
+                DbSizeChart.ItemsSource = sizes;
+            }
         }
         catch (Exception ex)
         {
@@ -105,9 +118,17 @@ public partial class FinOpsTab : UserControl
             ProvisioningStatusText.Text = "No Data";
             ProvisioningStatusBorder.Background = new SolidColorBrush(Colors.Gray);
             AvgCpuText.Text = P95CpuText.Text = MaxCpuText.Text = CpuSamplesText.Text = "-";
-            PhysicalMemoryText.Text = TargetMemoryText.Text = TotalMemoryText.Text = BufferPoolText.Text = MemoryRatioText.Text = "-";
+            WorkerThreadsText.Text = "-";
+            AvgCpuBar.Width = P95CpuBar.Width = MaxCpuBar.Width = 0;
+            MemoryUtilBar.Width = MemoryRatioBar.Width = 0;
+            MemoryUtilText.Text = MemoryRatioText.Text = "-";
+            PhysicalMemoryText.Text = TargetMemoryText.Text = TotalMemoryText.Text = BufferPoolText.Text = "-";
+            ClassificationExplanation.Text = "";
+            UtilizationContent.Visibility = Visibility.Collapsed;
             return;
         }
+
+        UtilizationContent.Visibility = Visibility.Visible;
 
         ProvisioningStatusText.Text = data.ProvisioningStatus.Replace("_", " ");
         switch (data.ProvisioningStatus)
@@ -130,16 +151,85 @@ public partial class FinOpsTab : UserControl
                 break;
         }
 
+        /* CPU text + bars */
         AvgCpuText.Text = $"{data.AvgCpuPct:N2}%";
         P95CpuText.Text = $"{data.P95CpuPct:N2}%";
         MaxCpuText.Text = $"{data.MaxCpuPct}%";
         CpuSamplesText.Text = data.CpuSamples.ToString("N0");
+        WorkerThreadsText.Text = $"{data.CurrentWorkersCount:N0} / {data.MaxWorkersCount:N0}";
+
+        SetBar(AvgCpuBar, AvgCpuFilled, AvgCpuEmpty, (double)data.AvgCpuPct);
+        SetBar(P95CpuBar, P95CpuFilled, P95CpuEmpty, (double)data.P95CpuPct);
+        SetBar(MaxCpuBar, MaxCpuFilled, MaxCpuEmpty, data.MaxCpuPct);
+
+        /* Stolen Memory % = (Total Server Memory - Buffer Pool) / Total Server Memory */
+        var stolenPct = data.TotalMemoryMb > 0
+            ? (double)(data.TotalMemoryMb - data.BufferPoolMb) / data.TotalMemoryMb * 100.0
+            : 0;
+        MemoryUtilText.Text = $"{stolenPct:N0}%";
+        SetBar(MemoryUtilBar, MemUtilFilled, MemUtilEmpty, stolenPct);
+
+        /* Buffer Pool % = Buffer Pool / Physical Memory */
+        var bpPct = data.PhysicalMemoryMb > 0
+            ? (double)data.BufferPoolMb / data.PhysicalMemoryMb * 100.0
+            : 0;
+        MemoryRatioText.Text = $"{bpPct:N0}%";
+        SetBar(MemoryRatioBar, MemRatioFilled, MemRatioEmpty, bpPct);
 
         PhysicalMemoryText.Text = $"{data.PhysicalMemoryMb:N0} MB";
         TargetMemoryText.Text = $"{data.TargetMemoryMb:N0} MB";
         TotalMemoryText.Text = $"{data.TotalMemoryMb:N0} MB";
         BufferPoolText.Text = $"{data.BufferPoolMb:N0} MB";
-        MemoryRatioText.Text = $"{data.MemoryRatio:N2}";
+
+        /* Contextual explanation — one sentence describing WHY this classification */
+        ClassificationExplanation.Text = data.ProvisioningStatus switch
+        {
+            "RIGHT_SIZED" => $"CPU is moderately loaded (avg {data.AvgCpuPct:N1}%, p95 {data.P95CpuPct:N1}%) and memory is well-utilized (buffer pool uses {bpPct:N0}% of physical RAM). No action needed.",
+            "OVER_PROVISIONED" => $"CPU is lightly loaded (avg {data.AvgCpuPct:N1}%, max {data.MaxCpuPct}%) and buffer pool uses only {bpPct:N0}% of physical RAM. This server may have more resources than it needs.",
+            "UNDER_PROVISIONED" => data.P95CpuPct > 85
+                ? $"CPU p95 is {data.P95CpuPct:N1}% (threshold: 85%). This server may need more CPU capacity."
+                : $"Buffer pool uses {bpPct:N0}% of physical RAM and memory ratio is {data.MemoryRatio:N2} (threshold: 0.95). Memory pressure is high.",
+            _ => ""
+        };
+    }
+
+    private static void SetBar(Border bar, ColumnDefinition filled, ColumnDefinition empty, double pct)
+    {
+        var clamped = Math.Max(0, Math.Min(100, pct));
+
+        /* Color thresholds: green < 60, orange 60-85, red > 85 */
+        var color = clamped switch
+        {
+            > 85 => "#E74C3C",
+            > 60 => "#F39C12",
+            _ => "#27AE60"
+        };
+        bar.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color));
+
+        /* Use star-width proportions — the layout engine handles sizing natively */
+        filled.Width = new GridLength(Math.Max(clamped, 0.1), GridUnitType.Star);
+        empty.Width = new GridLength(Math.Max(100 - clamped, 0.1), GridUnitType.Star);
+    }
+
+    private int GetResourceUsageHoursBack()
+    {
+        return ResourceUsageTimeRangeCombo.SelectedIndex switch
+        {
+            0 => 1,
+            1 => 4,
+            2 => 12,
+            3 => 24,
+            4 => 168,
+            _ => 24
+        };
+    }
+
+    private async void ResourceUsageTimeRange_Changed(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _dataService == null) return;
+        var serverId = GetSelectedServerId();
+        if (serverId == 0) return;
+        await LoadDatabaseResourcesAsync(serverId);
     }
 
     private async System.Threading.Tasks.Task LoadDatabaseResourcesAsync(int serverId)
@@ -148,7 +238,8 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetDatabaseResourceUsageAsync(serverId);
+            var hoursBack = GetResourceUsageHoursBack();
+            var data = await _dataService.GetDatabaseResourceUsageAsync(serverId, hoursBack);
             DatabaseResourcesDataGrid.ItemsSource = data;
             NoDatabaseResourcesMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             DbResourcesCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -86,7 +86,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 18;
+    internal const int CurrentSchemaVersion = 19;
 
     private readonly string _archivePath;
 
@@ -539,6 +539,20 @@ public class DuckDbInitializer
             /* v18: Added session_stats table for per-application connection tracking
                     from sys.dm_exec_sessions. New table only — created by GetAllTableStatements(). */
             _logger?.LogInformation("Running migration to v18: adding session_stats table for application connections");
+        }
+
+        if (fromVersion < 19)
+        {
+            _logger?.LogInformation("Running migration to v19: adding worker thread columns to memory_stats");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE memory_stats ADD COLUMN IF NOT EXISTS max_workers_count INTEGER");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE memory_stats ADD COLUMN IF NOT EXISTS current_workers_count INTEGER");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v19 encountered an error (non-fatal): {Error}", ex.Message);
+            }
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -175,7 +175,9 @@ CREATE TABLE IF NOT EXISTS memory_stats (
     target_server_memory_mb DECIMAL(18,2),
     total_server_memory_mb DECIMAL(18,2),
     buffer_pool_mb DECIMAL(18,2),
-    plan_cache_mb DECIMAL(18,2)
+    plan_cache_mb DECIMAL(18,2),
+    max_workers_count INTEGER,
+    current_workers_count INTEGER
 )";
 
     public const string CreateMemoryClerksTable = @"

--- a/Lite/Services/DeltaCalculator.cs
+++ b/Lite/Services/DeltaCalculator.cs
@@ -126,13 +126,37 @@ WHERE (server_id, collection_time) IN (
         if (count > 0) _logger?.LogDebug("Seeded {Count} wait_stats baseline rows", count);
     }
 
-    private Task SeedFileIoStatsAsync(DuckDBConnection connection)
+    private async Task SeedFileIoStatsAsync(DuckDBConnection connection)
     {
-        /* File I/O collector uses "{database_id}_{file_id}" as delta key,
-           but we don't store those IDs in DuckDB. Seeding for file I/O
-           is skipped — the first collection after restart will have delta=0,
-           and the second collection will produce accurate deltas. */
-        return Task.CompletedTask;
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+SELECT server_id, database_name, file_name,
+       num_of_reads, num_of_writes, read_bytes, write_bytes,
+       io_stall_read_ms, io_stall_write_ms,
+       io_stall_queued_read_ms, io_stall_queued_write_ms
+FROM file_io_stats
+WHERE (server_id, collection_time) IN (
+    SELECT server_id, MAX(collection_time) FROM file_io_stats GROUP BY server_id
+)";
+        using var reader = await cmd.ExecuteReaderAsync();
+        var count = 0;
+        while (await reader.ReadAsync())
+        {
+            var serverId = reader.GetInt32(0);
+            var dbName = reader.IsDBNull(1) ? "" : reader.GetString(1);
+            var fileName = reader.IsDBNull(2) ? "" : reader.GetString(2);
+            var deltaKey = $"{dbName}|{fileName}";
+            Seed(serverId, "file_io_reads", deltaKey, reader.IsDBNull(3) ? 0 : reader.GetInt64(3));
+            Seed(serverId, "file_io_writes", deltaKey, reader.IsDBNull(4) ? 0 : reader.GetInt64(4));
+            Seed(serverId, "file_io_read_bytes", deltaKey, reader.IsDBNull(5) ? 0 : reader.GetInt64(5));
+            Seed(serverId, "file_io_write_bytes", deltaKey, reader.IsDBNull(6) ? 0 : reader.GetInt64(6));
+            Seed(serverId, "file_io_stall_read", deltaKey, reader.IsDBNull(7) ? 0 : reader.GetInt64(7));
+            Seed(serverId, "file_io_stall_write", deltaKey, reader.IsDBNull(8) ? 0 : reader.GetInt64(8));
+            Seed(serverId, "file_io_stall_queued_read", deltaKey, reader.IsDBNull(9) ? 0 : reader.GetInt64(9));
+            Seed(serverId, "file_io_stall_queued_write", deltaKey, reader.IsDBNull(10) ? 0 : reader.GetInt64(10));
+            count++;
+        }
+        if (count > 0) _logger?.LogDebug("Seeded {Count} file_io_stats baseline rows", count);
     }
 
     private async Task SeedPerfmonStatsAsync(DuckDBConnection connection)

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -38,7 +38,7 @@ SELECT
     alert_sent,
     notification_type,
     send_error
-FROM config_alert_log
+FROM v_config_alert_log
 WHERE alert_time >= $1
 AND   server_id = $2
 AND   dismissed = FALSE
@@ -61,7 +61,7 @@ SELECT
     alert_sent,
     notification_type,
     send_error
-FROM config_alert_log
+FROM v_config_alert_log
 WHERE alert_time >= $1
 AND   dismissed = FALSE
 ORDER BY alert_time DESC

--- a/Lite/Services/LocalDataService.Config.cs
+++ b/Lite/Services/LocalDataService.Config.cs
@@ -24,9 +24,9 @@ public partial class LocalDataService
         using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT configuration_name, value_configured, value_in_use, is_dynamic, is_advanced
-FROM server_config
+FROM v_server_config
 WHERE server_id = $1
-AND   capture_time = (SELECT MAX(capture_time) FROM server_config WHERE server_id = $1)
+AND   capture_time = (SELECT MAX(capture_time) FROM v_server_config WHERE server_id = $1)
 ORDER BY configuration_name";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -64,9 +64,9 @@ SELECT database_name, state_desc, compatibility_level, collation_name, recovery_
        is_broker_enabled, is_cdc_enabled, is_mixed_page_allocation_on,
        log_reuse_wait_desc, page_verify_option, target_recovery_time_seconds, delayed_durability,
        is_accelerated_database_recovery_on, is_memory_optimized_enabled, is_optimized_locking_on
-FROM database_config
+FROM v_database_config
 WHERE server_id = $1
-AND   capture_time = (SELECT MAX(capture_time) FROM database_config WHERE server_id = $1)
+AND   capture_time = (SELECT MAX(capture_time) FROM v_database_config WHERE server_id = $1)
 ORDER BY database_name";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -121,9 +121,9 @@ ORDER BY database_name";
         using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT database_name, configuration_name, value, value_for_secondary
-FROM database_scoped_config
+FROM v_database_scoped_config
 WHERE server_id = $1
-AND   capture_time = (SELECT MAX(capture_time) FROM database_scoped_config WHERE server_id = $1)
+AND   capture_time = (SELECT MAX(capture_time) FROM v_database_scoped_config WHERE server_id = $1)
 ORDER BY database_name, configuration_name";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -153,9 +153,9 @@ ORDER BY database_name, configuration_name";
         using var command = connection.CreateCommand();
         command.CommandText = @"
 SELECT trace_flag, status, is_global, is_session
-FROM trace_flags
+FROM v_trace_flags
 WHERE server_id = $1
-AND   capture_time = (SELECT MAX(capture_time) FROM trace_flags WHERE server_id = $1)
+AND   capture_time = (SELECT MAX(capture_time) FROM v_trace_flags WHERE server_id = $1)
 ORDER BY trace_flag";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -34,10 +34,10 @@ SELECT
     volume_total_mb,
     volume_free_mb,
     recovery_model_desc
-FROM database_size_stats
+FROM v_database_size_stats
 WHERE (server_id, collection_time) IN (
     SELECT server_id, MAX(collection_time)
-    FROM database_size_stats
+    FROM v_database_size_stats
     GROUP BY server_id
 )
 ORDER BY server_name, database_name, file_type_desc, file_name";
@@ -85,10 +85,10 @@ SELECT
     cores_per_socket,
     is_hadr_enabled,
     is_clustered
-FROM server_properties
+FROM v_server_properties
 WHERE (server_id, collection_time) IN (
     SELECT server_id, MAX(collection_time)
-    FROM server_properties
+    FROM v_server_properties
     GROUP BY server_id
 )
 ORDER BY server_name";
@@ -132,7 +132,7 @@ SELECT
     collection_time,
     database_name,
     SUM(total_size_mb) AS total_size_mb
-FROM database_size_stats
+FROM v_database_size_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 GROUP BY collection_time, database_name
@@ -172,7 +172,7 @@ WITH cpu_stats AS (
         MAX(sqlserver_cpu_utilization) AS max_cpu_pct,
         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu_pct,
         COUNT(*) AS cpu_samples
-    FROM cpu_utilization_stats
+    FROM v_cpu_utilization_stats
     WHERE server_id = $1
     AND   collection_time >= $2
 ),
@@ -182,8 +182,10 @@ mem_latest AS (
         target_server_memory_mb,
         total_physical_memory_mb,
         buffer_pool_mb,
+        max_workers_count,
+        current_workers_count,
         CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
-    FROM memory_stats
+    FROM v_memory_stats
     WHERE server_id = $1
     ORDER BY collection_time DESC
     LIMIT 1
@@ -197,7 +199,9 @@ SELECT
     m.target_server_memory_mb,
     m.total_physical_memory_mb,
     m.buffer_pool_mb,
-    m.memory_ratio
+    m.memory_ratio,
+    m.max_workers_count,
+    m.current_workers_count
 FROM cpu_stats c
 CROSS JOIN mem_latest m";
 
@@ -229,19 +233,21 @@ CROSS JOIN mem_latest m";
             PhysicalMemoryMb = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
             BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
             MemoryRatio = memRatio,
-            ProvisioningStatus = status
+            ProvisioningStatus = status,
+            MaxWorkersCount = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
+            CurrentWorkersCount = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10))
         };
     }
 
     /// <summary>
-    /// Computes per-database resource usage from query_stats + file_io_stats deltas (last 24 hours).
+    /// Computes per-database resource usage from query_stats + file_io_stats deltas.
     /// </summary>
-    public async Task<List<DatabaseResourceUsageRow>> GetDatabaseResourceUsageAsync(int serverId)
+    public async Task<List<DatabaseResourceUsageRow>> GetDatabaseResourceUsageAsync(int serverId, int hoursBack = 24)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 
-        var cutoff = DateTime.UtcNow.AddHours(-24);
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
         command.CommandText = @"
 WITH workload AS (
@@ -252,7 +258,7 @@ WITH workload AS (
         SUM(delta_physical_reads) AS physical_reads,
         SUM(delta_logical_writes) AS logical_writes,
         SUM(delta_execution_count) AS execution_count
-    FROM query_stats
+    FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   delta_worker_time IS NOT NULL
@@ -264,7 +270,7 @@ io AS (
         SUM(delta_read_bytes) / 1048576.0 AS io_read_mb,
         SUM(delta_write_bytes) / 1048576.0 AS io_write_mb,
         SUM(delta_stall_read_ms + delta_stall_write_ms) AS io_stall_ms
-    FROM file_io_stats
+    FROM v_file_io_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   delta_read_bytes IS NOT NULL
@@ -347,10 +353,12 @@ ORDER BY c.cpu_time_ms DESC";
         command.CommandText = @"
 SELECT
     program_name,
+    CAST(AVG(connection_count) AS INTEGER) AS avg_connections,
     MAX(connection_count) AS max_connections,
+    COUNT(*) AS sample_count,
     MIN(collection_time) AS first_seen,
     MAX(collection_time) AS last_seen
-FROM session_stats
+FROM v_session_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 GROUP BY program_name
@@ -366,14 +374,230 @@ ORDER BY max_connections DESC";
             items.Add(new ApplicationConnectionRow
             {
                 ApplicationName = reader.GetString(0),
-                SampleCount = ToInt64(reader.GetValue(1)),
-                FirstSeen = reader.GetDateTime(2),
-                LastSeen = reader.GetDateTime(3)
+                AvgConnections = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1)),
+                MaxConnections = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                SampleCount = reader.IsDBNull(3) ? 0 : ToInt64(reader.GetValue(3)),
+                FirstSeen = reader.GetDateTime(4),
+                LastSeen = reader.GetDateTime(5)
             });
         }
 
         return items;
     }
+
+    /// <summary>
+    /// Gets top N databases by total CPU for the utilization summary.
+    /// </summary>
+    public async Task<List<TopResourceConsumerRow>> GetTopResourceConsumersByTotalAsync(int serverId, int hoursBack = 24, int topN = 5)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        command.CommandText = @"
+WITH workload AS (
+    SELECT
+        database_name,
+        SUM(delta_worker_time) / 1000 AS cpu_time_ms,
+        SUM(delta_execution_count) AS execution_count
+    FROM v_query_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_worker_time IS NOT NULL
+    GROUP BY database_name
+),
+io AS (
+    SELECT
+        database_name,
+        SUM(delta_read_bytes + delta_write_bytes) / 1048576.0 AS io_total_mb
+    FROM v_file_io_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_read_bytes IS NOT NULL
+    GROUP BY database_name
+),
+combined AS (
+    SELECT
+        COALESCE(w.database_name, i.database_name) AS database_name,
+        COALESCE(w.cpu_time_ms, 0) AS cpu_time_ms,
+        COALESCE(w.execution_count, 0) AS execution_count,
+        COALESCE(i.io_total_mb, 0) AS io_total_mb
+    FROM workload w
+    FULL JOIN io i ON i.database_name = w.database_name
+),
+totals AS (
+    SELECT
+        NULLIF(SUM(cpu_time_ms), 0) AS total_cpu,
+        NULLIF(SUM(io_total_mb), 0) AS total_io
+    FROM combined
+)
+SELECT
+    c.database_name,
+    c.cpu_time_ms,
+    c.execution_count,
+    CAST(c.io_total_mb AS DECIMAL(19,2)),
+    CAST(c.cpu_time_ms * 100.0 / t.total_cpu AS DECIMAL(5,2)),
+    CAST(c.io_total_mb * 100.0 / t.total_io AS DECIMAL(5,2))
+FROM combined c
+CROSS JOIN totals t
+WHERE c.database_name IS NOT NULL
+ORDER BY c.cpu_time_ms DESC
+LIMIT $3";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+        command.Parameters.Add(new DuckDBParameter { Value = topN });
+
+        var items = new List<TopResourceConsumerRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new TopResourceConsumerRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                CpuTimeMs = reader.IsDBNull(1) ? 0 : ToInt64(reader.GetValue(1)),
+                ExecutionCount = reader.IsDBNull(2) ? 0 : ToInt64(reader.GetValue(2)),
+                IoTotalMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                PctCpu = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                PctIo = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5))
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Gets top N databases by average CPU per execution for the utilization summary.
+    /// </summary>
+    public async Task<List<TopResourceConsumerRow>> GetTopResourceConsumersByAvgAsync(int serverId, int hoursBack = 24, int topN = 5)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        command.CommandText = @"
+WITH workload AS (
+    SELECT
+        database_name,
+        SUM(delta_worker_time) / 1000 AS cpu_time_ms,
+        SUM(delta_execution_count) AS execution_count
+    FROM v_query_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_worker_time IS NOT NULL
+    GROUP BY database_name
+    HAVING SUM(delta_execution_count) > 0
+),
+io AS (
+    SELECT
+        database_name,
+        SUM(delta_read_bytes + delta_write_bytes) / 1048576.0 AS io_total_mb
+    FROM v_file_io_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   delta_read_bytes IS NOT NULL
+    GROUP BY database_name
+)
+SELECT
+    w.database_name,
+    CAST(w.cpu_time_ms * 1.0 / w.execution_count AS DECIMAL(19,2)) AS avg_cpu_ms,
+    w.execution_count,
+    CAST(COALESCE(i.io_total_mb, 0) AS DECIMAL(19,2)),
+    w.cpu_time_ms,
+    CAST(COALESCE(i.io_total_mb, 0) * 1.0 / w.execution_count AS DECIMAL(19,4)) AS avg_io_mb
+FROM workload w
+LEFT JOIN io i ON i.database_name = w.database_name
+ORDER BY avg_cpu_ms DESC
+LIMIT $3";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+        command.Parameters.Add(new DuckDBParameter { Value = topN });
+
+        var items = new List<TopResourceConsumerRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new TopResourceConsumerRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                CpuTimeMs = reader.IsDBNull(1) ? 0 : ToInt64(reader.GetValue(1)),
+                ExecutionCount = reader.IsDBNull(2) ? 0 : ToInt64(reader.GetValue(2)),
+                IoTotalMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                TotalCpuTimeMs = reader.IsDBNull(4) ? 0 : ToInt64(reader.GetValue(4)),
+                AvgIoMb = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5))
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Gets per-database total allocated and used space for the utilization size chart.
+    /// Aggregates across all files per database for the selected server.
+    /// </summary>
+    public async Task<List<DatabaseSizeSummaryRow>> GetDatabaseSizeSummaryAsync(int serverId, int topN = 10)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT
+    database_name,
+    SUM(total_size_mb) AS total_mb,
+    SUM(used_size_mb) AS used_mb
+FROM v_database_size_stats
+WHERE server_id = $1
+AND   collection_time = (
+    SELECT MAX(collection_time) FROM v_database_size_stats WHERE server_id = $1
+)
+GROUP BY database_name
+ORDER BY total_mb DESC
+LIMIT $2";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = topN });
+
+        var items = new List<DatabaseSizeSummaryRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new DatabaseSizeSummaryRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                TotalMb = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                UsedMb = reader.IsDBNull(2) ? null : Convert.ToDecimal(reader.GetValue(2))
+            });
+        }
+        return items;
+    }
+}
+
+public class TopResourceConsumerRow
+{
+    public string DatabaseName { get; set; } = "";
+    public long CpuTimeMs { get; set; }
+    public long ExecutionCount { get; set; }
+    public decimal IoTotalMb { get; set; }
+    public decimal PctCpu { get; set; }
+    public decimal PctIo { get; set; }
+    public long TotalCpuTimeMs { get; set; }
+    public decimal AvgIoMb { get; set; }
+}
+
+public class DatabaseSizeSummaryRow
+{
+    public string DatabaseName { get; set; } = "";
+    public decimal TotalMb { get; set; }
+    public decimal? UsedMb { get; set; }
+    public decimal FreeMb => UsedMb.HasValue ? TotalMb - UsedMb.Value : TotalMb;
+    public decimal UsedPct => TotalMb > 0 && UsedMb.HasValue ? Math.Round(UsedMb.Value * 100m / TotalMb, 1) : 0;
+
+    /* Star-width GridLength for XAML binding — drives the stacked bar proportions */
+    public System.Windows.GridLength UsedStarWidth =>
+        new(Math.Max((double)(UsedMb ?? 0m), 0.1), System.Windows.GridUnitType.Star);
+    public System.Windows.GridLength FreeStarWidth =>
+        new(Math.Max((double)FreeMb, 0.1), System.Windows.GridUnitType.Star);
 }
 
 public class UtilizationEfficiencyRow
@@ -387,6 +611,8 @@ public class UtilizationEfficiencyRow
     public int PhysicalMemoryMb { get; set; }
     public int BufferPoolMb { get; set; }
     public decimal MemoryRatio { get; set; }
+    public int MaxWorkersCount { get; set; }
+    public int CurrentWorkersCount { get; set; }
     public string ProvisioningStatus { get; set; } = "";
 }
 
@@ -408,6 +634,8 @@ public class DatabaseResourceUsageRow
 public class ApplicationConnectionRow
 {
     public string ApplicationName { get; set; } = "";
+    public int AvgConnections { get; set; }
+    public int MaxConnections { get; set; }
     public long SampleCount { get; set; }
     public DateTime FirstSeen { get; set; }
     public DateTime LastSeen { get; set; }

--- a/Lite/Services/LocalDataService.MemoryGrants.cs
+++ b/Lite/Services/LocalDataService.MemoryGrants.cs
@@ -32,7 +32,7 @@ SELECT
     0 AS target_server_memory_mb,
     0 AS buffer_pool_mb,
     SUM(granted_memory_mb) AS total_granted_mb
-FROM memory_grant_stats
+FROM v_memory_grant_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -78,7 +78,7 @@ SELECT
     SUM(waiter_count) AS waiter_count,
     SUM(timeout_error_count_delta) AS timeout_error_count_delta,
     SUM(forced_grant_count_delta) AS forced_grant_count_delta
-FROM memory_grant_stats
+FROM v_memory_grant_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3

--- a/Lite/Services/LocalDataService.RunningJobs.cs
+++ b/Lite/Services/LocalDataService.RunningJobs.cs
@@ -36,11 +36,11 @@ SELECT
     successful_run_count,
     is_running_long,
     percent_of_average
-FROM running_jobs
+FROM v_running_jobs
 WHERE server_id = $1
 AND   collection_time = (
     SELECT MAX(collection_time)
-    FROM running_jobs
+    FROM v_running_jobs
     WHERE server_id = $1
 )
 ORDER BY current_duration_seconds DESC";
@@ -90,9 +90,9 @@ SELECT
     p95_duration_seconds,
     percent_of_average,
     start_time
-FROM running_jobs
+FROM v_running_jobs
 WHERE server_id = $1
-AND collection_time = (SELECT MAX(collection_time) FROM running_jobs WHERE server_id = $1)
+AND collection_time = (SELECT MAX(collection_time) FROM v_running_jobs WHERE server_id = $1)
 AND avg_duration_seconds >= 60
 AND percent_of_average >= $2
 ORDER BY percent_of_average DESC

--- a/Lite/Services/LocalDataService.WaitingTasks.cs
+++ b/Lite/Services/LocalDataService.WaitingTasks.cs
@@ -31,7 +31,7 @@ SELECT
     blocking_session_id,
     resource_description,
     database_name
-FROM waiting_tasks
+FROM v_waiting_tasks
 WHERE server_id = $1
 AND   collection_time >= $2
 ORDER BY collection_time DESC, wait_duration_ms DESC";
@@ -73,7 +73,7 @@ SELECT
     collection_time,
     wait_type,
     SUM(wait_duration_ms) AS total_wait_ms
-FROM waiting_tasks
+FROM v_waiting_tasks
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
@@ -118,7 +118,7 @@ SELECT
     collection_time,
     database_name,
     COUNT(*) AS blocked_count
-FROM waiting_tasks
+FROM v_waiting_tasks
 WHERE server_id = $1
 AND   blocking_session_id > 0
 AND   collection_time >= $2

--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -32,6 +32,35 @@ public partial class RemoteCollectorService
 
         const string onPremQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SET NOCOUNT ON;
+
+CREATE TABLE #file_space
+(
+    database_id int NOT NULL,
+    file_id int NOT NULL,
+    used_size_mb decimal(19,2) NULL
+);
+
+DECLARE
+    @sql nvarchar(MAX) = N'';
+
+SELECT
+    @sql += N'
+USE ' + QUOTENAME(d.name) + N';
+INSERT #file_space (database_id, file_id, used_size_mb)
+SELECT
+    DB_ID(),
+    df.file_id,
+    CONVERT(decimal(19,2), FILEPROPERTY(df.name, N''SpaceUsed'') * 8.0 / 1024.0)
+FROM sys.database_files AS df;
+'
+FROM sys.databases AS d
+WHERE d.state_desc = N'ONLINE'
+AND   d.database_id > 0
+ORDER BY
+    d.name;
+
+EXEC sys.sp_executesql @sql;
 
 SELECT
     database_name = d.name,
@@ -43,7 +72,7 @@ SELECT
     total_size_mb =
         CONVERT(decimal(19,2), mf.size * 8.0 / 1024.0),
     used_size_mb =
-        CONVERT(decimal(19,2), NULL),
+        fs.used_size_mb,
     auto_growth_mb =
         CASE
             WHEN mf.is_percent_growth = 1
@@ -74,6 +103,9 @@ FROM sys.master_files AS mf
 JOIN sys.databases AS d
   ON d.database_id = mf.database_id
 CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) AS vs
+LEFT JOIN #file_space AS fs
+  ON  fs.database_id = mf.database_id
+  AND fs.file_id = mf.file_id
 WHERE d.state_desc = N'ONLINE'
 ORDER BY
     d.name,

--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -138,7 +138,7 @@ OPTION(RECOMPILE);";
             {
                 foreach (var stat in fileStats)
                 {
-                    var deltaKey = $"{stat.DatabaseId}_{stat.FileId}";
+                    var deltaKey = $"{stat.DatabaseName}|{stat.FileName}";
                     var deltaReads = _deltaCalculator.CalculateDelta(serverId, "file_io_reads", deltaKey, stat.NumOfReads);
                     var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "file_io_writes", deltaKey, stat.NumOfWrites);
                     var deltaReadBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_read_bytes", deltaKey, stat.ReadBytes);

--- a/Lite/Services/RemoteCollectorService.Memory.cs
+++ b/Lite/Services/RemoteCollectorService.Memory.cs
@@ -44,7 +44,9 @@ SELECT
     target_server_memory_mb = CONVERT(decimal(18,2), pc_target.cntr_value / 1024.0),
     total_server_memory_mb = CONVERT(decimal(18,2), pc_total.cntr_value / 1024.0),
     buffer_pool_mb = CONVERT(decimal(18,2), pc_buffer.cntr_value / 1024.0),
-    plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0)
+    plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0),
+    max_workers_count = osi.max_workers_count,
+    current_workers_count = w.current_workers
 FROM sys.dm_os_sys_info AS osi
 CROSS JOIN
 (
@@ -71,6 +73,12 @@ CROSS JOIN
     WHERE counter_name = N'Cache Pages'
       AND object_name LIKE N'%:Plan Cache%'
 ) AS pc_plan
+CROSS JOIN
+(
+    SELECT current_workers = SUM(active_workers_count)
+    FROM sys.dm_os_schedulers
+    WHERE status = N'VISIBLE ONLINE'
+) AS w
 OPTION(RECOMPILE);"
             : @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -85,7 +93,9 @@ SELECT
     target_server_memory_mb = CONVERT(decimal(18,2), pc_target.cntr_value / 1024.0),
     total_server_memory_mb = CONVERT(decimal(18,2), pc_total.cntr_value / 1024.0),
     buffer_pool_mb = CONVERT(decimal(18,2), pc_buffer.cntr_value / 1024.0),
-    plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0)
+    plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0),
+    max_workers_count = osi.max_workers_count,
+    current_workers_count = w.current_workers
 FROM sys.dm_os_sys_memory AS osm
 CROSS JOIN sys.dm_os_sys_info AS osi
 CROSS JOIN
@@ -113,6 +123,12 @@ CROSS JOIN
     WHERE counter_name = N'Cache Pages'
       AND object_name LIKE N'%:Plan Cache%'
 ) AS pc_plan
+CROSS JOIN
+(
+    SELECT current_workers = SUM(active_workers_count)
+    FROM sys.dm_os_schedulers
+    WHERE status = N'VISIBLE ONLINE'
+) AS w
 OPTION(RECOMPILE);";
 
         var serverId = GetServerId(server);
@@ -142,6 +158,8 @@ OPTION(RECOMPILE);";
         var totalServerMemoryMb = reader.IsDBNull(7) ? 0m : reader.GetDecimal(7);
         var bufferPoolMb = reader.IsDBNull(8) ? 0m : reader.GetDecimal(8);
         var planCacheMb = reader.IsDBNull(9) ? 0m : reader.GetDecimal(9);
+        var maxWorkersCount = reader.IsDBNull(10) ? 0 : reader.GetInt32(10);
+        var currentWorkersCount = reader.IsDBNull(11) ? 0 : reader.GetInt32(11);
         sqlSw.Stop();
 
         /* Insert into DuckDB using Appender */
@@ -168,6 +186,8 @@ OPTION(RECOMPILE);";
                    .AppendValue(totalServerMemoryMb)
                    .AppendValue(bufferPoolMb)
                    .AppendValue(planCacheMb)
+                   .AppendValue(maxWorkersCount)
+                   .AppendValue(currentWorkersCount)
                    .EndRow();
             }
         }


### PR DESCRIPTION
## Summary
- **Dashboard**: Redesign Utilization sub-tab with bar-based layout matching Lite (CPU bars, memory bars, classification explanation, Top Total/Avg CPU grids, Database Sizes chart)
- **Both apps**: Replace confusing "Committed %" with "Stolen Mem %" and "Buffer Pool %", using identical formulas and data sources (perfmon counter `Total Server Memory (KB)`)
- **Lite**: Add worker thread collection/display under CPU detail, fix Application Connections to show AVG + MAX + sample count

## Test plan
- [x] Both apps build clean (0 warnings, 0 errors on Lite; 2 pre-existing PlanAnalyzer warnings on Dashboard)
- [x] Dashboard FinOps Utilization tab loads with data, bars render correctly
- [x] Lite FinOps Utilization tab shows matching Stolen Mem % and Buffer Pool %
- [x] Worker threads display in both apps under CPU detail
- [x] Lite Application Connections shows Avg, Max, and Samples columns
- [x] DuckDB schema migration v19 adds worker thread columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)