### PR TITLE
Fix RetrievedFromCache always showing False

### DIFF
--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -409,7 +409,7 @@ public static class ShowPlanParser
         stmt.CachedPlanSizeKB = ParseLong(queryPlanEl.Attribute("CachedPlanSize")?.Value);
         stmt.DegreeOfParallelism = (int)ParseDouble(queryPlanEl.Attribute("DegreeOfParallelism")?.Value);
         stmt.NonParallelPlanReason = queryPlanEl.Attribute("NonParallelPlanReason")?.Value;
-        stmt.RetrievedFromCache = queryPlanEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
+        stmt.RetrievedFromCache = stmtEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
         stmt.CompileTimeMs = ParseLong(queryPlanEl.Attribute("CompileTime")?.Value);
         stmt.CompileMemoryKB = ParseLong(queryPlanEl.Attribute("CompileMemory")?.Value);
         stmt.CompileCPUMs = ParseLong(queryPlanEl.Attribute("CompileCPU")?.Value);

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -409,7 +409,7 @@ public static class ShowPlanParser
         stmt.CachedPlanSizeKB = ParseLong(queryPlanEl.Attribute("CachedPlanSize")?.Value);
         stmt.DegreeOfParallelism = (int)ParseDouble(queryPlanEl.Attribute("DegreeOfParallelism")?.Value);
         stmt.NonParallelPlanReason = queryPlanEl.Attribute("NonParallelPlanReason")?.Value;
-        stmt.RetrievedFromCache = queryPlanEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
+        stmt.RetrievedFromCache = stmtEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
         stmt.CompileTimeMs = ParseLong(queryPlanEl.Attribute("CompileTime")?.Value);
         stmt.CompileMemoryKB = ParseLong(queryPlanEl.Attribute("CompileMemory")?.Value);
         stmt.CompileCPUMs = ParseLong(queryPlanEl.Attribute("CompileCPU")?.Value);


### PR DESCRIPTION
## Summary
- Ports the fix from PerformanceStudio#89 (reported as PerformanceStudio#88)
- `RetrievedFromCache` is an attribute on `<StmtSimple>`, but the parser was reading it from the child `<QueryPlan>` element where it never exists — always defaulting to False
- Fixed in both Dashboard and Lite copies of `ShowPlanParser.cs`

## Test plan
- [ ] Manual: open a cached plan in Dashboard/Lite and confirm "Retrieved From Cache" shows True

🤖 Generated with [Claude Code](https://claude.com/claude-code)