### PR TITLE
Email alerts when monitored servers go offline (#529)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -423,10 +423,29 @@ namespace PerformanceMonitorDashboard
                             _notificationService?.ShowServerOfflineNotification(
                                 item.DisplayName,
                                 newStatus.ErrorMessage);
+
+                            var errorDetail = newStatus.ErrorMessage ?? "Connection failed";
+                            _emailAlertService.RecordAlert(item.Id, item.DisplayName, "Server Unreachable",
+                                errorDetail, "Online", true, "email");
+                            _ = _emailAlertService.TrySendAlertEmailAsync(
+                                "Server Unreachable",
+                                item.DisplayName,
+                                errorDetail,
+                                "Online",
+                                item.Id);
                         }
                         else if (!wasOnline && isOnline && prefs.NotifyOnConnectionRestored)
                         {
                             _notificationService?.ShowConnectionRestoredNotification(item.DisplayName);
+
+                            _emailAlertService.RecordAlert(item.Id, item.DisplayName, "Server Restored",
+                                "Online", "Online", true, "email");
+                            _ = _emailAlertService.TrySendAlertEmailAsync(
+                                "Server Restored",
+                                item.DisplayName,
+                                "Connection restored",
+                                "Online",
+                                item.Id);
                         }
                     }
 

--- a/Dashboard/Services/EmailTemplateBuilder.cs
+++ b/Dashboard/Services/EmailTemplateBuilder.cs
@@ -74,6 +74,8 @@ namespace PerformanceMonitorDashboard.Services
                 "Long-Running Query" => ("#D97706", "WARNING"),
                 "TempDB Space" => ("#D97706", "WARNING"),
                 "Long-Running Job" => ("#D97706", "WARNING"),
+                "Server Unreachable" => ("#DC2626", "CRITICAL"),
+                "Server Restored" => ("#16A34A", "RESOLVED"),
                 _ => ("#2eaef1", "INFO")
             };
         }


### PR DESCRIPTION
## Summary
- Sends email alert on online→offline transition (fires once, not repeatedly)
- Sends "Server Restored" email on offline→online transition
- Uses existing `NotifyOnConnectionLost` / `NotifyOnConnectionRestored` preferences — no new settings
- Adds `Server Unreachable` (red/CRITICAL) and `Server Restored` (green/RESOLVED) to email template severity map
- Rate-limited by EmailAlertService cooldown if a server flaps

Fixes #529

## Test plan
- [ ] Configure SMTP, stop a monitored SQL Server, verify email arrives once
- [ ] Verify no repeat emails while server stays offline
- [ ] Restart server, verify "Server Restored" email arrives
- [ ] Verify tray notifications still work alongside emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)