### PR TITLE
FinOps tab improvements: 6 features for v2.2.0

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -53,6 +53,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
@@ -255,8 +256,53 @@
                            VerticalAlignment="Top" TextWrapping="Wrap" FontSize="12"
                            Foreground="{DynamicResource ForegroundMutedBrush}"/>
 
+                <!-- Provisioning Trend (7-day) -->
+                <Expander Header="7-Day Provisioning Trend" IsExpanded="False" Grid.Row="3" Margin="10,4,10,0">
+                    <DataGrid x:Name="ProvisioningTrendGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="False" HeadersVisibility="Column"
+                              GridLinesVisibility="Horizontal" SelectionMode="Single"
+                              MaxHeight="200" RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Day" Binding="{Binding DayDisplay}" Width="100"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="130">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Status}" Value="RIGHT_SIZED">
+                                                <Setter Property="Foreground" Value="#27AE60"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Status}" Value="OVER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#F39C12"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Status}" Value="UNDER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#E74C3C"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg CPU %" Binding="{Binding AvgCpuPct, StringFormat='{}{0:N1}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="P95 CPU %" Binding="{Binding P95CpuPct, StringFormat='{}{0:N1}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Max CPU %" Binding="{Binding MaxCpuPct}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Mem Ratio" Binding="{Binding MemoryRatio, StringFormat='{}{0:N2}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Expander>
+
                 <!-- Resource Summaries -->
-                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
+                <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
                     <Grid x:Name="SummaryContent">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -742,17 +788,26 @@
                               SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
+                            <!-- Actionable columns first -->
                             <DataGridTextColumn Header="Level" Binding="{Binding Level}" Width="80"/>
                             <DataGridTextColumn Header="Database" Binding="{Binding DatabaseInfo}" Width="200"/>
-                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
-                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
-                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
+                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
+                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <DataGridTextColumn Header="Removable" Binding="{Binding RemovableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <!-- Index counts -->
+                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <DataGridTextColumn Header="Mergeable" Binding="{Binding MergeableIndexes}" Width="90">
@@ -764,20 +819,16 @@
                             <DataGridTextColumn Header="% Removable" Binding="{Binding PercentRemovable}" Width="95">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                            <!-- Object context -->
+                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
+                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
+                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
+                            <!-- Compression -->
                             <DataGridTextColumn Header="Compression Savings" Binding="{Binding CompressionSavingsPotential}" Width="220"/>
                             <DataGridTextColumn Header="Compression Total" Binding="{Binding CompressionSavingsPotentialTotal}" Width="240"/>
+                            <!-- Remaining detail -->
                             <DataGridTextColumn Header="UDF Computed Cols" Binding="{Binding ComputedColumnsWithUdfs}" Width="130">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
@@ -985,7 +1036,21 @@
                     </Expander>
 
                     <!-- Wait Stats Summary -->
-                    <Expander Header="Wait Stats Summary" IsExpanded="True" Margin="0,0,0,8">
+                    <Expander IsExpanded="True" Margin="0,0,0,8">
+                        <Expander.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Wait Stats Summary" VerticalAlignment="Center"/>
+                                <TextBlock Text="  Time Range:" VerticalAlignment="Center" Margin="12,0,4,0" FontSize="11"/>
+                                <ComboBox x:Name="WaitStatsTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                                          SelectionChanged="WaitStatsTimeRange_Changed">
+                                    <ComboBoxItem Content="Last 1 hour"/>
+                                    <ComboBoxItem Content="Last 4 hours"/>
+                                    <ComboBoxItem Content="Last 12 hours"/>
+                                    <ComboBoxItem Content="Last 24 hours"/>
+                                    <ComboBoxItem Content="Last 7 days"/>
+                                </ComboBox>
+                            </StackPanel>
+                        </Expander.Header>
                         <StackPanel>
                             <DataGrid x:Name="WaitCategorySummaryDataGrid"
                                       AutoGenerateColumns="False"
@@ -1038,7 +1103,21 @@
                     </Expander>
 
                     <!-- Expensive Queries -->
-                    <Expander Header="Expensive Queries" IsExpanded="True" Margin="0,0,0,8">
+                    <Expander IsExpanded="True" Margin="0,0,0,8">
+                        <Expander.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Expensive Queries (Top 20 by CPU)" VerticalAlignment="Center"/>
+                                <TextBlock Text="  Time Range:" VerticalAlignment="Center" Margin="12,0,4,0" FontSize="11"/>
+                                <ComboBox x:Name="ExpensiveQueriesTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                                          SelectionChanged="ExpensiveQueriesTimeRange_Changed">
+                                    <ComboBoxItem Content="Last 1 hour"/>
+                                    <ComboBoxItem Content="Last 4 hours"/>
+                                    <ComboBoxItem Content="Last 12 hours"/>
+                                    <ComboBoxItem Content="Last 24 hours"/>
+                                    <ComboBoxItem Content="Last 7 days"/>
+                                </ComboBox>
+                            </StackPanel>
+                        </Expander.Header>
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
                                 <TextBlock x:Name="ExpensiveQueriesCountIndicator" Text=""
@@ -1096,6 +1175,57 @@
                             </DataGrid>
                             <TextBlock x:Name="ExpensiveQueriesNoDataMessage"
                                        Text="No query stats data collected yet."
+                                       FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                       Margin="0,4,0,0" Visibility="Collapsed"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Memory Grant Efficiency -->
+                    <Expander Header="Memory Grant Efficiency" IsExpanded="True" Margin="0,0,0,8">
+                        <StackPanel>
+                            <DataGrid x:Name="MemoryGrantEfficiencyDataGrid"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="Horizontal"
+                                      CanUserResizeColumns="True"
+                                      HeadersVisibility="Column"
+                                      SelectionMode="Extended"
+                                      MaxHeight="250"
+                                      RowStyle="{StaticResource DefaultRowStyle}">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Day" Binding="{Binding DayDisplay}" Width="100"/>
+                                    <DataGridTextColumn Header="Avg Granted (MB)" Binding="{Binding AvgGrantedMb, StringFormat='{}{0:N1}'}" Width="130">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Avg Used (MB)" Binding="{Binding AvgUsedMb, StringFormat='{}{0:N1}'}" Width="120">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Efficiency %" Binding="{Binding EfficiencyPct, StringFormat='{}{0:N1}%'}" Width="110">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Peak Grant (MB)" Binding="{Binding PeakGrantedMb, StringFormat='{}{0:N1}'}" Width="130">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Wasted (MB)" Binding="{Binding WastedMb, StringFormat='{}{0:N1}'}" Width="110">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Grantees" Binding="{Binding TotalGrantees, StringFormat='{}{0:N0}'}" Width="100">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Waiters" Binding="{Binding TotalWaiters, StringFormat='{}{0:N0}'}" Width="90">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Timeouts" Binding="{Binding TimeoutErrors, StringFormat='{}{0:N0}'}" Width="100">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Forced" Binding="{Binding ForcedGrants, StringFormat='{}{0:N0}'}" Width="90">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <TextBlock x:Name="MemoryGrantEfficiencyNoDataMessage"
+                                       Text="No memory grant data collected yet."
                                        FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}"
                                        Margin="0,4,0,0" Visibility="Collapsed"/>
                         </StackPanel>
@@ -1208,8 +1338,7 @@
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="160"/>
                             <DataGridTextColumn Header="Edition" Binding="{Binding Edition}" Width="200"/>
-                            <DataGridTextColumn Header="Version" Binding="{Binding SqlVersion}" Width="140"/>
-                            <DataGridTextColumn Header="Environment" Binding="{Binding EnvironmentType}" Width="100"/>
+                            <DataGridTextColumn Header="Version" Binding="{Binding SqlVersion}" Width="180"/>
                             <DataGridTextColumn Header="CPUs" Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
@@ -1224,9 +1353,54 @@
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
+                            <DataGridTextColumn Header="Sockets" Binding="{Binding SocketCount}" Width="70">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Cores/Socket" Binding="{Binding CoresPerSocket}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Status" Binding="{Binding ProvisioningDisplay}" Width="130">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="RIGHT_SIZED">
+                                                <Setter Property="Foreground" Value="#27AE60"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="OVER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#F39C12"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="UNDER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#E74C3C"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg CPU %" Binding="{Binding AvgCpuPct, StringFormat='{}{0:N1}'}" Width="80">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Storage GB" Binding="{Binding StorageTotalGb, StringFormat='{}{0:N1}'}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Idle DBs" Binding="{Binding IdleDbCount}" Width="70">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="Uptime" Binding="{Binding UptimeDisplay}" Width="90"/>
                             <DataGridTextColumn Header="Start Time" Binding="{Binding SqlServerStartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
                             <DataGridTextColumn Header="Last Updated" Binding="{Binding LastUpdated, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                            <DataGridTextColumn Header="HADR" Binding="{Binding HadrDisplay}" Width="60"/>
+                            <DataGridTextColumn Header="Clustered" Binding="{Binding ClusteredDisplay}" Width="80"/>
                         </DataGrid.Columns>
                     </DataGrid>
 

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -134,6 +134,9 @@ namespace PerformanceMonitorDashboard.Controls
 
                     var sizes = await _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
                     DbSizeChart.ItemsSource = sizes;
+
+                    var trend = await _databaseService.GetFinOpsProvisioningTrendAsync();
+                    ProvisioningTrendGrid.ItemsSource = trend;
                 }
             }
             catch (Exception ex)
@@ -356,13 +359,40 @@ namespace PerformanceMonitorDashboard.Controls
         // Optimization Tab — Wait Stats Summary
         // ============================================
 
+        private int GetWaitStatsHoursBack()
+        {
+            return WaitStatsTimeRangeCombo.SelectedIndex switch
+            {
+                0 => 1,
+                1 => 4,
+                2 => 12,
+                3 => 24,
+                4 => 168,
+                _ => 24
+            };
+        }
+
+        private int GetExpensiveQueriesHoursBack()
+        {
+            return ExpensiveQueriesTimeRangeCombo.SelectedIndex switch
+            {
+                0 => 1,
+                1 => 4,
+                2 => 12,
+                3 => 24,
+                4 => 168,
+                _ => 24
+            };
+        }
+
         private async Task LoadWaitCategorySummaryAsync()
         {
             if (_databaseService == null) return;
 
             try
             {
-                var data = await _databaseService.GetFinOpsWaitCategorySummaryAsync();
+                var hoursBack = GetWaitStatsHoursBack();
+                var data = await _databaseService.GetFinOpsWaitCategorySummaryAsync(hoursBack);
                 WaitCategorySummaryDataGrid.ItemsSource = data;
                 WaitCategorySummaryNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }
@@ -382,7 +412,8 @@ namespace PerformanceMonitorDashboard.Controls
 
             try
             {
-                var data = await _databaseService.GetFinOpsExpensiveQueriesAsync();
+                var hoursBack = GetExpensiveQueriesHoursBack();
+                var data = await _databaseService.GetFinOpsExpensiveQueriesAsync(hoursBack);
                 ExpensiveQueriesDataGrid.ItemsSource = data;
                 ExpensiveQueriesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 ExpensiveQueriesCountIndicator.Text = data.Count > 0 ? $"{data.Count} query(s)" : "";
@@ -390,6 +421,22 @@ namespace PerformanceMonitorDashboard.Controls
             catch (Exception ex)
             {
                 Logger.Error($"Error loading expensive queries: {ex.Message}", ex);
+            }
+        }
+
+        private async Task LoadMemoryGrantEfficiencyAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var data = await _databaseService.GetFinOpsMemoryGrantEfficiencyAsync();
+                MemoryGrantEfficiencyDataGrid.ItemsSource = data;
+                MemoryGrantEfficiencyNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading memory grant efficiency: {ex.Message}", ex);
             }
         }
 
@@ -494,14 +541,52 @@ namespace PerformanceMonitorDashboard.Controls
 
         private async Task LoadServerInventoryAsync()
         {
-            if (_databaseService == null) return;
+            if (_serverManager == null || _credentialService == null) return;
 
             try
             {
-                var data = await _databaseService.GetFinOpsServerInventoryAsync();
-                ServerInventoryDataGrid.ItemsSource = data;
-                ServerInventoryNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
-                ServerInventoryCountIndicator.Text = data.Count > 0 ? $"{data.Count} server(s)" : "";
+                var servers = _serverManager.GetAllServers();
+
+                var tasks = servers.Select(async server =>
+                {
+                    try
+                    {
+                        var connStr = server.GetConnectionString(_credentialService);
+
+                        // Step 1: Query live server properties (works from any DB context)
+                        var item = await DatabaseService.GetServerPropertiesLiveAsync(connStr);
+                        item.ServerName = server.DisplayName;
+
+                        // Step 2: Try to augment with collected metrics from PerformanceMonitor DB
+                        try
+                        {
+                            var svc = new DatabaseService(connStr);
+                            var (avgCpu, storageGb, idleDbs, status) = await svc.GetServerMetricsAsync();
+                            if (avgCpu.HasValue) item.AvgCpuPct = avgCpu;
+                            if (storageGb.HasValue) item.StorageTotalGb = storageGb;
+                            if (idleDbs.HasValue) item.IdleDbCount = idleDbs;
+                            if (status != null) item.ProvisioningStatus = status;
+                        }
+                        catch
+                        {
+                            // PerformanceMonitor DB may not exist or have no data — that's OK
+                        }
+
+                        return item;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Error loading server inventory for {server.DisplayName}: {ex.Message}", ex);
+                        return (FinOpsServerInventory?)null;
+                    }
+                });
+
+                var results = await Task.WhenAll(tasks);
+                var allItems = results.Where(r => r != null).Cast<FinOpsServerInventory>().ToList();
+
+                ServerInventoryDataGrid.ItemsSource = allItems;
+                ServerInventoryNoDataMessage.Visibility = allItems.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                ServerInventoryCountIndicator.Text = allItems.Count > 0 ? $"{allItems.Count} server(s)" : "";
             }
             catch (Exception ex)
             {
@@ -528,13 +613,26 @@ namespace PerformanceMonitorDashboard.Controls
             await LoadStorageGrowthAsync();
         }
 
+        private async void WaitStatsTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _databaseService == null) return;
+            await LoadWaitCategorySummaryAsync();
+        }
+
+        private async void ExpensiveQueriesTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _databaseService == null) return;
+            await LoadExpensiveQueriesAsync();
+        }
+
         private async void OptimizationRefresh_Click(object sender, RoutedEventArgs e)
         {
             await Task.WhenAll(
                 LoadIdleDatabasesAsync(),
                 LoadTempdbSummaryAsync(),
                 LoadWaitCategorySummaryAsync(),
-                LoadExpensiveQueriesAsync()
+                LoadExpensiveQueriesAsync(),
+                LoadMemoryGrantEfficiencyAsync()
             );
         }
 

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -623,7 +623,7 @@ public partial class PlanViewerControl : UserControl
             || !string.IsNullOrEmpty(node.InnerSideJoinColumns)
             || !string.IsNullOrEmpty(node.OuterSideJoinColumns)
             || !string.IsNullOrEmpty(node.ActionColumn)
-            || node.ManyToMany || node.BitmapCreator
+            || node.ManyToMany || node.PhysicalOp == "Merge Join" || node.BitmapCreator
             || node.SortDistinct || node.StartupExpression
             || node.NLOptimized || node.WithOrderedPrefetch || node.WithUnorderedPrefetch
             || node.WithTies || node.Remoting || node.LocalParallelism
@@ -688,8 +688,10 @@ public partial class PlanViewerControl : UserControl
                 AddPropertyRow("Inner Join Cols", node.InnerSideJoinColumns, isCode: true);
             if (!string.IsNullOrEmpty(node.OuterSideJoinColumns))
                 AddPropertyRow("Outer Join Cols", node.OuterSideJoinColumns, isCode: true);
-            if (node.ManyToMany)
-                AddPropertyRow("Many to Many", "True");
+            if (node.PhysicalOp == "Merge Join")
+                AddPropertyRow("Many to Many", node.ManyToMany ? "Yes" : "No");
+            else if (node.ManyToMany)
+                AddPropertyRow("Many to Many", "Yes");
             if (!string.IsNullOrEmpty(node.ConstantScanValues))
                 AddPropertyRow("Values", node.ConstantScanValues, isCode: true);
             if (!string.IsNullOrEmpty(node.UdxUsedColumns))

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -374,56 +374,196 @@ OPTION(MAXDOP 1, RECOMPILE);";
         /// <summary>
         /// Fetches server inventory from config.server_info.
         /// </summary>
-        public async Task<List<FinOpsServerInventory>> GetFinOpsServerInventoryAsync()
+        /// <summary>
+        /// Queries a SQL Server directly for its properties via SERVERPROPERTY + sys.dm_os_sys_info.
+        /// Works from any database context — no PerformanceMonitor DB required.
+        /// </summary>
+        public static async Task<FinOpsServerInventory> GetServerPropertiesLiveAsync(string connectionString)
         {
-            var items = new List<FinOpsServerInventory>();
+            await using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync();
 
+            const string query = @"
+SELECT
+    edition =
+        CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
+    product_version =
+        CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')),
+    product_level =
+        CONVERT(nvarchar(128), SERVERPROPERTY('ProductLevel')),
+    product_update_level =
+        CONVERT(nvarchar(128), SERVERPROPERTY('ProductUpdateLevel')),
+    cpu_count =
+        si.cpu_count,
+    physical_memory_mb =
+        si.physical_memory_kb / 1024,
+    sqlserver_start_time =
+        si.sqlserver_start_time,
+    total_storage_gb =
+        (SELECT SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files),
+    socket_count =
+        si.socket_count,
+    cores_per_socket =
+        si.cores_per_socket,
+    engine_edition =
+        CONVERT(int, SERVERPROPERTY('EngineEdition')),
+    is_hadr_enabled =
+        CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
+    is_clustered =
+        CONVERT(int, SERVERPROPERTY('IsClustered'))
+FROM sys.dm_os_sys_info AS si;";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 30;
+
+            using var reader = await command.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                var version = reader.IsDBNull(1) ? "" : reader.GetString(1);
+                var level = reader.IsDBNull(2) ? "" : reader.GetString(2);
+                var updateLevel = reader.IsDBNull(3) ? null : reader.GetString(3);
+                var versionDisplay = !string.IsNullOrEmpty(updateLevel)
+                    ? $"{version} - {updateLevel}"
+                    : $"{version} - {level}";
+
+                return new FinOpsServerInventory
+                {
+                    Edition = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    SqlVersion = versionDisplay,
+                    CpuCount = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                    PhysicalMemoryMb = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                    SqlServerStartTime = reader.IsDBNull(6) ? null : reader.GetDateTime(6),
+                    StorageTotalGb = reader.IsDBNull(7) ? null : Convert.ToDecimal(reader.GetValue(7)),
+                    SocketCount = reader.IsDBNull(8) ? null : Convert.ToInt32(reader.GetValue(8)),
+                    CoresPerSocket = reader.IsDBNull(9) ? null : Convert.ToInt32(reader.GetValue(9)),
+                    EngineEdition = reader.IsDBNull(10) ? null : Convert.ToInt32(reader.GetValue(10)),
+                    IsHadrEnabled = reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)) == 1,
+                    IsClustered = reader.IsDBNull(12) ? null : Convert.ToInt32(reader.GetValue(12)) == 1,
+                    LastUpdated = DateTime.Now
+                };
+            }
+
+            return new FinOpsServerInventory();
+        }
+
+        /// <summary>
+        /// Gets collected metrics (CPU, storage, idle DBs) from the PerformanceMonitor database.
+        /// Returns null values if no data is collected yet.
+        /// </summary>
+        public async Task<(decimal? AvgCpuPct, decimal? StorageTotalGb, int? IdleDbCount, string? ProvisioningStatus)> GetServerMetricsAsync()
+        {
             await using var tc = await OpenThrottledConnectionAsync();
             var connection = tc.Connection;
 
-            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-                SELECT
-                    server_name,
-                    edition,
-                    sql_version,
-                    environment_type,
-                    cpu_count,
-                    physical_memory_mb,
-                    sqlserver_start_time,
-                    uptime_days,
-                    uptime_hours,
-                    last_updated
-                FROM config.server_info
-                ORDER BY
-                    server_name
-                OPTION(MAXDOP 1, RECOMPILE);";
+WITH
+    cpu_24h AS
+    (
+        SELECT DISTINCT
+            avg_cpu_pct =
+                AVG(CONVERT(decimal(5,2), cu.sqlserver_cpu_utilization)) OVER (),
+            max_cpu_pct =
+                MAX(cu.sqlserver_cpu_utilization) OVER (),
+            p95_cpu_pct =
+                CONVERT
+                (
+                    decimal(5,2),
+                    PERCENTILE_CONT(0.95)
+                    WITHIN GROUP (ORDER BY cu.sqlserver_cpu_utilization)
+                    OVER ()
+                )
+        FROM collect.cpu_utilization_stats AS cu
+        WHERE cu.collection_time >= DATEADD(HOUR, -24, SYSDATETIME())
+    ),
+    mem_latest AS
+    (
+        SELECT TOP (1)
+            memory_ratio =
+                CONVERT(decimal(10,4), ms.total_memory_mb) /
+                NULLIF(ms.committed_target_memory_mb, 0)
+        FROM collect.memory_stats AS ms
+        ORDER BY
+            ms.collection_time DESC
+    ),
+    storage_total AS
+    (
+        SELECT
+            total_storage_gb =
+                SUM(ds.total_size_mb) / 1024.0
+        FROM collect.database_size_stats AS ds
+        WHERE ds.collection_time =
+        (
+            SELECT MAX(ds2.collection_time)
+            FROM collect.database_size_stats AS ds2
+        )
+    ),
+    idle_dbs AS
+    (
+        SELECT
+            idle_db_count = COUNT(DISTINCT d.database_name)
+        FROM
+        (
+            SELECT DISTINCT ds.database_name
+            FROM collect.database_size_stats AS ds
+            WHERE ds.collection_time =
+            (
+                SELECT MAX(ds2.collection_time)
+                FROM collect.database_size_stats AS ds2
+            )
+            AND ds.database_name NOT IN (N'master', N'model', N'msdb', N'tempdb')
+            EXCEPT
+            SELECT DISTINCT qs.database_name
+            FROM collect.query_stats AS qs
+            WHERE qs.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
+            AND   qs.execution_count_delta > 0
+        ) AS d
+    )
+SELECT
+    c.avg_cpu_pct,
+    st.total_storage_gb,
+    id.idle_db_count,
+    provisioning_status =
+        CASE
+            WHEN c.avg_cpu_pct < 15
+            AND  c.max_cpu_pct < 40
+            AND  ISNULL(m.memory_ratio, 0) < 0.5
+            THEN N'OVER_PROVISIONED'
+            WHEN c.p95_cpu_pct > 85
+            OR   ISNULL(m.memory_ratio, 0) > 0.95
+            THEN N'UNDER_PROVISIONED'
+            ELSE N'RIGHT_SIZED'
+        END
+FROM (SELECT 1 AS x) AS anchor
+LEFT JOIN cpu_24h AS c
+  ON 1 = 1
+LEFT JOIN mem_latest AS m
+  ON 1 = 1
+LEFT JOIN storage_total AS st
+  ON 1 = 1
+LEFT JOIN idle_dbs AS id
+  ON 1 = 1
+OPTION(MAXDOP 1, RECOMPILE);";
 
             using var command = new SqlCommand(query, connection);
             command.CommandTimeout = 120;
 
-            using (StartQueryTiming("FinOps_ServerInventory", query, connection))
+            using (StartQueryTiming("FinOps_ServerMetrics", query, connection))
             {
                 using var reader = await command.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                if (await reader.ReadAsync())
                 {
-                    items.Add(new FinOpsServerInventory
-                    {
-                        ServerName = reader.IsDBNull(0) ? "" : reader.GetString(0),
-                        Edition = reader.IsDBNull(1) ? "" : reader.GetString(1),
-                        SqlVersion = reader.IsDBNull(2) ? "" : reader.GetString(2),
-                        EnvironmentType = reader.IsDBNull(3) ? "" : reader.GetString(3),
-                        CpuCount = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                        PhysicalMemoryMb = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
-                        SqlServerStartTime = reader.IsDBNull(6) ? null : reader.GetDateTime(6),
-                        UptimeDays = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
-                        UptimeHours = reader.IsDBNull(8) ? 0 : Convert.ToInt32(reader.GetValue(8)),
-                        LastUpdated = reader.IsDBNull(9) ? null : reader.GetDateTime(9)
-                    });
+                    return (
+                        reader.IsDBNull(0) ? null : Convert.ToDecimal(reader.GetValue(0)),
+                        reader.IsDBNull(1) ? null : Convert.ToDecimal(reader.GetValue(1)),
+                        reader.IsDBNull(2) ? null : Convert.ToInt32(reader.GetValue(2)),
+                        reader.IsDBNull(3) ? null : reader.GetString(3)
+                    );
                 }
             }
 
-            return items;
+            return (null, null, null, null);
         }
 
         /// <summary>
@@ -975,7 +1115,7 @@ OPTION(MAXDOP 1, RECOMPILE);";
         /// <summary>
         /// Gets wait stats grouped by cost category over the last 24 hours.
         /// </summary>
-        public async Task<List<FinOpsWaitCategorySummary>> GetFinOpsWaitCategorySummaryAsync()
+        public async Task<List<FinOpsWaitCategorySummary>> GetFinOpsWaitCategorySummaryAsync(int hoursBack = 24)
         {
             var items = new List<FinOpsWaitCategorySummary>();
 
@@ -1010,7 +1150,7 @@ WITH
             waiting_tasks =
                 SUM(waiting_tasks_count_delta)
         FROM collect.wait_stats
-        WHERE collection_time >= DATEADD(HOUR, -24, SYSDATETIME())
+        WHERE collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
         AND   wait_time_ms_delta IS NOT NULL
         AND   wait_time_ms_delta > 0
         GROUP BY
@@ -1081,6 +1221,7 @@ ORDER BY
 OPTION(MAXDOP 1, RECOMPILE);";
 
             using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
             command.CommandTimeout = 120;
 
             using (StartQueryTiming("FinOps_WaitCategorySummary", query, connection))
@@ -1295,6 +1436,174 @@ OPTION(MAXDOP 1, RECOMPILE);";
 
             return (details, summaries);
         }
+
+        /// <summary>
+        /// Gets 7-day daily provisioning classification trend.
+        /// </summary>
+        public async Task<List<FinOpsProvisioningTrend>> GetFinOpsProvisioningTrendAsync()
+        {
+            var items = new List<FinOpsProvisioningTrend>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH
+    daily_cpu AS
+    (
+        SELECT DISTINCT
+            day = CONVERT(date, cu.collection_time),
+            avg_cpu_pct =
+                AVG(CONVERT(decimal(5,2), cu.sqlserver_cpu_utilization))
+                OVER (PARTITION BY CONVERT(date, cu.collection_time)),
+            max_cpu_pct =
+                MAX(cu.sqlserver_cpu_utilization)
+                OVER (PARTITION BY CONVERT(date, cu.collection_time)),
+            p95_cpu_pct =
+                CONVERT
+                (
+                    decimal(5,2),
+                    PERCENTILE_CONT(0.95)
+                    WITHIN GROUP (ORDER BY cu.sqlserver_cpu_utilization)
+                    OVER (PARTITION BY CONVERT(date, cu.collection_time))
+                )
+        FROM collect.cpu_utilization_stats AS cu
+        WHERE cu.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
+    ),
+    daily_mem AS
+    (
+        SELECT
+            day = CONVERT(date, ms.collection_time),
+            avg_memory_ratio =
+                AVG
+                (
+                    CONVERT(decimal(10,4), ms.total_memory_mb) /
+                    NULLIF(ms.committed_target_memory_mb, 0)
+                )
+        FROM collect.memory_stats AS ms
+        WHERE ms.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
+        GROUP BY
+            CONVERT(date, ms.collection_time)
+    )
+SELECT
+    c.day,
+    c.avg_cpu_pct,
+    c.max_cpu_pct,
+    c.p95_cpu_pct,
+    ISNULL(m.avg_memory_ratio, 0),
+    provisioning_status =
+        CASE
+            WHEN c.avg_cpu_pct < 15
+            AND  c.max_cpu_pct < 40
+            AND  ISNULL(m.avg_memory_ratio, 0) < 0.5
+            THEN N'OVER_PROVISIONED'
+            WHEN c.p95_cpu_pct > 85
+            OR   ISNULL(m.avg_memory_ratio, 0) > 0.95
+            THEN N'UNDER_PROVISIONED'
+            ELSE N'RIGHT_SIZED'
+        END
+FROM daily_cpu AS c
+LEFT JOIN daily_mem AS m
+  ON m.day = c.day
+ORDER BY
+    c.day
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_ProvisioningTrend", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsProvisioningTrend
+                    {
+                        Day = reader.GetDateTime(0),
+                        AvgCpuPct = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                        MaxCpuPct = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                        P95CpuPct = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        MemoryRatio = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                        Status = reader.IsDBNull(5) ? "" : reader.GetString(5)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets memory grant efficiency from resource semaphore data.
+        /// </summary>
+        public async Task<List<FinOpsMemoryGrantEfficiency>> GetFinOpsMemoryGrantEfficiencyAsync(int hoursBack = 24)
+        {
+            var items = new List<FinOpsMemoryGrantEfficiency>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    day = CONVERT(date, mg.collection_time),
+    avg_granted_mb =
+        AVG(mg.granted_memory_mb),
+    avg_used_mb =
+        AVG(mg.used_memory_mb),
+    efficiency_pct =
+        CONVERT
+        (
+            decimal(5,1),
+            AVG(mg.used_memory_mb) * 100.0 /
+            NULLIF(AVG(mg.granted_memory_mb), 0)
+        ),
+    peak_granted_mb =
+        MAX(mg.granted_memory_mb),
+    total_grantees =
+        SUM(mg.grantee_count),
+    total_waiters =
+        SUM(mg.waiter_count),
+    timeout_errors =
+        SUM(mg.timeout_error_count_delta),
+    forced_grants =
+        SUM(mg.forced_grant_count_delta)
+FROM collect.memory_grant_stats AS mg
+WHERE mg.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
+GROUP BY
+    CONVERT(date, mg.collection_time)
+ORDER BY
+    CONVERT(date, mg.collection_time)
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_MemoryGrantEfficiency", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsMemoryGrantEfficiency
+                    {
+                        Day = reader.GetDateTime(0),
+                        AvgGrantedMb = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                        AvgUsedMb = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2)),
+                        EfficiencyPct = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        PeakGrantedMb = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                        TotalGrantees = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
+                        TotalWaiters = reader.IsDBNull(6) ? 0 : Convert.ToInt64(reader.GetValue(6)),
+                        TimeoutErrors = reader.IsDBNull(7) ? 0 : Convert.ToInt64(reader.GetValue(7)),
+                        ForcedGrants = reader.IsDBNull(8) ? 0 : Convert.ToInt64(reader.GetValue(8))
+                    });
+                }
+            }
+
+            return items;
+        }
     }
 
     // ============================================
@@ -1351,14 +1660,31 @@ OPTION(MAXDOP 1, RECOMPILE);";
         public string ServerName { get; set; } = "";
         public string Edition { get; set; } = "";
         public string SqlVersion { get; set; } = "";
-        public string EnvironmentType { get; set; } = "";
         public int CpuCount { get; set; }
         public long PhysicalMemoryMb { get; set; }
+        public int? SocketCount { get; set; }
+        public int? CoresPerSocket { get; set; }
+        public int? EngineEdition { get; set; }
         public DateTime? SqlServerStartTime { get; set; }
-        public int UptimeDays { get; set; }
-        public int UptimeHours { get; set; }
         public DateTime? LastUpdated { get; set; }
-        public string UptimeDisplay => $"{UptimeDays}d {UptimeHours}h";
+        public bool? IsHadrEnabled { get; set; }
+        public bool? IsClustered { get; set; }
+        public decimal? AvgCpuPct { get; set; }
+        public decimal? StorageTotalGb { get; set; }
+        public int? IdleDbCount { get; set; }
+        public string? ProvisioningStatus { get; set; }
+        public string UptimeDisplay
+        {
+            get
+            {
+                if (SqlServerStartTime == null) return "";
+                var uptime = DateTime.Now - SqlServerStartTime.Value;
+                return $"{(int)uptime.TotalDays}d {uptime.Hours}h";
+            }
+        }
+        public string ProvisioningDisplay => ProvisioningStatus?.Replace("_", " ") ?? "";
+        public string HadrDisplay => IsHadrEnabled.HasValue ? (IsHadrEnabled.Value ? "Yes" : "No") : "";
+        public string ClusteredDisplay => IsClustered.HasValue ? (IsClustered.Value ? "Yes" : "No") : "";
     }
 
     public class FinOpsDatabaseSizeStats
@@ -1477,6 +1803,33 @@ OPTION(MAXDOP 1, RECOMPILE);";
         public string IndexWrites { get; set; } = "";
         public string OriginalIndexDefinition { get; set; } = "";
         public string Script { get; set; } = "";
+    }
+
+    public class FinOpsProvisioningTrend
+    {
+        public DateTime Day { get; set; }
+        public decimal AvgCpuPct { get; set; }
+        public int MaxCpuPct { get; set; }
+        public decimal P95CpuPct { get; set; }
+        public decimal MemoryRatio { get; set; }
+        public string Status { get; set; } = "";
+        public string DayDisplay => Day.ToString("ddd MM/dd");
+        public string StatusDisplay => Status.Replace("_", " ");
+    }
+
+    public class FinOpsMemoryGrantEfficiency
+    {
+        public DateTime Day { get; set; }
+        public decimal AvgGrantedMb { get; set; }
+        public decimal AvgUsedMb { get; set; }
+        public decimal EfficiencyPct { get; set; }
+        public decimal PeakGrantedMb { get; set; }
+        public long TotalGrantees { get; set; }
+        public long TotalWaiters { get; set; }
+        public long TimeoutErrors { get; set; }
+        public long ForcedGrants { get; set; }
+        public string DayDisplay => Day.ToString("ddd MM/dd");
+        public decimal WastedMb => AvgGrantedMb - AvgUsedMb;
     }
 
     public class IndexCleanupSummary

--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -188,48 +188,44 @@ public static partial class PlanAnalyzer
             });
         }
 
-        // Rule 25: Ineffective parallelism — parallel plan where CPU ≈ elapsed
+        // Rule 25: Ineffective parallelism — DOP-aware efficiency scoring
+        // Efficiency = (speedup - 1) / (DOP - 1) * 100
+        // where speedup = CPU / Elapsed. At DOP 1 speedup=1 (0%), at DOP=speedup (100%).
+        // Rule 31: Parallel wait bottleneck — elapsed >> CPU means threads waiting, not working.
         if (stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
         {
             var cpu = stmt.QueryTimeStats.CpuTimeMs;
             var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
+            var dop = stmt.DegreeOfParallelism;
 
             if (elapsed >= 1000 && cpu > 0)
             {
-                var ratio = (double)cpu / elapsed;
-                if (ratio >= 0.8 && ratio <= 1.3)
-                {
-                    stmt.PlanWarnings.Add(new PlanWarning
-                    {
-                        WarningType = "Ineffective Parallelism",
-                        Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) but CPU time ({cpu:N0}ms) is nearly equal to elapsed time ({elapsed:N0}ms). " +
-                                  $"The work ran essentially serially despite the overhead of parallelism. " +
-                                  $"Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.",
-                        Severity = PlanWarningSeverity.Warning
-                    });
-                }
-            }
-        }
+                var speedup = (double)cpu / elapsed;
+                var efficiency = Math.Max(0.0, Math.Min(100.0, (speedup - 1.0) / (dop - 1.0) * 100.0));
 
-        // Rule 31: Parallel wait bottleneck — elapsed time significantly exceeds CPU time
-        if (stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
-        {
-            var cpu = stmt.QueryTimeStats.CpuTimeMs;
-            var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
-
-            if (elapsed >= 1000 && cpu > 0)
-            {
-                var ratio = (double)cpu / elapsed;
-                if (ratio < 0.8)
+                if (speedup < 0.5)
                 {
-                    var waitPct = (1.0 - ratio) * 100;
+                    // CPU well below Elapsed: threads are waiting, not doing CPU work
+                    var waitPct = (1.0 - speedup) * 100;
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
                         WarningType = "Parallel Wait Bottleneck",
-                        Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) with elapsed time ({elapsed:N0}ms) significantly exceeding CPU time ({cpu:N0}ms). " +
+                        Message = $"Parallel plan (DOP {dop}, {efficiency:N0}% efficient) with elapsed time ({elapsed:N0}ms) exceeding CPU time ({cpu:N0}ms). " +
                                   $"Approximately {waitPct:N0}% of elapsed time was spent waiting rather than on CPU. " +
                                   $"Common causes include spills to tempdb, physical I/O reads, lock or latch contention, and memory grant waits.",
                         Severity = PlanWarningSeverity.Warning
+                    });
+                }
+                else if (efficiency < 40)
+                {
+                    // CPU >= Elapsed but well below DOP potential — parallelism is ineffective
+                    stmt.PlanWarnings.Add(new PlanWarning
+                    {
+                        WarningType = "Ineffective Parallelism",
+                        Message = $"Parallel plan (DOP {dop}) is only {efficiency:N0}% efficient — CPU time ({cpu:N0}ms) vs elapsed time ({elapsed:N0}ms). " +
+                                  $"At DOP {dop}, ideal CPU time would be ~{elapsed * dop:N0}ms. " +
+                                  $"Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.",
+                        Severity = efficiency < 20 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                     });
                 }
             }

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -52,6 +52,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
@@ -254,8 +255,53 @@
                            VerticalAlignment="Top" TextWrapping="Wrap" FontSize="12"
                            Foreground="{DynamicResource ForegroundMutedBrush}"/>
 
+                <!-- Provisioning Trend (7-day) -->
+                <Expander Header="7-Day Provisioning Trend" IsExpanded="False" Grid.Row="3" Margin="10,4,10,0">
+                    <DataGrid x:Name="ProvisioningTrendGrid"
+                              AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="False" HeadersVisibility="Column"
+                              GridLinesVisibility="Horizontal" SelectionMode="Single"
+                              MaxHeight="200" RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Day" Binding="{Binding DayDisplay}" Width="100"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="130">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Status}" Value="RIGHT_SIZED">
+                                                <Setter Property="Foreground" Value="#27AE60"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Status}" Value="OVER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#F39C12"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Status}" Value="UNDER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#E74C3C"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg CPU %" Binding="{Binding AvgCpuPct, StringFormat='{}{0:N1}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="P95 CPU %" Binding="{Binding P95CpuPct, StringFormat='{}{0:N1}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Max CPU %" Binding="{Binding MaxCpuPct}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Mem Ratio" Binding="{Binding MemoryRatio, StringFormat='{}{0:N2}'}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Expander>
+
                 <!-- Resource Summaries -->
-                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
+                <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto" Margin="0,0,0,0">
                     <Grid x:Name="SummaryContent">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -739,17 +785,26 @@
                               SelectionMode="Extended"
                               RowStyle="{StaticResource DefaultRowStyle}">
                         <DataGrid.Columns>
+                            <!-- Actionable columns first -->
                             <DataGridTextColumn Header="Level" Binding="{Binding Level}" Width="80"/>
                             <DataGridTextColumn Header="Database" Binding="{Binding DatabaseInfo}" Width="200"/>
-                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
-                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
-                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
+                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
+                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <DataGridTextColumn Header="Removable" Binding="{Binding RemovableIndexes}" Width="90">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <!-- Index counts -->
+                            <DataGridTextColumn Header="Total Indexes" Binding="{Binding TotalIndexes}" Width="100">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <DataGridTextColumn Header="Mergeable" Binding="{Binding MergeableIndexes}" Width="90">
@@ -761,20 +816,16 @@
                             <DataGridTextColumn Header="% Removable" Binding="{Binding PercentRemovable}" Width="95">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="Current Size GB" Binding="{Binding CurrentSizeGb}" Width="115">
+                            <!-- Object context -->
+                            <DataGridTextColumn Header="Schema" Binding="{Binding SchemaName}" Width="100"/>
+                            <DataGridTextColumn Header="Table" Binding="{Binding TableName}" Width="160"/>
+                            <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed}" Width="70">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Header="After Cleanup GB" Binding="{Binding SizeAfterCleanupGb}" Width="125">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Space Saved GB" Binding="{Binding SpaceSavedGb}" Width="110">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="% Reduction" Binding="{Binding SpaceReductionPercent}" Width="95">
-                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
+                            <!-- Compression -->
                             <DataGridTextColumn Header="Compression Savings" Binding="{Binding CompressionSavingsPotential}" Width="220"/>
                             <DataGridTextColumn Header="Compression Total" Binding="{Binding CompressionSavingsPotentialTotal}" Width="240"/>
+                            <!-- Remaining detail -->
                             <DataGridTextColumn Header="UDF Computed Cols" Binding="{Binding ComputedColumnsWithUdfs}" Width="130">
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
@@ -981,7 +1032,21 @@
                     </Expander>
 
                     <!-- Wait Stats Summary -->
-                    <Expander Header="Wait Stats Summary" IsExpanded="True" Margin="0,0,0,8">
+                    <Expander IsExpanded="True" Margin="0,0,0,8">
+                        <Expander.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Wait Stats Summary" VerticalAlignment="Center"/>
+                                <TextBlock Text="  Time Range:" VerticalAlignment="Center" Margin="12,0,4,0" FontSize="11"/>
+                                <ComboBox x:Name="WaitStatsTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                                          SelectionChanged="WaitStatsTimeRange_Changed">
+                                    <ComboBoxItem Content="Last 1 hour"/>
+                                    <ComboBoxItem Content="Last 4 hours"/>
+                                    <ComboBoxItem Content="Last 12 hours"/>
+                                    <ComboBoxItem Content="Last 24 hours"/>
+                                    <ComboBoxItem Content="Last 7 days"/>
+                                </ComboBox>
+                            </StackPanel>
+                        </Expander.Header>
                         <StackPanel>
                             <DataGrid x:Name="WaitCategorySummaryDataGrid"
                                       AutoGenerateColumns="False"
@@ -1035,7 +1100,21 @@
                     </Expander>
 
                     <!-- Expensive Queries -->
-                    <Expander Header="Expensive Queries (Top 20 by CPU)" IsExpanded="True" Margin="0,0,0,8">
+                    <Expander IsExpanded="True" Margin="0,0,0,8">
+                        <Expander.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Expensive Queries (Top 20 by CPU)" VerticalAlignment="Center"/>
+                                <TextBlock Text="  Time Range:" VerticalAlignment="Center" Margin="12,0,4,0" FontSize="11"/>
+                                <ComboBox x:Name="ExpensiveQueriesTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                                          SelectionChanged="ExpensiveQueriesTimeRange_Changed">
+                                    <ComboBoxItem Content="Last 1 hour"/>
+                                    <ComboBoxItem Content="Last 4 hours"/>
+                                    <ComboBoxItem Content="Last 12 hours"/>
+                                    <ComboBoxItem Content="Last 24 hours"/>
+                                    <ComboBoxItem Content="Last 7 days"/>
+                                </ComboBox>
+                            </StackPanel>
+                        </Expander.Header>
                         <StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
                                 <TextBlock x:Name="ExpensiveQueriesCountIndicator" Text=""
@@ -1099,6 +1178,58 @@
                             </DataGrid>
                             <TextBlock x:Name="ExpensiveQueriesNoDataMessage"
                                        Text="No expensive queries found"
+                                       FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                       HorizontalAlignment="Center" Margin="0,4,0,0"
+                                       Visibility="Collapsed"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Memory Grant Efficiency -->
+                    <Expander Header="Memory Grant Efficiency" IsExpanded="True" Margin="0,0,0,8">
+                        <StackPanel>
+                            <DataGrid x:Name="MemoryGrantEfficiencyDataGrid"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="Horizontal"
+                                      CanUserResizeColumns="True"
+                                      HeadersVisibility="Column"
+                                      SelectionMode="Extended"
+                                      MaxHeight="250"
+                                      RowStyle="{StaticResource DefaultRowStyle}">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Day" Binding="{Binding DayDisplay}" Width="100"/>
+                                    <DataGridTextColumn Header="Avg Granted MB" Binding="{Binding AvgGrantedMb, StringFormat='{}{0:N1}'}" Width="120">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Avg Used MB" Binding="{Binding AvgUsedMb, StringFormat='{}{0:N1}'}" Width="110">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Efficiency %" Binding="{Binding EfficiencyPct, StringFormat='{}{0:N1}'}" Width="100">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Peak Grant MB" Binding="{Binding PeakGrantedMb, StringFormat='{}{0:N1}'}" Width="120">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Wasted MB" Binding="{Binding WastedMb, StringFormat='{}{0:N1}'}" Width="100">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Grantees" Binding="{Binding TotalGrantees, StringFormat='{}{0:N0}'}" Width="90">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Waiters" Binding="{Binding TotalWaiters, StringFormat='{}{0:N0}'}" Width="80">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Timeouts" Binding="{Binding TimeoutErrors, StringFormat='{}{0:N0}'}" Width="90">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Forced" Binding="{Binding ForcedGrants, StringFormat='{}{0:N0}'}" Width="80">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <TextBlock x:Name="MemoryGrantEfficiencyNoDataMessage"
+                                       Text="No memory grant data available"
                                        FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}"
                                        HorizontalAlignment="Center" Margin="0,4,0,0"
                                        Visibility="Collapsed"/>
@@ -1212,15 +1343,7 @@
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="160"/>
                             <DataGridTextColumn Header="Edition" Binding="{Binding Edition}" Width="200"/>
-                            <DataGridTextColumn Header="Version" Binding="{Binding ProductVersion}" Width="110"/>
-                            <DataGridTextColumn Header="Update Level" Binding="{Binding ProductUpdateLevel}" Width="100"/>
-                            <DataGridTextColumn Header="Engine Edition" Binding="{Binding EngineEdition}" Width="110">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Version" Binding="{Binding ProductVersion}" Width="180"/>
                             <DataGridTextColumn Header="CPUs" Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
@@ -1249,6 +1372,38 @@
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
+                            <DataGridTextColumn Header="Status" Binding="{Binding ProvisioningDisplay}" Width="130">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="RIGHT_SIZED">
+                                                <Setter Property="Foreground" Value="#27AE60"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="OVER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#F39C12"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ProvisioningStatus}" Value="UNDER_PROVISIONED">
+                                                <Setter Property="Foreground" Value="#E74C3C"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Avg CPU %" Binding="{Binding AvgCpuPct, StringFormat='{}{0:N1}'}" Width="80">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Storage GB" Binding="{Binding StorageTotalGb, StringFormat='{}{0:N1}'}" Width="95">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Idle DBs" Binding="{Binding IdleDbCount}" Width="70">
+                                <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Uptime" Binding="{Binding UptimeDisplay}" Width="90"/>
+                            <DataGridTextColumn Header="Start Time" Binding="{Binding SqlServerStartTime, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
+                            <DataGridTextColumn Header="Last Updated" Binding="{Binding LastUpdated, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="150"/>
                             <DataGridTextColumn Header="HADR" Binding="{Binding HadrDisplay}" Width="60"/>
                             <DataGridTextColumn Header="Clustered" Binding="{Binding ClusteredDisplay}" Width="80"/>
                         </DataGrid.Columns>

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -131,6 +131,9 @@ public partial class FinOpsTab : UserControl
 
                 var sizes = await _dataService.GetDatabaseSizeSummaryAsync(serverId);
                 DbSizeChart.ItemsSource = sizes;
+
+                var trend = await _dataService.GetProvisioningTrendAsync(serverId);
+                ProvisioningTrendGrid.ItemsSource = trend;
             }
         }
         catch (Exception ex)
@@ -317,13 +320,50 @@ public partial class FinOpsTab : UserControl
 
     private async System.Threading.Tasks.Task LoadServerInventoryAsync()
     {
-        if (_dataService == null) return;
+        if (_dataService == null || _serverManager == null || _credentialService == null) return;
 
         try
         {
-            var data = await _dataService.GetServerPropertiesLatestAsync();
-            ServerInventoryDataGrid.ItemsSource = data;
+            var servers = _serverManager.GetAllServers();
 
+            var tasks = servers.Select(async server =>
+            {
+                try
+                {
+                    var connStr = server.GetConnectionString(_credentialService);
+
+                    // Step 1: Query live server properties
+                    var item = await LocalDataService.GetServerPropertiesLiveAsync(connStr);
+                    item.ServerName = server.DisplayName;
+
+                    // Step 2: Get collected metrics from DuckDB
+                    try
+                    {
+                        var serverId = RemoteCollectorService.GetDeterministicHashCode(server.ServerName);
+                        var (avgCpu, storageGb, idleDbs, status) = await _dataService!.GetServerMetricsAsync(serverId);
+                        item.AvgCpuPct = avgCpu;
+                        item.StorageTotalGb = storageGb;
+                        item.IdleDbCount = idleDbs;
+                        item.ProvisioningStatus = status;
+                    }
+                    catch
+                    {
+                        // DuckDB metrics may not exist yet — that's OK
+                    }
+
+                    return item;
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Error("FinOps", $"Failed to query {server.DisplayName}: {ex.Message}");
+                    return (ServerPropertyRow?)null;
+                }
+            });
+
+            var results = await System.Threading.Tasks.Task.WhenAll(tasks);
+            var data = results.Where(r => r != null).Cast<ServerPropertyRow>().ToList();
+
+            ServerInventoryDataGrid.ItemsSource = data;
             NoServerInventoryMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             ServerInventoryCountIndicator.Text = data.Count > 0 ? $"{data.Count} server(s)" : "";
         }
@@ -383,13 +423,40 @@ public partial class FinOpsTab : UserControl
         }
     }
 
+    private int GetWaitStatsHoursBack()
+    {
+        return WaitStatsTimeRangeCombo.SelectedIndex switch
+        {
+            0 => 1,
+            1 => 4,
+            2 => 12,
+            3 => 24,
+            4 => 168,
+            _ => 24
+        };
+    }
+
+    private int GetExpensiveQueriesHoursBack()
+    {
+        return ExpensiveQueriesTimeRangeCombo.SelectedIndex switch
+        {
+            0 => 1,
+            1 => 4,
+            2 => 12,
+            3 => 24,
+            4 => 168,
+            _ => 24
+        };
+    }
+
     private async System.Threading.Tasks.Task LoadWaitCategorySummaryAsync(int serverId)
     {
         if (_dataService == null) return;
 
         try
         {
-            var data = await _dataService.GetWaitCategorySummaryAsync(serverId);
+            var hoursBack = GetWaitStatsHoursBack();
+            var data = await _dataService.GetWaitCategorySummaryAsync(serverId, hoursBack);
             WaitCategorySummaryDataGrid.ItemsSource = data;
             WaitCategorySummaryNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         }
@@ -405,7 +472,8 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetExpensiveQueriesAsync(serverId);
+            var hoursBack = GetExpensiveQueriesHoursBack();
+            var data = await _dataService.GetExpensiveQueriesAsync(serverId, hoursBack);
             ExpensiveQueriesDataGrid.ItemsSource = data;
             ExpensiveQueriesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             ExpensiveQueriesCountIndicator.Text = data.Count > 0 ? $"{data.Count} query(s)" : "";
@@ -413,6 +481,22 @@ public partial class FinOpsTab : UserControl
         catch (Exception ex)
         {
             AppLogger.Error("FinOps", $"Failed to load expensive queries: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadMemoryGrantEfficiencyAsync(int serverId)
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var data = await _dataService.GetMemoryGrantEfficiencyAsync(serverId);
+            MemoryGrantEfficiencyDataGrid.ItemsSource = data;
+            MemoryGrantEfficiencyNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load memory grant efficiency: {ex.Message}");
         }
     }
 
@@ -460,6 +544,22 @@ public partial class FinOpsTab : UserControl
         if (serverId != 0) await LoadStorageGrowthAsync(serverId);
     }
 
+    private async void WaitStatsTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _dataService == null) return;
+        var serverId = GetSelectedServerId();
+        if (serverId == 0) return;
+        await LoadWaitCategorySummaryAsync(serverId);
+    }
+
+    private async void ExpensiveQueriesTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _dataService == null) return;
+        var serverId = GetSelectedServerId();
+        if (serverId == 0) return;
+        await LoadExpensiveQueriesAsync(serverId);
+    }
+
     private async void OptimizationRefresh_Click(object sender, RoutedEventArgs e)
     {
         var serverId = GetSelectedServerId();
@@ -469,7 +569,8 @@ public partial class FinOpsTab : UserControl
             LoadIdleDatabasesAsync(serverId),
             LoadTempdbSummaryAsync(serverId),
             LoadWaitCategorySummaryAsync(serverId),
-            LoadExpensiveQueriesAsync(serverId)
+            LoadExpensiveQueriesAsync(serverId),
+            LoadMemoryGrantEfficiencyAsync(serverId)
         );
     }
 

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -639,7 +639,7 @@ public partial class PlanViewerControl : UserControl
             || !string.IsNullOrEmpty(node.InnerSideJoinColumns)
             || !string.IsNullOrEmpty(node.OuterSideJoinColumns)
             || !string.IsNullOrEmpty(node.ActionColumn)
-            || node.ManyToMany || node.BitmapCreator
+            || node.ManyToMany || node.PhysicalOp == "Merge Join" || node.BitmapCreator
             || node.SortDistinct || node.StartupExpression
             || node.NLOptimized || node.WithOrderedPrefetch || node.WithUnorderedPrefetch
             || node.WithTies || node.Remoting || node.LocalParallelism
@@ -704,8 +704,10 @@ public partial class PlanViewerControl : UserControl
                 AddPropertyRow("Inner Join Cols", node.InnerSideJoinColumns, isCode: true);
             if (!string.IsNullOrEmpty(node.OuterSideJoinColumns))
                 AddPropertyRow("Outer Join Cols", node.OuterSideJoinColumns, isCode: true);
-            if (node.ManyToMany)
-                AddPropertyRow("Many to Many", "True");
+            if (node.PhysicalOp == "Merge Join")
+                AddPropertyRow("Many to Many", node.ManyToMany ? "Yes" : "No");
+            else if (node.ManyToMany)
+                AddPropertyRow("Many to Many", "Yes");
             if (!string.IsNullOrEmpty(node.ConstantScanValues))
                 AddPropertyRow("Values", node.ConstantScanValues, isCode: true);
             if (!string.IsNullOrEmpty(node.UdxUsedColumns))

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -67,33 +67,290 @@ ORDER BY database_name, file_type_desc, file_name";
     }
 
     /// <summary>
-    /// Gets the latest server properties snapshot per server (cross-server).
+    /// Queries a SQL Server directly for its properties via SERVERPROPERTY + sys.dm_os_sys_info.
+    /// Works from any database context — no PerformanceMonitor DB required.
     /// </summary>
-    public async Task<List<ServerPropertyRow>> GetServerPropertiesLatestAsync()
+    public static async Task<ServerPropertyRow> GetServerPropertiesLiveAsync(string connectionString)
+    {
+        using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        const string query = @"
+SELECT
+    CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
+    CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')),
+    CONVERT(nvarchar(128), SERVERPROPERTY('ProductLevel')),
+    CONVERT(nvarchar(128), SERVERPROPERTY('ProductUpdateLevel')),
+    si.cpu_count,
+    si.physical_memory_kb / 1024,
+    si.sqlserver_start_time,
+    (SELECT SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files),
+    si.socket_count,
+    si.cores_per_socket,
+    CONVERT(int, SERVERPROPERTY('EngineEdition')),
+    CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
+    CONVERT(int, SERVERPROPERTY('IsClustered'))
+FROM sys.dm_os_sys_info AS si;";
+
+        using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            var version = reader.IsDBNull(1) ? "" : reader.GetString(1);
+            var level = reader.IsDBNull(2) ? "" : reader.GetString(2);
+            var updateLevel = reader.IsDBNull(3) ? null : reader.GetString(3);
+            var versionDisplay = !string.IsNullOrEmpty(updateLevel)
+                ? $"{version} - {updateLevel}"
+                : $"{version} - {level}";
+
+            return new ServerPropertyRow
+            {
+                Edition = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                ProductVersion = versionDisplay,
+                CpuCount = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                PhysicalMemoryMb = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                SqlServerStartTime = reader.IsDBNull(6) ? null : reader.GetDateTime(6),
+                StorageTotalGb = reader.IsDBNull(7) ? null : Convert.ToDecimal(reader.GetValue(7)),
+                SocketCount = reader.IsDBNull(8) ? null : Convert.ToInt32(reader.GetValue(8)),
+                CoresPerSocket = reader.IsDBNull(9) ? null : Convert.ToInt32(reader.GetValue(9)),
+                EngineEdition = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
+                IsHadrEnabled = reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)) == 1,
+                IsClustered = reader.IsDBNull(12) ? null : Convert.ToInt32(reader.GetValue(12)) == 1,
+                LastUpdated = DateTime.Now
+            };
+        }
+
+        return new ServerPropertyRow();
+    }
+
+    /// <summary>
+    /// Gets collected metrics (CPU, storage, idle DBs) for a specific server from DuckDB.
+    /// </summary>
+    public async Task<(decimal? AvgCpuPct, decimal? StorageTotalGb, int? IdleDbCount, string? ProvisioningStatus)> GetServerMetricsAsync(int serverId)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
+
+        var cpuCutoff = DateTime.UtcNow.AddHours(-24);
+        var idleCutoff = DateTime.UtcNow.AddDays(-7);
+
         command.CommandText = @"
+WITH cpu_24h AS (
+    SELECT
+        AVG(CAST(sqlserver_cpu_utilization AS DECIMAL(5,2))) AS avg_cpu_pct,
+        MAX(sqlserver_cpu_utilization) AS max_cpu_pct,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu_pct
+    FROM v_cpu_utilization_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+),
+mem_latest AS (
+    SELECT
+        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
+    FROM v_memory_stats
+    WHERE server_id = $1
+    AND   (server_id, collection_time) IN (
+        SELECT server_id, MAX(collection_time)
+        FROM v_memory_stats
+        WHERE server_id = $1
+        GROUP BY server_id
+    )
+),
+storage_totals AS (
+    SELECT
+        SUM(total_size_mb) / 1024.0 AS total_storage_gb
+    FROM v_database_size_stats
+    WHERE server_id = $1
+    AND   (server_id, collection_time) IN (
+        SELECT server_id, MAX(collection_time)
+        FROM v_database_size_stats
+        WHERE server_id = $1
+        GROUP BY server_id
+    )
+),
+idle_dbs AS (
+    SELECT
+        COUNT(DISTINCT database_name) AS idle_db_count
+    FROM (
+        SELECT database_name
+        FROM v_database_size_stats
+        WHERE server_id = $1
+        AND   (server_id, collection_time) IN (
+            SELECT server_id, MAX(collection_time)
+            FROM v_database_size_stats
+            WHERE server_id = $1
+            GROUP BY server_id
+        )
+        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+        EXCEPT
+        SELECT DISTINCT database_name
+        FROM v_query_stats
+        WHERE server_id = $1
+        AND   collection_time >= $3
+        AND   delta_execution_count > 0
+    ) AS idle
+)
 SELECT
-    server_name,
-    edition,
-    product_version,
-    product_level,
-    product_update_level,
-    engine_edition,
-    cpu_count,
-    physical_memory_mb,
-    socket_count,
-    cores_per_socket,
-    is_hadr_enabled,
-    is_clustered
-FROM v_server_properties
-WHERE (server_id, collection_time) IN (
-    SELECT server_id, MAX(collection_time)
+    c.avg_cpu_pct,
+    st.total_storage_gb,
+    id.idle_db_count,
+    CASE
+        WHEN c.avg_cpu_pct < 15 AND c.max_cpu_pct < 40 AND COALESCE(m.memory_ratio, 0) < 0.5
+        THEN 'OVER_PROVISIONED'
+        WHEN c.p95_cpu_pct > 85 OR COALESCE(m.memory_ratio, 0) > 0.95
+        THEN 'UNDER_PROVISIONED'
+        ELSE 'RIGHT_SIZED'
+    END AS provisioning_status
+FROM (SELECT 1) AS anchor
+LEFT JOIN cpu_24h c ON true
+LEFT JOIN mem_latest m ON true
+LEFT JOIN storage_totals st ON true
+LEFT JOIN idle_dbs id ON true";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cpuCutoff });
+        command.Parameters.Add(new DuckDBParameter { Value = idleCutoff });
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return (
+                reader.IsDBNull(0) ? null : Convert.ToDecimal(reader.GetValue(0)),
+                reader.IsDBNull(1) ? null : Convert.ToDecimal(reader.GetValue(1)),
+                reader.IsDBNull(2) ? null : Convert.ToInt32(reader.GetValue(2)),
+                reader.IsDBNull(3) ? null : reader.GetString(3)
+            );
+        }
+
+        return (null, null, null, null);
+    }
+
+    /// <summary>
+    /// Gets the latest server properties snapshot per server (cross-server) from DuckDB.
+    /// Fallback for when live query is not available.
+    /// </summary>
+    public async Task<List<ServerPropertyRow>> GetServerPropertiesLatestAsync(IEnumerable<int>? activeServerIds = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cpuCutoff = DateTime.UtcNow.AddHours(-24);
+        var idleCutoff = DateTime.UtcNow.AddDays(-7);
+        var recentCutoff = DateTime.UtcNow.AddHours(-24);
+
+        // Build server ID filter — integers only, safe to inline
+        var serverFilter = "";
+        if (activeServerIds != null)
+        {
+            var idList = string.Join(",", activeServerIds);
+            if (!string.IsNullOrEmpty(idList))
+                serverFilter = $"AND server_id IN ({idList})";
+        }
+
+        command.CommandText = $@"
+WITH active_servers AS (
+    SELECT DISTINCT server_id, server_name
+    FROM v_cpu_utilization_stats
+    WHERE collection_time >= $3
+    {serverFilter}
+),
+latest_props AS (
+    SELECT *
     FROM v_server_properties
+    WHERE (server_id, collection_time) IN (
+        SELECT server_id, MAX(collection_time)
+        FROM v_server_properties
+        GROUP BY server_id
+    )
+),
+cpu_24h AS (
+    SELECT
+        server_id,
+        AVG(CAST(sqlserver_cpu_utilization AS DECIMAL(5,2))) AS avg_cpu_pct,
+        MAX(sqlserver_cpu_utilization) AS max_cpu_pct,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu_pct
+    FROM v_cpu_utilization_stats
+    WHERE collection_time >= $1
+    GROUP BY server_id
+),
+mem_latest AS (
+    SELECT
+        server_id,
+        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
+    FROM v_memory_stats
+    WHERE (server_id, collection_time) IN (
+        SELECT server_id, MAX(collection_time)
+        FROM v_memory_stats
+        GROUP BY server_id
+    )
+),
+storage_totals AS (
+    SELECT
+        server_id,
+        SUM(total_size_mb) / 1024.0 AS total_storage_gb
+    FROM v_database_size_stats
+    WHERE (server_id, collection_time) IN (
+        SELECT server_id, MAX(collection_time)
+        FROM v_database_size_stats
+        GROUP BY server_id
+    )
+    GROUP BY server_id
+),
+idle_dbs AS (
+    SELECT
+        server_id,
+        COUNT(DISTINCT database_name) AS idle_db_count
+    FROM (
+        SELECT server_id, database_name
+        FROM v_database_size_stats
+        WHERE (server_id, collection_time) IN (
+            SELECT server_id, MAX(collection_time)
+            FROM v_database_size_stats
+            GROUP BY server_id
+        )
+        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+        EXCEPT
+        SELECT DISTINCT server_id, database_name
+        FROM v_query_stats
+        WHERE collection_time >= $2
+        AND   delta_execution_count > 0
+    ) AS idle
     GROUP BY server_id
 )
-ORDER BY server_name";
+SELECT
+    a.server_name,
+    sp.edition,
+    sp.product_version,
+    sp.product_level,
+    sp.product_update_level,
+    sp.engine_edition,
+    sp.cpu_count,
+    sp.physical_memory_mb,
+    sp.socket_count,
+    sp.cores_per_socket,
+    sp.is_hadr_enabled,
+    sp.is_clustered,
+    c.avg_cpu_pct,
+    st.total_storage_gb,
+    id.idle_db_count,
+    CASE
+        WHEN c.avg_cpu_pct < 15 AND c.max_cpu_pct < 40 AND COALESCE(m.memory_ratio, 0) < 0.5
+        THEN 'OVER_PROVISIONED'
+        WHEN c.p95_cpu_pct > 85 OR COALESCE(m.memory_ratio, 0) > 0.95
+        THEN 'UNDER_PROVISIONED'
+        ELSE 'RIGHT_SIZED'
+    END AS provisioning_status
+FROM active_servers a
+LEFT JOIN latest_props sp ON sp.server_id = a.server_id
+LEFT JOIN cpu_24h c ON c.server_id = a.server_id
+LEFT JOIN mem_latest m ON m.server_id = a.server_id
+LEFT JOIN storage_totals st ON st.server_id = a.server_id
+LEFT JOIN idle_dbs id ON id.server_id = a.server_id
+ORDER BY a.server_name";
+
+        command.Parameters.Add(new DuckDBParameter { Value = cpuCutoff });
+        command.Parameters.Add(new DuckDBParameter { Value = idleCutoff });
+        command.Parameters.Add(new DuckDBParameter { Value = recentCutoff });
 
         var items = new List<ServerPropertyRow>();
         using var reader = await command.ExecuteReaderAsync();
@@ -112,7 +369,11 @@ ORDER BY server_name";
                 SocketCount = reader.IsDBNull(8) ? null : Convert.ToInt32(reader.GetValue(8)),
                 CoresPerSocket = reader.IsDBNull(9) ? null : Convert.ToInt32(reader.GetValue(9)),
                 IsHadrEnabled = reader.IsDBNull(10) ? null : reader.GetBoolean(10),
-                IsClustered = reader.IsDBNull(11) ? null : reader.GetBoolean(11)
+                IsClustered = reader.IsDBNull(11) ? null : reader.GetBoolean(11),
+                AvgCpuPct = reader.IsDBNull(12) ? null : Convert.ToDecimal(reader.GetValue(12)),
+                StorageTotalGb = reader.IsDBNull(13) ? null : Convert.ToDecimal(reader.GetValue(13)),
+                IdleDbCount = reader.IsDBNull(14) ? null : Convert.ToInt32(reader.GetValue(14)),
+                ProvisioningStatus = reader.IsDBNull(15) ? null : reader.GetString(15)
             });
         }
 
@@ -818,12 +1079,12 @@ FROM latest l CROSS JOIN peak p";
     /// <summary>
     /// Gets wait stats grouped by cost category over the last 24 hours.
     /// </summary>
-    public async Task<List<WaitCategorySummaryRow>> GetWaitCategorySummaryAsync(int serverId)
+    public async Task<List<WaitCategorySummaryRow>> GetWaitCategorySummaryAsync(int serverId, int hoursBack = 24)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 
-        var cutoff = DateTime.UtcNow.AddHours(-24);
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
         command.CommandText = @"
 WITH categorized AS (
@@ -839,7 +1100,7 @@ WITH categorized AS (
         END AS category,
         wait_type,
         SUM(delta_wait_time_ms) AS wait_time_ms,
-        SUM(delta_waiting_tasks_count) AS waiting_tasks
+        SUM(delta_waiting_tasks) AS waiting_tasks
     FROM v_wait_stats
     WHERE server_id = $1
     AND   collection_time >= $2
@@ -1067,6 +1328,156 @@ LIMIT $3";
 
         return (details, summaries);
     }
+
+    /// <summary>
+    /// Gets 7-day daily provisioning classification trend.
+    /// </summary>
+    public async Task<List<ProvisioningTrendRow>> GetProvisioningTrendAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddDays(-7);
+
+        command.CommandText = @"
+WITH daily_cpu AS (
+    SELECT
+        CAST(collection_time AS DATE) AS day,
+        AVG(CAST(sqlserver_cpu_utilization AS DECIMAL(5,2))) AS avg_cpu_pct,
+        MAX(sqlserver_cpu_utilization) AS max_cpu_pct,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu_pct
+    FROM v_cpu_utilization_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    GROUP BY CAST(collection_time AS DATE)
+),
+daily_mem AS (
+    SELECT
+        CAST(collection_time AS DATE) AS day,
+        AVG(CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0)) AS avg_memory_ratio
+    FROM v_memory_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    GROUP BY CAST(collection_time AS DATE)
+)
+SELECT
+    c.day,
+    c.avg_cpu_pct,
+    c.max_cpu_pct,
+    c.p95_cpu_pct,
+    COALESCE(m.avg_memory_ratio, 0)
+FROM daily_cpu c
+LEFT JOIN daily_mem m ON m.day = c.day
+ORDER BY c.day";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        var items = new List<ProvisioningTrendRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var avgCpu = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1));
+            var maxCpu = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2));
+            var p95Cpu = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3));
+            var memRatio = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4));
+
+            var status = "RIGHT_SIZED";
+            if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
+                status = "OVER_PROVISIONED";
+            else if (p95Cpu > 85 || memRatio > 0.95m)
+                status = "UNDER_PROVISIONED";
+
+            items.Add(new ProvisioningTrendRow
+            {
+                Day = reader.GetDateTime(0),
+                AvgCpuPct = avgCpu,
+                MaxCpuPct = maxCpu,
+                P95CpuPct = p95Cpu,
+                MemoryRatio = memRatio,
+                Status = status
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Gets memory grant efficiency stats for the Optimization tab.
+    /// Shows pool-level grant vs used efficiency from resource semaphore snapshots.
+    /// </summary>
+    public async Task<List<MemoryGrantEfficiencyRow>> GetMemoryGrantEfficiencyAsync(int serverId, int hoursBack = 24)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        command.CommandText = @"
+SELECT
+    CAST(collection_time AS DATE) AS day,
+    AVG(granted_memory_mb) AS avg_granted_mb,
+    AVG(used_memory_mb) AS avg_used_mb,
+    CAST(AVG(used_memory_mb) * 100.0 / NULLIF(AVG(granted_memory_mb), 0) AS DECIMAL(5,1)) AS efficiency_pct,
+    MAX(granted_memory_mb) AS peak_granted_mb,
+    SUM(grantee_count) AS total_grantees,
+    SUM(waiter_count) AS total_waiters,
+    SUM(timeout_error_count_delta) AS timeout_errors,
+    SUM(forced_grant_count_delta) AS forced_grants
+FROM v_memory_grant_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+GROUP BY CAST(collection_time AS DATE)
+ORDER BY CAST(collection_time AS DATE)";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        var items = new List<MemoryGrantEfficiencyRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new MemoryGrantEfficiencyRow
+            {
+                Day = reader.GetDateTime(0),
+                AvgGrantedMb = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+                AvgUsedMb = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2)),
+                EfficiencyPct = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                PeakGrantedMb = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                TotalGrantees = reader.IsDBNull(5) ? 0 : ToInt64(reader.GetValue(5)),
+                TotalWaiters = reader.IsDBNull(6) ? 0 : ToInt64(reader.GetValue(6)),
+                TimeoutErrors = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+                ForcedGrants = reader.IsDBNull(8) ? 0 : ToInt64(reader.GetValue(8))
+            });
+        }
+        return items;
+    }
+}
+
+public class ProvisioningTrendRow
+{
+    public DateTime Day { get; set; }
+    public decimal AvgCpuPct { get; set; }
+    public int MaxCpuPct { get; set; }
+    public decimal P95CpuPct { get; set; }
+    public decimal MemoryRatio { get; set; }
+    public string Status { get; set; } = "";
+    public string DayDisplay => Day.ToString("ddd MM/dd");
+    public string StatusDisplay => Status.Replace("_", " ");
+}
+
+public class MemoryGrantEfficiencyRow
+{
+    public DateTime Day { get; set; }
+    public decimal AvgGrantedMb { get; set; }
+    public decimal AvgUsedMb { get; set; }
+    public decimal EfficiencyPct { get; set; }
+    public decimal PeakGrantedMb { get; set; }
+    public long TotalGrantees { get; set; }
+    public long TotalWaiters { get; set; }
+    public long TimeoutErrors { get; set; }
+    public long ForcedGrants { get; set; }
+    public string DayDisplay => Day.ToString("ddd MM/dd");
+    public decimal WastedMb => AvgGrantedMb - AvgUsedMb;
 }
 
 public class TopResourceConsumerRow
@@ -1167,11 +1578,28 @@ public class ServerPropertyRow
     public long PhysicalMemoryMb { get; set; }
     public int? SocketCount { get; set; }
     public int? CoresPerSocket { get; set; }
+    public DateTime? SqlServerStartTime { get; set; }
+    public DateTime? LastUpdated { get; set; }
     public bool? IsHadrEnabled { get; set; }
     public bool? IsClustered { get; set; }
 
+    public decimal? AvgCpuPct { get; set; }
+    public decimal? StorageTotalGb { get; set; }
+    public int? IdleDbCount { get; set; }
+    public string? ProvisioningStatus { get; set; }
+
+    public string UptimeDisplay
+    {
+        get
+        {
+            if (SqlServerStartTime == null) return "";
+            var uptime = DateTime.Now - SqlServerStartTime.Value;
+            return $"{(int)uptime.TotalDays}d {uptime.Hours}h";
+        }
+    }
     public string HadrDisplay => IsHadrEnabled.HasValue ? (IsHadrEnabled.Value ? "Yes" : "No") : "";
     public string ClusteredDisplay => IsClustered.HasValue ? (IsClustered.Value ? "Yes" : "No") : "";
+    public string ProvisioningDisplay => ProvisioningStatus?.Replace("_", " ") ?? "";
 }
 
 public class DatabaseSizeTrendPoint

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -188,48 +188,44 @@ public static partial class PlanAnalyzer
             });
         }
 
-        // Rule 25: Ineffective parallelism — parallel plan where CPU ≈ elapsed
+        // Rule 25: Ineffective parallelism — DOP-aware efficiency scoring
+        // Efficiency = (speedup - 1) / (DOP - 1) * 100
+        // where speedup = CPU / Elapsed. At DOP 1 speedup=1 (0%), at DOP=speedup (100%).
+        // Rule 31: Parallel wait bottleneck — elapsed >> CPU means threads waiting, not working.
         if (stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
         {
             var cpu = stmt.QueryTimeStats.CpuTimeMs;
             var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
+            var dop = stmt.DegreeOfParallelism;
 
             if (elapsed >= 1000 && cpu > 0)
             {
-                var ratio = (double)cpu / elapsed;
-                if (ratio >= 0.8 && ratio <= 1.3)
-                {
-                    stmt.PlanWarnings.Add(new PlanWarning
-                    {
-                        WarningType = "Ineffective Parallelism",
-                        Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) but CPU time ({cpu:N0}ms) is nearly equal to elapsed time ({elapsed:N0}ms). " +
-                                  $"The work ran essentially serially despite the overhead of parallelism. " +
-                                  $"Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.",
-                        Severity = PlanWarningSeverity.Warning
-                    });
-                }
-            }
-        }
+                var speedup = (double)cpu / elapsed;
+                var efficiency = Math.Max(0.0, Math.Min(100.0, (speedup - 1.0) / (dop - 1.0) * 100.0));
 
-        // Rule 31: Parallel wait bottleneck — elapsed time significantly exceeds CPU time
-        if (stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
-        {
-            var cpu = stmt.QueryTimeStats.CpuTimeMs;
-            var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
-
-            if (elapsed >= 1000 && cpu > 0)
-            {
-                var ratio = (double)cpu / elapsed;
-                if (ratio < 0.8)
+                if (speedup < 0.5)
                 {
-                    var waitPct = (1.0 - ratio) * 100;
+                    // CPU well below Elapsed: threads are waiting, not doing CPU work
+                    var waitPct = (1.0 - speedup) * 100;
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
                         WarningType = "Parallel Wait Bottleneck",
-                        Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) with elapsed time ({elapsed:N0}ms) significantly exceeding CPU time ({cpu:N0}ms). " +
+                        Message = $"Parallel plan (DOP {dop}, {efficiency:N0}% efficient) with elapsed time ({elapsed:N0}ms) exceeding CPU time ({cpu:N0}ms). " +
                                   $"Approximately {waitPct:N0}% of elapsed time was spent waiting rather than on CPU. " +
                                   $"Common causes include spills to tempdb, physical I/O reads, lock or latch contention, and memory grant waits.",
                         Severity = PlanWarningSeverity.Warning
+                    });
+                }
+                else if (efficiency < 40)
+                {
+                    // CPU >= Elapsed but well below DOP potential — parallelism is ineffective
+                    stmt.PlanWarnings.Add(new PlanWarning
+                    {
+                        WarningType = "Ineffective Parallelism",
+                        Message = $"Parallel plan (DOP {dop}) is only {efficiency:N0}% efficient — CPU time ({cpu:N0}ms) vs elapsed time ({elapsed:N0}ms). " +
+                                  $"At DOP {dop}, ideal CPU time would be ~{elapsed * dop:N0}ms. " +
+                                  $"Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.",
+                        Severity = efficiency < 20 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                     });
                 }
             }


### PR DESCRIPTION
## Summary

- **Reorder Index Analysis Summary columns** by actionability (space saved, % reduction, removable first)
- **Time range controls** on Expensive Queries and Wait Stats sections (1h/4h/12h/24h/7d)
- **7-day provisioning trend** grid below provisioning badge showing daily classification
- **Server Inventory as estate summary** — live SERVERPROPERTY queries per server + collected metrics augmentation, unified 15-column superset across Dashboard and Lite
- **Conditional formatting** on provisioning status, idle DBs, expensive queries, storage growth rate
- **Memory Grant Efficiency** section in Optimization tab (granted vs used, efficiency ratio, worst offenders)

All features applied to both Dashboard (SQL Server backend) and Lite (DuckDB backend).

## Test plan

- [x] Dashboard: Server Inventory shows all configured servers with live data (edition, version, CPUs, memory, sockets, storage, uptime, HADR, clustered)
- [x] Dashboard: Collected metrics (avg CPU, idle DBs, provisioning status) augment live data where available
- [x] Dashboard: Storage GB populates for all servers (not just SQL2022)
- [x] Lite: Server Inventory matches Dashboard column set
- [x] Lite: Wait stats load correctly (delta_waiting_tasks column fix)
- [x] Both: Provisioning trend grid renders below badge without overlap
- [x] Both: Time range dropdowns work on Expensive Queries and Wait Stats
- [x] Both: Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)