### PR TITLE
Add missing date columns to Query Stats and Procedure Stats (#649, #651)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -338,6 +338,12 @@
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding CreationTimeLocal}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Creation Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -463,6 +469,12 @@
                                     <DataGridTextColumn Binding="{Binding ObjectType}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding CachedTimeFormatted}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Cached Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -529,9 +541,6 @@
                                     <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding CachedTimeFormatted}" Width="140">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Cached Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding PlanHandle}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanHandle" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Handle" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -564,6 +573,12 @@
                                     <DataGridTextColumn Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan ID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding FirstExecutionTimeLocal}" Width="140">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FirstExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="First Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -591,9 +606,6 @@
                                     <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="130">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -617,9 +629,6 @@
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding ExecutionTypeDesc}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionTypeDesc" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Exec Type" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding FirstExecutionTimeLocal}" Width="130">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FirstExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="First Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgClrTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -48,6 +48,8 @@ WHERE d.name = @database_name;", connection);
 SELECT
     database_name,
     query_hash,
+    MAX(last_execution_time) AS last_execution_time,
+    MAX(creation_time) AS creation_time,
     SUM(delta_execution_count) AS total_executions,
     SUM(delta_worker_time) AS total_cpu_us,
     SUM(delta_elapsed_time) AS total_elapsed_us,
@@ -100,33 +102,35 @@ LIMIT $4";
             {
                 DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
                 QueryHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
-                TotalExecutions = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
-                TotalCpuUs = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
-                TotalElapsedUs = reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
-                TotalLogicalReads = reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
-                TotalRows = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
-                TotalLogicalWrites = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
-                TotalPhysicalReads = reader.IsDBNull(8) ? 0 : reader.GetInt64(8),
-                TotalSpills = reader.IsDBNull(9) ? 0 : reader.GetInt64(9),
-                MinDop = reader.IsDBNull(10) ? 0 : reader.GetInt32(10),
-                MaxDop = reader.IsDBNull(11) ? 0 : reader.GetInt32(11),
-                MinCpuUs = reader.IsDBNull(12) ? 0 : reader.GetInt64(12),
-                MaxCpuUs = reader.IsDBNull(13) ? 0 : reader.GetInt64(13),
-                MinElapsedUs = reader.IsDBNull(14) ? 0 : reader.GetInt64(14),
-                MaxElapsedUs = reader.IsDBNull(15) ? 0 : reader.GetInt64(15),
-                MinPhysicalReads = reader.IsDBNull(16) ? 0 : reader.GetInt64(16),
-                MaxPhysicalReads = reader.IsDBNull(17) ? 0 : reader.GetInt64(17),
-                MinRows = reader.IsDBNull(18) ? 0 : reader.GetInt64(18),
-                MaxRows = reader.IsDBNull(19) ? 0 : reader.GetInt64(19),
-                MinGrantKb = reader.IsDBNull(20) ? 0 : reader.GetInt64(20),
-                MaxGrantKb = reader.IsDBNull(21) ? 0 : reader.GetInt64(21),
-                MinSpills = reader.IsDBNull(22) ? 0 : reader.GetInt64(22),
-                MaxSpills = reader.IsDBNull(23) ? 0 : reader.GetInt64(23),
-                QueryPlanHash = reader.IsDBNull(24) ? "" : reader.GetString(24),
-                SqlHandle = reader.IsDBNull(25) ? "" : reader.GetString(25),
-                PlanHandle = reader.IsDBNull(26) ? "" : reader.GetString(26),
-                QueryText = reader.IsDBNull(27) ? "" : reader.GetString(27),
-                QueryPlan = reader.IsDBNull(28) ? null : reader.GetString(28)
+                LastExecutionTime = reader.IsDBNull(2) ? null : reader.GetDateTime(2),
+                CreationTime = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                TotalExecutions = reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                TotalCpuUs = reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
+                TotalElapsedUs = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                TotalLogicalReads = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                TotalRows = reader.IsDBNull(8) ? 0 : reader.GetInt64(8),
+                TotalLogicalWrites = reader.IsDBNull(9) ? 0 : reader.GetInt64(9),
+                TotalPhysicalReads = reader.IsDBNull(10) ? 0 : reader.GetInt64(10),
+                TotalSpills = reader.IsDBNull(11) ? 0 : reader.GetInt64(11),
+                MinDop = reader.IsDBNull(12) ? 0 : reader.GetInt32(12),
+                MaxDop = reader.IsDBNull(13) ? 0 : reader.GetInt32(13),
+                MinCpuUs = reader.IsDBNull(14) ? 0 : reader.GetInt64(14),
+                MaxCpuUs = reader.IsDBNull(15) ? 0 : reader.GetInt64(15),
+                MinElapsedUs = reader.IsDBNull(16) ? 0 : reader.GetInt64(16),
+                MaxElapsedUs = reader.IsDBNull(17) ? 0 : reader.GetInt64(17),
+                MinPhysicalReads = reader.IsDBNull(18) ? 0 : reader.GetInt64(18),
+                MaxPhysicalReads = reader.IsDBNull(19) ? 0 : reader.GetInt64(19),
+                MinRows = reader.IsDBNull(20) ? 0 : reader.GetInt64(20),
+                MaxRows = reader.IsDBNull(21) ? 0 : reader.GetInt64(21),
+                MinGrantKb = reader.IsDBNull(22) ? 0 : reader.GetInt64(22),
+                MaxGrantKb = reader.IsDBNull(23) ? 0 : reader.GetInt64(23),
+                MinSpills = reader.IsDBNull(24) ? 0 : reader.GetInt64(24),
+                MaxSpills = reader.IsDBNull(25) ? 0 : reader.GetInt64(25),
+                QueryPlanHash = reader.IsDBNull(26) ? "" : reader.GetString(26),
+                SqlHandle = reader.IsDBNull(27) ? "" : reader.GetString(27),
+                PlanHandle = reader.IsDBNull(28) ? "" : reader.GetString(28),
+                QueryText = reader.IsDBNull(29) ? "" : reader.GetString(29),
+                QueryPlan = reader.IsDBNull(30) ? null : reader.GetString(30)
             });
         }
 
@@ -414,6 +418,7 @@ SELECT
     MIN(min_spills) AS min_spills,
     MAX(max_spills) AS max_spills,
     MAX(cached_time) AS cached_time,
+    MAX(last_execution_time) AS last_execution_time,
     MAX(sql_handle) AS sql_handle,
     MAX(plan_handle) AS plan_handle
 FROM v_procedure_stats
@@ -462,8 +467,9 @@ LIMIT $4";
                 MinSpills = reader.IsDBNull(21) ? 0 : reader.GetInt64(21),
                 MaxSpills = reader.IsDBNull(22) ? 0 : reader.GetInt64(22),
                 CachedTime = reader.IsDBNull(23) ? (DateTime?)null : reader.GetDateTime(23),
-                SqlHandle = reader.IsDBNull(24) ? "" : reader.GetString(24),
-                PlanHandle = reader.IsDBNull(25) ? "" : reader.GetString(25)
+                LastExecutionTime = reader.IsDBNull(24) ? (DateTime?)null : reader.GetDateTime(24),
+                SqlHandle = reader.IsDBNull(25) ? "" : reader.GetString(25),
+                PlanHandle = reader.IsDBNull(26) ? "" : reader.GetString(26)
             });
         }
 
@@ -625,6 +631,10 @@ public class QueryStatsRow
 {
     public string DatabaseName { get; set; } = "";
     public string QueryHash { get; set; } = "";
+    public DateTime? LastExecutionTime { get; set; }
+    public DateTime? CreationTime { get; set; }
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
+    public string CreationTimeLocal => Services.ServerTimeHelper.FormatServerTime(CreationTime);
     public long TotalExecutions { get; set; }
     public long TotalCpuUs { get; set; }
     public long TotalElapsedUs { get; set; }
@@ -690,6 +700,7 @@ public class ProcedureStatsRow
     public long MinSpills { get; set; }
     public long MaxSpills { get; set; }
     public DateTime? CachedTime { get; set; }
+    public DateTime? LastExecutionTime { get; set; }
     public string SqlHandle { get; set; } = "";
     public string PlanHandle { get; set; } = "";
     public string FullName => string.IsNullOrEmpty(SchemaName) ? ObjectName : $"{SchemaName}.{ObjectName}";
@@ -702,7 +713,8 @@ public class ProcedureStatsRow
     public double MaxCpuMs => MaxWorkerTimeUs / 1000.0;
     public double MinElapsedMs => MinElapsedTimeUs / 1000.0;
     public double MaxElapsedMs => MaxElapsedTimeUs / 1000.0;
-    public string CachedTimeFormatted => CachedTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "";
+    public string CachedTimeFormatted => Services.ServerTimeHelper.FormatServerTime(CachedTime);
+    public string LastExecutionTimeLocal => Services.ServerTimeHelper.FormatServerTime(LastExecutionTime);
 }
 
 public class QueryStatsHistoryRow


### PR DESCRIPTION
## Summary
- **Query Stats**: Added Last Execution and Creation Time columns (prominently after Database)
- **Procedure Stats**: Added Last Execution column, moved Cached Time to front (after Type)
- **Query Store**: Moved Last Execution and First Execution from scattered positions to right after Plan ID

All three query tabs now have date columns consistently positioned after identity columns and before metrics.

## Test plan
- [x] Build: 0 errors
- [x] Query Stats shows Last Execution and Creation Time
- [x] Procedure Stats shows Last Execution and Cached Time near the front
- [x] Query Store date columns moved to prominent position

Closes #649
Closes #651
Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)