### PR TITLE
Update changelog and README for v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2026-03-09
+## [2.2.0] - 2026-03-11
 
 **Contributors:** [@HannahVernon](https://github.com/HannahVernon), [@ClaudioESSilva](https://github.com/ClaudioESSilva), [@dphugo](https://github.com/dphugo), [@Orestes](https://github.com/Orestes) — thank you!
 
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **LOB compression and deduplication** for query stats tables to reduce storage ([#419])
 - **Volume-level drive space** enrichment in database size stats via `dm_os_volume_stats`
 - **GUI installer installation history** logging to `config.installation_history` ([#414])
+- **ReadOnlyIntent connection option** — Lite connections can set `ApplicationIntent=ReadOnly` for automatic read routing to Always On AG readable secondaries ([#515])
+- **SignPath code signing** — all release binaries (Dashboard, Lite, Installers) are digitally signed, eliminating Windows SmartScreen warnings ([#511])
 - CI version bump check on PRs to main
 - Permissions section in README with least-privilege setup ([#421])
 
@@ -49,6 +51,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User's locale used for date/time formatting in WPF bindings ([#459])
 - XML processing instructions stripped from sql_command/sql_text display
 - Parameterized queries in blocking/deadlock alert filtering
+- **DuckDB 1.5.0 upgrade** — non-blocking checkpointing eliminates read stalls during WAL flushes, free block reuse stabilizes database file size without archive-and-reset cycles ([#516])
+- **Automatic parquet compaction** — archive files are merged into monthly files after each archive cycle, reducing file count from 2,600+ to ~75 and eliminating per-file metadata overhead on glob scans ([#516])
+
+  Combined with the UI responsiveness overhaul (#510), Lite's refresh cycle improved 13-26x:
+
+  | Metric | Before | After |
+  |---|---|---|
+  | Lite `RefreshAllDataAsync` | 6-13s | < 500ms |
+  | Parquet files scanned per query | 233 | 19 |
+  | Archive-and-reset frequency | 21/day | ~0 |
+  | `v_wait_stats` query time | 1,700ms | 27ms |
+
+- **Monthly archive retention** — switched from 90-day file-age deletion to 3-month calendar-month rolling window, aligned with compacted monthly filenames ([#516])
+- **Lite status bar** shows used data size vs file size (e.g., "Database: 175.5 / 423.8 MB") via DuckDB `pragma_database_size()` ([#517])
+- **Query Store collector diagnostics** — reader/append/flush timing breakdown logged when collection exceeds 2 seconds, for identifying SQL Server DMV contention under heavy workloads ([#518])
+- SSMS-parity edge tooltips on plan viewer operator connections and ManyToMany indicator always shown for merge join operators ([#504])
 - **Lite UI responsiveness overhaul** — visible-tab-only refresh, sub-tab awareness, Query Store collector optimization (NULL plan XML + LOOP JOIN hint), and DuckDB write reduction ([#510])
 
   Timer tick improvements measured under TPC-C load on SQL2022:
@@ -85,6 +103,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formatted duration columns sorting alphabetically instead of numerically
 - Settings window staying open on validation errors
 - Deserialization clamping and validation abort issues
+- **sp_IndexCleanup** summary grid column mapping off-by-one, expanded both grids to show all columns from both result sets ([#503])
+- **Rule 22 table variable** false positive on modification operators — INSERT/UPDATE/DELETE on table variables is expected ([#513])
+- **ComboBox focus steal** in plan viewer stealing keyboard focus from other controls ([#508])
+- **DOP 2 skew** false positive — parallel skew rule no longer fires at DOP 2 ([#508])
 
 [2.2.0]: https://github.com/erikdarlingdata/PerformanceMonitor/compare/v2.1.0...v2.2.0
 
@@ -482,4 +504,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#482]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/482
 [#488]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/488
 [#489]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/489
+[#503]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/503
+[#504]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/504
+[#508]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/508
 [#510]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/510
+[#511]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/511
+[#513]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/513
+[#515]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/515
+[#516]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/516
+[#517]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/517
+[#518]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/518

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 Both editions include real-time alerts (system tray + email), charts and graphs, dark and light themes, CSV export, and a built-in MCP server for AI-powered analysis with tools like Claude.
 
+All release binaries are digitally signed via [SignPath](https://signpath.io) — no more Windows SmartScreen warnings.
+
 ---
 
 ## What People Are Saying
@@ -79,6 +81,8 @@ Both editions include real-time alerts (system tray + email), charts and graphs,
 
 Data starts flowing within 1–5 minutes. That's it. No installation on your server, no Agent jobs, no sysadmin required.
 
+**Always On AG?** Enable **ReadOnlyIntent** in the connection settings to route Lite's monitoring queries to a readable secondary, keeping the primary clear.
+
 ### Lite Collectors
 
 23 collectors run on independent, configurable schedules:
@@ -111,8 +115,9 @@ Data starts flowing within 1–5 minutes. That's it. No installation on your ser
 
 ### Lite Data Storage
 
-- **Hot data** in DuckDB (7–90 days, configurable)
-- **Archive** to Parquet with ZSTD compression (~10x reduction, 30–180 days configurable)
+- **Hot data** in DuckDB 1.5.0 — non-blocking checkpoints, free block reuse, stable file size without periodic resets
+- **Archive** to Parquet with ZSTD compression (~10x reduction) — automatic monthly compaction keeps file count low (~75 files vs thousands)
+- **Retention**: 3-month calendar-month rolling window
 - Typical size: ~50–200 MB per server per week
 
 ### Lite Configuration
@@ -328,7 +333,7 @@ Plus a NOC-style landing page with server health cards (green/yellow/red severit
 | **Blocking** | Blocking/deadlock trends, blocked process reports, deadlock history |
 | **Perfmon** | Selectable SQL Server performance counters over time |
 | **Configuration** | Server configuration, database configuration, scoped configuration, trace flags |
-| **FinOps** | Database size tracking, storage growth analysis (7d/30d), server properties, capacity planning |
+| **FinOps** | Utilization & provisioning analysis, database resource breakdown, storage growth (7d/30d), idle database detection, index analysis via sp_IndexCleanup, application connections, wait/query/TempDB/memory grant optimization |
 
 Both editions feature auto-refresh, configurable time ranges, right-click CSV export, system tray integration, dark and light themes, and timezone display options (server time, local time, or UTC).
 


### PR DESCRIPTION
## Summary
- Add missing changelog entries for PRs #503-#518 merged after release prep
- Update README: SignPath code signing, DuckDB 1.5.0 data storage, ReadOnlyIntent, expanded FinOps description
- Release date set to 2026-03-11

## Test plan
- [x] Documentation-only changes, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)