### PR TITLE
Fix Azure SQL DB: all FinOps collectors + Server Inventory (#557)

### DIFF
--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -75,7 +75,19 @@ ORDER BY database_name, file_type_desc, file_name";
         using var connection = new SqlConnection(connectionString);
         await connection.OpenAsync();
 
+        // sys.master_files doesn't exist on Azure SQL DB — dynamic SQL picks the right catalog view
         const string query = @"
+DECLARE
+    @storage_sql nvarchar(MAX) =
+        CASE
+            WHEN CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5
+            THEN N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.database_files'
+            ELSE N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files'
+        END,
+    @storage_gb decimal(19,2);
+
+EXEC sys.sp_executesql @storage_sql, N'@gb decimal(19,2) OUTPUT', @gb = @storage_gb OUTPUT;
+
 SELECT
     CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
     CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')),
@@ -84,7 +96,7 @@ SELECT
     si.cpu_count,
     si.physical_memory_kb / 1024,
     si.sqlserver_start_time,
-    (SELECT SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files),
+    @storage_gb,
     si.socket_count,
     si.cores_per_socket,
     CONVERT(int, SERVERPROPERTY('EngineEdition')),

--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -192,37 +192,13 @@ OPTION(RECOMPILE);";
         if (isAzureSqlDb)
         {
             // Azure SQL DB: each database is isolated, so we must connect to each one individually.
-            // First get the database list from master, then query sys.database_files per database.
-            var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
-            var databases = new List<string>();
-
-            using (var masterConn = new SqlConnection(
-                new SqlConnectionStringBuilder(baseConnStr) { ConnectTimeout = ConnectionTimeoutSeconds, InitialCatalog = "master" }.ConnectionString))
-            {
-                await masterConn.OpenAsync(cancellationToken);
-                // HAS_DBACCESS() returns false for user databases when queried from master on Azure SQL DB,
-                // so we skip that filter here — inaccessible databases are handled by the try/catch below.
-                using var dbListCmd = new SqlCommand(
-                    "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
-                    masterConn);
-                dbListCmd.CommandTimeout = CommandTimeoutSeconds;
-                using var dbReader = await dbListCmd.ExecuteReaderAsync(cancellationToken);
-                while (await dbReader.ReadAsync(cancellationToken))
-                    databases.Add(dbReader.GetString(0));
-            }
+            var databases = await GetAzureDatabaseListAsync(server, cancellationToken);
 
             foreach (var dbName in databases)
             {
                 try
                 {
-                    var dbConnStr = new SqlConnectionStringBuilder(baseConnStr)
-                    {
-                        ConnectTimeout = ConnectionTimeoutSeconds,
-                        InitialCatalog = dbName
-                    }.ConnectionString;
-
-                    using var dbConn = new SqlConnection(dbConnStr);
-                    await dbConn.OpenAsync(cancellationToken);
+                    using var dbConn = await OpenAzureDatabaseConnectionAsync(server, dbName, cancellationToken);
                     using var cmd = new SqlCommand(azureSqlDbQuery, dbConn);
                     cmd.CommandTimeout = CommandTimeoutSeconds;
                     using var reader = await cmd.ExecuteReaderAsync(cancellationToken);

--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -92,11 +92,6 @@ OPTION(RECOMPILE);";
         _lastDuckDbMs = 0;
 
         var sqlSw = Stopwatch.StartNew();
-        using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
-        using var command = new SqlCommand(query, sqlConnection);
-        command.CommandTimeout = CommandTimeoutSeconds;
-
-        using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         /* Collect all rows first */
         var fileStats = new List<(
@@ -105,25 +100,34 @@ OPTION(RECOMPILE);";
             long IoStallReadMs, long IoStallWriteMs, long IoStallQueuedReadMs, long IoStallQueuedWriteMs,
             int DatabaseId, int FileId)>();
 
-        while (await reader.ReadAsync(cancellationToken))
+        if (isAzureSqlDb)
         {
-            fileStats.Add((
-                DatabaseName: reader.IsDBNull(0) ? "Unknown" : reader.GetString(0),
-                FileName: reader.IsDBNull(1) ? "Unknown" : reader.GetString(1),
-                FileType: reader.IsDBNull(2) ? "Unknown" : reader.GetString(2),
-                PhysicalName: reader.IsDBNull(3) ? "" : reader.GetString(3),
-                SizeMb: reader.IsDBNull(4) ? 0m : reader.GetDecimal(4),
-                NumOfReads: reader.IsDBNull(5) ? 0L : reader.GetInt64(5),
-                NumOfWrites: reader.IsDBNull(6) ? 0L : reader.GetInt64(6),
-                ReadBytes: reader.IsDBNull(7) ? 0L : reader.GetInt64(7),
-                WriteBytes: reader.IsDBNull(8) ? 0L : reader.GetInt64(8),
-                IoStallReadMs: reader.IsDBNull(9) ? 0L : reader.GetInt64(9),
-                IoStallWriteMs: reader.IsDBNull(10) ? 0L : reader.GetInt64(10),
-                IoStallQueuedReadMs: reader.IsDBNull(11) ? 0L : reader.GetInt64(11),
-                IoStallQueuedWriteMs: reader.IsDBNull(12) ? 0L : reader.GetInt64(12),
-                DatabaseId: reader.IsDBNull(13) ? 0 : Convert.ToInt32(reader.GetValue(13)),
-                FileId: reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14))
-            ));
+            // Azure SQL DB: dm_io_virtual_file_stats is scoped to the connected database,
+            // so we must connect to each database individually.
+            var databases = await GetAzureDatabaseListAsync(server, cancellationToken);
+            foreach (var dbName in databases)
+            {
+                try
+                {
+                    using var dbConn = await OpenAzureDatabaseConnectionAsync(server, dbName, cancellationToken);
+                    using var cmd = new SqlCommand(query, dbConn) { CommandTimeout = CommandTimeoutSeconds };
+                    using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                    while (await reader.ReadAsync(cancellationToken))
+                        fileStats.Add(ReadFileIoRow(reader));
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Skipping database '{Database}' for file I/O: {Error}", dbName, ex.Message);
+                }
+            }
+        }
+        else
+        {
+            using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+            using var command = new SqlCommand(query, sqlConnection) { CommandTimeout = CommandTimeoutSeconds };
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                fileStats.Add(ReadFileIoRow(reader));
         }
         sqlSw.Stop();
 
@@ -187,5 +191,28 @@ OPTION(RECOMPILE);";
 
         _logger?.LogDebug("Collected {RowCount} file I/O stats for server '{Server}'", rowsCollected, server.DisplayName);
         return rowsCollected;
+    }
+
+    private static (string DatabaseName, string FileName, string FileType, string PhysicalName,
+        decimal SizeMb, long NumOfReads, long NumOfWrites, long ReadBytes, long WriteBytes,
+        long IoStallReadMs, long IoStallWriteMs, long IoStallQueuedReadMs, long IoStallQueuedWriteMs,
+        int DatabaseId, int FileId) ReadFileIoRow(SqlDataReader reader)
+    {
+        return (
+            DatabaseName: reader.IsDBNull(0) ? "Unknown" : reader.GetString(0),
+            FileName: reader.IsDBNull(1) ? "Unknown" : reader.GetString(1),
+            FileType: reader.IsDBNull(2) ? "Unknown" : reader.GetString(2),
+            PhysicalName: reader.IsDBNull(3) ? "" : reader.GetString(3),
+            SizeMb: reader.IsDBNull(4) ? 0m : reader.GetDecimal(4),
+            NumOfReads: reader.IsDBNull(5) ? 0L : reader.GetInt64(5),
+            NumOfWrites: reader.IsDBNull(6) ? 0L : reader.GetInt64(6),
+            ReadBytes: reader.IsDBNull(7) ? 0L : reader.GetInt64(7),
+            WriteBytes: reader.IsDBNull(8) ? 0L : reader.GetInt64(8),
+            IoStallReadMs: reader.IsDBNull(9) ? 0L : reader.GetInt64(9),
+            IoStallWriteMs: reader.IsDBNull(10) ? 0L : reader.GetInt64(10),
+            IoStallQueuedReadMs: reader.IsDBNull(11) ? 0L : reader.GetInt64(11),
+            IoStallQueuedWriteMs: reader.IsDBNull(12) ? 0L : reader.GetInt64(12),
+            DatabaseId: reader.IsDBNull(13) ? 0 : Convert.ToInt32(reader.GetValue(13)),
+            FileId: reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14)));
     }
 }

--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -180,8 +180,6 @@ ORDER BY
     qs.total_elapsed_time DESC
 OPTION(RECOMPILE);";
 
-        string query = isAzureSqlDb ? azureSqlDbQuery : standardQuery;
-
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
         var rowsCollected = 0;
@@ -189,14 +187,36 @@ OPTION(RECOMPILE);";
         _lastDuckDbMs = 0;
 
         var sqlSw = Stopwatch.StartNew();
-        using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
-        using var command = new SqlCommand(query, sqlConnection);
-        command.CommandTimeout = CommandTimeoutSeconds;
 
-        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        // Build list of (SqlConnection, query) pairs to execute
+        var connections = new List<(SqlConnection Connection, string Query, bool OwnsConnection)>();
 
-        sqlSw.Stop();
+        if (isAzureSqlDb)
+        {
+            // Azure SQL DB: dm_exec_query_stats is scoped to the connected database,
+            // so we must connect to each database individually.
+            var databases = await GetAzureDatabaseListAsync(server, cancellationToken);
+            foreach (var dbName in databases)
+            {
+                try
+                {
+                    var conn = await OpenAzureDatabaseConnectionAsync(server, dbName, cancellationToken);
+                    connections.Add((conn, azureSqlDbQuery, true));
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Skipping database '{Database}' for query stats: {Error}", dbName, ex.Message);
+                }
+            }
+        }
+        else
+        {
+            var conn = await CreateConnectionAsync(server, cancellationToken);
+            connections.Add((conn, standardQuery, true));
+        }
 
+        try
+        {
         var duckSw = Stopwatch.StartNew();
 
         using (var duckConnection = _duckDb.CreateConnection())
@@ -205,6 +225,13 @@ OPTION(RECOMPILE);";
 
             using (var appender = duckConnection.CreateAppender("query_stats"))
             {
+                foreach (var (sqlConnection, query, _) in connections)
+                {
+                using var command = new SqlCommand(query, sqlConnection);
+                command.CommandTimeout = CommandTimeoutSeconds;
+
+                using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
                 while (await reader.ReadAsync(cancellationToken))
                 {
                     /* Reader ordinals match SELECT column order:
@@ -306,12 +333,20 @@ OPTION(RECOMPILE);";
 
                     rowsCollected++;
                 }
+                } // end foreach connection
             }
         }
 
+        sqlSw.Stop();
         duckSw.Stop();
         _lastSqlMs = sqlSw.ElapsedMilliseconds;
         _lastDuckDbMs = duckSw.ElapsedMilliseconds;
+        }
+        finally
+        {
+            foreach (var (conn, _, _) in connections)
+                conn.Dispose();
+        }
 
         _logger?.LogDebug("Collected {RowCount} query stats for server '{Server}'", rowsCollected, server.DisplayName);
         return rowsCollected;

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -483,6 +483,50 @@ public partial class RemoteCollectorService
     }
 
     /// <summary>
+    /// Enumerates online databases on an Azure SQL DB logical server.
+    /// HAS_DBACCESS() returns false for user databases from master on Azure SQL DB,
+    /// so we skip that filter — inaccessible databases should be handled by callers via try/catch.
+    /// </summary>
+    protected async Task<List<string>> GetAzureDatabaseListAsync(ServerConnection server, CancellationToken cancellationToken)
+    {
+        var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+        var connStr = new SqlConnectionStringBuilder(baseConnStr)
+        {
+            ConnectTimeout = ConnectionTimeoutSeconds,
+            InitialCatalog = "master"
+        }.ConnectionString;
+
+        var databases = new List<string>();
+        using var conn = new SqlConnection(connStr);
+        await conn.OpenAsync(cancellationToken);
+        using var cmd = new SqlCommand(
+            "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
+            conn)
+        { CommandTimeout = CommandTimeoutSeconds };
+        using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+            databases.Add(reader.GetString(0));
+        return databases;
+    }
+
+    /// <summary>
+    /// Opens a SQL connection to a specific database on an Azure SQL DB logical server.
+    /// </summary>
+    protected async Task<SqlConnection> OpenAzureDatabaseConnectionAsync(ServerConnection server, string databaseName, CancellationToken cancellationToken)
+    {
+        var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+        var connStr = new SqlConnectionStringBuilder(baseConnStr)
+        {
+            ConnectTimeout = ConnectionTimeoutSeconds,
+            InitialCatalog = databaseName
+        }.ConnectionString;
+
+        var conn = new SqlConnection(connStr);
+        await conn.OpenAsync(cancellationToken);
+        return conn;
+    }
+
+    /// <summary>
     /// Creates a SQL connection to a remote server.
     /// Throws InvalidOperationException if MFA authentication was cancelled by user.
     /// </summary>


### PR DESCRIPTION
## Summary
Follow-up to PRs #560 and #561. Extends the per-database connection approach to all affected Azure SQL DB collectors:

- **Database sizes**: already fixed in #560, refactored to use shared helpers
- **Query stats**: `dm_exec_query_stats` is database-scoped on Azure — now iterates all databases
- **File I/O**: `dm_io_virtual_file_stats` is database-scoped on Azure — now iterates all databases
- **Server Inventory**: `sys.master_files` doesn't exist on Azure SQL DB — uses dynamic SQL to pick `sys.database_files` when EngineEdition = 5
- **Shared helpers**: `GetAzureDatabaseListAsync` and `OpenAzureDatabaseConnectionAsync` added to `RemoteCollectorService` to deduplicate the pattern

## Testing
Tested end-to-end against Azure SQL logical server `finops-test-557b.database.windows.net` with 3 databases (master, SalesDB, InventoryDB):
- Storage Growth: all 3 databases visible
- Database Sizes: all 3 databases visible
- Database Resources: all databases with query activity visible
- Server Inventory: Azure server now appears (was silently dropped before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)