### PR TITLE
feature/Add Teams and Slack webhook notifications

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -103,6 +103,7 @@ namespace PerformanceMonitorDashboard
 
             _credentialService = new CredentialService();
             _emailAlertService = new EmailAlertService(_preferencesService);
+            _ = new WebhookAlertService(_preferencesService);
 
             _alertCheckTimer = new DispatcherTimer();
             _alertCheckTimer.Tick += AlertCheckTimer_Tick;

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -117,6 +117,16 @@ namespace PerformanceMonitorDashboard.Models
         public string SmtpFromAddress { get; set; } = "";
         public string SmtpRecipients { get; set; } = "";
 
+        // Teams webhook settings
+        public bool TeamsWebhookEnabled { get; set; } = false;
+        public string TeamsWebhookUrl { get; set; } = "";
+        public string TeamsProxyAddress { get; set; } = "";
+
+        // Slack webhook settings
+        public bool SlackWebhookEnabled { get; set; } = false;
+        public string SlackWebhookUrl { get; set; } = "";
+        public string SlackProxyAddress { get; set; } = "";
+
         // MCP server settings
         public bool McpEnabled { get; set; } = false;
         public int McpPort { get; set; } = 5150;

--- a/Dashboard/Services/EmailAlertService.cs
+++ b/Dashboard/Services/EmailAlertService.cs
@@ -64,7 +64,8 @@ namespace PerformanceMonitorDashboard.Services
         }
 
         /// <summary>
-        /// Attempts to send an alert email if SMTP is enabled and cooldown has elapsed.
+        /// Attempts to send alert notifications (email, Teams, Slack) based on enabled channels.
+        /// Each channel operates independently — disabling email does not affect webhooks.
         /// Never throws.
         /// </summary>
         public async Task TrySendAlertEmailAsync(
@@ -78,64 +79,70 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var prefs = _preferencesService.GetPreferences();
-                if (!prefs.SmtpEnabled) return;
-
-                if (string.IsNullOrWhiteSpace(prefs.SmtpServer) ||
-                    string.IsNullOrWhiteSpace(prefs.SmtpFromAddress) ||
-                    string.IsNullOrWhiteSpace(prefs.SmtpRecipients))
-                {
-                    return;
-                }
-
-                var cooldownKey = $"{serverId}:{metricName}";
-                if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
-                    DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes))
-                {
-                    return;
-                }
-
-                var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
-                var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
-                    metricName, serverName, currentValue, thresholdValue, prefs.EmailCooldownMinutes, context);
-
                 string? sendError = null;
                 bool sent = false;
+                string notificationType = "tray";
 
-                try
+                /* Attempt email delivery if SMTP is fully configured */
+                if (prefs.SmtpEnabled &&
+                    !string.IsNullOrWhiteSpace(prefs.SmtpServer) &&
+                    !string.IsNullOrWhiteSpace(prefs.SmtpFromAddress) &&
+                    !string.IsNullOrWhiteSpace(prefs.SmtpRecipients))
                 {
-                    await SendEmailAsync(prefs, subject, htmlBody, plainTextBody, context);
-                    sent = true;
-                    _cooldowns[cooldownKey] = DateTime.UtcNow;
+                    var cooldownKey = $"{serverId}:{metricName}";
+                    var withinCooldown = _cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
+                        DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes);
 
-                    /* Log recovery if we had previous failures */
-                    if (_consecutiveFailures > 0)
+                    if (!withinCooldown)
                     {
-                        Logger.Info($"Alert email delivery recovered after {_consecutiveFailures} failure(s)");
-                    }
-                    _consecutiveFailures = 0;
-                    _lastFailureError = null;
+                        notificationType = "email";
+                        var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
+                        var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
+                            metricName, serverName, currentValue, thresholdValue, prefs.EmailCooldownMinutes, context);
 
-                    Logger.Info($"Alert email sent for {metricName} on {serverName}");
-                }
-                catch (Exception ex)
-                {
-                    sendError = ex.Message;
-                    _consecutiveFailures++;
-                    _lastFailureError = ex.Message;
+                        try
+                        {
+                            await SendEmailAsync(prefs, subject, htmlBody, plainTextBody, context);
+                            sent = true;
+                            _cooldowns[cooldownKey] = DateTime.UtcNow;
 
-                    /* Loud on first 3 failures, then periodic reminders */
-                    if (_consecutiveFailures <= 3)
-                    {
-                        Logger.Error($"ALERT EMAIL FAILED ({_consecutiveFailures}x): {ex.GetType().Name}: {ex.Message}");
-                    }
-                    else if (_consecutiveFailures % 50 == 0)
-                    {
-                        Logger.Error($"ALERT EMAIL STILL FAILING: {_consecutiveFailures} consecutive failures. Last error: {ex.Message}");
+                            if (_consecutiveFailures > 0)
+                            {
+                                Logger.Info($"Alert email delivery recovered after {_consecutiveFailures} failure(s)");
+                            }
+                            _consecutiveFailures = 0;
+                            _lastFailureError = null;
+
+                            Logger.Info($"Alert email sent for {metricName} on {serverName}");
+                        }
+                        catch (Exception ex)
+                        {
+                            sendError = ex.Message;
+                            _consecutiveFailures++;
+                            _lastFailureError = ex.Message;
+
+                            if (_consecutiveFailures <= 3)
+                            {
+                                Logger.Error($"ALERT EMAIL FAILED ({_consecutiveFailures}x): {ex.GetType().Name}: {ex.Message}");
+                            }
+                            else if (_consecutiveFailures % 50 == 0)
+                            {
+                                Logger.Error($"ALERT EMAIL STILL FAILING: {_consecutiveFailures} consecutive failures. Last error: {ex.Message}");
+                            }
+                        }
                     }
                 }
 
                 /* Log the alert attempt */
-                RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, "email", sendError);
+                RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, notificationType, sendError);
+
+                /* Send webhook notifications (Teams / Slack) — independent of email */
+                var webhookService = WebhookAlertService.Current;
+                if (webhookService != null)
+                {
+                    await webhookService.TrySendWebhookAlertsAsync(
+                        metricName, serverName, currentValue, thresholdValue, serverId, context);
+                }
             }
             catch (Exception ex)
             {

--- a/Dashboard/Services/WebhookAlertService.cs
+++ b/Dashboard/Services/WebhookAlertService.cs
@@ -1,0 +1,429 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    /// <summary>
+    /// Sends alert notifications to Microsoft Teams and/or Slack via incoming webhooks.
+    /// Color-coded accent bars match the existing email alert severity mapping.
+    /// </summary>
+    public class WebhookAlertService
+    {
+        private const string EditionName = "Performance Monitor Dashboard";
+        private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
+
+        private readonly UserPreferencesService _preferencesService;
+        private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+
+        private int _consecutiveTeamsFailures;
+        private string? _lastTeamsError;
+        private int _consecutiveSlackFailures;
+        private string? _lastSlackError;
+
+        public static WebhookAlertService? Current { get; private set; }
+
+        public WebhookAlertService(UserPreferencesService preferencesService)
+        {
+            _preferencesService = preferencesService;
+            Current = this;
+        }
+
+        /// <summary>
+        /// Sends webhook alerts to all configured channels (Teams and/or Slack).
+        /// Respects the email cooldown setting for throttling. Never throws.
+        /// </summary>
+        public async Task TrySendWebhookAlertsAsync(
+            string metricName,
+            string serverName,
+            string currentValue,
+            string thresholdValue,
+            string serverId = "",
+            AlertContext? context = null)
+        {
+            try
+            {
+                var prefs = _preferencesService.GetPreferences();
+
+                var cooldownKey = $"webhook:{serverId}:{metricName}";
+                if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
+                    DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes))
+                {
+                    return;
+                }
+
+                bool sent = false;
+
+                if (prefs.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(prefs.TeamsWebhookUrl))
+                {
+                    sent |= await TrySendTeamsAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
+                }
+
+                if (prefs.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(prefs.SlackWebhookUrl))
+                {
+                    sent |= await TrySendSlackAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
+                }
+
+                if (sent)
+                {
+                    _cooldowns[cooldownKey] = DateTime.UtcNow;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"TrySendWebhookAlertsAsync outer error: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Sends a test notification to Microsoft Teams. Returns null on success, error message on failure.
+        /// </summary>
+        public static async Task<string?> SendTestTeamsAsync(string webhookUrl, string? proxyAddress)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(webhookUrl))
+                    return "Teams webhook URL is not configured.";
+
+                var payload = BuildTeamsPayload("Test Notification", "", "SMTP and webhook configuration verified", "", isTest: true);
+                return await PostWebhookAsync(webhookUrl, payload, proxyAddress);
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
+            }
+        }
+
+        /// <summary>
+        /// Sends a test notification to Slack. Returns null on success, error message on failure.
+        /// </summary>
+        public static async Task<string?> SendTestSlackAsync(string webhookUrl, string? proxyAddress)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(webhookUrl))
+                    return "Slack webhook URL is not configured.";
+
+                var payload = BuildSlackPayload("Test Notification", "", "SMTP and webhook configuration verified", "", isTest: true);
+                return await PostWebhookAsync(webhookUrl, payload, proxyAddress);
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
+            }
+        }
+
+        public (int ConsecutiveFailures, string? LastError) GetTeamsHealth() =>
+            (_consecutiveTeamsFailures, _lastTeamsError);
+
+        public (int ConsecutiveFailures, string? LastError) GetSlackHealth() =>
+            (_consecutiveSlackFailures, _lastSlackError);
+
+        #region Teams
+
+        private async Task<bool> TrySendTeamsAlertAsync(
+            UserPreferences prefs,
+            string metricName,
+            string serverName,
+            string currentValue,
+            string thresholdValue,
+            AlertContext? context)
+        {
+            try
+            {
+                var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, context: context);
+                var error = await PostWebhookAsync(prefs.TeamsWebhookUrl, payload, prefs.TeamsProxyAddress);
+
+                if (error != null)
+                {
+                    _consecutiveTeamsFailures++;
+                    _lastTeamsError = error;
+
+                    if (_consecutiveTeamsFailures <= 3)
+                        Logger.Error($"TEAMS WEBHOOK FAILED ({_consecutiveTeamsFailures}x): {error}");
+                    else if (_consecutiveTeamsFailures % 50 == 0)
+                        Logger.Error($"TEAMS WEBHOOK STILL FAILING: {_consecutiveTeamsFailures} consecutive failures. Last error: {error}");
+
+                    return false;
+                }
+
+                if (_consecutiveTeamsFailures > 0)
+                    Logger.Info($"Teams webhook delivery recovered after {_consecutiveTeamsFailures} failure(s)");
+
+                _consecutiveTeamsFailures = 0;
+                _lastTeamsError = null;
+                Logger.Info($"Teams webhook sent for {metricName} on {serverName}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _consecutiveTeamsFailures++;
+                _lastTeamsError = ex.Message;
+                Logger.Error($"Teams webhook error: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Builds an O365 MessageCard payload for Teams incoming webhooks.
+        /// The themeColor property renders as a colored accent bar at the top of the card.
+        /// </summary>
+        internal static string BuildTeamsPayload(
+            string metricName,
+            string serverName,
+            string currentValue,
+            string thresholdValue,
+            bool isTest = false,
+            AlertContext? context = null)
+        {
+            var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+            var themeColor = hexColor.TrimStart('#');
+            var utcNow = DateTime.UtcNow;
+            var localNow = DateTime.Now;
+
+            var facts = new List<object>();
+
+            if (isTest)
+            {
+                facts.Add(new { name = "Status", value = "Webhook configuration is working correctly" });
+                facts.Add(new { name = "Sent at", value = localNow.ToString("yyyy-MM-dd HH:mm:ss") });
+            }
+            else
+            {
+                facts.Add(new { name = "Server", value = serverName });
+                facts.Add(new { name = "Current Value", value = currentValue });
+                facts.Add(new { name = "Threshold", value = thresholdValue });
+                facts.Add(new { name = "Time (UTC)", value = utcNow.ToString("yyyy-MM-dd HH:mm:ss") });
+                facts.Add(new { name = "Time (Local)", value = localNow.ToString("yyyy-MM-dd HH:mm:ss") });
+            }
+
+            if (context?.Details != null)
+            {
+                foreach (var detail in context.Details)
+                {
+                    foreach (var (label, value) in detail.Fields)
+                    {
+                        facts.Add(new { name = label, value });
+                    }
+                }
+            }
+
+            var title = isTest
+                ? $"{emoji} TEST — {metricName}"
+                : $"{emoji} {badgeText} — {metricName}";
+
+            var sections = new List<object>
+            {
+                new
+                {
+                    activityTitle = title,
+                    activitySubtitle = isTest ? EditionName : $"{EditionName} — {serverName}",
+                    facts,
+                    markdown = true
+                }
+            };
+
+            var card = new
+            {
+                @type = "MessageCard",
+                @context = "http://schema.org/extensions",
+                themeColor,
+                summary = isTest
+                    ? $"[SQL Monitor] Test Notification"
+                    : $"[SQL Monitor] {badgeText}: {metricName} on {serverName}",
+                sections
+            };
+
+            return JsonSerializer.Serialize(card, s_jsonOptions);
+        }
+
+        #endregion
+
+        #region Slack
+
+        private async Task<bool> TrySendSlackAlertAsync(
+            UserPreferences prefs,
+            string metricName,
+            string serverName,
+            string currentValue,
+            string thresholdValue,
+            AlertContext? context)
+        {
+            try
+            {
+                var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, context: context);
+                var error = await PostWebhookAsync(prefs.SlackWebhookUrl, payload, prefs.SlackProxyAddress);
+
+                if (error != null)
+                {
+                    _consecutiveSlackFailures++;
+                    _lastSlackError = error;
+
+                    if (_consecutiveSlackFailures <= 3)
+                        Logger.Error($"SLACK WEBHOOK FAILED ({_consecutiveSlackFailures}x): {error}");
+                    else if (_consecutiveSlackFailures % 50 == 0)
+                        Logger.Error($"SLACK WEBHOOK STILL FAILING: {_consecutiveSlackFailures} consecutive failures. Last error: {error}");
+
+                    return false;
+                }
+
+                if (_consecutiveSlackFailures > 0)
+                    Logger.Info($"Slack webhook delivery recovered after {_consecutiveSlackFailures} failure(s)");
+
+                _consecutiveSlackFailures = 0;
+                _lastSlackError = null;
+                Logger.Info($"Slack webhook sent for {metricName} on {serverName}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _consecutiveSlackFailures++;
+                _lastSlackError = ex.Message;
+                Logger.Error($"Slack webhook error: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Builds a Slack incoming webhook payload with a colored attachment sidebar.
+        /// Uses Slack Block Kit for rich formatting.
+        /// </summary>
+        internal static string BuildSlackPayload(
+            string metricName,
+            string serverName,
+            string currentValue,
+            string thresholdValue,
+            bool isTest = false,
+            AlertContext? context = null)
+        {
+            var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+            var utcNow = DateTime.UtcNow;
+            var localNow = DateTime.Now;
+
+            var title = isTest
+                ? $"{emoji} TEST — {metricName}"
+                : $"{emoji} {badgeText} — {metricName}";
+
+            var blocks = new List<object>
+            {
+                new
+                {
+                    type = "header",
+                    text = new { type = "plain_text", text = title, emoji = true }
+                }
+            };
+
+            var fields = new List<object>();
+
+            if (isTest)
+            {
+                fields.Add(new { type = "mrkdwn", text = "*Status:*\nWebhook configuration is working correctly" });
+                fields.Add(new { type = "mrkdwn", text = $"*Sent at:*\n{localNow:yyyy-MM-dd HH:mm:ss}" });
+            }
+            else
+            {
+                fields.Add(new { type = "mrkdwn", text = $"*Server:*\n{serverName}" });
+                fields.Add(new { type = "mrkdwn", text = $"*Current Value:*\n{currentValue}" });
+                fields.Add(new { type = "mrkdwn", text = $"*Threshold:*\n{thresholdValue}" });
+                fields.Add(new { type = "mrkdwn", text = $"*Time (UTC):*\n{utcNow:yyyy-MM-dd HH:mm:ss}" });
+                fields.Add(new { type = "mrkdwn", text = $"*Time (Local):*\n{localNow:yyyy-MM-dd HH:mm:ss}" });
+            }
+
+            blocks.Add(new { type = "section", fields });
+
+            if (context?.Details != null)
+            {
+                foreach (var detail in context.Details)
+                {
+                    blocks.Add(new { type = "divider" });
+
+                    var detailFields = new List<object>();
+                    detailFields.Add(new { type = "mrkdwn", text = $"*{detail.Heading}*" });
+
+                    foreach (var (label, value) in detail.Fields)
+                    {
+                        detailFields.Add(new { type = "mrkdwn", text = $"*{label}:*\n{value}" });
+                    }
+
+                    blocks.Add(new { type = "section", fields = detailFields });
+                }
+            }
+
+            blocks.Add(new
+            {
+                type = "context",
+                elements = new object[]
+                {
+                    new { type = "mrkdwn", text = $"Sent by {EditionName}" }
+                }
+            });
+
+            var payload = new
+            {
+                attachments = new object[]
+                {
+                    new { color = hexColor, blocks }
+                }
+            };
+
+            return JsonSerializer.Serialize(payload, s_jsonOptions);
+        }
+
+        #endregion
+
+        #region Shared
+
+        private static (string HexColor, string BadgeText, string Emoji) GetSeverity(string metricName) => metricName switch
+        {
+            "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
+            "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
+            "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
+            "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
+            "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
+            "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
+            _ => ("#2eaef1", "INFO", "\U0001F535")
+        };
+
+        /// <summary>
+        /// Posts a JSON payload to a webhook URL. Returns null on success, error message on failure.
+        /// </summary>
+        private static async Task<string?> PostWebhookAsync(string webhookUrl, string jsonPayload, string? proxyAddress)
+        {
+            var handler = new HttpClientHandler();
+            if (!string.IsNullOrWhiteSpace(proxyAddress))
+            {
+                handler.Proxy = new WebProxy(proxyAddress);
+                handler.UseProxy = true;
+            }
+
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+            using var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+            var response = await client.PostAsync(webhookUrl, content);
+
+            if (response.IsSuccessStatusCode)
+                return null;
+
+            var body = await response.Content.ReadAsStringAsync();
+            return $"HTTP {(int)response.StatusCode}: {body}";
+        }
+
+        #endregion
+    }
+}

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -2,9 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Settings"
-        Height="550" Width="550"
+        Height="600" Width="680"
+        MinHeight="500" MinWidth="600"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize"
+        ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="15">
         <Grid.RowDefinitions>
@@ -363,6 +364,123 @@
                                            FontStyle="Italic" Foreground="Gray" VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
                             </StackPanel>
                         </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Webhooks Tab -->
+            <TabItem Header="Webhooks">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="15">
+                    <StackPanel>
+                        <!-- Microsoft Teams Section -->
+                        <TextBlock Text="Microsoft Teams" FontWeight="Bold" FontSize="13" Margin="0,0,0,5"/>
+                        <TextBlock Text="Send alert notifications to a Microsoft Teams channel via incoming webhook. Color-coded accent bars indicate alert severity."
+                                   TextWrapping="Wrap" Margin="0,0,0,10" FontStyle="Italic" Foreground="Gray"/>
+
+                        <CheckBox x:Name="TeamsWebhookEnabledCheckBox"
+                                  Content="Enable Teams notifications"
+                                  Margin="0,0,0,10"
+                                  Checked="TeamsWebhookEnabledCheckBox_Changed"
+                                  Unchecked="TeamsWebhookEnabledCheckBox_Changed"/>
+
+                        <Grid Margin="20,0,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" x:Name="TeamsWebhookUrlTextBox" Margin="0,0,0,6"
+                                     ToolTip="Paste your Teams Incoming Webhook or Power Automate Workflows URL here"/>
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" x:Name="TeamsProxyAddressTextBox" Margin="0,0,0,6"
+                                     ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                            <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                                <Button x:Name="TestTeamsButton" Content="Send Test Notification" Padding="10,3"
+                                        Click="TestTeamsButton_Click"/>
+                                <TextBlock x:Name="TestTeamsStatusText" FontStyle="Italic" Foreground="Gray"
+                                           VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Margin="20,10,0,0" TextWrapping="Wrap" FontSize="11" Foreground="Gray">
+                            <Run Text="Setup: Create an Incoming Webhook connector or a Power Automate Workflows webhook for your Teams channel. "/>
+                            <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+                                       RequestNavigate="Hyperlink_RequestNavigate">
+                                Teams Webhooks Documentation
+                            </Hyperlink>
+                        </TextBlock>
+
+                        <!-- Slack Section -->
+                        <TextBlock Text="Slack" FontWeight="Bold" FontSize="13" Margin="0,25,0,5"/>
+                        <TextBlock Text="Send alert notifications to a Slack channel via incoming webhook. Color-coded sidebar indicates alert severity."
+                                   TextWrapping="Wrap" Margin="0,0,0,10" FontStyle="Italic" Foreground="Gray"/>
+
+                        <CheckBox x:Name="SlackWebhookEnabledCheckBox"
+                                  Content="Enable Slack notifications"
+                                  Margin="0,0,0,10"
+                                  Checked="SlackWebhookEnabledCheckBox_Changed"
+                                  Unchecked="SlackWebhookEnabledCheckBox_Changed"/>
+
+                        <Grid Margin="20,0,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" x:Name="SlackWebhookUrlTextBox" Margin="0,0,0,6"
+                                     ToolTip="Paste your Slack Incoming Webhook URL here"/>
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" x:Name="SlackProxyAddressTextBox" Margin="0,0,0,6"
+                                     ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                            <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                                <Button x:Name="TestSlackButton" Content="Send Test Notification" Padding="10,3"
+                                        Click="TestSlackButton_Click"/>
+                                <TextBlock x:Name="TestSlackStatusText" FontStyle="Italic" Foreground="Gray"
+                                           VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Margin="20,10,0,0" TextWrapping="Wrap" FontSize="11" Foreground="Gray">
+                            <Run Text="Setup: Create an Incoming Webhook app in your Slack workspace settings. "/>
+                            <Hyperlink NavigateUri="https://api.slack.com/messaging/webhooks"
+                                       RequestNavigate="Hyperlink_RequestNavigate">
+                                Slack Webhooks Documentation
+                            </Hyperlink>
+                        </TextBlock>
+
+                        <!-- Severity Color Reference -->
+                        <TextBlock Text="Alert Severity Colors" FontWeight="Bold" FontSize="12" Margin="0,25,0,6"/>
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="Gray" Margin="0,0,0,2">
+                            <Run Foreground="#DC2626" FontWeight="Bold" Text="&#x25A0; Red" /> — Critical (Deadlocks, Poison Waits, Server Unreachable)
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="Gray" Margin="0,0,0,2">
+                            <Run Foreground="#D97706" FontWeight="Bold" Text="&#x25A0; Orange" /> — Alert / Warning (Blocking, Long-Running Queries, TempDB, Jobs)
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="Gray" Margin="0,0,0,2">
+                            <Run Foreground="#F59E0B" FontWeight="Bold" Text="&#x25A0; Yellow" /> — Warning (High CPU)
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="Gray" Margin="0,0,0,2">
+                            <Run Foreground="#16A34A" FontWeight="Bold" Text="&#x25A0; Green" /> — Resolved (Server Restored)
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="Gray">
+                            <Run Foreground="#2eaef1" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
+                        </TextBlock>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Navigation;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Services;
@@ -205,6 +206,16 @@ namespace PerformanceMonitorDashboard
             }
 
             UpdateSmtpControlStates();
+
+            // Webhook settings (Teams / Slack)
+            TeamsWebhookEnabledCheckBox.IsChecked = prefs.TeamsWebhookEnabled;
+            TeamsWebhookUrlTextBox.Text = prefs.TeamsWebhookUrl;
+            TeamsProxyAddressTextBox.Text = prefs.TeamsProxyAddress;
+            SlackWebhookEnabledCheckBox.IsChecked = prefs.SlackWebhookEnabled;
+            SlackWebhookUrlTextBox.Text = prefs.SlackWebhookUrl;
+            SlackProxyAddressTextBox.Text = prefs.SlackProxyAddress;
+            UpdateTeamsControlStates();
+            UpdateSlackControlStates();
 
         }
 
@@ -690,6 +701,14 @@ namespace PerformanceMonitorDashboard
                 EmailAlertService.SaveSmtpPassword(SmtpPasswordBox.Password, prefs.SmtpUsername);
             }
 
+            // Save webhook settings (Teams / Slack)
+            prefs.TeamsWebhookEnabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+            prefs.TeamsWebhookUrl = TeamsWebhookUrlTextBox.Text?.Trim() ?? "";
+            prefs.TeamsProxyAddress = TeamsProxyAddressTextBox.Text?.Trim() ?? "";
+            prefs.SlackWebhookEnabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+            prefs.SlackWebhookUrl = SlackWebhookUrlTextBox.Text?.Trim() ?? "";
+            prefs.SlackProxyAddress = SlackProxyAddressTextBox.Text?.Trim() ?? "";
+
             // Save MCP server settings
             bool mcpWasEnabled = prefs.McpEnabled;
             prefs.McpEnabled = McpEnabledCheckBox.IsChecked == true;
@@ -789,6 +808,118 @@ namespace PerformanceMonitorDashboard
                     "SMTP configuration has issues:\n\n" + string.Join("\n", errors),
                     "SMTP Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
+        }
+
+        // ============================================
+        // Webhooks Tab (Teams / Slack)
+        // ============================================
+
+        private void TeamsWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateTeamsControlStates();
+        }
+
+        private void SlackWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateSlackControlStates();
+        }
+
+        private void UpdateTeamsControlStates()
+        {
+            bool enabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+            TeamsWebhookUrlTextBox.IsEnabled = enabled;
+            TeamsProxyAddressTextBox.IsEnabled = enabled;
+            TestTeamsButton.IsEnabled = enabled;
+        }
+
+        private void UpdateSlackControlStates()
+        {
+            bool enabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+            SlackWebhookUrlTextBox.IsEnabled = enabled;
+            SlackProxyAddressTextBox.IsEnabled = enabled;
+            TestSlackButton.IsEnabled = enabled;
+        }
+
+        private async void TestTeamsButton_Click(object sender, RoutedEventArgs e)
+        {
+            TestTeamsButton.IsEnabled = false;
+            TestTeamsButton.Content = "Sending...";
+            TestTeamsStatusText.Text = "";
+
+            try
+            {
+                var url = TeamsWebhookUrlTextBox.Text?.Trim() ?? "";
+                var proxy = TeamsProxyAddressTextBox.Text?.Trim();
+                var error = await WebhookAlertService.SendTestTeamsAsync(url, proxy);
+
+                if (error == null)
+                {
+                    TestTeamsStatusText.Text = "Test notification sent!";
+                    MessageBox.Show("Teams test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    TestTeamsStatusText.Text = $"Failed: {error}";
+                    MessageBox.Show($"Failed to send Teams test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                TestTeamsStatusText.Text = $"Error: {ex.Message}";
+                MessageBox.Show($"Failed to send Teams test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                TestTeamsButton.Content = "Send Test Notification";
+                TestTeamsButton.IsEnabled = true;
+            }
+        }
+
+        private async void TestSlackButton_Click(object sender, RoutedEventArgs e)
+        {
+            TestSlackButton.IsEnabled = false;
+            TestSlackButton.Content = "Sending...";
+            TestSlackStatusText.Text = "";
+
+            try
+            {
+                var url = SlackWebhookUrlTextBox.Text?.Trim() ?? "";
+                var proxy = SlackProxyAddressTextBox.Text?.Trim();
+                var error = await WebhookAlertService.SendTestSlackAsync(url, proxy);
+
+                if (error == null)
+                {
+                    TestSlackStatusText.Text = "Test notification sent!";
+                    MessageBox.Show("Slack test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    TestSlackStatusText.Text = $"Failed: {error}";
+                    MessageBox.Show($"Failed to send Slack test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                TestSlackStatusText.Text = $"Error: {ex.Message}";
+                MessageBox.Show($"Failed to send Slack test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                TestSlackButton.Content = "Send Test Notification";
+                TestSlackButton.IsEnabled = true;
+            }
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo { FileName = e.Uri.AbsoluteUri, UseShellExecute = true });
+            }
+            catch { }
+            e.Handled = true;
         }
 
         private async void TestEmailButton_Click(object sender, RoutedEventArgs e)

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -102,6 +102,16 @@ public partial class App : Application
     /* Update check settings */
     public static bool CheckForUpdatesOnStartup { get; set; } = true;
 
+    /* Teams webhook settings */
+    public static bool TeamsWebhookEnabled { get; set; } = false;
+    public static string TeamsWebhookUrl { get; set; } = "";
+    public static string TeamsProxyAddress { get; set; } = "";
+
+    /* Slack webhook settings */
+    public static bool SlackWebhookEnabled { get; set; } = false;
+    public static string SlackWebhookUrl { get; set; } = "";
+    public static string SlackProxyAddress { get; set; } = "";
+
     /* SMTP email alert settings */
     public static bool SmtpEnabled { get; set; } = false;
     public static string SmtpServer { get; set; } = "";
@@ -323,6 +333,16 @@ public partial class App : Application
 
             /* Update check settings */
             if (root.TryGetProperty("check_for_updates_on_startup", out v)) CheckForUpdatesOnStartup = v.GetBoolean();
+
+            /* Teams webhook settings */
+            if (root.TryGetProperty("teams_webhook_enabled", out v)) TeamsWebhookEnabled = v.GetBoolean();
+            if (root.TryGetProperty("teams_webhook_url", out v)) TeamsWebhookUrl = v.GetString() ?? "";
+            if (root.TryGetProperty("teams_proxy_address", out v)) TeamsProxyAddress = v.GetString() ?? "";
+
+            /* Slack webhook settings */
+            if (root.TryGetProperty("slack_webhook_enabled", out v)) SlackWebhookEnabled = v.GetBoolean();
+            if (root.TryGetProperty("slack_webhook_url", out v)) SlackWebhookUrl = v.GetString() ?? "";
+            if (root.TryGetProperty("slack_proxy_address", out v)) SlackProxyAddress = v.GetString() ?? "";
 
             /* SMTP settings */
             if (root.TryGetProperty("smtp_enabled", out v)) SmtpEnabled = v.GetBoolean();

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -26,6 +26,7 @@ public class EmailAlertService
 {
     private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
     private readonly DuckDbInitializer? _duckDb;
+    private readonly WebhookAlertService _webhookAlertService = new();
 
     /* Failure tracking for louder logging */
     private int _consecutiveSmtpFailures;
@@ -108,6 +109,13 @@ public class EmailAlertService
                         }
                     }
                 }
+            }
+
+            /* Send webhook notifications (Teams / Slack) alongside email */
+            if (!muted)
+            {
+                await _webhookAlertService.TrySendWebhookAlertsAsync(
+                    metricName, serverName, currentValue, thresholdValue, serverId, context);
             }
 
             /* Always log the alert to DuckDB, regardless of email status */

--- a/Lite/Services/WebhookAlertService.cs
+++ b/Lite/Services/WebhookAlertService.cs
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Sends alert notifications to Microsoft Teams and/or Slack via incoming webhooks.
+/// Color-coded accent bars match the existing email alert severity mapping.
+/// </summary>
+public class WebhookAlertService
+{
+    private const string EditionName = "Performance Monitor Lite";
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
+
+    private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+
+    private int _consecutiveTeamsFailures;
+    private string? _lastTeamsError;
+    private int _consecutiveSlackFailures;
+    private string? _lastSlackError;
+
+    /// <summary>
+    /// Sends webhook alerts to all configured channels (Teams and/or Slack).
+    /// Respects the email cooldown setting for throttling. Never throws.
+    /// </summary>
+    public async Task TrySendWebhookAlertsAsync(
+        string metricName,
+        string serverName,
+        string currentValue,
+        string thresholdValue,
+        int serverId = 0,
+        AlertContext? context = null)
+    {
+        try
+        {
+            var cooldownKey = $"webhook:{serverId}:{metricName}";
+            if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
+                DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(App.EmailCooldownMinutes))
+            {
+                return;
+            }
+
+            bool sent = false;
+
+            if (App.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(App.TeamsWebhookUrl))
+            {
+                sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context);
+            }
+
+            if (App.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(App.SlackWebhookUrl))
+            {
+                sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context);
+            }
+
+            if (sent)
+            {
+                _cooldowns[cooldownKey] = DateTime.UtcNow;
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Webhook", $"TrySendWebhookAlertsAsync outer error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Sends a test notification to Microsoft Teams. Returns null on success, error message on failure.
+    /// </summary>
+    public static async Task<string?> SendTestTeamsAsync(string webhookUrl, string? proxyAddress)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(webhookUrl))
+                return "Teams webhook URL is not configured.";
+
+            var payload = BuildTeamsPayload("Test Notification", "", "Webhook configuration verified", "", isTest: true);
+            return await PostWebhookAsync(webhookUrl, payload, proxyAddress);
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// Sends a test notification to Slack. Returns null on success, error message on failure.
+    /// </summary>
+    public static async Task<string?> SendTestSlackAsync(string webhookUrl, string? proxyAddress)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(webhookUrl))
+                return "Slack webhook URL is not configured.";
+
+            var payload = BuildSlackPayload("Test Notification", "", "Webhook configuration verified", "", isTest: true);
+            return await PostWebhookAsync(webhookUrl, payload, proxyAddress);
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    #region Teams
+
+    private async Task<bool> TrySendTeamsAlertAsync(
+        string metricName,
+        string serverName,
+        string currentValue,
+        string thresholdValue,
+        AlertContext? context)
+    {
+        try
+        {
+            var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, context: context);
+            var error = await PostWebhookAsync(App.TeamsWebhookUrl, payload, App.TeamsProxyAddress);
+
+            if (error != null)
+            {
+                _consecutiveTeamsFailures++;
+                _lastTeamsError = error;
+
+                if (_consecutiveTeamsFailures <= 3)
+                    AppLogger.Error("Webhook", $"TEAMS WEBHOOK FAILED ({_consecutiveTeamsFailures}x): {error}");
+                else if (_consecutiveTeamsFailures % 50 == 0)
+                    AppLogger.Error("Webhook", $"TEAMS WEBHOOK STILL FAILING: {_consecutiveTeamsFailures} failures. Last: {error}");
+
+                return false;
+            }
+
+            if (_consecutiveTeamsFailures > 0)
+                AppLogger.Info("Webhook", $"Teams webhook recovered after {_consecutiveTeamsFailures} failure(s)");
+
+            _consecutiveTeamsFailures = 0;
+            _lastTeamsError = null;
+            AppLogger.Info("Webhook", $"Teams webhook sent for {metricName} on {serverName}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _consecutiveTeamsFailures++;
+            _lastTeamsError = ex.Message;
+            AppLogger.Error("Webhook", $"Teams webhook error: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Builds an O365 MessageCard payload for Teams incoming webhooks.
+    /// The themeColor property renders as a colored accent bar at the top of the card.
+    /// </summary>
+    internal static string BuildTeamsPayload(
+        string metricName,
+        string serverName,
+        string currentValue,
+        string thresholdValue,
+        bool isTest = false,
+        AlertContext? context = null)
+    {
+        var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+        var themeColor = hexColor.TrimStart('#');
+        var utcNow = DateTime.UtcNow;
+        var localNow = DateTime.Now;
+
+        var facts = new List<object>();
+
+        if (isTest)
+        {
+            facts.Add(new { name = "Status", value = "Webhook configuration is working correctly" });
+            facts.Add(new { name = "Sent at", value = localNow.ToString("yyyy-MM-dd HH:mm:ss") });
+        }
+        else
+        {
+            facts.Add(new { name = "Server", value = serverName });
+            facts.Add(new { name = "Current Value", value = currentValue });
+            facts.Add(new { name = "Threshold", value = thresholdValue });
+            facts.Add(new { name = "Time (UTC)", value = utcNow.ToString("yyyy-MM-dd HH:mm:ss") });
+            facts.Add(new { name = "Time (Local)", value = localNow.ToString("yyyy-MM-dd HH:mm:ss") });
+        }
+
+        if (context?.Details != null)
+        {
+            foreach (var detail in context.Details)
+            {
+                foreach (var (label, value) in detail.Fields)
+                {
+                    facts.Add(new { name = label, value });
+                }
+            }
+        }
+
+        var title = isTest
+            ? $"{emoji} TEST \u2014 {metricName}"
+            : $"{emoji} {badgeText} \u2014 {metricName}";
+
+        var sections = new List<object>
+        {
+            new
+            {
+                activityTitle = title,
+                activitySubtitle = isTest ? EditionName : $"{EditionName} \u2014 {serverName}",
+                facts,
+                markdown = true
+            }
+        };
+
+        var card = new
+        {
+            @type = "MessageCard",
+            @context = "http://schema.org/extensions",
+            themeColor,
+            summary = isTest
+                ? "[SQL Monitor] Test Notification"
+                : $"[SQL Monitor] {badgeText}: {metricName} on {serverName}",
+            sections
+        };
+
+        return JsonSerializer.Serialize(card, s_jsonOptions);
+    }
+
+    #endregion
+
+    #region Slack
+
+    private async Task<bool> TrySendSlackAlertAsync(
+        string metricName,
+        string serverName,
+        string currentValue,
+        string thresholdValue,
+        AlertContext? context)
+    {
+        try
+        {
+            var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, context: context);
+            var error = await PostWebhookAsync(App.SlackWebhookUrl, payload, App.SlackProxyAddress);
+
+            if (error != null)
+            {
+                _consecutiveSlackFailures++;
+                _lastSlackError = error;
+
+                if (_consecutiveSlackFailures <= 3)
+                    AppLogger.Error("Webhook", $"SLACK WEBHOOK FAILED ({_consecutiveSlackFailures}x): {error}");
+                else if (_consecutiveSlackFailures % 50 == 0)
+                    AppLogger.Error("Webhook", $"SLACK WEBHOOK STILL FAILING: {_consecutiveSlackFailures} failures. Last: {error}");
+
+                return false;
+            }
+
+            if (_consecutiveSlackFailures > 0)
+                AppLogger.Info("Webhook", $"Slack webhook recovered after {_consecutiveSlackFailures} failure(s)");
+
+            _consecutiveSlackFailures = 0;
+            _lastSlackError = null;
+            AppLogger.Info("Webhook", $"Slack webhook sent for {metricName} on {serverName}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _consecutiveSlackFailures++;
+            _lastSlackError = ex.Message;
+            AppLogger.Error("Webhook", $"Slack webhook error: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Builds a Slack incoming webhook payload with a colored attachment sidebar.
+    /// Uses Slack Block Kit for rich formatting.
+    /// </summary>
+    internal static string BuildSlackPayload(
+        string metricName,
+        string serverName,
+        string currentValue,
+        string thresholdValue,
+        bool isTest = false,
+        AlertContext? context = null)
+    {
+        var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+        var utcNow = DateTime.UtcNow;
+        var localNow = DateTime.Now;
+
+        var title = isTest
+            ? $"{emoji} TEST \u2014 {metricName}"
+            : $"{emoji} {badgeText} \u2014 {metricName}";
+
+        var blocks = new List<object>
+        {
+            new
+            {
+                type = "header",
+                text = new { type = "plain_text", text = title, emoji = true }
+            }
+        };
+
+        var fields = new List<object>();
+
+        if (isTest)
+        {
+            fields.Add(new { type = "mrkdwn", text = "*Status:*\nWebhook configuration is working correctly" });
+            fields.Add(new { type = "mrkdwn", text = $"*Sent at:*\n{localNow:yyyy-MM-dd HH:mm:ss}" });
+        }
+        else
+        {
+            fields.Add(new { type = "mrkdwn", text = $"*Server:*\n{serverName}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Current Value:*\n{currentValue}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Threshold:*\n{thresholdValue}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Time (UTC):*\n{utcNow:yyyy-MM-dd HH:mm:ss}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Time (Local):*\n{localNow:yyyy-MM-dd HH:mm:ss}" });
+        }
+
+        blocks.Add(new { type = "section", fields });
+
+        if (context?.Details != null)
+        {
+            foreach (var detail in context.Details)
+            {
+                blocks.Add(new { type = "divider" });
+
+                var detailFields = new List<object>();
+                detailFields.Add(new { type = "mrkdwn", text = $"*{detail.Heading}*" });
+
+                foreach (var (label, value) in detail.Fields)
+                {
+                    detailFields.Add(new { type = "mrkdwn", text = $"*{label}:*\n{value}" });
+                }
+
+                blocks.Add(new { type = "section", fields = detailFields });
+            }
+        }
+
+        blocks.Add(new
+        {
+            type = "context",
+            elements = new object[]
+            {
+                new { type = "mrkdwn", text = $"Sent by {EditionName}" }
+            }
+        });
+
+        var payload = new
+        {
+            attachments = new object[]
+            {
+                new { color = hexColor, blocks }
+            }
+        };
+
+        return JsonSerializer.Serialize(payload, s_jsonOptions);
+    }
+
+    #endregion
+
+    #region Shared
+
+    private static (string HexColor, string BadgeText, string Emoji) GetSeverity(string metricName) => metricName switch
+    {
+        "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
+        "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
+        "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
+        "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
+        "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
+        "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
+        _ => ("#2eaef1", "INFO", "\U0001F535")
+    };
+
+    /// <summary>
+    /// Posts a JSON payload to a webhook URL. Returns null on success, error message on failure.
+    /// </summary>
+    private static async Task<string?> PostWebhookAsync(string webhookUrl, string jsonPayload, string? proxyAddress)
+    {
+        var handler = new HttpClientHandler();
+        if (!string.IsNullOrWhiteSpace(proxyAddress))
+        {
+            handler.Proxy = new WebProxy(proxyAddress);
+            handler.UseProxy = true;
+        }
+
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+        using var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(webhookUrl, content);
+
+        if (response.IsSuccessStatusCode)
+            return null;
+
+        var body = await response.Content.ReadAsStringAsync();
+        return $"HTTP {(int)response.StatusCode}: {body}";
+    }
+
+    #endregion
+}

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -28,6 +28,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -332,8 +333,113 @@
             </StackPanel>
         </Border>
 
-        <!-- Collector Schedules (Per-Server) -->
+        <!-- Webhooks (Teams / Slack) -->
         <Border Grid.Row="6" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <!-- Microsoft Teams -->
+                <TextBlock Text="Microsoft Teams Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Send alert notifications to a Teams channel via incoming webhook. Color-coded accent bars indicate alert severity."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="TeamsWebhookEnabledCheckBox" Content="Enable Teams notifications" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="TeamsWebhookEnabledCheckBox_Changed" Unchecked="TeamsWebhookEnabledCheckBox_Changed"/>
+                <Grid Margin="20,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="110"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" x:Name="TeamsWebhookUrlBox" Margin="0,0,0,4"
+                             ToolTip="Paste your Teams Incoming Webhook or Power Automate Workflows URL here"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" x:Name="TeamsProxyAddressBox" Margin="0,0,0,4"
+                             ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                    <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestTeamsButton" Content="Send Test Notification" Click="TestTeamsButton_Click"/>
+                        <TextBlock x:Name="TeamsStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+                <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Text="Setup: Create an Incoming Webhook connector or a Power Automate Workflows webhook for your Teams channel. "/>
+                    <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+                               RequestNavigate="Hyperlink_RequestNavigate">
+                        Teams Webhooks Documentation
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Slack -->
+                <TextBlock Text="Slack Notifications" FontSize="14" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,20,0,0"/>
+                <TextBlock Text="Send alert notifications to a Slack channel via incoming webhook. Color-coded sidebar indicates alert severity."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="SlackWebhookEnabledCheckBox" Content="Enable Slack notifications" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="SlackWebhookEnabledCheckBox_Changed" Unchecked="SlackWebhookEnabledCheckBox_Changed"/>
+                <Grid Margin="20,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="110"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" x:Name="SlackWebhookUrlBox" Margin="0,0,0,4"
+                             ToolTip="Paste your Slack Incoming Webhook URL here"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" x:Name="SlackProxyAddressBox" Margin="0,0,0,4"
+                             ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                    <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestSlackButton" Content="Send Test Notification" Click="TestSlackButton_Click"/>
+                        <TextBlock x:Name="SlackStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+                <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Text="Setup: Create an Incoming Webhook app in your Slack workspace settings. "/>
+                    <Hyperlink NavigateUri="https://api.slack.com/messaging/webhooks"
+                               RequestNavigate="Hyperlink_RequestNavigate">
+                        Slack Webhooks Documentation
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Severity Color Reference -->
+                <TextBlock Text="Alert Severity Colors" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,16,0,4"/>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#DC2626" FontWeight="Bold" Text="&#x25A0; Red" /> — Critical (Deadlocks, Poison Waits, Server Unreachable)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#D97706" FontWeight="Bold" Text="&#x25A0; Orange" /> — Alert / Warning (Blocking, Long-Running Queries, TempDB, Jobs)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#F59E0B" FontWeight="Bold" Text="&#x25A0; Yellow" /> — Warning (High CPU)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#16A34A" FontWeight="Bold" Text="&#x25A0; Green" /> — Resolved (Server Restored)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Foreground="#2eaef1" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
+                </TextBlock>
+            </StackPanel>
+        </Border>
+
+        <!-- Collector Schedules (Per-Server) -->
+        <Border Grid.Row="7" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -375,7 +481,7 @@
         </Border>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button Content="Save" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
             <Button Content="Close" Click="CloseButton_Click"/>
         </StackPanel>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -17,6 +18,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Navigation;
 using PerformanceMonitorLite.Mcp;
 using PerformanceMonitorLite.Services;
 
@@ -55,6 +57,7 @@ public partial class SettingsWindow : Window
         LoadTimeDisplayMode();
         LoadAlertSettings();
         LoadSmtpSettings();
+        LoadWebhookSettings();
     }
 
     private void LoadServerScheduleSummary()
@@ -211,6 +214,7 @@ public partial class SettingsWindow : Window
         SaveTimeDisplayMode();
         bool alertsValid = SaveAlertSettings();
         SaveSmtpSettings();
+        SaveWebhookSettings();
 
         _saved = true;
         if (mcpChanged) McpSettingsChanged = true;
@@ -949,6 +953,159 @@ public partial class SettingsWindow : Window
             TestEmailButton.Content = "Send Test Email";
             TestEmailButton.IsEnabled = true;
         }
+    }
+
+    // ============================================
+    // Webhooks (Teams / Slack)
+    // ============================================
+
+    private void LoadWebhookSettings()
+    {
+        TeamsWebhookEnabledCheckBox.IsChecked = App.TeamsWebhookEnabled;
+        TeamsWebhookUrlBox.Text = App.TeamsWebhookUrl;
+        TeamsProxyAddressBox.Text = App.TeamsProxyAddress;
+        SlackWebhookEnabledCheckBox.IsChecked = App.SlackWebhookEnabled;
+        SlackWebhookUrlBox.Text = App.SlackWebhookUrl;
+        SlackProxyAddressBox.Text = App.SlackProxyAddress;
+        UpdateTeamsControlStates();
+        UpdateSlackControlStates();
+    }
+
+    private void SaveWebhookSettings()
+    {
+        App.TeamsWebhookEnabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+        App.TeamsWebhookUrl = TeamsWebhookUrlBox.Text?.Trim() ?? "";
+        App.TeamsProxyAddress = TeamsProxyAddressBox.Text?.Trim() ?? "";
+        App.SlackWebhookEnabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+        App.SlackWebhookUrl = SlackWebhookUrlBox.Text?.Trim() ?? "";
+        App.SlackProxyAddress = SlackProxyAddressBox.Text?.Trim() ?? "";
+
+        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
+        try
+        {
+            JsonNode? root;
+            if (File.Exists(settingsPath))
+            {
+                var json = File.ReadAllText(settingsPath);
+                root = JsonNode.Parse(json) ?? new JsonObject();
+            }
+            else
+            {
+                root = new JsonObject();
+            }
+
+            root["teams_webhook_enabled"] = App.TeamsWebhookEnabled;
+            root["teams_webhook_url"] = App.TeamsWebhookUrl;
+            root["teams_proxy_address"] = App.TeamsProxyAddress;
+            root["slack_webhook_enabled"] = App.SlackWebhookEnabled;
+            root["slack_webhook_url"] = App.SlackWebhookUrl;
+            root["slack_proxy_address"] = App.SlackProxyAddress;
+
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(settingsPath, root.ToJsonString(options));
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Settings", $"Failed to save webhook settings: {ex.Message}");
+        }
+    }
+
+    private void TeamsWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        UpdateTeamsControlStates();
+    }
+
+    private void SlackWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        UpdateSlackControlStates();
+    }
+
+    private void UpdateTeamsControlStates()
+    {
+        bool enabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+        TeamsWebhookUrlBox.IsEnabled = enabled;
+        TeamsProxyAddressBox.IsEnabled = enabled;
+        TestTeamsButton.IsEnabled = enabled;
+    }
+
+    private void UpdateSlackControlStates()
+    {
+        bool enabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+        SlackWebhookUrlBox.IsEnabled = enabled;
+        SlackProxyAddressBox.IsEnabled = enabled;
+        TestSlackButton.IsEnabled = enabled;
+    }
+
+    private async void TestTeamsButton_Click(object sender, RoutedEventArgs e)
+    {
+        TestTeamsButton.IsEnabled = false;
+        TestTeamsButton.Content = "Sending...";
+
+        try
+        {
+            var url = TeamsWebhookUrlBox.Text?.Trim() ?? "";
+            var proxy = TeamsProxyAddressBox.Text?.Trim();
+            var error = await WebhookAlertService.SendTestTeamsAsync(url, proxy);
+
+            if (error == null)
+            {
+                MessageBox.Show("Teams test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show($"Failed to send Teams test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to send Teams test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            TestTeamsButton.Content = "Send Test Notification";
+            TestTeamsButton.IsEnabled = true;
+        }
+    }
+
+    private async void TestSlackButton_Click(object sender, RoutedEventArgs e)
+    {
+        TestSlackButton.IsEnabled = false;
+        TestSlackButton.Content = "Sending...";
+
+        try
+        {
+            var url = SlackWebhookUrlBox.Text?.Trim() ?? "";
+            var proxy = SlackProxyAddressBox.Text?.Trim();
+            var error = await WebhookAlertService.SendTestSlackAsync(url, proxy);
+
+            if (error == null)
+            {
+                MessageBox.Show("Slack test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show($"Failed to send Slack test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to send Slack test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            TestSlackButton.Content = "Send Test Notification";
+            TestSlackButton.IsEnabled = true;
+        }
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = e.Uri.AbsoluteUri, UseShellExecute = true });
+        }
+        catch { }
+        e.Handled = true;
     }
 
     private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);


### PR DESCRIPTION
## What does this PR do?

In environments where email notifications are restricted, alert visibility is limited unless you’re actively connected to the host running PerformanceMonitor.  This change introduces Teams and Slack webhook notifications, allowing alerts to surface in real time removing the need to stay connected to an RDP/jumpbox session.

Adds webhook-based notifications for Microsoft Teams and Slack to both Full and Lite dashboards.

- Teams and Slack channels can be configured independently of email alerts
- Supports any combination of email, Teams, and Slack notifications
- Severity colour mapping (red/orange/yellow/green/blue) aligns with scheme in existing 'Alert History'
- Per-channel configuration includes webhook URL, optional HTTP proxy, and test button
- Direct links to Teams and Slack webhook documentation included in the UI
- Fully respects muted alert rules

## Which component(s) does this affect?

- [x] Full Dashboard
- [X] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

- Added webhook configuration to both Full and Lite dashboards
- Verified successful delivery of alerts to both Teams and Slack via test and live alerts
- Confirmed severity colouring and message formatting 
- Validated muted alert rules are honoured


Dashboard Full Webhooks option:
<img width="602" height="480" alt="image" src="https://github.com/user-attachments/assets/43ff299a-3fe2-402e-9e04-401c29aee9c6" />

Dashboard Lite Webhooks option:
<img width="500" height="429" alt="image" src="https://github.com/user-attachments/assets/eadf3042-9ec4-4cc4-94f7-9dc8effea57d" />


Slack notification test:
<img width="515" height="560" alt="image" src="https://github.com/user-attachments/assets/d5130e87-2992-479a-ba5d-415f8b35bb6e" />

Slack notification live alerts:
<img width="617" height="434" alt="image" src="https://github.com/user-attachments/assets/ba86fb1d-101f-44f8-bde3-dd3b5da7a901" />



Teams notification test:
<img width="737" height="517" alt="image" src="https://github.com/user-attachments/assets/71e0b646-42f6-4a55-b7f4-4db6911e83f6" />

Teams notification live alerts:
<img width="641" height="551" alt="image" src="https://github.com/user-attachments/assets/03677abc-428f-4cb7-bd4a-66105b857b21" />



## Checklist

- [X] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [X] My code builds with zero warnings (`dotnet build -c Debug`)
- [X] I have tested my changes against at least one SQL Server version
- [X] I have not introduced any hardcoded credentials or server names
