### PR TITLE
Fix FinOps expensive queries error + imported parquet warnings

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -247,6 +247,28 @@ COPY (
                 }
             }
 
+            /* imported_YYYYMM_tablename (imported from previous install) */
+            if (month == null)
+            {
+                m = Regex.Match(name, @"^imported_(\d{6})_(.+)$");
+                if (m.Success)
+                {
+                    month = m.Groups[1].Value;
+                    table = m.Groups[2].Value;
+                }
+            }
+
+            /* imported_YYYYMMDD_HHMM_tablename (imported per-cycle files) */
+            if (month == null)
+            {
+                m = Regex.Match(name, @"^imported_(\d{8})_\d{4}_(.+)$");
+                if (m.Success)
+                {
+                    month = m.Groups[1].Value[..6];
+                    table = m.Groups[2].Value;
+                }
+            }
+
             /* YYYYMM_tablename (already monthly — our target format) */
             if (month == null)
             {

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1219,8 +1219,6 @@ AND   delta_worker_time > 0
 GROUP BY
     database_name,
     sql_handle,
-    statement_start_offset,
-    statement_end_offset,
     query_text
 ORDER BY SUM(delta_worker_time) DESC
 LIMIT $3";


### PR DESCRIPTION
Two Lite bugs: missing DuckDB columns in FinOps query, and archive compaction not recognizing imported_ prefix.