### PR TITLE
Fix slicer time ranges, add Blocking/Deadlock slicers (#681)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -968,11 +968,18 @@
                             </Grid>
                         </TabItem>
                         <TabItem Header="Blocked Process Reports">
-                            <DataGrid x:Name="BlockedProcessReportGrid"
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
+                            <DataGrid x:Name="BlockedProcessReportGrid" Grid.Row="1"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource BlockingRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                                      HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                      HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                                      Sorting="BlockedProcessReportGrid_Sorting">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
@@ -1065,9 +1072,16 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            </Grid>
                         </TabItem>
                         <TabItem Header="Deadlocks">
-                            <DataGrid x:Name="DeadlockGrid"
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <controls:TimeRangeSlicerControl x:Name="DeadlockSlicer" Grid.Row="0"/>
+                            <DataGrid x:Name="DeadlockGrid" Grid.Row="1"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -1149,6 +1163,7 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            </Grid>
                         </TabItem>
                     </TabControl>
                 </Grid>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -275,6 +275,8 @@ public partial class ServerTab : UserControl
         QueryStatsSlicer.RangeChanged += OnQueryStatsSlicerChanged;
         ProcStatsSlicer.RangeChanged += OnProcStatsSlicerChanged;
         QueryStoreSlicer.RangeChanged += OnQueryStoreSlicerChanged;
+        BlockingSlicer.RangeChanged += OnBlockingSlicerChanged;
+        DeadlockSlicer.RangeChanged += OnDeadlockSlicerChanged;
 
         /* Initial load is triggered by MainWindow.ConnectToServer calling RefreshData()
            after collectors finish - no Loaded handler needed */
@@ -357,6 +359,22 @@ public partial class ServerTab : UserControl
             4 => 168,
             _ => 4
         };
+    }
+
+    /// <summary>
+    /// Gets the UTC time range for slicer display, matching GetTimeRange in LocalDataService.
+    /// </summary>
+    private static (DateTime start, DateTime end) GetSlicerTimeRange(
+        int hoursBack, DateTime? fromDate, DateTime? toDate)
+    {
+        if (fromDate.HasValue && toDate.HasValue)
+        {
+            var startUtc = fromDate.Value.AddMinutes(-ServerTimeHelper.UtcOffsetMinutes);
+            var endUtc = toDate.Value.AddMinutes(-ServerTimeHelper.UtcOffsetMinutes);
+            return (startUtc, endUtc);
+        }
+
+        return (DateTime.UtcNow.AddHours(-hoursBack), DateTime.UtcNow);
     }
 
     /// <summary>
@@ -458,6 +476,8 @@ public partial class ServerTab : UserControl
         QueryStatsSlicer.Redraw();
         ProcStatsSlicer.Redraw();
         QueryStoreSlicer.Redraw();
+        BlockingSlicer.Redraw();
+        DeadlockSlicer.Redraw();
     }
 
     private async void TimeRangeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1084,10 +1104,12 @@ public partial class ServerTab : UserControl
                     case 2: // Blocked Process Reports
                         var bpr = await _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate);
                         _blockedProcessFilterMgr!.UpdateData(bpr);
+                        await LoadBlockingSlicerAsync();
                         break;
                     case 3: // Deadlocks
                         var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate);
                         _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(dlr));
+                        await LoadDeadlockSlicerAsync();
                         break;
                 }
                 /* Always keep alert badge current when Blocking tab is visible */
@@ -1118,6 +1140,9 @@ public partial class ServerTab : UserControl
             UpdateCurrentWaitsDurationChart(currentWaitsDurationTask.Result, hoursBack, fromDate, toDate);
             UpdateCurrentWaitsBlockedChart(currentWaitsBlockedTask.Result, hoursBack, fromDate, toDate);
 
+            await LoadBlockingSlicerAsync();
+            await LoadDeadlockSlicerAsync();
+
             /* Notify parent of alert counts for tab badge */
             var blockingCount = blockedProcessTask.Result.Count;
             var deadlockCount = deadlockTask.Result.Count;
@@ -1133,6 +1158,143 @@ public partial class ServerTab : UserControl
         catch (Exception ex)
         {
             AppLogger.Info("ServerTab", $"[{_server.DisplayName}] RefreshBlockingAsync failed: {ex.Message}");
+        }
+    }
+
+    // ── Blocking Slicer ──
+
+    private string _blockingSlicerMetric = "Events";
+    private List<Models.TimeSliceBucket>? _blockingSlicerData;
+
+    private async System.Threading.Tasks.Task LoadBlockingSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetBlockingSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _blockingSlicerData = data;
+            _blockingSlicerMetric = "Events";
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
+            if (data.Count > 0)
+                BlockingSlicer.LoadData(data, "Blocking Events", slicerStart, slicerEnd);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadBlockingSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void OnBlockingSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+
+            var bpr = await _dataService.GetRecentBlockedProcessReportsAsync(_serverId, 0, fromServer, toServer);
+            _blockedProcessFilterMgr!.UpdateData(bpr);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnBlockingSlicerChanged failed: {ex.Message}");
+        }
+    }
+
+    private void BlockedProcessReportGrid_Sorting(object sender, DataGridSortingEventArgs e)
+    {
+        if (_blockingSlicerData == null || _blockingSlicerData.Count == 0) return;
+
+        var col = e.Column.SortMemberPath ?? "";
+        if (string.IsNullOrEmpty(col))
+        {
+            if (e.Column is DataGridBoundColumn bc && bc.Binding is System.Windows.Data.Binding b)
+                col = b.Path.Path;
+        }
+        var (metric, label) = col switch
+        {
+            "WaitTimeMs" => ("TotalCpu", "Total Wait (sec)"),
+            "BlockingSpid" => ("TotalElapsed", "Distinct Blockers"),
+            "BlockedSpid" => ("TotalReads", "Distinct Blocked"),
+            "DatabaseName" => ("TotalLogicalReads", "Distinct Databases"),
+            _ => ("Events", "Blocking Events"),
+        };
+
+        if (metric == _blockingSlicerMetric) return;
+        _blockingSlicerMetric = metric;
+
+        foreach (var bucket in _blockingSlicerData)
+        {
+            bucket.Value = metric switch
+            {
+                "TotalCpu" => bucket.TotalCpu,
+                "TotalElapsed" => bucket.TotalElapsed,
+                "TotalReads" => bucket.TotalReads,
+                "TotalLogicalReads" => bucket.TotalLogicalReads,
+                _ => bucket.SessionCount,
+            };
+        }
+
+        BlockingSlicer.UpdateMetric(label);
+    }
+
+    // ── Deadlock Slicer ──
+
+    private List<Models.TimeSliceBucket>? _deadlockSlicerData;
+
+    private async System.Threading.Tasks.Task LoadDeadlockSlicerAsync()
+    {
+        try
+        {
+            var hoursBack = GetHoursBack();
+            DateTime? fromDate = null, toDate = null;
+            if (IsCustomRange)
+            {
+                var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromLocal.HasValue && toLocal.HasValue)
+                {
+                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
+                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                }
+            }
+
+            var data = await _dataService.GetDeadlockSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            _deadlockSlicerData = data;
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
+            if (data.Count > 0)
+                DeadlockSlicer.LoadData(data, "Deadlocks", slicerStart, slicerEnd);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadDeadlockSlicerAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void OnDeadlockSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+    {
+        try
+        {
+            var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
+            var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
+
+            var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromServer, toServer);
+            _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(dlr));
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] OnDeadlockSlicerChanged failed: {ex.Message}");
         }
     }
 
@@ -3712,8 +3874,9 @@ public partial class ServerTab : UserControl
             var data = await _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
             _activeQueriesSlicerData = data;
             _activeQueriesSlicerMetric = "Sessions";
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
             if (data.Count > 0)
-                ActiveQueriesSlicer.LoadData(data, "Sessions");
+                ActiveQueriesSlicer.LoadData(data, "Sessions", slicerStart, slicerEnd);
         }
         catch (Exception ex)
         {
@@ -3807,8 +3970,9 @@ public partial class ServerTab : UserControl
             var data = await _dataService.GetQueryStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
             _queryStatsSlicerData = data;
             _queryStatsSlicerMetric = "TotalCpu";
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
             if (data.Count > 0)
-                QueryStatsSlicer.LoadData(data, "Total CPU (ms)");
+                QueryStatsSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
         }
         catch (Exception ex)
         {
@@ -3900,8 +4064,9 @@ public partial class ServerTab : UserControl
             var data = await _dataService.GetQueryStoreSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
             _queryStoreSlicerData = data;
             _queryStoreSlicerMetric = "TotalCpu";
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
             if (data.Count > 0)
-                QueryStoreSlicer.LoadData(data, "Total CPU (ms)");
+                QueryStoreSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
         }
         catch (Exception ex)
         {
@@ -3992,8 +4157,9 @@ public partial class ServerTab : UserControl
             var data = await _dataService.GetProcStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
             _procStatsSlicerData = data;
             _procStatsSlicerMetric = "TotalCpu";
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
             if (data.Count > 0)
-                ProcStatsSlicer.LoadData(data, "Total CPU (ms)");
+                ProcStatsSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
         }
         catch (Exception ex)
         {

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -14,6 +14,8 @@ namespace PerformanceMonitorLite.Controls;
 public partial class TimeRangeSlicerControl : UserControl
 {
     private List<TimeSliceBucket> _data = new();
+    private DateTime? _requestedStartUtc;
+    private DateTime? _requestedEndUtc;
     private string _metricLabel = "Sessions";
     private bool _isExpanded = true;
 
@@ -59,9 +61,12 @@ public partial class TimeRangeSlicerControl : UserControl
 
     /// <summary>
     /// Loads slicer data. All timestamps must be UTC.
+    /// requestedStartUtc/requestedEndUtc define the full time window so the slicer
+    /// shows the correct span even when data is sparse. Empty hours get zero-value buckets.
     /// Selection defaults to the full range (no filtering until user interacts).
     /// </summary>
-    public void LoadData(List<TimeSliceBucket> data, string metricLabel)
+    public void LoadData(List<TimeSliceBucket> data, string metricLabel,
+        DateTime? requestedStartUtc = null, DateTime? requestedEndUtc = null)
     {
         // Preserve selection if we already have data (auto-refresh)
         DateTime? prevStart = null, prevEnd = null;
@@ -71,7 +76,9 @@ public partial class TimeRangeSlicerControl : UserControl
             prevEnd = UtcAtNorm(_rangeEnd);
         }
 
-        _data = data;
+        _requestedStartUtc = requestedStartUtc;
+        _requestedEndUtc = requestedEndUtc;
+        _data = FillEmptyBuckets(data, requestedStartUtc, requestedEndUtc);
         _metricLabel = metricLabel;
 
         if (prevStart.HasValue && prevEnd.HasValue && _data.Count >= 2)
@@ -101,8 +108,38 @@ public partial class TimeRangeSlicerControl : UserControl
 
     // ── Time mapping ──
 
-    private DateTime DataStartUtc => _data[0].BucketTimeUtc;
-    private DateTime DataEndUtc => _data[^1].BucketTimeUtc.AddHours(1);
+    private DateTime DataStartUtc => _requestedStartUtc ?? _data[0].BucketTimeUtc;
+    private DateTime DataEndUtc => _requestedEndUtc ?? _data[^1].BucketTimeUtc.AddHours(1);
+
+    /// <summary>
+    /// Fills in zero-value buckets for hours with no data so the slicer
+    /// spans the full requested time range.
+    /// </summary>
+    private static List<TimeSliceBucket> FillEmptyBuckets(
+        List<TimeSliceBucket> data, DateTime? requestedStart, DateTime? requestedEnd)
+    {
+        if (data.Count == 0 || !requestedStart.HasValue || !requestedEnd.HasValue)
+            return data;
+
+        var floorStart = FloorToHour(requestedStart.Value);
+        // Floor the end too — we don't want a bucket for the current partial hour extending into the future
+        var floorEnd = FloorToHour(requestedEnd.Value);
+
+        var existing = new Dictionary<long, TimeSliceBucket>();
+        foreach (var b in data)
+            existing[FloorToHour(b.BucketTimeUtc).Ticks] = b;
+
+        var result = new List<TimeSliceBucket>();
+        for (var t = floorStart; t <= floorEnd; t = t.AddHours(1))
+        {
+            if (existing.TryGetValue(t.Ticks, out var bucket))
+                result.Add(bucket);
+            else
+                result.Add(new TimeSliceBucket { BucketTimeUtc = t });
+        }
+
+        return result;
+    }
 
     private DateTime UtcAtNorm(double norm)
     {
@@ -122,7 +159,7 @@ public partial class TimeRangeSlicerControl : UserControl
     public void Redraw()
     {
         SlicerCanvas.Children.Clear();
-        if (_data.Count < 2) return;
+        if (_data.Count < 1) return;
 
         var w = SlicerBorder.ActualWidth;
         var h = SlicerBorder.ActualHeight;

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -417,6 +417,96 @@ LIMIT 200";
     }
 
     /// <summary>
+    /// Gets hourly-bucketed metrics from blocked process reports for the time-range slicer.
+    /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetBlockingSlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(*) AS event_count,
+    COALESCE(SUM(wait_time_ms), 0) / 1000.0 AS total_wait_sec,
+    COUNT(DISTINCT blocking_spid) AS distinct_blockers,
+    COUNT(DISTINCT blocked_spid) AS distinct_blocked,
+    COUNT(DISTINCT database_name) AS distinct_databases
+FROM v_blocked_process_reports
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var eventCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1));
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = eventCount,
+                TotalCpu = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)),
+                TotalElapsed = reader.IsDBNull(3) ? 0 : ToDouble(reader.GetValue(3)),
+                TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalLogicalReads = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                Value = eventCount,
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Gets hourly-bucketed metrics from deadlocks for the time-range slicer.
+    /// </summary>
+    public async Task<List<Models.TimeSliceBucket>> GetDeadlockSlicerDataAsync(
+        int serverId, int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
+        command.CommandText = @"
+SELECT
+    date_trunc('hour', collection_time) AS bucket,
+    COUNT(*) AS deadlock_count
+FROM v_deadlocks
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+GROUP BY date_trunc('hour', collection_time)
+ORDER BY bucket";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+        var items = new List<Models.TimeSliceBucket>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var count = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1));
+            items.Add(new Models.TimeSliceBucket
+            {
+                BucketTimeUtc = reader.GetDateTime(0),
+                SessionCount = count,
+                Value = count,
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
     /// Gets blocking incident trend (count of distinct blocking events per time bucket).
     /// Uses blocked_process_reports from Extended Events for more reliable detection.
     /// Falls back to blocking_snapshots if no XE data available.


### PR DESCRIPTION
Fixes #681 — slicer time ranges were derived from data buckets instead of the requested window, causing sparse tabs to show 1h and dense tabs to show an extra future hour.

Changes:
- Pass requested UTC time range to LoadData, fill empty hourly buckets for the full window
- Use requested range for DataStartUtc/DataEndUtc instead of bucket positions
- Add time-range slicers to Blocked Process Reports and Deadlocks sub-tabs
- Single-bucket rendering support (count < 1 guard)

All 6 slicers now use the same consistent pattern.