### PR TITLE
Lite: grid-to-slicer overlay for query/procedure/Query Store (#683)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -342,6 +342,7 @@
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      SelectionChanged="QueryStatsGrid_SelectionChanged"
                                       Sorting="QueryStatsGrid_Sorting"
                                       MouseDoubleClick="QueryStatsGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
@@ -475,6 +476,7 @@
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      SelectionChanged="ProcedureStatsGrid_SelectionChanged"
                                       Sorting="ProcedureStatsGrid_Sorting"
                                       MouseDoubleClick="ProcedureStatsGrid_MouseDoubleClick">
                                 <DataGrid.Columns>
@@ -587,6 +589,7 @@
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       CanUserSortColumns="True"
+                                      SelectionChanged="QueryStoreGrid_SelectionChanged"
                                       Sorting="QueryStoreGrid_Sorting"
                                       MouseDoubleClick="QueryStoreGrid_MouseDoubleClick">
                                 <DataGrid.Columns>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -2312,6 +2312,147 @@ public partial class ServerTab : UserControl
         QueryStoreDurationTrendChart.Refresh();
     }
 
+    // ── Grid → Slicer Overlay (#683) ──
+
+    private (DateTime? fromDate, DateTime? toDate) GetCurrentViewDates()
+    {
+        if (IsCustomRange)
+        {
+            var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+            var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+            if (fromLocal.HasValue && toLocal.HasValue)
+                return (ServerTimeHelper.LocalToServerTime(fromLocal.Value),
+                        ServerTimeHelper.LocalToServerTime(toLocal.Value));
+        }
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Computes per-interval deltas from cumulative history values.
+    /// Picks the metric field based on the current slicer sort metric.
+    /// </summary>
+    private static List<(DateTime TimeUtc, double Value)> ComputeQueryOverlayPoints(
+        List<QueryStatsHistoryRow> history, string slicerMetric)
+    {
+        Func<QueryStatsHistoryRow, long> selector = slicerMetric switch
+        {
+            "TotalCpu" or "AvgCpu" => h => h.DeltaCpuUs,
+            "TotalReads" or "AvgReads" => h => h.DeltaLogicalReads,
+            "TotalWrites" => h => h.DeltaLogicalWrites,
+            "TotalPhysReads" => h => h.DeltaPhysicalReads,
+            _ => h => h.DeltaElapsedUs, // TotalElapsed, AvgElapsed, default
+        };
+        bool isMicroseconds = slicerMetric is "TotalCpu" or "AvgCpu" or "TotalElapsed" or "AvgElapsed";
+
+        var points = new List<(DateTime TimeUtc, double Value)>();
+        for (int i = 1; i < history.Count; i++)
+        {
+            var delta = selector(history[i]) - selector(history[i - 1]);
+            if (delta > 0)
+                points.Add((history[i].CollectionTime, isMicroseconds ? delta / 1000.0 : delta));
+        }
+        return points;
+    }
+
+    private static List<(DateTime TimeUtc, double Value)> ComputeProcOverlayPoints(
+        List<ProcedureStatsHistoryRow> history, string slicerMetric)
+    {
+        Func<ProcedureStatsHistoryRow, long> selector = slicerMetric switch
+        {
+            "TotalCpu" or "AvgCpu" => h => h.DeltaCpuUs,
+            "TotalReads" or "AvgReads" => h => h.DeltaLogicalReads,
+            "TotalWrites" => h => h.DeltaLogicalWrites,
+            "TotalPhysReads" => h => h.DeltaPhysicalReads,
+            _ => h => h.DeltaElapsedUs,
+        };
+        bool isMicroseconds = slicerMetric is "TotalCpu" or "AvgCpu" or "TotalElapsed" or "AvgElapsed";
+
+        var points = new List<(DateTime TimeUtc, double Value)>();
+        for (int i = 1; i < history.Count; i++)
+        {
+            var delta = selector(history[i]) - selector(history[i - 1]);
+            if (delta > 0)
+                points.Add((history[i].CollectionTime, isMicroseconds ? delta / 1000.0 : delta));
+        }
+        return points;
+    }
+
+    private async void QueryStatsGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (QueryStatsGrid.SelectedItem is not QueryStatsRow row || string.IsNullOrEmpty(row.QueryHash))
+        {
+            QueryStatsSlicer.ClearOverlay();
+            return;
+        }
+
+        try
+        {
+            var hoursBack = GetHoursBack();
+            var (fromDate, toDate) = GetCurrentViewDates();
+            var history = await _dataService.GetQueryStatsHistoryAsync(_serverId, row.DatabaseName, row.QueryHash, hoursBack, fromDate, toDate);
+
+            var points = ComputeQueryOverlayPoints(history, _queryStatsSlicerMetric);
+            QueryStatsSlicer.SetOverlay(points, row.QueryHash);
+        }
+        catch { QueryStatsSlicer.ClearOverlay(); }
+    }
+
+    private async void ProcedureStatsGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ProcedureStatsGrid.SelectedItem is not ProcedureStatsRow row || string.IsNullOrEmpty(row.ObjectName))
+        {
+            ProcStatsSlicer.ClearOverlay();
+            return;
+        }
+
+        try
+        {
+            var hoursBack = GetHoursBack();
+            var (fromDate, toDate) = GetCurrentViewDates();
+            var history = await _dataService.GetProcedureStatsHistoryAsync(_serverId, row.DatabaseName, row.SchemaName, row.ObjectName, hoursBack, fromDate, toDate);
+
+            var points = ComputeProcOverlayPoints(history, _procStatsSlicerMetric);
+            var label = row.ObjectName.Length > 30 ? row.ObjectName[..30] + "..." : row.ObjectName;
+            ProcStatsSlicer.SetOverlay(points, label);
+        }
+        catch { ProcStatsSlicer.ClearOverlay(); }
+    }
+
+    private async void QueryStoreGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (QueryStoreGrid.SelectedItem is not QueryStoreRow row)
+        {
+            QueryStoreSlicer.ClearOverlay();
+            return;
+        }
+
+        try
+        {
+            var hoursBack = GetHoursBack();
+            var (fromDate, toDate) = GetCurrentViewDates();
+            var history = await _dataService.GetQueryStoreHistoryAsync(_serverId, row.DatabaseName, row.QueryId, row.PlanId, hoursBack, fromDate, toDate);
+
+            // Query Store values are already per-interval averages, not cumulative
+            Func<QueryStoreHistoryRow, double> selector = _queryStoreSlicerMetric switch
+            {
+                "TotalCpu" or "AvgCpu" => h => h.TotalCpuMs,
+                "TotalReads" or "AvgReads" => h => h.AvgLogicalReads * h.ExecutionCount,
+                _ => h => h.TotalDurationMs,
+            };
+
+            var points = history
+                .Where(h => selector(h) > 0)
+                .Select(h => (h.CollectionTime, selector(h)))
+                .ToList();
+
+            var qsLabel = !string.IsNullOrWhiteSpace(row.ModuleName)
+                ? row.ModuleName
+                : $"Query {row.QueryId} / Plan {row.PlanId}";
+            QueryStoreSlicer.SetOverlay(points, qsLabel);
+        }
+        catch { QueryStoreSlicer.ClearOverlay(); }
+    }
+
     private void UpdateExecutionCountTrendChart(List<QueryTrendPoint> data)
     {
         ClearChart(ExecutionCountTrendChart);
@@ -4037,6 +4178,10 @@ public partial class ServerTab : UserControl
         }
 
         QueryStatsSlicer.UpdateMetric(label);
+
+        // Re-compute overlay with new metric if a row is selected
+        if (QueryStatsGrid.SelectedItem != null)
+            QueryStatsGrid_SelectionChanged(QueryStatsGrid, null!);
     }
 
     // ── Query Store Slicer ──
@@ -4130,6 +4275,9 @@ public partial class ServerTab : UserControl
         }
 
         QueryStoreSlicer.UpdateMetric(label);
+
+        if (QueryStoreGrid.SelectedItem != null)
+            QueryStoreGrid_SelectionChanged(QueryStoreGrid, null!);
     }
 
     // ── Procedure Stats Slicer ──
@@ -4221,6 +4369,9 @@ public partial class ServerTab : UserControl
         }
 
         ProcStatsSlicer.UpdateMetric(label);
+
+        if (ProcedureStatsGrid.SelectedItem != null)
+            ProcedureStatsGrid_SelectionChanged(ProcedureStatsGrid, null!);
     }
 
     private async void LiveSnapshot_Click(object sender, RoutedEventArgs e)

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -19,6 +19,10 @@ public partial class TimeRangeSlicerControl : UserControl
     private string _metricLabel = "Sessions";
     private bool _isExpanded = true;
 
+    // Overlay: per-item trend drawn on top of the aggregate area chart
+    private List<(DateTime TimeUtc, double Value)>? _overlayData;
+    private string? _overlayLabel;
+
     // Range as normalised [0..1] positions within the data span
     private double _rangeStart;
     private double _rangeEnd = 1.0;
@@ -93,6 +97,26 @@ public partial class TimeRangeSlicerControl : UserControl
         }
 
         UpdateRangeLabel();
+        Redraw();
+    }
+
+    /// <summary>
+    /// Sets an overlay trend line on the slicer. Drawn on its own Y scale
+    /// so it's visible regardless of the aggregate chart's magnitude.
+    /// </summary>
+    public void SetOverlay(List<(DateTime TimeUtc, double Value)> data, string label)
+    {
+        _overlayData = data.Count >= 3 ? data : null;
+        _overlayLabel = label;
+        Redraw();
+    }
+
+    /// <summary>Removes the overlay trend line.</summary>
+    public void ClearOverlay()
+    {
+        if (_overlayData == null) return;
+        _overlayData = null;
+        _overlayLabel = null;
         Redraw();
     }
 
@@ -248,6 +272,46 @@ public partial class TimeRangeSlicerControl : UserControl
 
         AddLine(selLeft, 0, selRight, 0, handleBrush, 0.5);
         AddLine(selLeft, h, selRight, h, handleBrush, 0.5);
+
+        // Overlay trend line (per-item highlight from grid selection)
+        if (_overlayData != null && _overlayData.Count >= 2)
+        {
+            var overlayMax = _overlayData.Max(d => d.Value);
+            if (overlayMax <= 0) overlayMax = 1;
+
+            var overlayPoints = new List<Point>();
+            foreach (var pt in _overlayData)
+            {
+                var ox = NormAtUtc(pt.TimeUtc) * w;
+                var oy = Math.Clamp(chartBottom - (pt.Value / overlayMax) * chartHeight, chartTop, chartBottom);
+                overlayPoints.Add(new Point(ox, oy));
+            }
+
+            var overlayLineBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF6F00"));
+            var overlayGeo = new StreamGeometry();
+            using (var ctx = overlayGeo.Open())
+            {
+                ctx.BeginFigure(overlayPoints[0], false, false);
+                for (int i = 1; i < overlayPoints.Count; i++)
+                    ctx.LineTo(overlayPoints[i], true, false);
+            }
+            SlicerCanvas.Children.Add(new Path { Data = overlayGeo, Stroke = overlayLineBrush, StrokeThickness = 2 });
+
+            // Overlay label top-left
+            if (!string.IsNullOrEmpty(_overlayLabel))
+            {
+                var overlayLabelTb = new TextBlock
+                {
+                    Text = _overlayLabel,
+                    FontSize = 11,
+                    FontWeight = FontWeights.SemiBold,
+                    Foreground = overlayLineBrush
+                };
+                Canvas.SetLeft(overlayLabelTb, 8);
+                Canvas.SetTop(overlayLabelTb, 2);
+                SlicerCanvas.Children.Add(overlayLabelTb);
+            }
+        }
     }
 
     private void AddRect(double x, double y, double width, double height, Brush fill)

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -186,10 +186,11 @@ LIMIT $4";
     /// <summary>
     /// Gets collection-level history for a specific query hash (for drilldown).
     /// </summary>
-    public async Task<List<QueryStatsHistoryRow>> GetQueryStatsHistoryAsync(int serverId, string databaseName, string queryHash, int hoursBack = 24)
+    public async Task<List<QueryStatsHistoryRow>> GetQueryStatsHistoryAsync(int serverId, string databaseName, string queryHash, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
         command.CommandText = @"
 SELECT
     collection_time,
@@ -214,12 +215,14 @@ WHERE server_id = $1
 AND   database_name = $2
 AND   query_hash = $3
 AND   collection_time >= $4
+AND   collection_time <= $5
 ORDER BY collection_time";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = databaseName });
         command.Parameters.Add(new DuckDBParameter { Value = queryHash });
-        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-hoursBack) });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
 
         var items = new List<QueryStatsHistoryRow>();
         using var reader = await command.ExecuteReaderAsync();
@@ -253,10 +256,11 @@ ORDER BY collection_time";
     /// <summary>
     /// Gets collection-level history for a specific procedure (for drilldown).
     /// </summary>
-    public async Task<List<ProcedureStatsHistoryRow>> GetProcedureStatsHistoryAsync(int serverId, string databaseName, string schemaName, string objectName, int hoursBack = 24)
+    public async Task<List<ProcedureStatsHistoryRow>> GetProcedureStatsHistoryAsync(int serverId, string databaseName, string schemaName, string objectName, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
         command.CommandText = @"
 SELECT
     collection_time,
@@ -277,13 +281,15 @@ AND   database_name = $2
 AND   schema_name = $3
 AND   object_name = $4
 AND   collection_time >= $5
+AND   collection_time <= $6
 ORDER BY collection_time";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = databaseName });
         command.Parameters.Add(new DuckDBParameter { Value = schemaName });
         command.Parameters.Add(new DuckDBParameter { Value = objectName });
-        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-hoursBack) });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
 
         var items = new List<ProcedureStatsHistoryRow>();
         using var reader = await command.ExecuteReaderAsync();

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -164,10 +164,11 @@ LIMIT $4";
     /// <summary>
     /// Gets collection-level history for a specific Query Store query (for drilldown).
     /// </summary>
-    public async Task<List<QueryStoreHistoryRow>> GetQueryStoreHistoryAsync(int serverId, string databaseName, long queryId, long planId, int hoursBack = 24)
+    public async Task<List<QueryStoreHistoryRow>> GetQueryStoreHistoryAsync(int serverId, string databaseName, long queryId, long planId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
         command.CommandText = @"
 SELECT
     collection_time,
@@ -187,13 +188,15 @@ AND   database_name = $2
 AND   query_id = $3
 AND   plan_id = $4
 AND   collection_time >= $5
+AND   collection_time <= $6
 ORDER BY collection_time";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = databaseName });
         command.Parameters.Add(new DuckDBParameter { Value = queryId });
         command.Parameters.Add(new DuckDBParameter { Value = planId });
-        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-hoursBack) });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
 
         var items = new List<QueryStoreHistoryRow>();
         using var reader = await command.ExecuteReaderAsync();


### PR DESCRIPTION
Click a row in Top Queries, Top Procedures, or Query Store → orange trend overlay appears on the slicer chart above the grid.

- Overlay drawn on slicer canvas with independent Y scale
- Metric follows sort column (CPU, duration, reads, etc.)
- Per-interval deltas from cumulative DMV values, zero-delta filtered
- Query Store uses module name when available, falls back to Query/Plan ID
- Minimum 3 data points to show overlay
- History queries support fromDate/toDate for correct time window