### PR TITLE
Fix Index Analysis scroll not working with many results (#554)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -774,8 +774,8 @@
 
                 <Grid Grid.Row="1" Margin="10,0,10,10">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="2*"/>
                     </Grid.RowDefinitions>
 
                     <!-- Summary Grid -->

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -772,8 +772,8 @@
 
                 <Grid Grid.Row="1" Margin="10,0,10,10">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="2*"/>
                     </Grid.RowDefinitions>
 
                     <DataGrid x:Name="IndexAnalysisSummaryGrid" Grid.Row="0"


### PR DESCRIPTION
## Summary
- The Index Analysis summary DataGrid used `Height="Auto"`, letting it grow unbounded and push the detail grid off-screen
- Changed both grids to proportional heights (`*` and `2*`) so they share available space and scroll internally
- Fixed in both Lite and Dashboard

Fixes #554

## Test plan
- [ ] Run Index Analysis against a database with many indexes (400+)
- [ ] Verify both summary and detail grids scroll independently
- [ ] Verify layout looks correct with few results (< 10 indexes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)