### PR TITLE
Add performance instrumentation, caching, and parallelization

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -128,17 +128,10 @@ namespace PerformanceMonitorDashboard.Controls
 
                 if (efficiency != null)
                 {
-                    var topTotalTask = _databaseService.GetFinOpsTopResourceConsumersByTotalAsync();
-                    var topAvgTask = _databaseService.GetFinOpsTopResourceConsumersByAvgAsync();
-                    var sizesTask = _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
-                    var trendTask = _databaseService.GetFinOpsProvisioningTrendAsync();
-
-                    await Task.WhenAll(topTotalTask, topAvgTask, sizesTask, trendTask);
-
-                    TopTotalGrid.ItemsSource = topTotalTask.Result;
-                    TopAvgGrid.ItemsSource = topAvgTask.Result;
-                    DbSizeChart.ItemsSource = sizesTask.Result;
-                    ProvisioningTrendGrid.ItemsSource = trendTask.Result;
+                    TopTotalGrid.ItemsSource = await _databaseService.GetFinOpsTopResourceConsumersByTotalAsync();
+                    TopAvgGrid.ItemsSource = await _databaseService.GetFinOpsTopResourceConsumersByAvgAsync();
+                    DbSizeChart.ItemsSource = await _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
+                    ProvisioningTrendGrid.ItemsSource = await _databaseService.GetFinOpsProvisioningTrendAsync();
                 }
             }
             catch (Exception ex)

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -28,6 +28,8 @@ namespace PerformanceMonitorDashboard.Controls
         private DatabaseService? _databaseService;
         private ServerManager? _serverManager;
         private CredentialService? _credentialService;
+        private List<FinOpsServerInventory>? _serverInventoryCache;
+        private DateTime _serverInventoryCacheTime;
 
         public FinOpsContent()
         {
@@ -126,17 +128,17 @@ namespace PerformanceMonitorDashboard.Controls
 
                 if (efficiency != null)
                 {
-                    var topTotal = await _databaseService.GetFinOpsTopResourceConsumersByTotalAsync();
-                    TopTotalGrid.ItemsSource = topTotal;
+                    var topTotalTask = _databaseService.GetFinOpsTopResourceConsumersByTotalAsync();
+                    var topAvgTask = _databaseService.GetFinOpsTopResourceConsumersByAvgAsync();
+                    var sizesTask = _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
+                    var trendTask = _databaseService.GetFinOpsProvisioningTrendAsync();
 
-                    var topAvg = await _databaseService.GetFinOpsTopResourceConsumersByAvgAsync();
-                    TopAvgGrid.ItemsSource = topAvg;
+                    await Task.WhenAll(topTotalTask, topAvgTask, sizesTask, trendTask);
 
-                    var sizes = await _databaseService.GetFinOpsDatabaseSizeSummaryAsync();
-                    DbSizeChart.ItemsSource = sizes;
-
-                    var trend = await _databaseService.GetFinOpsProvisioningTrendAsync();
-                    ProvisioningTrendGrid.ItemsSource = trend;
+                    TopTotalGrid.ItemsSource = topTotalTask.Result;
+                    TopAvgGrid.ItemsSource = topAvgTask.Result;
+                    DbSizeChart.ItemsSource = sizesTask.Result;
+                    ProvisioningTrendGrid.ItemsSource = trendTask.Result;
                 }
             }
             catch (Exception ex)
@@ -539,9 +541,19 @@ namespace PerformanceMonitorDashboard.Controls
         // Server Inventory Tab
         // ============================================
 
-        private async Task LoadServerInventoryAsync()
+        private async Task LoadServerInventoryAsync(bool forceRefresh = false)
         {
             if (_serverManager == null || _credentialService == null) return;
+
+            // Use cache if available and less than 5 minutes old
+            if (!forceRefresh && _serverInventoryCache != null
+                && (DateTime.Now - _serverInventoryCacheTime).TotalMinutes < 5)
+            {
+                ServerInventoryDataGrid.ItemsSource = _serverInventoryCache;
+                ServerInventoryNoDataMessage.Visibility = _serverInventoryCache.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                ServerInventoryCountIndicator.Text = _serverInventoryCache.Count > 0 ? $"{_serverInventoryCache.Count} server(s)" : "";
+                return;
+            }
 
             try
             {
@@ -583,6 +595,9 @@ namespace PerformanceMonitorDashboard.Controls
 
                 var results = await Task.WhenAll(tasks);
                 var allItems = results.Where(r => r != null).Cast<FinOpsServerInventory>().ToList();
+
+                _serverInventoryCache = allItems;
+                _serverInventoryCacheTime = DateTime.Now;
 
                 ServerInventoryDataGrid.ItemsSource = allItems;
                 ServerInventoryNoDataMessage.Visibility = allItems.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
@@ -648,7 +663,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         private async void ServerInventoryRefresh_Click(object sender, RoutedEventArgs e)
         {
-            await LoadServerInventoryAsync();
+            await LoadServerInventoryAsync(forceRefresh: true);
         }
 
         // ============================================

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -2034,7 +2034,7 @@ public partial class PlanViewerControl : UserControl
         if (statement.MemoryGrant != null)
         {
             var mg = statement.MemoryGrant;
-            AddRow("Memory grant", $"{mg.GrantedMemoryKB:N0} KB granted, {mg.MaxUsedMemoryKB:N0} KB used");
+            AddRow("Memory grant", $"{FormatMemoryGrantKB(mg.GrantedMemoryKB)} granted, {FormatMemoryGrantKB(mg.MaxUsedMemoryKB)} used");
             if (mg.GrantWaitTimeMs > 0)
                 AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms");
         }
@@ -2076,6 +2076,19 @@ public partial class PlanViewerControl : UserControl
             AddRow("Early abort", statement.StatementOptmEarlyAbortReason);
 
         RuntimeSummaryContent.Children.Add(grid);
+    }
+
+    /// <summary>
+    /// Formats a memory value given in KB to a human-readable string.
+    /// Under 1,024 KB: show KB. 1,024-1,048,576 KB: show MB (1 decimal). Over 1,048,576 KB: show GB (2 decimals).
+    /// </summary>
+    private static string FormatMemoryGrantKB(long kb)
+    {
+        if (kb < 1024)
+            return $"{kb:N0} KB";
+        if (kb < 1024 * 1024)
+            return $"{kb / 1024.0:N1} MB";
+        return $"{kb / (1024.0 * 1024.0):N2} GB";
     }
 
     private void UpdateInsightsHeader()

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -189,6 +189,8 @@ public partial class App : Application
         // Initialize logging
         var logDirectory = Path.Combine(exeDirectory, "logs");
         AppLogger.Initialize(logDirectory);
+        Helpers.MethodProfiler.Initialize(logDirectory);
+        Helpers.QueryLogger.Initialize(logDirectory);
         AppLogger.Info("App", $"Starting PerformanceMonitorLite v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
         AppLogger.Info("App", $"Data directory: {DataDirectory}");
 

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -108,12 +108,10 @@ public partial class FinOpsTab : UserControl
         var serverId = GetSelectedServerId();
         if (serverId == 0 || _dataService == null) return;
 
-        await System.Threading.Tasks.Task.WhenAll(
-            LoadUtilizationAsync(serverId),
-            LoadDatabaseResourcesAsync(serverId),
-            LoadApplicationConnectionsAsync(serverId),
-            LoadDatabaseSizesAsync(serverId)
-        );
+        await LoadUtilizationAsync(serverId);
+        await LoadDatabaseResourcesAsync(serverId);
+        await LoadApplicationConnectionsAsync(serverId);
+        await LoadDatabaseSizesAsync(serverId);
     }
 
     private async System.Threading.Tasks.Task LoadUtilizationAsync(int serverId)
@@ -129,17 +127,10 @@ public partial class FinOpsTab : UserControl
 
             if (data != null)
             {
-                var topTotalTask = _dataService.GetTopResourceConsumersByTotalAsync(serverId);
-                var topAvgTask = _dataService.GetTopResourceConsumersByAvgAsync(serverId);
-                var sizesTask = _dataService.GetDatabaseSizeSummaryAsync(serverId);
-                var trendTask = _dataService.GetProvisioningTrendAsync(serverId);
-
-                await System.Threading.Tasks.Task.WhenAll(topTotalTask, topAvgTask, sizesTask, trendTask);
-
-                TopTotalGrid.ItemsSource = topTotalTask.Result;
-                TopAvgGrid.ItemsSource = topAvgTask.Result;
-                DbSizeChart.ItemsSource = sizesTask.Result;
-                ProvisioningTrendGrid.ItemsSource = trendTask.Result;
+                TopTotalGrid.ItemsSource = await _dataService.GetTopResourceConsumersByTotalAsync(serverId);
+                TopAvgGrid.ItemsSource = await _dataService.GetTopResourceConsumersByAvgAsync(serverId);
+                DbSizeChart.ItemsSource = await _dataService.GetDatabaseSizeSummaryAsync(serverId);
+                ProvisioningTrendGrid.ItemsSource = await _dataService.GetProvisioningTrendAsync(serverId);
             }
         }
         catch (Exception ex)

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -26,6 +26,8 @@ public partial class FinOpsTab : UserControl
     private LocalDataService? _dataService;
     private ServerManager? _serverManager;
     private CredentialService? _credentialService;
+    private List<ServerPropertyRow>? _serverInventoryCache;
+    private DateTime _serverInventoryCacheTime;
 
     public FinOpsTab()
     {
@@ -52,6 +54,7 @@ public partial class FinOpsTab : UserControl
     public void RefreshServerList()
     {
         if (_serverManager == null) return;
+        _serverInventoryCache = null; // Invalidate cache when server list changes
 
         var previousSelection = ServerSelector.SelectedItem as ServerConnection;
         var servers = _serverManager.GetAllServers();
@@ -101,13 +104,16 @@ public partial class FinOpsTab : UserControl
 
     private async System.Threading.Tasks.Task LoadPerServerDataAsync()
     {
+        using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-PerServerData");
         var serverId = GetSelectedServerId();
         if (serverId == 0 || _dataService == null) return;
 
-        await LoadUtilizationAsync(serverId);
-        await LoadDatabaseResourcesAsync(serverId);
-        await LoadApplicationConnectionsAsync(serverId);
-        await LoadDatabaseSizesAsync(serverId);
+        await System.Threading.Tasks.Task.WhenAll(
+            LoadUtilizationAsync(serverId),
+            LoadDatabaseResourcesAsync(serverId),
+            LoadApplicationConnectionsAsync(serverId),
+            LoadDatabaseSizesAsync(serverId)
+        );
     }
 
     private async System.Threading.Tasks.Task LoadUtilizationAsync(int serverId)
@@ -123,17 +129,17 @@ public partial class FinOpsTab : UserControl
 
             if (data != null)
             {
-                var topTotal = await _dataService.GetTopResourceConsumersByTotalAsync(serverId);
-                TopTotalGrid.ItemsSource = topTotal;
+                var topTotalTask = _dataService.GetTopResourceConsumersByTotalAsync(serverId);
+                var topAvgTask = _dataService.GetTopResourceConsumersByAvgAsync(serverId);
+                var sizesTask = _dataService.GetDatabaseSizeSummaryAsync(serverId);
+                var trendTask = _dataService.GetProvisioningTrendAsync(serverId);
 
-                var topAvg = await _dataService.GetTopResourceConsumersByAvgAsync(serverId);
-                TopAvgGrid.ItemsSource = topAvg;
+                await System.Threading.Tasks.Task.WhenAll(topTotalTask, topAvgTask, sizesTask, trendTask);
 
-                var sizes = await _dataService.GetDatabaseSizeSummaryAsync(serverId);
-                DbSizeChart.ItemsSource = sizes;
-
-                var trend = await _dataService.GetProvisioningTrendAsync(serverId);
-                ProvisioningTrendGrid.ItemsSource = trend;
+                TopTotalGrid.ItemsSource = topTotalTask.Result;
+                TopAvgGrid.ItemsSource = topAvgTask.Result;
+                DbSizeChart.ItemsSource = sizesTask.Result;
+                ProvisioningTrendGrid.ItemsSource = trendTask.Result;
             }
         }
         catch (Exception ex)
@@ -318,9 +324,20 @@ public partial class FinOpsTab : UserControl
         }
     }
 
-    private async System.Threading.Tasks.Task LoadServerInventoryAsync()
+    private async System.Threading.Tasks.Task LoadServerInventoryAsync(bool forceRefresh = false)
     {
+        using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-ServerInventory");
         if (_dataService == null || _serverManager == null || _credentialService == null) return;
+
+        // Use cache if available and less than 5 minutes old
+        if (!forceRefresh && _serverInventoryCache != null
+            && (DateTime.Now - _serverInventoryCacheTime).TotalMinutes < 5)
+        {
+            ServerInventoryDataGrid.ItemsSource = _serverInventoryCache;
+            NoServerInventoryMessage.Visibility = _serverInventoryCache.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            ServerInventoryCountIndicator.Text = _serverInventoryCache.Count > 0 ? $"{_serverInventoryCache.Count} server(s)" : "";
+            return;
+        }
 
         try
         {
@@ -341,10 +358,10 @@ public partial class FinOpsTab : UserControl
                     {
                         var serverId = RemoteCollectorService.GetDeterministicHashCode(server.ServerName);
                         var (avgCpu, storageGb, idleDbs, status) = await _dataService!.GetServerMetricsAsync(serverId);
-                        item.AvgCpuPct = avgCpu;
-                        item.StorageTotalGb = storageGb;
-                        item.IdleDbCount = idleDbs;
-                        item.ProvisioningStatus = status;
+                        if (avgCpu.HasValue) item.AvgCpuPct = avgCpu;
+                        if (storageGb.HasValue) item.StorageTotalGb = storageGb;
+                        if (idleDbs.HasValue) item.IdleDbCount = idleDbs;
+                        if (status != null) item.ProvisioningStatus = status;
                     }
                     catch
                     {
@@ -362,6 +379,9 @@ public partial class FinOpsTab : UserControl
 
             var results = await System.Threading.Tasks.Task.WhenAll(tasks);
             var data = results.Where(r => r != null).Cast<ServerPropertyRow>().ToList();
+
+            _serverInventoryCache = data;
+            _serverInventoryCacheTime = DateTime.Now;
 
             ServerInventoryDataGrid.ItemsSource = data;
             NoServerInventoryMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
@@ -535,7 +555,7 @@ public partial class FinOpsTab : UserControl
 
     private async void RefreshServerInventory_Click(object sender, RoutedEventArgs e)
     {
-        await LoadServerInventoryAsync();
+        await LoadServerInventoryAsync(forceRefresh: true);
     }
 
     private async void RefreshStorageGrowth_Click(object sender, RoutedEventArgs e)
@@ -562,6 +582,7 @@ public partial class FinOpsTab : UserControl
 
     private async void OptimizationRefresh_Click(object sender, RoutedEventArgs e)
     {
+        using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-OptimizationRefresh");
         var serverId = GetSelectedServerId();
         if (serverId == 0 || _dataService == null) return;
 
@@ -576,6 +597,7 @@ public partial class FinOpsTab : UserControl
 
     private async void RunIndexAnalysis_Click(object sender, RoutedEventArgs e)
     {
+        using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-IndexAnalysis");
         if (_serverManager == null || _credentialService == null) return;
 
         var server = ServerSelector.SelectedItem as ServerConnection;

--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -2045,7 +2045,7 @@ public partial class PlanViewerControl : UserControl
         if (statement.MemoryGrant != null)
         {
             var mg = statement.MemoryGrant;
-            AddRow("Memory grant", $"{mg.GrantedMemoryKB:N0} KB granted, {mg.MaxUsedMemoryKB:N0} KB used");
+            AddRow("Memory grant", $"{FormatMemoryGrantKB(mg.GrantedMemoryKB)} granted, {FormatMemoryGrantKB(mg.MaxUsedMemoryKB)} used");
             if (mg.GrantWaitTimeMs > 0)
                 AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms");
         }
@@ -2087,6 +2087,19 @@ public partial class PlanViewerControl : UserControl
             AddRow("Early abort", statement.StatementOptmEarlyAbortReason);
 
         RuntimeSummaryContent.Children.Add(grid);
+    }
+
+    /// <summary>
+    /// Formats a memory value given in KB to a human-readable string.
+    /// Under 1,024 KB: show KB. 1,024-1,048,576 KB: show MB (1 decimal). Over 1,048,576 KB: show GB (2 decimals).
+    /// </summary>
+    private static string FormatMemoryGrantKB(long kb)
+    {
+        if (kb < 1024)
+            return $"{kb:N0} KB";
+        if (kb < 1024 * 1024)
+            return $"{kb / 1024.0:N1} MB";
+        return $"{kb / (1024.0 * 1024.0):N2} GB";
     }
 
     private void UpdateInsightsHeader()

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -561,6 +561,7 @@ public partial class ServerTab : UserControl
 
         try
         {
+            using var _profiler = Helpers.MethodProfiler.StartTiming($"ServerTab-{_server?.DisplayName}");
             var loadSw = Stopwatch.StartNew();
 
             /* Load all tabs in parallel */

--- a/Lite/Helpers/MethodProfiler.cs
+++ b/Lite/Helpers/MethodProfiler.cs
@@ -1,0 +1,152 @@
+/*
+ * SQL Server Performance Monitor Lite
+ *
+ * Method profiler for tracking slow application code
+ */
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Profiles method execution time and logs slow methods.
+/// Usage: using var _ = MethodProfiler.StartTiming("context");
+/// </summary>
+public static class MethodProfiler
+{
+    private static string s_logDirectory = "";
+    private static readonly object _lock = new();
+    private static volatile bool _isEnabled = true;
+    private static double _thresholdMs = 500;
+
+    public static void Initialize(string logDirectory)
+    {
+        s_logDirectory = logDirectory;
+        try
+        {
+            if (!Directory.Exists(s_logDirectory))
+                Directory.CreateDirectory(s_logDirectory);
+            CleanOldLogs();
+        }
+        catch { }
+    }
+
+    public static string GetCurrentLogFile()
+        => Path.Combine(s_logDirectory, $"MethodProfile_{DateTime.Now:yyyyMMdd}.log");
+
+    public static string GetLogDirectory() => s_logDirectory;
+
+    public static void SetEnabled(bool enabled) => _isEnabled = enabled;
+    public static bool IsEnabled => _isEnabled;
+
+    public static void SetThresholdMs(double thresholdMs) => _thresholdMs = thresholdMs;
+    public static double ThresholdMs => _thresholdMs;
+
+    public static MethodTimingContext StartTiming(
+        string? context = null,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0)
+    {
+        return new MethodTimingContext(context, memberName, filePath, lineNumber);
+    }
+
+    internal static void LogSlowMethod(
+        DateTime startTime,
+        DateTime endTime,
+        double elapsedMs,
+        string? context,
+        string memberName,
+        string filePath,
+        int lineNumber)
+    {
+        if (!_isEnabled || string.IsNullOrEmpty(s_logDirectory))
+            return;
+
+        if (elapsedMs < _thresholdMs)
+            return;
+
+        try
+        {
+            lock (_lock)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "SLOW METHOD: {0:F0}ms - {1}", elapsedMs, memberName));
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Start Time:   {0:yyyy-MM-dd HH:mm:ss.fff}", startTime));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "End Time:     {0:yyyy-MM-dd HH:mm:ss.fff}", endTime));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Elapsed:      {0:F0}ms", elapsedMs));
+
+                if (!string.IsNullOrEmpty(context))
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Context:      {0}", context));
+
+                var fileName = Path.GetFileName(filePath);
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Location:     {0}:{1}", fileName, lineNumber));
+                sb.AppendLine();
+
+                File.AppendAllText(GetCurrentLogFile(), sb.ToString());
+            }
+        }
+        catch { }
+    }
+
+    private static void CleanOldLogs()
+    {
+        try
+        {
+            var files = Directory.GetFiles(s_logDirectory, "MethodProfile_*.log");
+            var cutoff = DateTime.Now.AddDays(-7);
+            foreach (var file in files)
+            {
+                if (new FileInfo(file).CreationTime < cutoff)
+                    File.Delete(file);
+            }
+        }
+        catch { }
+    }
+}
+
+/// <summary>
+/// Disposable context for timing method execution.
+/// </summary>
+public sealed class MethodTimingContext : IDisposable
+{
+    private readonly DateTime _startTime;
+    private readonly Stopwatch _stopwatch;
+    private readonly string? _context;
+    private readonly string _memberName;
+    private readonly string _filePath;
+    private readonly int _lineNumber;
+    private bool _disposed;
+
+    internal MethodTimingContext(string? context, string memberName, string filePath, int lineNumber)
+    {
+        _startTime = DateTime.Now;
+        _stopwatch = Stopwatch.StartNew();
+        _context = context;
+        _memberName = memberName;
+        _filePath = filePath;
+        _lineNumber = lineNumber;
+    }
+
+    public double ElapsedMs => _stopwatch.Elapsed.TotalMilliseconds;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _stopwatch.Stop();
+
+        MethodProfiler.LogSlowMethod(
+            _startTime, DateTime.Now, _stopwatch.Elapsed.TotalMilliseconds,
+            _context, _memberName, _filePath, _lineNumber);
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Lite/Helpers/QueryLogger.cs
+++ b/Lite/Helpers/QueryLogger.cs
@@ -1,0 +1,163 @@
+/*
+ * SQL Server Performance Monitor Lite
+ *
+ * Query logger for tracking slow DuckDB and SQL Server queries
+ */
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace PerformanceMonitorLite.Helpers;
+
+/// <summary>
+/// Logs slow queries to a dedicated log file for performance analysis.
+/// Covers both DuckDB reads and SQL Server collector queries.
+/// Usage: using var _ = QueryLogger.StartQuery("context", sql, source: "DuckDB");
+/// </summary>
+public static class QueryLogger
+{
+    private static string s_logDirectory = "";
+    private static readonly object _lock = new();
+    private static volatile bool _isEnabled = true;
+    private static double _thresholdSeconds = 0.5;
+
+    public static void Initialize(string logDirectory)
+    {
+        s_logDirectory = logDirectory;
+        try
+        {
+            if (!Directory.Exists(s_logDirectory))
+                Directory.CreateDirectory(s_logDirectory);
+            CleanOldLogs();
+        }
+        catch { }
+    }
+
+    public static string GetCurrentLogFile()
+        => Path.Combine(s_logDirectory, $"SlowQueries_{DateTime.Now:yyyyMMdd}.log");
+
+    public static string GetLogDirectory() => s_logDirectory;
+
+    public static void SetEnabled(bool enabled) => _isEnabled = enabled;
+    public static bool IsEnabled => _isEnabled;
+
+    public static void SetThreshold(double thresholdSeconds) => _thresholdSeconds = thresholdSeconds;
+    public static double ThresholdSeconds => _thresholdSeconds;
+
+    public static void LogSlowQuery(
+        DateTime startTime,
+        DateTime endTime,
+        double elapsedMs,
+        string context,
+        string queryText,
+        string? source = null,
+        string? serverName = null)
+    {
+        if (!_isEnabled || string.IsNullOrEmpty(s_logDirectory))
+            return;
+
+        double elapsedSeconds = elapsedMs / 1000.0;
+        if (elapsedSeconds < _thresholdSeconds)
+            return;
+
+        try
+        {
+            lock (_lock)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("================================================================================");
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "SLOW QUERY DETECTED - {0:F3} seconds", elapsedSeconds));
+                sb.AppendLine("================================================================================");
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Start Time:   {0:yyyy-MM-dd HH:mm:ss.fff}", startTime));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "End Time:     {0:yyyy-MM-dd HH:mm:ss.fff}", endTime));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Elapsed:      {0:F3} seconds ({1:N0} ms)", elapsedSeconds, elapsedMs));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Context:      {0}", context));
+
+                if (!string.IsNullOrEmpty(source))
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Source:       {0}", source));
+
+                if (!string.IsNullOrEmpty(serverName))
+                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "Server:       {0}", serverName));
+
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine("Query:");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                sb.AppendLine(queryText);
+                sb.AppendLine("================================================================================");
+                sb.AppendLine();
+
+                File.AppendAllText(GetCurrentLogFile(), sb.ToString());
+            }
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// Creates a query execution context for timing queries.
+    /// </summary>
+    public static QueryExecutionContext StartQuery(
+        string context,
+        string queryText,
+        string? source = null,
+        string? serverName = null)
+    {
+        return new QueryExecutionContext(context, queryText, source, serverName);
+    }
+
+    private static void CleanOldLogs()
+    {
+        try
+        {
+            var files = Directory.GetFiles(s_logDirectory, "SlowQueries_*.log");
+            var cutoff = DateTime.Now.AddDays(-7);
+            foreach (var file in files)
+            {
+                if (new FileInfo(file).CreationTime < cutoff)
+                    File.Delete(file);
+            }
+        }
+        catch { }
+    }
+}
+
+/// <summary>
+/// Disposable context for timing query execution.
+/// </summary>
+public sealed class QueryExecutionContext : IDisposable
+{
+    private readonly DateTime _startTime;
+    private readonly Stopwatch _stopwatch;
+    private readonly string _context;
+    private readonly string _queryText;
+    private readonly string? _source;
+    private readonly string? _serverName;
+    private bool _disposed;
+
+    internal QueryExecutionContext(string context, string queryText, string? source, string? serverName)
+    {
+        _startTime = DateTime.Now;
+        _stopwatch = Stopwatch.StartNew();
+        _context = context;
+        _queryText = queryText;
+        _source = source;
+        _serverName = serverName;
+    }
+
+    public double ElapsedMs => _stopwatch.Elapsed.TotalMilliseconds;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _stopwatch.Stop();
+
+        QueryLogger.LogSlowQuery(
+            _startTime, DateTime.Now, _stopwatch.Elapsed.TotalMilliseconds,
+            _context, _queryText, _source, _serverName);
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -136,6 +136,7 @@ LIMIT 50";
     /// </summary>
     public async Task<List<QuerySnapshotRow>> GetLatestQuerySnapshotsAsync(int serverId, int hoursBack = 4, DateTime? fromDate = null, DateTime? toDate = null)
     {
+        using var _q = TimeQuery("GetLatestQuerySnapshotsAsync", "v_query_snapshots latest");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -20,6 +20,7 @@ public partial class LocalDataService
     /// </summary>
     public async Task<DailySummaryRow?> GetDailySummaryAsync(int serverId, DateTime? summaryDate = null)
     {
+        using var _q = TimeQuery("GetDailySummaryAsync", "daily summary aggregation");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -423,6 +423,7 @@ ORDER BY collection_time, database_name";
     /// </summary>
     public async Task<UtilizationEfficiencyRow?> GetUtilizationEfficiencyAsync(int serverId)
     {
+        using var _q = TimeQuery("GetUtilizationEfficiencyAsync", "utilization efficiency stats");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -38,6 +38,7 @@ WHERE d.name = @database_name;", connection);
     /// </summary>
     public async Task<List<QueryStatsRow>> GetTopQueriesByCpuAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null, int utcOffsetMinutes = 0)
     {
+        using var _q = TimeQuery("GetTopQueriesByCpuAsync", "v_query_stats top N by CPU");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 
@@ -381,6 +382,7 @@ OPTION(RECOMPILE);',
     /// </summary>
     public async Task<List<ProcedureStatsRow>> GetTopProceduresByCpuAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null, int utcOffsetMinutes = 0)
     {
+        using var _q = TimeQuery("GetTopProceduresByCpuAsync", "v_procedure_stats top N by CPU");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -23,6 +23,7 @@ public partial class LocalDataService
     /// </summary>
     public async Task<List<QueryStoreRow>> GetQueryStoreTopQueriesAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null)
     {
+        using var _q = TimeQuery("GetQueryStoreTopQueriesAsync", "v_query_store_stats top N");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -20,6 +20,7 @@ public partial class LocalDataService
     /// </summary>
     public async Task<List<WaitStatsRow>> GetWaitStatsAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
     {
+        using var _q = TimeQuery("GetWaitStatsAsync", "v_wait_stats top by delta");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -107,4 +107,13 @@ public partial class LocalDataService
         return (serverNow.AddHours(-hoursBack), serverNow);
     }
 
+    /// <summary>
+    /// Starts query timing for performance logging. Use with 'using' statement.
+    /// Only logs queries that exceed the slow query threshold (default 500ms).
+    /// </summary>
+    protected static Helpers.QueryExecutionContext TimeQuery(string context, string sql)
+    {
+        return Helpers.QueryLogger.StartQuery(context, sql, source: "DuckDB");
+    }
+
 }


### PR DESCRIPTION
## Summary
- **Performance profilers**: Port MethodProfiler and QueryLogger from Dashboard to Lite — logs slow methods (>500ms) and slow DuckDB queries with daily rotating files and 7-day cleanup
- **Server inventory caching**: 5-minute in-memory cache in both Dashboard and Lite eliminates 12s repeat loads when revisiting the FinOps tab
- **Parallel data loading**: `LoadPerServerDataAsync` (4 sub-loads) and `LoadUtilizationAsync` (4 inner queries) now use `Task.WhenAll` in both apps
- **Query timing**: Added instrumentation to 7 `LocalDataService` methods for DuckDB query performance visibility
- **Dashboard Plan Viewer fix**: `PreviewMouseDown` no longer steals focus from ComboBox/DataGrid (complements Lite fix from #508)

## Test plan
- [x] Both apps build clean (0 warnings, 0 errors)
- [x] Lite MethodProfiler logs slow methods correctly
- [x] Server inventory cache returns instantly on repeat FinOps tab visits
- [x] No new SlowQueries log entries (all DuckDB queries under 500ms)
- [ ] Verify Dashboard Plan Viewer ComboBox statement selection works in multi-statement plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)