### PR TITLE
Add Velopack package and startup hook to Dashboard (#635)

### DIFF
--- a/Dashboard/App.xaml.cs
+++ b/Dashboard/App.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Threading;
 using PerformanceMonitorDashboard.Helpers;
+using Velopack;
 
 namespace PerformanceMonitorDashboard
 {
@@ -25,6 +26,8 @@ namespace PerformanceMonitorDashboard
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            VelopackApp.Build().Run();
+
             NativeMethods.SetAppUserModelId("DarlingData.PerformanceMonitor.Dashboard");
 
             // Check for existing instance

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Foundation for auto-update support. Adds the Velopack NuGet package and the required `VelopackApp.Build().Run()` startup hook to handle install/uninstall/update lifecycle events.

This is the app-side prerequisite. The build pipeline changes (vpk pack, self-contained publish, delta generation, GitHub Releases upload) will follow in a separate PR once the packaging is tested locally.

No behavior change — without Velopack packages on GitHub Releases, the hook is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)