### PR TITLE
Fix query tooltips — show full text, not truncated

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1288,7 +1288,13 @@
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Header="Query Preview" Binding="{Binding QueryPreview}" Width="400"/>
+                                    <DataGridTextColumn Header="Query Preview" Binding="{Binding QueryPreview}" Width="400">
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="ToolTip" Value="{Binding QueryPreview}"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <TextBlock x:Name="ExpensiveQueriesNoDataMessage"

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1306,14 +1306,10 @@ SELECT TOP(@topN)
     executions =
         SUM(qs.execution_count_delta),
     query_preview =
-        LEFT
+        CONVERT
         (
-            CONVERT
-            (
-                nvarchar(max),
-                DECOMPRESS(qs.query_text)
-            ),
-            200
+            nvarchar(max),
+            DECOMPRESS(qs.query_text)
         )
 FROM collect.query_stats AS qs
 WHERE qs.collection_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())
@@ -1434,7 +1430,7 @@ WITH
                 SELECT TOP (1)
                     CASE
                         WHEN qs2.query_text IS NOT NULL
-                        THEN LEFT(CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max)), 200)
+                        THEN CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max))
                         ELSE N''
                     END
                 FROM collect.query_stats AS qs2

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1201,7 +1201,7 @@ SELECT
     SUM(delta_logical_reads) AS total_reads,
     CAST(SUM(delta_logical_reads) * 1.0 / NULLIF(SUM(delta_execution_count), 0) AS DECIMAL(19,0)) AS avg_reads,
     SUM(delta_execution_count) AS executions,
-    LEFT(query_text, 200) AS query_preview
+    query_text AS query_preview
 FROM v_query_stats
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -1259,7 +1259,7 @@ SELECT
     SUM(delta_logical_reads) AS total_reads,
     SUM(delta_logical_writes) AS total_writes,
     SUM(COALESCE(max_grant_kb, 0)) / 1024.0 AS total_memory_mb,
-    (SELECT LEFT(qs2.query_text, 200) FROM query_stats qs2
+    (SELECT qs2.query_text FROM query_stats qs2
      WHERE qs2.query_hash = qs.query_hash
      AND qs2.server_id = $1
      AND qs2.collection_time >= $2


### PR DESCRIPTION
Remove LEFT(200) from SQL, add tooltip where missing. Full text in tooltip, visual truncation in row.