### PR TITLE
Add per-server Utility Database setting (#555)

### DIFF
--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -153,10 +153,12 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var connectionString = (ServerSelector.SelectedItem as Models.ServerConnection)?.GetConnectionString(_credentialService);
+            var selectedServer = ServerSelector.SelectedItem as Models.ServerConnection;
+            var connectionString = selectedServer?.GetConnectionString(_credentialService);
             if (string.IsNullOrEmpty(connectionString)) return;
 
-            var data = await _dataService.GetRecommendationsAsync(serverId, connectionString, _currentServerMonthlyCost);
+            var utilityConnectionString = selectedServer!.GetUtilityConnectionString(_credentialService);
+            var data = await _dataService.GetRecommendationsAsync(serverId, connectionString, utilityConnectionString, _currentServerMonthlyCost);
             RecommendationsDataGrid.ItemsSource = data;
             RecommendationsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             RecommendationsCountIndicator.Text = data.Count > 0 ? $"{data.Count} recommendation(s)" : "";
@@ -747,9 +749,9 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var connectionString = server.GetConnectionString(_credentialService);
+            var utilityConnectionString = server.GetUtilityConnectionString(_credentialService);
 
-            var exists = await LocalDataService.CheckSpIndexCleanupExistsAsync(connectionString);
+            var exists = await LocalDataService.CheckSpIndexCleanupExistsAsync(utilityConnectionString);
             if (!exists)
             {
                 IndexAnalysisNotInstalledMessage.Visibility = Visibility.Visible;
@@ -768,7 +770,7 @@ public partial class FinOpsTab : UserControl
             var getAllDatabases = IndexAnalysisAllDatabases.IsChecked == true;
 
             var (details, summaries) = await LocalDataService.RunIndexAnalysisAsync(
-                connectionString,
+                utilityConnectionString,
                 string.IsNullOrWhiteSpace(databaseName) ? null : databaseName,
                 getAllDatabases);
 

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -77,6 +77,12 @@ public class ServerConnection
     public string? DatabaseName { get; set; }
 
     /// <summary>
+    /// Optional database where community stored procedures (sp_IndexCleanup) are installed.
+    /// When null or empty, falls back to the connection database.
+    /// </summary>
+    public string? UtilityDatabase { get; set; }
+
+    /// <summary>
     /// When true, sets ApplicationIntent=ReadOnly on the connection string.
     /// Required for connecting to AG listener read-only replicas and
     /// Azure SQL Business Critical / Managed Instance built-in read replicas.
@@ -165,6 +171,24 @@ public class ServerConnection
         }
 
         return BuildConnectionString(username, password);
+    }
+
+    /// <summary>
+    /// Returns a connection string targeting UtilityDatabase if set, otherwise falls back to GetConnectionString().
+    /// Used for locating community stored procedures (sp_IndexCleanup) that may be installed in a non-default database.
+    /// </summary>
+    public string GetUtilityConnectionString(CredentialService credentialService)
+    {
+        var baseConnStr = GetConnectionString(credentialService);
+
+        if (string.IsNullOrWhiteSpace(UtilityDatabase))
+            return baseConnStr;
+
+        var builder = new SqlConnectionStringBuilder(baseConnStr)
+        {
+            InitialCatalog = UtilityDatabase
+        };
+        return builder.ConnectionString;
     }
 
     /// <summary>

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1474,7 +1474,7 @@ ORDER BY CAST(collection_time AS DATE)";
     /// Runs all Phase 1 recommendation checks and returns a consolidated list.
     /// Uses DuckDB for collected data and live SQL queries for server-specific checks.
     /// </summary>
-    public async Task<List<RecommendationRow>> GetRecommendationsAsync(int serverId, string connectionString, decimal monthlyCost)
+    public async Task<List<RecommendationRow>> GetRecommendationsAsync(int serverId, string connectionString, string utilityConnectionString, decimal monthlyCost)
     {
         var recommendations = new List<RecommendationRow>();
 
@@ -1583,7 +1583,7 @@ FROM sys.dm_db_persisted_sku_features", sqlConn);
         // 4. Unused index cost quantification (live SQL query)
         try
         {
-            var spExists = await CheckSpIndexCleanupExistsAsync(connectionString);
+            var spExists = await CheckSpIndexCleanupExistsAsync(utilityConnectionString);
             if (!spExists)
             {
                 recommendations.Add(new RecommendationRow

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -88,6 +88,11 @@
                 <TextBox x:Name="DatabaseNameBox" Width="250"
                          ToolTip="Required for Azure SQL Database. Leave empty for on-premises SQL Server."/>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Utility DB:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBox x:Name="UtilityDatabaseBox" Width="250"
+                         ToolTip="Database where community stored procedures (sp_IndexCleanup) are installed. Leave empty to use the connection database."/>
+            </StackPanel>
             <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="Read-only intent (for AG listeners and readable replicas)"
                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
                       ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -59,6 +59,7 @@ public partial class AddServerDialog : Window
         FavoriteCheckBox.IsChecked = existing.IsFavorite;
         DescriptionTextBox.Text = existing.Description ?? "";
         DatabaseNameBox.Text = existing.DatabaseName ?? "";
+        UtilityDatabaseBox.Text = existing.UtilityDatabase ?? "";
         ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
         MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
@@ -347,6 +348,7 @@ public partial class AddServerDialog : Window
                 AddedServer.IsFavorite = FavoriteCheckBox.IsChecked == true;
                 AddedServer.Description = DescriptionTextBox.Text.Trim();
                 AddedServer.DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
+                AddedServer.UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim();
                 AddedServer.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     AddedServer.MonthlyCostUsd = editCost;
@@ -371,6 +373,7 @@ public partial class AddServerDialog : Window
                     IsFavorite = FavoriteCheckBox.IsChecked == true,
                     Description = DescriptionTextBox.Text.Trim(),
                     DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim(),
+                    UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim(),
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
                     MonthlyCostUsd = monthlyCost
                 };


### PR DESCRIPTION
## Summary
Adds a per-server "Utility Database" setting to Lite so users can install community stored procedures (sp_IndexCleanup) in a database other than master.

### Changes
- **ServerConnection model**: New `UtilityDatabase` property + `GetUtilityConnectionString()` helper
- **FinOps tab**: Index Analysis and Recommendations sp_IndexCleanup checks use the utility connection string
- **Add/Edit Server dialog**: New "Utility DB" text box in connection options

### Backward compatible
- `UtilityDatabase = null` (default for existing configs) = use normal connection database = identical to current behavior
- No migration, no installer changes

### Not included (follow-up)
- Dashboard equivalent (same pattern, separate PR)

Fixes #555

## Test plan
- [ ] Add a server without setting Utility DB — Index Analysis works as before
- [ ] Install sp_IndexCleanup in a utility database, set Utility DB to that name — verify Index Analysis runs against the correct database
- [ ] Edit an existing server, add Utility DB, save — verify setting persists
- [ ] Verify Recommendations tab still checks sp_IndexCleanup correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)