### PR TITLE
Add bad actor detection — per-query scoring (#593)

### DIFF
--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -70,6 +70,9 @@ public class DrillDownCollector
                 if (pathKeys.Contains("MEMORY_GRANT_PENDING"))
                     await CollectPendingGrants(finding, context);
 
+                if (pathKeys.Any(k => k.StartsWith("BAD_ACTOR_")))
+                    await CollectBadActorDetail(finding, context);
+
                 // Remove empty drill-down dictionaries
                 if (finding.DrillDown.Count == 0)
                     finding.DrillDown = null;
@@ -539,5 +542,65 @@ LIMIT 5";
 
         if (items.Count > 0)
             finding.DrillDown!["pending_grants"] = items;
+    }
+
+    private async Task CollectBadActorDetail(AnalysisFinding finding, AnalysisContext context)
+    {
+        // Extract query_hash from the fact key (BAD_ACTOR_0x...)
+        var queryHash = finding.RootFactKey.Replace("BAD_ACTOR_", "");
+        if (string.IsNullOrEmpty(queryHash)) return;
+
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+SELECT database_name, query_hash,
+       LEFT(MAX(query_text), 500) AS query_text,
+       SUM(delta_execution_count)::BIGINT AS exec_count,
+       CASE WHEN SUM(delta_execution_count) > 0
+            THEN SUM(delta_worker_time)::DOUBLE / SUM(delta_execution_count) / 1000.0
+            ELSE 0 END AS avg_cpu_ms,
+       CASE WHEN SUM(delta_execution_count) > 0
+            THEN SUM(delta_elapsed_time)::DOUBLE / SUM(delta_execution_count) / 1000.0
+            ELSE 0 END AS avg_elapsed_ms,
+       CASE WHEN SUM(delta_execution_count) > 0
+            THEN SUM(delta_logical_reads)::DOUBLE / SUM(delta_execution_count)
+            ELSE 0 END AS avg_reads,
+       SUM(delta_worker_time)::BIGINT AS total_cpu_us,
+       SUM(delta_logical_reads)::BIGINT AS total_reads,
+       SUM(delta_spills)::BIGINT AS total_spills,
+       MAX(max_dop) AS max_dop
+FROM v_query_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   query_hash = $4
+GROUP BY database_name, query_hash";
+
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
+        cmd.Parameters.Add(new DuckDBParameter { Value = queryHash });
+
+        using var reader = await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            finding.DrillDown!["bad_actor_query"] = new
+            {
+                database = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                query_hash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                query_text = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                execution_count = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3)),
+                avg_cpu_ms = reader.IsDBNull(4) ? 0.0 : Math.Round(Convert.ToDouble(reader.GetValue(4)), 2),
+                avg_elapsed_ms = reader.IsDBNull(5) ? 0.0 : Math.Round(Convert.ToDouble(reader.GetValue(5)), 2),
+                avg_reads = reader.IsDBNull(6) ? 0.0 : Math.Round(Convert.ToDouble(reader.GetValue(6)), 0),
+                total_cpu_ms = reader.IsDBNull(7) ? 0.0 : Convert.ToDouble(reader.GetValue(7)) / 1000.0,
+                total_reads = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                total_spills = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                max_dop = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10))
+            };
+        }
     }
 }

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -39,6 +39,7 @@ public class DuckDbFactCollector : IFactCollector
         await CollectTempDbFactsAsync(context, facts);
         await CollectMemoryGrantFactsAsync(context, facts);
         await CollectQueryStatsFactsAsync(context, facts);
+        await CollectBadActorFactsAsync(context, facts);
         await CollectPerfmonFactsAsync(context, facts);
         await CollectMemoryClerkFactsAsync(context, facts);
         await CollectDatabaseConfigFactsAsync(context, facts);
@@ -746,6 +747,97 @@ AND   delta_execution_count > 0";
                         ["high_dop_query_count"] = highDopQueries,
                         ["total_cpu_time_us"] = totalCpuTimeUs,
                         ["total_executions"] = totalExecutions
+                    }
+                });
+            }
+        }
+        catch { /* Table may not exist or have no data */ }
+    }
+
+    /// <summary>
+    /// Identifies individual queries that are consistently terrible ("bad actors").
+    /// These queries don't necessarily cause server-level symptoms but waste resources
+    /// on every execution. Detection uses execution count tiers x per-execution impact.
+    /// Top 5 worst offenders become individual BAD_ACTOR facts.
+    /// </summary>
+    private async Task CollectBadActorFactsAsync(AnalysisContext context, List<Fact> facts)
+    {
+        try
+        {
+            using var readLock = _duckDb.AcquireReadLock();
+            using var connection = _duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SELECT
+    database_name,
+    query_hash,
+    SUM(delta_execution_count)::BIGINT AS exec_count,
+    CASE WHEN SUM(delta_execution_count) > 0
+         THEN SUM(delta_worker_time)::DOUBLE / SUM(delta_execution_count) / 1000.0
+         ELSE 0 END AS avg_cpu_ms,
+    CASE WHEN SUM(delta_execution_count) > 0
+         THEN SUM(delta_elapsed_time)::DOUBLE / SUM(delta_execution_count) / 1000.0
+         ELSE 0 END AS avg_elapsed_ms,
+    CASE WHEN SUM(delta_execution_count) > 0
+         THEN SUM(delta_logical_reads)::DOUBLE / SUM(delta_execution_count)
+         ELSE 0 END AS avg_reads,
+    SUM(delta_worker_time)::BIGINT AS total_cpu_us,
+    SUM(delta_logical_reads)::BIGINT AS total_reads,
+    SUM(delta_spills)::BIGINT AS total_spills,
+    MAX(max_dop) AS max_dop,
+    LEFT(MAX(query_text), 200) AS query_text
+FROM v_query_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   delta_execution_count > 0
+GROUP BY database_name, query_hash
+HAVING SUM(delta_execution_count) >= 100
+ORDER BY SUM(delta_worker_time)::DOUBLE / GREATEST(SUM(delta_execution_count), 1) *
+         LN(GREATEST(SUM(delta_execution_count), 1)) DESC
+LIMIT 5";
+
+            cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+            cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
+            cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
+                var execCount = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2));
+                var avgCpuMs = reader.IsDBNull(3) ? 0.0 : Convert.ToDouble(reader.GetValue(3));
+                var avgElapsedMs = reader.IsDBNull(4) ? 0.0 : Convert.ToDouble(reader.GetValue(4));
+                var avgReads = reader.IsDBNull(5) ? 0.0 : Convert.ToDouble(reader.GetValue(5));
+                var totalCpuUs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6));
+                var totalReads = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7));
+                var totalSpills = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8));
+                var maxDop = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9));
+                var queryText = reader.IsDBNull(10) ? "" : reader.GetString(10);
+
+                // Skip low-impact queries — need meaningful per-execution cost
+                if (avgCpuMs < 10 && avgReads < 1000) continue;
+
+                facts.Add(new Fact
+                {
+                    Source = "bad_actor",
+                    Key = $"BAD_ACTOR_{queryHash}",
+                    Value = avgCpuMs, // Primary scoring dimension
+                    ServerId = context.ServerId,
+                    DatabaseName = dbName,
+                    Metadata = new Dictionary<string, double>
+                    {
+                        ["execution_count"] = execCount,
+                        ["avg_cpu_ms"] = avgCpuMs,
+                        ["avg_elapsed_ms"] = avgElapsedMs,
+                        ["avg_reads"] = avgReads,
+                        ["total_cpu_us"] = totalCpuUs,
+                        ["total_reads"] = totalReads,
+                        ["total_spills"] = totalSpills,
+                        ["max_dop"] = maxDop
                     }
                 });
             }

--- a/Lite/Analysis/FactScorer.cs
+++ b/Lite/Analysis/FactScorer.cs
@@ -36,6 +36,7 @@ public class FactScorer
                 "database_config" => ScoreDatabaseConfigFact(fact),
                 "jobs" => ScoreJobFact(fact),
                 "disk" => ScoreDiskFact(fact),
+                "bad_actor" => ScoreBadActorFact(fact),
                 _ => 0.0
             };
         }
@@ -43,7 +44,7 @@ public class FactScorer
         // Build lookup for amplifier evaluation (include context facts that amplifiers reference)
         var contextSources = new HashSet<string>
             { "config", "cpu", "io", "tempdb", "memory", "queries", "perfmon",
-              "database_config", "jobs", "sessions", "disk" };
+              "database_config", "jobs", "sessions", "disk", "bad_actor" };
         var factsByKey = facts
             .Where(f => f.BaseSeverity > 0 || contextSources.Contains(f.Source))
             .ToDictionary(f => f.Key, f => f);
@@ -263,6 +264,40 @@ public class FactScorer
         if (freePct < 0.10) return 0.5 + 0.5 * (0.10 - freePct) / 0.05;
         if (freePct < 0.20) return 0.5 * (0.20 - freePct) / 0.10;
         return 0.0;
+    }
+
+    /// <summary>
+    /// Scores bad actor queries using execution count tier x per-execution impact.
+    /// A query running 100K times at 1ms CPU is different from 100K times at 5s CPU.
+    /// The tier gets it in the door, per-execution impact determines how bad it is.
+    /// </summary>
+    private static double ScoreBadActorFact(Fact fact)
+    {
+        var execCount = fact.Metadata.GetValueOrDefault("execution_count");
+        var avgCpuMs = fact.Metadata.GetValueOrDefault("avg_cpu_ms");
+        var avgReads = fact.Metadata.GetValueOrDefault("avg_reads");
+
+        // Execution count tier base — higher tiers for more frequent queries
+        var tierBase = execCount switch
+        {
+            < 1_000 => 0.5,
+            < 10_000 => 0.7,
+            < 100_000 => 0.85,
+            _ => 1.0
+        };
+
+        // Per-execution impact: use the worse of CPU or reads
+        // CPU: concerning at 50ms, critical at 2000ms
+        var cpuImpact = ApplyThresholdFormula(avgCpuMs, 50, 2000);
+        // Reads: concerning at 5K, critical at 250K
+        var readsImpact = ApplyThresholdFormula(avgReads, 5_000, 250_000);
+
+        var impact = Math.Max(cpuImpact, readsImpact);
+
+        // Final: tier * impact. Both must be meaningful.
+        // A high-frequency query with trivial per-execution cost won't score.
+        // A heavy query that only runs once won't score high either.
+        return tierBase * impact;
     }
 
     /// <summary>

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -742,6 +742,12 @@ internal static class ToolRecommendations
             new("get_running_jobs", "See currently running jobs with duration vs historical"),
             new("get_cpu_utilization", "Check if long-running jobs are consuming CPU")
         ],
+        ["BAD_ACTOR"] =
+        [
+            new("get_top_queries_by_cpu", "See full query stats for this query"),
+            new("analyze_query_plan", "Analyze the execution plan for optimization opportunities"),
+            new("get_query_trend", "Track this query's performance over time")
+        ],
         ["DISK_SPACE"] =
         [
             new("get_file_io_stats", "Check per-file sizes and I/O"),
@@ -761,7 +767,13 @@ internal static class ToolRecommendations
 
         foreach (var key in factKeys)
         {
-            if (!ByFactKey.TryGetValue(key, out var recommendations)) continue;
+            if (!ByFactKey.TryGetValue(key, out var recommendations))
+            {
+                // Handle dynamic keys like BAD_ACTOR_0x... by checking prefix
+                if (key.StartsWith("BAD_ACTOR_"))
+                    ByFactKey.TryGetValue("BAD_ACTOR", out recommendations);
+                if (recommendations == null) continue;
+            }
 
             foreach (var rec in recommendations)
             {


### PR DESCRIPTION
## Summary
- Identifies individual queries that are consistently terrible regardless of server-level symptoms
- Execution count tier (0.5-1.0) x per-execution impact (CPU or reads) scoring
- Top 5 worst offenders become BAD_ACTOR findings with full drill-down (query text, metrics, DOP)
- Minimum thresholds: 100+ executions AND (avg CPU >= 10ms OR avg reads >= 1K)

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 131 tests pass
- [x] 5 HammerDB queries surface as bad actor findings (severity 0.54-0.70)
- [x] All 5 have populated drill-down with query text and full metrics

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)