### PR TITLE
Add 8 Lite MCP tools for coverage gaps (#576)

### DIFF
--- a/Lite/Mcp/McpConfigTools.cs
+++ b/Lite/Mcp/McpConfigTools.cs
@@ -1,0 +1,187 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Mcp;
+
+[McpServerToolType]
+public sealed class McpConfigTools
+{
+    [McpServerTool(Name = "get_server_config"), Description("Gets the current SQL Server instance configuration (sys.configurations). Shows all sp_configure settings with configured and in-use values. Useful for checking CTFP, MAXDOP, max memory, and other instance-level settings.")]
+    public static async Task<string> GetServerConfig(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestServerConfigAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No server configuration data available. The config collector may not have run yet.";
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                setting_count = rows.Count,
+                settings = rows.Select(r => new
+                {
+                    name = r.ConfigurationName,
+                    value_configured = r.ValueConfigured,
+                    value_in_use = r.ValueInUse,
+                    values_match = r.ValuesMatch,
+                    is_dynamic = r.IsDynamic,
+                    is_advanced = r.IsAdvanced
+                })
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_server_config", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_database_config"), Description("Gets database-level configuration for all databases (sys.databases). Shows recovery model, RCSI, auto-shrink, auto-close, Query Store, compatibility level, page verify, and other settings. Critical for identifying misconfigured databases.")]
+    public static async Task<string> GetDatabaseConfig(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Filter to a specific database. Omit for all databases.")] string? database_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestDatabaseConfigAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No database configuration data available. The config collector may not have run yet.";
+
+            IEnumerable<DatabaseConfigRow> filtered = rows;
+            if (!string.IsNullOrEmpty(database_name))
+                filtered = filtered.Where(r => r.DatabaseName.Equals(database_name, StringComparison.OrdinalIgnoreCase));
+
+            var result = filtered.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                state = r.StateDesc,
+                compatibility_level = r.CompatibilityLevel,
+                recovery_model = r.RecoveryModel,
+                rcsi = r.IsRcsiOn,
+                snapshot_isolation = r.SnapshotIsolationState,
+                auto_close = r.IsAutoCloseOn,
+                auto_shrink = r.IsAutoShrinkOn,
+                auto_create_stats = r.IsAutoCreateStatsOn,
+                auto_update_stats = r.IsAutoUpdateStatsOn,
+                auto_update_stats_async = r.IsAutoUpdateStatsAsyncOn,
+                query_store = r.IsQueryStoreOn,
+                page_verify = r.PageVerifyOption,
+                parameterization_forced = r.IsParameterizationForced,
+                delayed_durability = r.DelayedDurability,
+                target_recovery_time_seconds = r.TargetRecoveryTimeSeconds,
+                encrypted = r.IsEncrypted,
+                accelerated_database_recovery = r.IsAcceleratedDatabaseRecoveryOn,
+                optimized_locking = r.IsOptimizedLockingOn,
+                log_reuse_wait = r.LogReuseWaitDesc
+            }).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                database_count = result.Count,
+                databases = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_database_config", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_database_scoped_config"), Description("Gets database-scoped configuration settings (sys.database_scoped_configurations). Shows MAXDOP, legacy CE, parameter sniffing, and other per-database settings.")]
+    public static async Task<string> GetDatabaseScopedConfig(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Filter to a specific database. Omit for all databases.")] string? database_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestDatabaseScopedConfigAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No database-scoped configuration data available. The config collector may not have run yet.";
+
+            IEnumerable<DatabaseScopedConfigRow> filtered = rows;
+            if (!string.IsNullOrEmpty(database_name))
+                filtered = filtered.Where(r => r.DatabaseName.Equals(database_name, StringComparison.OrdinalIgnoreCase));
+
+            var grouped = filtered
+                .GroupBy(r => r.DatabaseName)
+                .Select(g => new
+                {
+                    database_name = g.Key,
+                    settings = g.Select(r => new
+                    {
+                        name = r.ConfigurationName,
+                        value = r.Value,
+                        value_for_secondary = string.IsNullOrEmpty(r.ValueForSecondary) ? null : r.ValueForSecondary
+                    })
+                }).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                database_count = grouped.Count,
+                databases = grouped
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_database_scoped_config", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_trace_flags"), Description("Gets active trace flags on the SQL Server instance. Shows flag number, enabled status, and whether the flag is global or session-scoped.")]
+    public static async Task<string> GetTraceFlags(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestTraceFlagsAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No trace flags found (none enabled, or the config collector has not run yet).";
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                trace_flag_count = rows.Count,
+                trace_flags = rows.Select(r => new
+                {
+                    trace_flag = r.TraceFlag,
+                    enabled = r.Status,
+                    is_global = r.IsGlobal,
+                    is_session = r.IsSession
+                })
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_trace_flags", ex);
+        }
+    }
+}

--- a/Lite/Mcp/McpHostService.cs
+++ b/Lite/Mcp/McpHostService.cs
@@ -78,6 +78,9 @@ public sealed class McpHostService : BackgroundService
                 .WithTools<McpAlertTools>()
                 .WithTools<McpJobTools>()
                 .WithTools<McpPlanTools>()
+                .WithTools<McpConfigTools>()
+                .WithTools<McpServerInfoTools>()
+                .WithTools<McpSessionTools>()
                 .WithTools<McpAnalysisTools>();
 
             _app = builder.Build();

--- a/Lite/Mcp/McpInstructions.cs
+++ b/Lite/Mcp/McpInstructions.cs
@@ -107,6 +107,26 @@ internal static class McpInstructions
         |------|---------|----------------|
         | `get_running_jobs` | Currently running SQL Agent jobs with duration vs historical average/p95 | `server_name` |
 
+        ### Configuration Tools
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `get_server_config` | sp_configure settings with configured and in-use values | `server_name` |
+        | `get_database_config` | Database-level settings: RCSI, recovery model, auto-shrink, Query Store, etc. | `server_name`, `database_name` |
+        | `get_database_scoped_config` | Database-scoped configuration (MAXDOP, legacy CE, parameter sniffing) | `server_name`, `database_name` |
+        | `get_trace_flags` | Active trace flags with global/session scope | `server_name` |
+
+        ### Server Information Tools
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `get_server_properties` | Server inventory: edition, version, CPU count, memory, socket topology | `server_name` |
+        | `get_database_sizes` | Database file sizes, space usage, and volume free space | `server_name` |
+
+        ### Session & Active Query Tools
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `get_active_queries` | Active query snapshots from sp_WhoIsActive — what was running at each collection point | `server_name`, `hours_back` (default 1), `database_name`, `blocking_only`, `limit` |
+        | `get_session_stats` | Connection counts and resource usage grouped by application | `server_name` |
+
         ### Execution Plan Analysis Tools
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
@@ -151,8 +171,10 @@ internal static class McpInstructions
         5. **Deep dive**: Use `get_analysis_facts` to inspect what the engine sees, including amplifier details and raw metric values
         6. **Compare**: Use `compare_analysis` to see if problems are new (compare last 4 hours vs yesterday same time)
         7. **Config**: Use `audit_config` for edition-aware configuration recommendations
-        8. **Query investigation**: After finding a problematic query via `get_top_queries_by_cpu`, use `get_query_trend` with its `query_hash` to see performance history
-        9. **Plan analysis**: Use `analyze_query_plan` with the `query_hash` from step 8 to get detailed plan analysis with warnings, missing indexes, and optimization recommendations
+        8. **Active queries**: Use `get_active_queries` to see what was running at a specific time — critical for correlating CPU spikes, blocking events, or deadlocks with actual queries
+        9. **Configuration**: Use `get_server_config`, `get_database_config`, or `get_database_scoped_config` to check server and database settings
+        10. **Query investigation**: After finding a problematic query via `get_top_queries_by_cpu`, use `get_query_trend` with its `query_hash` to see performance history
+        11. **Plan analysis**: Use `analyze_query_plan` with the `query_hash` from step 10 to get detailed plan analysis with warnings, missing indexes, and optimization recommendations
 
         ## Wait Type to Tool Mapping
 

--- a/Lite/Mcp/McpServerInfoTools.cs
+++ b/Lite/Mcp/McpServerInfoTools.cs
@@ -1,0 +1,101 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Mcp;
+
+[McpServerToolType]
+public sealed class McpServerInfoTools
+{
+    [McpServerTool(Name = "get_server_properties"), Description("Gets SQL Server instance properties: edition, version, CPU count, physical memory, socket/core topology, HADR status, and clustering. Use for capacity planning and edition-aware recommendations.")]
+    public static async Task<string> GetServerProperties(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var row = await dataService.GetLatestServerPropertiesAsync(resolved.Value.ServerId);
+            if (row == null)
+                return "No server properties available. The properties collector may not have run yet.";
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                collection_time = row.CollectionTime.ToString("o"),
+                edition = row.Edition,
+                engine_edition = row.EngineEdition,
+                product_version = row.ProductVersion,
+                product_level = row.ProductLevel,
+                product_update_level = string.IsNullOrEmpty(row.ProductUpdateLevel) ? null : row.ProductUpdateLevel,
+                cpu_count = row.CpuCount,
+                hyperthread_ratio = row.HyperthreadRatio,
+                socket_count = row.SocketCount,
+                cores_per_socket = row.CoresPerSocket,
+                physical_memory_mb = row.PhysicalMemoryMb,
+                is_hadr_enabled = row.IsHadrEnabled,
+                is_clustered = row.IsClustered,
+                enterprise_features = string.IsNullOrEmpty(row.EnterpriseFeatures) ? null : row.EnterpriseFeatures,
+                service_objective = string.IsNullOrEmpty(row.ServiceObjective) ? null : row.ServiceObjective
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_server_properties", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_database_sizes"), Description("Gets database file sizes, space usage, and volume free space. Shows each database file with total size, used space, auto-growth settings, and the underlying volume's capacity. Use for capacity planning and identifying space pressure.")]
+    public static async Task<string> GetDatabaseSizes(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestDatabaseSizeStatsAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No database size data available. The size collector may not have run yet.";
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                collection_time = rows[0].CollectionTime.ToString("o"),
+                file_count = rows.Count,
+                databases = rows
+                    .GroupBy(r => r.DatabaseName)
+                    .Select(g => new
+                    {
+                        database_name = g.Key,
+                        total_size_mb = g.Sum(r => r.TotalSizeMb),
+                        used_size_mb = g.Sum(r => r.UsedSizeMb),
+                        files = g.Select(r => new
+                        {
+                            file_name = r.FileName,
+                            file_type = r.FileTypeDesc,
+                            total_size_mb = r.TotalSizeMb,
+                            used_size_mb = r.UsedSizeMb,
+                            auto_growth_mb = r.AutoGrowthMb,
+                            max_size_mb = r.MaxSizeMb,
+                            volume_mount_point = r.VolumeMountPoint,
+                            volume_total_mb = r.VolumeTotalMb,
+                            volume_free_mb = r.VolumeFreeMb
+                        })
+                    })
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_database_sizes", ex);
+        }
+    }
+}

--- a/Lite/Mcp/McpSessionTools.cs
+++ b/Lite/Mcp/McpSessionTools.cs
@@ -1,0 +1,134 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Mcp;
+
+[McpServerToolType]
+public sealed class McpSessionTools
+{
+    [McpServerTool(Name = "get_active_queries"), Description("Gets active query snapshots captured by sp_WhoIsActive. Shows what queries were running at each collection point: session ID, query text, wait type, CPU time, elapsed time, blocking info, DOP, and memory grants. Use hours_back to look at a specific time window — critical for finding what was running during a CPU spike or blocking event.")]
+    public static async Task<string> GetActiveQueries(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Hours of data to retrieve. Default 1.")] int hours_back = 1,
+        [Description("Filter to a specific database.")] string? database_name = null,
+        [Description("Show only queries involved in blocking (blocking_session_id > 0 or is a head blocker).")] bool blocking_only = false,
+        [Description("Maximum number of rows to return. Default 50.")] int limit = 50)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        var validation = McpHelpers.ValidateHoursBack(hours_back);
+        if (validation != null) return validation;
+
+        try
+        {
+            var rows = await dataService.GetLatestQuerySnapshotsAsync(resolved.Value.ServerId, hours_back);
+            if (rows.Count == 0)
+                return "No active query snapshots found in the requested time range.";
+
+            IEnumerable<QuerySnapshotRow> filtered = rows;
+
+            if (!string.IsNullOrEmpty(database_name))
+                filtered = filtered.Where(r => r.DatabaseName.Equals(database_name, StringComparison.OrdinalIgnoreCase));
+
+            if (blocking_only)
+                filtered = filtered.Where(r => r.BlockingSessionId > 0
+                    || rows.Any(other => other.BlockingSessionId == r.SessionId));
+
+            var result = filtered.Take(limit).Select(r => new
+            {
+                collection_time = r.CollectionTime.ToString("o"),
+                session_id = r.SessionId,
+                database_name = r.DatabaseName,
+                status = r.Status,
+                cpu_time_ms = r.CpuTimeMs,
+                elapsed_time_ms = r.TotalElapsedTimeMs,
+                elapsed_time_formatted = r.ElapsedTimeFormatted,
+                logical_reads = r.LogicalReads,
+                reads = r.Reads,
+                writes = r.Writes,
+                wait_type = string.IsNullOrEmpty(r.WaitType) ? null : r.WaitType,
+                wait_time_ms = r.WaitTimeMs > 0 ? r.WaitTimeMs : (long?)null,
+                blocking_session_id = r.BlockingSessionId > 0 ? r.BlockingSessionId : (int?)null,
+                dop = r.Dop > 0 ? r.Dop : (int?)null,
+                parallel_worker_count = r.ParallelWorkerCount > 0 ? r.ParallelWorkerCount : (int?)null,
+                granted_query_memory_gb = r.GrantedQueryMemoryGb > 0 ? r.GrantedQueryMemoryGb : (double?)null,
+                transaction_isolation_level = string.IsNullOrEmpty(r.TransactionIsolationLevel) ? null : r.TransactionIsolationLevel,
+                open_transaction_count = r.OpenTransactionCount > 0 ? r.OpenTransactionCount : (int?)null,
+                login_name = r.LoginName,
+                host_name = r.HostName,
+                program_name = r.ProgramName,
+                query_text = McpHelpers.Truncate(r.QueryText, 2000)
+            }).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                hours_back,
+                total_snapshots = rows.Count,
+                shown = result.Count,
+                queries = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_active_queries", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_session_stats"), Description("Gets connection and session statistics grouped by application. Shows connection counts, running/sleeping/dormant breakdown, and aggregate resource usage per application.")]
+    public static async Task<string> GetSessionStats(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+
+        try
+        {
+            var rows = await dataService.GetLatestSessionStatsAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+                return "No session statistics available. The session collector may not have run yet.";
+
+            var totalConnections = rows.Sum(r => r.ConnectionCount);
+            var totalRunning = rows.Sum(r => r.RunningCount);
+            var totalSleeping = rows.Sum(r => r.SleepingCount);
+            var totalDormant = rows.Sum(r => r.DormantCount);
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                collection_time = rows[0].CollectionTime.ToString("o"),
+                summary = new
+                {
+                    total_connections = totalConnections,
+                    total_running = totalRunning,
+                    total_sleeping = totalSleeping,
+                    total_dormant = totalDormant,
+                    distinct_applications = rows.Count
+                },
+                applications = rows.Select(r => new
+                {
+                    program_name = r.ProgramName,
+                    connections = r.ConnectionCount,
+                    running = r.RunningCount,
+                    sleeping = r.SleepingCount,
+                    dormant = r.DormantCount,
+                    total_cpu_time_ms = r.TotalCpuTimeMs,
+                    total_logical_reads = r.TotalLogicalReads
+                })
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_session_stats", ex);
+        }
+    }
+}

--- a/Lite/Services/LocalDataService.ServerInfo.cs
+++ b/Lite/Services/LocalDataService.ServerInfo.cs
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    /// <summary>
+    /// Gets the latest server properties snapshot (edition, version, CPU, memory).
+    /// </summary>
+    public async Task<ServerPropertiesRow?> GetLatestServerPropertiesAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT edition, product_version, product_level, product_update_level,
+       engine_edition, cpu_count, hyperthread_ratio, physical_memory_mb,
+       socket_count, cores_per_socket, is_hadr_enabled, is_clustered,
+       enterprise_features, service_objective, collection_time
+FROM v_server_properties
+WHERE server_id = $1
+ORDER BY collection_time DESC
+LIMIT 1";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return null;
+
+        return new ServerPropertiesRow
+        {
+            Edition = reader.IsDBNull(0) ? "" : reader.GetString(0),
+            ProductVersion = reader.IsDBNull(1) ? "" : reader.GetString(1),
+            ProductLevel = reader.IsDBNull(2) ? "" : reader.GetString(2),
+            ProductUpdateLevel = reader.IsDBNull(3) ? "" : reader.GetString(3),
+            EngineEdition = reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+            CpuCount = reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+            HyperthreadRatio = reader.IsDBNull(6) ? 0 : reader.GetInt32(6),
+            PhysicalMemoryMb = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+            SocketCount = reader.IsDBNull(8) ? 0 : reader.GetInt32(8),
+            CoresPerSocket = reader.IsDBNull(9) ? 0 : reader.GetInt32(9),
+            IsHadrEnabled = !reader.IsDBNull(10) && reader.GetBoolean(10),
+            IsClustered = !reader.IsDBNull(11) && reader.GetBoolean(11),
+            EnterpriseFeatures = reader.IsDBNull(12) ? "" : reader.GetString(12),
+            ServiceObjective = reader.IsDBNull(13) ? "" : reader.GetString(13),
+            CollectionTime = reader.GetDateTime(14)
+        };
+    }
+
+    /// <summary>
+    /// Gets the latest database size stats (file sizes, volume space).
+    /// </summary>
+    public async Task<List<DatabaseSizeStatsRow>> GetLatestDatabaseSizeStatsAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT database_name, file_name, file_type_desc, physical_name,
+       total_size_mb, used_size_mb, auto_growth_mb, max_size_mb,
+       volume_mount_point, volume_total_mb, volume_free_mb,
+       collection_time
+FROM v_database_size_stats
+WHERE server_id = $1
+AND   collection_time = (SELECT MAX(collection_time) FROM v_database_size_stats WHERE server_id = $1)
+ORDER BY database_name, file_type_desc, file_name";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<DatabaseSizeStatsRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new DatabaseSizeStatsRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                FileName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                FileTypeDesc = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                PhysicalName = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                TotalSizeMb = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                UsedSizeMb = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                AutoGrowthMb = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
+                MaxSizeMb = reader.IsDBNull(7) ? 0 : ToDouble(reader.GetValue(7)),
+                VolumeMountPoint = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                VolumeTotalMb = reader.IsDBNull(9) ? 0 : ToDouble(reader.GetValue(9)),
+                VolumeFreeMb = reader.IsDBNull(10) ? 0 : ToDouble(reader.GetValue(10)),
+                CollectionTime = reader.GetDateTime(11)
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets the latest session stats (connection counts by application).
+    /// </summary>
+    public async Task<List<SessionStatsRow>> GetLatestSessionStatsAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT program_name, connection_count, running_count, sleeping_count, dormant_count,
+       total_cpu_time_ms, total_reads, total_writes, total_logical_reads,
+       collection_time
+FROM v_session_stats
+WHERE server_id = $1
+AND   collection_time = (SELECT MAX(collection_time) FROM v_session_stats WHERE server_id = $1)
+ORDER BY connection_count DESC";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<SessionStatsRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new SessionStatsRow
+            {
+                ProgramName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                ConnectionCount = reader.IsDBNull(1) ? 0 : ToInt64(reader.GetValue(1)),
+                RunningCount = reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+                SleepingCount = reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+                DormantCount = reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+                TotalCpuTimeMs = reader.IsDBNull(5) ? 0 : ToInt64(reader.GetValue(5)),
+                TotalReads = reader.IsDBNull(6) ? 0 : ToInt64(reader.GetValue(6)),
+                TotalWrites = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+                TotalLogicalReads = reader.IsDBNull(8) ? 0 : ToInt64(reader.GetValue(8)),
+                CollectionTime = reader.GetDateTime(9)
+            });
+        }
+
+        return items;
+    }
+}
+
+public class ServerPropertiesRow
+{
+    public string Edition { get; set; } = "";
+    public string ProductVersion { get; set; } = "";
+    public string ProductLevel { get; set; } = "";
+    public string ProductUpdateLevel { get; set; } = "";
+    public int EngineEdition { get; set; }
+    public int CpuCount { get; set; }
+    public int HyperthreadRatio { get; set; }
+    public long PhysicalMemoryMb { get; set; }
+    public int SocketCount { get; set; }
+    public int CoresPerSocket { get; set; }
+    public bool IsHadrEnabled { get; set; }
+    public bool IsClustered { get; set; }
+    public string EnterpriseFeatures { get; set; } = "";
+    public string ServiceObjective { get; set; } = "";
+    public DateTime CollectionTime { get; set; }
+}
+
+public class DatabaseSizeStatsRow
+{
+    public string DatabaseName { get; set; } = "";
+    public string FileName { get; set; } = "";
+    public string FileTypeDesc { get; set; } = "";
+    public string PhysicalName { get; set; } = "";
+    public double TotalSizeMb { get; set; }
+    public double UsedSizeMb { get; set; }
+    public double AutoGrowthMb { get; set; }
+    public double MaxSizeMb { get; set; }
+    public string VolumeMountPoint { get; set; } = "";
+    public double VolumeTotalMb { get; set; }
+    public double VolumeFreeMb { get; set; }
+    public DateTime CollectionTime { get; set; }
+}
+
+public class SessionStatsRow
+{
+    public string ProgramName { get; set; } = "";
+    public long ConnectionCount { get; set; }
+    public int RunningCount { get; set; }
+    public int SleepingCount { get; set; }
+    public int DormantCount { get; set; }
+    public long TotalCpuTimeMs { get; set; }
+    public long TotalReads { get; set; }
+    public long TotalWrites { get; set; }
+    public long TotalLogicalReads { get; set; }
+    public DateTime CollectionTime { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds 8 new MCP tools covering all previously unexposed Lite DuckDB tables
- Config tools: `get_server_config`, `get_database_config`, `get_database_scoped_config`, `get_trace_flags`
- Server info tools: `get_server_properties`, `get_database_sizes`
- Session tools: `get_active_queries`, `get_session_stats`
- New service methods in `LocalDataService.ServerInfo.cs` for server properties, database sizes, and session stats
- All tools tested live against sql2022

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 131 tests pass
- [x] All 8 tools tested via MCP against sql2022 with HammerDB data
- [x] JSON output verified for structure, field names, and data quality

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)