### PR TITLE
Sync PlanAnalyzer rules from Performance Studio v1.0.0

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -577,7 +577,8 @@ public static partial class PlanAnalyzer
 
         // Rule 14: Lazy Table Spool unfavorable rebind/rewind ratio
         // Rebinds = cache misses (child re-executes), rewinds = cache hits (reuse cached result)
-        if (node.LogicalOp == "Lazy Spool")
+        if (node.LogicalOp == "Lazy Spool"
+            && !node.PhysicalOp.Contains("Index", StringComparison.OrdinalIgnoreCase))
         {
             var rebinds = node.HasActualStats ? (double)node.ActualRebinds : node.EstimateRebinds;
             var rewinds = node.HasActualStats ? (double)node.ActualRewinds : node.EstimateRewinds;
@@ -1217,8 +1218,8 @@ public static partial class PlanAnalyzer
         if (node.LogicalOp.Contains("Join", StringComparison.OrdinalIgnoreCase) && !node.IsAdaptive)
         {
             return ratio >= 10.0
-                ? "The underestimate may have caused the optimizer to choose a suboptimal join strategy."
-                : "The overestimate may have caused the optimizer to choose a suboptimal join strategy.";
+                ? "The underestimate may have caused the optimizer to make poor choices."
+                : "The overestimate may have caused the optimizer to make poor choices.";
         }
 
         // Walk up to check if a parent was harmed by this bad estimate
@@ -1245,8 +1246,8 @@ public static partial class PlanAnalyzer
                     return null; // Adaptive join self-corrects — no harm
 
                 return ratio >= 10.0
-                    ? $"The underestimate may have caused the optimizer to choose {ancestor.PhysicalOp} when a different join type would be more efficient."
-                    : $"The overestimate may have caused the optimizer to choose {ancestor.PhysicalOp} when a different join type would be more efficient.";
+                    ? "The underestimate may have caused the optimizer to make poor choices."
+                    : "The overestimate may have caused the optimizer to make poor choices.";
             }
 
             // Parent Sort/Hash that spilled — downstream bad estimate caused the spill

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -1444,8 +1444,8 @@ public static class ShowPlanParser
             result.Add(new PlanWarning
             {
                 WarningType = "No Join Predicate",
-                Message = "This join has no join predicate (possible cross join)",
-                Severity = PlanWarningSeverity.Critical
+                Message = "This join triggered a no join predicate warning, which is worth checking on, but is often misleading. The optimizer may have removed a redundant predicate after simplification.",
+                Severity = PlanWarningSeverity.Warning
             });
         }
 

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -577,7 +577,7 @@ public static partial class PlanAnalyzer
 
         // Rule 14: Lazy Table Spool unfavorable rebind/rewind ratio
         // Rebinds = cache misses (child re-executes), rewinds = cache hits (reuse cached result)
-        if (node.LogicalOp == "Lazy Spool")
+        if (node.LogicalOp == "Lazy Spool" && !node.PhysicalOp.Contains("Index", StringComparison.OrdinalIgnoreCase))
         {
             var rebinds = node.HasActualStats ? (double)node.ActualRebinds : node.EstimateRebinds;
             var rewinds = node.HasActualStats ? (double)node.ActualRewinds : node.EstimateRewinds;
@@ -1217,8 +1217,8 @@ public static partial class PlanAnalyzer
         if (node.LogicalOp.Contains("Join", StringComparison.OrdinalIgnoreCase) && !node.IsAdaptive)
         {
             return ratio >= 10.0
-                ? "The underestimate may have caused the optimizer to choose a suboptimal join strategy."
-                : "The overestimate may have caused the optimizer to choose a suboptimal join strategy.";
+                ? "The underestimate may have caused the optimizer to make poor choices."
+                : "The overestimate may have caused the optimizer to make poor choices.";
         }
 
         // Walk up to check if a parent was harmed by this bad estimate
@@ -1245,8 +1245,8 @@ public static partial class PlanAnalyzer
                     return null; // Adaptive join self-corrects — no harm
 
                 return ratio >= 10.0
-                    ? $"The underestimate may have caused the optimizer to choose {ancestor.PhysicalOp} when a different join type would be more efficient."
-                    : $"The overestimate may have caused the optimizer to choose {ancestor.PhysicalOp} when a different join type would be more efficient.";
+                    ? "The underestimate may have caused the optimizer to make poor choices."
+                    : "The overestimate may have caused the optimizer to make poor choices.";
             }
 
             // Parent Sort/Hash that spilled — downstream bad estimate caused the spill

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -1444,8 +1444,8 @@ public static class ShowPlanParser
             result.Add(new PlanWarning
             {
                 WarningType = "No Join Predicate",
-                Message = "This join has no join predicate (possible cross join)",
-                Severity = PlanWarningSeverity.Critical
+                Message = "This join triggered a no join predicate warning, which is worth checking on, but is often misleading. The optimizer may have removed a redundant predicate after simplification.",
+                Severity = PlanWarningSeverity.Warning
             });
         }
 


### PR DESCRIPTION
## Summary
- **Rule 14**: Skip Lazy Index Spools — only fire for Lazy Table Spools (per Paul White's sql.kiwi guidance)
- **Estimate harm messages**: Simplified from join-strategy-specific language to generic "make poor choices"
- **NoJoinPredicate**: Downgraded from Critical to Warning with "often misleading" message explaining optimizer predicate removal

All changes applied to both Dashboard and Lite copies, matching Performance Studio v1.0.0.

## Test plan
- [x] Dashboard builds clean (0 warnings, 0 errors)
- [x] Lite builds clean (0 warnings, 0 errors)
- [x] Changes match Performance Studio source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)