### PR TITLE
Fix GUI installer encryption mapping and history logging

### DIFF
--- a/InstallerGui/Services/InstallationService.cs
+++ b/InstallerGui/Services/InstallationService.cs
@@ -137,6 +137,7 @@ namespace PerformanceMonitorInstallerGui.Services
             /*Set encryption mode: Optional, Mandatory, or Strict*/
             builder.Encrypt = encryption switch
             {
+                "Optional" => SqlConnectionEncryptOption.Optional,
                 "Mandatory" => SqlConnectionEncryptOption.Mandatory,
                 "Strict" => SqlConnectionEncryptOption.Strict,
                 _ => SqlConnectionEncryptOption.Mandatory
@@ -1458,101 +1459,94 @@ END;";
             int filesFailed,
             bool isSuccess)
         {
+            using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync().ConfigureAwait(false);
+
+            /*Check if this is an upgrade by checking for existing installation*/
+            string? previousVersion = null;
+            string installationType = "INSTALL";
+
             try
             {
-                using var connection = new SqlConnection(connectionString);
-                await connection.OpenAsync().ConfigureAwait(false);
+                using var checkCmd = new SqlCommand(@"
+                    SELECT TOP 1 installer_version
+                    FROM PerformanceMonitor.config.installation_history
+                    WHERE installation_status = 'SUCCESS'
+                    ORDER BY installation_date DESC;", connection);
 
-                /*Check if this is an upgrade by checking for existing installation*/
-                string? previousVersion = null;
-                string installationType = "INSTALL";
-
-                try
+                var result = await checkCmd.ExecuteScalarAsync().ConfigureAwait(false);
+                if (result != null && result != DBNull.Value)
                 {
-                    using var checkCmd = new SqlCommand(@"
-                        SELECT TOP 1 installer_version
-                        FROM PerformanceMonitor.config.installation_history
-                        WHERE installation_status = 'SUCCESS'
-                        ORDER BY installation_date DESC;", connection);
-
-                    var result = await checkCmd.ExecuteScalarAsync().ConfigureAwait(false);
-                    if (result != null && result != DBNull.Value)
-                    {
-                        previousVersion = result.ToString();
-                        bool isSameVersion = Version.TryParse(previousVersion, out var prevVer)
-                            && Version.TryParse(assemblyVersion, out var currVer)
-                            && prevVer == currVer;
-                        installationType = isSameVersion ? "REINSTALL" : "UPGRADE";
-                    }
+                    previousVersion = result.ToString();
+                    bool isSameVersion = Version.TryParse(previousVersion, out var prevVer)
+                        && Version.TryParse(assemblyVersion, out var currVer)
+                        && prevVer == currVer;
+                    installationType = isSameVersion ? "REINSTALL" : "UPGRADE";
                 }
-                catch (SqlException)
-                {
-                    /*Table might not exist yet on first install*/
-                }
-
-                /*Get SQL Server version info*/
-                string sqlVersion = "";
-                string sqlEdition = "";
-
-                using (var versionCmd = new SqlCommand("SELECT @@VERSION, SERVERPROPERTY('Edition');", connection))
-                using (var reader = await versionCmd.ExecuteReaderAsync().ConfigureAwait(false))
-                {
-                    if (await reader.ReadAsync().ConfigureAwait(false))
-                    {
-                        sqlVersion = reader.GetString(0);
-                        sqlEdition = reader.GetString(1);
-                    }
-                }
-
-                long durationMs = (long)(DateTime.Now - startTime).TotalMilliseconds;
-                string status = isSuccess ? "SUCCESS" : (filesFailed > 0 ? "PARTIAL" : "FAILED");
-
-                var insertSql = @"
-                    INSERT INTO PerformanceMonitor.config.installation_history
-                    (
-                        installer_version,
-                        installer_info_version,
-                        sql_server_version,
-                        sql_server_edition,
-                        installation_type,
-                        previous_version,
-                        installation_status,
-                        files_executed,
-                        files_failed,
-                        installation_duration_ms
-                    )
-                    VALUES
-                    (
-                        @installer_version,
-                        @installer_info_version,
-                        @sql_server_version,
-                        @sql_server_edition,
-                        @installation_type,
-                        @previous_version,
-                        @installation_status,
-                        @files_executed,
-                        @files_failed,
-                        @installation_duration_ms
-                    );";
-
-                using var insertCmd = new SqlCommand(insertSql, connection);
-                insertCmd.Parameters.Add(new SqlParameter("@installer_version", SqlDbType.NVarChar, 50) { Value = assemblyVersion });
-                insertCmd.Parameters.Add(new SqlParameter("@installer_info_version", SqlDbType.NVarChar, 100) { Value = (object?)infoVersion ?? DBNull.Value });
-                insertCmd.Parameters.Add(new SqlParameter("@sql_server_version", SqlDbType.NVarChar, 500) { Value = sqlVersion });
-                insertCmd.Parameters.Add(new SqlParameter("@sql_server_edition", SqlDbType.NVarChar, 128) { Value = sqlEdition });
-                insertCmd.Parameters.Add(new SqlParameter("@installation_type", SqlDbType.VarChar, 20) { Value = installationType });
-                insertCmd.Parameters.Add(new SqlParameter("@previous_version", SqlDbType.NVarChar, 50) { Value = (object?)previousVersion ?? DBNull.Value });
-                insertCmd.Parameters.Add(new SqlParameter("@installation_status", SqlDbType.VarChar, 20) { Value = status });
-                insertCmd.Parameters.Add(new SqlParameter("@files_executed", SqlDbType.Int) { Value = filesExecuted });
-                insertCmd.Parameters.Add(new SqlParameter("@files_failed", SqlDbType.Int) { Value = filesFailed });
-                insertCmd.Parameters.Add(new SqlParameter("@installation_duration_ms", SqlDbType.BigInt) { Value = durationMs });
-
-                await insertCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
-            catch
+            catch (SqlException)
             {
-                /*Don't let history logging failure break the installation*/
+                /*Table might not exist yet on first install*/
             }
+
+            /*Get SQL Server version info*/
+            string sqlVersion = "";
+            string sqlEdition = "";
+
+            using (var versionCmd = new SqlCommand("SELECT @@VERSION, SERVERPROPERTY('Edition');", connection))
+            using (var reader = await versionCmd.ExecuteReaderAsync().ConfigureAwait(false))
+            {
+                if (await reader.ReadAsync().ConfigureAwait(false))
+                {
+                    sqlVersion = reader.GetString(0);
+                    sqlEdition = reader.GetString(1);
+                }
+            }
+
+            long durationMs = (long)(DateTime.Now - startTime).TotalMilliseconds;
+            string status = isSuccess ? "SUCCESS" : (filesFailed > 0 ? "PARTIAL" : "FAILED");
+
+            var insertSql = @"
+                INSERT INTO PerformanceMonitor.config.installation_history
+                (
+                    installer_version,
+                    installer_info_version,
+                    sql_server_version,
+                    sql_server_edition,
+                    installation_type,
+                    previous_version,
+                    installation_status,
+                    files_executed,
+                    files_failed,
+                    installation_duration_ms
+                )
+                VALUES
+                (
+                    @installer_version,
+                    @installer_info_version,
+                    @sql_server_version,
+                    @sql_server_edition,
+                    @installation_type,
+                    @previous_version,
+                    @installation_status,
+                    @files_executed,
+                    @files_failed,
+                    @installation_duration_ms
+                );";
+
+            using var insertCmd = new SqlCommand(insertSql, connection);
+            insertCmd.Parameters.Add(new SqlParameter("@installer_version", SqlDbType.NVarChar, 50) { Value = assemblyVersion });
+            insertCmd.Parameters.Add(new SqlParameter("@installer_info_version", SqlDbType.NVarChar, 100) { Value = (object?)infoVersion ?? DBNull.Value });
+            insertCmd.Parameters.Add(new SqlParameter("@sql_server_version", SqlDbType.NVarChar, 500) { Value = sqlVersion });
+            insertCmd.Parameters.Add(new SqlParameter("@sql_server_edition", SqlDbType.NVarChar, 128) { Value = sqlEdition });
+            insertCmd.Parameters.Add(new SqlParameter("@installation_type", SqlDbType.VarChar, 20) { Value = installationType });
+            insertCmd.Parameters.Add(new SqlParameter("@previous_version", SqlDbType.NVarChar, 50) { Value = (object?)previousVersion ?? DBNull.Value });
+            insertCmd.Parameters.Add(new SqlParameter("@installation_status", SqlDbType.VarChar, 20) { Value = status });
+            insertCmd.Parameters.Add(new SqlParameter("@files_executed", SqlDbType.Int) { Value = filesExecuted });
+            insertCmd.Parameters.Add(new SqlParameter("@files_failed", SqlDbType.Int) { Value = filesFailed });
+            insertCmd.Parameters.Add(new SqlParameter("@installation_duration_ms", SqlDbType.BigInt) { Value = durationMs });
+
+            await insertCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
 
         [GeneratedRegex(@"^\d{2}[a-z]?_.*\.sql$")]


### PR DESCRIPTION
## Summary
- **Encryption "Optional" actually works now**: The switch statement was missing the `"Optional"` case — it fell through to the default which mapped to `Mandatory`. Every install using "Optional" encryption was silently using Mandatory.
- **History logging no longer silently swallowed**: Removed the bare `catch` inside `LogInstallationHistoryAsync`. Exceptions now propagate to the caller at `MainWindow.xaml.cs:472` which already has proper error handling (`LogMessage(..., "Warning")`). Previously, a failed history write was invisible, causing the next installer run to fall back to version `"1.0.0"` and re-run all upgrade scripts.

## Test plan
- [ ] Install with encryption set to "Optional" — verify connection uses optional encryption
- [ ] Run installer twice — verify second run detects the correct installed version (not "1.0.0")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional SQL Server encryption setting during installation configuration.
  * Enhanced installation history tracking to automatically detect and log upgrade vs. reinstall scenarios, including previous version information.

* **Bug Fixes**
  * Improved error resilience for installation history logging to prevent disruptions during initial installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->