### PR TITLE
Fix ComboBox focus steal in plan viewer + DOP 2 skew threshold

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -2122,7 +2122,28 @@ public partial class PlanViewerControl : UserControl
 
     private void PlanViewerControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
+        // Don't steal focus from interactive controls (ComboBox, DataGrid, TextBox, etc.)
+        // ComboBox dropdown items live in a separate visual tree (Popup), so also check
+        // for ComboBoxItem to avoid stealing focus when selecting dropdown items.
+        if (e.OriginalSource is System.Windows.Controls.Primitives.TextBoxBase
+            || e.OriginalSource is ComboBox
+            || e.OriginalSource is ComboBoxItem
+            || FindVisualParent<ComboBox>(e.OriginalSource as DependencyObject) != null
+            || FindVisualParent<ComboBoxItem>(e.OriginalSource as DependencyObject) != null
+            || FindVisualParent<DataGrid>(e.OriginalSource as DependencyObject) != null)
+            return;
+
         Focus();
+    }
+
+    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
+    {
+        while (child != null)
+        {
+            if (child is T parent) return parent;
+            child = VisualTreeHelper.GetParent(child);
+        }
+        return null;
     }
 
     private void PlanViewerControl_PreviewKeyDown(object sender, KeyEventArgs e)

--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -509,15 +509,19 @@ public static partial class PlanAnalyzer
 
         // Rule 8: Parallel thread skew (actual plans with per-thread stats)
         // Only warn when there are enough rows to meaningfully distribute across threads
+        // Filter out thread 0 (coordinator) which typically does 0 rows in parallel operators
         if (node.PerThreadStats.Count > 1)
         {
-            var totalRows = node.PerThreadStats.Sum(t => t.ActualRows);
-            var minRowsForSkew = node.PerThreadStats.Count * 1000;
+            var workerThreads = node.PerThreadStats.Where(t => t.ThreadId > 0).ToList();
+            if (workerThreads.Count < 2) workerThreads = node.PerThreadStats; // fallback
+            var totalRows = workerThreads.Sum(t => t.ActualRows);
+            var minRowsForSkew = workerThreads.Count * 1000;
             if (totalRows >= minRowsForSkew)
             {
-                var maxThread = node.PerThreadStats.OrderByDescending(t => t.ActualRows).First();
+                var maxThread = workerThreads.OrderByDescending(t => t.ActualRows).First();
                 var skewRatio = (double)maxThread.ActualRows / totalRows;
-                var skewThreshold = node.PerThreadStats.Count == 2 ? 0.75 : 0.50;
+                // At DOP 2, a 60/40 split is normal — use higher threshold
+                var skewThreshold = workerThreads.Count <= 2 ? 0.80 : 0.50;
                 if (skewRatio >= skewThreshold)
                 {
                     node.Warnings.Add(new PlanWarning

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -2133,7 +2133,28 @@ public partial class PlanViewerControl : UserControl
 
     private void PlanViewerControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
+        // Don't steal focus from interactive controls (ComboBox, TextBox, Button, etc.)
+        // ComboBox dropdown items live in a separate visual tree (Popup), so also check
+        // for ComboBoxItem to avoid stealing focus when selecting dropdown items.
+        if (e.OriginalSource is System.Windows.Controls.Primitives.TextBoxBase
+            || e.OriginalSource is ComboBox
+            || e.OriginalSource is ComboBoxItem
+            || FindVisualParent<ComboBox>(e.OriginalSource as DependencyObject) != null
+            || FindVisualParent<ComboBoxItem>(e.OriginalSource as DependencyObject) != null
+            || FindVisualParent<DataGrid>(e.OriginalSource as DependencyObject) != null)
+            return;
+
         Focus();
+    }
+
+    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
+    {
+        while (child != null)
+        {
+            if (child is T parent) return parent;
+            child = VisualTreeHelper.GetParent(child);
+        }
+        return null;
     }
 
     private void PlanViewerControl_PreviewKeyDown(object sender, KeyEventArgs e)

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -509,15 +509,19 @@ public static partial class PlanAnalyzer
 
         // Rule 8: Parallel thread skew (actual plans with per-thread stats)
         // Only warn when there are enough rows to meaningfully distribute across threads
+        // Filter out thread 0 (coordinator) which typically does 0 rows in parallel operators
         if (node.PerThreadStats.Count > 1)
         {
-            var totalRows = node.PerThreadStats.Sum(t => t.ActualRows);
-            var minRowsForSkew = node.PerThreadStats.Count * 1000;
+            var workerThreads = node.PerThreadStats.Where(t => t.ThreadId > 0).ToList();
+            if (workerThreads.Count < 2) workerThreads = node.PerThreadStats; // fallback
+            var totalRows = workerThreads.Sum(t => t.ActualRows);
+            var minRowsForSkew = workerThreads.Count * 1000;
             if (totalRows >= minRowsForSkew)
             {
-                var maxThread = node.PerThreadStats.OrderByDescending(t => t.ActualRows).First();
+                var maxThread = workerThreads.OrderByDescending(t => t.ActualRows).First();
                 var skewRatio = (double)maxThread.ActualRows / totalRows;
-                var skewThreshold = node.PerThreadStats.Count == 2 ? 0.75 : 0.50;
+                // At DOP 2, a 60/40 split is normal — use higher threshold
+                var skewThreshold = workerThreads.Count <= 2 ? 0.80 : 0.50;
                 if (skewRatio >= skewThreshold)
                 {
                     node.Warnings.Add(new PlanWarning


### PR DESCRIPTION
## Summary

**ComboBox statement selector (fixes #507):**
- `PreviewMouseDown` was calling `Focus()` which stole focus from ComboBox dropdown items, preventing statement selection in multi-statement plans
- Dropdown items live in a separate Popup visual tree, so `FindVisualParent<ComboBox>` couldn't walk back to the parent
- Added `ComboBoxItem` and `FindVisualParent<ComboBoxItem>` checks to both Dashboard and Lite
- Also added missing `FindVisualParent<DataGrid>` guard to Lite (Dashboard already had it)

**Parallel skew Rule 8 (synced from PerformanceStudio #73):**
- Filter out thread 0 (coordinator) from skew calculation — it inflates thread count
- Raise DOP 2 threshold from 75% to 80% — a 53/47 split with 2 workers is normal

## Test plan

- [ ] Load multi-statement plan in Lite → click different statements in ComboBox dropdown
- [ ] Load multi-statement plan in Dashboard → same test
- [ ] Verify DOP 2 plan with mild skew (53/47) no longer fires Parallel Skew warning
- [ ] Verify DOP 4+ plan with genuine skew still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)