### PR TITLE
Fix installer dropping database on every upgrade

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -103,6 +103,7 @@ END;";
         private const int ShortTimeoutSeconds = 60;       // Quick operations (cleanup, queries)
         private const int MediumTimeoutSeconds = 120;     // Dependency installation
         private const int LongTimeoutSeconds = 300;       // SQL file execution (5 minutes)
+        private const int UpgradeTimeoutSeconds = 3600;   // Upgrade data migrations (1 hour, large tables)
 
         /*
         Exit codes for granular error reporting
@@ -117,6 +118,7 @@ END;";
             public const int VersionCheckFailed = 5;
             public const int SqlFilesNotFound = 6;
             public const int UninstallFailed = 7;
+            public const int UpgradesFailed = 8;
         }
 
         static async Task<int> Main(string[] args)
@@ -523,8 +525,9 @@ END;";
                     string fileName = Path.GetFileName(f);
                     if (!SqlFileNamePattern.IsMatch(fileName))
                         return false;
-                    /*Exclude test and troubleshooting scripts from main install*/
-                    if (fileName.StartsWith("97_", StringComparison.Ordinal) ||
+                    /*Exclude uninstall, test, and troubleshooting scripts from main install*/
+                    if (fileName.StartsWith("00_", StringComparison.Ordinal) ||
+                        fileName.StartsWith("97_", StringComparison.Ordinal) ||
                         fileName.StartsWith("99_", StringComparison.Ordinal))
                         return false;
                     return true;
@@ -699,6 +702,21 @@ END;";
 
                         Console.WriteLine();
                         Console.WriteLine($"Upgrades complete: {upgradeSuccessCount} succeeded, {upgradeFailureCount} failed");
+
+                        /*Abort if any upgrade scripts failed — proceeding would reinstall over a partially-upgraded database*/
+                        if (upgradeFailureCount > 0)
+                        {
+                            Console.WriteLine();
+                            Console.WriteLine("================================================================================");
+                            Console.WriteLine("Installation aborted: upgrade scripts must succeed before installation can proceed.");
+                            Console.WriteLine("Fix the errors above and re-run the installer.");
+                            Console.WriteLine("================================================================================");
+                            if (!automatedMode)
+                            {
+                                WaitForExit();
+                            }
+                            return ExitCodes.UpgradesFailed;
+                        }
                     }
                     else
                     {
@@ -1332,7 +1350,15 @@ END;";
                         return version.ToString();
                     }
 
-                    return null;
+                    /*
+                    Fallback: database and history table exist but no SUCCESS rows.
+                    This can happen if a prior GUI install didn't write history (#538/#539).
+                    Return "1.0.0" so all idempotent upgrade scripts are attempted
+                    rather than treating this as a fresh install (which would drop the database).
+                    */
+                    Console.WriteLine("Warning: PerformanceMonitor database exists but installation_history has no records.");
+                    Console.WriteLine("Treating as v1.0.0 to apply all available upgrades.");
+                    return "1.0.0";
                 }
             }
             catch (SqlException ex)
@@ -1480,7 +1506,7 @@ END;";
 
                         using (var cmd = new SqlCommand(trimmedBatch, connection))
                         {
-                            cmd.CommandTimeout = LongTimeoutSeconds;
+                            cmd.CommandTimeout = UpgradeTimeoutSeconds;
                             try
                             {
                                 await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -408,6 +408,16 @@ namespace PerformanceMonitorInstallerGui
                             upgradeFailure == 0 ? "Success" : "Warning");
                         LogMessage("", "Info");
                     }
+
+                    /*Abort if any upgrade scripts failed — proceeding would reinstall over a partially-upgraded database*/
+                    if (upgradeFailure > 0)
+                    {
+                        LogMessage("", "Info");
+                        LogMessage("Installation aborted: upgrade scripts must succeed before installation can proceed.", "Error");
+                        LogMessage("Fix the errors above and re-run the installer.", "Error");
+                        SetUIState(installing: false);
+                        return;
+                    }
                 }
 
                 /*

--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -238,8 +238,9 @@ namespace PerformanceMonitorInstallerGui.Services
                         /*Match numbered SQL files but exclude 97 (tests) and 99 (troubleshooting)*/
                         if (!SqlFilePattern.IsMatch(fileName))
                             return false;
-                        /*Exclude test and troubleshooting scripts from main install*/
-                        if (fileName.StartsWith("97_", StringComparison.Ordinal) ||
+                        /*Exclude uninstall, test, and troubleshooting scripts from main install*/
+                        if (fileName.StartsWith("00_", StringComparison.Ordinal) ||
+                            fileName.StartsWith("97_", StringComparison.Ordinal) ||
                             fileName.StartsWith("99_", StringComparison.Ordinal))
                             return false;
                         return true;
@@ -1113,7 +1114,13 @@ END;";
                     return version.ToString();
                 }
 
-                return null;
+                /*
+                Fallback: database and history table exist but no SUCCESS rows.
+                This can happen if a prior GUI install didn't write history (#538/#539).
+                Return "1.0.0" so all idempotent upgrade scripts are attempted
+                rather than treating this as a fresh install (which would drop the database).
+                */
+                return "1.0.0";
             }
             catch (SqlException)
             {
@@ -1272,7 +1279,7 @@ END;";
                             continue;
 
                         using var cmd = new SqlCommand(trimmedBatch, connection);
-                        cmd.CommandTimeout = 300;
+                        cmd.CommandTimeout = 3600; /*1 hour — upgrade migrations on large tables need extended time*/
 
                         try
                         {


### PR DESCRIPTION
## Summary

Fixes #538. Fixes #539.

- **`00_uninstall.sql` excluded from install file list** — it was being picked up by the `install/*.sql` glob and executed as the first step of every install, silently dropping the database. Now filtered alongside `97_`/`99_`.
- **Abort on upgrade failure** — if any upgrade script fails, installation stops instead of falling through to a full reinstall over a partially-upgraded database. New CLI exit code `8` (`UpgradesFailed`).
- **Version detection fallback** — when `installation_history` exists but has no `SUCCESS` rows (prior GUI bug), returns `"1.0.0"` so all idempotent upgrades are attempted rather than treating it as a fresh install.
- **Upgrade timeout: 5min → 1hr** — `compress_query_stats` data migration timed out on 240GB+ databases at the old 300s `CommandTimeout`.

## Root cause

PR #431 added `install/00_uninstall.sql` as a standalone script for SSMS users. Both installers build their file list by globbing `install/*.sql` sorted alphabetically — so `00_uninstall.sql` became the first file executed on every install, including upgrades. Pre-release testing on small databases didn't catch it because there was no data to miss.

## Test plan

- [ ] CLI fresh install (`--reinstall`): verify `00_uninstall.sql` does NOT appear in the execution log
- [ ] CLI upgrade install: verify upgrades run, then install scripts start from `01_install_database.sql`
- [ ] CLI upgrade with simulated failure: verify installer aborts with exit code 8 and does NOT proceed to install
- [ ] GUI upgrade install: same verification — upgrades then install, no `00_uninstall`
- [ ] GUI upgrade with failure: verify abort message appears, install does not proceed
- [ ] Version detection with empty `installation_history`: verify "1.0.0" fallback, upgrades attempted
- [ ] `--uninstall` flag still works (uses its own code path, not the file list)
- [ ] Data survival: capture row counts before upgrade, verify equal or greater after

🤖 Generated with [Claude Code](https://claude.com/claude-code)