### PR TITLE
Add time display picker to Dashboard and Lite toolbars

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -227,6 +227,17 @@ namespace PerformanceMonitorDashboard.Controls
             _statusCallback = statusCallback;
         }
 
+        public void RefreshGridBindings()
+        {
+            QueryStatsDataGrid.Items.Refresh();
+            ProcStatsDataGrid.Items.Refresh();
+            QueryStoreDataGrid.Items.Refresh();
+            QueryStoreRegressionsDataGrid.Items.Refresh();
+            ActiveQueriesDataGrid.Items.Refresh();
+            CurrentActiveQueriesDataGrid.Items.Refresh();
+            LongRunningQueryPatternsDataGrid.Items.Refresh();
+        }
+
         /// <summary>
         /// Sets the time range for all sub-tabs.
         /// </summary>

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -104,6 +104,13 @@
                         <Button x:Name="RefreshButton" Content="Refresh Tab" Click="RefreshButton_Click" Margin="2,0" Padding="12,5" Style="{DynamicResource SuccessButton}"/>
                         <ToggleButton x:Name="AutoRefreshToggle" Content="Auto-Refresh: Off" Click="AutoRefreshToggle_Click" Margin="8,0,2,0" Padding="12,5" MinWidth="130" ToolTip="Toggle auto-refresh on/off. Configure interval in Settings."/>
                         <Button Content="Edit Schedules" Click="EditSchedules_Click" Margin="8,0,2,0" Padding="12,5" Style="{DynamicResource AccentButton}" ToolTip="Edit collector schedules (frequency, retention, enabled/disabled)"/>
+                        <TextBlock Text="|" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <TextBlock Text="Times:" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ComboBox x:Name="TimeDisplayModeBox" Width="120" SelectionChanged="TimeDisplayMode_SelectionChanged" ToolTip="How timestamps are displayed across all tabs">
+                            <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                            <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                            <ComboBoxItem Content="UTC" Tag="UTC"/>
+                        </ComboBox>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="2,4,0,0">
                         <TextBlock x:Name="GlobalDateRangeIndicator"

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -153,6 +153,17 @@ namespace PerformanceMonitorDashboard
             // Set default time range on UserControls based on user preferences
             var prefs = _preferencesService.GetPreferences();
             CriticalIssuesTab.SetTimeRange(prefs.DefaultHoursBack);
+
+            // Sync time display mode picker with current setting
+            var modeTag = ServerTimeHelper.CurrentDisplayMode.ToString();
+            for (int i = 0; i < TimeDisplayModeBox.Items.Count; i++)
+            {
+                if (TimeDisplayModeBox.Items[i] is ComboBoxItem item && item.Tag?.ToString() == modeTag)
+                {
+                    TimeDisplayModeBox.SelectedIndex = i;
+                    break;
+                }
+            }
         }
 
         private void ShowPlanLoading(string label)
@@ -1396,6 +1407,35 @@ namespace PerformanceMonitorDashboard
             var scheduleWindow = new CollectorScheduleWindow(_databaseService);
             scheduleWindow.Owner = Window.GetWindow(this);
             scheduleWindow.ShowDialog();
+        }
+
+        private void TimeDisplayMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (TimeDisplayModeBox.SelectedItem is not ComboBoxItem item) return;
+            var tag = item.Tag?.ToString();
+            var mode = tag switch
+            {
+                "LocalTime" => TimeDisplayMode.LocalTime,
+                "UTC" => TimeDisplayMode.UTC,
+                _ => TimeDisplayMode.ServerTime
+            };
+            if (mode == ServerTimeHelper.CurrentDisplayMode) return;
+
+            ServerTimeHelper.CurrentDisplayMode = mode;
+
+            // Persist preference
+            var prefs = _preferencesService.GetPreferences();
+            prefs.TimeDisplayMode = mode.ToString();
+            _preferencesService.SavePreferences(prefs);
+
+            // Refresh all DataGrid bindings so ServerTimeConverter re-evaluates
+            RefreshTimestampBindings();
+        }
+
+        private void RefreshTimestampBindings()
+        {
+            // Force WPF to re-evaluate converter bindings on all query performance grids
+            PerformanceTab.RefreshGridBindings();
         }
 
         private void DownloadQueryPlan_Click(object sender, RoutedEventArgs e)

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -113,6 +113,14 @@
                         <ComboBoxItem Content="1m"/>
                         <ComboBoxItem Content="5m"/>
                     </ComboBox>
+                    <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,2"/>
+                    <TextBlock Text="Times:" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="TimeDisplayModeBox" Width="120" SelectionChanged="TimeDisplayMode_SelectionChanged"
+                              ToolTip="How timestamps are displayed">
+                        <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                        <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                        <ComboBoxItem Content="UTC" Tag="UTC"/>
+                    </ComboBox>
                 </StackPanel>
             </Grid>
         </Border>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -25,6 +25,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Database;
 using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
 
@@ -159,6 +160,17 @@ public partial class ServerTab : UserControl
 
         /* Initialize time picker ComboBoxes */
         InitializeTimeComboBoxes();
+
+        /* Sync time display mode picker */
+        var modeTag = ServerTimeHelper.CurrentDisplayMode.ToString();
+        for (int i = 0; i < TimeDisplayModeBox.Items.Count; i++)
+        {
+            if (TimeDisplayModeBox.Items[i] is ComboBoxItem item && item.Tag?.ToString() == modeTag)
+            {
+                TimeDisplayModeBox.SelectedIndex = i;
+                break;
+            }
+        }
 
         /* Initialize column filter managers */
         InitializeFilterManagers();
@@ -400,6 +412,33 @@ public partial class ServerTab : UserControl
         {
             RefreshDataButton.IsEnabled = true;
         }
+    }
+
+    private void TimeDisplayMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded) return;
+        if (TimeDisplayModeBox.SelectedItem is not ComboBoxItem item) return;
+        var tag = item.Tag?.ToString();
+        var mode = tag switch
+        {
+            "LocalTime" => TimeDisplayMode.LocalTime,
+            "UTC" => TimeDisplayMode.UTC,
+            _ => TimeDisplayMode.ServerTime
+        };
+        if (mode == ServerTimeHelper.CurrentDisplayMode) return;
+
+        ServerTimeHelper.CurrentDisplayMode = mode;
+
+        // Refresh all DataGrid bindings so ServerTimeConverter re-evaluates
+        QuerySnapshotsGrid.Items.Refresh();
+        QueryStatsGrid.Items.Refresh();
+        ProcedureStatsGrid.Items.Refresh();
+        QueryStoreGrid.Items.Refresh();
+        BlockedProcessReportGrid.Items.Refresh();
+        DeadlockGrid.Items.Refresh();
+        RunningJobsGrid.Items.Refresh();
+        CollectionHealthGrid.Items.Refresh();
+        CollectionLogGrid.Items.Refresh();
     }
 
     private async void TimeRangeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- **Times picker** on both Dashboard and Lite global toolbars: Server Time, Local Time, UTC
- All timestamp columns across all grids update instantly when switching modes
- Dashboard persists the preference via UserPreferencesService
- Uses existing `ServerTimeConverter` + `ServerTimeHelper.CurrentDisplayMode` — no new converters needed

## Test plan
- [x] Dashboard builds: 0 errors
- [x] Lite builds: 0 errors
- [x] Picker syncs with Settings window preference on load
- [x] Switching modes refreshes all grid timestamps without re-querying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a timestamp display mode selector allowing users to choose how times are displayed: Server Time, Local Time, or UTC.
  * User preference is automatically saved and persists across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->