### PR TITLE
Widen installation_history version columns to nvarchar(512) (#712)

### DIFF
--- a/install/01_install_database.sql
+++ b/install/01_install_database.sql
@@ -746,8 +746,8 @@ BEGIN
         installation_date datetime2(7) NOT NULL DEFAULT SYSDATETIME(),
         installer_version nvarchar(50) NOT NULL,
         installer_info_version nvarchar(100) NULL,
-        sql_server_version nvarchar(255) NOT NULL,
-        sql_server_edition nvarchar(255) NOT NULL,
+        sql_server_version nvarchar(512) NOT NULL,
+        sql_server_edition nvarchar(512) NOT NULL,
         installation_type nvarchar(20) NOT NULL, /*INSTALL, UPGRADE, REINSTALL*/
         previous_version nvarchar(50) NULL,
         installation_status nvarchar(20) NOT NULL, /*SUCCESS, FAILED, PARTIAL*/

--- a/upgrades/2.4.0-to-2.5.0/01_widen_version_columns.sql
+++ b/upgrades/2.4.0-to-2.5.0/01_widen_version_columns.sql
@@ -1,0 +1,36 @@
+/*
+Widen sql_server_version and sql_server_edition columns in config.installation_history
+Some @@VERSION strings exceed 255 characters (#712)
+*/
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'config.installation_history')
+    AND   c.name = N'sql_server_version'
+    AND   c.max_length = 510 /* nvarchar(255) = 510 bytes */
+)
+BEGIN
+    ALTER TABLE config.installation_history
+        ALTER COLUMN sql_server_version nvarchar(512) NOT NULL;
+
+    PRINT 'Widened config.installation_history.sql_server_version to nvarchar(512)';
+END;
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'config.installation_history')
+    AND   c.name = N'sql_server_edition'
+    AND   c.max_length = 510
+)
+BEGIN
+    ALTER TABLE config.installation_history
+        ALTER COLUMN sql_server_edition nvarchar(512) NOT NULL;
+
+    PRINT 'Widened config.installation_history.sql_server_edition to nvarchar(512)';
+END;

--- a/upgrades/2.4.0-to-2.5.0/upgrade.txt
+++ b/upgrades/2.4.0-to-2.5.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_widen_version_columns.sql


### PR DESCRIPTION
@@VERSION can exceed 255 chars. Fixes install detection failing on long version strings. Upgrade script for existing installs, idempotent.