### PR TITLE
Fix High Impact query preview — full text in tooltip, ellipsis in row

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1467,6 +1467,7 @@
                         <DataGridTextColumn Header="Query Preview" Binding="{Binding SampleQueryText}" Width="400">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
+                                    <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                                     <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1434,7 +1434,7 @@ WITH
                 SELECT TOP (1)
                     CASE
                         WHEN qs2.query_text IS NOT NULL
-                        THEN LEFT(CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max)), 500)
+                        THEN CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max))
                         ELSE N''
                     END
                 FROM collect.query_stats AS qs2

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -1939,6 +1939,7 @@
                         <DataGridTextColumn Header="Query Preview" Binding="{Binding SampleQueryText}" Width="400">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
+                                    <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
                                     <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>


### PR DESCRIPTION
Remove SQL truncation, add TextTrimming for clean display.