### PR TITLE
Show used vs file size in Lite status bar

### DIFF
--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -733,6 +733,31 @@ public class DuckDbInitializer
     }
 
     /// <summary>
+    /// Gets the actual used data size inside the database by querying pragma_database_size().
+    /// Returns null if the query fails (e.g., database busy).
+    /// </summary>
+    public double? GetUsedDataSizeMb()
+    {
+        try
+        {
+            using var connection = CreateConnection();
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT (used_blocks * block_size)::BIGINT FROM pragma_database_size()";
+            var result = cmd.ExecuteScalar();
+            if (result != null && result != DBNull.Value)
+            {
+                return Convert.ToInt64(result) / (1024.0 * 1024.0);
+            }
+        }
+        catch
+        {
+            /* Database may be busy — fall back to null */
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Deletes the database and WAL files, then reinitializes with fresh empty tables
     /// and archive views pointing at the parquet files.
     /// Acquires its own write lock — caller must NOT already hold the lock.

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -314,10 +314,18 @@ public partial class MainWindow : Window
     private void UpdateStatusBar()
     {
         // Update database size
-        var sizeMb = _databaseInitializer.GetDatabaseSizeMb();
-        DatabaseSizeText.Text = sizeMb > 0
-            ? $"Database: {sizeMb:F1} MB"
-            : "Database: New";
+        var fileSizeMb = _databaseInitializer.GetDatabaseSizeMb();
+        var usedSizeMb = _databaseInitializer.GetUsedDataSizeMb();
+        if (fileSizeMb > 0)
+        {
+            DatabaseSizeText.Text = usedSizeMb.HasValue
+                ? $"Database: {usedSizeMb.Value:F1} / {fileSizeMb:F1} MB"
+                : $"Database: {fileSizeMb:F1} MB";
+        }
+        else
+        {
+            DatabaseSizeText.Text = "Database: New";
+        }
 
         // Update collection status
         if (_backgroundService != null)


### PR DESCRIPTION
## Summary
- DuckDB 1.5.0's free block reuse means the file size on disk stays frozen (~424 MB) even as data grows inside
- `GetDatabaseSizeMb()` reports file size, so the status bar showed a misleading static number
- New `GetUsedDataSizeMb()` queries `pragma_database_size()` for actual used blocks
- Status bar now shows `Database: 175.5 / 423.8 MB` (used / file size)
- Falls back to file-size-only display if the pragma query fails

## Test plan
- [x] Verified status bar shows `used / file` format after restart
- [x] Confirmed `pragma_database_size()` returns correct used_blocks (702 of 1774)
- [x] Build succeeds with zero errors
- [x] No errors in Lite logs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)