### PR TITLE
Fix query_store and database_scoped_config collectors on Azure SQL DB

### DIFF
--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -29,7 +29,10 @@ public partial class RemoteCollectorService
         /* First, get databases with Query Store actually enabled.
            Uses sys.database_query_store_options.actual_state instead of
            sys.databases.is_query_store_on, which can be out of sync on Azure SQL DB. */
-        const string dbQuery = @"
+        var serverStatus = _serverManager.GetConnectionStatus(server.Id);
+        bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
+
+        const string onPremDbQuery = @"
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -98,6 +101,69 @@ FROM @result
 ORDER BY
     name;";
 
+        const string azureDbQuery = @"
+SET NOCOUNT ON;
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+DECLARE
+    @result TABLE (name sysname);
+
+DECLARE
+    @db sysname,
+    @sql NVARCHAR(500);
+
+DECLARE db_check CURSOR LOCAL FAST_FORWARD FOR
+    SELECT /* PerformanceMonitorLite */
+        d.name
+    FROM sys.databases AS d
+    WHERE d.database_id > 4
+    AND   d.database_id < 32761
+    AND   d.state_desc = N'ONLINE'
+    AND   d.name <> N'PerformanceMonitor'
+    OPTION(RECOMPILE);
+
+OPEN db_check;
+
+FETCH NEXT
+FROM db_check
+INTO @db;
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    BEGIN TRY
+        SET @sql =
+            N'USE ' + QUOTENAME(@db) + N';
+            SELECT ' + QUOTENAME(@db, '''') + N'
+            WHERE EXISTS
+            (
+                SELECT
+                    1
+                FROM sys.database_query_store_options
+                WHERE actual_state > 0
+            );';
+
+        INSERT @result (name)
+        EXEC(@sql);
+    END TRY
+    BEGIN CATCH
+    END CATCH;
+
+    FETCH NEXT
+    FROM db_check
+    INTO @db;
+END;
+
+CLOSE db_check;
+DEALLOCATE db_check;
+
+SELECT
+    name
+FROM @result
+ORDER BY
+    name;";
+
+        string dbQuery = isAzureSqlDb ? azureDbQuery : onPremDbQuery;
+
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
         var totalRows = 0;
@@ -136,7 +202,6 @@ ORDER BY
            Controls: avg_num_physical_io_reads, avg_log_bytes_used, avg_tempdb_space_used, plan_forcing_type_desc.
            @hasPlanType = true for SQL Server 2022+ (product version >= 16).
            Controls: plan_type_desc. */
-        var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         int productVersion = 13; /* default to SQL 2016 */
         try
         {

--- a/Lite/Services/RemoteCollectorService.ServerConfig.cs
+++ b/Lite/Services/RemoteCollectorService.ServerConfig.cs
@@ -326,7 +326,10 @@ OPTION(RECOMPILE);";
     /// </summary>
     private async Task<int> CollectDatabaseScopedConfigAsync(ServerConnection server, CancellationToken cancellationToken)
     {
-        const string dbQuery = @"
+        var serverStatus = _serverManager.GetConnectionStatus(server.Id);
+        bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
+
+        const string onPremDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
@@ -346,6 +349,21 @@ AND
 )
 ORDER BY d.name
 OPTION(RECOMPILE);";
+
+        const string azureDbQuery = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    d.name
+FROM sys.databases AS d
+WHERE (d.database_id > 4 OR d.database_id = 2)
+AND   d.database_id < 32761
+AND   d.name <> N'PerformanceMonitor'
+AND   d.state_desc = N'ONLINE'
+ORDER BY d.name
+OPTION(RECOMPILE);";
+
+        string dbQuery = isAzureSqlDb ? azureDbQuery : onPremDbQuery;
 
         var serverId = GetServerId(server);
         var captureTime = DateTime.UtcNow;


### PR DESCRIPTION
Fixes #494 — skip HADR DMV join on Azure SQL DB (engine edition 5) using existing isAzureSqlDb pattern.