### PR TITLE
Fix TempDB grid scrollbar and Warning column width

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -1686,7 +1686,7 @@
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding Warning}" Width="200">
+                                    <DataGridTextColumn Binding="{Binding Warning}" Width="*">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">
                                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Warning" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -430,6 +430,7 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsTempdbSummaryAsync();
                 TempdbPressureDataGrid.ItemsSource = data;
+                TempdbPressureDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 TempdbPressureNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }
             catch (Exception ex)


### PR DESCRIPTION
Hide grid when empty, restore Width=* on Warning column.