### PR TITLE
Fix Add Server dialog buttons hidden with SQL auth

### DIFF
--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Add SQL Server"
-        SizeToContent="Height" Width="450" MaxHeight="700"
+        SizeToContent="Height" Width="450" MaxHeight="850"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Background="{DynamicResource BackgroundBrush}"


### PR DESCRIPTION
MaxHeight 700px wasn't enough for Username/Password fields. Bumped to 850px.