### PR TITLE
Add per-server collector schedule intervals

### DIFF
--- a/Dashboard/CollectorScheduleWindow.xaml.cs
+++ b/Dashboard/CollectorScheduleWindow.xaml.cs
@@ -123,12 +123,17 @@ namespace PerformanceMonitorDashboard
             }
         };
 
-        public CollectorScheduleWindow(DatabaseService databaseService)
+        public CollectorScheduleWindow(DatabaseService databaseService, string? serverDisplayName = null)
         {
             InitializeComponent();
             _databaseService = databaseService;
             Loaded += CollectorScheduleWindow_Loaded;
             Closing += CollectorScheduleWindow_Closing;
+
+            if (!string.IsNullOrEmpty(serverDisplayName))
+            {
+                Title = $"Collector Schedules - {serverDisplayName}";
+            }
         }
 
         private void CollectorScheduleWindow_Closing(object? sender, CancelEventArgs e)

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -1665,7 +1665,7 @@ namespace PerformanceMonitorDashboard
 
         private void EditSchedules_Click(object sender, RoutedEventArgs e)
         {
-            var scheduleWindow = new CollectorScheduleWindow(_databaseService);
+            var scheduleWindow = new CollectorScheduleWindow(_databaseService, _serverConnection.DisplayName);
             scheduleWindow.Owner = Window.GetWindow(this);
             scheduleWindow.ShowDialog();
         }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -557,7 +557,7 @@ public partial class MainWindow : Window
         {
             if (_collectorService != null)
             {
-                var onLoadCollectors = _scheduleManager.GetOnLoadCollectors();
+                var onLoadCollectors = _scheduleManager.GetOnLoadCollectorsForServer(server.Id);
                 foreach (var collector in onLoadCollectors)
                 {
                     try
@@ -848,7 +848,7 @@ public partial class MainWindow : Window
 
     private async void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        var window = new SettingsWindow(_scheduleManager, _backgroundService, _mcpService, _muteRuleService) { Owner = this };
+        var window = new SettingsWindow(_scheduleManager, _serverManager, _backgroundService, _mcpService, _muteRuleService) { Owner = this };
         window.ShowDialog();
         UpdateStatusBar();
 

--- a/Lite/Models/ServerScheduleOverride.cs
+++ b/Lite/Models/ServerScheduleOverride.cs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PerformanceMonitorLite.Models;
+
+/// <summary>
+/// Per-server schedule override. Contains the full collector list for one server.
+/// When present, replaces the default schedule entirely for that server.
+/// </summary>
+public class ServerScheduleOverride
+{
+    [JsonPropertyName("collectors")]
+    public List<CollectorSchedule> Collectors { get; set; } = new();
+}

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -32,7 +32,7 @@ public partial class RemoteCollectorService
     public async Task EnsureBlockedProcessXeSessionAsync(ServerConnection server, int engineEdition = 0, CancellationToken cancellationToken = default)
     {
         /* Skip if the blocked_process_report collector is disabled */
-        var schedule = _scheduleManager.GetSchedule("blocked_process_report");
+        var schedule = _scheduleManager.GetScheduleForServer(server.Id, "blocked_process_report");
         if (schedule == null || !schedule.Enabled)
         {
             return;

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -32,7 +32,7 @@ public partial class RemoteCollectorService
     public async Task EnsureDeadlockXeSessionAsync(ServerConnection server, int engineEdition = 0, CancellationToken cancellationToken = default)
     {
         /* Skip if the deadlock collector is disabled */
-        var schedule = _scheduleManager.GetSchedule("deadlocks");
+        var schedule = _scheduleManager.GetScheduleForServer(server.Id, "deadlocks");
         if (schedule == null || !schedule.Enabled)
         {
             return;

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -235,10 +235,9 @@ public partial class RemoteCollectorService
     /// </summary>
     public async Task RunDueCollectorsAsync(CancellationToken cancellationToken = default)
     {
-        var dueCollectors = _scheduleManager.GetDueCollectors();
         var enabledServers = _serverManager.GetEnabledServers();
 
-        if (dueCollectors.Count == 0 || enabledServers.Count == 0)
+        if (enabledServers.Count == 0)
         {
             return;
         }
@@ -258,15 +257,22 @@ public partial class RemoteCollectorService
             onlineServers.Add(server);
         }
 
-        _logger?.LogInformation("Running {CollectorCount} collectors for {OnlineCount}/{TotalCount} servers ({SkippedCount} offline, skipped)",
-            dueCollectors.Count, onlineServers.Count, enabledServers.Count, skippedOffline);
+        if (onlineServers.Count == 0)
+        {
+            return;
+        }
+
+        _logger?.LogInformation("Checking per-server schedules for {OnlineCount}/{TotalCount} servers ({SkippedCount} offline, skipped)",
+            onlineServers.Count, enabledServers.Count, skippedOffline);
 
         /* Run servers in parallel, but collectors within each server sequentially.
            DuckDB is single-writer; running all collectors in parallel causes spin-wait
            contention (50%+ CPU, multi-second stalls). Sequential per-server eliminates
-           this while still allowing multi-server parallelism. */
+           this while still allowing multi-server parallelism.
+           Each server gets its own due-collector list from per-server schedules. */
         var serverTasks = onlineServers.Select(server => Task.Run(async () =>
         {
+            var dueCollectors = _scheduleManager.GetDueCollectorsForServer(server.Id);
             foreach (var collector in dueCollectors)
             {
                 await RunCollectorAsync(server, collector.Name, cancellationToken);
@@ -299,8 +305,8 @@ public partial class RemoteCollectorService
     /// </summary>
     public async Task RunAllCollectorsForServerAsync(ServerConnection server, CancellationToken cancellationToken = default)
     {
-        var enabledSchedules = _scheduleManager.GetEnabledSchedules()
-            .Concat(_scheduleManager.GetOnLoadCollectors())
+        var enabledSchedules = _scheduleManager.GetSchedulesForServer(server.Id)
+            .Where(s => s.Enabled)
             .ToList();
 
         /* Ensure XE sessions are set up before collecting */
@@ -396,7 +402,7 @@ public partial class RemoteCollectorService
                 _ => throw new ArgumentException($"Unknown collector: {collectorName}")
             };
 
-            _scheduleManager.MarkCollectorRun(collectorName, startTime);
+            _scheduleManager.MarkCollectorRunForServer(server.Id, collectorName, startTime);
 
             var elapsed = (int)(DateTime.UtcNow - startTime).TotalMilliseconds;
             AppLogger.Info("Collector", $"  [{server.DisplayName}] {collectorName} => {rowsCollected} rows in {elapsed}ms (sql:{_lastSqlMs}ms, duck:{_lastDuckDbMs}ms)");

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -19,6 +19,7 @@ namespace PerformanceMonitorLite.Services;
 
 /// <summary>
 /// Manages collector schedules and determines when each collector should run.
+/// Supports per-server schedule overrides (v2 config format).
 /// </summary>
 public class ScheduleManager
 {
@@ -63,82 +64,96 @@ public class ScheduleManager
 
     private readonly string _schedulePath;
     private readonly ILogger<ScheduleManager>? _logger;
-    private List<CollectorSchedule> _schedules;
     private readonly object _lock = new();
+
+    private List<CollectorSchedule> _defaultSchedule;
+    private Dictionary<string, ServerScheduleOverride> _serverOverrides;
+
+    /// <summary>
+    /// Per-server runtime state: serverId → (collectorName → lastRunTime).
+    /// Kept separate from config because runtime state is not persisted to JSON.
+    /// </summary>
+    private readonly Dictionary<string, Dictionary<string, DateTime>> _serverRunState = new();
 
     public ScheduleManager(string configDirectory, ILogger<ScheduleManager>? logger = null)
     {
         _schedulePath = Path.Combine(configDirectory, "collection_schedule.json");
         _logger = logger;
-        _schedules = new List<CollectorSchedule>();
+        _defaultSchedule = new List<CollectorSchedule>();
+        _serverOverrides = new Dictionary<string, ServerScheduleOverride>();
 
         LoadSchedules();
     }
 
+    // ──────────────────────────────────────────────────────────────────
+    //  Existing public API — operates on the default schedule.
+    //  These methods are unchanged from v1 so existing callers keep working.
+    // ──────────────────────────────────────────────────────────────────
+
     /// <summary>
-    /// Gets all configured collector schedules.
+    /// Gets all configured collector schedules (default schedule).
     /// </summary>
     public IReadOnlyList<CollectorSchedule> GetAllSchedules()
     {
         lock (_lock)
         {
-            return _schedules.ToList();
+            return _defaultSchedule.ToList();
         }
     }
 
     /// <summary>
-    /// Gets only enabled and scheduled collectors.
+    /// Gets only enabled and scheduled collectors (default schedule).
     /// </summary>
     public IReadOnlyList<CollectorSchedule> GetEnabledSchedules()
     {
         lock (_lock)
         {
-            return _schedules.Where(s => s.Enabled && s.IsScheduled).ToList();
+            return _defaultSchedule.Where(s => s.Enabled && s.IsScheduled).ToList();
         }
     }
 
     /// <summary>
-    /// Gets collectors that are due to run.
+    /// Gets collectors that are due to run (default schedule, global run state).
     /// </summary>
     public IReadOnlyList<CollectorSchedule> GetDueCollectors()
     {
         lock (_lock)
         {
-            return _schedules.Where(s => s.IsDue).ToList();
+            return _defaultSchedule.Where(s => s.IsDue).ToList();
         }
     }
 
     /// <summary>
-    /// Gets on-load only collectors (frequency = 0).
+    /// Gets on-load only collectors (frequency = 0) from the default schedule.
     /// </summary>
     public IReadOnlyList<CollectorSchedule> GetOnLoadCollectors()
     {
         lock (_lock)
         {
-            return _schedules.Where(s => s.Enabled && !s.IsScheduled).ToList();
+            return _defaultSchedule.Where(s => s.Enabled && !s.IsScheduled).ToList();
         }
     }
 
     /// <summary>
-    /// Gets a specific collector schedule by name.
+    /// Gets a specific collector schedule by name (default schedule).
     /// </summary>
     public CollectorSchedule? GetSchedule(string collectorName)
     {
         lock (_lock)
         {
-            return _schedules.FirstOrDefault(s =>
+            return _defaultSchedule.FirstOrDefault(s =>
                 s.Name.Equals(collectorName, StringComparison.OrdinalIgnoreCase));
         }
     }
 
     /// <summary>
-    /// Marks a collector as having been run.
+    /// Marks a collector as having been run (default schedule, global run state).
     /// </summary>
     public void MarkCollectorRun(string collectorName, DateTime runTime)
     {
         lock (_lock)
         {
-            var schedule = _schedules.FirstOrDefault(s =>
+            var schedule = _defaultSchedule.FirstOrDefault(s =>
                 s.Name.Equals(collectorName, StringComparison.OrdinalIgnoreCase));
 
             if (schedule != null)
@@ -157,13 +172,13 @@ public class ScheduleManager
     }
 
     /// <summary>
-    /// Updates a collector's schedule settings.
+    /// Updates a collector's schedule settings (default schedule).
     /// </summary>
     public void UpdateSchedule(string collectorName, bool? enabled = null, int? frequencyMinutes = null, int? retentionDays = null)
     {
         lock (_lock)
         {
-            var schedule = _schedules.FirstOrDefault(s =>
+            var schedule = _defaultSchedule.FirstOrDefault(s =>
                 s.Name.Equals(collectorName, StringComparison.OrdinalIgnoreCase));
 
             if (schedule == null)
@@ -194,33 +209,18 @@ public class ScheduleManager
     }
 
     /// <summary>
-    /// Detects which preset matches the current intervals, or returns "Custom".
+    /// Detects which preset matches the current default schedule intervals, or returns "Custom".
     /// </summary>
     public string GetActivePreset()
     {
         lock (_lock)
         {
-            foreach (var (presetName, intervals) in s_presets)
-            {
-                bool matches = true;
-                foreach (var (collector, freq) in intervals)
-                {
-                    var schedule = _schedules.FirstOrDefault(s =>
-                        s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
-                    if (schedule != null && schedule.FrequencyMinutes != freq)
-                    {
-                        matches = false;
-                        break;
-                    }
-                }
-                if (matches) return presetName;
-            }
-            return "Custom";
+            return DetectPreset(_defaultSchedule);
         }
     }
 
     /// <summary>
-    /// Applies a named preset, changing all scheduled collector frequencies.
+    /// Applies a named preset to the default schedule.
     /// Does not modify enabled/disabled state or on-load (frequency=0) collectors.
     /// </summary>
     public void ApplyPreset(string presetName)
@@ -232,31 +232,287 @@ public class ScheduleManager
 
         lock (_lock)
         {
-            foreach (var (collector, freq) in intervals)
-            {
-                var schedule = _schedules.FirstOrDefault(s =>
-                    s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
-                if (schedule != null)
-                {
-                    schedule.FrequencyMinutes = freq;
-                }
-            }
-
+            ApplyPresetToList(_defaultSchedule, intervals);
             SaveSchedules();
 
-            _logger?.LogInformation("Applied collection preset '{Preset}'", presetName);
+            _logger?.LogInformation("Applied collection preset '{Preset}' to default schedule", presetName);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  New per-server API (v2)
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the default schedule list.
+    /// </summary>
+    public IReadOnlyList<CollectorSchedule> GetDefaultSchedule()
+    {
+        lock (_lock)
+        {
+            return _defaultSchedule.ToList();
         }
     }
 
     /// <summary>
-    /// Loads schedules from the JSON config file.
+    /// Returns the schedule for a specific server.
+    /// If the server has an override, returns those collectors; otherwise returns a copy of the default.
+    /// </summary>
+    public IReadOnlyList<CollectorSchedule> GetSchedulesForServer(string serverId)
+    {
+        lock (_lock)
+        {
+            if (_serverOverrides.TryGetValue(serverId, out var over))
+            {
+                return over.Collectors.ToList();
+            }
+
+            return CloneScheduleList(_defaultSchedule);
+        }
+    }
+
+    /// <summary>
+    /// Gets collectors that are due to run for a specific server, using per-server run state.
+    /// </summary>
+    public IReadOnlyList<CollectorSchedule> GetDueCollectorsForServer(string serverId)
+    {
+        lock (_lock)
+        {
+            var schedules = _serverOverrides.TryGetValue(serverId, out var over)
+                ? over.Collectors
+                : _defaultSchedule;
+
+            _serverRunState.TryGetValue(serverId, out var runState);
+
+            var due = new List<CollectorSchedule>();
+            foreach (var s in schedules)
+            {
+                if (!s.Enabled || !s.IsScheduled)
+                    continue;
+
+                if (runState == null || !runState.TryGetValue(s.Name, out var lastRun))
+                {
+                    due.Add(s); // never run — due immediately
+                    continue;
+                }
+
+                var elapsed = DateTime.UtcNow - lastRun;
+                if (elapsed.TotalMinutes >= s.FrequencyMinutes)
+                {
+                    due.Add(s);
+                }
+            }
+
+            return due;
+        }
+    }
+
+    /// <summary>
+    /// Gets on-load only collectors for a specific server.
+    /// </summary>
+    public IReadOnlyList<CollectorSchedule> GetOnLoadCollectorsForServer(string serverId)
+    {
+        lock (_lock)
+        {
+            var schedules = _serverOverrides.TryGetValue(serverId, out var over)
+                ? over.Collectors
+                : _defaultSchedule;
+
+            return schedules.Where(s => s.Enabled && !s.IsScheduled).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Gets a specific collector schedule by name for a server.
+    /// </summary>
+    public CollectorSchedule? GetScheduleForServer(string serverId, string collectorName)
+    {
+        lock (_lock)
+        {
+            var schedules = _serverOverrides.TryGetValue(serverId, out var over)
+                ? over.Collectors
+                : _defaultSchedule;
+
+            return schedules.FirstOrDefault(s =>
+                s.Name.Equals(collectorName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
+    /// Records a collector run for a specific server.
+    /// </summary>
+    public void MarkCollectorRunForServer(string serverId, string collectorName, DateTime runTime)
+    {
+        lock (_lock)
+        {
+            if (!_serverRunState.TryGetValue(serverId, out var runState))
+            {
+                runState = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+                _serverRunState[serverId] = runState;
+            }
+
+            runState[collectorName] = runTime;
+
+            _logger?.LogDebug("Marked collector '{Name}' as run for server {ServerId} at {Time}",
+                collectorName, serverId, runTime);
+        }
+    }
+
+    /// <summary>
+    /// Creates or updates a per-server schedule override.
+    /// </summary>
+    public void SetScheduleForServer(string serverId, List<CollectorSchedule> schedules)
+    {
+        lock (_lock)
+        {
+            _serverOverrides[serverId] = new ServerScheduleOverride { Collectors = schedules };
+            SaveSchedules();
+
+            _logger?.LogInformation("Set schedule override for server {ServerId} ({Count} collectors)",
+                serverId, schedules.Count);
+        }
+    }
+
+    /// <summary>
+    /// Removes a server's schedule override, reverting it to the default.
+    /// </summary>
+    public void RemoveServerOverride(string serverId)
+    {
+        lock (_lock)
+        {
+            if (_serverOverrides.Remove(serverId))
+            {
+                SaveSchedules();
+                _logger?.LogInformation("Removed schedule override for server {ServerId}", serverId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the server has a custom schedule override.
+    /// </summary>
+    public bool HasServerOverride(string serverId)
+    {
+        lock (_lock)
+        {
+            return _serverOverrides.ContainsKey(serverId);
+        }
+    }
+
+    /// <summary>
+    /// Applies a preset to a single server's schedule.
+    /// Creates an override if one doesn't exist (copies default first).
+    /// </summary>
+    public void ApplyPresetForServer(string serverId, string presetName)
+    {
+        if (!s_presets.TryGetValue(presetName, out var intervals))
+        {
+            throw new ArgumentException($"Unknown preset: {presetName}");
+        }
+
+        lock (_lock)
+        {
+            if (!_serverOverrides.TryGetValue(serverId, out var over))
+            {
+                over = new ServerScheduleOverride { Collectors = CloneScheduleList(_defaultSchedule) };
+                _serverOverrides[serverId] = over;
+            }
+
+            ApplyPresetToList(over.Collectors, intervals);
+            SaveSchedules();
+
+            _logger?.LogInformation("Applied preset '{Preset}' to server {ServerId}", presetName, serverId);
+        }
+    }
+
+    /// <summary>
+    /// Applies a preset to the default schedule (alias for ApplyPreset).
+    /// </summary>
+    public void ApplyPresetToDefault(string presetName)
+    {
+        ApplyPreset(presetName);
+    }
+
+    /// <summary>
+    /// Detects which preset matches a server's active schedule.
+    /// </summary>
+    public string GetActivePresetForServer(string serverId)
+    {
+        lock (_lock)
+        {
+            var schedules = _serverOverrides.TryGetValue(serverId, out var over)
+                ? over.Collectors
+                : _defaultSchedule;
+
+            return DetectPreset(schedules);
+        }
+    }
+
+    /// <summary>
+    /// Removes orphaned overrides for servers that no longer exist.
+    /// </summary>
+    public void CleanupRemovedServers(IEnumerable<string> activeServerIds)
+    {
+        lock (_lock)
+        {
+            var activeSet = new HashSet<string>(activeServerIds);
+            var orphaned = _serverOverrides.Keys.Where(id => !activeSet.Contains(id)).ToList();
+
+            if (orphaned.Count == 0)
+                return;
+
+            foreach (var id in orphaned)
+            {
+                _serverOverrides.Remove(id);
+                _serverRunState.Remove(id);
+            }
+
+            SaveSchedules();
+
+            _logger?.LogInformation("Cleaned up {Count} orphaned server schedule override(s)", orphaned.Count);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Persistence
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Saves schedules to the JSON config file (v2 format).
+    /// </summary>
+    public void SaveSchedules()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                var config = new ScheduleConfigV2
+                {
+                    Version = 2,
+                    DefaultSchedule = _defaultSchedule,
+                    ServerOverrides = _serverOverrides
+                };
+                string json = JsonSerializer.Serialize(config, s_jsonOptions);
+                File.WriteAllText(_schedulePath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to save collection_schedule.json");
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads schedules from the JSON config file, handling v1→v2 migration.
     /// </summary>
     private void LoadSchedules()
     {
         if (!File.Exists(_schedulePath))
         {
             _logger?.LogInformation("Schedule file not found, using defaults");
-            _schedules = GetDefaultSchedules();
+            _defaultSchedule = GetDefaultSchedules();
+            _serverOverrides = new Dictionary<string, ServerScheduleOverride>();
             SaveSchedules();
             return;
         }
@@ -264,16 +520,35 @@ public class ScheduleManager
         try
         {
             string json = File.ReadAllText(_schedulePath);
-            var config = JsonSerializer.Deserialize<ScheduleConfig>(json);
-            _schedules = config?.Collectors ?? GetDefaultSchedules();
 
-            /* Create backup of valid config */
-            try { File.Copy(_schedulePath, _schedulePath + ".bak", overwrite: true); }
-            catch { /* best effort */ }
+            if (TryLoadV2(json))
+            {
+                /* Create backup of valid config */
+                try { File.Copy(_schedulePath, _schedulePath + ".bak", overwrite: true); }
+                catch { /* best effort */ }
 
-            _logger?.LogInformation("Loaded {Count} collector schedules from configuration", _schedules.Count);
+                _logger?.LogInformation(
+                    "Loaded v2 schedule config: {DefaultCount} default collectors, {OverrideCount} server override(s)",
+                    _defaultSchedule.Count, _serverOverrides.Count);
+            }
+            else
+            {
+                /* v1 format — migrate */
+                var v1Config = JsonSerializer.Deserialize<ScheduleConfigV1>(json);
+                _defaultSchedule = v1Config?.Collectors ?? GetDefaultSchedules();
+                _serverOverrides = new Dictionary<string, ServerScheduleOverride>();
 
-            /* Add any new default collectors that are missing from the saved config */
+                /* Backup the v1 file before overwriting */
+                try { File.Copy(_schedulePath, _schedulePath + ".v1.bak", overwrite: true); }
+                catch { /* best effort */ }
+
+                SaveSchedules();
+
+                _logger?.LogInformation(
+                    "Migrated v1 schedule config to v2: {Count} collectors moved to default_schedule",
+                    _defaultSchedule.Count);
+            }
+
             MergeNewDefaults();
         }
         catch (Exception ex)
@@ -287,50 +562,62 @@ public class ScheduleManager
                 try
                 {
                     string bakJson = File.ReadAllText(bakPath);
-                    var bakConfig = JsonSerializer.Deserialize<ScheduleConfig>(bakJson);
-                    _schedules = bakConfig?.Collectors ?? GetDefaultSchedules();
-                    _logger?.LogInformation("Restored schedules from backup file");
+                    if (TryLoadV2(bakJson))
+                    {
+                        _logger?.LogInformation("Restored schedules from backup file");
+                        return;
+                    }
+
+                    var bakConfig = JsonSerializer.Deserialize<ScheduleConfigV1>(bakJson);
+                    _defaultSchedule = bakConfig?.Collectors ?? GetDefaultSchedules();
+                    _serverOverrides = new Dictionary<string, ServerScheduleOverride>();
+                    _logger?.LogInformation("Restored v1 schedules from backup file");
                     return;
                 }
                 catch { /* backup also corrupt, fall through to defaults */ }
             }
 
-            _schedules = GetDefaultSchedules();
+            _defaultSchedule = GetDefaultSchedules();
+            _serverOverrides = new Dictionary<string, ServerScheduleOverride>();
             SaveSchedules();
         }
     }
 
     /// <summary>
-    /// Merges any new default collectors that are missing from the loaded config,
-    /// and removes any obsolete/renamed collectors that no longer have a dispatch case.
-    /// This handles the case where new collectors are added to the code but the user
-    /// has an existing config file from an older version.
+    /// Attempts to load JSON as v2 format. Returns true if successful.
+    /// </summary>
+    private bool TryLoadV2(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("version", out var versionProp) || versionProp.GetInt32() < 2)
+            return false;
+
+        var config = JsonSerializer.Deserialize<ScheduleConfigV2>(json);
+        if (config == null)
+            return false;
+
+        _defaultSchedule = config.DefaultSchedule ?? GetDefaultSchedules();
+        _serverOverrides = config.ServerOverrides ?? new Dictionary<string, ServerScheduleOverride>();
+        return true;
+    }
+
+    /// <summary>
+    /// Merges any new default collectors into the default schedule and all server overrides.
+    /// Also removes obsolete collectors that no longer have a dispatch case.
     /// </summary>
     private void MergeNewDefaults()
     {
         var defaults = GetDefaultSchedules();
         var defaultNames = new HashSet<string>(defaults.Select(s => s.Name), StringComparer.OrdinalIgnoreCase);
-        var loadedNames = new HashSet<string>(_schedules.Select(s => s.Name), StringComparer.OrdinalIgnoreCase);
         var changed = false;
 
-        /* Remove obsolete collectors that are no longer in the defaults
-           (e.g., blocking_snapshot was renamed to blocked_process_report) */
-        var removed = _schedules.RemoveAll(s => !defaultNames.Contains(s.Name));
-        if (removed > 0)
-        {
-            _logger?.LogInformation("Removed {Count} obsolete collector(s) from schedule", removed);
-            changed = true;
-        }
+        /* Merge into default schedule */
+        changed |= MergeIntoList(_defaultSchedule, defaults, defaultNames);
 
-        /* Add any new default collectors that are missing */
-        foreach (var defaultSchedule in defaults)
+        /* Merge into each server override */
+        foreach (var over in _serverOverrides.Values)
         {
-            if (!loadedNames.Contains(defaultSchedule.Name))
-            {
-                _schedules.Add(defaultSchedule);
-                _logger?.LogInformation("Added missing collector '{Name}' from defaults", defaultSchedule.Name);
-                changed = true;
-            }
+            changed |= MergeIntoList(over.Collectors, defaults, defaultNames);
         }
 
         if (changed)
@@ -340,24 +627,100 @@ public class ScheduleManager
     }
 
     /// <summary>
-    /// Saves schedules to the JSON config file.
+    /// Merges new defaults into a collector list. Removes obsolete, adds missing.
+    /// Returns true if any changes were made.
     /// </summary>
-    public void SaveSchedules()
+    private bool MergeIntoList(List<CollectorSchedule> list, List<CollectorSchedule> defaults, HashSet<string> defaultNames)
     {
-        lock (_lock)
+        var loadedNames = new HashSet<string>(list.Select(s => s.Name), StringComparer.OrdinalIgnoreCase);
+        var changed = false;
+
+        /* Remove obsolete collectors */
+        var removed = list.RemoveAll(s => !defaultNames.Contains(s.Name));
+        if (removed > 0)
         {
-            try
+            _logger?.LogInformation("Removed {Count} obsolete collector(s) from schedule", removed);
+            changed = true;
+        }
+
+        /* Add missing collectors */
+        foreach (var defaultSchedule in defaults)
+        {
+            if (!loadedNames.Contains(defaultSchedule.Name))
             {
-                var config = new ScheduleConfig { Collectors = _schedules };
-                string json = JsonSerializer.Serialize(config, s_jsonOptions);
-                File.WriteAllText(_schedulePath, json);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, "Failed to save collection_schedule.json");
-                throw;
+                list.Add(CloneSchedule(defaultSchedule));
+                _logger?.LogInformation("Added missing collector '{Name}' from defaults", defaultSchedule.Name);
+                changed = true;
             }
         }
+
+        return changed;
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Detects which preset matches a list of collector schedules.
+    /// </summary>
+    private static string DetectPreset(List<CollectorSchedule> schedules)
+    {
+        foreach (var (presetName, intervals) in s_presets)
+        {
+            bool matches = true;
+            foreach (var (collector, freq) in intervals)
+            {
+                var schedule = schedules.FirstOrDefault(s =>
+                    s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+                if (schedule != null && schedule.FrequencyMinutes != freq)
+                {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return presetName;
+        }
+        return "Custom";
+    }
+
+    /// <summary>
+    /// Applies preset intervals to a collector list. Does not touch enabled/disabled or on-load collectors.
+    /// </summary>
+    private static void ApplyPresetToList(List<CollectorSchedule> schedules, Dictionary<string, int> intervals)
+    {
+        foreach (var (collector, freq) in intervals)
+        {
+            var schedule = schedules.FirstOrDefault(s =>
+                s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+            if (schedule != null)
+            {
+                schedule.FrequencyMinutes = freq;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deep-clones a schedule list (for creating overrides from defaults).
+    /// </summary>
+    private static List<CollectorSchedule> CloneScheduleList(List<CollectorSchedule> source)
+    {
+        return source.Select(CloneSchedule).ToList();
+    }
+
+    /// <summary>
+    /// Deep-clones a single CollectorSchedule (config properties only, not runtime state).
+    /// </summary>
+    private static CollectorSchedule CloneSchedule(CollectorSchedule s)
+    {
+        return new CollectorSchedule
+        {
+            Name = s.Name,
+            Enabled = s.Enabled,
+            FrequencyMinutes = s.FrequencyMinutes,
+            RetentionDays = s.RetentionDays,
+            Description = s.Description
+        };
     }
 
     /// <summary>
@@ -393,12 +756,31 @@ public class ScheduleManager
         };
     }
 
+    // ──────────────────────────────────────────────────────────────────
+    //  JSON config models
+    // ──────────────────────────────────────────────────────────────────
+
     /// <summary>
-    /// JSON wrapper for schedules list.
+    /// v1 JSON format: { "collectors": [...] }
     /// </summary>
-    private class ScheduleConfig
+    private class ScheduleConfigV1
     {
         [JsonPropertyName("collectors")]
         public List<CollectorSchedule> Collectors { get; set; } = new();
+    }
+
+    /// <summary>
+    /// v2 JSON format: { "version": 2, "default_schedule": [...], "server_overrides": { "guid": { "collectors": [...] } } }
+    /// </summary>
+    private class ScheduleConfigV2
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 2;
+
+        [JsonPropertyName("default_schedule")]
+        public List<CollectorSchedule> DefaultSchedule { get; set; } = new();
+
+        [JsonPropertyName("server_overrides")]
+        public Dictionary<string, ServerScheduleOverride> ServerOverrides { get; set; } = new();
     }
 }

--- a/Lite/Windows/CollectorScheduleEditorWindow.xaml
+++ b/Lite/Windows/CollectorScheduleEditorWindow.xaml
@@ -1,0 +1,87 @@
+<Window x:Class="PerformanceMonitorLite.Windows.CollectorScheduleEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Collector Schedules"
+        Height="600" Width="900"
+        MinHeight="400" MinWidth="700"
+        ResizeMode="CanResizeWithGrip"
+        WindowStartupLocation="CenterOwner"
+        Icon="/EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock x:Name="HeaderText" Text="Collector Schedules" FontSize="16" FontWeight="Bold"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock x:Name="SubHeaderText" FontSize="12"
+                       Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Preset + Use Default -->
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
+                <TextBlock Text="Preset:" Foreground="{DynamicResource ForegroundBrush}" FontSize="12"
+                           VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <ComboBox x:Name="PresetComboBox" Width="140" SelectionChanged="PresetComboBox_SelectionChanged">
+                    <ComboBoxItem Content="Custom" IsEnabled="False"/>
+                    <ComboBoxItem Content="Low-Impact"/>
+                    <ComboBoxItem Content="Balanced"/>
+                    <ComboBoxItem Content="Aggressive"/>
+                </ComboBox>
+            </StackPanel>
+
+            <CheckBox x:Name="UseDefaultCheckBox" Grid.Column="1" Content="Use default schedule"
+                      Margin="20,0,0,0" VerticalAlignment="Center"
+                      Foreground="{DynamicResource ForegroundBrush}"
+                      Checked="UseDefaultCheckBox_Changed" Unchecked="UseDefaultCheckBox_Changed"/>
+
+            <StackPanel Grid.Column="3" Orientation="Horizontal">
+                <Button x:Name="CopyFromDefaultButton" Content="Copy from Default" Click="CopyFromDefault_Click" Margin="0,0,8,0"/>
+                <ComboBox x:Name="CopyFromServerCombo" Width="160" Visibility="Collapsed"/>
+                <Button x:Name="CopyFromServerButton" Content="Copy from Server" Click="CopyFromServer_Click" Visibility="Collapsed"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Schedule DataGrid -->
+        <DataGrid Grid.Row="2" x:Name="ScheduleGrid"
+                  AutoGenerateColumns="False" IsReadOnly="False"
+                  CanUserAddRows="False" CanUserDeleteRows="False"
+                  SelectionMode="Single"
+                  Background="Transparent" BorderThickness="0"
+                  HeadersVisibility="Column" GridLinesVisibility="Horizontal">
+            <DataGrid.Columns>
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="65"/>
+                <DataGridTextColumn Header="Collector" Binding="{Binding Name}" Width="160" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Frequency (min)" Binding="{Binding FrequencyMinutes, UpdateSourceTrigger=LostFocus}" Width="110"/>
+                <DataGridTextColumn Header="Retention (days)" Binding="{Binding RetentionDays, UpdateSourceTrigger=LostFocus}" Width="110"/>
+                <DataGridTextColumn Header="Schedule" Binding="{Binding FrequencyDisplay}" Width="140" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*" IsReadOnly="True"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Status text -->
+        <TextBlock Grid.Row="3" x:Name="StatusText" FontSize="11" FontStyle="Italic"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,8,0,0"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Save" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Lite/Windows/CollectorScheduleEditorWindow.xaml.cs
+++ b/Lite/Windows/CollectorScheduleEditorWindow.xaml.cs
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Windows;
+
+public partial class CollectorScheduleEditorWindow : Window
+{
+    private readonly ScheduleManager _scheduleManager;
+    private readonly ServerManager _serverManager;
+    private readonly string? _serverId;
+    private readonly string? _serverDisplayName;
+    private List<CollectorSchedule> _editingSchedules = new();
+    private bool _suppressPresetChange;
+    private bool _isEditingDefault;
+
+    /// <summary>
+    /// True if the user saved changes.
+    /// </summary>
+    public bool Saved { get; private set; }
+
+    /// <summary>
+    /// Opens the editor for a specific server's schedule.
+    /// </summary>
+    public CollectorScheduleEditorWindow(
+        ScheduleManager scheduleManager,
+        ServerManager serverManager,
+        string serverId,
+        string serverDisplayName)
+    {
+        InitializeComponent();
+        _scheduleManager = scheduleManager;
+        _serverManager = serverManager;
+        _serverId = serverId;
+        _serverDisplayName = serverDisplayName;
+        _isEditingDefault = false;
+
+        Title = $"Collector Schedules - {serverDisplayName}";
+        HeaderText.Text = $"Collector Schedules - {serverDisplayName}";
+        SubHeaderText.Text = $"Server: {serverDisplayName}";
+
+        SetupCopyFromServerCombo();
+        LoadServerSchedule();
+    }
+
+    /// <summary>
+    /// Opens the editor for the default schedule.
+    /// </summary>
+    public CollectorScheduleEditorWindow(
+        ScheduleManager scheduleManager,
+        ServerManager serverManager)
+    {
+        InitializeComponent();
+        _scheduleManager = scheduleManager;
+        _serverManager = serverManager;
+        _isEditingDefault = true;
+
+        Title = "Default Collector Schedule";
+        HeaderText.Text = "Default Collector Schedule";
+        SubHeaderText.Text = "This schedule applies to all servers without a custom override.";
+
+        /* Hide server-specific controls */
+        UseDefaultCheckBox.Visibility = Visibility.Collapsed;
+        CopyFromDefaultButton.Visibility = Visibility.Collapsed;
+
+        _editingSchedules = CloneScheduleList(_scheduleManager.GetDefaultSchedule());
+        ScheduleGrid.ItemsSource = _editingSchedules;
+        DetectActivePreset();
+    }
+
+    private void SetupCopyFromServerCombo()
+    {
+        var servers = _serverManager.GetAllServers()
+            .Where(s => s.Id != _serverId)
+            .ToList();
+
+        if (servers.Count > 0)
+        {
+            CopyFromServerCombo.Visibility = Visibility.Visible;
+            CopyFromServerButton.Visibility = Visibility.Visible;
+            CopyFromServerCombo.DisplayMemberPath = "DisplayName";
+            CopyFromServerCombo.SelectedValuePath = "Id";
+            CopyFromServerCombo.ItemsSource = servers;
+            CopyFromServerCombo.SelectedIndex = 0;
+        }
+    }
+
+    private void LoadServerSchedule()
+    {
+        bool usesDefault = !_scheduleManager.HasServerOverride(_serverId!);
+        UseDefaultCheckBox.IsChecked = usesDefault;
+
+        _editingSchedules = CloneScheduleList(_scheduleManager.GetSchedulesForServer(_serverId!));
+        ScheduleGrid.ItemsSource = _editingSchedules;
+        UpdateEditableState(usesDefault);
+        DetectActivePreset();
+    }
+
+    private void UpdateEditableState(bool usesDefault)
+    {
+        bool editable = !usesDefault;
+        ScheduleGrid.IsReadOnly = usesDefault;
+        ScheduleGrid.Opacity = usesDefault ? 0.6 : 1.0;
+        PresetComboBox.IsEnabled = editable;
+        CopyFromDefaultButton.IsEnabled = editable;
+        CopyFromServerButton.IsEnabled = editable;
+        CopyFromServerCombo.IsEnabled = editable;
+
+        StatusText.Text = usesDefault
+            ? "Using default schedule (read-only). Uncheck 'Use default schedule' to customize this server."
+            : "Custom schedule. Changes apply only to this server.";
+    }
+
+    private void UseDefaultCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_isEditingDefault) return;
+
+        bool usesDefault = UseDefaultCheckBox.IsChecked == true;
+
+        if (!usesDefault)
+        {
+            /* Switching from default to custom — copy current defaults as starting point */
+            _editingSchedules = CloneScheduleList(_scheduleManager.GetDefaultSchedule());
+            ScheduleGrid.ItemsSource = _editingSchedules;
+        }
+        else
+        {
+            /* Switching to default — show the default schedule (read-only) */
+            _editingSchedules = CloneScheduleList(_scheduleManager.GetDefaultSchedule());
+            ScheduleGrid.ItemsSource = _editingSchedules;
+        }
+
+        UpdateEditableState(usesDefault);
+        DetectActivePreset();
+    }
+
+    private void DetectActivePreset()
+    {
+        _suppressPresetChange = true;
+        try
+        {
+            string active = DetectPresetForList(_editingSchedules);
+            for (int i = 0; i < PresetComboBox.Items.Count; i++)
+            {
+                if (PresetComboBox.Items[i] is ComboBoxItem item &&
+                    string.Equals(item.Content?.ToString(), active, StringComparison.OrdinalIgnoreCase))
+                {
+                    PresetComboBox.SelectedIndex = i;
+                    return;
+                }
+            }
+            PresetComboBox.SelectedIndex = 0;
+        }
+        finally
+        {
+            _suppressPresetChange = false;
+        }
+    }
+
+    private void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressPresetChange) return;
+        if (PresetComboBox.SelectedItem is not ComboBoxItem selected) return;
+
+        string presetName = selected.Content?.ToString() ?? "";
+        if (presetName == "Custom") return;
+
+        var result = MessageBox.Show(
+            $"Apply the \"{presetName}\" preset?\n\nThis will change all collector frequencies. Enabled/disabled state and retention settings are not affected.",
+            "Apply Collection Preset",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            DetectActivePreset();
+            return;
+        }
+
+        ApplyPresetToList(_editingSchedules, presetName);
+        ScheduleGrid.ItemsSource = null;
+        ScheduleGrid.ItemsSource = _editingSchedules;
+        DetectActivePreset();
+    }
+
+    private void CopyFromDefault_Click(object sender, RoutedEventArgs e)
+    {
+        var result = MessageBox.Show(
+            "Replace this server's schedule with a copy of the default schedule?",
+            "Copy from Default",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes) return;
+
+        _editingSchedules = CloneScheduleList(_scheduleManager.GetDefaultSchedule());
+        ScheduleGrid.ItemsSource = _editingSchedules;
+        DetectActivePreset();
+    }
+
+    private void CopyFromServer_Click(object sender, RoutedEventArgs e)
+    {
+        if (CopyFromServerCombo.SelectedItem is not Models.ServerConnection selected) return;
+        var sourceServerId = selected.Id;
+
+        var result = MessageBox.Show(
+            $"Replace this server's schedule with a copy of {selected.DisplayName}'s schedule?",
+            "Copy from Server",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes) return;
+
+        _editingSchedules = CloneScheduleList(_scheduleManager.GetSchedulesForServer(sourceServerId));
+        ScheduleGrid.ItemsSource = _editingSchedules;
+        DetectActivePreset();
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isEditingDefault)
+        {
+            /* Save to default schedule */
+            foreach (var edited in _editingSchedules)
+            {
+                _scheduleManager.UpdateSchedule(edited.Name,
+                    enabled: edited.Enabled,
+                    frequencyMinutes: edited.FrequencyMinutes,
+                    retentionDays: edited.RetentionDays);
+            }
+        }
+        else if (UseDefaultCheckBox.IsChecked == true)
+        {
+            /* Revert to default — remove override */
+            _scheduleManager.RemoveServerOverride(_serverId!);
+        }
+        else
+        {
+            /* Save per-server override */
+            _scheduleManager.SetScheduleForServer(_serverId!, _editingSchedules);
+        }
+
+        Saved = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private static readonly Dictionary<string, Dictionary<string, int>> s_presets = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Aggressive"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 1, ["query_stats"] = 1, ["procedure_stats"] = 1,
+            ["query_store"] = 2, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+            ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 2,
+            ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+            ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["blocked_process_report"] = 1, ["running_jobs"] = 2
+        },
+        ["Balanced"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 1, ["query_stats"] = 1, ["procedure_stats"] = 1,
+            ["query_store"] = 5, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+            ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 5,
+            ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+            ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["blocked_process_report"] = 1, ["running_jobs"] = 5
+        },
+        ["Low-Impact"] = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_stats"] = 5, ["query_stats"] = 10, ["procedure_stats"] = 10,
+            ["query_store"] = 30, ["query_snapshots"] = 5, ["cpu_utilization"] = 5,
+            ["file_io_stats"] = 10, ["memory_stats"] = 10, ["memory_clerks"] = 30,
+            ["tempdb_stats"] = 5, ["perfmon_stats"] = 5, ["deadlocks"] = 5,
+            ["memory_grant_stats"] = 5, ["waiting_tasks"] = 5,
+            ["blocked_process_report"] = 5, ["running_jobs"] = 30
+        }
+    };
+
+    private static string DetectPresetForList(List<CollectorSchedule> schedules)
+    {
+        foreach (var (presetName, intervals) in s_presets)
+        {
+            bool matches = true;
+            foreach (var (collector, freq) in intervals)
+            {
+                var schedule = schedules.FirstOrDefault(s =>
+                    s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+                if (schedule != null && schedule.FrequencyMinutes != freq)
+                {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return presetName;
+        }
+        return "Custom";
+    }
+
+    private static void ApplyPresetToList(List<CollectorSchedule> schedules, string presetName)
+    {
+        if (!s_presets.TryGetValue(presetName, out var intervals)) return;
+
+        foreach (var (collector, freq) in intervals)
+        {
+            var schedule = schedules.FirstOrDefault(s =>
+                s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+            if (schedule != null)
+            {
+                schedule.FrequencyMinutes = freq;
+            }
+        }
+    }
+
+    private static List<CollectorSchedule> CloneScheduleList(IReadOnlyList<CollectorSchedule> source)
+    {
+        return source.Select(s => new CollectorSchedule
+        {
+            Name = s.Name,
+            Enabled = s.Enabled,
+            FrequencyMinutes = s.FrequencyMinutes,
+            RetentionDays = s.RetentionDays,
+            Description = s.Description
+        }).ToList();
+    }
+}

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -332,49 +332,47 @@
             </StackPanel>
         </Border>
 
-        <!-- Collector Schedule Grid -->
-        <Grid Grid.Row="6">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <!-- Collector Schedules (Per-Server) -->
+        <Border Grid.Row="6" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0" Margin="0,0,0,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="Collector Schedules" FontSize="14" FontWeight="SemiBold"
-                           Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <TextBlock Text="Preset:" Foreground="{DynamicResource ForegroundBrush}" FontSize="12"
+                <TextBlock Grid.Row="0" Text="Collector Schedules" FontSize="14" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                <TextBlock Grid.Row="1" Text="Each server can have its own collection schedule, or inherit the default."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,8"/>
+
+                <DataGrid Grid.Row="2" x:Name="ServerScheduleGrid"
+                          AutoGenerateColumns="False" IsReadOnly="True"
+                          CanUserAddRows="False" CanUserDeleteRows="False"
+                          SelectionMode="Single"
+                          Background="Transparent" BorderThickness="0"
+                          HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                          MinHeight="80" MaxHeight="200"
+                          MouseDoubleClick="ServerScheduleGrid_DoubleClick">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="*"/>
+                        <DataGridTextColumn Header="Preset" Binding="{Binding Preset}" Width="110"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="100"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,8,0,0">
+                    <Button Content="Edit Selected..." x:Name="EditServerScheduleButton" Click="EditServerSchedule_Click" Margin="0,0,8,0"/>
+                    <Button Content="Edit Default..." x:Name="EditDefaultScheduleButton" Click="EditDefaultSchedule_Click" Margin="0,0,16,0"/>
+                    <TextBlock Text="Default preset:" Foreground="{DynamicResource ForegroundBrush}" FontSize="12"
                                VerticalAlignment="Center" Margin="0,0,8,0"/>
-                    <ComboBox x:Name="PresetComboBox" Width="140" SelectionChanged="PresetComboBox_SelectionChanged">
-                        <ComboBoxItem Content="Custom" IsEnabled="False"/>
-                        <ComboBoxItem Content="Low-Impact"/>
-                        <ComboBoxItem Content="Balanced"/>
-                        <ComboBoxItem Content="Aggressive"/>
-                    </ComboBox>
+                    <TextBlock x:Name="DefaultPresetText" FontSize="12" FontWeight="SemiBold"
+                               Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,16,0"/>
+                    <Button Content="Apply Default to All" Click="ApplyDefaultToAll_Click"/>
                 </StackPanel>
             </Grid>
-
-            <DataGrid Grid.Row="1" x:Name="ScheduleGrid"
-                      AutoGenerateColumns="False" IsReadOnly="False"
-                      CanUserAddRows="False" CanUserDeleteRows="False"
-                      SelectionMode="Single"
-                      Background="Transparent" BorderThickness="0"
-                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                      ContextMenu="{StaticResource DataGridContextMenu}">
-                <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="65"/>
-                    <DataGridTextColumn Header="Collector" Binding="{Binding Name}" Width="160" IsReadOnly="True"/>
-                    <DataGridTextColumn Header="Frequency (min)" Binding="{Binding FrequencyMinutes, UpdateSourceTrigger=LostFocus}" Width="110"/>
-                    <DataGridTextColumn Header="Retention (days)" Binding="{Binding RetentionDays, UpdateSourceTrigger=LostFocus}" Width="110"/>
-                    <DataGridTextColumn Header="Schedule" Binding="{Binding FrequencyDisplay}" Width="140" IsReadOnly="True"/>
-                    <DataGridTextColumn Header="Last Run" Binding="{Binding LastRunTime, StringFormat=HH:mm:ss}" Width="90" IsReadOnly="True"/>
-                </DataGrid.Columns>
-            </DataGrid>
-        </Grid>
+        </Border>
 
         <!-- Buttons -->
         <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -15,6 +16,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using PerformanceMonitorLite.Mcp;
 using PerformanceMonitorLite.Services;
 
@@ -23,23 +25,26 @@ namespace PerformanceMonitorLite.Windows;
 public partial class SettingsWindow : Window
 {
     private readonly ScheduleManager _scheduleManager;
+    private readonly ServerManager _serverManager;
     private readonly CollectionBackgroundService? _backgroundService;
     private readonly McpHostService? _mcpService;
     private readonly MuteRuleService? _muteRuleService;
 
     public SettingsWindow(
         ScheduleManager scheduleManager,
+        ServerManager serverManager,
         CollectionBackgroundService? backgroundService = null,
         McpHostService? mcpService = null,
         MuteRuleService? muteRuleService = null)
     {
         InitializeComponent();
         _scheduleManager = scheduleManager;
+        _serverManager = serverManager;
         _backgroundService = backgroundService;
         _mcpService = mcpService;
         _muteRuleService = muteRuleService;
 
-        LoadSchedules();
+        LoadServerScheduleSummary();
         UpdateCollectionStatus();
         LoadMcpSettings();
         UpdateMcpStatus();
@@ -52,62 +57,91 @@ public partial class SettingsWindow : Window
         LoadSmtpSettings();
     }
 
-    private bool _suppressPresetChange;
-
-    private void LoadSchedules()
+    private void LoadServerScheduleSummary()
     {
-        ScheduleGrid.ItemsSource = _scheduleManager.GetAllSchedules();
-        DetectActivePreset();
+        var servers = _serverManager.GetAllServers();
+        var rows = servers.Select(s => new ServerScheduleRow
+        {
+            ServerId = s.Id,
+            ServerName = s.DisplayName,
+            Preset = _scheduleManager.GetActivePresetForServer(s.Id),
+            Status = _scheduleManager.HasServerOverride(s.Id) ? "Customized" : "Default"
+        }).ToList();
+
+        ServerScheduleGrid.ItemsSource = rows;
+        DefaultPresetText.Text = _scheduleManager.GetActivePreset();
     }
 
-    private void DetectActivePreset()
+    private void EditServerSchedule_Click(object sender, RoutedEventArgs e)
     {
-        _suppressPresetChange = true;
-        try
+        OpenServerScheduleEditor();
+    }
+
+    private void ServerScheduleGrid_DoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        OpenServerScheduleEditor();
+    }
+
+    private void OpenServerScheduleEditor()
+    {
+        if (ServerScheduleGrid.SelectedItem is not ServerScheduleRow row) return;
+
+        var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == row.ServerId);
+        if (server == null) return;
+
+        var editor = new CollectorScheduleEditorWindow(_scheduleManager, _serverManager, server.Id, server.DisplayName) { Owner = this };
+        editor.ShowDialog();
+
+        if (editor.Saved)
         {
-            string active = _scheduleManager.GetActivePreset();
-            for (int i = 0; i < PresetComboBox.Items.Count; i++)
-            {
-                if (PresetComboBox.Items[i] is ComboBoxItem item &&
-                    string.Equals(item.Content?.ToString(), active, StringComparison.OrdinalIgnoreCase))
-                {
-                    PresetComboBox.SelectedIndex = i;
-                    return;
-                }
-            }
-            PresetComboBox.SelectedIndex = 0;
-        }
-        finally
-        {
-            _suppressPresetChange = false;
+            LoadServerScheduleSummary();
         }
     }
 
-    private void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void EditDefaultSchedule_Click(object sender, RoutedEventArgs e)
     {
-        if (_suppressPresetChange) return;
-        if (PresetComboBox.SelectedItem is not ComboBoxItem selected) return;
+        var editor = new CollectorScheduleEditorWindow(_scheduleManager, _serverManager) { Owner = this };
+        editor.ShowDialog();
 
-        string presetName = selected.Content?.ToString() ?? "";
-        if (presetName == "Custom") return;
-
-        var result = MessageBox.Show(
-            $"Apply the \"{presetName}\" preset?\n\nThis will change all collector frequencies. Enabled/disabled state and retention settings are not affected.",
-            "Apply Collection Preset",
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Question
-        );
-
-        if (result != MessageBoxResult.Yes)
+        if (editor.Saved)
         {
-            DetectActivePreset();
+            LoadServerScheduleSummary();
+        }
+    }
+
+    private void ApplyDefaultToAll_Click(object sender, RoutedEventArgs e)
+    {
+        var servers = _serverManager.GetAllServers();
+        var customCount = servers.Count(s => _scheduleManager.HasServerOverride(s.Id));
+
+        if (customCount == 0)
+        {
+            MessageBox.Show("All servers are already using the default schedule.", "Apply Default", MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
 
-        _scheduleManager.ApplyPreset(presetName);
-        ScheduleGrid.ItemsSource = null;
-        ScheduleGrid.ItemsSource = _scheduleManager.GetAllSchedules();
-        DetectActivePreset();
+        var result = MessageBox.Show(
+            $"Remove custom schedules from {customCount} server(s) and revert them to the default schedule?\n\nThis cannot be undone.",
+            "Apply Default to All",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+
+        if (result != MessageBoxResult.Yes) return;
+
+        foreach (var server in servers)
+        {
+            _scheduleManager.RemoveServerOverride(server.Id);
+        }
+
+        LoadServerScheduleSummary();
+    }
+
+    private class ServerScheduleRow
+    {
+        public string ServerId { get; set; } = "";
+        public string ServerName { get; set; } = "";
+        public string Preset { get; set; } = "";
+        public string Status { get; set; } = "";
     }
 
     private void UpdateCollectionStatus()
@@ -169,7 +203,6 @@ public partial class SettingsWindow : Window
 
     private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        _scheduleManager.SaveSchedules();
         var (mcpChanged, mcpValid) = await SaveMcpSettingsAsync();
         SaveDefaultTimeRange();
         SaveConnectionTimeout();


### PR DESCRIPTION
## Summary
- **Lite**: Per-server collector schedules with v2 JSON config format (`default_schedule` + `server_overrides`), automatic v1 migration, new `CollectorScheduleEditorWindow` for editing per-server or default schedules, `SettingsWindow` reworked with server summary panel
- **Dashboard**: `CollectorScheduleWindow` title now shows which server's schedule you're editing
- **Collector dispatch**: `RemoteCollectorService` uses per-server schedule lookups and run-state tracking

Closes #703

## Test plan
- [ ] Lite: Open Settings, verify server schedule summary shows all servers as "Default"
- [ ] Lite: Click "Edit Selected", uncheck "Use default schedule", change frequencies, Save — verify "Customized" status
- [ ] Lite: Verify preset dropdown and copy-from-server work in editor
- [ ] Lite: "Apply Default to All" reverts customized servers
- [ ] Lite: Restart app — verify v1 config migrates to v2 (check `collection_schedule.json`)
- [ ] Lite: Verify collectors still run on schedule after changes
- [ ] Dashboard: Open Collector Schedules — title shows server name

🤖 Generated with [Claude Code](https://claude.com/claude-code)