### PR TITLE
Dashboard: fix slicer time ranges, add Blocking/Deadlock/Default Trace slicers (#681)

### DIFF
--- a/Dashboard/Controls/DefaultTraceContent.xaml
+++ b/Dashboard/Controls/DefaultTraceContent.xaml
@@ -5,14 +5,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
+             xmlns:local="clr-namespace:PerformanceMonitorDashboard.Controls"
              Loaded="OnLoaded">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10" Background="{DynamicResource BackgroundLightBrush}">
+        <local:TimeRangeSlicerControl x:Name="DefaultTraceSlicer" Grid.Row="0"/>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="10" Background="{DynamicResource BackgroundLightBrush}">
             <TextBlock Text="Event Filter:" VerticalAlignment="Center" Margin="5,0" FontWeight="Bold"/>
             <ComboBox x:Name="DefaultTraceEventsFilterCombo" Width="200" Margin="2,0" SelectionChanged="DefaultTraceEventsFilter_Changed">
                 <ComboBoxItem Content="All Events" Tag="" IsSelected="True"/>
@@ -29,7 +33,7 @@
             <Button Content="Refresh" Click="DefaultTraceEvents_Refresh_Click" Margin="5,0" Padding="10,4" Style="{DynamicResource SuccessButton}"/>
         </StackPanel>
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="2">
             <DataGrid x:Name="DefaultTraceEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True" ContextMenu="{DynamicResource DataGridContextMenu}"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">

--- a/Dashboard/Controls/DefaultTraceContent.xaml.cs
+++ b/Dashboard/Controls/DefaultTraceContent.xaml.cs
@@ -43,6 +43,7 @@ namespace PerformanceMonitorDashboard.Controls
         public void Initialize(DatabaseService databaseService)
         {
             _databaseService = databaseService;
+            DefaultTraceSlicer.RangeChanged += OnDefaultTraceSlicerChanged;
         }
 
         public void SetTimeRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
@@ -104,11 +105,43 @@ namespace PerformanceMonitorDashboard.Controls
                 DefaultTraceEventsDataGrid.ItemsSource = data;
                 DefaultTraceEventsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 UpdateFilterButtonStyles(DefaultTraceEventsDataGrid, _defaultTraceFilters);
+                _ = LoadDefaultTraceSlicerAsync();
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error loading default trace events: {ex.Message}");
             }
+        }
+
+        private async Task LoadDefaultTraceSlicerAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetDefaultTraceSlicerDataAsync(
+                    _defaultTraceEventsHoursBack, _defaultTraceEventsFromDate, _defaultTraceEventsToDate);
+                var serverNow = Helpers.ServerTimeHelper.ServerNow;
+                var start = _defaultTraceEventsFromDate ?? serverNow.AddHours(-_defaultTraceEventsHoursBack);
+                var end = _defaultTraceEventsToDate ?? serverNow;
+                if (data.Count > 0)
+                    DefaultTraceSlicer.LoadData(data, "Events", start, end);
+            }
+            catch { }
+        }
+
+        private async void OnDefaultTraceSlicerChanged(object? sender, SlicerRangeEventArgs e)
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetDefaultTraceEventsAsync(0, e.Start, e.End, _defaultTraceEventsFilter);
+                _defaultTraceUnfilteredData = data;
+                _defaultTraceFilters.Clear();
+                DefaultTraceEventsDataGrid.ItemsSource = data;
+                DefaultTraceEventsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                UpdateFilterButtonStyles(DefaultTraceEventsDataGrid, _defaultTraceFilters);
+            }
+            catch { }
         }
 
         #endregion

--- a/Dashboard/Controls/DefaultTraceContent.xaml.cs
+++ b/Dashboard/Controls/DefaultTraceContent.xaml.cs
@@ -46,6 +46,12 @@ namespace PerformanceMonitorDashboard.Controls
             DefaultTraceSlicer.RangeChanged += OnDefaultTraceSlicerChanged;
         }
 
+        public void RefreshTimeDisplay()
+        {
+            DefaultTraceEventsDataGrid.Items.Refresh();
+            DefaultTraceSlicer.Redraw();
+        }
+
         public void SetTimeRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
         {
             _defaultTraceEventsHoursBack = hoursBack;

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -38,6 +38,15 @@ namespace PerformanceMonitorDashboard.Controls
         private DatabaseService? _databaseService;
         private Action<string>? _statusCallback;
 
+        private static (DateTime start, DateTime end) GetSlicerTimeRange(
+            int hoursBack, DateTime? fromDate, DateTime? toDate)
+        {
+            if (fromDate.HasValue && toDate.HasValue)
+                return (fromDate.Value, toDate.Value);
+            var serverNow = Helpers.ServerTimeHelper.ServerNow;
+            return (serverNow.AddHours(-hoursBack), serverNow);
+        }
+
         /// <summary>Raised when user wants to view a plan in the Plan Viewer tab. Args: (planXml, label, queryText)</summary>
         public event Action<string, string, string?>? ViewPlanRequested;
 
@@ -240,8 +249,9 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 var data = await _databaseService.GetActiveQuerySlicerDataAsync(
                     _activeQueriesHoursBack, _activeQueriesFromDate, _activeQueriesToDate);
+                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_activeQueriesHoursBack, _activeQueriesFromDate, _activeQueriesToDate);
                 if (data.Count > 0)
-                    ActiveQueriesSlicer.LoadData(data, "Sessions");
+                    ActiveQueriesSlicer.LoadData(data, "Sessions", slicerStart, slicerEnd);
             }
             catch { }
         }
@@ -274,8 +284,9 @@ namespace PerformanceMonitorDashboard.Controls
                     _queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate);
                 _queryStatsSlicerData = data;
                 _queryStatsSlicerMetric = "TotalCpu";
+                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate);
                 if (data.Count > 0)
-                    QueryStatsSlicer.LoadData(data, "Total CPU (ms)");
+                    QueryStatsSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
             }
             catch { }
         }
@@ -348,8 +359,9 @@ namespace PerformanceMonitorDashboard.Controls
                     _procStatsHoursBack, _procStatsFromDate, _procStatsToDate);
                 _procStatsSlicerData = data;
                 _procStatsSlicerMetric = "TotalCpu";
+                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_procStatsHoursBack, _procStatsFromDate, _procStatsToDate);
                 if (data.Count > 0)
-                    ProcStatsSlicer.LoadData(data, "Total CPU (ms)");
+                    ProcStatsSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
             }
             catch { }
         }
@@ -422,8 +434,9 @@ namespace PerformanceMonitorDashboard.Controls
                     _queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate);
                 _queryStoreSlicerData = data;
                 _queryStoreSlicerMetric = "TotalCpu";
+                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate);
                 if (data.Count > 0)
-                    QueryStoreSlicer.LoadData(data, "Total CPU (ms)");
+                    QueryStoreSlicer.LoadData(data, "Total CPU (ms)", slicerStart, slicerEnd);
             }
             catch { }
         }

--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
@@ -18,6 +18,8 @@ namespace PerformanceMonitorDashboard.Controls;
 public partial class TimeRangeSlicerControl : UserControl
 {
     private List<TimeSliceBucket> _data = new();
+    private DateTime? _requestedStart;
+    private DateTime? _requestedEnd;
     private string _metricLabel = "Sessions";
     private bool _isExpanded = true;
 
@@ -60,7 +62,8 @@ public partial class TimeRangeSlicerControl : UserControl
         }
     }
 
-    public void LoadData(List<TimeSliceBucket> data, string metricLabel)
+    public void LoadData(List<TimeSliceBucket> data, string metricLabel,
+        DateTime? requestedStart = null, DateTime? requestedEnd = null)
     {
         // Preserve selection if we already have data (auto-refresh)
         DateTime? prevStart = null, prevEnd = null;
@@ -70,7 +73,9 @@ public partial class TimeRangeSlicerControl : UserControl
             prevEnd = TimeAtNorm(_rangeEnd);
         }
 
-        _data = data;
+        _requestedStart = requestedStart;
+        _requestedEnd = requestedEnd;
+        _data = FillEmptyBuckets(data, requestedStart, requestedEnd);
         _metricLabel = metricLabel;
 
         if (prevStart.HasValue && prevEnd.HasValue && _data.Count >= 2)
@@ -98,8 +103,33 @@ public partial class TimeRangeSlicerControl : UserControl
     public DateTime? SelectionEnd => _data.Count > 0 ? TimeAtNorm(_rangeEnd) : null;
     public bool HasNarrowedSelection => _data.Count > 0 && (_rangeStart > 0.01 || _rangeEnd < 0.99);
 
-    private DateTime DataStart => _data[0].BucketTime;
-    private DateTime DataEnd => _data[^1].BucketTime.AddHours(1);
+    private DateTime DataStart => _requestedStart ?? _data[0].BucketTime;
+    private DateTime DataEnd => _requestedEnd ?? _data[^1].BucketTime.AddHours(1);
+
+    private static List<TimeSliceBucket> FillEmptyBuckets(
+        List<TimeSliceBucket> data, DateTime? requestedStart, DateTime? requestedEnd)
+    {
+        if (data.Count == 0 || !requestedStart.HasValue || !requestedEnd.HasValue)
+            return data;
+
+        var floorStart = FloorToHour(requestedStart.Value);
+        var floorEnd = FloorToHour(requestedEnd.Value);
+
+        var existing = new Dictionary<long, TimeSliceBucket>();
+        foreach (var b in data)
+            existing[FloorToHour(b.BucketTime).Ticks] = b;
+
+        var result = new List<TimeSliceBucket>();
+        for (var t = floorStart; t <= floorEnd; t = t.AddHours(1))
+        {
+            if (existing.TryGetValue(t.Ticks, out var bucket))
+                result.Add(bucket);
+            else
+                result.Add(new TimeSliceBucket { BucketTime = t });
+        }
+
+        return result;
+    }
 
     private DateTime TimeAtNorm(double norm)
     {
@@ -119,7 +149,7 @@ public partial class TimeRangeSlicerControl : UserControl
     public void Redraw()
     {
         SlicerCanvas.Children.Clear();
-        if (_data.Count < 2) return;
+        if (_data.Count < 1) return;
 
         var w = SlicerBorder.ActualWidth;
         var h = SlicerBorder.ActualHeight;

--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
@@ -148,6 +148,7 @@ public partial class TimeRangeSlicerControl : UserControl
 
     public void Redraw()
     {
+        UpdateRangeLabel();
         SlicerCanvas.Children.Clear();
         if (_data.Count < 1) return;
 

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -152,8 +152,9 @@ namespace PerformanceMonitorDashboard
             var startupPrefs = _preferencesService.GetPreferences();
             TabHelpers.CsvSeparator = startupPrefs.CsvSeparator;
             MuteRuleDialog.DefaultExpiration = startupPrefs.MuteRuleDefaultExpiration;
-            if (Enum.TryParse<Helpers.TimeDisplayMode>(startupPrefs.TimeDisplayMode, out var tdm))
-                Helpers.ServerTimeHelper.CurrentDisplayMode = tdm;
+            // Charts always render in server time; force the dropdown to match on startup
+            // so the display isn't misleading. The preference is still saved when changed.
+            Helpers.ServerTimeHelper.CurrentDisplayMode = Helpers.TimeDisplayMode.ServerTime;
 
             await LoadServerListAsync();
             InitializeNotificationService();

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -602,7 +602,12 @@
                     <!-- Blocking Sub-Tab -->
                     <TabItem Header="Blocking">
                         <Grid>
-                        <DataGrid x:Name="BlockingEventsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
+                        <DataGrid x:Name="BlockingEventsDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True"
                                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -784,14 +789,19 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                        <TextBlock x:Name="BlockingEventsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+                        <TextBlock x:Name="BlockingEventsNoDataMessage" Grid.Row="1" Style="{StaticResource NoDataMessage}"/>
                         </Grid>
                     </TabItem>
 
                     <!-- Deadlocks Sub-Tab -->
                     <TabItem Header="Deadlocks">
                         <Grid>
-                        <DataGrid x:Name="DeadlocksDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <controls:TimeRangeSlicerControl x:Name="DeadlockSlicer" Grid.Row="0"/>
+                        <DataGrid x:Name="DeadlocksDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True"
                                       RowHeight="28" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource DefaultRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -984,7 +994,7 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                        <TextBlock x:Name="DeadlocksNoDataMessage" Style="{StaticResource NoDataMessage}"/>
+                        <TextBlock x:Name="DeadlocksNoDataMessage" Grid.Row="1" Style="{StaticResource NoDataMessage}"/>
                         </Grid>
                     </TabItem>
 

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -120,6 +120,9 @@ namespace PerformanceMonitorDashboard
             SetupAutoRefresh();
             SetupSubTabContextMenus();
 
+            BlockingSlicer.RangeChanged += OnBlockingSlicerChanged;
+            DeadlockSlicer.RangeChanged += OnDeadlockSlicerChanged;
+
             Loaded += ServerTab_Loaded;
             Unloaded += ServerTab_Unloaded;
             KeyDown += ServerTab_KeyDown;
@@ -1324,6 +1327,9 @@ namespace PerformanceMonitorDashboard
                     Logger.Warning($"Could not load deadlocks: {deadlockEx.Message}");
                 }
 
+                _ = LoadBlockingSlicerAsync();
+                _ = LoadDeadlockSlicerAsync();
+
                 try
                 {
                     var blockingStats = await blockingStatsTask;
@@ -1623,6 +1629,73 @@ namespace PerformanceMonitorDashboard
                 168 => "Showing: Last 7 Days",
                 _ => $"Showing: Last {hoursBack} Hours"
             };
+        }
+
+        // ── Blocking Slicer ──
+
+        private async Task LoadBlockingSlicerAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetBlockingSlicerDataAsync(
+                    _blockingHoursBack, _blockingFromDate, _blockingToDate);
+                var (start, end) = GetLockingSlicerTimeRange(_blockingHoursBack, _blockingFromDate, _blockingToDate);
+                if (data.Count > 0)
+                    BlockingSlicer.LoadData(data, "Blocking Events", start, end);
+            }
+            catch { }
+        }
+
+        private async void OnBlockingSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetBlockingEventsAsync(0, e.Start, e.End);
+                BlockingEventsDataGrid.ItemsSource = data;
+                UpdateDataGridFilterButtonStyles(BlockingEventsDataGrid, _blockingEventsFilters);
+                BlockingEventsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch { }
+        }
+
+        // ── Deadlock Slicer ──
+
+        private async Task LoadDeadlockSlicerAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetDeadlockSlicerDataAsync(
+                    _deadlocksHoursBack, _deadlocksFromDate, _deadlocksToDate);
+                var (start, end) = GetLockingSlicerTimeRange(_deadlocksHoursBack, _deadlocksFromDate, _deadlocksToDate);
+                if (data.Count > 0)
+                    DeadlockSlicer.LoadData(data, "Deadlocks", start, end);
+            }
+            catch { }
+        }
+
+        private async void OnDeadlockSlicerChanged(object? sender, Controls.SlicerRangeEventArgs e)
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetDeadlocksAsync(0, e.Start, e.End);
+                DeadlocksDataGrid.ItemsSource = data;
+                UpdateDataGridFilterButtonStyles(DeadlocksDataGrid, _deadlocksFilters);
+                DeadlocksNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch { }
+        }
+
+        private static (DateTime start, DateTime end) GetLockingSlicerTimeRange(
+            int hoursBack, DateTime? fromDate, DateTime? toDate)
+        {
+            if (fromDate.HasValue && toDate.HasValue)
+                return (fromDate.Value, toDate.Value);
+            var serverNow = Helpers.ServerTimeHelper.ServerNow;
+            return (serverNow.AddHours(-hoursBack), serverNow);
         }
 
         // Blocking date range filtering state

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1442,6 +1442,15 @@ namespace PerformanceMonitorDashboard
         {
             // Force WPF to re-evaluate converter bindings on all query performance grids
             PerformanceTab.RefreshGridBindings();
+
+            // Refresh blocking/deadlock grids and slicers in Locking tab
+            BlockingEventsDataGrid.Items.Refresh();
+            DeadlocksDataGrid.Items.Refresh();
+            BlockingSlicer.Redraw();
+            DeadlockSlicer.Redraw();
+
+            // Refresh Default Trace slicer
+            DefaultTraceTab.RefreshTimeDisplay();
         }
 
         private void DownloadQueryPlan_Click(object sender, RoutedEventArgs e)

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -505,6 +505,96 @@ namespace PerformanceMonitorDashboard.Services
                     return items;
                 }
 
+                public async Task<List<Models.TimeSliceBucket>> GetBlockingSlicerDataAsync(
+                    int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+                {
+                    var items = new List<Models.TimeSliceBucket>();
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    var timeFilter = fromDate.HasValue && toDate.HasValue
+                        ? "WHERE b.collection_time >= @from_date AND b.collection_time <= @to_date"
+                        : "WHERE b.collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
+
+                    string query = $@"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    DATEADD(HOUR, DATEDIFF(HOUR, 0, b.collection_time), 0) AS bucket_hour,
+    COUNT(*) AS event_count,
+    ISNULL(SUM(b.wait_time_ms), 0) / 1000.0 AS total_wait_sec,
+    COUNT(DISTINCT b.spid) AS distinct_blocked,
+    COUNT(DISTINCT b.database_name) AS distinct_databases
+FROM collect.blocking_BlockedProcessReport AS b
+{timeFilter}
+GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, b.collection_time), 0)
+ORDER BY bucket_hour;";
+
+                    using var command = new SqlCommand(query, connection) { CommandTimeout = 120 };
+                    command.Parameters.Add(new SqlParameter("@hours_back", SqlDbType.Int) { Value = hoursBack });
+                    if (fromDate.HasValue) command.Parameters.Add(new SqlParameter("@from_date", SqlDbType.DateTime2) { Value = fromDate.Value });
+                    if (toDate.HasValue) command.Parameters.Add(new SqlParameter("@to_date", SqlDbType.DateTime2) { Value = toDate.Value });
+
+                    using var reader = await command.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                        var eventCount = Convert.ToInt64(reader.GetValue(1));
+                        items.Add(new Models.TimeSliceBucket
+                        {
+                            BucketTime = reader.GetDateTime(0),
+                            SessionCount = eventCount,
+                            TotalCpu = Convert.ToDouble(reader.GetValue(2)),
+                            TotalReads = Convert.ToDouble(reader.GetValue(3)),
+                            TotalLogicalReads = Convert.ToDouble(reader.GetValue(4)),
+                            Value = eventCount,
+                        });
+                    }
+
+                    return items;
+                }
+
+                public async Task<List<Models.TimeSliceBucket>> GetDeadlockSlicerDataAsync(
+                    int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+                {
+                    var items = new List<Models.TimeSliceBucket>();
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    var timeFilter = fromDate.HasValue && toDate.HasValue
+                        ? "WHERE d.event_date >= @from_date AND d.event_date <= @to_date"
+                        : "WHERE d.event_date >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
+
+                    string query = $@"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    DATEADD(HOUR, DATEDIFF(HOUR, 0, d.event_date), 0) AS bucket_hour,
+    COUNT(*) AS deadlock_count
+FROM collect.deadlocks AS d
+{timeFilter}
+GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, d.event_date), 0)
+ORDER BY bucket_hour;";
+
+                    using var command = new SqlCommand(query, connection) { CommandTimeout = 120 };
+                    command.Parameters.Add(new SqlParameter("@hours_back", SqlDbType.Int) { Value = hoursBack });
+                    if (fromDate.HasValue) command.Parameters.Add(new SqlParameter("@from_date", SqlDbType.DateTime2) { Value = fromDate.Value });
+                    if (toDate.HasValue) command.Parameters.Add(new SqlParameter("@to_date", SqlDbType.DateTime2) { Value = toDate.Value });
+
+                    using var reader = await command.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                        var count = Convert.ToInt64(reader.GetValue(1));
+                        items.Add(new Models.TimeSliceBucket
+                        {
+                            BucketTime = reader.GetDateTime(0),
+                            SessionCount = count,
+                            Value = count,
+                        });
+                    }
+
+                    return items;
+                }
+
                 public async Task<List<Models.TimeSliceBucket>> GetActiveQuerySlicerDataAsync(
                     int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
                 {

--- a/Dashboard/Services/DatabaseService.SystemEvents.cs
+++ b/Dashboard/Services/DatabaseService.SystemEvents.cs
@@ -127,6 +127,52 @@ namespace PerformanceMonitorDashboard.Services
                     return items;
                 }
 
+                public async Task<List<Models.TimeSliceBucket>> GetDefaultTraceSlicerDataAsync(
+                    int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
+                {
+                    var items = new List<Models.TimeSliceBucket>();
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    var timeFilter = fromDate.HasValue && toDate.HasValue
+                        ? "WHERE dte.event_time >= @fromDate AND dte.event_time <= @toDate"
+                        : "WHERE dte.event_time >= DATEADD(HOUR, -@hoursBack, SYSDATETIME())";
+
+                    string query = $@"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    DATEADD(HOUR, DATEDIFF(HOUR, 0, dte.event_time), 0) AS bucket_hour,
+    COUNT(*) AS event_count,
+    COUNT(DISTINCT dte.event_name) AS distinct_events,
+    COUNT(DISTINCT dte.database_name) AS distinct_databases
+FROM collect.default_trace_events AS dte
+{timeFilter}
+GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, dte.event_time), 0)
+ORDER BY bucket_hour;";
+
+                    using var command = new SqlCommand(query, connection) { CommandTimeout = 120 };
+                    command.Parameters.Add(new SqlParameter("@hoursBack", SqlDbType.Int) { Value = hoursBack });
+                    if (fromDate.HasValue) command.Parameters.Add(new SqlParameter("@fromDate", SqlDbType.DateTime2) { Value = fromDate.Value });
+                    if (toDate.HasValue) command.Parameters.Add(new SqlParameter("@toDate", SqlDbType.DateTime2) { Value = toDate.Value });
+
+                    using var reader = await command.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                        var count = Convert.ToInt64(reader.GetValue(1));
+                        items.Add(new Models.TimeSliceBucket
+                        {
+                            BucketTime = reader.GetDateTime(0),
+                            SessionCount = count,
+                            TotalCpu = Convert.ToDouble(reader.GetValue(2)),
+                            TotalLogicalReads = Convert.ToDouble(reader.GetValue(3)),
+                            Value = count,
+                        });
+                    }
+
+                    return items;
+                }
+
                 public async Task<List<TraceAnalysisItem>> GetTraceAnalysisAsync(int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
                 {
                     var items = new List<TraceAnalysisItem>();


### PR DESCRIPTION
Ports the Lite slicer time range fix (PR #697) to Dashboard, plus adds 3 new slicers.

Fixes:
- Same extra-future-hour and sparse-data-shows-1h bugs as Lite
- FillEmptyBuckets + requestedStart/requestedEnd in Dashboard slicer control
- All 4 existing slicer LoadData calls updated with time range

New slicers:
- Blocking events (Locking > Blocking)
- Deadlocks (Locking > Deadlocks)
- Default Trace events (Default Trace tab — Dashboard-only, not in Lite)

Tested: builds clean, 0 new warnings.