### PR TITLE
Add data import from previous Lite install (#566)

### DIFF
--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -168,6 +168,13 @@
                                 <TextBlock Text="Open Plan Viewer" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
+                        <Button x:Name="ImportDataButton" Click="ImportDataButton_Click" Margin="0,8,0,0"
+                                ToolTip="Import historical data from a previous Lite install">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8B5;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock x:Name="ImportDataButtonText" Text="Import Data" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <Button x:Name="SettingsButton" Click="SettingsButton_Click" Margin="0,8,0,0">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -840,6 +840,102 @@ public partial class MainWindow : Window
         window.ShowDialog();
     }
 
+    private async void ImportDataButton_Click(object sender, RoutedEventArgs e)
+    {
+        /* Open folder browser to select the old Lite install directory */
+        var dialog = new Microsoft.Win32.OpenFolderDialog
+        {
+            Title = "Select Previous Lite Install Folder",
+            Multiselect = false
+        };
+
+        if (dialog.ShowDialog(this) != true || string.IsNullOrWhiteSpace(dialog.FolderName))
+        {
+            return;
+        }
+
+        var sourceFolder = dialog.FolderName;
+
+        /* Validate that monitor.duckdb exists in the selected folder */
+        if (!DataImportService.ValidateSourceFolder(sourceFolder))
+        {
+            MessageBox.Show(
+                "The selected folder does not contain a monitor.duckdb file.\n\n" +
+                "Please select the folder where the previous Lite application was installed.",
+                "Invalid Folder",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            return;
+        }
+
+        /* Prevent double-clicks */
+        ImportDataButton.IsEnabled = false;
+        ImportDataButtonText.Text = "Importing...";
+        StatusText.Text = "Importing data from previous install...";
+
+        try
+        {
+            var importService = new DataImportService(_databaseInitializer, App.ArchiveDirectory);
+
+            /* The tryLockOldDb callback runs on the UI thread to show the retry dialog */
+            var result = await Task.Run(async () =>
+                await importService.RunImportAsync(sourceFolder, async _ =>
+                {
+                    var answer = MessageBoxResult.Cancel;
+                    await Dispatcher.InvokeAsync(() =>
+                    {
+                        answer = MessageBox.Show(
+                            "Could not lock the database to flush current data.\n\n" +
+                            "Close the previous Lite application and click OK to try again.",
+                            "Database Locked",
+                            MessageBoxButton.OKCancel,
+                            MessageBoxImage.Warning);
+                    });
+                    return answer == MessageBoxResult.OK;
+                }));
+
+            if (result.Success)
+            {
+                StatusText.Text = "Import complete";
+                MessageBox.Show(
+                    $"Import completed successfully.\n\n" +
+                    $"Tables flushed from old database: {result.TablesFlushed}\n" +
+                    $"Parquet files imported: {result.FilesImported}\n\n" +
+                    "Historical data is now available in all views.",
+                    "Import Complete",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            else
+            {
+                StatusText.Text = "Import cancelled or failed";
+                if (!string.IsNullOrEmpty(result.ErrorMessage))
+                {
+                    MessageBox.Show(
+                        result.ErrorMessage,
+                        "Import Failed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("DataImport", "Unhandled import error", ex);
+            StatusText.Text = "Import failed";
+            MessageBox.Show(
+                $"An unexpected error occurred during import:\n\n{ex.Message}",
+                "Import Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+        finally
+        {
+            ImportDataButton.IsEnabled = true;
+            ImportDataButtonText.Text = "Import Data";
+        }
+    }
+
     /// <summary>
     /// Gets the ServerConnection from a context menu click on a server list item.
     /// </summary>

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -33,7 +33,7 @@ public class ArchiveService
     /* Tables eligible for archival with their time column.
        IMPORTANT: Every table with time-series data must be listed here,
        or it will grow unbounded and push the DB past the 512 MB reset threshold. */
-    private static readonly (string Table, string TimeColumn)[] ArchivableTables =
+    internal static readonly (string Table, string TimeColumn)[] ArchivableTables =
     [
         ("wait_stats", "collection_time"),
         ("query_stats", "collection_time"),

--- a/Lite/Services/DataImportService.cs
+++ b/Lite/Services/DataImportService.cs
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitorLite.Database;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Imports historical data from a previous Lite install by flushing the old DuckDB
+/// hot tables to parquet, copying parquet files to the current archive folder,
+/// and refreshing archive views.
+/// </summary>
+public class DataImportService
+{
+    private readonly DuckDbInitializer _duckDb;
+    private readonly string _currentArchivePath;
+
+    public DataImportService(DuckDbInitializer duckDb, string currentArchivePath)
+    {
+        _duckDb = duckDb;
+        _currentArchivePath = currentArchivePath;
+    }
+
+    /// <summary>
+    /// Result of a data import operation.
+    /// </summary>
+    public sealed class ImportResult
+    {
+        public bool Success { get; init; }
+        public int FilesImported { get; init; }
+        public int TablesFlushed { get; init; }
+        public string? ErrorMessage { get; init; }
+    }
+
+    /// <summary>
+    /// Validates that the selected folder contains a monitor.duckdb file.
+    /// </summary>
+    public static bool ValidateSourceFolder(string folderPath)
+    {
+        return File.Exists(Path.Combine(folderPath, "monitor.duckdb"));
+    }
+
+    /// <summary>
+    /// Attempts to open the old DuckDB in read-write mode to flush hot table data to parquet.
+    /// Returns true if successful, false if the database is locked.
+    /// </summary>
+    public static (bool Locked, int TablesFlushed) FlushOldDatabase(string folderPath)
+    {
+        var dbPath = Path.Combine(folderPath, "monitor.duckdb");
+        var archivePath = Path.Combine(folderPath, "archive");
+        var tablesFlushed = 0;
+
+        DuckDBConnection? connection = null;
+        try
+        {
+            connection = new DuckDBConnection($"Data Source={dbPath}");
+            connection.Open();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warn("DataImport", $"Could not open old database for flushing: {ex.Message}");
+            connection?.Dispose();
+            return (true, 0);
+        }
+
+        try
+        {
+            if (!Directory.Exists(archivePath))
+            {
+                Directory.CreateDirectory(archivePath);
+            }
+
+            var timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmm");
+
+            foreach (var (table, _) in ArchiveService.ArchivableTables)
+            {
+                try
+                {
+                    /* Check if the table exists in the old database */
+                    using var checkCmd = connection.CreateCommand();
+                    checkCmd.CommandText = $"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '{table}'";
+                    var exists = Convert.ToInt64(checkCmd.ExecuteScalar()) > 0;
+                    if (!exists)
+                    {
+                        continue;
+                    }
+
+                    /* Check if the table has rows */
+                    using var countCmd = connection.CreateCommand();
+                    countCmd.CommandText = $"SELECT COUNT(*) FROM {table}";
+                    var rowCount = Convert.ToInt64(countCmd.ExecuteScalar());
+                    if (rowCount == 0)
+                    {
+                        continue;
+                    }
+
+                    /* Export all rows to parquet */
+                    var parquetPath = Path.Combine(archivePath, $"{timestamp}_{table}.parquet")
+                        .Replace("\\", "/");
+
+                    using var exportCmd = connection.CreateCommand();
+                    exportCmd.CommandText = $"COPY (SELECT * FROM {table}) TO '{parquetPath}' (FORMAT PARQUET, COMPRESSION ZSTD)";
+                    exportCmd.ExecuteNonQuery();
+
+                    tablesFlushed++;
+                    AppLogger.Info("DataImport", $"Flushed {rowCount} rows from old {table} to {Path.GetFileName(parquetPath)}");
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Warn("DataImport", $"Skipped flushing table {table}: {ex.Message}");
+                }
+            }
+        }
+        finally
+        {
+            connection.Dispose();
+        }
+
+        return (false, tablesFlushed);
+    }
+
+    /// <summary>
+    /// Copies all parquet files from the old install's archive folder to the current archive folder.
+    /// Files are prefixed with "imported_" to avoid naming collisions.
+    /// Returns the count of files copied.
+    /// </summary>
+    public int CopyParquetFiles(string sourceFolder)
+    {
+        var sourceArchive = Path.Combine(sourceFolder, "archive");
+        if (!Directory.Exists(sourceArchive))
+        {
+            AppLogger.Info("DataImport", "No archive folder found in source — nothing to copy");
+            return 0;
+        }
+
+        if (!Directory.Exists(_currentArchivePath))
+        {
+            Directory.CreateDirectory(_currentArchivePath);
+        }
+
+        var sourceFiles = Directory.GetFiles(sourceArchive, "*.parquet");
+        if (sourceFiles.Length == 0)
+        {
+            AppLogger.Info("DataImport", "No parquet files found in source archive");
+            return 0;
+        }
+
+        var copied = 0;
+        foreach (var sourceFile in sourceFiles)
+        {
+            try
+            {
+                var fileName = Path.GetFileName(sourceFile);
+
+                /* Prefix with imported_ (strip existing imported_ prefix if re-importing) */
+                if (fileName.StartsWith("imported_", StringComparison.OrdinalIgnoreCase))
+                {
+                    /* Already prefixed — keep the same name to overwrite on re-import */
+                }
+                else
+                {
+                    fileName = $"imported_{fileName}";
+                }
+
+                var destPath = Path.Combine(_currentArchivePath, fileName);
+                File.Copy(sourceFile, destPath, overwrite: true);
+                copied++;
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Warn("DataImport", $"Failed to copy {Path.GetFileName(sourceFile)}: {ex.Message}");
+            }
+        }
+
+        AppLogger.Info("DataImport", $"Copied {copied} parquet files to current archive");
+        return copied;
+    }
+
+    /// <summary>
+    /// Refreshes archive views so the imported parquet files are picked up by glob patterns.
+    /// </summary>
+    public async Task RefreshViewsAsync()
+    {
+        await _duckDb.CreateArchiveViewsAsync();
+        AppLogger.Info("DataImport", "Archive views refreshed after import");
+    }
+
+    /// <summary>
+    /// Runs the full import pipeline: flush old DB, copy parquet files, refresh views.
+    /// This method is designed to be called from a background thread via Task.Run.
+    /// The tryLockOldDb callback handles the retry/cancel dialog on the UI thread.
+    /// </summary>
+    public async Task<ImportResult> RunImportAsync(string sourceFolder, Func<string, Task<bool>> tryLockOldDb)
+    {
+        try
+        {
+            AppLogger.Info("DataImport", $"Starting import from {sourceFolder}");
+
+            /* Step 1: Flush old database */
+            var (locked, tablesFlushed) = FlushOldDatabase(sourceFolder);
+            while (locked)
+            {
+                var retry = await tryLockOldDb(sourceFolder);
+                if (!retry)
+                {
+                    AppLogger.Info("DataImport", "Import cancelled by user (database lock)");
+                    return new ImportResult { Success = false, ErrorMessage = "Import cancelled." };
+                }
+                (locked, tablesFlushed) = FlushOldDatabase(sourceFolder);
+            }
+
+            AppLogger.Info("DataImport", $"Flushed {tablesFlushed} tables from old database");
+
+            /* Step 2: Copy parquet files */
+            var filesCopied = CopyParquetFiles(sourceFolder);
+
+            /* Step 3: Refresh archive views */
+            await RefreshViewsAsync();
+
+            AppLogger.Info("DataImport", $"Import complete: {tablesFlushed} tables flushed, {filesCopied} files imported");
+
+            return new ImportResult
+            {
+                Success = true,
+                FilesImported = filesCopied,
+                TablesFlushed = tablesFlushed
+            };
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("DataImport", "Import failed", ex);
+            return new ImportResult
+            {
+                Success = false,
+                ErrorMessage = $"Import failed: {ex.Message}"
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds an "Import Data" button to Lite that brings in monitoring history from a previous install, preserving trend data across version upgrades.

### How it works
1. User clicks "Import Data" → selects old Lite install folder
2. **Flush**: Opens old `monitor.duckdb` read-write, exports all hot table data to parquet in the old `archive/` folder. If the old app is still running (write lock), shows a retry dialog.
3. **Copy**: Copies all `archive/*.parquet` from old install to current `archive/` folder with `imported_` prefix — avoids overwriting current files, safe to re-import
4. **Refresh**: Refreshes archive views so imported data is immediately visible

### Files changed
- **New**: `Lite/Services/DataImportService.cs` — import pipeline (flush → copy → refresh)
- **Modified**: `Lite/MainWindow.xaml` — "Import Data" button in sidebar
- **Modified**: `Lite/MainWindow.xaml.cs` — click handler with async import, retry dialog
- **Modified**: `Lite/Services/ArchiveService.cs` — `ArchivableTables` visibility changed to `internal`

Fixes #566

## Test plan
- [ ] Click Import Data, select a folder without `monitor.duckdb` — should show error
- [ ] Click Import Data with old Lite still running — should show retry/cancel dialog
- [ ] Close old Lite, retry — should flush and import successfully
- [ ] Verify imported parquet files have `imported_` prefix in archive folder
- [ ] Verify FinOps trend data from old install is visible after import
- [ ] Re-import same folder — should overwrite `imported_*` files cleanly
- [ ] Verify on-prem server data loads correctly after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)