### PR TITLE
Fix query preview — truncated in row, full text in tooltip

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1288,13 +1288,13 @@
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Header="Query Preview" Binding="{Binding QueryPreview}" Width="400">
-                                        <DataGridTextColumn.ElementStyle>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="ToolTip" Value="{Binding QueryPreview}"/>
-                                            </Style>
-                                        </DataGridTextColumn.ElementStyle>
-                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn Header="Query Preview" Width="400">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryPreview}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding FullQueryText}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <TextBlock x:Name="ExpensiveQueriesNoDataMessage"
@@ -1470,13 +1470,13 @@
                                 <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Header="Query Preview" Binding="{Binding SampleQueryText}" Width="400">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
+                        <DataGridTemplateColumn Header="Query Preview" Width="400">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding SampleQueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding FullQueryText}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
             </Grid>

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -1306,6 +1306,16 @@ SELECT TOP(@topN)
     executions =
         SUM(qs.execution_count_delta),
     query_preview =
+        LEFT
+        (
+            CONVERT
+            (
+                nvarchar(max),
+                DECOMPRESS(qs.query_text)
+            ),
+            200
+        ),
+    full_query_text =
         CONVERT
         (
             nvarchar(max),
@@ -1343,7 +1353,8 @@ OPTION(MAXDOP 1, RECOMPILE);";
                         TotalReads = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
                         AvgReadsPerExec = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
                         Executions = reader.IsDBNull(5) ? 0 : Convert.ToInt64(reader.GetValue(5)),
-                        QueryPreview = reader.IsDBNull(6) ? "" : reader.GetString(6)
+                        QueryPreview = reader.IsDBNull(6) ? "" : reader.GetString(6),
+                        FullQueryText = reader.IsDBNull(7) ? "" : reader.GetString(7)
                     });
                 }
             }
@@ -1475,7 +1486,8 @@ SELECT
             CASE WHEN memory_pctl IS NOT NULL THEN 1.0 ELSE 0 END +
             CASE WHEN executions_pctl IS NOT NULL THEN 1.0 ELSE 0 END
         ) * 100),
-    sample_query_text
+    query_preview = LEFT(sample_query_text, 200),
+    full_query_text = sample_query_text
 FROM with_text
 ORDER BY
     (
@@ -1514,7 +1526,8 @@ OPTION(MAXDOP 1, RECOMPILE);";
                         MemoryShare = reader.IsDBNull(12) ? 0m : Convert.ToDecimal(reader.GetValue(12)),
                         ExecutionsShare = reader.IsDBNull(13) ? 0m : Convert.ToDecimal(reader.GetValue(13)),
                         ImpactScore = reader.IsDBNull(14) ? 0 : Convert.ToInt32(reader.GetValue(14)),
-                        SampleQueryText = reader.IsDBNull(15) ? "" : reader.GetString(15)
+                        SampleQueryText = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                        FullQueryText = reader.IsDBNull(16) ? "" : reader.GetString(16)
                     });
                 }
             }
@@ -2417,6 +2430,7 @@ ORDER BY SUM(CAST(is_running_long AS int)) DESC", connection);
         public decimal AvgReadsPerExec { get; set; }
         public long Executions { get; set; }
         public string QueryPreview { get; set; } = "";
+        public string FullQueryText { get; set; } = "";
 
         // FinOps cost — proportional share of server monthly budget based on CPU fraction
         public decimal MonthlyCostShare { get; set; }
@@ -2564,6 +2578,7 @@ ORDER BY SUM(CAST(is_running_long AS int)) DESC", connection);
         public decimal ExecutionsShare { get; set; }
         public int ImpactScore { get; set; }
         public string SampleQueryText { get; set; } = "";
+        public string FullQueryText { get; set; } = "";
 
         public string ImpactScoreColor => ImpactScore switch
         {

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -1752,13 +1752,13 @@
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Header="Query Preview" Binding="{Binding QueryPreview}" Width="400">
-                                        <DataGridTextColumn.ElementStyle>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="ToolTip" Value="{Binding QueryPreview}"/>
-                                            </Style>
-                                        </DataGridTextColumn.ElementStyle>
-                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn Header="Query Preview" Width="400">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryPreview}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding FullQueryText}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <TextBlock x:Name="ExpensiveQueriesNoDataMessage"
@@ -2003,19 +2003,19 @@
                                 <Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding SampleQueryText}" Width="400">
-                            <DataGridTextColumn.Header>
+                        <DataGridTemplateColumn Width="400">
+                            <DataGridTemplateColumn.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleQueryText" Click="FilterButton_Click" Margin="0,0,4,0"/>
                                     <TextBlock Text="Query Preview" FontWeight="Bold" VerticalAlignment="Center"/>
                                 </StackPanel>
-                            </DataGridTextColumn.Header>
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="ToolTip" Value="{Binding SampleQueryText}"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
+                            </DataGridTemplateColumn.Header>
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding SampleQueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding FullQueryText}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
             </Grid>

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1201,7 +1201,8 @@ SELECT
     SUM(delta_logical_reads) AS total_reads,
     CAST(SUM(delta_logical_reads) * 1.0 / NULLIF(SUM(delta_execution_count), 0) AS DECIMAL(19,0)) AS avg_reads,
     SUM(delta_execution_count) AS executions,
-    query_text AS query_preview
+    LEFT(query_text, 200) AS query_preview,
+    query_text AS full_query_text
 FROM v_query_stats
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -1232,7 +1233,8 @@ LIMIT $3";
                 TotalReads = reader.IsDBNull(3) ? 0 : ToInt64(reader.GetValue(3)),
                 AvgReadsPerExec = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
                 Executions = reader.IsDBNull(5) ? 0 : ToInt64(reader.GetValue(5)),
-                QueryPreview = reader.IsDBNull(6) ? "" : reader.GetString(6)
+                QueryPreview = reader.IsDBNull(6) ? "" : reader.GetString(6),
+                FullQueryText = reader.IsDBNull(7) ? "" : reader.GetString(7)
             });
         }
         return items;
@@ -1259,13 +1261,20 @@ SELECT
     SUM(delta_logical_reads) AS total_reads,
     SUM(delta_logical_writes) AS total_writes,
     SUM(COALESCE(max_grant_kb, 0)) / 1024.0 AS total_memory_mb,
+    (SELECT LEFT(qs2.query_text, 200) FROM query_stats qs2
+     WHERE qs2.query_hash = qs.query_hash
+     AND qs2.server_id = $1
+     AND qs2.collection_time >= $2
+     AND qs2.query_text IS NOT NULL AND qs2.query_text != ''
+     ORDER BY qs2.delta_execution_count DESC NULLS LAST
+     LIMIT 1) AS sample_query_text,
     (SELECT qs2.query_text FROM query_stats qs2
      WHERE qs2.query_hash = qs.query_hash
      AND qs2.server_id = $1
      AND qs2.collection_time >= $2
      AND qs2.query_text IS NOT NULL AND qs2.query_text != ''
      ORDER BY qs2.delta_execution_count DESC NULLS LAST
-     LIMIT 1) AS sample_query_text
+     LIMIT 1) AS full_query_text
 FROM query_stats AS qs
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -1293,7 +1302,8 @@ ORDER BY SUM(delta_worker_time) DESC";
                 TotalReads = reader.IsDBNull(5) ? 0 : ToInt64(reader.GetValue(5)),
                 TotalWrites = reader.IsDBNull(6) ? 0 : ToInt64(reader.GetValue(6)),
                 TotalMemoryMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
-                SampleQueryText = reader.IsDBNull(8) ? "" : reader.GetString(8)
+                SampleQueryText = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                FullQueryText = reader.IsDBNull(9) ? "" : reader.GetString(9)
             });
         }
 
@@ -2201,6 +2211,7 @@ public class ExpensiveQueryRow
     public decimal AvgReadsPerExec { get; set; }
     public long Executions { get; set; }
     public string QueryPreview { get; set; } = "";
+    public string FullQueryText { get; set; } = "";
 
     // FinOps cost — proportional share of server monthly budget based on CPU fraction
     public decimal MonthlyCostShare { get; set; }
@@ -2321,6 +2332,7 @@ public class HighImpactQueryRow
     public decimal ExecutionsShare { get; set; }
     public int ImpactScore { get; set; }
     public string SampleQueryText { get; set; } = "";
+    public string FullQueryText { get; set; } = "";
 
     public string ImpactScoreColor => ImpactScore switch
     {


### PR DESCRIPTION
Two properties: QueryPreview/SampleQueryText (LEFT 200) for row, FullQueryText for tooltip. DataGridTemplateColumn with TextWrapping + MaxHeight=90.