### PR TITLE
Add compression ratio stats to 2.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Important
 
-- **Schema upgrade**: Three large collection tables (`query_stats`, `procedure_stats`, `query_store_data`) are migrated to use `COMPRESS()` for query text and plan columns, reducing storage by ~60-80%. The upgrade performs a table swap (create new → migrate data → rename) which may take several minutes on large tables. A `row_hash` column is added for deduplication. Three new tracking tables are also created. Volume stats columns are added to `database_size_stats`. Upgrade scripts run automatically via the CLI/GUI installer and use idempotent checks.
+- **Schema upgrade**: Three large collection tables (`query_stats`, `procedure_stats`, `query_store_data`) are migrated to use `COMPRESS()` for query text and plan columns. The upgrade performs a table swap (create new → migrate data → rename) which may take several minutes on large tables. A `row_hash` column is added for deduplication. Three new tracking tables are also created. Volume stats columns are added to `database_size_stats`. Upgrade scripts run automatically via the CLI/GUI installer and use idempotent checks.
+
+  Compression results measured on a production instance:
+
+  | Table | Compressed | Uncompressed | Ratio |
+  |---|---|---|---|
+  | query_stats | 18.0 MB | 339.0 MB | 18.8x |
+  | query_store_data | 13.5 MB | 258.0 MB | 19.1x |
+  | **Total** | **31.5 MB** | **597 MB** | **~19x** |
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Adds measured compression ratio table to the 2.2.0 changelog Important section
- Shows 19x compression on query_stats and query_store_data (597 MB → 31.5 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)