### PR TITLE
Add installer adversarial tests — Phase 1 (#543)

### DIFF
--- a/Installer.Tests/AdversarialTests.cs
+++ b/Installer.Tests/AdversarialTests.cs
@@ -1,0 +1,449 @@
+using Installer.Tests.Helpers;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitorInstallerGui.Services;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Adversarial/misery-path tests: designed to break the installer and verify
+/// it fails safely without data loss. These test the scenarios that caused #538.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Database")]
+public class AdversarialTests : IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+    }
+
+    /// <summary>
+    /// #538 root cause: upgrade script failed, but installer continued to the
+    /// install phase which ran 00_uninstall.sql and dropped the database.
+    /// Verify that upgrade failures prevent install scripts from running.
+    /// </summary>
+    [Fact]
+    public async Task UpgradeFailure_DoesNotDropDatabase()
+    {
+        // Setup: create a real database with data
+        await TestDatabaseHelper.CreatePartialInstallationAsync("2.0.0");
+
+        // Insert a canary row we can check survived
+        using (var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString()))
+        {
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                CREATE TABLE config.canary_data (id int NOT NULL, value nvarchar(50) NOT NULL);
+                INSERT INTO config.canary_data VALUES (1, 'must_survive');", conn);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Create a poisoned upgrade that will fail
+        using var dir = new TempDirectoryBuilder()
+            .WithInstallFiles("01_install_database.sql")
+            .WithUpgrade("2.0.0", "2.1.0", "01_will_fail.sql");
+
+        // Write a script that will definitely fail
+        File.WriteAllText(
+            Path.Combine(dir.UpgradesPath, "2.0.0-to-2.1.0", "01_will_fail.sql"),
+            "SELECT 1/0; -- division by zero");
+
+        // Run upgrades — should fail
+        var (_, failureCount, _) = await InstallationService.ExecuteAllUpgradesAsync(
+            dir.RootPath,
+            TestDatabaseHelper.GetTestDbConnectionString(),
+            "2.0.0",
+            "2.1.0");
+
+        Assert.True(failureCount > 0, "Upgrade should have failed");
+
+        // The critical assertion: database and data must still exist
+        using (var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString()))
+        {
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT value FROM config.canary_data WHERE id = 1;", conn);
+            var result = await cmd.ExecuteScalarAsync();
+            Assert.Equal("must_survive", result?.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Partial prior install: database exists with only installation_history,
+    /// all other tables missing. The install scripts must CREATE them without
+    /// failing on missing dependencies.
+    ///
+    /// Note: install scripts hardcode "PerformanceMonitor" as the database name,
+    /// so we rewrite references to point at our test database (same approach as
+    /// IdempotencyTests). This tests the scripts' IF NOT EXISTS / CREATE OR ALTER
+    /// guards against a partial schema.
+    /// </summary>
+    [Fact]
+    public async Task PartialInstall_InstallScriptsRecover()
+    {
+        await TestDatabaseHelper.CreatePartialInstallationAsync("2.0.0");
+
+        // Verify: only installation_history exists, no collect/report schemas
+        using (var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString()))
+        {
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT COUNT(*) FROM sys.tables WHERE schema_id != SCHEMA_ID('config');", conn);
+            var nonConfigTables = (int)(await cmd.ExecuteScalarAsync())!;
+            Assert.Equal(0, nonConfigTables);
+        }
+
+        // Run install scripts with DB name rewriting
+        var installDir = FindInstallDirectory();
+        Assert.NotNull(installDir);
+
+        var sqlFiles = GetFilteredInstallFiles(installDir!);
+        var connectionString = TestDatabaseHelper.GetTestDbConnectionString();
+
+        // Execute scripts with rewriting (same as IdempotencyTests)
+        var failures = new List<string>();
+        foreach (var file in sqlFiles)
+        {
+            var fileName = Path.GetFileName(file);
+            try
+            {
+                var sql = await File.ReadAllTextAsync(file);
+                sql = RewriteForTestDatabase(sql);
+                var batches = SplitGoBatches(sql);
+
+                using var conn = new SqlConnection(connectionString);
+                await conn.OpenAsync();
+
+                foreach (var batch in batches)
+                {
+                    if (string.IsNullOrWhiteSpace(batch)) continue;
+                    using var cmd = new SqlCommand(batch, conn) { CommandTimeout = 120 };
+                    try { await cmd.ExecuteNonQueryAsync(); }
+                    catch (SqlException ex)
+                    {
+                        if (IsExpectedTestFailure(ex, fileName)) continue;
+                        failures.Add($"{fileName}: {ex.Message}");
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!IsExpectedTestFailure(null, fileName))
+                    failures.Add($"{fileName}: {ex.Message}");
+            }
+        }
+
+        Assert.Empty(failures);
+
+        // Verify core tables were created from the partial state
+        using (var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString()))
+        {
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT COUNT(*) FROM sys.tables
+                WHERE schema_id = SCHEMA_ID('collect')
+                AND name IN ('wait_stats', 'query_stats', 'cpu_utilization_stats');", conn);
+            var collectTables = (int)(await cmd.ExecuteScalarAsync())!;
+            Assert.True(collectTables >= 3, $"Expected at least 3 collect tables, got {collectTables}");
+        }
+    }
+
+    /// <summary>
+    /// Critical file failure (01_, 02_, 03_) must abort the entire installation,
+    /// not continue executing the remaining 50+ scripts.
+    /// </summary>
+    [Fact]
+    public async Task CriticalFileFailure_AbortsInstallation()
+    {
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+
+        // Create install files where 02_ will fail
+        using var dir = new TempDirectoryBuilder()
+            .WithInstallFiles(
+                "01_install_database.sql",
+                "02_create_tables.sql",
+                "03_config.sql",
+                "04_schedule.sql",
+                "05_procs.sql");
+
+        // 01_ succeeds (harmless)
+        File.WriteAllText(Path.Combine(dir.InstallPath, "01_install_database.sql"),
+            "PRINT 'ok';");
+        // 02_ fails hard
+        File.WriteAllText(Path.Combine(dir.InstallPath, "02_create_tables.sql"),
+            "RAISERROR('Simulated critical failure', 16, 1);");
+        // 03_-05_ should never execute
+        File.WriteAllText(Path.Combine(dir.InstallPath, "03_config.sql"),
+            "CREATE TABLE dbo.should_not_exist (id int);");
+        File.WriteAllText(Path.Combine(dir.InstallPath, "04_schedule.sql"),
+            "CREATE TABLE dbo.also_should_not_exist (id int);");
+        File.WriteAllText(Path.Combine(dir.InstallPath, "05_procs.sql"),
+            "CREATE TABLE dbo.definitely_should_not_exist (id int);");
+
+        var files = dir.GetFilteredInstallFiles();
+        var result = await InstallationService.ExecuteInstallationAsync(
+            TestDatabaseHelper.GetTestDbConnectionString(),
+            files,
+            cleanInstall: false);
+
+        Assert.False(result.Success);
+        Assert.True(result.FilesFailed >= 1);
+
+        // Verify abort: scripts after 02_ must NOT have run
+        using var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString());
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(
+            "SELECT OBJECT_ID('dbo.should_not_exist', 'U');", conn);
+        var obj = await cmd.ExecuteScalarAsync();
+        Assert.True(obj == null || obj == DBNull.Value,
+            "03_config.sql should not have executed after 02_ critical failure");
+    }
+
+    /// <summary>
+    /// Cancellation mid-install should not leave the database in an unusable state.
+    /// The version should remain at the pre-upgrade level so a retry works.
+    /// </summary>
+    [Fact]
+    public async Task CancellationMidUpgrade_VersionUnchanged()
+    {
+        await TestDatabaseHelper.CreatePartialInstallationAsync("2.0.0");
+
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_slow.sql", "02_never_runs.sql");
+
+        // First script runs for a while then we cancel
+        File.WriteAllText(
+            Path.Combine(dir.UpgradesPath, "2.0.0-to-2.1.0", "01_slow.sql"),
+            "WAITFOR DELAY '00:00:05';");
+        File.WriteAllText(
+            Path.Combine(dir.UpgradesPath, "2.0.0-to-2.1.0", "02_never_runs.sql"),
+            "PRINT 'should not reach here';");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        try
+        {
+            await InstallationService.ExecuteAllUpgradesAsync(
+                dir.RootPath,
+                TestDatabaseHelper.GetTestDbConnectionString(),
+                "2.0.0",
+                "2.1.0",
+                cancellationToken: cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        // Version must still be 2.0.0 — no SUCCESS row written for 2.1.0
+        using var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString());
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            SELECT TOP 1 installer_version
+            FROM config.installation_history
+            WHERE installation_status = 'SUCCESS'
+            ORDER BY installation_date DESC;", conn);
+        var version = await cmd.ExecuteScalarAsync();
+        Assert.Equal("2.0.0", version?.ToString());
+    }
+
+    /// <summary>
+    /// Non-critical file failure (04_+) should NOT abort — remaining scripts still run.
+    /// </summary>
+    [Fact]
+    public async Task NonCriticalFileFailure_ContinuesInstallation()
+    {
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+
+        using var dir = new TempDirectoryBuilder()
+            .WithInstallFiles(
+                "01_setup.sql",
+                "04_will_fail.sql",
+                "05_should_still_run.sql");
+
+        File.WriteAllText(Path.Combine(dir.InstallPath, "01_setup.sql"),
+            "PRINT 'ok';");
+        File.WriteAllText(Path.Combine(dir.InstallPath, "04_will_fail.sql"),
+            "RAISERROR('Non-critical failure', 16, 1);");
+        File.WriteAllText(Path.Combine(dir.InstallPath, "05_should_still_run.sql"),
+            "CREATE TABLE dbo.proof_it_continued (id int);");
+
+        var files = dir.GetFilteredInstallFiles();
+        var result = await InstallationService.ExecuteInstallationAsync(
+            TestDatabaseHelper.GetTestDbConnectionString(),
+            files,
+            cleanInstall: false);
+
+        // 04_ failed but 05_ should have run
+        Assert.True(result.FilesFailed >= 1);
+
+        using var conn = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString());
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(
+            "SELECT OBJECT_ID('dbo.proof_it_continued', 'U');", conn);
+        var obj = await cmd.ExecuteScalarAsync();
+        Assert.True(obj != null && obj != DBNull.Value,
+            "05_ should have executed despite 04_ failure");
+    }
+
+    /// <summary>
+    /// Corrupt SQL content — garbage that isn't valid T-SQL.
+    /// Should fail gracefully, not crash the installer process.
+    /// </summary>
+    [Fact]
+    public async Task CorruptSqlContent_FailsGracefully()
+    {
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+
+        using var dir = new TempDirectoryBuilder()
+            .WithInstallFiles("01_setup.sql", "04_corrupt.sql");
+
+        File.WriteAllText(Path.Combine(dir.InstallPath, "01_setup.sql"),
+            "PRINT 'ok';");
+        File.WriteAllText(Path.Combine(dir.InstallPath, "04_corrupt.sql"),
+            "THIS IS NOT SQL AT ALL 🔥 §±∞ DROP TABLE BOBBY;; EXEC(((");
+
+        var files = dir.GetFilteredInstallFiles();
+        var result = await InstallationService.ExecuteInstallationAsync(
+            TestDatabaseHelper.GetTestDbConnectionString(),
+            files,
+            cleanInstall: false);
+
+        // Should complete (not throw), with 04_ counted as failed
+        Assert.True(result.FilesFailed >= 1);
+        Assert.True(result.FilesSucceeded >= 1); // 01_ should have succeeded
+    }
+
+    /// <summary>
+    /// Empty SQL file — should not crash, just be a no-op.
+    /// </summary>
+    [Fact]
+    public async Task EmptySqlFile_DoesNotCrash()
+    {
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+
+        using var dir = new TempDirectoryBuilder()
+            .WithInstallFiles("01_empty.sql");
+
+        File.WriteAllText(Path.Combine(dir.InstallPath, "01_empty.sql"), "");
+
+        var files = dir.GetFilteredInstallFiles();
+        var result = await InstallationService.ExecuteInstallationAsync(
+            TestDatabaseHelper.GetTestDbConnectionString(),
+            files,
+            cleanInstall: false);
+
+        Assert.True(result.Success);
+    }
+
+    /// <summary>
+    /// Version detection when database exists but connection is to wrong server/port.
+    /// GUI silently returns null (potential data-loss vector) — verify this behavior
+    /// is documented even if not fixed yet.
+    /// </summary>
+    [Fact]
+    public async Task VersionDetection_ConnectionFailure_ReturnsNull()
+    {
+        // Intentionally bad connection string
+        var badConnStr = "Server=DOESNOTEXIST;Database=master;User Id=sa;Password=x;TrustServerCertificate=true;Connect Timeout=2;";
+
+        var version = await InstallationService.GetInstalledVersionAsync(badConnStr);
+
+        // GUI swallows exceptions and returns null.
+        // This means a transient network failure could cause the GUI to treat
+        // an existing installation as a fresh install. Documenting this behavior.
+        Assert.Null(version);
+    }
+
+    #region Helpers
+
+    private static string? FindInstallDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; i < 10 && dir != null; i++)
+        {
+            var installPath = Path.Combine(dir.FullName, "install");
+            if (Directory.Exists(installPath) &&
+                Directory.GetFiles(installPath, "*.sql").Length > 0)
+                return installPath;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static List<string> GetFilteredInstallFiles(string installDir)
+    {
+        var pattern = new System.Text.RegularExpressions.Regex(@"^\d{2}[a-z]?_.*\.sql$");
+        return Directory.GetFiles(installDir, "*.sql")
+            .Where(f =>
+            {
+                var name = Path.GetFileName(f);
+                if (!pattern.IsMatch(name)) return false;
+                if (name.StartsWith("00_", StringComparison.Ordinal) ||
+                    name.StartsWith("97_", StringComparison.Ordinal) ||
+                    name.StartsWith("99_", StringComparison.Ordinal))
+                    return false;
+                return true;
+            })
+            .OrderBy(f => Path.GetFileName(f))
+            .ToList();
+    }
+
+    private static string RewriteForTestDatabase(string sql)
+    {
+        return sql
+            .Replace("[PerformanceMonitor]", "[PerformanceMonitor_Test]")
+            .Replace("N'PerformanceMonitor'", "N'PerformanceMonitor_Test'")
+            .Replace("'PerformanceMonitor'", "'PerformanceMonitor_Test'")
+            .Replace("USE PerformanceMonitor;", "USE PerformanceMonitor_Test;")
+            .Replace("USE PerformanceMonitor\r\n", "USE PerformanceMonitor_Test\r\n")
+            .Replace("USE PerformanceMonitor\n", "USE PerformanceMonitor_Test\n")
+            .Replace("DB_ID(N'PerformanceMonitor')", "DB_ID(N'PerformanceMonitor_Test')")
+            .Replace("PerformanceMonitor.dbo.", "PerformanceMonitor_Test.dbo.")
+            .Replace("PerformanceMonitor.collect.", "PerformanceMonitor_Test.collect.")
+            .Replace("PerformanceMonitor.config.", "PerformanceMonitor_Test.config.")
+            .Replace("PerformanceMonitor.report.", "PerformanceMonitor_Test.report.");
+    }
+
+    private static bool IsExpectedTestFailure(SqlException? ex, string fileName)
+    {
+        if (fileName.Contains("agent_jobs", StringComparison.OrdinalIgnoreCase) ||
+            fileName.Contains("hung_job", StringComparison.OrdinalIgnoreCase) ||
+            fileName.Contains("blocked_process_xe", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (ex?.Message.Contains("SQLServerAgent", StringComparison.OrdinalIgnoreCase) == true)
+            return true;
+        return false;
+    }
+
+    private static List<string> SplitGoBatches(string sql)
+    {
+        var batches = new List<string>();
+        var current = new System.Text.StringBuilder();
+        foreach (var line in sql.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r').Trim();
+            if (trimmed.Equals("GO", StringComparison.OrdinalIgnoreCase))
+            {
+                var batch = current.ToString().Trim();
+                if (!string.IsNullOrEmpty(batch)) batches.Add(batch);
+                current.Clear();
+            }
+            else
+            {
+                current.AppendLine(line.TrimEnd('\r'));
+            }
+        }
+        var last = current.ToString().Trim();
+        if (!string.IsNullOrEmpty(last)) batches.Add(last);
+        return batches;
+    }
+
+    #endregion
+}

--- a/Installer.Tests/FileFilteringTests.cs
+++ b/Installer.Tests/FileFilteringTests.cs
@@ -1,0 +1,118 @@
+using System.Text.RegularExpressions;
+using Installer.Tests.Helpers;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Tests the file filtering rules used by the installer to select SQL files.
+/// Verifies the #538 regression fix: 00_, 97_, 99_ prefixed files must be excluded.
+///
+/// Note: InstallationService.FindInstallationFiles() searches from CWD/AppDomain base,
+/// so we test the filtering rules directly using the same regex and exclusion logic.
+/// </summary>
+public class FileFilteringTests
+{
+    // Same regex the installer uses: ^\d{2}[a-z]?_.*\.sql$
+    private static readonly Regex SqlFilePattern = new(@"^\d{2}[a-z]?_.*\.sql$");
+
+    private static List<string> FilterFiles(IEnumerable<string> fileNames)
+    {
+        return fileNames
+            .Where(f =>
+            {
+                if (!SqlFilePattern.IsMatch(f))
+                    return false;
+                if (f.StartsWith("00_", StringComparison.Ordinal) ||
+                    f.StartsWith("97_", StringComparison.Ordinal) ||
+                    f.StartsWith("99_", StringComparison.Ordinal))
+                    return false;
+                return true;
+            })
+            .OrderBy(f => f)
+            .ToList();
+    }
+
+    [Fact]
+    public void ExcludesUninstallScript_Regression538()
+    {
+        var files = FilterFiles(["00_uninstall.sql", "01_install_database.sql", "02_create_tables.sql"]);
+
+        Assert.DoesNotContain("00_uninstall.sql", files);
+        Assert.Contains("01_install_database.sql", files);
+        Assert.Contains("02_create_tables.sql", files);
+    }
+
+    [Fact]
+    public void ExcludesTestAndTroubleshootingScripts()
+    {
+        var files = FilterFiles(["01_install.sql", "97_test_something.sql", "99_troubleshoot.sql"]);
+
+        Assert.Single(files);
+        Assert.Equal("01_install.sql", files[0]);
+    }
+
+    [Fact]
+    public void IncludesStandardNumberedFiles()
+    {
+        var files = FilterFiles([
+            "01_install_database.sql",
+            "02_create_tables.sql",
+            "45_create_agent_jobs.sql",
+            "54_create_finops_views.sql"
+        ]);
+
+        Assert.Equal(4, files.Count);
+    }
+
+    [Fact]
+    public void IncludesFilesWithLetterSuffix()
+    {
+        // Pattern allows optional letter after 2-digit prefix: \d{2}[a-z]?_
+        var files = FilterFiles(["41a_extra_schedule.sql", "02_create_tables.sql"]);
+
+        Assert.Equal(2, files.Count);
+        Assert.Contains("41a_extra_schedule.sql", files);
+    }
+
+    [Fact]
+    public void ExcludesNonSqlFiles()
+    {
+        var files = FilterFiles(["01_install.sql", "README.md", "config.json", "01_install.txt"]);
+
+        Assert.Single(files);
+        Assert.Equal("01_install.sql", files[0]);
+    }
+
+    [Fact]
+    public void ExcludesFilesNotMatchingPattern()
+    {
+        var files = FilterFiles(["install_database.sql", "abc_something.sql", "1_too_short.sql"]);
+
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void ReturnsSortedAlphabetically()
+    {
+        var files = FilterFiles(["45_jobs.sql", "02_tables.sql", "01_database.sql", "10_procs.sql"]);
+
+        Assert.Equal("01_database.sql", files[0]);
+        Assert.Equal("02_tables.sql", files[1]);
+        Assert.Equal("10_procs.sql", files[2]);
+        Assert.Equal("45_jobs.sql", files[3]);
+    }
+
+    [Fact]
+    public void EmptyInput_ReturnsEmpty()
+    {
+        var files = FilterFiles([]);
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void AllExcludedPrefixes_ReturnsEmpty()
+    {
+        var files = FilterFiles(["00_uninstall.sql", "97_test.sql", "99_debug.sql"]);
+        Assert.Empty(files);
+    }
+}

--- a/Installer.Tests/GlobalUsings.cs
+++ b/Installer.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using System.IO;

--- a/Installer.Tests/Helpers/TempDirectoryBuilder.cs
+++ b/Installer.Tests/Helpers/TempDirectoryBuilder.cs
@@ -1,0 +1,120 @@
+namespace Installer.Tests.Helpers;
+
+/// <summary>
+/// Creates temporary directory structures mimicking the installer's
+/// install/ and upgrades/ layout for unit testing file discovery and upgrade ordering.
+/// </summary>
+public sealed class TempDirectoryBuilder : IDisposable
+{
+    public string RootPath { get; }
+    public string InstallPath => Path.Combine(RootPath, "install");
+    public string UpgradesPath => Path.Combine(RootPath, "upgrades");
+
+    public TempDirectoryBuilder()
+    {
+        RootPath = Path.Combine(Path.GetTempPath(), $"pm_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(RootPath);
+    }
+
+    /// <summary>
+    /// Creates an install/ directory with the given SQL file names (content is dummy SQL).
+    /// </summary>
+    public TempDirectoryBuilder WithInstallFiles(params string[] fileNames)
+    {
+        Directory.CreateDirectory(InstallPath);
+        foreach (var name in fileNames)
+        {
+            File.WriteAllText(Path.Combine(InstallPath, name), $"-- {name}");
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Creates an upgrades/{from}-to-{to}/ directory with an upgrade.txt listing the given scripts.
+    /// </summary>
+    public TempDirectoryBuilder WithUpgrade(string fromVersion, string toVersion, params string[] scriptNames)
+    {
+        var folderName = $"{fromVersion}-to-{toVersion}";
+        var upgradePath = Path.Combine(UpgradesPath, folderName);
+        Directory.CreateDirectory(upgradePath);
+
+        File.WriteAllLines(
+            Path.Combine(upgradePath, "upgrade.txt"),
+            scriptNames);
+
+        foreach (var name in scriptNames)
+        {
+            File.WriteAllText(Path.Combine(upgradePath, name), $"-- {name}");
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Creates an upgrades folder with an invalid (non-version) name.
+    /// </summary>
+    public TempDirectoryBuilder WithMalformedUpgradeFolder(string folderName)
+    {
+        Directory.CreateDirectory(Path.Combine(UpgradesPath, folderName));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates an upgrade folder WITHOUT an upgrade.txt file.
+    /// </summary>
+    public TempDirectoryBuilder WithUpgradeNoManifest(string fromVersion, string toVersion)
+    {
+        var folderName = $"{fromVersion}-to-{toVersion}";
+        Directory.CreateDirectory(Path.Combine(UpgradesPath, folderName));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a non-SQL file to the install directory.
+    /// </summary>
+    public TempDirectoryBuilder WithNonSqlFile(string fileName)
+    {
+        Directory.CreateDirectory(InstallPath);
+        File.WriteAllText(Path.Combine(InstallPath, fileName), "not sql");
+        return this;
+    }
+
+    /// <summary>
+    /// Returns install files filtered the same way the real installer does:
+    /// matching pattern, excluding 00_/97_/99_, sorted alphabetically.
+    /// Returns full paths suitable for passing to ExecuteInstallationAsync.
+    /// </summary>
+    public List<string> GetFilteredInstallFiles()
+    {
+        if (!Directory.Exists(InstallPath))
+            return [];
+
+        var pattern = new System.Text.RegularExpressions.Regex(@"^\d{2}[a-z]?_.*\.sql$");
+        return Directory.GetFiles(InstallPath, "*.sql")
+            .Where(f =>
+            {
+                var name = Path.GetFileName(f);
+                if (!pattern.IsMatch(name)) return false;
+                if (name.StartsWith("00_", StringComparison.Ordinal) ||
+                    name.StartsWith("97_", StringComparison.Ordinal) ||
+                    name.StartsWith("99_", StringComparison.Ordinal))
+                    return false;
+                return true;
+            })
+            .OrderBy(f => Path.GetFileName(f))
+            .ToList();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(RootPath))
+                Directory.Delete(RootPath, recursive: true);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+}

--- a/Installer.Tests/Helpers/TestDatabaseHelper.cs
+++ b/Installer.Tests/Helpers/TestDatabaseHelper.cs
@@ -1,0 +1,144 @@
+using Microsoft.Data.SqlClient;
+
+namespace Installer.Tests.Helpers;
+
+public static class TestDatabaseHelper
+{
+    private const string TestDatabaseName = "PerformanceMonitor_Test";
+
+    public static string GetConnectionString(string database = "master")
+    {
+        return $"Server=SQL2022;Database={database};User Id=sa;Password=L!nt0044;TrustServerCertificate=true;";
+    }
+
+    public static string GetTestDbConnectionString()
+    {
+        return GetConnectionString(TestDatabaseName);
+    }
+
+    public static async Task CreateTestDatabaseAsync()
+    {
+        using var connection = new SqlConnection(GetConnectionString());
+        await connection.OpenAsync();
+
+        using var cmd = new SqlCommand($@"
+            IF DB_ID(N'{TestDatabaseName}') IS NULL
+                CREATE DATABASE [{TestDatabaseName}];", connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task DropTestDatabaseAsync()
+    {
+        using var connection = new SqlConnection(GetConnectionString());
+        await connection.OpenAsync();
+
+        using var cmd = new SqlCommand($@"
+            IF DB_ID(N'{TestDatabaseName}') IS NOT NULL
+            BEGIN
+                ALTER DATABASE [{TestDatabaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                DROP DATABASE [{TestDatabaseName}];
+            END;", connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Creates a partial installation: just the config schema and installation_history table
+    /// with a SUCCESS row for the given version. Simulates a broken or incomplete prior install.
+    /// </summary>
+    public static async Task CreatePartialInstallationAsync(string version)
+    {
+        await CreateTestDatabaseAsync();
+
+        using var connection = new SqlConnection(GetTestDbConnectionString());
+        await connection.OpenAsync();
+
+        // Must match the real schema from 01_install_database.sql exactly,
+        // otherwise CREATE OR ALTER VIEW on config.current_version will fail
+        // referencing columns that don't exist.
+        using var cmd = new SqlCommand($@"
+            IF SCHEMA_ID('config') IS NULL
+                EXEC('CREATE SCHEMA config;');
+
+            IF OBJECT_ID('config.installation_history', 'U') IS NULL
+                CREATE TABLE config.installation_history
+                (
+                    installation_id integer IDENTITY NOT NULL,
+                    installation_date datetime2(7) NOT NULL DEFAULT SYSDATETIME(),
+                    installer_version nvarchar(50) NOT NULL,
+                    installer_info_version nvarchar(100) NULL,
+                    sql_server_version nvarchar(255) NOT NULL DEFAULT N'Unknown',
+                    sql_server_edition nvarchar(255) NOT NULL DEFAULT N'Unknown',
+                    installation_type nvarchar(20) NOT NULL DEFAULT N'UPGRADE',
+                    previous_version nvarchar(50) NULL,
+                    installation_status nvarchar(20) NOT NULL,
+                    files_executed integer NULL,
+                    files_failed integer NULL,
+                    installation_duration_ms integer NULL,
+                    installation_notes nvarchar(max) NULL,
+                    CONSTRAINT PK_installation_history PRIMARY KEY CLUSTERED (installation_id)
+                );
+
+            INSERT INTO config.installation_history
+                (installer_version, installation_status, installation_type, sql_server_version, sql_server_edition)
+            VALUES
+                (N'{version}', N'SUCCESS', N'UPGRADE', @@VERSION, N'Test');",
+            connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Creates the database with installation_history but NO success rows.
+    /// This is the #538 scenario where the version detection fallback kicks in.
+    /// </summary>
+    public static async Task CreateInstallationWithNoSuccessRowsAsync()
+    {
+        await CreateTestDatabaseAsync();
+
+        using var connection = new SqlConnection(GetTestDbConnectionString());
+        await connection.OpenAsync();
+
+        using var cmd = new SqlCommand(@"
+            IF SCHEMA_ID('config') IS NULL
+                EXEC('CREATE SCHEMA config;');
+
+            IF OBJECT_ID('config.installation_history', 'U') IS NULL
+                CREATE TABLE config.installation_history
+                (
+                    installation_id integer IDENTITY NOT NULL,
+                    installation_date datetime2(7) NOT NULL DEFAULT SYSDATETIME(),
+                    installer_version nvarchar(50) NOT NULL,
+                    installer_info_version nvarchar(100) NULL,
+                    sql_server_version nvarchar(255) NOT NULL DEFAULT N'Unknown',
+                    sql_server_edition nvarchar(255) NOT NULL DEFAULT N'Unknown',
+                    installation_type nvarchar(20) NOT NULL DEFAULT N'UPGRADE',
+                    previous_version nvarchar(50) NULL,
+                    installation_status nvarchar(20) NOT NULL,
+                    files_executed integer NULL,
+                    files_failed integer NULL,
+                    installation_duration_ms integer NULL,
+                    installation_notes nvarchar(max) NULL,
+                    CONSTRAINT PK_installation_history PRIMARY KEY CLUSTERED (installation_id)
+                );",
+            connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Creates the database with only FAILED rows in installation_history.
+    /// </summary>
+    public static async Task CreateInstallationWithOnlyFailedRowsAsync()
+    {
+        await CreateInstallationWithNoSuccessRowsAsync();
+
+        using var connection = new SqlConnection(GetTestDbConnectionString());
+        await connection.OpenAsync();
+
+        using var cmd = new SqlCommand(@"
+            INSERT INTO config.installation_history
+                (installer_version, installation_status, installation_type, sql_server_version, sql_server_edition)
+            VALUES
+                (N'2.0.0', N'FAILED', N'UPGRADE', @@VERSION, N'Test');",
+            connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/Installer.Tests/IdempotencyTests.cs
+++ b/Installer.Tests/IdempotencyTests.cs
@@ -1,0 +1,204 @@
+using Installer.Tests.Helpers;
+using Microsoft.Data.SqlClient;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Verifies all install scripts can be run twice without errors.
+/// This is the single most important test for preventing #538-class bugs:
+/// every script must use IF NOT EXISTS / CREATE OR ALTER guards.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Database")]
+public class IdempotencyTests : IAsyncLifetime
+{
+    private static readonly string[] BatchSeparators = ["GO", "go", "Go"];
+
+    public async ValueTask InitializeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task AllInstallScripts_CanRunTwice_WithoutErrors()
+    {
+        var installDir = FindInstallDirectory();
+        Assert.NotNull(installDir);
+
+        var sqlFiles = GetFilteredInstallFiles(installDir!);
+        Assert.NotEmpty(sqlFiles);
+
+        var connectionString = TestDatabaseHelper.GetTestDbConnectionString();
+
+        // First run
+        var firstRunFailures = await ExecuteAllScriptsAsync(sqlFiles, connectionString);
+        Assert.Empty(firstRunFailures);
+
+        // Second run — the idempotency test
+        var secondRunFailures = await ExecuteAllScriptsAsync(sqlFiles, connectionString);
+        Assert.Empty(secondRunFailures);
+    }
+
+    private static string? FindInstallDirectory()
+    {
+        // Walk up from the test output directory to find the repo's install/ folder
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; i < 10 && dir != null; i++)
+        {
+            var installPath = Path.Combine(dir.FullName, "install");
+            if (Directory.Exists(installPath) &&
+                Directory.GetFiles(installPath, "*.sql").Length > 0)
+            {
+                return installPath;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static List<string> GetFilteredInstallFiles(string installDir)
+    {
+        var pattern = new System.Text.RegularExpressions.Regex(@"^\d{2}[a-z]?_.*\.sql$");
+
+        return Directory.GetFiles(installDir, "*.sql")
+            .Where(f =>
+            {
+                var name = Path.GetFileName(f);
+                if (!pattern.IsMatch(name)) return false;
+                if (name.StartsWith("00_", StringComparison.Ordinal) ||
+                    name.StartsWith("97_", StringComparison.Ordinal) ||
+                    name.StartsWith("99_", StringComparison.Ordinal))
+                    return false;
+                return true;
+            })
+            .OrderBy(f => Path.GetFileName(f))
+            .ToList();
+    }
+
+    private static async Task<List<(string File, string Error)>> ExecuteAllScriptsAsync(
+        List<string> sqlFiles, string connectionString)
+    {
+        var failures = new List<(string File, string Error)>();
+
+        foreach (var file in sqlFiles)
+        {
+            var fileName = Path.GetFileName(file);
+
+            try
+            {
+                var sql = await File.ReadAllTextAsync(file);
+
+                // Replace PerformanceMonitor database references with our test database
+                sql = RewriteForTestDatabase(sql);
+
+                var batches = SplitBatches(sql);
+
+                using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync();
+
+                foreach (var batch in batches)
+                {
+                    if (string.IsNullOrWhiteSpace(batch)) continue;
+
+                    using var cmd = new SqlCommand(batch, connection)
+                    {
+                        CommandTimeout = 120
+                    };
+
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                    catch (SqlException ex)
+                    {
+                        // Skip known non-fatal errors:
+                        // - SQL Agent job errors (Agent may not be running / no permissions in test)
+                        // - Extended events errors (may require sysadmin)
+                        if (IsExpectedTestFailure(ex, fileName))
+                            continue;
+
+                        failures.Add((File: fileName, Error: $"Batch failed: {ex.Message}"));
+                        break; // Stop this file on first real failure
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add((File: fileName, Error: $"File error: {ex.Message}"));
+            }
+        }
+
+        return failures;
+    }
+
+    private static string RewriteForTestDatabase(string sql)
+    {
+        // The install scripts reference PerformanceMonitor by name in USE statements,
+        // CREATE DATABASE, and cross-database references. Rewrite for our test database.
+        return sql
+            .Replace("[PerformanceMonitor]", "[PerformanceMonitor_Test]")
+            .Replace("N'PerformanceMonitor'", "N'PerformanceMonitor_Test'")
+            .Replace("'PerformanceMonitor'", "'PerformanceMonitor_Test'")
+            .Replace("USE PerformanceMonitor;", "USE PerformanceMonitor_Test;")
+            .Replace("USE PerformanceMonitor\r\n", "USE PerformanceMonitor_Test\r\n")
+            .Replace("USE PerformanceMonitor\n", "USE PerformanceMonitor_Test\n")
+            .Replace("DB_ID(N'PerformanceMonitor')", "DB_ID(N'PerformanceMonitor_Test')")
+            .Replace("PerformanceMonitor.dbo.", "PerformanceMonitor_Test.dbo.")
+            .Replace("PerformanceMonitor.collect.", "PerformanceMonitor_Test.collect.")
+            .Replace("PerformanceMonitor.config.", "PerformanceMonitor_Test.config.")
+            .Replace("PerformanceMonitor.report.", "PerformanceMonitor_Test.report.");
+    }
+
+    private static bool IsExpectedTestFailure(SqlException ex, string fileName)
+    {
+        // SQL Agent operations fail without Agent running or sysadmin
+        if (fileName.Contains("agent_jobs", StringComparison.OrdinalIgnoreCase) ||
+            fileName.Contains("hung_job", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Extended events may require specific permissions
+        if (fileName.Contains("blocked_process_xe", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // "Cannot find the object" for Agent-related objects
+        if (ex.Message.Contains("SQLServerAgent", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    private static List<string> SplitBatches(string sql)
+    {
+        var batches = new List<string>();
+        var currentBatch = new System.Text.StringBuilder();
+
+        foreach (var line in sql.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r').Trim();
+
+            if (BatchSeparators.Contains(trimmed))
+            {
+                var batch = currentBatch.ToString().Trim();
+                if (!string.IsNullOrEmpty(batch))
+                    batches.Add(batch);
+                currentBatch.Clear();
+            }
+            else
+            {
+                currentBatch.AppendLine(line.TrimEnd('\r'));
+            }
+        }
+
+        var lastBatch = currentBatch.ToString().Trim();
+        if (!string.IsNullOrEmpty(lastBatch))
+            batches.Add(lastBatch);
+
+        return batches;
+    }
+}

--- a/Installer.Tests/Installer.Tests.csproj
+++ b/Installer.Tests/Installer.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CS4014;NU1701;CA1001;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InstallerGui\InstallerGui.csproj" />
+  </ItemGroup>
+</Project>

--- a/Installer.Tests/UpgradeOrderingTests.cs
+++ b/Installer.Tests/UpgradeOrderingTests.cs
@@ -1,0 +1,148 @@
+using Installer.Tests.Helpers;
+using PerformanceMonitorInstallerGui.Services;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Tests the upgrade folder discovery and ordering logic.
+/// Uses temp directories to simulate various upgrade folder configurations.
+/// </summary>
+public class UpgradeOrderingTests
+{
+    [Fact]
+    public void ReturnsCorrectUpgradesForVersionRange()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("1.3.0", "2.0.0", "01_schema.sql")
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql")
+            .WithUpgrade("2.1.0", "2.2.0", "01_compress.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "1.3.0", "2.2.0");
+
+        Assert.Equal(3, upgrades.Count);
+        Assert.Equal("1.3.0-to-2.0.0", upgrades[0].FolderName);
+        Assert.Equal("2.0.0-to-2.1.0", upgrades[1].FolderName);
+        Assert.Equal("2.1.0-to-2.2.0", upgrades[2].FolderName);
+    }
+
+    [Fact]
+    public void SkipsAlreadyAppliedUpgrades()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("1.3.0", "2.0.0", "01_schema.sql")
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql")
+            .WithUpgrade("2.1.0", "2.2.0", "01_compress.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.0.0", "2.2.0");
+
+        Assert.Equal(2, upgrades.Count);
+        Assert.Equal("2.0.0-to-2.1.0", upgrades[0].FolderName);
+        Assert.Equal("2.1.0-to-2.2.0", upgrades[1].FolderName);
+    }
+
+    [Fact]
+    public void AlreadyAtTargetVersion_ReturnsEmpty()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql")
+            .WithUpgrade("2.1.0", "2.2.0", "01_compress.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.2.0", "2.2.0");
+
+        Assert.Empty(upgrades);
+    }
+
+    [Fact]
+    public void FourPartVersion_NormalizedToThreePart()
+    {
+        // The installer normalizes 4-part "2.2.0.0" (from DB) to 3-part "2.2.0" (folder names)
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.1.0", "2.2.0", "01_compress.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.1.0.0", "2.2.0");
+
+        Assert.Single(upgrades);
+        Assert.Equal("2.1.0-to-2.2.0", upgrades[0].FolderName);
+    }
+
+    [Fact]
+    public void MalformedFolderNames_Skipped()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql")
+            .WithMalformedUpgradeFolder("not-a-version")
+            .WithMalformedUpgradeFolder("foo-to-bar");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.0.0", "2.2.0");
+
+        Assert.Single(upgrades);
+        Assert.Equal("2.0.0-to-2.1.0", upgrades[0].FolderName);
+    }
+
+    [Fact]
+    public void MissingUpgradeTxt_FolderSkipped()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql")
+            .WithUpgradeNoManifest("2.1.0", "2.2.0");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.0.0", "2.2.0");
+
+        Assert.Single(upgrades);
+        Assert.Equal("2.0.0-to-2.1.0", upgrades[0].FolderName);
+    }
+
+    [Fact]
+    public void NoUpgradesFolder_ReturnsEmpty()
+    {
+        using var dir = new TempDirectoryBuilder();
+        // Don't create any upgrade folders
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.0.0", "2.2.0");
+
+        Assert.Empty(upgrades);
+    }
+
+    [Fact]
+    public void NullCurrentVersion_ReturnsEmpty()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_columns.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, null, "2.2.0");
+
+        Assert.Empty(upgrades);
+    }
+
+    [Fact]
+    public void OrderedByFromVersion()
+    {
+        // Create folders in reverse order to verify sorting
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.1.0", "2.2.0", "01_c.sql")
+            .WithUpgrade("1.3.0", "2.0.0", "01_a.sql")
+            .WithUpgrade("2.0.0", "2.1.0", "01_b.sql");
+
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "1.3.0", "2.2.0");
+
+        Assert.Equal(3, upgrades.Count);
+        Assert.Equal(new Version(1, 3, 0), upgrades[0].FromVersion);
+        Assert.Equal(new Version(2, 0, 0), upgrades[1].FromVersion);
+        Assert.Equal(new Version(2, 1, 0), upgrades[2].FromVersion);
+    }
+
+    [Fact]
+    public void DoesNotIncludeFutureUpgrades()
+    {
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.0.0", "2.1.0", "01_a.sql")
+            .WithUpgrade("2.1.0", "2.2.0", "01_b.sql")
+            .WithUpgrade("2.2.0", "2.3.0", "01_c.sql");
+
+        // Target is 2.2.0, so 2.2.0-to-2.3.0 should NOT be included
+        var upgrades = InstallationService.GetApplicableUpgrades(dir.RootPath, "2.0.0", "2.2.0");
+
+        Assert.Equal(2, upgrades.Count);
+        Assert.DoesNotContain(upgrades, u => u.FolderName == "2.2.0-to-2.3.0");
+    }
+}

--- a/Installer.Tests/VersionDetectionTests.cs
+++ b/Installer.Tests/VersionDetectionTests.cs
@@ -1,0 +1,143 @@
+using Installer.Tests.Helpers;
+using Microsoft.Data.SqlClient;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Tests version detection logic — the #538 regression fix is the most critical test here.
+///
+/// Note: InstallationService.GetInstalledVersionAsync hardcodes the database name
+/// "PerformanceMonitor", so these tests replicate the same SQL queries against a
+/// test database (PerformanceMonitor_Test) to avoid touching real data.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("Database")]
+public class VersionDetectionTests : IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await TestDatabaseHelper.DropTestDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task DatabaseDoesNotExist_ReturnsNull()
+    {
+        // Database was dropped in InitializeAsync
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public async Task DatabaseExists_WithSuccessRow_ReturnsVersion()
+    {
+        await TestDatabaseHelper.CreatePartialInstallationAsync("2.1.0");
+
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Equal("2.1.0", version);
+    }
+
+    [Fact]
+    public async Task DatabaseExists_NoHistoryTable_ReturnsNull()
+    {
+        // Create database but don't create the installation_history table
+        await TestDatabaseHelper.CreateTestDatabaseAsync();
+
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public async Task DatabaseExists_EmptyHistoryTable_ReturnsFallback_Regression538()
+    {
+        // This is the #538 regression test.
+        // When installation_history exists but has NO SUCCESS rows,
+        // the installer must return "1.0.0" (not null), so it attempts
+        // upgrades rather than treating the existing database as a fresh install.
+        await TestDatabaseHelper.CreateInstallationWithNoSuccessRowsAsync();
+
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Equal("1.0.0", version);
+    }
+
+    [Fact]
+    public async Task DatabaseExists_OnlyFailedRows_ReturnsFallback()
+    {
+        // All rows are FAILED — same fallback behavior as empty table
+        await TestDatabaseHelper.CreateInstallationWithOnlyFailedRowsAsync();
+
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Equal("1.0.0", version);
+    }
+
+    [Fact]
+    public async Task MultipleSuccessRows_ReturnsLatest()
+    {
+        await TestDatabaseHelper.CreatePartialInstallationAsync("1.3.0");
+
+        // Add a newer success row
+        using var connection = new SqlConnection(TestDatabaseHelper.GetTestDbConnectionString());
+        await connection.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            -- Use explicit future date to ensure this row sorts first
+            INSERT INTO config.installation_history
+                (installer_version, installation_status, installation_type, sql_server_version, sql_server_edition, installation_date)
+            VALUES
+                (N'2.2.0', N'SUCCESS', N'UPGRADE', @@VERSION, N'Test', DATEADD(HOUR, 1, SYSDATETIME()));",
+            connection);
+        await cmd.ExecuteNonQueryAsync();
+
+        var version = await GetInstalledVersionFromTestDbAsync();
+        Assert.Equal("2.2.0", version);
+    }
+
+    /// <summary>
+    /// Replicates the same SQL logic as InstallationService.GetInstalledVersionAsync
+    /// but queries PerformanceMonitor_Test instead of the hardcoded PerformanceMonitor.
+    /// </summary>
+    private static async Task<string?> GetInstalledVersionFromTestDbAsync()
+    {
+        const string testDbName = "PerformanceMonitor_Test";
+
+        try
+        {
+            using var connection = new SqlConnection(TestDatabaseHelper.GetConnectionString());
+            await connection.OpenAsync();
+
+            // Check if database exists
+            using var dbCheckCmd = new SqlCommand($@"
+                SELECT database_id FROM sys.databases WHERE name = N'{testDbName}';", connection);
+            var dbExists = await dbCheckCmd.ExecuteScalarAsync();
+            if (dbExists == null || dbExists == DBNull.Value)
+                return null;
+
+            // Check if installation_history table exists
+            using var tableCheckCmd = new SqlCommand($@"
+                SELECT OBJECT_ID(N'{testDbName}.config.installation_history', N'U');", connection);
+            var tableExists = await tableCheckCmd.ExecuteScalarAsync();
+            if (tableExists == null || tableExists == DBNull.Value)
+                return null;
+
+            // Get most recent successful version
+            using var versionCmd = new SqlCommand($@"
+                SELECT TOP 1 installer_version
+                FROM {testDbName}.config.installation_history
+                WHERE installation_status = 'SUCCESS'
+                ORDER BY installation_date DESC;", connection);
+            var version = await versionCmd.ExecuteScalarAsync();
+            if (version != null && version != DBNull.Value)
+                return version.ToString();
+
+            // Fallback: database + table exist but no SUCCESS rows → return "1.0.0"
+            return "1.0.0";
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/PerformanceMonitor.sln
+++ b/PerformanceMonitor.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lite.Tests", "Lite.Tests\Li
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceMonitorInstaller", "Installer\PerformanceMonitorInstaller.csproj", "{0F1EFD0D-61B6-D475-3A2E-ED7FD83BCE6E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer.Tests", "Installer.Tests\Installer.Tests.csproj", "{9B2800D2-8F32-450E-A169-86B381EA5560}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{0F1EFD0D-61B6-D475-3A2E-ED7FD83BCE6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F1EFD0D-61B6-D475-3A2E-ED7FD83BCE6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F1EFD0D-61B6-D475-3A2E-ED7FD83BCE6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B2800D2-8F32-450E-A169-86B381EA5560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B2800D2-8F32-450E-A169-86B381EA5560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B2800D2-8F32-450E-A169-86B381EA5560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B2800D2-8F32-450E-A169-86B381EA5560}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
New `Installer.Tests` project with 34 tests — focused on adversarial/misery-path scenarios to prevent another #538-class data-loss bug.

### Adversarial tests (8 integration, against sql2022)
- **Upgrade failure doesn't drop database**: poisoned upgrade script fails → canary data survives
- **Partial install recovery**: database with only `installation_history` → install scripts create all missing tables
- **Critical file abort**: `02_` failure → scripts `03_`+ never execute
- **Non-critical file continues**: `04_` failure → `05_` still runs
- **Cancellation mid-upgrade**: cancel token fires → version stays at pre-upgrade level
- **Corrupt SQL content**: garbage input → fails gracefully, no crash
- **Empty SQL file**: no-op, no crash
- **Connection failure**: bad server → returns null (documents GUI exception-swallowing behavior)

### Version detection tests (6 integration)
- SUCCESS row returns version
- Empty history → "1.0.0" fallback (#538 regression)
- FAILED-only rows → "1.0.0" fallback
- Missing table → null
- Missing database → null
- Multiple rows → returns latest

### Idempotency test (1 integration)
- All install scripts executed twice against test database with zero failures

### Unit tests (19, no SQL Server)
- File filtering: `00_`/`97_`/`99_` exclusion (#538 regression), pattern matching, sorting
- Upgrade ordering: version ranges, normalization, malformed folders, already-at-target

### Test results
```
Total: 34 passed, 0 failed (~2 min)
```

## Test plan
- [x] `dotnet test --filter "Category!=Integration"` — 19 passed
- [x] `dotnet test --filter "Category=Integration"` — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)