### PR TITLE
Skip running jobs collector when login lacks msdb access

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1204,10 +1204,15 @@
                 <Grid Margin="8">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0" Text="Currently Running SQL Agent Jobs" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,8"/>
-                    <DataGrid Grid.Row="1" x:Name="RunningJobsGrid"
+                    <TextBlock Grid.Row="1" x:Name="RunningJobsMsdbWarning"
+                               Text="Running Jobs requires msdb access. Grant the login access to msdb to enable this feature."
+                               Foreground="#FFD700" FontSize="12" Margin="0,0,0,8" Visibility="Collapsed"
+                               TextWrapping="Wrap"/>
+                    <DataGrid Grid.Row="2" x:Name="RunningJobsGrid"
                               AutoGenerateColumns="False" IsReadOnly="True"
                               HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                               CanUserSortColumns="True">

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -105,6 +105,7 @@ public partial class ServerTab : UserControl
     };
 
     public int UtcOffsetMinutes { get; }
+    private readonly bool _hasMsdbAccess;
 
     /// <summary>
     /// Raised after each data refresh with alert counts for tab badge display.
@@ -113,7 +114,7 @@ public partial class ServerTab : UserControl
     public event Action<int>? ApplyTimeRangeRequested; /* selectedIndex */
     public event Func<Task>? ManualRefreshRequested;
 
-    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialService credentialService, int utcOffsetMinutes = 0)
+    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialService credentialService, int utcOffsetMinutes = 0, bool hasMsdbAccess = true)
     {
         InitializeComponent();
 
@@ -122,6 +123,7 @@ public partial class ServerTab : UserControl
         _serverId = RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(server));
         _credentialService = credentialService;
         UtcOffsetMinutes = utcOffsetMinutes;
+        _hasMsdbAccess = hasMsdbAccess;
         ServerTimeHelper.UtcOffsetMinutes = utcOffsetMinutes;
 
         ServerNameText.Text = server.ReadOnlyIntent ? $"{server.DisplayName} (Read-Only)" : server.DisplayName;
@@ -157,6 +159,12 @@ public partial class ServerTab : UserControl
             }
         };
         _refreshTimer.Start();
+
+        /* Show warning on Running Jobs tab if login lacks msdb access */
+        if (!_hasMsdbAccess)
+        {
+            RunningJobsMsdbWarning.Visibility = System.Windows.Visibility.Visible;
+        }
 
         /* Initialize time picker ComboBoxes */
         InitializeTimeComboBoxes();

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -507,7 +507,7 @@ public partial class MainWindow : Window
         }
 
         var utcOffset = status.UtcOffsetMinutes ?? 0;
-        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialService, utcOffset);
+        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialService, utcOffset, status.HasMsdbAccess);
         var tabHeader = CreateTabHeader(server);
         var tabItem = new TabItem
         {

--- a/Lite/Models/ServerConnectionStatus.cs
+++ b/Lite/Models/ServerConnectionStatus.cs
@@ -82,6 +82,12 @@ public class ServerConnectionStatus
     public bool IsAwsRds { get; set; }
 
     /// <summary>
+    /// Whether the connected login has access to msdb.
+    /// Used for gating collectors that query msdb system tables (e.g., running jobs).
+    /// </summary>
+    public bool HasMsdbAccess { get; set; } = true;
+
+    /// <summary>
     /// The server's UTC offset in minutes, queried via DATEDIFF(MINUTE, GETUTCDATE(), GETDATE()).
     /// Used to convert UTC collection_time values to server-local time for display.
     /// </summary>

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -317,8 +317,9 @@ public partial class RemoteCollectorService
             var majorVersion = serverStatus.SqlMajorVersion;
             var engineEdition = serverStatus.SqlEngineEdition;
             var isAwsRds = serverStatus.IsAwsRds;
+            var hasMsdbAccess = serverStatus.HasMsdbAccess;
 
-            if (!IsCollectorSupported(collectorName, majorVersion, engineEdition, isAwsRds))
+            if (!IsCollectorSupported(collectorName, majorVersion, engineEdition, isAwsRds, hasMsdbAccess))
             {
                 AppLogger.Info("Collector", $"  [{server.DisplayName}] {collectorName} SKIPPED (version {majorVersion}, edition {engineEdition})");
                 return;
@@ -740,7 +741,7 @@ WHERE server_id = $3";
     /// Version 13 = SQL Server 2016, 14 = 2017, 15 = 2019, 16 = 2022, 17 = 2025.
     /// Engine edition 5 = Azure SQL DB, 8 = Azure MI.
     /// </summary>
-    private static bool IsCollectorSupported(string collectorName, int majorVersion, int engineEdition, bool isAwsRds = false)
+    private static bool IsCollectorSupported(string collectorName, int majorVersion, int engineEdition, bool isAwsRds = false, bool hasMsdbAccess = true)
     {
         bool isAzureSqlDb = engineEdition == 5;
         bool isAzureMi = engineEdition == 8;
@@ -777,6 +778,16 @@ WHERE server_id = $3";
             switch (collectorName)
             {
                 case "running_jobs":      /* msdb.dbo.syssessions not accessible */
+                    return false;
+            }
+        }
+
+        /* msdb access gate — login may not have access to msdb on any edition */
+        if (!hasMsdbAccess)
+        {
+            switch (collectorName)
+            {
+                case "running_jobs":      /* requires msdb.dbo.sysjobs, sysjobactivity, etc. */
                     return false;
             }
         }

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -347,7 +347,8 @@ public class ServerManager
                         CONVERT(integer, SERVERPROPERTY('ProductMajorVersion')) AS major_version,
                         DATEDIFF(MINUTE, GETUTCDATE(), GETDATE()) AS utc_offset_minutes,
                         CONVERT(integer, SERVERPROPERTY('EngineEdition')) AS engine_edition,
-                        CASE WHEN DB_ID('rdsadmin') IS NOT NULL THEN 1 ELSE 0 END AS is_aws_rds
+                        CASE WHEN DB_ID('rdsadmin') IS NOT NULL THEN 1 ELSE 0 END AS is_aws_rds,
+                        HAS_DBACCESS(N'msdb') AS has_msdb_access
                     FROM sys.dm_os_sys_info", connection);
                 command.CommandTimeout = ConnectionCheckTimeoutSeconds;
 
@@ -366,6 +367,8 @@ public class ServerManager
                         status.SqlEngineEdition = Convert.ToInt32(reader.GetValue(4));
                     if (!reader.IsDBNull(5))
                         status.IsAwsRds = Convert.ToInt32(reader.GetValue(5)) == 1;
+                    if (!reader.IsDBNull(6))
+                        status.HasMsdbAccess = Convert.ToInt32(reader.GetValue(6)) == 1;
                 }
             }
             catch (SqlException metaEx)


### PR DESCRIPTION
Closes #656

## Summary
- Add `HAS_DBACCESS('msdb')` check to the connectivity probe so we detect msdb permissions at connect time
- Gate the `running_jobs` collector via `IsCollectorSupported()` — collector is silently skipped instead of failing
- Show a yellow warning message on the Running Jobs tab: "Running Jobs requires msdb access. Grant the login access to msdb to enable this feature."

## Changes
- `ServerConnectionStatus.HasMsdbAccess` — new property, defaults to `true`
- `ServerManager.cs` — connectivity probe query adds `HAS_DBACCESS(N'msdb')` column
- `RemoteCollectorService.cs` — `IsCollectorSupported()` gates `running_jobs` on `hasMsdbAccess`
- `ServerTab.xaml` / `.cs` — warning TextBlock, collapsed by default, shown when `!hasMsdbAccess`
- `MainWindow.xaml.cs` — passes `status.HasMsdbAccess` to `ServerTab` constructor

## Test plan
- [ ] Connect with sa login — Running Jobs tab works normally, no warning
- [ ] Connect with a login that lacks msdb access — warning shown, no collector errors in log
- [ ] Azure SQL DB / AWS RDS — existing gates still skip running_jobs before msdb check

🤖 Generated with [Claude Code](https://claude.com/claude-code)