### PR TITLE
Fix Azure SQL DB FinOps showing only master database (#557)

### DIFF
--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -175,8 +175,6 @@ ORDER BY
     df.file_id
 OPTION(RECOMPILE);";
 
-        string query = isAzureSqlDb ? azureSqlDbQuery : onPremQuery;
-
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
         var rowsCollected = 0;
@@ -190,30 +188,64 @@ OPTION(RECOMPILE);";
             decimal? VolumeTotalMb, decimal? VolumeFreeMb)>();
 
         var sqlSw = Stopwatch.StartNew();
-        using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
-        using var command = new SqlCommand(query, sqlConnection);
-        command.CommandTimeout = CommandTimeoutSeconds;
 
-        using var reader = await command.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
+        if (isAzureSqlDb)
         {
-            rows.Add((
-                reader.GetString(0),
-                Convert.ToInt32(reader.GetValue(1)),
-                Convert.ToInt32(reader.GetValue(2)),
-                reader.GetString(3),
-                reader.GetString(4),
-                reader.GetString(5),
-                reader.GetDecimal(6),
-                reader.IsDBNull(7) ? null : reader.GetDecimal(7),
-                reader.IsDBNull(8) ? null : reader.GetDecimal(8),
-                reader.IsDBNull(9) ? null : reader.GetDecimal(9),
-                reader.IsDBNull(10) ? null : reader.GetString(10),
-                reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)),
-                reader.IsDBNull(12) ? null : reader.GetString(12),
-                reader.IsDBNull(13) ? null : reader.GetString(13),
-                reader.IsDBNull(14) ? null : reader.GetDecimal(14),
-                reader.IsDBNull(15) ? null : reader.GetDecimal(15)));
+            // Azure SQL DB: each database is isolated, so we must connect to each one individually.
+            // First get the database list from master, then query sys.database_files per database.
+            var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+            var databases = new List<string>();
+
+            using (var masterConn = new SqlConnection(
+                new SqlConnectionStringBuilder(baseConnStr) { ConnectTimeout = ConnectionTimeoutSeconds, InitialCatalog = "master" }.ConnectionString))
+            {
+                await masterConn.OpenAsync(cancellationToken);
+                using var dbListCmd = new SqlCommand(
+                    "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 AND HAS_DBACCESS(name) = 1 ORDER BY name;",
+                    masterConn);
+                dbListCmd.CommandTimeout = CommandTimeoutSeconds;
+                using var dbReader = await dbListCmd.ExecuteReaderAsync(cancellationToken);
+                while (await dbReader.ReadAsync(cancellationToken))
+                    databases.Add(dbReader.GetString(0));
+            }
+
+            foreach (var dbName in databases)
+            {
+                try
+                {
+                    var dbConnStr = new SqlConnectionStringBuilder(baseConnStr)
+                    {
+                        ConnectTimeout = ConnectionTimeoutSeconds,
+                        InitialCatalog = dbName
+                    }.ConnectionString;
+
+                    using var dbConn = new SqlConnection(dbConnStr);
+                    await dbConn.OpenAsync(cancellationToken);
+                    using var cmd = new SqlCommand(azureSqlDbQuery, dbConn);
+                    cmd.CommandTimeout = CommandTimeoutSeconds;
+                    using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                    while (await reader.ReadAsync(cancellationToken))
+                    {
+                        rows.Add(ReadSizeRow(reader));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Skipping database '{Database}' for size collection: {Error}", dbName, ex.Message);
+                }
+            }
+        }
+        else
+        {
+            using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+            using var command = new SqlCommand(onPremQuery, sqlConnection);
+            command.CommandTimeout = CommandTimeoutSeconds;
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                rows.Add(ReadSizeRow(reader));
+            }
         }
         sqlSw.Stop();
 
@@ -260,5 +292,30 @@ OPTION(RECOMPILE);";
 
         _logger?.LogDebug("Collected {RowCount} database size rows for server '{Server}'", rowsCollected, server.DisplayName);
         return rowsCollected;
+    }
+
+    private static (string DatabaseName, int DatabaseId, int FileId, string FileTypeDesc,
+        string FileName, string PhysicalName, decimal TotalSizeMb, decimal? UsedSizeMb,
+        decimal? AutoGrowthMb, decimal? MaxSizeMb, string? RecoveryModel,
+        int? CompatibilityLevel, string? StateDesc, string? VolumeMountPoint,
+        decimal? VolumeTotalMb, decimal? VolumeFreeMb) ReadSizeRow(SqlDataReader reader)
+    {
+        return (
+            reader.GetString(0),
+            Convert.ToInt32(reader.GetValue(1)),
+            Convert.ToInt32(reader.GetValue(2)),
+            reader.GetString(3),
+            reader.GetString(4),
+            reader.GetString(5),
+            reader.GetDecimal(6),
+            reader.IsDBNull(7) ? null : reader.GetDecimal(7),
+            reader.IsDBNull(8) ? null : reader.GetDecimal(8),
+            reader.IsDBNull(9) ? null : reader.GetDecimal(9),
+            reader.IsDBNull(10) ? null : reader.GetString(10),
+            reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)),
+            reader.IsDBNull(12) ? null : reader.GetString(12),
+            reader.IsDBNull(13) ? null : reader.GetString(13),
+            reader.IsDBNull(14) ? null : reader.GetDecimal(14),
+            reader.IsDBNull(15) ? null : reader.GetDecimal(15));
     }
 }


### PR DESCRIPTION
## Summary
- Azure SQL DB isolates databases — `sys.database_files` only returns files for the connected database
- Collector now enumerates all databases via `sys.databases` on master, then connects to each individually
- Extracted `ReadSizeRow` helper to deduplicate reader parsing between Azure and on-prem paths
- On-prem/MI/RDS path unchanged (still uses `sys.master_files` cursor approach)

Note: The Dashboard's server-side collector (`52_collect_database_size_stats.sql`) has the same limitation but requires a different fix since it runs as a stored procedure inside SQL Agent. That's a separate issue.

Fixes #557

## Test plan
- [ ] Connect Lite to an Azure SQL logical server with multiple databases
- [ ] Verify Storage Growth shows all databases, not just master
- [ ] Verify Database Sizes shows all databases
- [ ] Verify on-prem collection still works unchanged
- [ ] Verify inaccessible databases are skipped gracefully (logged, not fatal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)