### PR TITLE
Fix HAS_DBACCESS filtering out Azure SQL DB user databases (#557)

### DIFF
--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -200,8 +200,10 @@ OPTION(RECOMPILE);";
                 new SqlConnectionStringBuilder(baseConnStr) { ConnectTimeout = ConnectionTimeoutSeconds, InitialCatalog = "master" }.ConnectionString))
             {
                 await masterConn.OpenAsync(cancellationToken);
+                // HAS_DBACCESS() returns false for user databases when queried from master on Azure SQL DB,
+                // so we skip that filter here — inaccessible databases are handled by the try/catch below.
                 using var dbListCmd = new SqlCommand(
-                    "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 AND HAS_DBACCESS(name) = 1 ORDER BY name;",
+                    "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
                     masterConn);
                 dbListCmd.CommandTimeout = CommandTimeoutSeconds;
                 using var dbReader = await dbListCmd.ExecuteReaderAsync(cancellationToken);


### PR DESCRIPTION
## Summary
Follow-up to PR #560. Testing against a real Azure SQL logical server revealed that `HAS_DBACCESS(name)` returns false for user databases when queried from `master` on Azure SQL DB, so the database enumeration only found `master`.

Removed the `HAS_DBACCESS` filter for the Azure path — inaccessible databases are already handled by the per-database try/catch block.

## Testing
Tested against Azure SQL logical server `finops-test-557.database.windows.net` with 3 databases:
- **Before fix**: enumeration returned only `master` (1 database)
- **After fix**: enumeration returned `master`, `testdb1`, `testdb2` (3 databases, 8 file rows total)

Null `used_size_mb` values (e.g., XTP/FILESTREAM files) handled correctly by existing `IsDBNull` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)