### PR TITLE
Fix FinOps server dropdown not updating on server add

### DIFF
--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -45,6 +45,32 @@ public partial class FinOpsTab : UserControl
         RefreshData();
     }
 
+    /// <summary>
+    /// Refreshes the server dropdown from the current server list.
+    /// Called when servers are added or removed.
+    /// </summary>
+    public void RefreshServerList()
+    {
+        if (_serverManager == null) return;
+
+        var previousSelection = ServerSelector.SelectedItem as ServerConnection;
+        var servers = _serverManager.GetAllServers();
+        ServerSelector.ItemsSource = servers;
+
+        if (previousSelection != null)
+        {
+            var match = servers.FirstOrDefault(s => s.Id == previousSelection.Id);
+            if (match != null)
+            {
+                ServerSelector.SelectedItem = match;
+                return;
+            }
+        }
+
+        if (servers.Count > 0)
+            ServerSelector.SelectedIndex = 0;
+    }
+
     private void PopulateServerSelector()
     {
         if (_serverManager == null) return;

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -304,6 +304,9 @@ public partial class MainWindow : Window
 
         ServerCountText.Text = $"Servers: {servers.Count}";
 
+        // Refresh FinOps server dropdown when server list changes
+        FinOpsContent.RefreshServerList();
+
         // Refresh overview when server list changes
         _ = RefreshOverviewAsync();
     }


### PR DESCRIPTION
Fixes #496 — call FinOpsContent.RefreshServerList() from MainWindow.RefreshServerList() so the dropdown updates when servers change.