### PR TITLE
Add SQL Server version check to installers (#543)

### DIFF
--- a/Installer.Tests/AdversarialTests.cs
+++ b/Installer.Tests/AdversarialTests.cs
@@ -343,6 +343,62 @@ public class AdversarialTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// TestConnectionAsync must report the SQL Server version so the installer
+    /// can reject unsupported versions before running any scripts.
+    /// Verifies IsSupportedVersion returns true for sql2022 (on-prem, version 16).
+    /// </summary>
+    [Fact]
+    public async Task VersionCheck_Sql2022_IsSupported()
+    {
+        var info = await InstallationService.TestConnectionAsync(
+            TestDatabaseHelper.GetConnectionString());
+
+        Assert.True(info.IsConnected);
+        Assert.True(info.ProductMajorVersion >= 13,
+            $"Expected ProductMajorVersion >= 13, got {info.ProductMajorVersion}");
+        Assert.True(info.IsSupportedVersion);
+        Assert.True(info.EngineEdition is 2 or 3,
+            $"Expected Standard (2) or Enterprise (3), got {info.EngineEdition}");
+    }
+
+    /// <summary>
+    /// IsSupportedVersion must return false for old SQL Server versions.
+    /// We can't connect to an old server in tests, so test the logic directly.
+    /// </summary>
+    [Fact]
+    public void VersionCheck_OldVersion_IsNotSupported()
+    {
+        var info = new ServerInfo
+        {
+            IsConnected = true,
+            EngineEdition = 3, // Enterprise
+            ProductMajorVersion = 12 // SQL Server 2014
+        };
+        Assert.False(info.IsSupportedVersion);
+        Assert.Equal("SQL Server 2014", info.ProductMajorVersionName);
+
+        info.ProductMajorVersion = 11; // SQL Server 2012
+        Assert.False(info.IsSupportedVersion);
+        Assert.Equal("SQL Server 2012", info.ProductMajorVersionName);
+    }
+
+    /// <summary>
+    /// Azure MI (EngineEdition 8) should always be considered supported
+    /// regardless of what ProductMajorVersion reports.
+    /// </summary>
+    [Fact]
+    public void VersionCheck_AzureMI_AlwaysSupported()
+    {
+        var info = new ServerInfo
+        {
+            IsConnected = true,
+            EngineEdition = 8,
+            ProductMajorVersion = 0 // Even if unknown
+        };
+        Assert.True(info.IsSupportedVersion);
+    }
+
+    /// <summary>
     /// Version detection when database exists but connection is to wrong server/port.
     /// GUI silently returns null (potential data-loss vector) — verify this behavior
     /// is documented even if not fixed yet.

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -425,7 +425,12 @@ END;";
                     Console.WriteLine("Connection successful!");
 
                     /*Capture SQL Server version for summary report*/
-                    using (var versionCmd = new SqlCommand("SELECT @@VERSION, SERVERPROPERTY('Edition');", connection))
+                    using (var versionCmd = new SqlCommand(@"
+                        SELECT
+                            @@VERSION,
+                            SERVERPROPERTY('Edition'),
+                            CONVERT(int, SERVERPROPERTY('EngineEdition')),
+                            SERVERPROPERTY('ProductMajorVersion');", connection))
                     {
                         using (var reader = await versionCmd.ExecuteReaderAsync().ConfigureAwait(false))
                         {
@@ -433,6 +438,29 @@ END;";
                             {
                                 sqlServerVersion = reader.GetString(0);
                                 sqlServerEdition = reader.GetString(1);
+
+                                var engineEdition = reader.IsDBNull(2) ? 0 : reader.GetInt32(2);
+                                var majorVersion = reader.IsDBNull(3) ? 0 : int.TryParse(reader.GetValue(3).ToString(), out var v) ? v : 0;
+
+                                /*Check minimum SQL Server version — 2016+ required for on-prem (Standard/Enterprise).
+                                  Azure MI (EngineEdition 8) is always current, skip the check.*/
+                                if (engineEdition is not 8 && majorVersion > 0 && majorVersion < 13)
+                                {
+                                    string versionName = majorVersion switch
+                                    {
+                                        11 => "SQL Server 2012",
+                                        12 => "SQL Server 2014",
+                                        _ => $"SQL Server (version {majorVersion})"
+                                    };
+                                    Console.WriteLine();
+                                    Console.WriteLine($"ERROR: {versionName} is not supported.");
+                                    Console.WriteLine("Performance Monitor requires SQL Server 2016 (13.x) or later.");
+                                    if (!automatedMode)
+                                    {
+                                        WaitForExit();
+                                    }
+                                    return ExitCodes.VersionCheckFailed;
+                                }
                             }
                         }
                     }

--- a/InstallerGui/MainWindow.xaml.cs
+++ b/InstallerGui/MainWindow.xaml.cs
@@ -267,6 +267,21 @@ namespace PerformanceMonitorInstallerGui
                         LogMessage($"Version: {versionLines[0]}", "Info");
                     }
 
+                    /*Check minimum SQL Server version (2016+ required for on-prem)*/
+                    if (!_serverInfo.IsSupportedVersion)
+                    {
+                        LogMessage($"{_serverInfo.ProductMajorVersionName} is not supported. SQL Server 2016 or later is required.", "Error");
+                        InstallButton.IsEnabled = false;
+                        MessageBox.Show(this,
+                            $"{_serverInfo.ProductMajorVersionName} is not supported.\n\n" +
+                            $"Performance Monitor requires SQL Server 2016 (13.x) or later.\n" +
+                            $"Server: {_serverInfo.ServerName}",
+                            "Unsupported SQL Server Version",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error);
+                        return;
+                    }
+
                     /*Check for installed version*/
                     _installedVersion = await InstallationService.GetInstalledVersionAsync(_connectionString);
                     if (_installedVersion != null)

--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -42,6 +42,31 @@ namespace PerformanceMonitorInstallerGui.Services
         public string SqlServerEdition { get; set; } = string.Empty;
         public bool IsConnected { get; set; }
         public string? ErrorMessage { get; set; }
+        public int EngineEdition { get; set; }
+        public int ProductMajorVersion { get; set; }
+
+        /// <summary>
+        /// Returns true if the SQL Server version is supported (2016+).
+        /// Only checked for on-prem Standard (2) and Enterprise (3).
+        /// Azure MI (8) is always current and skips the check.
+        /// </summary>
+        public bool IsSupportedVersion =>
+            EngineEdition is 8 || ProductMajorVersion >= 13;
+
+        /// <summary>
+        /// Human-readable version name for error messages.
+        /// </summary>
+        public string ProductMajorVersionName => ProductMajorVersion switch
+        {
+            11 => "SQL Server 2012",
+            12 => "SQL Server 2014",
+            13 => "SQL Server 2016",
+            14 => "SQL Server 2017",
+            15 => "SQL Server 2019",
+            16 => "SQL Server 2022",
+            17 => "SQL Server 2025",
+            _ => $"SQL Server (version {ProductMajorVersion})"
+        };
     }
 
     /// <summary>
@@ -149,7 +174,13 @@ namespace PerformanceMonitorInstallerGui.Services
 
                 info.IsConnected = true;
 
-                using var command = new SqlCommand("SELECT @@VERSION, SERVERPROPERTY('Edition'), @@SERVERNAME;", connection);
+                using var command = new SqlCommand(@"
+                    SELECT
+                        @@VERSION,
+                        SERVERPROPERTY('Edition'),
+                        @@SERVERNAME,
+                        CONVERT(int, SERVERPROPERTY('EngineEdition')),
+                        SERVERPROPERTY('ProductMajorVersion');", connection);
                 using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
 
                 if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -157,6 +188,8 @@ namespace PerformanceMonitorInstallerGui.Services
                     info.SqlServerVersion = reader.GetString(0);
                     info.SqlServerEdition = reader.GetString(1);
                     info.ServerName = reader.GetString(2);
+                    info.EngineEdition = reader.IsDBNull(3) ? 0 : reader.GetInt32(3);
+                    info.ProductMajorVersion = reader.IsDBNull(4) ? 0 : int.TryParse(reader.GetValue(4).ToString(), out var v) ? v : 0;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
Both installers now reject SQL Server 2014 and earlier before running any scripts.

### Changes
- **GUI**: After connection test, checks `IsSupportedVersion`. Shows error in log + MessageBox, disables Install button.
- **CLI**: Same check after connection. Prints clear error, returns exit code 5 (`VersionCheckFailed`).
- **ServerInfo**: New `EngineEdition`, `ProductMajorVersion`, `IsSupportedVersion`, `ProductMajorVersionName` properties.
- **Azure MI**: EngineEdition 8 skips the version check (always current).

### Tests (3 new, 38 total)
- `VersionCheck_Sql2022_IsSupported` — integration test confirms sql2022 passes
- `VersionCheck_OldVersion_IsNotSupported` — unit test for 2012/2014 rejection
- `VersionCheck_AzureMI_AlwaysSupported` — unit test for EngineEdition 8 bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)