### PR TITLE
Hide IdleDatabases grid when empty to fix scrollbar artifact

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -408,6 +408,7 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsIdleDatabasesAsync();
                 IdleDatabasesDataGrid.ItemsSource = data;
+                IdleDatabasesDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 IdleDatabasesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 IdleDatabasesCountIndicator.Text = data.Count > 0 ? $"{data.Count} idle database(s)" : "";
             }


### PR DESCRIPTION
Collapse the DataGrid when no idle databases found instead of showing an empty grid with a white scrollbar.