### PR TITLE
Fix slicer custom range display and cascading refresh (#704)

### DIFF
--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
@@ -337,7 +337,8 @@ public partial class TimeRangeSlicerControl : UserControl
         var start = ServerTimeHelper.ConvertForDisplay(TimeAtNorm(_rangeStart), ServerTimeHelper.CurrentDisplayMode);
         var end = ServerTimeHelper.ConvertForDisplay(TimeAtNorm(_rangeEnd), ServerTimeHelper.CurrentDisplayMode);
         var span = end - start;
-        RangeLabel.Text = $"{start:yyyy-MM-dd HH:mm} \u2192 {end:yyyy-MM-dd HH:mm}  ({span.TotalHours:F0}h)";
+        var spanLabel = span.TotalHours >= 1 ? $"{span.TotalHours:F0}h" : $"{span.TotalMinutes:F0}m";
+        RangeLabel.Text = $"{start:yyyy-MM-dd HH:mm} \u2192 {end:yyyy-MM-dd HH:mm}  ({spanLabel})";
     }
 
     // ── Mouse interaction ──

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -487,7 +487,7 @@ public partial class ServerTab : UserControl
 
     private async void TimeRangeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (!IsLoaded) return;
+        if (!IsLoaded || _isRefreshing) return;
 
         /* Show/hide custom date pickers and time ComboBoxes */
         var isCustom = TimeRangeCombo.SelectedIndex == 5;
@@ -518,7 +518,7 @@ public partial class ServerTab : UserControl
 
     private async void CustomDateRange_Changed(object sender, SelectionChangedEventArgs e)
     {
-        if (!IsLoaded) return;
+        if (!IsLoaded || _isRefreshing) return;
         if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
         {
             await RefreshAllDataAsync(fullRefresh: false);
@@ -527,7 +527,7 @@ public partial class ServerTab : UserControl
 
     private async void CustomTimeCombo_Changed(object sender, SelectionChangedEventArgs e)
     {
-        if (!IsLoaded) return;
+        if (!IsLoaded || _isRefreshing) return;
         /* Only refresh if we have valid dates selected */
         if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
         {

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -355,7 +355,8 @@ public partial class TimeRangeSlicerControl : UserControl
         var startDisplay = ServerTimeHelper.FormatServerTime(UtcAtNorm(_rangeStart), "yyyy-MM-dd HH:mm");
         var endDisplay = ServerTimeHelper.FormatServerTime(UtcAtNorm(_rangeEnd), "yyyy-MM-dd HH:mm");
         var spanHours = (UtcAtNorm(_rangeEnd) - UtcAtNorm(_rangeStart)).TotalHours;
-        RangeLabel.Text = $"{startDisplay} \u2192 {endDisplay}  ({spanHours:F0}h)";
+        var spanLabel = spanHours >= 1 ? $"{spanHours:F0}h" : $"{spanHours * 60:F0}m";
+        RangeLabel.Text = $"{startDisplay} \u2192 {endDisplay}  ({spanLabel})";
     }
 
     // ── Mouse interaction ──


### PR DESCRIPTION
Two fixes:
1. Sub-hour ranges showed "(0h)" — now shows "30m" for ranges under 1 hour
2. Drill-down setting pickers programmatically triggered cascading refreshes mid-update — suppressed with _isRefreshing guard

The slicer showing server time while pickers show local time is correct behavior, not a bug (server in Pacific, user in Eastern).