### PR TITLE
Fix Dashboard drill-down: Unicode arrow in story path split

### DIFF
--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -45,7 +45,7 @@ public class SqlServerDrillDownCollector
             try
             {
                 finding.DrillDown = new Dictionary<string, object>();
-                var pathKeys = finding.StoryPath.Split(" -> ", StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+                var pathKeys = finding.StoryPath.Split(" → ", StringSplitOptions.RemoveEmptyEntries).ToHashSet();
 
                 if (pathKeys.Contains("DEADLOCKS"))
                     await CollectTopDeadlocks(finding, context);
@@ -90,7 +90,7 @@ public class SqlServerDrillDownCollector
             catch (Exception ex)
             {
                 Logger.Error(
-                    $"[SqlServerDrillDownCollector] Drill-down failed for {finding.StoryPath}: {ex.GetType().Name}: {ex.Message}");
+                    $"[SqlServerDrillDownCollector] Drill-down failed for {finding.StoryPath}: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
                 // Don't null out -- keep whatever was collected before the error
             }
         }


### PR DESCRIPTION
## Summary
Single character fix — `SqlServerDrillDownCollector` was splitting story paths on ASCII `->` instead of Unicode `→`. All path key lookups failed silently.

## Result
Before: 2/10 findings had drill-downs (only bad actors, which use `StartsWith` instead of `Contains`)
After: 8/10 findings have drill-downs (the 2 nulls are `RUNNING_JOBS` and `ANOMALY_CPU_SPIKE` which have no applicable drill-down methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)