### PR TITLE
Fix FinOps grid scrollbars — disable horizontal scroll

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -73,7 +73,7 @@
                            Foreground="{DynamicResource ForegroundMutedBrush}" FontStyle="Italic"/>
 
                 <!-- Recommendations DataGrid -->
-                <DataGrid x:Name="RecommendationsDataGrid" Grid.Row="2" Margin="10,4,10,10"
+                <DataGrid x:Name="RecommendationsDataGrid" Grid.Row="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,4,10,10"
                           AutoGenerateColumns="False" IsReadOnly="True"
                           CanUserSortColumns="True" CanUserResizeColumns="True"
                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -605,7 +605,7 @@
 
                 <!-- DataGrid -->
                 <Grid Grid.Row="1" Margin="10,0,10,10">
-                    <DataGrid x:Name="DatabaseResourcesDataGrid"
+                    <DataGrid x:Name="DatabaseResourcesDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserSortColumns="True"
@@ -786,7 +786,7 @@
                 </StackPanel>
 
                 <Grid Grid.Row="1" Margin="10,0,10,10">
-                    <DataGrid x:Name="StorageGrowthDataGrid"
+                    <DataGrid x:Name="StorageGrowthDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserSortColumns="True"
@@ -929,7 +929,7 @@
 
                 <!-- DataGrid -->
                 <Grid Grid.Row="1" Margin="10,0,10,10">
-                    <DataGrid x:Name="DatabaseSizesDataGrid"
+                    <DataGrid x:Name="DatabaseSizesDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserSortColumns="True"
@@ -1576,7 +1576,7 @@
                                 <TextBlock x:Name="IdleDatabasesCountIndicator" Text=""
                                            FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                             </StackPanel>
-                            <DataGrid x:Name="IdleDatabasesDataGrid"
+                            <DataGrid x:Name="IdleDatabasesDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserSortColumns="True"
@@ -1641,7 +1641,7 @@
                     <!-- Tempdb Pressure -->
                     <Expander Header="Tempdb Pressure" IsExpanded="True" Margin="0,0,0,8">
                         <StackPanel>
-                            <DataGrid x:Name="TempdbPressureDataGrid"
+                            <DataGrid x:Name="TempdbPressureDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserSortColumns="True"
@@ -1720,7 +1720,7 @@
                             </StackPanel>
                         </Expander.Header>
                         <StackPanel>
-                            <DataGrid x:Name="WaitCategorySummaryDataGrid"
+                            <DataGrid x:Name="WaitCategorySummaryDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserSortColumns="True"
@@ -1843,7 +1843,7 @@
                                 <TextBlock x:Name="ExpensiveQueriesCountIndicator" Text=""
                                            FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                             </StackPanel>
-                            <DataGrid x:Name="ExpensiveQueriesDataGrid"
+                            <DataGrid x:Name="ExpensiveQueriesDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserSortColumns="True"
@@ -1959,7 +1959,7 @@
                     <!-- Memory Grant Efficiency -->
                     <Expander Header="Memory Grant Efficiency" IsExpanded="True" Margin="0,0,0,8">
                         <StackPanel>
-                            <DataGrid x:Name="MemoryGrantEfficiencyDataGrid"
+                            <DataGrid x:Name="MemoryGrantEfficiencyDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True"
                                       CanUserSortColumns="True"
@@ -2109,7 +2109,7 @@
                            Foreground="{DynamicResource ForegroundMutedBrush}" FontStyle="Italic"/>
 
                 <!-- High Impact DataGrid -->
-                <DataGrid x:Name="HighImpactDataGrid" Grid.Row="2" Margin="10,4,10,10"
+                <DataGrid x:Name="HighImpactDataGrid" Grid.Row="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,4,10,10"
                           AutoGenerateColumns="False" IsReadOnly="True"
                           CanUserSortColumns="True" CanUserResizeColumns="True"
                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -2284,7 +2284,7 @@
 
                 <!-- DataGrid -->
                 <Grid Grid.Row="1" Margin="10,0,10,10">
-                    <DataGrid x:Name="ApplicationConnectionsDataGrid"
+                    <DataGrid x:Name="ApplicationConnectionsDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserSortColumns="True"
@@ -2392,7 +2392,7 @@
 
                 <!-- DataGrid -->
                 <Grid Grid.Row="1" Margin="10,0,10,10">
-                    <DataGrid x:Name="ServerInventoryDataGrid"
+                    <DataGrid x:Name="ServerInventoryDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
                               CanUserSortColumns="True"

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -145,7 +145,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsRecommendationsAsync(_currentServerMonthlyCost);
                 RecommendationsDataGrid.ItemsSource = data;
-                RecommendationsDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 RecommendationsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 RecommendationsCountIndicator.Text = data.Count > 0 ? $"{data.Count} recommendation(s)" : "";
             }
@@ -367,7 +366,6 @@ namespace PerformanceMonitorDashboard.Controls
                 var hoursBack = GetResourceUsageHoursBack();
                 var data = await _databaseService.GetFinOpsDatabaseResourceUsageAsync(hoursBack);
                 DatabaseResourcesDataGrid.ItemsSource = data;
-                DatabaseResourcesDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 DatabaseResourcesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 DbResourcesCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
             }
@@ -389,7 +387,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsStorageGrowthAsync();
                 StorageGrowthDataGrid.ItemsSource = data;
-                StorageGrowthDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 StorageGrowthNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 StorageGrowthCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
             }
@@ -411,7 +408,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsIdleDatabasesAsync();
                 IdleDatabasesDataGrid.ItemsSource = data;
-                IdleDatabasesDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 IdleDatabasesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 IdleDatabasesCountIndicator.Text = data.Count > 0 ? $"{data.Count} idle database(s)" : "";
             }
@@ -433,7 +429,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsTempdbSummaryAsync();
                 TempdbPressureDataGrid.ItemsSource = data;
-                TempdbPressureDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 TempdbPressureNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }
             catch (Exception ex)
@@ -494,7 +489,6 @@ namespace PerformanceMonitorDashboard.Controls
                 }
 
                 WaitCategorySummaryDataGrid.ItemsSource = data;
-                WaitCategorySummaryDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 WaitCategorySummaryNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }
             catch (Exception ex)
@@ -529,7 +523,6 @@ namespace PerformanceMonitorDashboard.Controls
                 }
 
                 ExpensiveQueriesDataGrid.ItemsSource = data;
-                ExpensiveQueriesDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 ExpensiveQueriesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 ExpensiveQueriesCountIndicator.Text = data.Count > 0 ? $"{data.Count} query(s)" : "";
             }
@@ -547,7 +540,6 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetFinOpsMemoryGrantEfficiencyAsync();
                 MemoryGrantEfficiencyDataGrid.ItemsSource = data;
-                MemoryGrantEfficiencyDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 MemoryGrantEfficiencyNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }
             catch (Exception ex)
@@ -771,7 +763,6 @@ namespace PerformanceMonitorDashboard.Controls
                 var hoursBack = GetHighImpactHoursBack();
                 var data = await _databaseService.GetFinOpsHighImpactQueriesAsync(hoursBack);
                 HighImpactDataGrid.ItemsSource = data;
-                HighImpactDataGrid.Visibility = data.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
                 HighImpactNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 HighImpactCountIndicator.Text = data.Count > 0 ? $"{data.Count} high-impact query(s)" : "";
             }


### PR DESCRIPTION
Root cause fix: disable horizontal scrollbar on all grids. Revert empty-grid visibility hacks.