### PR TITLE
Add FinOps High Impact Queries tab (#564)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1353,6 +1353,129 @@
             </Grid>
         </TabItem>
 
+        <!-- High Impact Sub-Tab -->
+        <TabItem Header="High Impact">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="High Impact Queries" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="HighImpactRefresh_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock Text="Time Range:" VerticalAlignment="Center" Margin="16,0,4,0" FontSize="11"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="HighImpactTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                              SelectionChanged="HighImpactTimeRange_Changed">
+                        <ComboBoxItem Content="Last 1 hour"/>
+                        <ComboBoxItem Content="Last 4 hours"/>
+                        <ComboBoxItem Content="Last 12 hours"/>
+                        <ComboBoxItem Content="Last 24 hours"/>
+                        <ComboBoxItem Content="Last 7 days"/>
+                    </ComboBox>
+                    <TextBlock x:Name="HighImpactCountIndicator" VerticalAlignment="Center" Margin="12,0,0,0"
+                               FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- No Data Message -->
+                <TextBlock x:Name="HighImpactNoDataMessage" Grid.Row="1"
+                           Text="No high-impact queries found for this time range."
+                           Margin="10,0" Visibility="Collapsed"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" FontStyle="Italic"/>
+
+                <!-- High Impact DataGrid -->
+                <DataGrid x:Name="HighImpactDataGrid" Grid.Row="2" Margin="10,4,10,10"
+                          AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserSortColumns="True" CanUserResizeColumns="True"
+                          HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                          RowStyle="{StaticResource DefaultRowStyle}"
+                          Background="Transparent" BorderThickness="0"
+                          RowBackground="Transparent"
+                          AlternatingRowBackground="{DynamicResource DataGridAlternatingRowBrush}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Score" Binding="{Binding ImpactScore}" Width="60">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#E74C3C">
+                                            <Setter Property="Foreground" Value="#E74C3C"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#F39C12">
+                                            <Setter Property="Foreground" Value="#F39C12"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#27AE60">
+                                            <Setter Property="Foreground" Value="#27AE60"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="120"/>
+                        <DataGridTextColumn Header="Executions" Binding="{Binding TotalExecutions, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="CPU %" Binding="{Binding CpuShare, StringFormat='{}{0:N1}%'}" Width="70">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat='{}{0:N0}'}" Width="110">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Duration %" Binding="{Binding DurationShare, StringFormat='{}{0:N1}%'}" Width="80">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Reads" Binding="{Binding TotalReads, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Reads %" Binding="{Binding ReadsShare, StringFormat='{}{0:N1}%'}" Width="70">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Writes" Binding="{Binding TotalWrites, StringFormat='{}{0:N0}'}" Width="90">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Memory (MB)" Binding="{Binding TotalMemoryMb, StringFormat='{}{0:N1}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Query Preview" Binding="{Binding SampleQueryText}" Width="400">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </TabItem>
+
         <!-- Application Connections Sub-Tab -->
         <TabItem Header="Application Connections">
             <Grid>

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -54,6 +54,7 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.AutoSizeColumnMinWidths(ExpensiveQueriesDataGrid);
             TabHelpers.AutoSizeColumnMinWidths(IndexAnalysisSummaryGrid);
             TabHelpers.AutoSizeColumnMinWidths(IndexAnalysisDetailGrid);
+            TabHelpers.AutoSizeColumnMinWidths(HighImpactDataGrid);
 
             TabHelpers.FreezeColumns(RecommendationsDataGrid, 1);
             TabHelpers.FreezeColumns(DatabaseResourcesDataGrid, 1);
@@ -67,6 +68,7 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.FreezeColumns(WaitCategorySummaryDataGrid, 1);
             TabHelpers.FreezeColumns(ExpensiveQueriesDataGrid, 1);
             TabHelpers.FreezeColumns(IndexAnalysisDetailGrid, 1);
+            TabHelpers.FreezeColumns(HighImpactDataGrid, 1);
         }
 
         /// <summary>
@@ -120,7 +122,8 @@ namespace PerformanceMonitorDashboard.Controls
                     LoadTempdbSummaryAsync(),
                     LoadWaitCategorySummaryAsync(),
                     LoadExpensiveQueriesAsync(),
-                    LoadMemoryGrantEfficiencyAsync()
+                    LoadMemoryGrantEfficiencyAsync(),
+                    LoadHighImpactQueriesAsync()
                 );
             }
             catch (Exception ex)
@@ -734,6 +737,41 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         // ============================================
+        // High Impact Queries Tab
+        // ============================================
+
+        private int GetHighImpactHoursBack()
+        {
+            return HighImpactTimeRangeCombo.SelectedIndex switch
+            {
+                0 => 1,
+                1 => 4,
+                2 => 12,
+                3 => 24,
+                4 => 168,
+                _ => 24
+            };
+        }
+
+        private async Task LoadHighImpactQueriesAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var hoursBack = GetHighImpactHoursBack();
+                var data = await _databaseService.GetFinOpsHighImpactQueriesAsync(hoursBack);
+                HighImpactDataGrid.ItemsSource = data;
+                HighImpactNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                HighImpactCountIndicator.Text = data.Count > 0 ? $"{data.Count} high-impact query(s)" : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading high-impact queries: {ex.Message}", ex);
+            }
+        }
+
+        // ============================================
         // Refresh Button Handlers
         // ============================================
 
@@ -783,6 +821,17 @@ namespace PerformanceMonitorDashboard.Controls
         private async void DatabaseSizesRefresh_Click(object sender, RoutedEventArgs e)
         {
             await LoadDatabaseSizesAsync();
+        }
+
+        private async void HighImpactRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadHighImpactQueriesAsync();
+        }
+
+        private async void HighImpactTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _databaseService == null) return;
+            await LoadHighImpactQueriesAsync();
         }
 
         private async void ApplicationConnectionsRefresh_Click(object sender, RoutedEventArgs e)

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1356,6 +1356,177 @@ OPTION(MAXDOP 1, RECOMPILE);";
         }
 
         /// <summary>
+        /// Fetches high-impact queries — 80/20 analysis across CPU, duration, reads, writes, memory, executions.
+        /// </summary>
+        public async Task<List<FinOpsHighImpactQuery>> GetFinOpsHighImpactQueriesAsync(int hoursBack = 24)
+        {
+            var items = new List<FinOpsHighImpactQuery>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+DECLARE @cutoff datetime2(7) = DATEADD(HOUR, -@hoursBack, SYSDATETIME());
+
+WITH
+    agg AS
+    (
+        SELECT
+            qs.query_hash,
+            database_name = MIN(qs.database_name),
+            total_executions = SUM(qs.execution_count_delta),
+            total_cpu_ms = SUM(qs.total_worker_time_delta) / 1000.0,
+            total_duration_ms = SUM(qs.total_elapsed_time_delta) / 1000.0,
+            total_reads = SUM(qs.total_logical_reads_delta),
+            total_writes = SUM(qs.total_logical_writes_delta),
+            total_memory_mb = SUM(ISNULL(qs.max_grant_kb, 0)) / 1024.0
+        FROM collect.query_stats AS qs
+        WHERE qs.collection_time >= @cutoff
+        AND   qs.query_hash IS NOT NULL
+        AND   qs.execution_count_delta > 0
+        GROUP BY
+            qs.query_hash
+        HAVING
+            SUM(qs.execution_count_delta) > 0
+    ),
+    interesting AS
+    (
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_cpu_ms DESC) x
+        UNION
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_duration_ms DESC) x
+        UNION
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_reads DESC) x
+        UNION
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_writes DESC) x
+        UNION
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_memory_mb DESC) x
+        UNION
+        SELECT query_hash FROM (SELECT TOP (10) query_hash FROM agg ORDER BY total_executions DESC) x
+    ),
+    scored AS
+    (
+        SELECT
+            a.*,
+            cpu_pctl = PERCENT_RANK() OVER (ORDER BY a.total_cpu_ms),
+            duration_pctl = PERCENT_RANK() OVER (ORDER BY a.total_duration_ms),
+            reads_pctl = PERCENT_RANK() OVER (ORDER BY a.total_reads),
+            writes_pctl = PERCENT_RANK() OVER (ORDER BY a.total_writes),
+            memory_pctl = PERCENT_RANK() OVER (ORDER BY a.total_memory_mb),
+            executions_pctl = PERCENT_RANK() OVER (ORDER BY a.total_executions),
+            cpu_share = CONVERT(decimal(5,1), 100.0 * a.total_cpu_ms / NULLIF(SUM(a.total_cpu_ms) OVER (), 0)),
+            duration_share = CONVERT(decimal(5,1), 100.0 * a.total_duration_ms / NULLIF(SUM(a.total_duration_ms) OVER (), 0)),
+            reads_share = CONVERT(decimal(5,1), 100.0 * a.total_reads / NULLIF(SUM(CONVERT(float, a.total_reads)) OVER (), 0)),
+            writes_share = CONVERT(decimal(5,1), 100.0 * a.total_writes / NULLIF(SUM(CONVERT(float, a.total_writes)) OVER (), 0)),
+            memory_share = CONVERT(decimal(5,1), 100.0 * a.total_memory_mb / NULLIF(SUM(a.total_memory_mb) OVER (), 0)),
+            executions_share = CONVERT(decimal(5,1), 100.0 * a.total_executions / NULLIF(SUM(CONVERT(float, a.total_executions)) OVER (), 0))
+        FROM agg AS a
+        JOIN interesting AS i
+          ON a.query_hash = i.query_hash
+    ),
+    with_text AS
+    (
+        SELECT
+            s.*,
+            sample_query_text =
+            (
+                SELECT TOP (1)
+                    CASE
+                        WHEN qs2.query_text IS NOT NULL
+                        THEN LEFT(CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max)), 500)
+                        ELSE N''
+                    END
+                FROM collect.query_stats AS qs2
+                WHERE qs2.query_hash = s.query_hash
+                AND   qs2.collection_time >= @cutoff
+                AND   qs2.query_text IS NOT NULL
+                ORDER BY
+                    qs2.execution_count_delta DESC
+            )
+        FROM scored AS s
+    )
+SELECT
+    query_hash_display = CONVERT(varchar(20), query_hash, 1),
+    database_name,
+    total_executions,
+    total_cpu_ms,
+    total_duration_ms,
+    total_reads,
+    total_writes,
+    total_memory_mb,
+    cpu_share,
+    duration_share,
+    reads_share,
+    writes_share,
+    memory_share,
+    executions_share,
+    impact_score =
+        CONVERT(int,
+        (
+            ISNULL(cpu_pctl, 0) +
+            ISNULL(duration_pctl, 0) +
+            ISNULL(reads_pctl, 0) +
+            ISNULL(writes_pctl, 0) +
+            ISNULL(memory_pctl, 0) +
+            ISNULL(executions_pctl, 0)
+        ) /
+        (
+            CASE WHEN cpu_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN duration_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN reads_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN writes_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN memory_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN executions_pctl IS NOT NULL THEN 1.0 ELSE 0 END
+        ) * 100),
+    sample_query_text
+FROM with_text
+ORDER BY
+    (
+        ISNULL(cpu_pctl, 0) +
+        ISNULL(duration_pctl, 0) +
+        ISNULL(reads_pctl, 0) +
+        ISNULL(writes_pctl, 0) +
+        ISNULL(memory_pctl, 0) +
+        ISNULL(executions_pctl, 0)
+    ) DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@hoursBack", hoursBack);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_HighImpactQueries", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new FinOpsHighImpactQuery
+                    {
+                        QueryHashDisplay = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        TotalExecutions = reader.IsDBNull(2) ? 0 : Convert.ToInt64(reader.GetValue(2)),
+                        TotalCpuMs = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        TotalDurationMs = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                        TotalReads = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
+                        TotalWrites = reader.IsDBNull(6) ? 0 : Convert.ToInt64(reader.GetValue(6)),
+                        TotalMemoryMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                        CpuShare = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                        DurationShare = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                        ReadsShare = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10)),
+                        WritesShare = reader.IsDBNull(11) ? 0m : Convert.ToDecimal(reader.GetValue(11)),
+                        MemoryShare = reader.IsDBNull(12) ? 0m : Convert.ToDecimal(reader.GetValue(12)),
+                        ExecutionsShare = reader.IsDBNull(13) ? 0m : Convert.ToDecimal(reader.GetValue(13)),
+                        ImpactScore = reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14)),
+                        SampleQueryText = reader.IsDBNull(15) ? "" : reader.GetString(15)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
         /// Checks if sp_IndexCleanup is installed on the target server.
         /// </summary>
         public async Task<bool> CheckSpIndexCleanupExistsAsync()
@@ -2377,5 +2548,32 @@ ORDER BY SUM(CAST(is_running_long AS int)) DESC", connection);
         public string Detail { get; set; } = "";
         public decimal? EstMonthlySavings { get; set; }
         public string EstMonthlySavingsDisplay => EstMonthlySavings.HasValue ? $"${EstMonthlySavings.Value:N0}" : "";
+    }
+
+    public class FinOpsHighImpactQuery
+    {
+        public string QueryHashDisplay { get; set; } = "";
+        public string DatabaseName { get; set; } = "";
+        public long TotalExecutions { get; set; }
+        public decimal TotalCpuMs { get; set; }
+        public decimal TotalDurationMs { get; set; }
+        public long TotalReads { get; set; }
+        public long TotalWrites { get; set; }
+        public decimal TotalMemoryMb { get; set; }
+        public decimal CpuShare { get; set; }
+        public decimal DurationShare { get; set; }
+        public decimal ReadsShare { get; set; }
+        public decimal WritesShare { get; set; }
+        public decimal MemoryShare { get; set; }
+        public decimal ExecutionsShare { get; set; }
+        public int ImpactScore { get; set; }
+        public string SampleQueryText { get; set; } = "";
+
+        public string ImpactScoreColor => ImpactScore switch
+        {
+            >= 80 => "#E74C3C",
+            >= 60 => "#F39C12",
+            _ => "#27AE60"
+        };
     }
 }

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -1825,6 +1825,129 @@
             </Grid>
         </TabItem>
 
+        <!-- High Impact Sub-Tab -->
+        <TabItem Header="High Impact">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="High Impact Queries" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshHighImpact_Click"
+                            Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock Text="Time Range:" VerticalAlignment="Center" Margin="16,0,4,0" FontSize="11"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="HighImpactTimeRangeCombo" SelectedIndex="3" Width="120" FontSize="11"
+                              SelectionChanged="HighImpactTimeRange_Changed">
+                        <ComboBoxItem Content="Last 1 hour"/>
+                        <ComboBoxItem Content="Last 4 hours"/>
+                        <ComboBoxItem Content="Last 12 hours"/>
+                        <ComboBoxItem Content="Last 24 hours"/>
+                        <ComboBoxItem Content="Last 7 days"/>
+                    </ComboBox>
+                    <TextBlock x:Name="HighImpactCountIndicator" VerticalAlignment="Center" Margin="12,0,0,0"
+                               FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+
+                <!-- No Data Message -->
+                <TextBlock x:Name="HighImpactNoDataMessage" Grid.Row="1"
+                           Text="No high-impact queries found for this time range."
+                           Margin="10,0" Visibility="Collapsed"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" FontStyle="Italic"/>
+
+                <!-- High Impact DataGrid -->
+                <DataGrid x:Name="HighImpactDataGrid" Grid.Row="2" Margin="10,4,10,10"
+                          AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserSortColumns="True" CanUserResizeColumns="True"
+                          HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                          RowStyle="{StaticResource DefaultRowStyle}"
+                          Background="Transparent" BorderThickness="0"
+                          RowBackground="Transparent"
+                          AlternatingRowBackground="{DynamicResource DataGridAlternatingRowBrush}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Score" Binding="{Binding ImpactScore}" Width="60">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#E74C3C">
+                                            <Setter Property="Foreground" Value="#E74C3C"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#F39C12">
+                                            <Setter Property="Foreground" Value="#F39C12"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding ImpactScoreColor}" Value="#27AE60">
+                                            <Setter Property="Foreground" Value="#27AE60"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="120"/>
+                        <DataGridTextColumn Header="Executions" Binding="{Binding TotalExecutions, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="CPU %" Binding="{Binding CpuShare, StringFormat='{}{0:N1}%'}" Width="70">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat='{}{0:N0}'}" Width="110">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Duration %" Binding="{Binding DurationShare, StringFormat='{}{0:N1}%'}" Width="80">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Reads" Binding="{Binding TotalReads, StringFormat='{}{0:N0}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Reads %" Binding="{Binding ReadsShare, StringFormat='{}{0:N1}%'}" Width="70">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Writes" Binding="{Binding TotalWrites, StringFormat='{}{0:N0}'}" Width="90">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Memory (MB)" Binding="{Binding TotalMemoryMb, StringFormat='{}{0:N1}'}" Width="100">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Header="Query Preview" Binding="{Binding SampleQueryText}" Width="400">
+                            <DataGridTextColumn.ElementStyle>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
+                                </Style>
+                            </DataGridTextColumn.ElementStyle>
+                        </DataGridTextColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </TabItem>
+
         <!-- Application Connections Sub-Tab -->
         <TabItem Header="Application Connections">
             <Grid>

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -42,6 +42,7 @@ public partial class FinOpsTab : UserControl
     private DataGridFilterManager<IndexCleanupResultRow>? _indexDetailFilterMgr;
     private DataGridFilterManager<ApplicationConnectionRow>? _appConnectionsFilterMgr;
     private DataGridFilterManager<ServerPropertyRow>? _serverInventoryFilterMgr;
+    private DataGridFilterManager<HighImpactQueryRow>? _highImpactFilterMgr;
 
     public FinOpsTab()
     {
@@ -143,7 +144,8 @@ public partial class FinOpsTab : UserControl
             LoadTempdbSummaryAsync(serverId),
             LoadWaitCategorySummaryAsync(serverId),
             LoadExpensiveQueriesAsync(serverId),
-            LoadMemoryGrantEfficiencyAsync(serverId)
+            LoadMemoryGrantEfficiencyAsync(serverId),
+            LoadHighImpactQueriesAsync(serverId)
         );
     }
 
@@ -555,6 +557,37 @@ public partial class FinOpsTab : UserControl
         }
     }
 
+    private int GetHighImpactHoursBack()
+    {
+        return HighImpactTimeRangeCombo.SelectedIndex switch
+        {
+            0 => 1,
+            1 => 4,
+            2 => 12,
+            3 => 24,
+            4 => 168,
+            _ => 24
+        };
+    }
+
+    private async System.Threading.Tasks.Task LoadHighImpactQueriesAsync(int serverId)
+    {
+        if (_dataService == null) return;
+
+        try
+        {
+            var hoursBack = GetHighImpactHoursBack();
+            var data = await _dataService.GetHighImpactQueriesAsync(serverId, hoursBack);
+            HighImpactDataGrid.ItemsSource = data;
+            HighImpactNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            HighImpactCountIndicator.Text = data.Count > 0 ? $"{data.Count} high-impact query(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load high-impact queries: {ex.Message}");
+        }
+    }
+
     private int GetWaitStatsHoursBack()
     {
         return WaitStatsTimeRangeCombo.SelectedIndex switch
@@ -722,6 +755,20 @@ public partial class FinOpsTab : UserControl
         var serverId = GetSelectedServerId();
         if (serverId == 0) return;
         await LoadExpensiveQueriesAsync(serverId);
+    }
+
+    private async void RefreshHighImpact_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadHighImpactQueriesAsync(serverId);
+    }
+
+    private async void HighImpactTimeRange_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _dataService == null) return;
+        var serverId = GetSelectedServerId();
+        if (serverId == 0) return;
+        await LoadHighImpactQueriesAsync(serverId);
     }
 
     private async void OptimizationRefresh_Click(object sender, RoutedEventArgs e)
@@ -913,6 +960,7 @@ public partial class FinOpsTab : UserControl
         _indexDetailFilterMgr = new DataGridFilterManager<IndexCleanupResultRow>(IndexAnalysisDetailGrid);
         _appConnectionsFilterMgr = new DataGridFilterManager<ApplicationConnectionRow>(ApplicationConnectionsDataGrid);
         _serverInventoryFilterMgr = new DataGridFilterManager<ServerPropertyRow>(ServerInventoryDataGrid);
+        _highImpactFilterMgr = new DataGridFilterManager<HighImpactQueryRow>(HighImpactDataGrid);
 
         _filterManagers[DatabaseResourcesDataGrid] = _dbResourcesFilterMgr;
         _filterManagers[StorageGrowthDataGrid] = _storageGrowthFilterMgr;
@@ -921,6 +969,7 @@ public partial class FinOpsTab : UserControl
         _filterManagers[IndexAnalysisDetailGrid] = _indexDetailFilterMgr;
         _filterManagers[ApplicationConnectionsDataGrid] = _appConnectionsFilterMgr;
         _filterManagers[ServerInventoryDataGrid] = _serverInventoryFilterMgr;
+        _filterManagers[HighImpactDataGrid] = _highImpactFilterMgr;
     }
 
     private void EnsureFilterPopup()

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1239,6 +1239,125 @@ LIMIT $3";
     }
 
     /// <summary>
+    /// Fetches high-impact queries — 80/20 analysis across CPU, duration, reads, writes, memory, executions.
+    /// Aggregates to query_hash level from DuckDB, then scores in C#.
+    /// </summary>
+    public async Task<List<HighImpactQueryRow>> GetHighImpactQueriesAsync(int serverId, int hoursBack = 24)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
+
+        command.CommandText = @"
+SELECT
+    query_hash,
+    MIN(database_name) AS database_name,
+    SUM(delta_execution_count) AS total_executions,
+    SUM(delta_worker_time) / 1000.0 AS total_cpu_ms,
+    SUM(delta_elapsed_time) / 1000.0 AS total_duration_ms,
+    SUM(delta_logical_reads) AS total_reads,
+    SUM(delta_logical_writes) AS total_writes,
+    SUM(COALESCE(max_grant_kb, 0)) / 1024.0 AS total_memory_mb,
+    (SELECT qs2.query_text FROM query_stats qs2
+     WHERE qs2.query_hash = qs.query_hash
+     AND qs2.server_id = $1
+     AND qs2.collection_time >= $2
+     AND qs2.query_text IS NOT NULL AND qs2.query_text != ''
+     ORDER BY qs2.delta_execution_count DESC NULLS LAST
+     LIMIT 1) AS sample_query_text
+FROM query_stats AS qs
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   query_hash IS NOT NULL AND query_hash != ''
+AND   delta_execution_count > 0
+GROUP BY query_hash
+HAVING SUM(delta_execution_count) > 0
+ORDER BY SUM(delta_worker_time) DESC";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff });
+
+        // Step 1: Read aggregated data
+        var allRows = new List<HighImpactQueryRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            allRows.Add(new HighImpactQueryRow
+            {
+                QueryHash = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TotalExecutions = reader.IsDBNull(2) ? 0 : ToInt64(reader.GetValue(2)),
+                TotalCpuMs = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                TotalDurationMs = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                TotalReads = reader.IsDBNull(5) ? 0 : ToInt64(reader.GetValue(5)),
+                TotalWrites = reader.IsDBNull(6) ? 0 : ToInt64(reader.GetValue(6)),
+                TotalMemoryMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                SampleQueryText = reader.IsDBNull(8) ? "" : reader.GetString(8)
+            });
+        }
+
+        if (allRows.Count == 0) return allRows;
+
+        // Step 2: Find "interesting" hashes — top 10 per dimension via UNION
+        var interesting = new HashSet<string>();
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalCpuMs).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalDurationMs).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalReads).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalWrites).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalMemoryMb).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+        foreach (var hash in allRows.OrderByDescending(r => r.TotalExecutions).Take(10).Select(r => r.QueryHash)) interesting.Add(hash);
+
+        var filtered = allRows.Where(r => interesting.Contains(r.QueryHash)).ToList();
+
+        if (filtered.Count == 0) return filtered;
+
+        // Step 3: Compute PERCENT_RANK and share for the interesting set
+        var cpuValues = filtered.Select(r => r.TotalCpuMs).OrderBy(v => v).ToList();
+        var durationValues = filtered.Select(r => r.TotalDurationMs).OrderBy(v => v).ToList();
+        var readsValues = filtered.Select(r => (decimal)r.TotalReads).OrderBy(v => v).ToList();
+        var writesValues = filtered.Select(r => (decimal)r.TotalWrites).OrderBy(v => v).ToList();
+        var memoryValues = filtered.Select(r => r.TotalMemoryMb).OrderBy(v => v).ToList();
+        var execValues = filtered.Select(r => (decimal)r.TotalExecutions).OrderBy(v => v).ToList();
+
+        var totalCpu = filtered.Sum(r => r.TotalCpuMs);
+        var totalDuration = filtered.Sum(r => r.TotalDurationMs);
+        var totalReads = filtered.Sum(r => (decimal)r.TotalReads);
+        var totalWrites = filtered.Sum(r => (decimal)r.TotalWrites);
+        var totalMemory = filtered.Sum(r => r.TotalMemoryMb);
+        var totalExecs = filtered.Sum(r => (decimal)r.TotalExecutions);
+
+        foreach (var row in filtered)
+        {
+            var cpuPctl = PercentRank(cpuValues, row.TotalCpuMs);
+            var durationPctl = PercentRank(durationValues, row.TotalDurationMs);
+            var readsPctl = PercentRank(readsValues, (decimal)row.TotalReads);
+            var writesPctl = PercentRank(writesValues, (decimal)row.TotalWrites);
+            var memoryPctl = PercentRank(memoryValues, row.TotalMemoryMb);
+            var execsPctl = PercentRank(execValues, (decimal)row.TotalExecutions);
+
+            row.CpuShare = totalCpu > 0 ? Math.Round(100m * row.TotalCpuMs / totalCpu, 1) : 0;
+            row.DurationShare = totalDuration > 0 ? Math.Round(100m * row.TotalDurationMs / totalDuration, 1) : 0;
+            row.ReadsShare = totalReads > 0 ? Math.Round(100m * row.TotalReads / totalReads, 1) : 0;
+            row.WritesShare = totalWrites > 0 ? Math.Round(100m * row.TotalWrites / totalWrites, 1) : 0;
+            row.MemoryShare = totalMemory > 0 ? Math.Round(100m * row.TotalMemoryMb / totalMemory, 1) : 0;
+            row.ExecutionsShare = totalExecs > 0 ? Math.Round(100m * row.TotalExecutions / totalExecs, 1) : 0;
+
+            var pctlSum = cpuPctl + durationPctl + readsPctl + writesPctl + memoryPctl + execsPctl;
+            row.ImpactScore = (int)(pctlSum / 6m * 100m);
+        }
+
+        return filtered.OrderByDescending(r => r.ImpactScore).ToList();
+    }
+
+    private static decimal PercentRank(List<decimal> sortedValues, decimal value)
+    {
+        if (sortedValues.Count <= 1) return 0;
+        int rank = sortedValues.Count(v => v < value);
+        return (decimal)rank / (sortedValues.Count - 1);
+    }
+
+    /// <summary>
     /// Checks if sp_IndexCleanup is installed on the target SQL Server.
     /// </summary>
     public static async Task<bool> CheckSpIndexCleanupExistsAsync(string connectionString)
@@ -2182,4 +2301,31 @@ public class RecommendationRow
     public string Detail { get; set; } = "";
     public decimal? EstMonthlySavings { get; set; }
     public string EstMonthlySavingsDisplay => EstMonthlySavings.HasValue ? $"${EstMonthlySavings.Value:N0}" : "";
+}
+
+public class HighImpactQueryRow
+{
+    public string QueryHash { get; set; } = "";
+    public string DatabaseName { get; set; } = "";
+    public long TotalExecutions { get; set; }
+    public decimal TotalCpuMs { get; set; }
+    public decimal TotalDurationMs { get; set; }
+    public long TotalReads { get; set; }
+    public long TotalWrites { get; set; }
+    public decimal TotalMemoryMb { get; set; }
+    public decimal CpuShare { get; set; }
+    public decimal DurationShare { get; set; }
+    public decimal ReadsShare { get; set; }
+    public decimal WritesShare { get; set; }
+    public decimal MemoryShare { get; set; }
+    public decimal ExecutionsShare { get; set; }
+    public int ImpactScore { get; set; }
+    public string SampleQueryText { get; set; } = "";
+
+    public string ImpactScoreColor => ImpactScore switch
+    {
+        >= 80 => "#E74C3C",
+        >= 60 => "#F39C12",
+        _ => "#27AE60"
+    };
 }


### PR DESCRIPTION
## Summary
- New **High Impact** sub-tab on the FinOps tab in both Dashboard and Lite
- Identifies the "vital few" queries consuming disproportionate resources — an 80/20 analysis across CPU, duration, reads, writes, memory, and executions
- Aggregates to `query_hash` level over a selectable time window (1h/4h/12h/24h/7d), finds top 10 per dimension via UNION, scores each with PERCENT_RANK, and computes a composite impact score (0-100)
- Score column is color-coded: red (>=80), orange (>=60), green (<60)
- Dashboard implementation uses a single SQL CTE query with server-side PERCENT_RANK
- Lite implementation queries DuckDB for aggregated data, then computes PERCENT_RANK scoring in C#
- Tab placed after Optimization, before Application Connections

## Test plan
- [ ] Build Dashboard and Lite — verify 0 errors
- [ ] Open Dashboard FinOps tab, navigate to High Impact sub-tab
- [ ] Verify data loads with score color coding
- [ ] Test time range selector (1h/4h/12h/24h/7d)
- [ ] Test refresh button
- [ ] Verify empty state message when no data
- [ ] Open Lite FinOps tab, repeat above checks
- [ ] Verify context menu (copy cell/row/all, export CSV) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)