### PR TITLE
Dashboard: chart drill-down for CPU, Memory, TempDB, Blocking, Deadlocks (#682)

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -30,6 +30,30 @@ namespace PerformanceMonitorDashboard.Controls
     /// </summary>
     public partial class MemoryContent : UserControl
     {
+        public event Action<string, DateTime>? ChartDrillDownRequested;
+
+        private void AddDrillDown(ScottPlot.WPF.WpfPlot chart, ContextMenu menu,
+            Helpers.ChartHoverHelper? hover, string label, string chartType)
+        {
+            menu.Items.Insert(0, new Separator());
+            var item = new MenuItem { Header = label };
+            menu.Items.Insert(0, item);
+
+            menu.Opened += (s, _) =>
+            {
+                var pos = System.Windows.Input.Mouse.GetPosition(chart);
+                var nearest = hover?.GetNearestSeries(pos);
+                item.Tag = nearest?.Time;
+                item.IsEnabled = nearest.HasValue;
+            };
+
+            item.Click += (s, _) =>
+            {
+                if (item.Tag is DateTime time)
+                    ChartDrillDownRequested?.Invoke(chartType, time);
+            };
+        }
+
         private DatabaseService? _databaseService;
 
         // Memory Stats state
@@ -121,7 +145,8 @@ namespace PerformanceMonitorDashboard.Controls
         private void SetupChartContextMenus()
         {
             // Memory Stats Overview chart
-            TabHelpers.SetupChartContextMenu(MemoryStatsOverviewChart, "Memory_Stats_Overview", "collect.memory_stats");
+            var memOverviewMenu = TabHelpers.SetupChartContextMenu(MemoryStatsOverviewChart, "Memory_Stats_Overview", "collect.memory_stats");
+            AddDrillDown(MemoryStatsOverviewChart, memOverviewMenu, _memoryStatsOverviewHover, "Show Active Queries at This Time", "Memory");
 
             // Memory Grant charts
             TabHelpers.SetupChartContextMenu(MemoryGrantSizingChart, "Memory_Grant_Sizing", "collect.memory_grant_stats");

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -33,6 +33,31 @@ namespace PerformanceMonitorDashboard.Controls
     /// </summary>
     public partial class ResourceMetricsContent : UserControl
     {
+        /// <summary>Raised when user drills down on a chart point. Args: (chartType, serverLocalTime)</summary>
+        public event Action<string, DateTime>? ChartDrillDownRequested;
+
+        private void AddDrillDown(ScottPlot.WPF.WpfPlot chart, ContextMenu menu,
+            Helpers.ChartHoverHelper? hover, string label, string chartType)
+        {
+            menu.Items.Insert(0, new Separator());
+            var item = new MenuItem { Header = label };
+            menu.Items.Insert(0, item);
+
+            menu.Opened += (s, _) =>
+            {
+                var pos = System.Windows.Input.Mouse.GetPosition(chart);
+                var nearest = hover?.GetNearestSeries(pos);
+                item.Tag = nearest?.Time;
+                item.IsEnabled = nearest.HasValue;
+            };
+
+            item.Click += (s, _) =>
+            {
+                if (item.Tag is DateTime time)
+                    ChartDrillDownRequested?.Invoke(chartType, time);
+            };
+        }
+
         private DatabaseService? _databaseService;
 
         // Latch Stats state
@@ -190,8 +215,10 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.SetupChartContextMenu(TempDbLatencyChart, "TempDB_Latency", "collect.file_io_stats");
 
             // Server Utilization Trends charts
-            TabHelpers.SetupChartContextMenu(ServerUtilTrendsCpuChart, "Server_CPU_Trends", "collect.cpu_utilization_stats");
-            TabHelpers.SetupChartContextMenu(ServerUtilTrendsTempdbChart, "Server_TempDB_Trends", "collect.tempdb_stats");
+            var cpuTrendsMenu = TabHelpers.SetupChartContextMenu(ServerUtilTrendsCpuChart, "Server_CPU_Trends", "collect.cpu_utilization_stats");
+            AddDrillDown(ServerUtilTrendsCpuChart, cpuTrendsMenu, _serverTrendsCpuHover, "Show Active Queries at This Time", "CPU");
+            var tempDbTrendsMenu = TabHelpers.SetupChartContextMenu(ServerUtilTrendsTempdbChart, "Server_TempDB_Trends", "collect.tempdb_stats");
+            AddDrillDown(ServerUtilTrendsTempdbChart, tempDbTrendsMenu, _serverTrendsTempdbHover, "Show Active Queries at This Time", "TempDB");
             TabHelpers.SetupChartContextMenu(ServerUtilTrendsMemoryChart, "Server_Memory_Trends", "collect.memory_stats");
             TabHelpers.SetupChartContextMenu(ServerUtilTrendsPerfmonChart, "Server_Perfmon_Trends", "collect.perfmon_stats");
 

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -137,6 +137,7 @@ namespace PerformanceMonitorDashboard
             CurrentConfigTab.Initialize(_databaseService);
             ConfigChangesTab.Initialize(_databaseService);
             MemoryTab.Initialize(_databaseService);
+            MemoryTab.ChartDrillDownRequested += OnChildChartDrillDown;
             PerformanceTab.Initialize(_databaseService, s => StatusText.Text = s);
             PerformanceTab.ViewPlanRequested += (planXml, label, queryText) =>
             {
@@ -153,6 +154,7 @@ namespace PerformanceMonitorDashboard
             };
             SystemEventsContent.Initialize(_databaseService);
             ResourceMetricsContent.Initialize(_databaseService);
+            ResourceMetricsContent.ChartDrillDownRequested += OnChildChartDrillDown;
 
             // Set default time range on UserControls based on user preferences
             var prefs = _preferencesService.GetPreferences();
@@ -527,9 +529,11 @@ namespace PerformanceMonitorDashboard
 
             // Blocking Stats charts
             Helpers.TabHelpers.SetupChartContextMenu(LockWaitStatsChart, "Lock_Wait_Stats", "collect.wait_stats");
-            Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsBlockingEventsChart, "Blocking_Events", "collect.blocking_deadlock_stats");
+            var blockingEventsMenu = Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsBlockingEventsChart, "Blocking_Events", "collect.blocking_deadlock_stats");
+            AddChartDrillDownMenuItem(BlockingStatsBlockingEventsChart, blockingEventsMenu, _blockingEventsHover, "Show Blocking at This Time", OnBlockingChartDrillDown);
             Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsDurationChart, "Blocking_Duration", "collect.blocking_deadlock_stats");
-            Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsDeadlocksChart, "Deadlocks", "collect.blocking_deadlock_stats");
+            var deadlocksMenu = Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsDeadlocksChart, "Deadlocks", "collect.blocking_deadlock_stats");
+            AddChartDrillDownMenuItem(BlockingStatsDeadlocksChart, deadlocksMenu, _deadlocksHover, "Show Deadlocks at This Time", OnDeadlockChartDrillDown);
             Helpers.TabHelpers.SetupChartContextMenu(BlockingStatsDeadlockWaitTimeChart, "Deadlock_Wait_Time", "collect.blocking_deadlock_stats");
 
             // Current Waits charts
@@ -1430,6 +1434,90 @@ namespace PerformanceMonitorDashboard
 
             win.Content = grid;
             win.ShowDialog();
+        }
+
+        // ── Chart Drill-Down (#682) ──
+
+        private void AddChartDrillDownMenuItem(
+            ScottPlot.WPF.WpfPlot chart, ContextMenu contextMenu,
+            Helpers.ChartHoverHelper? hover, string label, Action<DateTime> handler)
+        {
+            contextMenu.Items.Insert(0, new Separator());
+            var item = new MenuItem { Header = label };
+            contextMenu.Items.Insert(0, item);
+
+            contextMenu.Opened += (s, _) =>
+            {
+                var pos = System.Windows.Input.Mouse.GetPosition(chart);
+                var nearest = hover?.GetNearestSeries(pos);
+                if (nearest.HasValue)
+                {
+                    item.Tag = nearest.Value.Time;
+                    item.IsEnabled = true;
+                }
+                else
+                {
+                    item.Tag = null;
+                    item.IsEnabled = false;
+                }
+            };
+
+            item.Click += (s, _) =>
+            {
+                if (item.Tag is DateTime time)
+                    handler(time);
+            };
+        }
+
+        private void SetDrillDownGlobalRange(DateTime from, DateTime to)
+        {
+            SetPickersFromDateTime(from, GlobalFromDate, GlobalFromHour, GlobalFromMinute);
+            SetPickersFromDateTime(to, GlobalToDate, GlobalToHour, GlobalToMinute);
+            _globalHoursBack = 0;
+            _globalFromDate = from;
+            _globalToDate = to;
+            HighlightTimeButton(0);
+            GlobalDateRangeIndicator.Text = GetGlobalDateRangeText();
+        }
+
+        private async void OnBlockingChartDrillDown(DateTime time)
+        {
+            var from = time.AddMinutes(-30);
+            var to = time.AddMinutes(30);
+            SetDrillDownGlobalRange(from, to);
+
+            LockingSubTabControl.SelectedIndex = 2; // Blocked Process Reports
+            _blockingHoursBack = 0;
+            _blockingFromDate = from;
+            _blockingToDate = to;
+            await RefreshLockingTabAsync();
+        }
+
+        private async void OnDeadlockChartDrillDown(DateTime time)
+        {
+            var from = time.AddMinutes(-30);
+            var to = time.AddMinutes(30);
+            SetDrillDownGlobalRange(from, to);
+
+            LockingSubTabControl.SelectedIndex = 3; // Deadlocks
+            _deadlocksHoursBack = 0;
+            _deadlocksFromDate = from;
+            _deadlocksToDate = to;
+            await RefreshLockingTabAsync();
+        }
+
+        private async void OnChildChartDrillDown(string chartType, DateTime time)
+        {
+            var from = time.AddMinutes(-30);
+            var to = time.AddMinutes(30);
+            SetDrillDownGlobalRange(from, to);
+
+            // All chart drill-downs go to Query Performance for root cause
+            QueriesTabItem.IsSelected = true;
+            PerformanceTab.SetTimeRange(0, from, to);
+            PerformanceTab.IsRefreshing = true;
+            try { await RefreshQueriesTabAsync(); }
+            finally { PerformanceTab.IsRefreshing = false; }
         }
 
         private async Task RefreshLockingTabAsync()


### PR DESCRIPTION
Port of Lite drill-down. Right-click chart spike → navigate to detail tab with ±30 min window.

- Blocking/Deadlock charts: direct in ServerTab
- CPU/TempDB/Memory charts: events from child UserControls → ServerTab handles navigation
- Global date pickers populated for cross-tab investigation