### PR TITLE
Fix PerfMon first-value spike that skews graphs

### DIFF
--- a/Lite/Services/DeltaCalculator.cs
+++ b/Lite/Services/DeltaCalculator.cs
@@ -65,7 +65,7 @@ public class DeltaCalculator
     /// Counter reset (value decreased): returns 0 to avoid inflated deltas from plan cache churn.
     /// Thread-safe via atomic AddOrUpdate.
     /// </summary>
-    public long CalculateDelta(int serverId, string collectorName, string key, long currentValue)
+    public long CalculateDelta(int serverId, string collectorName, string key, long currentValue, bool baselineOnly = false)
     {
         var serverCache = _cache.GetOrAdd(serverId, _ => new ConcurrentDictionary<string, ConcurrentDictionary<string, long>>());
         var collectorCache = serverCache.GetOrAdd(collectorName, _ => new ConcurrentDictionary<string, long>());
@@ -74,11 +74,12 @@ public class DeltaCalculator
 
         collectorCache.AddOrUpdate(
             key,
-            /* Add: first time seeing this key — use current value as delta
-               so queries that execute once still surface in top-N views */
+            /* Add: first time seeing this key.
+               baselineOnly = true: store baseline only, return 0 (for cumulative counters like perfmon).
+               baselineOnly = false: use current value as delta so single-execution queries surface. */
             _ =>
             {
-                delta = currentValue;
+                delta = baselineOnly ? 0 : currentValue;
                 return currentValue;
             },
             /* Update: compute delta atomically */

--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -139,14 +139,14 @@ OPTION(RECOMPILE);";
                 foreach (var stat in fileStats)
                 {
                     var deltaKey = $"{stat.DatabaseName}|{stat.FileName}";
-                    var deltaReads = _deltaCalculator.CalculateDelta(serverId, "file_io_reads", deltaKey, stat.NumOfReads);
-                    var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "file_io_writes", deltaKey, stat.NumOfWrites);
-                    var deltaReadBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_read_bytes", deltaKey, stat.ReadBytes);
-                    var deltaWriteBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_write_bytes", deltaKey, stat.WriteBytes);
-                    var deltaStallReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_read", deltaKey, stat.IoStallReadMs);
-                    var deltaStallWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_write", deltaKey, stat.IoStallWriteMs);
-                    var deltaStallQueuedReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_queued_read", deltaKey, stat.IoStallQueuedReadMs);
-                    var deltaStallQueuedWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_queued_write", deltaKey, stat.IoStallQueuedWriteMs);
+                    var deltaReads = _deltaCalculator.CalculateDelta(serverId, "file_io_reads", deltaKey, stat.NumOfReads, baselineOnly: true);
+                    var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "file_io_writes", deltaKey, stat.NumOfWrites, baselineOnly: true);
+                    var deltaReadBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_read_bytes", deltaKey, stat.ReadBytes, baselineOnly: true);
+                    var deltaWriteBytes = _deltaCalculator.CalculateDelta(serverId, "file_io_write_bytes", deltaKey, stat.WriteBytes, baselineOnly: true);
+                    var deltaStallReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_read", deltaKey, stat.IoStallReadMs, baselineOnly: true);
+                    var deltaStallWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_write", deltaKey, stat.IoStallWriteMs, baselineOnly: true);
+                    var deltaStallQueuedReadMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_queued_read", deltaKey, stat.IoStallQueuedReadMs, baselineOnly: true);
+                    var deltaStallQueuedWriteMs = _deltaCalculator.CalculateDelta(serverId, "file_io_stall_queued_write", deltaKey, stat.IoStallQueuedWriteMs, baselineOnly: true);
 
                     var row = appender.CreateRow();
                     row.AppendValue(GenerateCollectionId())

--- a/Lite/Services/RemoteCollectorService.MemoryGrants.cs
+++ b/Lite/Services/RemoteCollectorService.MemoryGrants.cs
@@ -92,8 +92,8 @@ OPTION(RECOMPILE);";
                 foreach (var r in rows)
                 {
                     var deltaKey = $"{r.PoolId}_{r.ResourceSemaphoreId}";
-                    var deltaTimeouts = _deltaCalculator.CalculateDelta(serverId, "memory_grants_timeouts", deltaKey, r.TimeoutErrorCount);
-                    var deltaForced = _deltaCalculator.CalculateDelta(serverId, "memory_grants_forced", deltaKey, r.ForcedGrantCount);
+                    var deltaTimeouts = _deltaCalculator.CalculateDelta(serverId, "memory_grants_timeouts", deltaKey, r.TimeoutErrorCount, baselineOnly: true);
+                    var deltaForced = _deltaCalculator.CalculateDelta(serverId, "memory_grants_forced", deltaKey, r.ForcedGrantCount, baselineOnly: true);
 
                     var row = appender.CreateRow();
                     row.AppendValue(GenerateCollectionId())

--- a/Lite/Services/RemoteCollectorService.Perfmon.cs
+++ b/Lite/Services/RemoteCollectorService.Perfmon.cs
@@ -180,7 +180,7 @@ OPTION(RECOMPILE);";
 
                     /* Delta for per-second counters */
                     var deltaKey = $"{objectName}|{counterName}|{instanceName}";
-                    var deltaCntrValue = _deltaCalculator.CalculateDelta(serverId, "perfmon", deltaKey, cntrValue);
+                    var deltaCntrValue = _deltaCalculator.CalculateDelta(serverId, "perfmon", deltaKey, cntrValue, baselineOnly: true);
 
                     var row = appender.CreateRow();
                     row.AppendValue(GenerateCollectionId())

--- a/Lite/Services/RemoteCollectorService.WaitStats.cs
+++ b/Lite/Services/RemoteCollectorService.WaitStats.cs
@@ -127,9 +127,9 @@ OPTION(RECOMPILE);";
                 foreach (var stat in waitStats)
                 {
                     var deltaKey = stat.WaitType;
-                    var deltaWaitingTasks = _deltaCalculator.CalculateDelta(serverId, "wait_stats_tasks", deltaKey, stat.WaitingTasks);
-                    var deltaWaitTimeMs = _deltaCalculator.CalculateDelta(serverId, "wait_stats_time", deltaKey, stat.WaitTimeMs);
-                    var deltaSignalWaitTimeMs = _deltaCalculator.CalculateDelta(serverId, "wait_stats_signal", deltaKey, stat.SignalWaitTimeMs);
+                    var deltaWaitingTasks = _deltaCalculator.CalculateDelta(serverId, "wait_stats_tasks", deltaKey, stat.WaitingTasks, baselineOnly: true);
+                    var deltaWaitTimeMs = _deltaCalculator.CalculateDelta(serverId, "wait_stats_time", deltaKey, stat.WaitTimeMs, baselineOnly: true);
+                    var deltaSignalWaitTimeMs = _deltaCalculator.CalculateDelta(serverId, "wait_stats_signal", deltaKey, stat.SignalWaitTimeMs, baselineOnly: true);
 
                     var row = appender.CreateRow();
                     row.AppendValue(GenerateCollectionId())    /* collection_id BIGINT */


### PR DESCRIPTION
## Summary
- Fixes #482
- Added `baselineOnly` parameter to `DeltaCalculator.CalculateDelta()` — when `true`, the first read stores the baseline and returns `0` instead of the raw cumulative value
- Applied to all cumulative-counter collectors: PerfMon, WaitStats, FileIO, MemoryGrants
- Query/proc stats unchanged (single-execution queries still surface in top-N views)
- X-axis anchoring issue was a visual side effect of the spike dominating the Y scale

## Test plan
- [ ] Start Lite, open Server > PerfMon tab
- [ ] Verify first data point does not create a spike for any counter group
- [ ] Verify chart scales normally after 2+ collections
- [ ] Verify WaitStats, FileIO, MemoryGrants tabs also have no first-value spike
- [ ] Verify Top Queries / Top Procs still show single-execution entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)