### PR TITLE
Add Query Store collector spike diagnostic timing

### DIFF
--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -339,11 +339,18 @@ EXECUTE [{escapedDbName}].sys.sp_executesql
                     sqlSw.Stop();
 
                     duckSw.Start();
+                    var flushSw = new Stopwatch();
+                    var readerSw = new Stopwatch();
+                    var appendSw = new Stopwatch();
 
                     using (var appender = duckConnection.CreateAppender("query_store_stats"))
                     {
-                        while (await reader.ReadAsync(cancellationToken))
+                        while (true)
                         {
+                            readerSw.Start();
+                            var hasRow = await reader.ReadAsync(cancellationToken);
+                            readerSw.Stop();
+                            if (!hasRow) break;
                             /* Reader ordinals match SELECT column order:
                                0=query_id, 1=plan_id, 2=execution_type_desc,
                                3=first_execution_time (dto), 4=last_execution_time (dto),
@@ -364,6 +371,7 @@ EXECUTE [{escapedDbName}].sys.sp_executesql
                                46=is_forced_plan, 47=force_failure_count, 48=last_force_failure_reason,
                                49=compatibility_level, 50=query_plan_text, 51=query_plan_hash */
 
+                            appendSw.Start();
                             var row = appender.CreateRow();
                             row.AppendValue(GenerateCollectionId())                                                             /* collection_id */
                                .AppendValue(collectionTime)                                                                     /* collection_time */
@@ -423,12 +431,28 @@ EXECUTE [{escapedDbName}].sys.sp_executesql
                                .AppendValue(reader.IsDBNull(50) ? (string?)null : reader.GetString(50))                         /* query_plan_text */
                                .AppendValue(reader.IsDBNull(51) ? (string?)null : reader.GetString(51))                         /* query_plan_hash */
                                .EndRow();
+                            appendSw.Stop();
 
                             totalRows++;
                         }
-                    }
+
+                        flushSw.Start();
+                    } /* appender.Dispose() flushes here */
+                    flushSw.Stop();
 
                     duckSw.Stop();
+
+                    if (duckSw.ElapsedMilliseconds > 2000)
+                    {
+                        _logger?.LogWarning(
+                            "Query Store DuckDB write spike: {TotalMs}ms total (reader: {ReaderMs}ms, append: {AppendMs}ms, flush: {FlushMs}ms, rows: {Rows}, db: {Db})",
+                            duckSw.ElapsedMilliseconds,
+                            readerSw.ElapsedMilliseconds,
+                            appendSw.ElapsedMilliseconds,
+                            flushSw.ElapsedMilliseconds,
+                            totalRows,
+                            dbName);
+                    }
                 }
                 catch (SqlException ex)
                 {


### PR DESCRIPTION
## Summary
- Splits the Query Store collector's DuckDB write stopwatch into three components: **reader** (SqlDataReader), **append** (DuckDB appender), and **flush** (appender dispose)
- Logs a warning when total exceeds 2 seconds, showing the breakdown
- Zero overhead under normal operation (Stopwatch is nanosecond-cost, warning only fires on spikes)

## Context
During HammerDB TPC-H load testing, the Query Store collector showed 7-22 second spikes. This diagnostic identified the root cause: SQL Server's Query Store DMVs are slow to return rows under heavy analytical workload (reader: 11,764ms, append: 20ms, flush: 10ms). DuckDB is not the bottleneck.

## Test plan
- [x] Monitored for 4+ hours with zero issues
- [x] Confirmed warning fires correctly during TPC-H load spikes
- [x] Verified zero log spam during normal idle operation (15-row collections at 300-550ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)