### PR TITLE
Fix Azure SQL DB server_id collision (#677)

### DIFF
--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -682,12 +682,22 @@ WHERE server_id = $3";
 
     /// <summary>
     /// Gets the server name used for DuckDB storage and hashing.
+    /// Appends "/DatabaseName" when set so Azure SQL DB connections to different
+    /// databases on the same logical server get distinct server_ids (#677).
     /// Appends ":RO" for ReadOnlyIntent connections so they get a
     /// different server_id than read-write connections to the same host.
     /// </summary>
     internal static string GetServerNameForStorage(ServerConnection server)
     {
-        return server.ReadOnlyIntent ? server.ServerName + ":RO" : server.ServerName;
+        var name = server.ServerName;
+
+        if (!string.IsNullOrWhiteSpace(server.DatabaseName))
+            name += "/" + server.DatabaseName;
+
+        if (server.ReadOnlyIntent)
+            name += ":RO";
+
+        return name;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #677 — Azure SQL DB connections to different databases on the same logical server shared the same server_id, causing CPU and other database-scoped DMV data to interleave.

GetServerNameForStorage() now appends /DatabaseName when set, so myserver.database.windows.net/Db1 and myserver.database.windows.net/Db2 hash to different server_ids.

Existing data under the old hash becomes orphaned (acceptable — it was mixed/incorrect anyway).

## Test plan
- Builds clean (no new warnings)
- On-prem connections without DatabaseName unaffected (empty/null check)
- ReadOnlyIntent suffix still appended correctly after database name
- MCP ServerResolver still resolves by ServerName/DisplayName (unaffected)