### PR TITLE
Use sys.dm_database_replica_states for Azure SQL Database

### DIFF
--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -119,10 +119,18 @@ DECLARE db_check CURSOR LOCAL FAST_FORWARD FOR
     SELECT /* PerformanceMonitorLite */
         d.name
     FROM sys.databases AS d
+    LEFT JOIN sys.dm_database_replica_states AS drs
+        ON d.database_id = drs.database_id
+        AND drs.is_local = 1
     WHERE d.database_id > 4
     AND   d.database_id < 32761
     AND   d.state_desc = N'ONLINE'
     AND   d.name <> N'PerformanceMonitor'
+    AND
+    (
+        drs.database_id IS NULL          /*not in any AG*/
+        OR drs.is_primary_replica = 1    /*primary replica*/
+    )
     OPTION(RECOMPILE);
 
 OPEN db_check;

--- a/Lite/Services/RemoteCollectorService.ServerConfig.cs
+++ b/Lite/Services/RemoteCollectorService.ServerConfig.cs
@@ -356,10 +356,18 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SELECT
     d.name
 FROM sys.databases AS d
+LEFT JOIN sys.dm_database_replica_states AS drs
+    ON d.database_id = drs.database_id
+    AND drs.is_local = 1
 WHERE (d.database_id > 4 OR d.database_id = 2)
 AND   d.database_id < 32761
 AND   d.name <> N'PerformanceMonitor'
 AND   d.state_desc = N'ONLINE'
+AND
+(
+    drs.database_id IS NULL          /*not in any AG*/
+    OR drs.is_primary_replica = 1    /*primary replica*/
+)
 ORDER BY d.name
 OPTION(RECOMPILE);";
 

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -292,28 +292,56 @@ BEGIN
 
         DECLARE @db_check_cursor CURSOR
 
-            SET @db_check_cursor =
-                CURSOR
-                LOCAL
-                FAST_FORWARD
-            FOR
-            SELECT
-                d.name
-            FROM sys.databases AS d
-            LEFT JOIN sys.dm_hadr_database_replica_states AS drs
-                ON d.database_id = drs.database_id
-                AND drs.is_local = 1
-            WHERE d.state_desc = N'ONLINE'
-            AND   d.database_id > 4
-            AND   d.is_read_only = 0
-            AND   d.name <> N'PerformanceMonitor'
-            AND   d.database_id < 32761 /*exclude contained AG system databases*/
-            AND
-            (
-                drs.database_id IS NULL          /*not in any AG*/
-                OR drs.is_primary_replica = 1    /*primary replica*/
-            )
-            OPTION(RECOMPILE);
+            IF @engine = 5 /*Azure SQL Database*/
+            BEGIN
+                SET @db_check_cursor =
+                    CURSOR
+                    LOCAL
+                    FAST_FORWARD
+                FOR
+                SELECT
+                    d.name
+                FROM sys.databases AS d
+                LEFT JOIN sys.dm_database_replica_states AS drs
+                    ON d.database_id = drs.database_id
+                    AND drs.is_local = 1
+                WHERE d.state_desc = N'ONLINE'
+                AND   d.database_id > 4
+                AND   d.is_read_only = 0
+                AND   d.name <> N'PerformanceMonitor'
+                AND   d.database_id < 32761 /*exclude contained AG system databases*/
+                AND
+                (
+                    drs.database_id IS NULL          /*not in any AG*/
+                    OR drs.is_primary_replica = 1    /*primary replica*/
+                )
+                OPTION(RECOMPILE);
+            END;
+            ELSE
+            BEGIN
+                SET @db_check_cursor =
+                    CURSOR
+                    LOCAL
+                    FAST_FORWARD
+                FOR
+                SELECT
+                    d.name
+                FROM sys.databases AS d
+                LEFT JOIN sys.dm_hadr_database_replica_states AS drs
+                    ON d.database_id = drs.database_id
+                    AND drs.is_local = 1
+                WHERE d.state_desc = N'ONLINE'
+                AND   d.database_id > 4
+                AND   d.is_read_only = 0
+                AND   d.name <> N'PerformanceMonitor'
+                AND   d.database_id < 32761 /*exclude contained AG system databases*/
+                AND
+                (
+                    drs.database_id IS NULL          /*not in any AG*/
+                    OR drs.is_primary_replica = 1    /*primary replica*/
+                )
+                OPTION(RECOMPILE);
+            END;
 
         OPEN @db_check_cursor;
 

--- a/install/39_collect_database_configuration.sql
+++ b/install/39_collect_database_configuration.sql
@@ -48,7 +48,13 @@ BEGIN
         @error_message nvarchar(4000),
         @database_name sysname,
         @database_id integer,
-        @sql nvarchar(max) = N'';
+        @sql nvarchar(max) = N'',
+        @engine integer =
+            CONVERT
+            (
+                integer,
+                SERVERPROPERTY('ENGINEEDITION')
+            );
 
     BEGIN TRY
         IF @debug = 1
@@ -156,7 +162,42 @@ BEGIN
         Collect database scoped configurations using dynamic SQL
         This avoids hardcoding configuration names which may change over time
         */
-        DECLARE database_cursor CURSOR LOCAL FAST_FORWARD FOR
+        DECLARE @database_cursor CURSOR;
+
+        IF @engine = 5 /*Azure SQL Database*/
+        BEGIN
+            SET @database_cursor =
+                CURSOR
+                LOCAL
+                FAST_FORWARD
+            FOR
+            SELECT
+                database_id = d.database_id,
+                database_name = d.name
+            FROM sys.databases AS d
+            LEFT JOIN sys.dm_database_replica_states AS drs
+                ON d.database_id = drs.database_id
+                AND drs.is_local = 1
+            WHERE d.database_id > 4
+            AND   d.name != DB_NAME()
+            AND   d.state_desc = N'ONLINE'
+            AND   d.database_id < 32761 /*exclude contained AG system databases*/
+            AND
+            (
+                drs.database_id IS NULL          /*not in any AG*/
+                OR drs.is_primary_replica = 1    /*primary replica*/
+            )
+            ORDER BY
+                d.name
+            OPTION (RECOMPILE);
+        END;
+        ELSE
+        BEGIN
+            SET @database_cursor =
+                CURSOR
+                LOCAL
+                FAST_FORWARD
+            FOR
             SELECT
                 database_id = d.database_id,
                 database_name = d.name
@@ -176,9 +217,10 @@ BEGIN
             ORDER BY
                 d.name
             OPTION (RECOMPILE);
+        END;
 
-        OPEN database_cursor;
-        FETCH NEXT FROM database_cursor INTO @database_id, @database_name;
+        OPEN @database_cursor;
+        FETCH NEXT FROM @database_cursor INTO @database_id, @database_name;
 
         WHILE @@FETCH_STATUS = 0
         BEGIN
@@ -256,11 +298,11 @@ OPTION (RECOMPILE);
                             END;
                         END CATCH;
 
-            FETCH NEXT FROM database_cursor INTO @database_id, @database_name;
+            FETCH NEXT FROM @database_cursor INTO @database_id, @database_name;
         END;
 
-        CLOSE database_cursor;
-        DEALLOCATE database_cursor;
+        CLOSE @database_cursor;
+        DEALLOCATE @database_cursor;
 
         /*
         Switch back to PerformanceMonitor database


### PR DESCRIPTION
## Summary

- `sys.dm_hadr_database_replica_states` does not exist on Azure SQL Database (engine edition 5), causing query failures when the monitor connects to Azure SQL DB instances.
- Added IF/ELSE branching in the SQL install scripts (`09_collect_query_store.sql`, `39_collect_database_configuration.sql`) using `SERVERPROPERTY('ENGINEEDITION') = 5` to select the correct DMV: `sys.dm_database_replica_states` for Azure SQL DB, `sys.dm_hadr_database_replica_states` for on-prem and Azure Managed Instance.
- Updated the Lite C# service Azure query paths (`RemoteCollectorService.QueryStore.cs`, `RemoteCollectorService.ServerConfig.cs`) to join `sys.dm_database_replica_states` so primary replica filtering is applied consistently on Azure SQL DB.

## Files changed

| File | Change |
|------|--------|
| `install/09_collect_query_store.sql` | IF/ELSE on `@engine = 5` around cursor assignment |
| `install/39_collect_database_configuration.sql` | Added `@engine` variable, IF/ELSE on `@engine = 5` around cursor (converted to cursor variable) |
| `Lite/Services/RemoteCollectorService.QueryStore.cs` | Added `sys.dm_database_replica_states` join to Azure query |
| `Lite/Services/RemoteCollectorService.ServerConfig.cs` | Added `sys.dm_database_replica_states` join to Azure query |

## Test plan

- [ ] Verify on Azure SQL Database (engine edition 5) that the install scripts and Lite service queries execute without errors
- [ ] Verify on on-prem SQL Server that existing behavior is unchanged (ELSE branch uses original `sys.dm_hadr_database_replica_states`)
- [ ] Verify on Azure SQL Managed Instance (engine edition 8) that existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database filtering in Query Store and Server Configuration collection to correctly identify primary replicas in availability groups across on-premises and Azure SQL environments. Database discovery now properly excludes non-primary replicas, ensuring accurate data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->