### PR TITLE
Add Investigate button to Critical Issues (#684)

### DIFF
--- a/Dashboard/Controls/CriticalIssuesContent.xaml
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml
@@ -38,6 +38,13 @@
               GridLinesVisibility="All" CanUserResizeColumns="True"
               RowStyle="{StaticResource DefaultRowStyle}">
         <DataGrid.Columns>
+            <DataGridTemplateColumn Header="Action" Width="80">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Button Content="Investigate" Click="Investigate_Click" Padding="4,2" FontSize="11"/>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
             <DataGridTextColumn Binding="{Binding IssueId}" ElementStyle="{StaticResource NumericCell}" Width="80">
                 <DataGridTextColumn.Header>
                     <StackPanel Orientation="Horizontal">

--- a/Dashboard/Controls/CriticalIssuesContent.xaml.cs
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml.cs
@@ -28,6 +28,12 @@ namespace PerformanceMonitorDashboard.Controls
     /// </summary>
     public partial class CriticalIssuesContent : UserControl
     {
+        /// <summary>
+        /// Raised when the user clicks Investigate on an issue.
+        /// Args: (problemArea, logDate, affectedDatabase, investigateQuery)
+        /// </summary>
+        public event Action<string, DateTime, string?, string?>? InvestigateRequested;
+
         private DatabaseService? _databaseService;
 
         // Time range state
@@ -60,6 +66,16 @@ namespace PerformanceMonitorDashboard.Controls
         public void Initialize(DatabaseService databaseService)
         {
             _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+        }
+
+        private void Investigate_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not CriticalIssueItem item) return;
+            InvestigateRequested?.Invoke(
+                item.ProblemArea,
+                item.LogDate,
+                string.IsNullOrWhiteSpace(item.AffectedDatabase) ? null : item.AffectedDatabase,
+                string.IsNullOrWhiteSpace(item.InvestigateQuery) ? null : item.InvestigateQuery);
         }
 
         /// <summary>

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -410,7 +410,7 @@
             </TabItem>
 
             <!-- Queries Tab -->
-            <TabItem Header="Queries">
+            <TabItem Header="Queries" x:Name="QueriesTabItem">
                 <controls:QueryPerformanceContent x:Name="PerformanceTab"/>
             </TabItem>
 
@@ -488,7 +488,7 @@
                         </Border>
                     </StackPanel>
                 </TabItem.Header>
-                <TabControl>
+                <TabControl x:Name="LockingSubTabControl">
                     <!-- Blocking/Deadlock Stats Sub-Tab (default tab) -->
                     <TabItem Header="Blocking/Deadlock Trends">
                         <Grid>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -132,6 +132,7 @@ namespace PerformanceMonitorDashboard
             // Initialize Overview sub-tab UserControls
             DailySummaryTab.Initialize(_databaseService);
             CriticalIssuesTab.Initialize(_databaseService);
+            CriticalIssuesTab.InvestigateRequested += OnInvestigateCriticalIssue;
             DefaultTraceTab.Initialize(_databaseService);
             CurrentConfigTab.Initialize(_databaseService);
             ConfigChangesTab.Initialize(_databaseService);
@@ -1294,6 +1295,143 @@ namespace PerformanceMonitorDashboard
         /// Refreshes the Locking tab: Blocking events, deadlocks, blocking/deadlock stats,
         /// lock wait stats, current waits duration, and current waits blocked sessions.
         /// </summary>
+
+        // ── Critical Issues → Investigate Navigation (#684) ──
+
+        private async void OnInvestigateCriticalIssue(string problemArea, DateTime logDate, string? affectedDatabase, string? investigateQuery)
+        {
+            // Set a 2-hour window centered on the incident
+            var from = logDate.AddHours(-1);
+            var to = logDate.AddHours(1);
+
+            // Populate global custom date pickers so user can Apply to All
+            SetPickersFromDateTime(from, GlobalFromDate, GlobalFromHour, GlobalFromMinute);
+            SetPickersFromDateTime(to, GlobalToDate, GlobalToHour, GlobalToMinute);
+
+            // Set global range so Apply to All works
+            _globalHoursBack = 0;
+            _globalFromDate = from;
+            _globalToDate = to;
+            HighlightTimeButton(0); // deselect preset buttons
+            GlobalDateRangeIndicator.Text = GetGlobalDateRangeText();
+
+            switch (problemArea)
+            {
+                case "Blocking":
+                    LockingTabItem.IsSelected = true;
+                    LockingSubTabControl.SelectedIndex = 2; // Blocked Process Reports
+                    _blockingHoursBack = 0;
+                    _blockingFromDate = from;
+                    _blockingToDate = to;
+                    await RefreshLockingTabAsync();
+                    break;
+
+                case "Deadlocking":
+                    LockingTabItem.IsSelected = true;
+                    LockingSubTabControl.SelectedIndex = 3; // Deadlocks
+                    _deadlocksHoursBack = 0;
+                    _deadlocksFromDate = from;
+                    _deadlocksToDate = to;
+                    await RefreshLockingTabAsync();
+                    break;
+
+                case "Blocking and Deadlocking":
+                    LockingTabItem.IsSelected = true;
+                    LockingSubTabControl.SelectedIndex = 0; // Blocking/Deadlock Trends
+                    _blockingStatsHoursBack = 0;
+                    _blockingStatsFromDate = from;
+                    _blockingStatsToDate = to;
+                    await RefreshLockingTabAsync();
+                    break;
+
+                case "CPU Scheduling Pressure":
+                    QueriesTabItem.IsSelected = true;
+                    PerformanceTab.SetTimeRange(0, from, to);
+                    await RefreshQueriesTabAsync();
+                    break;
+
+                case "Memory Pressure":
+                case "Memory Grant Pressure":
+                case "Memory Clerk Growth":
+                    MemoryTabItem.IsSelected = true;
+                    MemoryTab.SetTimeRange(0, from, to);
+                    await RefreshMemoryTabAsync();
+                    break;
+
+                default:
+                    ShowInvestigateQuery(problemArea, logDate, affectedDatabase, investigateQuery);
+                    break;
+            }
+        }
+
+        private void ShowInvestigateQuery(string problemArea, DateTime logDate, string? affectedDatabase, string? investigateQuery)
+        {
+            var query = investigateQuery;
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                query = $"-- No investigate query available for: {problemArea}";
+            }
+
+            var header = $"{problemArea}";
+            if (!string.IsNullOrWhiteSpace(affectedDatabase))
+                header += $" — {affectedDatabase}";
+            header += $"\n{Helpers.ServerTimeHelper.ConvertForDisplay(logDate, Helpers.ServerTimeHelper.CurrentDisplayMode):yyyy-MM-dd HH:mm:ss}";
+
+            var win = new Window
+            {
+                Title = "Investigate: " + problemArea,
+                Width = 700,
+                Height = 400,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Owner = Window.GetWindow(this),
+                Background = (System.Windows.Media.Brush)FindResource("BackgroundBrush")
+            };
+
+            var grid = new Grid { Margin = new Thickness(12) };
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var headerTb = new TextBlock
+            {
+                Text = header,
+                FontSize = 13,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = (System.Windows.Media.Brush)FindResource("ForegroundBrush"),
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            Grid.SetRow(headerTb, 0);
+            grid.Children.Add(headerTb);
+
+            var queryBox = new TextBox
+            {
+                Text = query,
+                IsReadOnly = true,
+                TextWrapping = TextWrapping.Wrap,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                FontFamily = new System.Windows.Media.FontFamily("Consolas"),
+                FontSize = 12,
+                Background = (System.Windows.Media.Brush)FindResource("BackgroundLightBrush"),
+                Foreground = (System.Windows.Media.Brush)FindResource("ForegroundBrush"),
+                Padding = new Thickness(8)
+            };
+            Grid.SetRow(queryBox, 1);
+            grid.Children.Add(queryBox);
+
+            var buttonPanel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 8, 0, 0) };
+            var copyBtn = new Button { Content = "Copy to Clipboard", Padding = new Thickness(12, 4, 12, 4), Margin = new Thickness(0, 0, 8, 0) };
+            copyBtn.Click += (_, _) => { Clipboard.SetText(query ?? ""); };
+            var closeBtn = new Button { Content = "Close", Padding = new Thickness(12, 4, 12, 4) };
+            closeBtn.Click += (_, _) => win.Close();
+            buttonPanel.Children.Add(copyBtn);
+            buttonPanel.Children.Add(closeBtn);
+            Grid.SetRow(buttonPanel, 2);
+            grid.Children.Add(buttonPanel);
+
+            win.Content = grid;
+            win.ShowDialog();
+        }
+
         private async Task RefreshLockingTabAsync()
         {
             try


### PR DESCRIPTION
Turns Critical Issues from a notification log into a launch pad.

Navigate to relevant tab with incident time window:
- Blocking/Deadlocking → Locking sub-tabs
- CPU Scheduling Pressure → Query Performance
- Memory Pressure/Grant/Clerk → Memory

Global date pickers populated for Apply to All. Config issues show investigate query dialog with Copy to Clipboard.