### PR TITLE
Add ReadOnlyIntent connection option to Lite

### DIFF
--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -71,6 +71,13 @@ public class ServerConnection
     public string? DatabaseName { get; set; }
 
     /// <summary>
+    /// When true, sets ApplicationIntent=ReadOnly on the connection string.
+    /// Required for connecting to AG listener read-only replicas and
+    /// Azure SQL Business Critical / Managed Instance built-in read replicas.
+    /// </summary>
+    public bool ReadOnlyIntent { get; set; } = false;
+
+    /// <summary>
     /// Display-only property for showing authentication type in UI.
     /// </summary>
     [JsonIgnore]
@@ -153,7 +160,8 @@ public class ServerConnection
             ConnectTimeout = 15,
             CommandTimeout = 60,
             TrustServerCertificate = TrustServerCertificate,
-            MultipleActiveResultSets = true
+            MultipleActiveResultSets = true,
+            ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite
         };
 
         // Set encryption mode

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -88,6 +88,9 @@
                 <TextBox x:Name="DatabaseNameBox" Width="250"
                          ToolTip="Required for Azure SQL Database. Leave empty for on-premises SQL Server."/>
             </StackPanel>
+            <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="Read-only intent (for AG listeners and readable replicas)"
+                      Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
+                      ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
         </StackPanel>
 
         <!-- Status -->

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -59,6 +59,7 @@ public partial class AddServerDialog : Window
         FavoriteCheckBox.IsChecked = existing.IsFavorite;
         DescriptionTextBox.Text = existing.Description ?? "";
         DatabaseNameBox.Text = existing.DatabaseName ?? "";
+        ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
 
         // Set authentication mode
         if (existing.AuthenticationType == AuthenticationTypes.EntraMFA)
@@ -140,7 +141,10 @@ public partial class AddServerDialog : Window
             ApplicationName = "PerformanceMonitorLite",
             ConnectTimeout = 10,
             TrustServerCertificate = TrustCertCheckBox.IsChecked == true,
-            Encrypt = ParseEncryptOption(GetSelectedEncryptMode())
+            Encrypt = ParseEncryptOption(GetSelectedEncryptMode()),
+            ApplicationIntent = ReadOnlyIntentCheckBox.IsChecked == true
+                ? ApplicationIntent.ReadOnly
+                : ApplicationIntent.ReadWrite
         };
 
         if (WindowsAuthRadio.IsChecked == true)
@@ -342,6 +346,7 @@ public partial class AddServerDialog : Window
                 AddedServer.IsFavorite = FavoriteCheckBox.IsChecked == true;
                 AddedServer.Description = DescriptionTextBox.Text.Trim();
                 AddedServer.DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
+                AddedServer.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
 
                 _serverManager.UpdateServer(AddedServer, username, password);
             }
@@ -358,7 +363,8 @@ public partial class AddServerDialog : Window
                     EncryptMode = GetSelectedEncryptMode(),
                     IsFavorite = FavoriteCheckBox.IsChecked == true,
                     Description = DescriptionTextBox.Text.Trim(),
-                    DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim()
+                    DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim(),
+                    ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true
                 };
 
                 _serverManager.AddServer(AddedServer, username, password);


### PR DESCRIPTION
## Summary
- Adds `ReadOnlyIntent` bool property to Lite's `ServerConnection` model (persisted to `servers.json`, defaults to `false`)
- Sets `ApplicationIntent=ReadOnly` on the connection string when enabled
- Adds checkbox in Add/Edit Server dialog: "Read-only intent (for AG listeners and readable replicas)"
- Test Connection button also respects the setting

## Why
Required for users connecting Lite via:
- **AG listeners** — routes to readable secondary
- **Azure SQL failover group endpoints** — same listener-based routing
- **Business Critical / Managed Instance** built-in read replicas (only reachable via intent flag)

Dashboard excluded since it requires a writable `PerformanceMonitor` database.

## Test plan
- [ ] Add a server without the checkbox — verify connection string has no `ApplicationIntent` change
- [ ] Add a server with the checkbox — verify `ApplicationIntent=ReadOnly` in connection string
- [ ] Edit an existing server, toggle the checkbox, save — verify persistence
- [ ] Test Connection works with the checkbox enabled against a readable replica

🤖 Generated with [Claude Code](https://claude.com/claude-code)