### PR TITLE
Sync analyzer improvements from Performance Studio

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -183,11 +183,23 @@ public partial class PlanViewerControl : UserControl
             BorderThickness = new Thickness(isExpensive ? 2 : 1),
             CornerRadius = new CornerRadius(4),
             Padding = new Thickness(6, 4, 6, 4),
-            ToolTip = BuildNodeTooltip(node),
             Cursor = Cursors.Hand,
             SnapsToDevicePixels = true,
             Tag = node
         };
+
+        // Tooltip — root node includes statement-level PlanWarnings
+        if (totalWarningCount > 0 && _currentStatement != null)
+        {
+            var allWarnings = new List<PlanWarning>();
+            allWarnings.AddRange(_currentStatement.PlanWarnings);
+            CollectWarnings(node, allWarnings);
+            border.ToolTip = BuildNodeTooltip(node, allWarnings);
+        }
+        else
+        {
+            border.ToolTip = BuildNodeTooltip(node);
+        }
 
         // Click to select + show properties
         border.MouseLeftButtonUp += Node_Click;
@@ -1467,7 +1479,7 @@ public partial class PlanViewerControl : UserControl
 
     #region Tooltips
 
-    private ToolTip BuildNodeTooltip(PlanNode node)
+    private ToolTip BuildNodeTooltip(PlanNode node, List<PlanWarning>? allWarnings = null)
     {
         var tip = new ToolTip
         {
@@ -1607,22 +1619,51 @@ public partial class PlanViewerControl : UserControl
             AddTooltipRow(stack, "Columns", node.OutputColumns, isCode: true);
         }
 
-        // Warnings
-        if (node.HasWarnings)
+        // Warnings — use allWarnings (includes statement-level) for root, node.Warnings for others
+        var warnings = allWarnings ?? (node.HasWarnings ? node.Warnings : null);
+        if (warnings != null && warnings.Count > 0)
         {
             stack.Children.Add(new Separator { Margin = new Thickness(0, 6, 0, 6) });
-            foreach (var w in node.Warnings)
+
+            if (allWarnings != null)
             {
-                var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
-                    : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
-                stack.Children.Add(new TextBlock
+                // Root node: show distinct warning type names only
+                var distinct = warnings
+                    .GroupBy(w => w.WarningType)
+                    .Select(g => (Type: g.Key, MaxSeverity: g.Max(w => w.Severity), Count: g.Count()))
+                    .OrderByDescending(g => g.MaxSeverity)
+                    .ThenBy(g => g.Type);
+
+                foreach (var (type, severity, count) in distinct)
                 {
-                    Text = $"\u26A0 {w.WarningType}: {w.Message}",
-                    Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
-                    FontSize = 11,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Thickness(0, 2, 0, 0)
-                });
+                    var warnColor = severity == PlanWarningSeverity.Critical ? "#E57373"
+                        : severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
+                    var label = count > 1 ? $"\u26A0 {type} ({count})" : $"\u26A0 {type}";
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = label,
+                        Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
+                        FontSize = 11,
+                        Margin = new Thickness(0, 2, 0, 0)
+                    });
+                }
+            }
+            else
+            {
+                // Individual node: show full warning messages
+                foreach (var w in warnings)
+                {
+                    var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
+                        : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = $"\u26A0 {w.WarningType}: {w.Message}",
+                        Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
+                        FontSize = 11,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 2, 0, 0)
+                    });
+                }
             }
         }
 

--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -295,6 +295,53 @@ public static partial class PlanAnalyzer
                 }
             }
         }
+
+        // Rule 22 (statement-level): Table variable warnings
+        if (stmt.RootNode != null)
+        {
+            var hasTableVar = false;
+            var isModification = stmt.StatementType is "INSERT" or "UPDATE" or "DELETE" or "MERGE";
+            var modifiesTableVar = false;
+            CheckForTableVariables(stmt.RootNode, isModification, ref hasTableVar, ref modifiesTableVar);
+
+            if (hasTableVar)
+            {
+                stmt.PlanWarnings.Add(new PlanWarning
+                {
+                    WarningType = "Table Variable",
+                    Message = "Table variable detected. Table variables lack column-level statistics, which causes bad row estimates, join choices, and memory grant decisions. Replace with a #temp table.",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
+
+            if (modifiesTableVar)
+            {
+                stmt.PlanWarnings.Add(new PlanWarning
+                {
+                    WarningType = "Table Variable",
+                    Message = "This query modifies a table variable, which forces the entire plan to run single-threaded. SQL Server cannot use parallelism for modifications to table variables. Replace with a #temp table to allow parallel execution.",
+                    Severity = PlanWarningSeverity.Critical
+                });
+            }
+        }
+    }
+
+    private static void CheckForTableVariables(PlanNode node, bool isModification,
+        ref bool hasTableVar, ref bool modifiesTableVar)
+    {
+        if (!string.IsNullOrEmpty(node.ObjectName) && node.ObjectName.StartsWith("@"))
+        {
+            hasTableVar = true;
+            if (isModification && (node.PhysicalOp.Contains("Insert", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Update", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Delete", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Merge", StringComparison.OrdinalIgnoreCase)))
+            {
+                modifiesTableVar = true;
+            }
+        }
+        foreach (var child in node.Children)
+            CheckForTableVariables(child, isModification, ref hasTableVar, ref modifiesTableVar);
     }
 
     private static void AnalyzeNodeTree(PlanNode node, PlanStatement stmt)
@@ -508,7 +555,7 @@ public static partial class PlanAnalyzer
             {
                 WarningType = "Key Lookup",
                 Message = $"Key Lookup — SQL Server found rows via a nonclustered index but had to go back to the clustered index for additional columns. Alter the nonclustered index to add the predicate column as a key column or as an INCLUDE column.\nPredicate: {Truncate(node.Predicate, 200)}",
-                Severity = PlanWarningSeverity.Warning
+                Severity = PlanWarningSeverity.Critical
             });
         }
 
@@ -732,35 +779,38 @@ public static partial class PlanAnalyzer
             });
         }
 
-        // Rule 24: Top above a scan on the inner side of Nested Loops
-        // This pattern means the scan executes once per outer row, and the Top
-        // limits each iteration — but with no supporting index the scan is a
-        // linear search repeated potentially millions of times.
-        if (node.PhysicalOp == "Nested Loops" && node.Children.Count >= 2)
+        // Rule 24: Top above a scan
+        // Detects Top or Top N Sort operators feeding from a scan. This often means the
+        // query is scanning the entire table/index and sorting just to return a few rows,
+        // when an appropriate index could satisfy the request directly.
         {
-            var inner = node.Children[1];
+            var isTop = node.PhysicalOp == "Top";
+            var isTopNSort = node.LogicalOp == "Top N Sort";
 
-            // Walk through pass-through operators to find Top
-            while (inner.PhysicalOp == "Compute Scalar" && inner.Children.Count > 0)
-                inner = inner.Children[0];
-
-            if (inner.PhysicalOp == "Top" && inner.Children.Count > 0)
+            if ((isTop || isTopNSort) && node.Children.Count > 0)
             {
                 // Walk through pass-through operators below the Top to find the scan
-                var scanCandidate = inner.Children[0];
-                while (scanCandidate.PhysicalOp == "Compute Scalar" && scanCandidate.Children.Count > 0)
+                var scanCandidate = node.Children[0];
+                while ((scanCandidate.PhysicalOp == "Compute Scalar" || scanCandidate.PhysicalOp == "Parallelism")
+                    && scanCandidate.Children.Count > 0)
                     scanCandidate = scanCandidate.Children[0];
 
                 if (IsScanOperator(scanCandidate))
                 {
+                    var topLabel = isTopNSort ? "Top N Sort" : "Top";
+                    var onInner = node.Parent?.PhysicalOp == "Nested Loops" && node.Parent.Children.Count >= 2
+                        && node.Parent.Children[1] == node;
+                    var innerNote = onInner
+                        ? $" This is on the inner side of Nested Loops (Node {node.Parent!.NodeId}), so the scan repeats for every outer row."
+                        : "";
                     var predInfo = !string.IsNullOrEmpty(scanCandidate.Predicate)
                         ? " The scan has a residual predicate, so it may read many rows before the Top is satisfied."
                         : "";
-                    inner.Warnings.Add(new PlanWarning
+                    node.Warnings.Add(new PlanWarning
                     {
                         WarningType = "Top Above Scan",
-                        Message = $"Top operator reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}) on the inner side of Nested Loops (Node {node.NodeId}).{predInfo} Check that you have appropriate indexes to convert the scan into a seek.",
-                        Severity = PlanWarningSeverity.Warning
+                        Message = $"{topLabel} reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}).{innerNote}{predInfo} An index on the ORDER BY columns could eliminate the scan and sort entirely.",
+                        Severity = onInner ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                     });
                 }
             }
@@ -997,8 +1047,8 @@ public static partial class PlanAnalyzer
         while (parent != null && parent.PhysicalOp == "Compute Scalar")
             parent = parent.Parent;
 
-        // Expect TopN Sort
-        if (parent == null || parent.LogicalOp != "TopN Sort")
+        // Expect TopN Sort (XML says "TopN Sort", parser normalizes to "Top N Sort")
+        if (parent == null || parent.LogicalOp != "Top N Sort")
             return false;
 
         // Walk up to Merge Interval

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -651,6 +651,10 @@ public static class ShowPlanParser
         var physicalOpEl = GetOperatorElement(relOpEl);
         if (physicalOpEl != null)
         {
+            // Top N Sort — XML element is <TopSort> but PhysicalOp is "Sort"
+            if (physicalOpEl.Name.LocalName == "TopSort")
+                node.LogicalOp = "Top N Sort";
+
             // Object reference (table/index name) — scoped to stop at child RelOps
             var objEl = ScopedDescendants(physicalOpEl, Ns + "Object").FirstOrDefault();
             if (objEl != null)

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -199,11 +199,23 @@ public partial class PlanViewerControl : UserControl
             BorderThickness = new Thickness(isExpensive ? 2 : 1),
             CornerRadius = new CornerRadius(4),
             Padding = new Thickness(6, 4, 6, 4),
-            ToolTip = BuildNodeTooltip(node),
             Cursor = Cursors.Hand,
             SnapsToDevicePixels = true,
             Tag = node
         };
+
+        // Tooltip — root node includes statement-level PlanWarnings
+        if (totalWarningCount > 0 && _currentStatement != null)
+        {
+            var allWarnings = new List<PlanWarning>();
+            allWarnings.AddRange(_currentStatement.PlanWarnings);
+            CollectWarnings(node, allWarnings);
+            border.ToolTip = BuildNodeTooltip(node, allWarnings);
+        }
+        else
+        {
+            border.ToolTip = BuildNodeTooltip(node);
+        }
 
         // Click to select + show properties
         border.MouseLeftButtonUp += Node_Click;
@@ -1478,7 +1490,7 @@ public partial class PlanViewerControl : UserControl
 
     #region Tooltips
 
-    private ToolTip BuildNodeTooltip(PlanNode node)
+    private ToolTip BuildNodeTooltip(PlanNode node, List<PlanWarning>? allWarnings = null)
     {
         var tip = new ToolTip
         {
@@ -1618,22 +1630,51 @@ public partial class PlanViewerControl : UserControl
             AddTooltipRow(stack, "Columns", node.OutputColumns, isCode: true);
         }
 
-        // Warnings
-        if (node.HasWarnings)
+        // Warnings — use allWarnings (includes statement-level) for root, node.Warnings for others
+        var warnings = allWarnings ?? (node.HasWarnings ? node.Warnings : null);
+        if (warnings != null && warnings.Count > 0)
         {
             stack.Children.Add(new Separator { Margin = new Thickness(0, 6, 0, 6) });
-            foreach (var w in node.Warnings)
+
+            if (allWarnings != null)
             {
-                var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
-                    : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
-                stack.Children.Add(new TextBlock
+                // Root node: show distinct warning type names only
+                var distinct = warnings
+                    .GroupBy(w => w.WarningType)
+                    .Select(g => (Type: g.Key, MaxSeverity: g.Max(w => w.Severity), Count: g.Count()))
+                    .OrderByDescending(g => g.MaxSeverity)
+                    .ThenBy(g => g.Type);
+
+                foreach (var (type, severity, count) in distinct)
                 {
-                    Text = $"\u26A0 {w.WarningType}: {w.Message}",
-                    Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
-                    FontSize = 11,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Thickness(0, 2, 0, 0)
-                });
+                    var warnColor = severity == PlanWarningSeverity.Critical ? "#E57373"
+                        : severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
+                    var label = count > 1 ? $"\u26A0 {type} ({count})" : $"\u26A0 {type}";
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = label,
+                        Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
+                        FontSize = 11,
+                        Margin = new Thickness(0, 2, 0, 0)
+                    });
+                }
+            }
+            else
+            {
+                // Individual node: show full warning messages
+                foreach (var w in warnings)
+                {
+                    var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
+                        : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
+                    stack.Children.Add(new TextBlock
+                    {
+                        Text = $"\u26A0 {w.WarningType}: {w.Message}",
+                        Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(warnColor)),
+                        FontSize = 11,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 2, 0, 0)
+                    });
+                }
             }
         }
 

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -295,6 +295,53 @@ public static partial class PlanAnalyzer
                 }
             }
         }
+
+        // Rule 22 (statement-level): Table variable warnings
+        if (stmt.RootNode != null)
+        {
+            var hasTableVar = false;
+            var isModification = stmt.StatementType is "INSERT" or "UPDATE" or "DELETE" or "MERGE";
+            var modifiesTableVar = false;
+            CheckForTableVariables(stmt.RootNode, isModification, ref hasTableVar, ref modifiesTableVar);
+
+            if (hasTableVar)
+            {
+                stmt.PlanWarnings.Add(new PlanWarning
+                {
+                    WarningType = "Table Variable",
+                    Message = "Table variable detected. Table variables lack column-level statistics, which causes bad row estimates, join choices, and memory grant decisions. Replace with a #temp table.",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
+
+            if (modifiesTableVar)
+            {
+                stmt.PlanWarnings.Add(new PlanWarning
+                {
+                    WarningType = "Table Variable",
+                    Message = "This query modifies a table variable, which forces the entire plan to run single-threaded. SQL Server cannot use parallelism for modifications to table variables. Replace with a #temp table to allow parallel execution.",
+                    Severity = PlanWarningSeverity.Critical
+                });
+            }
+        }
+    }
+
+    private static void CheckForTableVariables(PlanNode node, bool isModification,
+        ref bool hasTableVar, ref bool modifiesTableVar)
+    {
+        if (!string.IsNullOrEmpty(node.ObjectName) && node.ObjectName.StartsWith("@"))
+        {
+            hasTableVar = true;
+            if (isModification && (node.PhysicalOp.Contains("Insert", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Update", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Delete", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Merge", StringComparison.OrdinalIgnoreCase)))
+            {
+                modifiesTableVar = true;
+            }
+        }
+        foreach (var child in node.Children)
+            CheckForTableVariables(child, isModification, ref hasTableVar, ref modifiesTableVar);
     }
 
     private static void AnalyzeNodeTree(PlanNode node, PlanStatement stmt)
@@ -508,7 +555,7 @@ public static partial class PlanAnalyzer
             {
                 WarningType = "Key Lookup",
                 Message = $"Key Lookup — SQL Server found rows via a nonclustered index but had to go back to the clustered index for additional columns. Alter the nonclustered index to add the predicate column as a key column or as an INCLUDE column.\nPredicate: {Truncate(node.Predicate, 200)}",
-                Severity = PlanWarningSeverity.Warning
+                Severity = PlanWarningSeverity.Critical
             });
         }
 
@@ -731,35 +778,38 @@ public static partial class PlanAnalyzer
             });
         }
 
-        // Rule 24: Top above a scan on the inner side of Nested Loops
-        // This pattern means the scan executes once per outer row, and the Top
-        // limits each iteration — but with no supporting index the scan is a
-        // linear search repeated potentially millions of times.
-        if (node.PhysicalOp == "Nested Loops" && node.Children.Count >= 2)
+        // Rule 24: Top above a scan
+        // Detects Top or Top N Sort operators feeding from a scan. This often means the
+        // query is scanning the entire table/index and sorting just to return a few rows,
+        // when an appropriate index could satisfy the request directly.
         {
-            var inner = node.Children[1];
+            var isTop = node.PhysicalOp == "Top";
+            var isTopNSort = node.LogicalOp == "Top N Sort";
 
-            // Walk through pass-through operators to find Top
-            while (inner.PhysicalOp == "Compute Scalar" && inner.Children.Count > 0)
-                inner = inner.Children[0];
-
-            if (inner.PhysicalOp == "Top" && inner.Children.Count > 0)
+            if ((isTop || isTopNSort) && node.Children.Count > 0)
             {
                 // Walk through pass-through operators below the Top to find the scan
-                var scanCandidate = inner.Children[0];
-                while (scanCandidate.PhysicalOp == "Compute Scalar" && scanCandidate.Children.Count > 0)
+                var scanCandidate = node.Children[0];
+                while ((scanCandidate.PhysicalOp == "Compute Scalar" || scanCandidate.PhysicalOp == "Parallelism")
+                    && scanCandidate.Children.Count > 0)
                     scanCandidate = scanCandidate.Children[0];
 
                 if (IsScanOperator(scanCandidate))
                 {
+                    var topLabel = isTopNSort ? "Top N Sort" : "Top";
+                    var onInner = node.Parent?.PhysicalOp == "Nested Loops" && node.Parent.Children.Count >= 2
+                        && node.Parent.Children[1] == node;
+                    var innerNote = onInner
+                        ? $" This is on the inner side of Nested Loops (Node {node.Parent!.NodeId}), so the scan repeats for every outer row."
+                        : "";
                     var predInfo = !string.IsNullOrEmpty(scanCandidate.Predicate)
                         ? " The scan has a residual predicate, so it may read many rows before the Top is satisfied."
                         : "";
-                    inner.Warnings.Add(new PlanWarning
+                    node.Warnings.Add(new PlanWarning
                     {
                         WarningType = "Top Above Scan",
-                        Message = $"Top operator reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}) on the inner side of Nested Loops (Node {node.NodeId}).{predInfo} Check that you have appropriate indexes to convert the scan into a seek.",
-                        Severity = PlanWarningSeverity.Warning
+                        Message = $"{topLabel} reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}).{innerNote}{predInfo} An index on the ORDER BY columns could eliminate the scan and sort entirely.",
+                        Severity = onInner ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                     });
                 }
             }
@@ -996,8 +1046,8 @@ public static partial class PlanAnalyzer
         while (parent != null && parent.PhysicalOp == "Compute Scalar")
             parent = parent.Parent;
 
-        // Expect TopN Sort
-        if (parent == null || parent.LogicalOp != "TopN Sort")
+        // Expect TopN Sort (XML says "TopN Sort", parser normalizes to "Top N Sort")
+        if (parent == null || parent.LogicalOp != "Top N Sort")
             return false;
 
         // Walk up to Merge Interval

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -651,6 +651,10 @@ public static class ShowPlanParser
         var physicalOpEl = GetOperatorElement(relOpEl);
         if (physicalOpEl != null)
         {
+            // Top N Sort — XML element is <TopSort> but PhysicalOp is "Sort"
+            if (physicalOpEl.Name.LocalName == "TopSort")
+                node.LogicalOp = "Top N Sort";
+
             // Object reference (table/index name) — scoped to stop at child RelOps
             var objEl = ScopedDescendants(physicalOpEl, Ns + "Object").FirstOrDefault();
             if (objEl != null)


### PR DESCRIPTION
## Summary
- **Root tooltip**: Now includes statement-level PlanWarnings (distinct names for root, full messages for individual nodes)
- **Key Lookup with predicate**: Upgrade from Warning to Critical
- **Table variable warnings**: New statement-level warnings for missing stats + modification forces serial execution (Critical)
- **Top N Sort**: Parse `<TopSort>` XML element, display as "Sort (Top N Sort)" matching SSMS
- **Rule 24 broadened**: Any Top or Top N Sort above a scan (Critical when on NL inner side, Warning standalone)
- **IsOrExpansionChain fix**: Match normalized "Top N Sort" LogicalOp

## Test plan
- [x] Dashboard builds clean (0 errors)
- [x] Lite builds clean (0 errors)
- [x] Changes match Performance Studio source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)