### PR TITLE
Fix FinOps recommendations: remove noise, exclude PerformanceMonitor DB, refresh cost

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -101,6 +101,13 @@ namespace PerformanceMonitorDashboard.Controls
         {
             try
             {
+                // Re-read monthly cost from server manager in case user edited the server config
+                if (ServerSelector.SelectedItem is ServerConnection selectedServer && _serverManager != null)
+                {
+                    var fresh = _serverManager.GetServerById(selectedServer.Id);
+                    _currentServerMonthlyCost = fresh?.MonthlyCostUsd ?? selectedServer.MonthlyCostUsd;
+                }
+
                 await Task.WhenAll(
                     LoadRecommendationsAsync(),
                     LoadUtilizationAsync(),

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1005,7 +1005,7 @@ FROM db_sizes AS ds
 LEFT JOIN db_activity AS a
   ON a.database_name = ds.database_name
 WHERE ISNULL(a.total_executions, 0) = 0
-AND   ds.database_name NOT IN (N'master', N'model', N'msdb', N'tempdb')
+AND   ds.database_name NOT IN (N'master', N'model', N'msdb', N'tempdb', N'PerformanceMonitor')
 ORDER BY
     ds.total_size_mb DESC
 OPTION(MAXDOP 1, RECOMPILE);";
@@ -1939,46 +1939,6 @@ AND   database_id > 4", connection);
             catch (Exception ex)
             {
                 Logger.Error($"Recommendation check failed (Dev/test detection): {ex.Message}", ex);
-            }
-
-            // 8. tempdb over-provisioning
-            try
-            {
-                using var tempdbCmd = new SqlCommand(@"
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT
-    allocated_mb =
-        (SELECT SUM(size) * 8.0 / 1024 FROM tempdb.sys.database_files WHERE type = 0),
-    peak_used_mb =
-        ISNULL((SELECT MAX(total_reserved_mb) FROM collect.tempdb_stats
-         WHERE collection_time >= DATEADD(DAY, -7, SYSDATETIME())), 0)
-OPTION(MAXDOP 1, RECOMPILE);", connection);
-                tempdbCmd.CommandTimeout = 30;
-
-                using var tempdbReader = await tempdbCmd.ExecuteReaderAsync();
-                if (await tempdbReader.ReadAsync())
-                {
-                    var allocatedMb = tempdbReader.IsDBNull(0) ? 0m : Convert.ToDecimal(tempdbReader.GetValue(0));
-                    var peakUsedMb = tempdbReader.IsDBNull(1) ? 0m : Convert.ToDecimal(tempdbReader.GetValue(1));
-
-                    if (allocatedMb > 1024 && peakUsedMb > 0 && (peakUsedMb / allocatedMb) < 0.25m)
-                    {
-                        var usagePct = peakUsedMb / allocatedMb * 100m;
-                        recommendations.Add(new FinOpsRecommendation
-                        {
-                            Category = "tempdb",
-                            Severity = usagePct < 10 ? "Medium" : "Low",
-                            Confidence = "Medium",
-                            Finding = $"tempdb over-provisioned (peak usage {usagePct:N0}% of {allocatedMb / 1024:N1}GB allocated)",
-                            Detail = $"tempdb is pre-allocated at {allocatedMb:N0}MB but 7-day peak usage was only " +
-                                     $"{peakUsedMb:N0}MB ({usagePct:N1}%). Consider reducing initial size to reclaim disk space."
-                        });
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Recommendation check failed (tempdb): {ex.Message}", ex);
             }
 
             return recommendations;

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -125,9 +125,12 @@ public partial class FinOpsTab : UserControl
         var serverId = GetSelectedServerId();
         if (serverId == 0 || _dataService == null) return;
 
-        // Capture monthly cost from selected server
-        if (ServerSelector.SelectedItem is Models.ServerConnection selectedServer)
-            _currentServerMonthlyCost = selectedServer.MonthlyCostUsd;
+        // Re-read monthly cost from server manager in case user edited the server config
+        if (ServerSelector.SelectedItem is Models.ServerConnection selectedServer && _serverManager != null)
+        {
+            var fresh = _serverManager.GetServerById(selectedServer.Id);
+            _currentServerMonthlyCost = fresh?.MonthlyCostUsd ?? selectedServer.MonthlyCostUsd;
+        }
 
         await System.Threading.Tasks.Task.WhenAll(
             LoadRecommendationsAsync(serverId),

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -194,7 +194,7 @@ idle_dbs AS (
             WHERE server_id = $1
             GROUP BY server_id
         )
-        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb', 'PerformanceMonitor')
         EXCEPT
         SELECT DISTINCT database_name
         FROM v_query_stats
@@ -321,7 +321,7 @@ idle_dbs AS (
             FROM v_database_size_stats
             GROUP BY server_id
         )
-        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+        AND database_name NOT IN ('master', 'model', 'msdb', 'tempdb', 'PerformanceMonitor')
         EXCEPT
         SELECT DISTINCT server_id, database_name
         FROM v_query_stats
@@ -1004,7 +1004,7 @@ SELECT
 FROM db_sizes ds
 LEFT JOIN db_activity a ON a.database_name = ds.database_name
 WHERE COALESCE(a.total_executions, 0) = 0
-AND   ds.database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+AND   ds.database_name NOT IN ('master', 'model', 'msdb', 'tempdb', 'PerformanceMonitor')
 ORDER BY ds.total_size_mb DESC";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -1743,44 +1743,6 @@ AND   database_id > 4", sqlConn);
         catch (Exception ex)
         {
             AppLogger.Error("FinOps", $"Recommendation check failed (Dev/test detection): {ex.Message}");
-        }
-
-        // 8. tempdb over-provisioning (DuckDB for peak usage, live SQL for allocated size)
-        try
-        {
-            // Get peak usage from DuckDB
-            var tempdbData = await GetTempdbSummaryAsync(serverId);
-            var totalReservedRow = tempdbData.FirstOrDefault(t => t.Metric == "Total Reserved");
-            var peakUsedMb = totalReservedRow?.Peak24hMb ?? 0m;
-
-            // Get allocated size from live SQL
-            using var sqlConn = new SqlConnection(connectionString);
-            await sqlConn.OpenAsync();
-
-            using var allocCmd = new SqlCommand(
-                "SELECT SUM(size) * 8.0 / 1024 FROM tempdb.sys.database_files WHERE type = 0", sqlConn);
-            allocCmd.CommandTimeout = 30;
-            var allocResult = await allocCmd.ExecuteScalarAsync();
-            var allocatedMb = allocResult != null && allocResult != DBNull.Value
-                ? Convert.ToDecimal(allocResult) : 0m;
-
-            if (allocatedMb > 1024 && peakUsedMb > 0 && (peakUsedMb / allocatedMb) < 0.25m)
-            {
-                var usagePct = peakUsedMb / allocatedMb * 100m;
-                recommendations.Add(new RecommendationRow
-                {
-                    Category = "tempdb",
-                    Severity = usagePct < 10 ? "Medium" : "Low",
-                    Confidence = "Medium",
-                    Finding = $"tempdb over-provisioned (peak usage {usagePct:N0}% of {allocatedMb / 1024:N1}GB allocated)",
-                    Detail = $"tempdb is pre-allocated at {allocatedMb:N0}MB but peak usage was only " +
-                             $"{peakUsedMb:N0}MB ({usagePct:N1}%). Consider reducing initial size to reclaim disk space."
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error("FinOps", $"Recommendation check failed (tempdb): {ex.Message}");
         }
 
         return recommendations;


### PR DESCRIPTION
## Summary
- Remove tempdb over-provisioning check — intentional pre-allocation is not actionable
- Exclude PerformanceMonitor database from idle/dormant detection (all queries, both apps)
- Re-read monthly cost from ServerManager on every refresh so edits take effect without restart

## Test plan
- [ ] Recommendations tab no longer shows tempdb finding
- [ ] PerformanceMonitor database no longer shows as idle/dormant
- [ ] Edit server monthly cost in Manage Servers, hit Refresh on FinOps — costs update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)