### PR TITLE
Add per-tab time range slicers to Lite query tabs

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -216,9 +216,11 @@
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
-                                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                                <controls:TimeRangeSlicerControl x:Name="ActiveQueriesSlicer" Grid.Row="0"/>
+                                <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,8">
                                     <TextBlock Text="Currently Running Queries" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                     <Button x:Name="LiveSnapshotButton" Content="Live Snapshot"
                                             Click="LiveSnapshot_Click" Padding="12,4" Margin="16,0,8,0"
@@ -226,11 +228,12 @@
                                     <TextBlock x:Name="LiveSnapshotIndicator" Text="" FontSize="12"
                                                Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                <DataGrid Grid.Row="1" x:Name="QuerySnapshotsGrid"
+                                <DataGrid Grid.Row="2" x:Name="QuerySnapshotsGrid"
                                           AutoGenerateColumns="False" IsReadOnly="True"
                                           RowStyle="{StaticResource GridRowStyle}"
                                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                                          CanUserSortColumns="True">
+                                          CanUserSortColumns="True"
+                                          Sorting="QuerySnapshotsGrid_Sorting">
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="55">
                                             <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
@@ -328,11 +331,18 @@
                             </Grid>
                         </TabItem>
                         <TabItem Header="Top Queries by Duration">
-                            <DataGrid x:Name="QueryStatsGrid"
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <controls:TimeRangeSlicerControl x:Name="QueryStatsSlicer" Grid.Row="0"/>
+                            <DataGrid Grid.Row="1" x:Name="QueryStatsGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      Sorting="QueryStatsGrid_Sorting"
                                       MouseDoubleClick="QueryStatsGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
@@ -451,13 +461,21 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            </Grid>
                         </TabItem>
                         <TabItem Header="Top Procedures by Duration">
-                            <DataGrid x:Name="ProcedureStatsGrid"
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <controls:TimeRangeSlicerControl x:Name="ProcStatsSlicer" Grid.Row="0"/>
+                            <DataGrid Grid.Row="1" x:Name="ProcedureStatsGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      Sorting="ProcedureStatsGrid_Sorting"
                                       MouseDoubleClick="ProcedureStatsGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
@@ -555,13 +573,21 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            </Grid>
                         </TabItem>
                         <TabItem Header="Query Store by Duration">
-                            <DataGrid x:Name="QueryStoreGrid"
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <controls:TimeRangeSlicerControl x:Name="QueryStoreSlicer" Grid.Row="0"/>
+                            <DataGrid Grid.Row="1" x:Name="QueryStoreGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      Sorting="QueryStoreGrid_Sorting"
                                       MouseDoubleClick="QueryStoreGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
@@ -662,6 +688,7 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            </Grid>
                         </TabItem>
                     </TabControl>
                 </Grid>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -263,6 +263,11 @@ public partial class ServerTab : UserControl
         Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
         Unloaded += (_, _) => Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
 
+        ActiveQueriesSlicer.RangeChanged += OnActiveQueriesSlicerChanged;
+        QueryStatsSlicer.RangeChanged += OnQueryStatsSlicerChanged;
+        ProcStatsSlicer.RangeChanged += OnProcStatsSlicerChanged;
+        QueryStoreSlicer.RangeChanged += OnQueryStoreSlicerChanged;
+
         /* Initial load is triggered by MainWindow.ConnectToServer calling RefreshData()
            after collectors finish - no Loaded handler needed */
 
@@ -439,6 +444,12 @@ public partial class ServerTab : UserControl
         RunningJobsGrid.Items.Refresh();
         CollectionHealthGrid.Items.Refresh();
         CollectionLogGrid.Items.Refresh();
+
+        // Refresh slicer labels
+        ActiveQueriesSlicer.Redraw();
+        QueryStatsSlicer.Redraw();
+        ProcStatsSlicer.Redraw();
+        QueryStoreSlicer.Redraw();
     }
 
     private async void TimeRangeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -868,21 +879,25 @@ public partial class ServerTab : UserControl
                         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate);
                         _querySnapshotsFilterMgr!.UpdateData(snapshots);
                         LiveSnapshotIndicator.Text = "";
+                        _ = LoadActiveQueriesSlicerAsync();
                         break;
                     case 2: // Top Queries by Duration
                         var queryStats = await _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes);
                         _queryStatsFilterMgr!.UpdateData(queryStats);
                         SetInitialSort(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+                        _ = LoadQueryStatsSlicerAsync();
                         break;
                     case 3: // Top Procedures by Duration
                         var procStats = await _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes);
                         _procStatsFilterMgr!.UpdateData(procStats);
                         SetInitialSort(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+                        _ = LoadProcStatsSlicerAsync();
                         break;
                     case 4: // Query Store by Duration
                         var qsData = await _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate);
                         _queryStoreFilterMgr!.UpdateData(qsData);
                         SetInitialSort(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
+                        _ = LoadQueryStoreSlicerAsync();
                         break;
                 }
                 return;
@@ -904,12 +919,18 @@ public partial class ServerTab : UserControl
 
             _querySnapshotsFilterMgr!.UpdateData(snapshotsTask.Result);
             LiveSnapshotIndicator.Text = "";
+
+            _ = LoadActiveQueriesSlicerAsync();
+
             _queryStatsFilterMgr!.UpdateData(queryStatsTask.Result);
             SetInitialSort(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+            _ = LoadQueryStatsSlicerAsync();
             _procStatsFilterMgr!.UpdateData(procStatsTask.Result);
             SetInitialSort(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+            _ = LoadProcStatsSlicerAsync();
             _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
             SetInitialSort(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
+            _ = LoadQueryStoreSlicerAsync();
 
             UpdateQueryDurationTrendChart(queryDurationTrendTask.Result);
             UpdateProcDurationTrendChart(procDurationTrendTask.Result);
@@ -3659,6 +3680,373 @@ public partial class ServerTab : UserControl
             return await LocalDataService.FetchQueryPlanOnDemandAsync(connStr, queryHash);
         }
         catch { return null; }
+    }
+
+    // ── Active Queries Slicer ──
+
+    private async System.Threading.Tasks.Task LoadActiveQueriesSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _activeQueriesSlicerData = data;
+            _activeQueriesSlicerMetric = "Sessions";
+            if (data.Count > 0)
+                ActiveQueriesSlicer.LoadData(data, "Sessions");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadActiveQueriesSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private string _activeQueriesSlicerMetric = "Sessions";
+    private List<Models.TimeSliceBucket>? _activeQueriesSlicerData;
+
+    private void QuerySnapshotsGrid_Sorting(object sender, DataGridSortingEventArgs e)
+    {
+        if (_activeQueriesSlicerData == null || _activeQueriesSlicerData.Count == 0) return;
+
+        var col = e.Column.SortMemberPath ?? "";
+        if (string.IsNullOrEmpty(col))
+        {
+            // Fall back to binding path
+            if (e.Column is DataGridBoundColumn bc && bc.Binding is System.Windows.Data.Binding b)
+                col = b.Path.Path;
+        }
+        var (metric, label) = col switch
+        {
+            "CpuTimeMs" => ("TotalCpu", "Total CPU (ms)"),
+            "TotalElapsedTimeMs" => ("TotalElapsed", "Total Elapsed (ms)"),
+            "Reads" => ("TotalReads", "Total Reads"),
+            "LogicalReads" => ("TotalLogicalReads", "Total Logical Reads"),
+            "Writes" => ("TotalWrites", "Total Writes"),
+            _ => ("Sessions", "Sessions"),
+        };
+
+        if (metric == _activeQueriesSlicerMetric) return;
+        _activeQueriesSlicerMetric = metric;
+
+        foreach (var bucket in _activeQueriesSlicerData)
+        {
+            bucket.Value = metric switch
+            {
+                "TotalCpu" => bucket.TotalCpu,
+                "TotalElapsed" => bucket.TotalElapsed,
+                "TotalReads" => bucket.TotalReads,
+                "TotalLogicalReads" => bucket.TotalLogicalReads,
+                "TotalWrites" => bucket.TotalWrites,
+                _ => bucket.SessionCount,
+            };
+        }
+
+        ActiveQueriesSlicer.UpdateMetric(label);
+    }
+
+    private async void OnActiveQueriesSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            // Slicer sends UTC dates; GetTimeRange expects server time for fromDate/toDate
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+
+            var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromServer, toServer);
+            _querySnapshotsFilterMgr!.UpdateData(snapshots);
+            LiveSnapshotIndicator.Text = "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnActiveQueriesSlicerChanged failed: {ex.Message}");
+        }
+    }
+
+    // ── Query Stats Slicer ──
+
+    private string _queryStatsSlicerMetric = "TotalCpu";
+    private List<Models.TimeSliceBucket>? _queryStatsSlicerData;
+
+    private async System.Threading.Tasks.Task LoadQueryStatsSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetQueryStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _queryStatsSlicerData = data;
+            _queryStatsSlicerMetric = "TotalCpu";
+            if (data.Count > 0)
+                QueryStatsSlicer.LoadData(data, "Total CPU (ms)");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadQueryStatsSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void OnQueryStatsSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+            var queryStats = await _dataService.GetTopQueriesByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
+            _queryStatsFilterMgr!.UpdateData(queryStats);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnQueryStatsSlicerChanged failed: {ex.Message}");
+        }
+    }
+
+    private void QueryStatsGrid_Sorting(object sender, DataGridSortingEventArgs e)
+    {
+        if (_queryStatsSlicerData == null || _queryStatsSlicerData.Count == 0) return;
+
+        var col = e.Column.SortMemberPath ?? "";
+        if (string.IsNullOrEmpty(col) && e.Column is DataGridBoundColumn bc && bc.Binding is System.Windows.Data.Binding b)
+            col = b.Path.Path;
+
+        var (metric, label) = col switch
+        {
+            "TotalCpuMs" => ("TotalCpu", "Total CPU (ms)"),
+            "AvgCpuMs" => ("AvgCpu", "Avg CPU (ms)"),
+            "TotalElapsedMs" => ("TotalElapsed", "Total Duration (ms)"),
+            "AvgElapsedMs" => ("AvgElapsed", "Avg Duration (ms)"),
+            "TotalLogicalReads" => ("TotalReads", "Total Reads"),
+            "AvgReads" => ("AvgReads", "Avg Reads"),
+            "TotalLogicalWrites" => ("TotalWrites", "Total Writes"),
+            "TotalPhysicalReads" => ("TotalPhysReads", "Total Physical Reads"),
+            _ => ("TotalCpu", "Total CPU (ms)"),
+        };
+
+        if (metric == _queryStatsSlicerMetric) return;
+        _queryStatsSlicerMetric = metric;
+
+        foreach (var bucket in _queryStatsSlicerData)
+        {
+            var n = bucket.SessionCount > 0 ? bucket.SessionCount : 1;
+            bucket.Value = metric switch
+            {
+                "TotalCpu" => bucket.TotalCpu,
+                "AvgCpu" => bucket.TotalCpu / n,
+                "TotalElapsed" => bucket.TotalElapsed,
+                "AvgElapsed" => bucket.TotalElapsed / n,
+                "TotalReads" => bucket.TotalReads,
+                "AvgReads" => bucket.TotalReads / n,
+                "TotalWrites" => bucket.TotalWrites,
+                "TotalPhysReads" => bucket.TotalLogicalReads,
+                _ => bucket.TotalCpu,
+            };
+        }
+
+        QueryStatsSlicer.UpdateMetric(label);
+    }
+
+    // ── Query Store Slicer ──
+
+    private string _queryStoreSlicerMetric = "TotalCpu";
+    private List<Models.TimeSliceBucket>? _queryStoreSlicerData;
+
+    private async System.Threading.Tasks.Task LoadQueryStoreSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetQueryStoreSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _queryStoreSlicerData = data;
+            _queryStoreSlicerMetric = "TotalCpu";
+            if (data.Count > 0)
+                QueryStoreSlicer.LoadData(data, "Total CPU (ms)");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadQueryStoreSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void OnQueryStoreSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+            var qsData = await _dataService.GetQueryStoreTopQueriesAsync(_serverId, 0, 50, fromServer, toServer);
+            _queryStoreFilterMgr!.UpdateData(qsData);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnQueryStoreSlicerChanged failed: {ex.Message}");
+        }
+    }
+
+    private void QueryStoreGrid_Sorting(object sender, DataGridSortingEventArgs e)
+    {
+        if (_queryStoreSlicerData == null || _queryStoreSlicerData.Count == 0) return;
+
+        var col = e.Column.SortMemberPath ?? "";
+        if (string.IsNullOrEmpty(col) && e.Column is DataGridBoundColumn bc && bc.Binding is System.Windows.Data.Binding b)
+            col = b.Path.Path;
+
+        var (metric, label) = col switch
+        {
+            "TotalCpuMs" => ("TotalCpu", "Total CPU (ms)"),
+            "AvgCpuTimeMs" => ("AvgCpu", "Avg CPU (ms)"),
+            "TotalDurationMs" => ("TotalElapsed", "Total Duration (ms)"),
+            "AvgDurationMs" => ("AvgElapsed", "Avg Duration (ms)"),
+            "AvgLogicalReads" => ("TotalReads", "Avg Reads"),
+            "AvgLogicalWrites" => ("TotalWrites", "Avg Writes"),
+            "AvgPhysicalReads" => ("TotalReads", "Avg Physical Reads"),
+            "TotalExecutions" => ("Sessions", "Executions"),
+            _ => ("TotalCpu", "Total CPU (ms)"),
+        };
+
+        if (metric == _queryStoreSlicerMetric) return;
+        _queryStoreSlicerMetric = metric;
+
+        foreach (var bucket in _queryStoreSlicerData)
+        {
+            var n = bucket.SessionCount > 0 ? bucket.SessionCount : 1;
+            bucket.Value = metric switch
+            {
+                "TotalCpu" => bucket.TotalCpu,
+                "AvgCpu" => bucket.TotalCpu / n,
+                "TotalElapsed" => bucket.TotalElapsed,
+                "AvgElapsed" => bucket.TotalElapsed / n,
+                "TotalReads" => bucket.TotalReads,
+                "TotalWrites" => bucket.TotalWrites,
+                "Sessions" => bucket.SessionCount,
+                _ => bucket.TotalCpu,
+            };
+        }
+
+        QueryStoreSlicer.UpdateMetric(label);
+    }
+
+    // ── Procedure Stats Slicer ──
+
+    private string _procStatsSlicerMetric = "TotalCpu";
+    private List<Models.TimeSliceBucket>? _procStatsSlicerData;
+
+    private async System.Threading.Tasks.Task LoadProcStatsSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetProcStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _procStatsSlicerData = data;
+            _procStatsSlicerMetric = "TotalCpu";
+            if (data.Count > 0)
+                ProcStatsSlicer.LoadData(data, "Total CPU (ms)");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadProcStatsSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void OnProcStatsSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+            var procStats = await _dataService.GetTopProceduresByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
+            _procStatsFilterMgr!.UpdateData(procStats);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnProcStatsSlicerChanged failed: {ex.Message}");
+        }
+    }
+
+    private void ProcedureStatsGrid_Sorting(object sender, DataGridSortingEventArgs e)
+    {
+        if (_procStatsSlicerData == null || _procStatsSlicerData.Count == 0) return;
+
+        var col = e.Column.SortMemberPath ?? "";
+        if (string.IsNullOrEmpty(col) && e.Column is DataGridBoundColumn bc && bc.Binding is System.Windows.Data.Binding b)
+            col = b.Path.Path;
+
+        var (metric, label) = col switch
+        {
+            "TotalCpuMs" => ("TotalCpu", "Total CPU (ms)"),
+            "AvgCpuMs" => ("AvgCpu", "Avg CPU (ms)"),
+            "TotalElapsedMs" => ("TotalElapsed", "Total Duration (ms)"),
+            "AvgElapsedMs" => ("AvgElapsed", "Avg Duration (ms)"),
+            "TotalLogicalReads" or "AvgReads" => ("TotalReads", "Total Reads"),
+            "TotalLogicalWrites" => ("TotalWrites", "Total Writes"),
+            "TotalPhysicalReads" => ("TotalReads", "Total Physical Reads"),
+            _ => ("TotalCpu", "Total CPU (ms)"),
+        };
+
+        if (metric == _procStatsSlicerMetric) return;
+        _procStatsSlicerMetric = metric;
+
+        foreach (var bucket in _procStatsSlicerData)
+        {
+            var n = bucket.SessionCount > 0 ? bucket.SessionCount : 1;
+            bucket.Value = metric switch
+            {
+                "TotalCpu" => bucket.TotalCpu,
+                "AvgCpu" => bucket.TotalCpu / n,
+                "TotalElapsed" => bucket.TotalElapsed,
+                "AvgElapsed" => bucket.TotalElapsed / n,
+                "TotalReads" => bucket.TotalReads,
+                "TotalWrites" => bucket.TotalWrites,
+                _ => bucket.TotalCpu,
+            };
+        }
+
+        ProcStatsSlicer.UpdateMetric(label);
     }
 
     private async void LiveSnapshot_Click(object sender, RoutedEventArgs e)

--- a/Lite/Controls/TimeRangeSlicerControl.xaml
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml
@@ -1,0 +1,43 @@
+<UserControl x:Class="PerformanceMonitorLite.Controls.TimeRangeSlicerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="{DynamicResource SlicerBackgroundBrush}"
+            BorderBrush="{DynamicResource SlicerBorderBrush}"
+            BorderThickness="0,0,0,1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Button x:Name="ToggleButton" Grid.Row="0"
+                    Background="Transparent" BorderThickness="0"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                    Padding="8,4" Cursor="Hand"
+                    Click="Toggle_Click">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock x:Name="ToggleIcon" Text="▾" FontSize="12"
+                               Foreground="{DynamicResource SlicerToggleBrush}"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBlock x:Name="ToggleLabel" Text="Time Range"
+                               FontSize="11" FontWeight="SemiBold"
+                               Foreground="{DynamicResource SlicerToggleBrush}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock x:Name="RangeLabel" Text=""
+                               FontSize="11"
+                               Foreground="{DynamicResource SlicerLabelBrush}"
+                               VerticalAlignment="Center" Margin="12,0,0,0"/>
+                </StackPanel>
+            </Button>
+            <Border x:Name="SlicerBorder" Grid.Row="1" Height="100" Margin="8,0,8,6"
+                    Background="{DynamicResource SlicerBackgroundBrush}"
+                    CornerRadius="4" ClipToBounds="True">
+                <Canvas x:Name="SlicerCanvas"
+                        Background="Transparent"
+                        MouseLeftButtonDown="Canvas_MouseLeftButtonDown"
+                        MouseMove="Canvas_MouseMove"
+                        MouseLeftButtonUp="Canvas_MouseLeftButtonUp"
+                        MouseWheel="Canvas_MouseWheel"/>
+            </Border>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Controls;
+
+public partial class TimeRangeSlicerControl : UserControl
+{
+    private List<TimeSliceBucket> _data = new();
+    private string _metricLabel = "Sessions";
+    private bool _isExpanded = true;
+
+    // Range as normalised [0..1] positions within the data span
+    private double _rangeStart;
+    private double _rangeEnd = 1.0;
+
+    private const double HandleWidthPx = 8;
+    private const double HandleGripWidthPx = 20;
+    private const double MinRangeNorm = 0.02; // minimum ~2% of total span
+    private const double ChartPaddingTop = 16;
+    private const double ChartPaddingBottom = 20;
+
+    private enum DragMode { None, MoveRange, DragStart, DragEnd }
+    private DragMode _dragMode = DragMode.None;
+    private double _dragOriginX;
+    private double _dragOriginRangeStart;
+    private double _dragOriginRangeEnd;
+
+    /// <summary>
+    /// Fired when the user finishes adjusting the slicer handles.
+    /// StartUtc/EndUtc are in UTC (matching DuckDB collection_time).
+    /// </summary>
+    public event EventHandler<SlicerRangeEventArgs>? RangeChanged;
+
+    public TimeRangeSlicerControl()
+    {
+        InitializeComponent();
+        SlicerBorder.SizeChanged += (_, _) => Redraw();
+        IsVisibleChanged += (_, _) => { if (IsVisible) Redraw(); };
+    }
+
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            _isExpanded = value;
+            SlicerBorder.Visibility = _isExpanded ? Visibility.Visible : Visibility.Collapsed;
+            ToggleIcon.Text = _isExpanded ? "▾" : "▸";
+        }
+    }
+
+    /// <summary>
+    /// Loads slicer data. All timestamps must be UTC.
+    /// Selection defaults to the full range (no filtering until user interacts).
+    /// </summary>
+    public void LoadData(List<TimeSliceBucket> data, string metricLabel)
+    {
+        _data = data;
+        _metricLabel = metricLabel;
+        _rangeStart = 0;
+        _rangeEnd = 1.0;
+        UpdateRangeLabel();
+        Redraw();
+    }
+
+    /// <summary>Updates the metric label and redraws (when sort column changes).</summary>
+    public void UpdateMetric(string metricLabel)
+    {
+        _metricLabel = metricLabel;
+        Redraw();
+    }
+
+    public DateTime? SelectionStartUtc => _data.Count > 0 ? UtcAtNorm(_rangeStart) : null;
+    public DateTime? SelectionEndUtc => _data.Count > 0 ? UtcAtNorm(_rangeEnd) : null;
+
+    // ── Time mapping ──
+
+    private DateTime DataStartUtc => _data[0].BucketTimeUtc;
+    private DateTime DataEndUtc => _data[^1].BucketTimeUtc.AddHours(1);
+
+    private DateTime UtcAtNorm(double norm)
+    {
+        var ticks = DataStartUtc.Ticks + (long)((DataEndUtc.Ticks - DataStartUtc.Ticks) * norm);
+        return new DateTime(Math.Clamp(ticks, DataStartUtc.Ticks, DataEndUtc.Ticks), DateTimeKind.Utc);
+    }
+
+    private double NormAtUtc(DateTime utc)
+    {
+        var span = DataEndUtc.Ticks - DataStartUtc.Ticks;
+        if (span <= 0) return 0;
+        return Math.Clamp((double)(utc.Ticks - DataStartUtc.Ticks) / span, 0, 1);
+    }
+
+    // ── Drawing ──
+
+    public void Redraw()
+    {
+        SlicerCanvas.Children.Clear();
+        if (_data.Count < 2) return;
+
+        var w = SlicerBorder.ActualWidth;
+        var h = SlicerBorder.ActualHeight;
+        if (w <= 0 || h <= 0) return;
+
+        var values = _data.Select(d => d.Value).ToArray();
+        var max = values.Max();
+        if (max <= 0) max = 1;
+
+        var chartTop = ChartPaddingTop;
+        var chartBottom = h - ChartPaddingBottom;
+        var chartHeight = chartBottom - chartTop;
+        if (chartHeight <= 0) return;
+
+        var n = values.Length;
+        var stepX = w / n;
+
+        // Area chart
+        var linePoints = new List<Point>(n);
+        for (int i = 0; i < n; i++)
+        {
+            var x = i * stepX + stepX / 2;
+            var y = chartBottom - (values[i] / max) * chartHeight;
+            linePoints.Add(new Point(x, y));
+        }
+
+        var fillBrush = FindBrush("SlicerChartFillBrush", "#332EAEF1");
+        var areaGeo = new StreamGeometry();
+        using (var ctx = areaGeo.Open())
+        {
+            ctx.BeginFigure(new Point(linePoints[0].X, chartBottom), true, true);
+            foreach (var pt in linePoints) ctx.LineTo(pt, true, false);
+            ctx.LineTo(new Point(linePoints[^1].X, chartBottom), true, false);
+        }
+        SlicerCanvas.Children.Add(new Path { Data = areaGeo, Fill = fillBrush });
+
+        var lineBrush = FindBrush("SlicerChartLineBrush", "#2EAEF1");
+        var lineGeo = new StreamGeometry();
+        using (var ctx = lineGeo.Open())
+        {
+            ctx.BeginFigure(linePoints[0], false, false);
+            for (int i = 1; i < linePoints.Count; i++) ctx.LineTo(linePoints[i], true, false);
+        }
+        SlicerCanvas.Children.Add(new Path { Data = lineGeo, Stroke = lineBrush, StrokeThickness = 1.5 });
+
+        // X-axis labels
+        var labelBrush = FindBrush("SlicerLabelBrush", "#99E4E6EB");
+        int labelInterval = Math.Max(1, n / 8);
+        for (int i = 0; i < n; i += labelInterval)
+        {
+            var x = i * stepX + stepX / 2;
+            var dt = ServerTimeHelper.FormatServerTime(_data[i].BucketTimeUtc, "MM/dd HH:mm");
+            var tb = new TextBlock { Text = dt, FontSize = 9, Foreground = labelBrush };
+            Canvas.SetLeft(tb, x - 25);
+            Canvas.SetTop(tb, chartBottom + 2);
+            SlicerCanvas.Children.Add(tb);
+        }
+
+        // Metric label top-right
+        var metricBrush = FindBrush("SlicerToggleBrush", "#E4E6EB");
+        var metricTb = new TextBlock { Text = _metricLabel, FontSize = 11, FontWeight = FontWeights.SemiBold, Foreground = metricBrush };
+        Canvas.SetLeft(metricTb, w - 120);
+        Canvas.SetTop(metricTb, 2);
+        SlicerCanvas.Children.Add(metricTb);
+
+        // Selection overlays
+        var overlayBrush = FindBrush("SlicerOverlayBrush", "#99000000");
+        var selectedBrush = FindBrush("SlicerSelectedBrush", "#22FFFFFF");
+        var handleBrush = FindBrush("SlicerHandleBrush", "#E4E6EB");
+
+        var selLeft = _rangeStart * w;
+        var selRight = _rangeEnd * w;
+
+        if (selLeft > 0) AddRect(0, 0, selLeft, h, overlayBrush);
+        if (selRight < w) AddRect(selRight, 0, w - selRight, h, overlayBrush);
+        AddRect(selLeft, 0, Math.Max(0, selRight - selLeft), h, selectedBrush);
+
+        DrawHandle(selLeft, h, handleBrush);
+        DrawHandle(selRight - HandleWidthPx, h, handleBrush);
+
+        AddLine(selLeft, 0, selRight, 0, handleBrush, 0.5);
+        AddLine(selLeft, h, selRight, h, handleBrush, 0.5);
+    }
+
+    private void AddRect(double x, double y, double width, double height, Brush fill)
+    {
+        var rect = new Rectangle { Width = width, Height = height, Fill = fill };
+        Canvas.SetLeft(rect, x); Canvas.SetTop(rect, y);
+        SlicerCanvas.Children.Add(rect);
+    }
+
+    private void AddLine(double x1, double y1, double x2, double y2, Brush stroke, double opacity)
+    {
+        SlicerCanvas.Children.Add(new Line
+        {
+            X1 = x1, Y1 = y1, X2 = x2, Y2 = y2,
+            Stroke = stroke, StrokeThickness = 1, Opacity = opacity
+        });
+    }
+
+    private void DrawHandle(double x, double canvasHeight, Brush brush)
+    {
+        AddRect(x, 0, HandleWidthPx, canvasHeight, brush);
+        ((Rectangle)SlicerCanvas.Children[^1]).Opacity = 0.7;
+        var midY = canvasHeight / 2;
+        for (int i = -1; i <= 1; i++)
+        {
+            SlicerCanvas.Children.Add(new Line
+            {
+                X1 = x + 2, Y1 = midY + i * 5, X2 = x + HandleWidthPx - 2, Y2 = midY + i * 5,
+                Stroke = Brushes.Black, StrokeThickness = 1, Opacity = 0.6
+            });
+        }
+    }
+
+    private Brush FindBrush(string key, string fallbackHex)
+    {
+        if (TryFindResource(key) is Brush b) return b;
+        return new SolidColorBrush((Color)ColorConverter.ConvertFromString(fallbackHex));
+    }
+
+    // ── Range label ──
+
+    private void UpdateRangeLabel()
+    {
+        if (_data.Count == 0) { RangeLabel.Text = ""; return; }
+        var startDisplay = ServerTimeHelper.FormatServerTime(UtcAtNorm(_rangeStart), "yyyy-MM-dd HH:mm");
+        var endDisplay = ServerTimeHelper.FormatServerTime(UtcAtNorm(_rangeEnd), "yyyy-MM-dd HH:mm");
+        var spanHours = (UtcAtNorm(_rangeEnd) - UtcAtNorm(_rangeStart)).TotalHours;
+        RangeLabel.Text = $"{startDisplay} \u2192 {endDisplay}  ({spanHours:F0}h)";
+    }
+
+    // ── Mouse interaction ──
+
+    private void Toggle_Click(object sender, RoutedEventArgs e) => IsExpanded = !IsExpanded;
+
+    private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_data.Count < 2) return;
+        var w = SlicerBorder.ActualWidth;
+        if (w <= 0) return;
+        var pos = e.GetPosition(SlicerCanvas);
+
+        var selLeft = _rangeStart * w;
+        var selRight = _rangeEnd * w;
+
+        _dragOriginX = pos.X;
+        _dragOriginRangeStart = _rangeStart;
+        _dragOriginRangeEnd = _rangeEnd;
+
+        if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx)
+        { _dragMode = DragMode.DragStart; SlicerCanvas.CaptureMouse(); e.Handled = true; return; }
+        if (Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
+        { _dragMode = DragMode.DragEnd; SlicerCanvas.CaptureMouse(); e.Handled = true; return; }
+        if (pos.X >= selLeft && pos.X <= selRight)
+        { _dragMode = DragMode.MoveRange; SlicerCanvas.CaptureMouse(); e.Handled = true; }
+    }
+
+    private void Canvas_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (_data.Count < 2) return;
+        var w = SlicerBorder.ActualWidth;
+        if (w <= 0) return;
+        var pos = e.GetPosition(SlicerCanvas);
+
+        if (_dragMode == DragMode.None)
+        {
+            var selLeft = _rangeStart * w;
+            var selRight = _rangeEnd * w;
+            if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx || Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
+                SlicerCanvas.Cursor = Cursors.SizeWE;
+            else if (pos.X >= selLeft && pos.X <= selRight)
+                SlicerCanvas.Cursor = Cursors.SizeAll;
+            else
+                SlicerCanvas.Cursor = Cursors.Arrow;
+            return;
+        }
+
+        var deltaNorm = (pos.X - _dragOriginX) / w;
+
+        switch (_dragMode)
+        {
+            case DragMode.DragStart:
+                _rangeStart = Math.Clamp(_dragOriginRangeStart + deltaNorm, 0, _rangeEnd - MinRangeNorm);
+                break;
+            case DragMode.DragEnd:
+                _rangeEnd = Math.Clamp(_dragOriginRangeEnd + deltaNorm, _rangeStart + MinRangeNorm, 1);
+                break;
+            case DragMode.MoveRange:
+                var span = _dragOriginRangeEnd - _dragOriginRangeStart;
+                var newStart = _dragOriginRangeStart + deltaNorm;
+                if (newStart < 0) newStart = 0;
+                if (newStart + span > 1) newStart = 1 - span;
+                _rangeStart = newStart;
+                _rangeEnd = newStart + span;
+                break;
+        }
+
+        UpdateRangeLabel();
+        Redraw();
+        e.Handled = true;
+    }
+
+    private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (_dragMode != DragMode.None)
+        {
+            _dragMode = DragMode.None;
+            SlicerCanvas.ReleaseMouseCapture();
+            FireRangeChanged();
+            e.Handled = true;
+        }
+    }
+
+    private void Canvas_MouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (_data.Count < 2) return;
+        if (!Keyboard.Modifiers.HasFlag(ModifierKeys.Control)) return;
+
+        var w = SlicerBorder.ActualWidth;
+        if (w <= 0) return;
+
+        var pos = e.GetPosition(SlicerCanvas);
+        var pivot = Math.Clamp(pos.X / w, 0, 1);
+        var span = _rangeEnd - _rangeStart;
+
+        var zoomFactor = e.Delta > 0 ? 0.85 : 1.0 / 0.85;
+        var newSpan = Math.Clamp(span * zoomFactor, MinRangeNorm, 1.0);
+
+        var pivotInRange = (pivot - _rangeStart) / span;
+        var newStart = pivot - pivotInRange * newSpan;
+        var newEnd = newStart + newSpan;
+
+        if (newStart < 0) { newStart = 0; newEnd = newSpan; }
+        if (newEnd > 1) { newEnd = 1; newStart = 1 - newSpan; }
+
+        _rangeStart = Math.Max(0, newStart);
+        _rangeEnd = Math.Min(1, newEnd);
+
+        UpdateRangeLabel();
+        Redraw();
+        FireRangeChanged();
+        e.Handled = true;
+    }
+
+    private void FireRangeChanged()
+    {
+        if (_data.Count == 0) return;
+        // Snap to hour boundaries so slider positions align with the hourly buckets shown in the graph
+        var startUtc = FloorToHour(UtcAtNorm(_rangeStart));
+        var endUtc = CeilToHour(UtcAtNorm(_rangeEnd));
+        RangeChanged?.Invoke(this, new SlicerRangeEventArgs(startUtc, endUtc));
+    }
+
+    private static DateTime FloorToHour(DateTime dt) =>
+        new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, 0, 0, dt.Kind);
+
+    private static DateTime CeilToHour(DateTime dt)
+    {
+        var floored = FloorToHour(dt);
+        return floored == dt ? dt : floored.AddHours(1);
+    }
+}
+
+public class SlicerRangeEventArgs : EventArgs
+{
+    public DateTime StartUtc { get; }
+    public DateTime EndUtc { get; }
+    public SlicerRangeEventArgs(DateTime startUtc, DateTime endUtc) { StartUtc = startUtc; EndUtc = endUtc; }
+}

--- a/Lite/Models/TimeSliceBucket.cs
+++ b/Lite/Models/TimeSliceBucket.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PerformanceMonitorLite.Models;
+
+/// <summary>
+/// One hourly bucket of aggregated metrics for a time-range slicer.
+/// Timestamps are in UTC (matching DuckDB collection_time storage).
+/// </summary>
+public class TimeSliceBucket
+{
+    public DateTime BucketTimeUtc { get; set; }
+    public long SessionCount { get; set; }
+    public double TotalCpu { get; set; }
+    public double TotalElapsed { get; set; }
+    public double TotalReads { get; set; }
+    public double TotalLogicalReads { get; set; }
+    public double TotalWrites { get; set; }
+
+    /// <summary>The display value used by the slicer chart. Set by the caller based on sort column.</summary>
+    public double Value { get; set; }
+}

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -132,6 +132,58 @@ LIMIT 50";
     }
 
     /// <summary>
+    /// Gets hourly-bucketed metrics from query snapshots for the time-range slicer.
+    /// The metric column is determined by the caller's sort preference.
+    /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetActiveQuerySlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(*) AS session_count,
+    COALESCE(SUM(cpu_time_ms), 0) AS total_cpu,
+    COALESCE(SUM(total_elapsed_time_ms), 0) AS total_elapsed,
+    COALESCE(SUM(reads), 0) AS total_reads,
+    COALESCE(SUM(logical_reads), 0) AS total_logical_reads,
+    COALESCE(SUM(writes), 0) AS total_writes
+FROM v_query_snapshots
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                TotalCpu = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+                TotalElapsed = reader.IsDBNull(3) ? 0 : ToDouble(reader.GetValue(3)),
+                TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalLogicalReads = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                TotalWrites = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
+                Value = reader.IsDBNull(1) ? 0 : Convert.ToDouble(reader.GetValue(1)), // default: session count
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
     /// Gets query snapshots (currently running queries) for a server.
     /// </summary>
     public async Task<List<QuerySnapshotRow>> GetLatestQuerySnapshotsAsync(int serverId, int hoursBack = 4, DateTime? fromDate = null, DateTime? toDate = null)

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -36,6 +36,52 @@ WHERE d.name = @database_name;", connection);
     /// <summary>
     /// Gets top queries by CPU for a server over a time period.
     /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetQueryStatsSlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(DISTINCT query_hash) AS query_count,
+    COALESCE(SUM(delta_worker_time), 0) / 1000.0 AS total_cpu_ms,
+    COALESCE(SUM(delta_elapsed_time), 0) / 1000.0 AS total_elapsed_ms,
+    COALESCE(SUM(delta_logical_reads), 0) AS total_reads,
+    COALESCE(SUM(delta_logical_writes), 0) AS total_writes,
+    COALESCE(SUM(delta_physical_reads), 0) AS total_physical_reads
+FROM v_query_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                TotalCpu = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+                TotalElapsed = reader.IsDBNull(3) ? 0 : ToDouble(reader.GetValue(3)),
+                TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalWrites = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                TotalLogicalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                Value = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)), // default: total CPU
+            });
+        }
+        return items;
+    }
+
     public async Task<List<QueryStatsRow>> GetTopQueriesByCpuAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null, int utcOffsetMinutes = 0)
     {
         using var _q = TimeQuery("GetTopQueriesByCpuAsync", "v_query_stats top N by CPU");
@@ -384,6 +430,52 @@ OPTION(RECOMPILE);',
     /// <summary>
     /// Gets top procedures by CPU for a server.
     /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetProcStatsSlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(DISTINCT object_name) AS proc_count,
+    COALESCE(SUM(delta_worker_time), 0) / 1000.0 AS total_cpu_ms,
+    COALESCE(SUM(delta_elapsed_time), 0) / 1000.0 AS total_elapsed_ms,
+    COALESCE(SUM(delta_logical_reads), 0) AS total_reads,
+    COALESCE(SUM(delta_logical_writes), 0) AS total_writes,
+    COALESCE(SUM(delta_physical_reads), 0) AS total_physical_reads
+FROM v_procedure_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                TotalCpu = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+                TotalElapsed = reader.IsDBNull(3) ? 0 : ToDouble(reader.GetValue(3)),
+                TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalWrites = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                TotalLogicalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                Value = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+            });
+        }
+        return items;
+    }
+
     public async Task<List<ProcedureStatsRow>> GetTopProceduresByCpuAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null, int utcOffsetMinutes = 0)
     {
         using var _q = TimeQuery("GetTopProceduresByCpuAsync", "v_procedure_stats top N by CPU");

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -21,6 +21,52 @@ public partial class LocalDataService
     /// Gets the latest Query Store snapshot for a server, aggregated across all databases.
     /// Shows top queries by total duration (execution_count * avg_duration).
     /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetQueryStoreSlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(DISTINCT query_id) AS query_count,
+    COALESCE(SUM(CAST(avg_cpu_time_us AS DOUBLE) * execution_count), 0) / 1000.0 AS total_cpu_ms,
+    COALESCE(SUM(CAST(avg_duration_us AS DOUBLE) * execution_count), 0) / 1000.0 AS total_duration_ms,
+    COALESCE(SUM(CAST(avg_logical_io_reads AS DOUBLE) * execution_count), 0) AS total_reads,
+    COALESCE(SUM(CAST(avg_logical_io_writes AS DOUBLE) * execution_count), 0) AS total_writes,
+    COALESCE(SUM(CAST(avg_physical_io_reads AS DOUBLE) * execution_count), 0) AS total_physical_reads
+FROM v_query_store_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+                TotalCpu = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+                TotalElapsed = reader.IsDBNull(3) ? 0 : ToDouble(reader.GetValue(3)),
+                TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalWrites = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                TotalLogicalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                Value = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+            });
+        }
+        return items;
+    }
+
     public async Task<List<QueryStoreRow>> GetQueryStoreTopQueriesAsync(int serverId, int hoursBack = 24, int top = 50, DateTime? fromDate = null, DateTime? toDate = null)
     {
         using var _q = TimeQuery("GetQueryStoreTopQueriesAsync", "v_query_store_stats top N");

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -1205,5 +1205,15 @@
         <Setter Property="Padding" Value="10,8"/>
     </Style>
 
+    <!-- Time Range Slicer -->
+    <SolidColorBrush x:Key="SlicerBackgroundBrush" Color="#15171C"/>
+    <SolidColorBrush x:Key="SlicerChartLineBrush" Color="#2EAEF1"/>
+    <SolidColorBrush x:Key="SlicerChartFillBrush" Color="#332EAEF1"/>
+    <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#99000000"/>
+    <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#22FFFFFF"/>
+    <SolidColorBrush x:Key="SlicerHandleBrush" Color="#E4E6EB"/>
+    <SolidColorBrush x:Key="SlicerBorderBrush" Color="#3A3D45"/>
+    <SolidColorBrush x:Key="SlicerLabelBrush" Color="#99E4E6EB"/>
+    <SolidColorBrush x:Key="SlicerToggleBrush" Color="#E4E6EB"/>
 
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
Interactive time range slicers on all four Lite query sub-tabs:

- **Active Queries**: Sessions/CPU/Elapsed/Reads per hour
- **Top Queries by Duration**: Total/Avg CPU, Duration, Reads, Writes
- **Top Procedures by Duration**: Same metrics as Query Stats
- **Query Store by Duration**: Total/Avg CPU, Duration, Reads, Executions

Each slicer:
- Respects the global time picker (1h/4h/24h/7d) and reloads on change
- Updates metric + chart when the grid sort column changes (total vs avg)
- Snaps to hourly bucket boundaries for accurate filtering
- Supports Local/UTC/Server time display mode
- Drag handles to narrow time range, Ctrl+scroll to zoom

Also includes date column fixes from #649/#651:
- Query Stats: Last Execution + Creation Time columns added after Database
- Procedure Stats: Last Execution added, Cached Time moved from end to after Type
- Query Store: Last Execution + First Execution moved to after Plan ID

## Test plan
- [x] Build: 0 errors
- [x] All four slicers render and load data
- [x] Slider drag filters grid results
- [x] Sort column changes slicer metric label and chart
- [x] Time picker change reloads slicer
- [x] Local/UTC/Server display mode updates slicer labels
- [x] Hour-boundary snapping prevents data disappearing at bucket edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)