### PR TITLE
Fix sp_IndexCleanup column mapping and show all columns

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -740,44 +740,80 @@
                               CanUserResizeColumns="True"
                               HeadersVisibility="Column"
                               SelectionMode="Extended"
-                              MaxHeight="200"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="180"/>
-                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes, StringFormat='{}{0:N0}'}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Level" Binding="{Binding Level}" Width="80"/>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseInfo}" Width="200"/>
+                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
+                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
+                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Unused" Binding="{Binding UnusedIndexes, StringFormat='{}{0:N0}'}" Width="80">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Duplicate" Binding="{Binding DuplicateIndexes, StringFormat='{}{0:N0}'}" Width="90">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Removable" Binding="{Binding RemovableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Compressible" Binding="{Binding CompressibleIndexes, StringFormat='{}{0:N0}'}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Mergeable" Binding="{Binding MergeableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Total Size (GB)" Binding="{Binding TotalSizeGb}" Width="120">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Compressable" Binding="{Binding CompressableIndexes}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="% Removable" Binding="{Binding PercentRemovable}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Compression Savings" Binding="{Binding CompressionSavingsPotential}" Width="220"/>
+                            <DataGridTextColumn Header="Compression Total" Binding="{Binding CompressionSavingsPotentialTotal}" Width="240"/>
+                            <DataGridTextColumn Header="UDF Computed Cols" Binding="{Binding ComputedColumnsWithUdfs}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="UDF Check Constraints" Binding="{Binding CheckConstraintsWithUdfs}" Width="150">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Filtered Idx Missing Incl" Binding="{Binding FilteredIndexesNeedingIncludes}" Width="170">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Total Rows" Binding="{Binding TotalRows}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Reads" Binding="{Binding ReadsBreakdown}" Width="220"/>
+                            <DataGridTextColumn Header="Writes" Binding="{Binding Writes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Writes Saved" Binding="{Binding DailyWriteOpsSaved}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Lock Waits" Binding="{Binding LockWaitCount}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Lock Waits Saved" Binding="{Binding DailyLockWaitsSaved}" Width="150">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg Lock Wait ms" Binding="{Binding AvgLockWaitMs}" Width="120">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Latch Waits" Binding="{Binding LatchWaitCount}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Latch Waits Saved" Binding="{Binding DailyLatchWaitsSaved}" Width="155">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg Latch Wait ms" Binding="{Binding AvgLatchWaitMs}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
@@ -794,30 +830,37 @@
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Action" Binding="{Binding ScriptType}" Width="100"/>
+                            <DataGridTextColumn Header="Info" Binding="{Binding AdditionalInfo}" Width="160"/>
                             <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="140"/>
                             <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="80"/>
                             <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
                             <DataGridTextColumn Header="Index" Binding="{Binding IndexName}" Width="200"/>
                             <DataGridTextColumn Header="Rule" Binding="{Binding ConsolidationRule}" Width="160"/>
                             <DataGridTextColumn Header="Target Index" Binding="{Binding TargetIndexName}" Width="160"/>
-                            <DataGridTextColumn Header="Size (GB)" Binding="{Binding IndexSizeGb}" Width="90">
+                            <DataGridTextColumn Header="Superseded By" Binding="{Binding SupersededInfo}" Width="160"/>
+                            <DataGridTextColumn Header="Size GB" Binding="{Binding IndexSizeGb}" Width="80">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding IndexRows}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Reads" Binding="{Binding IndexReads}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Writes" Binding="{Binding IndexWrites}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Definition" Binding="{Binding OriginalIndexDefinition}" Width="300">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                        <Setter Property="ToolTip" Value="{Binding OriginalIndexDefinition}"/>
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Reads" Binding="{Binding IndexReads}" Width="100">
+                            <DataGridTextColumn Header="Script" Binding="{Binding Script}" Width="300">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Writes" Binding="{Binding IndexWrites}" Width="100">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                        <Setter Property="ToolTip" Value="{Binding Script}"/>
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1256,15 +1256,39 @@ OPTION(MAXDOP 1, RECOMPILE);";
             {
                 while (await reader.ReadAsync())
                 {
-                    var fieldCount = reader.FieldCount;
+                    var fc = reader.FieldCount;
+                    string Col(int i) => fc > i && !reader.IsDBNull(i) ? reader.GetValue(i).ToString() ?? "" : "";
                     summaries.Add(new IndexCleanupSummary
                     {
-                        DatabaseName = fieldCount > 1 && !reader.IsDBNull(1) ? reader.GetValue(1).ToString() ?? "" : "",
-                        TotalIndexes = fieldCount > 4 && !reader.IsDBNull(4) ? reader.GetValue(4).ToString() ?? "" : "",
-                        UnusedIndexes = fieldCount > 5 && !reader.IsDBNull(5) ? reader.GetValue(5).ToString() ?? "" : "",
-                        DuplicateIndexes = fieldCount > 6 && !reader.IsDBNull(6) ? reader.GetValue(6).ToString() ?? "" : "",
-                        CompressibleIndexes = fieldCount > 7 && !reader.IsDBNull(7) ? reader.GetValue(7).ToString() ?? "" : "",
-                        TotalSizeGb = fieldCount > 8 && !reader.IsDBNull(8) ? reader.GetValue(8).ToString() ?? "" : ""
+                        Level = Col(0),
+                        DatabaseInfo = Col(1),
+                        SchemaName = Col(2),
+                        TableName = Col(3),
+                        TablesAnalyzed = Col(4),
+                        TotalIndexes = Col(5),
+                        RemovableIndexes = Col(6),
+                        MergeableIndexes = Col(7),
+                        CompressableIndexes = Col(8),
+                        PercentRemovable = Col(9),
+                        CurrentSizeGb = Col(10),
+                        SizeAfterCleanupGb = Col(11),
+                        SpaceSavedGb = Col(12),
+                        SpaceReductionPercent = Col(13),
+                        CompressionSavingsPotential = Col(14),
+                        CompressionSavingsPotentialTotal = Col(15),
+                        ComputedColumnsWithUdfs = Col(16),
+                        CheckConstraintsWithUdfs = Col(17),
+                        FilteredIndexesNeedingIncludes = Col(18),
+                        TotalRows = Col(19),
+                        ReadsBreakdown = Col(20),
+                        Writes = Col(21),
+                        DailyWriteOpsSaved = Col(22),
+                        LockWaitCount = Col(23),
+                        DailyLockWaitsSaved = Col(24),
+                        AvgLockWaitMs = Col(25),
+                        LatchWaitCount = Col(26),
+                        DailyLatchWaitsSaved = Col(27),
+                        AvgLatchWaitMs = Col(28)
                     });
                 }
             }
@@ -1457,11 +1481,34 @@ OPTION(MAXDOP 1, RECOMPILE);";
 
     public class IndexCleanupSummary
     {
-        public string DatabaseName { get; set; } = "";
+        public string Level { get; set; } = "";
+        public string DatabaseInfo { get; set; } = "";
+        public string SchemaName { get; set; } = "";
+        public string TableName { get; set; } = "";
+        public string TablesAnalyzed { get; set; } = "";
         public string TotalIndexes { get; set; } = "";
-        public string UnusedIndexes { get; set; } = "";
-        public string DuplicateIndexes { get; set; } = "";
-        public string CompressibleIndexes { get; set; } = "";
-        public string TotalSizeGb { get; set; } = "";
+        public string RemovableIndexes { get; set; } = "";
+        public string MergeableIndexes { get; set; } = "";
+        public string CompressableIndexes { get; set; } = "";
+        public string PercentRemovable { get; set; } = "";
+        public string CurrentSizeGb { get; set; } = "";
+        public string SizeAfterCleanupGb { get; set; } = "";
+        public string SpaceSavedGb { get; set; } = "";
+        public string SpaceReductionPercent { get; set; } = "";
+        public string CompressionSavingsPotential { get; set; } = "";
+        public string CompressionSavingsPotentialTotal { get; set; } = "";
+        public string ComputedColumnsWithUdfs { get; set; } = "";
+        public string CheckConstraintsWithUdfs { get; set; } = "";
+        public string FilteredIndexesNeedingIncludes { get; set; } = "";
+        public string TotalRows { get; set; } = "";
+        public string ReadsBreakdown { get; set; } = "";
+        public string Writes { get; set; } = "";
+        public string DailyWriteOpsSaved { get; set; } = "";
+        public string LockWaitCount { get; set; } = "";
+        public string DailyLockWaitsSaved { get; set; } = "";
+        public string AvgLockWaitMs { get; set; } = "";
+        public string LatchWaitCount { get; set; } = "";
+        public string DailyLatchWaitsSaved { get; set; } = "";
+        public string AvgLatchWaitMs { get; set; } = "";
     }
 }

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -725,7 +725,7 @@
 
                 <Grid Grid.Row="1" Margin="10,0,10,10">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" MaxHeight="200"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
@@ -739,41 +739,78 @@
                               SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="180"/>
-                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Level" Binding="{Binding Level}" Width="80"/>
+                            <DataGridTextColumn Header="Database" Binding="{Binding DatabaseInfo}" Width="200"/>
+                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
+                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
+                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Unused" Binding="{Binding UnusedIndexes}" Width="90">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Duplicate" Binding="{Binding DuplicateIndexes}" Width="90">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Removable" Binding="{Binding RemovableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Compressible" Binding="{Binding CompressibleIndexes}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Mergeable" Binding="{Binding MergeableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Total Size GB" Binding="{Binding TotalSizeGb}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Compressable" Binding="{Binding CompressableIndexes}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="% Removable" Binding="{Binding PercentRemovable}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Compression Savings" Binding="{Binding CompressionSavingsPotential}" Width="220"/>
+                            <DataGridTextColumn Header="Compression Total" Binding="{Binding CompressionSavingsPotentialTotal}" Width="240"/>
+                            <DataGridTextColumn Header="UDF Computed Cols" Binding="{Binding ComputedColumnsWithUdfs}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="UDF Check Constraints" Binding="{Binding CheckConstraintsWithUdfs}" Width="150">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Filtered Idx Missing Incl" Binding="{Binding FilteredIndexesNeedingIncludes}" Width="170">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Total Rows" Binding="{Binding TotalRows}" Width="100">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Reads" Binding="{Binding ReadsBreakdown}" Width="220"/>
+                            <DataGridTextColumn Header="Writes" Binding="{Binding Writes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Writes Saved" Binding="{Binding DailyWriteOpsSaved}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Lock Waits" Binding="{Binding LockWaitCount}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Lock Waits Saved" Binding="{Binding DailyLockWaitsSaved}" Width="150">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg Lock Wait ms" Binding="{Binding AvgLockWaitMs}" Width="120">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Latch Waits" Binding="{Binding LatchWaitCount}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Daily Latch Waits Saved" Binding="{Binding DailyLatchWaitsSaved}" Width="155">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg Latch Wait ms" Binding="{Binding AvgLatchWaitMs}" Width="130">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
@@ -788,37 +825,38 @@
                               SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Type" Binding="{Binding ScriptType}" Width="100"/>
+                            <DataGridTextColumn Header="Action" Binding="{Binding ScriptType}" Width="100"/>
+                            <DataGridTextColumn Header="Info" Binding="{Binding AdditionalInfo}" Width="160"/>
                             <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="140"/>
                             <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="80"/>
                             <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
-                            <DataGridTextColumn Header="Index" Binding="{Binding IndexName}" Width="180"/>
-                            <DataGridTextColumn Header="Rule" Binding="{Binding ConsolidationRule}" Width="140"/>
+                            <DataGridTextColumn Header="Index" Binding="{Binding IndexName}" Width="200"/>
+                            <DataGridTextColumn Header="Rule" Binding="{Binding ConsolidationRule}" Width="160"/>
+                            <DataGridTextColumn Header="Target Index" Binding="{Binding TargetIndexName}" Width="160"/>
+                            <DataGridTextColumn Header="Superseded By" Binding="{Binding SupersededInfo}" Width="160"/>
                             <DataGridTextColumn Header="Size GB" Binding="{Binding IndexSizeGb}" Width="80">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Reads" Binding="{Binding IndexReads}" Width="80">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding IndexRows}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Writes" Binding="{Binding IndexWrites}" Width="80">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
+                            <DataGridTextColumn Header="Reads" Binding="{Binding IndexReads}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Definition" Binding="{Binding OriginalIndexDefinition}" Width="400">
+                            <DataGridTextColumn Header="Writes" Binding="{Binding IndexWrites}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Definition" Binding="{Binding OriginalIndexDefinition}" Width="300">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="ToolTip" Value="{Binding OriginalIndexDefinition}"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Script" Binding="{Binding Script}" Width="300">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="ToolTip" Value="{Binding Script}"/>
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1028,15 +1028,39 @@ LIMIT $3";
         {
             while (await reader.ReadAsync())
             {
-                var fieldCount = reader.FieldCount;
+                var fc = reader.FieldCount;
+                string Col(int i) => fc > i && !reader.IsDBNull(i) ? reader.GetValue(i).ToString() ?? "" : "";
                 summaries.Add(new IndexCleanupSummaryRow
                 {
-                    DatabaseName = fieldCount > 1 && !reader.IsDBNull(1) ? reader.GetValue(1).ToString() ?? "" : "",
-                    TotalIndexes = fieldCount > 4 && !reader.IsDBNull(4) ? reader.GetValue(4).ToString() ?? "" : "",
-                    UnusedIndexes = fieldCount > 5 && !reader.IsDBNull(5) ? reader.GetValue(5).ToString() ?? "" : "",
-                    DuplicateIndexes = fieldCount > 6 && !reader.IsDBNull(6) ? reader.GetValue(6).ToString() ?? "" : "",
-                    CompressibleIndexes = fieldCount > 7 && !reader.IsDBNull(7) ? reader.GetValue(7).ToString() ?? "" : "",
-                    TotalSizeGb = fieldCount > 8 && !reader.IsDBNull(8) ? reader.GetValue(8).ToString() ?? "" : ""
+                    Level = Col(0),
+                    DatabaseInfo = Col(1),
+                    SchemaName = Col(2),
+                    TableName = Col(3),
+                    TablesAnalyzed = Col(4),
+                    TotalIndexes = Col(5),
+                    RemovableIndexes = Col(6),
+                    MergeableIndexes = Col(7),
+                    CompressableIndexes = Col(8),
+                    PercentRemovable = Col(9),
+                    CurrentSizeGb = Col(10),
+                    SizeAfterCleanupGb = Col(11),
+                    SpaceSavedGb = Col(12),
+                    SpaceReductionPercent = Col(13),
+                    CompressionSavingsPotential = Col(14),
+                    CompressionSavingsPotentialTotal = Col(15),
+                    ComputedColumnsWithUdfs = Col(16),
+                    CheckConstraintsWithUdfs = Col(17),
+                    FilteredIndexesNeedingIncludes = Col(18),
+                    TotalRows = Col(19),
+                    ReadsBreakdown = Col(20),
+                    Writes = Col(21),
+                    DailyWriteOpsSaved = Col(22),
+                    LockWaitCount = Col(23),
+                    DailyLockWaitsSaved = Col(24),
+                    AvgLockWaitMs = Col(25),
+                    LatchWaitCount = Col(26),
+                    DailyLatchWaitsSaved = Col(27),
+                    AvgLatchWaitMs = Col(28)
                 });
             }
         }
@@ -1227,10 +1251,33 @@ public class IndexCleanupResultRow
 
 public class IndexCleanupSummaryRow
 {
-    public string DatabaseName { get; set; } = "";
+    public string Level { get; set; } = "";
+    public string DatabaseInfo { get; set; } = "";
+    public string SchemaName { get; set; } = "";
+    public string TableName { get; set; } = "";
+    public string TablesAnalyzed { get; set; } = "";
     public string TotalIndexes { get; set; } = "";
-    public string UnusedIndexes { get; set; } = "";
-    public string DuplicateIndexes { get; set; } = "";
-    public string CompressibleIndexes { get; set; } = "";
-    public string TotalSizeGb { get; set; } = "";
+    public string RemovableIndexes { get; set; } = "";
+    public string MergeableIndexes { get; set; } = "";
+    public string CompressableIndexes { get; set; } = "";
+    public string PercentRemovable { get; set; } = "";
+    public string CurrentSizeGb { get; set; } = "";
+    public string SizeAfterCleanupGb { get; set; } = "";
+    public string SpaceSavedGb { get; set; } = "";
+    public string SpaceReductionPercent { get; set; } = "";
+    public string CompressionSavingsPotential { get; set; } = "";
+    public string CompressionSavingsPotentialTotal { get; set; } = "";
+    public string ComputedColumnsWithUdfs { get; set; } = "";
+    public string CheckConstraintsWithUdfs { get; set; } = "";
+    public string FilteredIndexesNeedingIncludes { get; set; } = "";
+    public string TotalRows { get; set; } = "";
+    public string ReadsBreakdown { get; set; } = "";
+    public string Writes { get; set; } = "";
+    public string DailyWriteOpsSaved { get; set; } = "";
+    public string LockWaitCount { get; set; } = "";
+    public string DailyLockWaitsSaved { get; set; } = "";
+    public string AvgLockWaitMs { get; set; } = "";
+    public string LatchWaitCount { get; set; } = "";
+    public string DailyLatchWaitsSaved { get; set; } = "";
+    public string AvgLatchWaitMs { get; set; } = "";
 }


### PR DESCRIPTION
## Summary
- Fixed summary grid ordinal mapping — every column after DatabaseName was mapped to the wrong SP column (off by one)
- Expanded summary grid from 6 to all 29 columns from sp_IndexCleanup's second result set
- Added Script column (with tooltip) to detail grid — the actual DROP/CREATE INDEX T-SQL
- Added missing detail columns: AdditionalInfo, SupersededInfo, IndexRows, Definition (Dashboard), TargetIndex (Lite)
- Applied to both Dashboard and Lite

## Test plan
- [x] Build Dashboard and Lite — 0 warnings, 0 errors
- [ ] Run Index Analysis in Dashboard against sql2022, verify all columns populated correctly
- [ ] Run Index Analysis in Lite against sql2022, verify matching columns
- [ ] Verify Script column tooltip shows full T-SQL on hover
- [ ] Verify right-click copy works on new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)