### PR TITLE
Fix webhook alert recording and delivery tracking

### DIFF
--- a/Dashboard/Services/EmailAlertService.cs
+++ b/Dashboard/Services/EmailAlertService.cs
@@ -79,9 +79,6 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var prefs = _preferencesService.GetPreferences();
-                string? sendError = null;
-                bool sent = false;
-                string notificationType = "tray";
 
                 /* Attempt email delivery if SMTP is fully configured */
                 if (prefs.SmtpEnabled &&
@@ -95,7 +92,8 @@ namespace PerformanceMonitorDashboard.Services
 
                     if (!withinCooldown)
                     {
-                        notificationType = "email";
+                        bool sent = false;
+                        string? sendError = null;
                         var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
                         var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
                             metricName, serverName, currentValue, thresholdValue, prefs.EmailCooldownMinutes, context);
@@ -130,18 +128,21 @@ namespace PerformanceMonitorDashboard.Services
                                 Logger.Error($"ALERT EMAIL STILL FAILING: {_consecutiveFailures} consecutive failures. Last error: {ex.Message}");
                             }
                         }
+
+                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, "email", sendError);
                     }
                 }
-
-                /* Log the alert attempt */
-                RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, notificationType, sendError);
 
                 /* Send webhook notifications (Teams / Slack) — independent of email */
                 var webhookService = WebhookAlertService.Current;
                 if (webhookService != null)
                 {
-                    await webhookService.TrySendWebhookAlertsAsync(
+                    var webhookSent = await webhookService.TrySendWebhookAlertsAsync(
                         metricName, serverName, currentValue, thresholdValue, serverId, context);
+                    if (webhookSent)
+                    {
+                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, true, "webhook");
+                    }
                 }
             }
             catch (Exception ex)

--- a/Dashboard/Services/WebhookAlertService.cs
+++ b/Dashboard/Services/WebhookAlertService.cs
@@ -46,7 +46,7 @@ namespace PerformanceMonitorDashboard.Services
         /// Sends webhook alerts to all configured channels (Teams and/or Slack).
         /// Respects the email cooldown setting for throttling. Never throws.
         /// </summary>
-        public async Task TrySendWebhookAlertsAsync(
+        public async Task<bool> TrySendWebhookAlertsAsync(
             string metricName,
             string serverName,
             string currentValue,
@@ -62,7 +62,7 @@ namespace PerformanceMonitorDashboard.Services
                 if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
                     DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes))
                 {
-                    return;
+                    return false;
                 }
 
                 bool sent = false;
@@ -81,10 +81,13 @@ namespace PerformanceMonitorDashboard.Services
                 {
                     _cooldowns[cooldownKey] = DateTime.UtcNow;
                 }
+
+                return sent;
             }
             catch (Exception ex)
             {
                 Logger.Error($"TrySendWebhookAlertsAsync outer error: {ex.Message}");
+                return false;
             }
         }
 

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -112,10 +112,18 @@ public class EmailAlertService
             }
 
             /* Send webhook notifications (Teams / Slack) alongside email */
+            bool webhookSent = false;
             if (!muted)
             {
-                await _webhookAlertService.TrySendWebhookAlertsAsync(
+                webhookSent = await _webhookAlertService.TrySendWebhookAlertsAsync(
                     metricName, serverName, currentValue, thresholdValue, serverId, context);
+            }
+
+            /* Reflect webhook delivery in notification type */
+            if (webhookSent)
+            {
+                notificationType = notificationType == "email" ? "email+webhook" : "webhook";
+                sent = true;
             }
 
             /* Always log the alert to DuckDB, regardless of email status */

--- a/Lite/Services/WebhookAlertService.cs
+++ b/Lite/Services/WebhookAlertService.cs
@@ -37,7 +37,7 @@ public class WebhookAlertService
     /// Sends webhook alerts to all configured channels (Teams and/or Slack).
     /// Respects the email cooldown setting for throttling. Never throws.
     /// </summary>
-    public async Task TrySendWebhookAlertsAsync(
+    public async Task<bool> TrySendWebhookAlertsAsync(
         string metricName,
         string serverName,
         string currentValue,
@@ -51,7 +51,7 @@ public class WebhookAlertService
             if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
                 DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(App.EmailCooldownMinutes))
             {
-                return;
+                return false;
             }
 
             bool sent = false;
@@ -70,10 +70,13 @@ public class WebhookAlertService
             {
                 _cooldowns[cooldownKey] = DateTime.UtcNow;
             }
+
+            return sent;
         }
         catch (Exception ex)
         {
             AppLogger.Error("Webhook", $"TrySendWebhookAlertsAsync outer error: {ex.Message}");
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- **Dashboard**: Moves `RecordAlert` back inside the SMTP block so it only fires when an email is actually attempted — eliminates duplicate "tray" entries introduced by #725 when SMTP is disabled. Adds a separate "webhook" record when Teams/Slack notifications are delivered.
- **Lite**: Captures webhook send result and reflects it in the DuckDB `notification_type` column (`"webhook"` when only webhooks sent, `"email+webhook"` when both).
- **Both**: Changes `TrySendWebhookAlertsAsync` return type from `Task` to `Task<bool>` so callers can act on delivery status.

Follows up on #725.

## Test plan
- [ ] Dashboard: disable SMTP, enable webhooks — alert history should show "tray" (from MainWindow) + "webhook" (from email service), not duplicate "tray" entries
- [ ] Dashboard: enable both SMTP and webhooks — alert history should show "tray" + "email" + "webhook"
- [ ] Lite: disable SMTP, enable webhooks — DuckDB alert log `notification_type` should be "webhook"
- [ ] Lite: enable both — `notification_type` should be "email+webhook"

🤖 Generated with [Claude Code](https://claude.com/claude-code)