### PR TITLE
Fix File I/O NULL fallbacks for restricted permissions (#633)

### DIFF
--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -59,10 +59,10 @@ OPTION(RECOMPILE);"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    database_name = ISNULL(d.name, N'Unknown'),
-    file_name = mf.name,
-    file_type = mf.type_desc,
-    physical_name = mf.physical_name,
+    database_name = ISNULL(d.name, DB_NAME(vfs.database_id)),
+    file_name = ISNULL(mf.name, N'File_' + CONVERT(nvarchar(10), vfs.file_id)),
+    file_type = ISNULL(mf.type_desc, N'UNKNOWN'),
+    physical_name = ISNULL(mf.physical_name, N''),
     size_mb = CONVERT(decimal(18,2), vfs.size_on_disk_bytes / 1048576.0),
     num_of_reads = vfs.num_of_reads,
     num_of_writes = vfs.num_of_writes,

--- a/install/20_collect_file_io_stats.sql
+++ b/install/20_collect_file_io_stats.sql
@@ -134,14 +134,14 @@ BEGIN
                 ISNULL
                 (
                     d.name,
-                    N'UNKNOWN'
+                    DB_NAME(vfs.database_id)
                 ),
             file_id = vfs.file_id,
             file_name =
                 ISNULL
                 (
                     mf.name,
-                    N'UNKNOWN'
+                    N'File_' + CONVERT(nvarchar(10), vfs.file_id)
                 ),
             file_type_desc =
                 ISNULL
@@ -149,7 +149,7 @@ BEGIN
                     mf.type_desc,
                     N'UNKNOWN'
                 ),
-            physical_name = mf.physical_name,
+            physical_name = ISNULL(mf.physical_name, N''),
             size_on_disk_bytes = vfs.size_on_disk_bytes,
             num_of_reads = vfs.num_of_reads,
             num_of_bytes_read = vfs.num_of_bytes_read,


### PR DESCRIPTION
When sys.master_files is inaccessible, ISNULL now falls back to DB_NAME() and File_{id}.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file I/O statistics collection by implementing improved null-value handling and more robust fallback values when critical metadata such as database names, file names, and physical paths are unavailable or missing.
  * Refined data collection expressions to ensure complete and accurate file I/O statistics, preventing incomplete or malformed records in collected metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->