### PR TITLE
Preserve overlay through Dashboard auto-refresh (#683)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -37,6 +37,7 @@ namespace PerformanceMonitorDashboard.Controls
     {
         private DatabaseService? _databaseService;
         private Action<string>? _statusCallback;
+        internal bool IsRefreshing { get; set; }
 
         private static (DateTime start, DateTime end) GetSlicerTimeRange(
             int hoursBack, DateTime? fromDate, DateTime? toDate)
@@ -509,7 +510,7 @@ namespace PerformanceMonitorDashboard.Controls
             if (_databaseService == null) return;
             if (QueryStatsDataGrid.SelectedItem is not Models.QueryStatsItem row || string.IsNullOrEmpty(row.QueryHash))
             {
-                QueryStatsSlicer.ClearOverlay();
+                if (!IsRefreshing) QueryStatsSlicer.ClearOverlay();
                 return;
             }
 
@@ -543,7 +544,7 @@ namespace PerformanceMonitorDashboard.Controls
             if (_databaseService == null) return;
             if (ProcStatsDataGrid.SelectedItem is not Models.ProcedureStatsItem row || string.IsNullOrEmpty(row.ProcedureName))
             {
-                ProcStatsSlicer.ClearOverlay();
+                if (!IsRefreshing) ProcStatsSlicer.ClearOverlay();
                 return;
             }
 
@@ -578,7 +579,7 @@ namespace PerformanceMonitorDashboard.Controls
             if (_databaseService == null) return;
             if (QueryStoreDataGrid.SelectedItem is not Models.QueryStoreItem row)
             {
-                QueryStoreSlicer.ClearOverlay();
+                if (!IsRefreshing) QueryStoreSlicer.ClearOverlay();
                 return;
             }
 

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1059,7 +1059,9 @@ namespace PerformanceMonitorDashboard
                     case "Queries":
                         // Queries tab content is in QueryPerformanceContent UserControl
                         PerformanceTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
-                        await PerformanceTab.RefreshAllDataAsync();
+                        PerformanceTab.IsRefreshing = true;
+                        try { await PerformanceTab.RefreshAllDataAsync(); }
+                        finally { PerformanceTab.IsRefreshing = false; }
                         break;
 
                     case "Memory":
@@ -1248,7 +1250,9 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                await PerformanceTab.RefreshAllDataAsync(fullRefresh);
+                PerformanceTab.IsRefreshing = true;
+                try { await PerformanceTab.RefreshAllDataAsync(fullRefresh); }
+                finally { PerformanceTab.IsRefreshing = false; }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Adds IsRefreshing flag to QueryPerformanceContent so the overlay dots persist when auto-refresh replaces grid ItemsSource.