### PR TITLE
Fix SQL dumps on mirroring passive servers from FinOps collectors

### DIFF
--- a/install/52_collect_database_size_stats.sql
+++ b/install/52_collect_database_size_stats.sql
@@ -176,7 +176,7 @@ BEGIN
                     d.name,
                     d.database_id
                 FROM sys.databases AS d
-                WHERE d.state_desc = N'ONLINE'
+                WHERE d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
                 AND   d.database_id > 0
                 AND   HAS_DBACCESS(d.name) = 1
                 ORDER BY

--- a/install/53_collect_server_properties.sql
+++ b/install/53_collect_server_properties.sql
@@ -133,8 +133,9 @@ BEGIN
                 SELECT
                     d.name
                 FROM sys.databases AS d
-                WHERE d.state_desc = N'ONLINE'
+                WHERE d.state = 0 /*ONLINE only — skip RESTORING databases (mirroring/AG secondary)*/
                 AND   d.database_id > 4 /*Skip system databases*/
+                AND   HAS_DBACCESS(d.name) = 1
                 ORDER BY
                     d.database_id;
 


### PR DESCRIPTION
## Summary
- **database_size_stats collector**: Change `state_desc = N'ONLINE'` to `d.state = 0` filter to match the pattern from #384/#430 fix
- **server_properties collector**: Change `state_desc = N'ONLINE'` to `d.state = 0` filter, add missing `HAS_DBACCESS(d.name) = 1` check — this collector was iterating into databases it couldn't access on mirroring passive servers, triggering severity 22 engine crashes

## Test plan
- [ ] Install on SQL 2016 mirroring passive server — verify no dumps
- [ ] Verify both FinOps collectors complete successfully on servers with RESTORING databases

Fixes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)