### PR TITLE
Add Entra ID interactive MFA authentication to installers

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -152,6 +152,7 @@ END;";
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> [options]                 Windows Auth");
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username> <password>     SQL Auth");
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username>                SQL Auth (password via env var)");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> --entra <email>           Entra ID (MFA)");
                 Console.WriteLine();
                 Console.WriteLine("Options:");
                 Console.WriteLine("  -h, --help           Show this help message");
@@ -160,6 +161,7 @@ END;";
                 Console.WriteLine("  --reset-schedule     Reset collection schedule to recommended defaults");
                 Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                 Console.WriteLine("  --trust-cert         Trust server certificate without validation");
+                Console.WriteLine("  --entra <email>      Use Microsoft Entra ID interactive authentication (MFA)");
                 Console.WriteLine();
                 Console.WriteLine("Environment Variables:");
                 Console.WriteLine("  PM_SQL_PASSWORD      SQL Auth password (avoids passing on command line)");
@@ -181,6 +183,18 @@ END;";
             bool uninstallMode = args.Any(a => a.Equals("--uninstall", StringComparison.OrdinalIgnoreCase));
             bool resetSchedule = args.Any(a => a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase));
             bool trustCert = args.Any(a => a.Equals("--trust-cert", StringComparison.OrdinalIgnoreCase));
+            bool entraMode = args.Any(a => a.Equals("--entra", StringComparison.OrdinalIgnoreCase));
+
+            /*Parse --entra email (the argument following --entra)*/
+            string? entraEmail = null;
+            if (entraMode)
+            {
+                int entraIndex = Array.FindIndex(args, a => a.Equals("--entra", StringComparison.OrdinalIgnoreCase));
+                if (entraIndex >= 0 && entraIndex + 1 < args.Length && !args[entraIndex + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    entraEmail = args[entraIndex + 1];
+                }
+            }
 
             /*Parse encryption option (default: Mandatory)*/
             var encryptArg = args.FirstOrDefault(a => a.StartsWith("--encrypt=", StringComparison.OrdinalIgnoreCase));
@@ -197,17 +211,28 @@ END;";
             }
 
             /*Filter out option flags to get positional arguments*/
-            var filteredArgs = args
+            /*Filter out option flags and --entra <email> to get positional arguments*/
+            var filteredArgsList = args
                 .Where(a => !a.Equals("--reinstall", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.Equals("--uninstall", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.Equals("--trust-cert", StringComparison.OrdinalIgnoreCase))
                 .Where(a => !a.StartsWith("--encrypt=", StringComparison.OrdinalIgnoreCase))
-                .ToArray();
+                .Where(a => !a.Equals("--entra", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            /*Remove the entra email from positional args if present*/
+            if (entraEmail != null)
+            {
+                filteredArgsList.Remove(entraEmail);
+            }
+
+            var filteredArgs = filteredArgsList.ToArray();
             string? serverName;
             string? username = null;
             string? password = null;
             bool useWindowsAuth;
+            bool useEntraAuth = false;
 
             if (automatedMode)
             {
@@ -216,7 +241,25 @@ END;";
                 */
                 serverName = filteredArgs.Length > 0 ? filteredArgs[0] : null;
 
-                if (filteredArgs.Length >= 2)
+                if (entraMode)
+                {
+                    /*Microsoft Entra ID interactive authentication*/
+                    useWindowsAuth = false;
+                    useEntraAuth = true;
+                    username = entraEmail;
+
+                    if (string.IsNullOrWhiteSpace(username))
+                    {
+                        Console.WriteLine("Error: Email address is required for Entra ID authentication.");
+                        Console.WriteLine("Usage: PerformanceMonitorInstaller.exe <server> --entra <email>");
+                        return ExitCodes.InvalidArguments;
+                    }
+
+                    Console.WriteLine($"Server: {serverName}");
+                    Console.WriteLine($"Authentication: Microsoft Entra ID ({username})");
+                    Console.WriteLine("A browser window will open for interactive authentication...");
+                }
+                else if (filteredArgs.Length >= 2)
                 {
                     /*SQL Authentication - password from env var or command-line*/
                     useWindowsAuth = false;
@@ -285,13 +328,37 @@ END;";
                     return ExitCodes.InvalidArguments;
                 }
 
-                Console.Write("Use Windows Authentication? (Y/N, default Y): ");
-                string? authResponse = Console.ReadLine();
-                useWindowsAuth = string.IsNullOrWhiteSpace(authResponse) ||
-                                       authResponse.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase);
+                Console.WriteLine("Authentication type:");
+                Console.WriteLine("  [W] Windows Authentication (default)");
+                Console.WriteLine("  [S] SQL Server Authentication");
+                Console.WriteLine("  [E] Microsoft Entra ID (interactive MFA)");
+                Console.Write("Choice (W/S/E, default W): ");
+                string? authResponse = Console.ReadLine()?.Trim();
 
-                if (!useWindowsAuth)
+                if (string.IsNullOrWhiteSpace(authResponse) || authResponse.Equals("W", StringComparison.OrdinalIgnoreCase))
                 {
+                    useWindowsAuth = true;
+                }
+                else if (authResponse.Equals("E", StringComparison.OrdinalIgnoreCase))
+                {
+                    useWindowsAuth = false;
+                    useEntraAuth = true;
+
+                    Console.Write("Email address (UPN): ");
+                    username = Console.ReadLine();
+                    if (string.IsNullOrWhiteSpace(username))
+                    {
+                        Console.WriteLine("Error: Email address is required for Entra ID authentication.");
+                        WaitForExit();
+                        return ExitCodes.InvalidArguments;
+                    }
+
+                    Console.WriteLine("A browser window will open for interactive authentication...");
+                }
+                else
+                {
+                    useWindowsAuth = false;
+
                     Console.Write("SQL Server login: ");
                     username = Console.ReadLine();
                     if (string.IsNullOrWhiteSpace(username))
@@ -322,11 +389,19 @@ END;";
                 DataSource = serverName,
                 InitialCatalog = "master",
                 Encrypt = encryptOption,
-                TrustServerCertificate = trustCert,
-                IntegratedSecurity = useWindowsAuth
+                TrustServerCertificate = trustCert
             };
 
-            if (!useWindowsAuth)
+            if (useEntraAuth)
+            {
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
+                builder.UserID = username;
+            }
+            else if (useWindowsAuth)
+            {
+                builder.IntegratedSecurity = true;
+            }
+            else
             {
                 builder.UserID = username;
                 builder.Password = password;

--- a/InstallerGui/MainWindow.xaml
+++ b/InstallerGui/MainWindow.xaml
@@ -81,6 +81,12 @@
                                  Content="SQL Server Authentication"
                                  GroupName="Auth"
                                  Checked="AuthType_Changed"
+                                 Margin="0,0,20,0"
+                                 Foreground="{DynamicResource ForegroundBrush}"/>
+                    <RadioButton x:Name="EntraAuthRadio"
+                                 Content="Microsoft Entra MFA"
+                                 GroupName="Auth"
+                                 Checked="AuthType_Changed"
                                  Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
 

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -141,10 +141,12 @@ namespace PerformanceMonitorInstallerGui
                 return;
 
             bool useSqlAuth = SqlAuthRadio.IsChecked == true;
+            bool useEntraAuth = EntraAuthRadio.IsChecked == true;
 
-            UsernameTextBox.IsEnabled = useSqlAuth;
+            UsernameTextBox.IsEnabled = useSqlAuth || useEntraAuth;
             PasswordBox.IsEnabled = useSqlAuth;
-            UsernameLabel.Opacity = useSqlAuth ? 1.0 : 0.5;
+            UsernameLabel.Text = useEntraAuth ? "Email:" : "Username:";
+            UsernameLabel.Opacity = (useSqlAuth || useEntraAuth) ? 1.0 : 0.5;
             PasswordLabel.Opacity = useSqlAuth ? 1.0 : 0.5;
 
             InvalidateConnection();
@@ -190,10 +192,20 @@ namespace PerformanceMonitorInstallerGui
             }
 
             bool useWindowsAuth = WindowsAuthRadio.IsChecked == true;
-            string? username = useWindowsAuth ? null : UsernameTextBox.Text.Trim();
-            string? password = useWindowsAuth ? null : PasswordBox.Password;
+            bool useEntraAuth = EntraAuthRadio.IsChecked == true;
+            string? username = (useWindowsAuth) ? null : UsernameTextBox.Text.Trim();
+            string? password = (useWindowsAuth || useEntraAuth) ? null : PasswordBox.Password;
 
-            if (!useWindowsAuth)
+            if (useEntraAuth)
+            {
+                if (string.IsNullOrEmpty(username))
+                {
+                    MessageBox.Show(this, "Please enter an email address for Entra ID authentication.",
+                        "Validation Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+            }
+            else if (!useWindowsAuth)
             {
                 if (string.IsNullOrEmpty(username))
                 {
@@ -221,7 +233,7 @@ namespace PerformanceMonitorInstallerGui
 
                 Logger.LogToFile("TestConnection_Click", $"Encryption: {encryption}, TrustCert: {trustCertificate}");
 
-                _connectionString = InstallationService.BuildConnectionString(server, useWindowsAuth, username, password, encryption, trustCertificate);
+                _connectionString = InstallationService.BuildConnectionString(server, useWindowsAuth, username, password, encryption, trustCertificate, useEntraAuth);
 
                 Logger.LogToFile("TestConnection_Click", "Connection string built, clearing log");
 
@@ -803,7 +815,8 @@ namespace PerformanceMonitorInstallerGui
             ServerTextBox.IsEnabled = !installing;
             WindowsAuthRadio.IsEnabled = !installing;
             SqlAuthRadio.IsEnabled = !installing;
-            UsernameTextBox.IsEnabled = !installing && SqlAuthRadio.IsChecked == true;
+            EntraAuthRadio.IsEnabled = !installing;
+            UsernameTextBox.IsEnabled = !installing && (SqlAuthRadio.IsChecked == true || EntraAuthRadio.IsChecked == true);
             PasswordBox.IsEnabled = !installing && SqlAuthRadio.IsChecked == true;
             TestConnectionButton.IsEnabled = !installing;
             CleanInstallCheckBox.IsEnabled = !installing;

--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -99,14 +99,14 @@ namespace PerformanceMonitorInstallerGui.Services
             string? username = null,
             string? password = null,
             string encryption = "Mandatory",
-            bool trustCertificate = false)
+            bool trustCertificate = false,
+            bool useEntraAuth = false)
         {
             var builder = new SqlConnectionStringBuilder
             {
                 DataSource = server,
                 InitialCatalog = "master",
-                TrustServerCertificate = trustCertificate,
-                IntegratedSecurity = useWindowsAuth
+                TrustServerCertificate = trustCertificate
             };
 
             /*Set encryption mode: Optional, Mandatory, or Strict*/
@@ -117,7 +117,16 @@ namespace PerformanceMonitorInstallerGui.Services
                 _ => SqlConnectionEncryptOption.Mandatory
             };
 
-            if (!useWindowsAuth)
+            if (useEntraAuth)
+            {
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
+                builder.UserID = username;
+            }
+            else if (useWindowsAuth)
+            {
+                builder.IntegratedSecurity = true;
+            }
+            else
             {
                 builder.UserID = username;
                 builder.Password = password;


### PR DESCRIPTION
## Summary
- Fixes #481
- Added "Microsoft Entra MFA" as a third auth option in both CLI and GUI installers
- CLI: new `--entra <email>` flag + interactive W/S/E auth menu
- GUI: new radio button, enables email field, disables password field when selected
- Uses `Authentication=Active Directory Interactive` via `Microsoft.Data.SqlClient` (already a dependency, no new packages)
- Lite/Dashboard already support Entra auth — no changes needed there

## Test plan
- [ ] CLI installer: `--entra user@domain.com` connects via browser MFA prompt
- [ ] CLI installer: interactive mode shows W/S/E menu, selecting E prompts for email
- [ ] GUI installer: Entra radio button enables email, disables password
- [ ] GUI installer: Test Connection works with Entra against Azure SQL MI
- [ ] Windows Auth and SQL Auth still work as before in both installers

🤖 Generated with [Claude Code](https://claude.com/claude-code)