### PR TITLE
Port read-only intent support from Lite to Dashboard

### DIFF
--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -96,6 +96,12 @@
                           ToolTip="When checked, accepts any server certificate without validation.&#x0a;Uncheck for stricter security (requires valid certificate)."
                           Margin="0,0,0,6"/>
 
+                <!-- Read-Only Intent -->
+                <CheckBox x:Name="ReadOnlyIntentCheckBox"
+                          Content="Read-only intent (for AG listeners and readable replicas)"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
+                          ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
+
                 <!-- Is Favorite -->
                 <CheckBox x:Name="IsFavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -52,6 +52,7 @@ namespace PerformanceMonitorDashboard
                 _ => 0 // Optional
             };
             TrustServerCertificateCheckBox.IsChecked = existingServer.TrustServerCertificate;
+            ReadOnlyIntentCheckBox.IsChecked = existingServer.ReadOnlyIntent;
 
             if (existingServer.AuthenticationType == AuthenticationTypes.EntraMFA)
             {
@@ -125,7 +126,10 @@ namespace PerformanceMonitorDashboard
                 ApplicationName = "PerformanceMonitorDashboard",
                 ConnectTimeout = 10,
                 TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true,
-                Encrypt = ParseEncryptOption(GetSelectedEncryptMode())
+                Encrypt = ParseEncryptOption(GetSelectedEncryptMode()),
+                ApplicationIntent = ReadOnlyIntentCheckBox.IsChecked == true
+                    ? ApplicationIntent.ReadOnly
+                    : ApplicationIntent.ReadWrite
             };
 
             if (WindowsAuthRadio.IsChecked == true)
@@ -329,6 +333,7 @@ namespace PerformanceMonitorDashboard
                 ServerConnection.IsFavorite = IsFavoriteCheckBox.IsChecked == true;
                 ServerConnection.EncryptMode = GetSelectedEncryptMode();
                 ServerConnection.TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true;
+                ServerConnection.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostTextBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     ServerConnection.MonthlyCostUsd = editCost;
             }
@@ -349,6 +354,7 @@ namespace PerformanceMonitorDashboard
                     LastConnected = DateTime.Now,
                     EncryptMode = GetSelectedEncryptMode(),
                     TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true,
+                    ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
                     MonthlyCostUsd = monthlyCost
                 };
             }

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -558,7 +558,7 @@ namespace PerformanceMonitorDashboard
             {
                 var inner = ex.InnerException?.Message ?? ex.Message;
                 System.Windows.MessageBox.Show(
-                    $"Failed to open server tab for '{server.DisplayName}'.\n\n" +
+                    $"Failed to open server tab for '{server.DisplayNameWithIntent}'.\n\n" +
                     $"This is usually caused by a missing Visual C++ Redistributable (x64) " +
                     $"or an OS compatibility issue with the SkiaSharp rendering library.\n\n" +
                     $"Download the latest VC++ Redistributable from:\n" +
@@ -571,7 +571,7 @@ namespace PerformanceMonitorDashboard
             }
             serverTab.AlertAcknowledged += (_, _) =>
             {
-                _emailAlertService.HideAllAlerts(8760, server.DisplayName);
+                _emailAlertService.HideAllAlerts(8760, server.DisplayNameWithIntent);
                 UpdateAlertBadge();
                 _alertsHistoryContent?.RefreshAlerts();
             };
@@ -579,7 +579,7 @@ namespace PerformanceMonitorDashboard
             var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };
             var headerText = new TextBlock
             {
-                Text = server.DisplayName,
+                Text = server.ReadOnlyIntent ? $"{server.DisplayName} (RO)" : server.DisplayName,
                 VerticalAlignment = VerticalAlignment.Center
             };
             var closeButton = new Button
@@ -912,7 +912,7 @@ namespace PerformanceMonitorDashboard
                     await LoadServerListAsync();
 
                     MessageBox.Show(
-                        $"Server '{server.DisplayName}' added successfully!\n\n" +
+                        $"Server '{server.DisplayNameWithIntent}' added successfully!\n\n" +
                         (server.AuthenticationType == Models.AuthenticationTypes.Windows ? "Using Windows Authentication" : $"Using {server.AuthenticationDisplay} — credentials saved securely to Windows Credential Manager"),
                         "Server Added",
                         MessageBoxButton.OK,
@@ -953,12 +953,12 @@ namespace PerformanceMonitorDashboard
                             if (tabItem.Header is StackPanel headerPanel &&
                                 headerPanel.Children[0] is TextBlock headerText)
                             {
-                                headerText.Text = updatedServer.DisplayName;
+                                headerText.Text = updatedServer.ReadOnlyIntent ? $"{updatedServer.DisplayName} (RO)" : updatedServer.DisplayName;
                             }
                         }
 
                         MessageBox.Show(
-                            $"Server '{updatedServer.DisplayName}' updated successfully!\n\n" +
+                            $"Server '{updatedServer.DisplayNameWithIntent}' updated successfully!\n\n" +
                             (updatedServer.AuthenticationType == Models.AuthenticationTypes.Windows ? "Using Windows Authentication" : $"Using {updatedServer.AuthenticationDisplay} — credentials updated securely in Windows Credential Manager"),
                             "Server Updated",
                             MessageBoxButton.OK,
@@ -983,7 +983,7 @@ namespace PerformanceMonitorDashboard
             if (ServerListView.SelectedItem is ServerListItem item)
             {
                 var server = item.Server;
-                var dialog = new RemoveServerDialog(server.DisplayName);
+                var dialog = new RemoveServerDialog(server.DisplayNameWithIntent);
                 dialog.Owner = this;
 
                 if (dialog.ShowDialog() == true)
@@ -998,7 +998,7 @@ namespace PerformanceMonitorDashboard
                         catch (Exception ex)
                         {
                             MessageBox.Show(
-                                $"Could not drop the PerformanceMonitor database on '{server.DisplayName}':\n\n{ex.Message}\n\nThe server will still be removed from the Dashboard.",
+                                $"Could not drop the PerformanceMonitor database on '{server.DisplayNameWithIntent}':\n\n{ex.Message}\n\nThe server will still be removed from the Dashboard.",
                                 "Database Drop Failed",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Warning
@@ -1020,7 +1020,7 @@ namespace PerformanceMonitorDashboard
                     await LoadServerListAsync();
 
                     MessageBox.Show(
-                        $"Server '{server.DisplayName}' removed successfully!",
+                        $"Server '{server.DisplayNameWithIntent}' removed successfully!",
                         "Server Removed",
                         MessageBoxButton.OK,
                         MessageBoxImage.Information
@@ -1251,7 +1251,7 @@ namespace PerformanceMonitorDashboard
                            so the badge delta calculation sees the correct baseline. */
                         var prevDeadlockCount = _previousDeadlockCounts.TryGetValue(server.Id, out var pdc) ? pdc : 0;
 
-                        await EvaluateAlertConditionsAsync(server.Id, server.DisplayName, health, databaseService);
+                        await EvaluateAlertConditionsAsync(server.Id, server.DisplayNameWithIntent, health, databaseService);
 
                         /* Update tab badges from alert health data.
                            This ensures badges update even when the NOC view isn't active. */
@@ -1956,7 +1956,7 @@ namespace PerformanceMonitorDashboard
                 var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == serverId);
                 if (server != null)
                 {
-                    _emailAlertService.HideAllAlerts(8760, server.DisplayName);
+                    _emailAlertService.HideAllAlerts(8760, server.DisplayNameWithIntent);
                     UpdateAlertBadge();
                     _alertsHistoryContent?.RefreshAlerts();
                 }

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -54,7 +54,7 @@ namespace PerformanceMonitorDashboard
                     ServersModified = true;
 
                     MessageBox.Show(
-                        $"Server '{dialog.ServerConnection.DisplayName}' added successfully!",
+                        $"Server '{dialog.ServerConnection.DisplayNameWithIntent}' added successfully!",
                         "Server Added",
                         MessageBoxButton.OK,
                         MessageBoxImage.Information
@@ -93,7 +93,7 @@ namespace PerformanceMonitorDashboard
                         ServersModified = true;
 
                         MessageBox.Show(
-                            $"Server '{dialog.ServerConnection.DisplayName}' updated successfully!",
+                            $"Server '{dialog.ServerConnection.DisplayNameWithIntent}' updated successfully!",
                             "Server Updated",
                             MessageBoxButton.OK,
                             MessageBoxImage.Information
@@ -145,7 +145,7 @@ namespace PerformanceMonitorDashboard
         {
             if (ServersDataGrid.SelectedItem is ServerConnection server)
             {
-                var dialog = new RemoveServerDialog(server.DisplayName);
+                var dialog = new RemoveServerDialog(server.DisplayNameWithIntent);
                 dialog.Owner = this;
 
                 if (dialog.ShowDialog() == true)
@@ -159,7 +159,7 @@ namespace PerformanceMonitorDashboard
                         catch (Exception ex)
                         {
                             MessageBox.Show(
-                                $"Could not drop the PerformanceMonitor database on '{server.DisplayName}':\n\n{ex.Message}\n\nThe server will still be removed from the Dashboard.",
+                                $"Could not drop the PerformanceMonitor database on '{server.DisplayNameWithIntent}':\n\n{ex.Message}\n\nThe server will still be removed from the Dashboard.",
                                 "Database Drop Failed",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Warning
@@ -172,7 +172,7 @@ namespace PerformanceMonitorDashboard
                     ServersModified = true;
 
                     MessageBox.Show(
-                        $"Server '{server.DisplayName}' removed successfully!",
+                        $"Server '{server.DisplayNameWithIntent}' removed successfully!",
                         "Server Removed",
                         MessageBoxButton.OK,
                         MessageBoxImage.Information

--- a/Dashboard/Mcp/McpDiscoveryTools.cs
+++ b/Dashboard/Mcp/McpDiscoveryTools.cs
@@ -23,9 +23,10 @@ public sealed class McpDiscoveryTools
             var lines = new List<string> { $"Monitored servers ({servers.Count}):\n" };
             foreach (var s in servers)
             {
+                var roTag = s.ReadOnlyIntent ? " [Read-Only]" : "";
                 var display = string.IsNullOrEmpty(s.DisplayName) || s.DisplayName == s.ServerName
-                    ? s.ServerName
-                    : $"{s.DisplayName} ({s.ServerName})";
+                    ? $"{s.ServerName}{roTag}"
+                    : $"{s.DisplayName} ({s.ServerName}){roTag}";
 
                 var status = serverManager.GetConnectionStatus(s.Id);
                 var statusText = status.IsOnline switch

--- a/Dashboard/Mcp/ServerResolver.cs
+++ b/Dashboard/Mcp/ServerResolver.cs
@@ -71,9 +71,12 @@ internal static class ServerResolver
         }
 
         var lines = servers.Select(s =>
-            string.IsNullOrEmpty(s.DisplayName) || s.DisplayName == s.ServerName
-                ? s.ServerName
-                : $"{s.DisplayName} ({s.ServerName})");
+        {
+            var roTag = s.ReadOnlyIntent ? " [Read-Only]" : "";
+            return string.IsNullOrEmpty(s.DisplayName) || s.DisplayName == s.ServerName
+                ? $"{s.ServerName}{roTag}"
+                : $"{s.DisplayName} ({s.ServerName}){roTag}";
+        });
 
         return string.Join("\n", lines);
     }

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -63,10 +63,24 @@ namespace PerformanceMonitorDashboard.Models
         public bool TrustServerCertificate { get; set; } = false;
 
         /// <summary>
+        /// When true, sets ApplicationIntent=ReadOnly on the connection string.
+        /// Required for connecting to AG listener read-only replicas and
+        /// Azure SQL Business Critical / Managed Instance built-in read replicas.
+        /// </summary>
+        public bool ReadOnlyIntent { get; set; } = false;
+
+        /// <summary>
         /// Monthly cost of this server in USD, used for FinOps cost attribution.
         /// Set to 0 to hide cost columns. All FinOps costs are proportional to this budget.
         /// </summary>
         public decimal MonthlyCostUsd { get; set; } = 0m;
+
+        /// <summary>
+        /// Display name with "(Read-Only)" suffix when ReadOnlyIntent is enabled.
+        /// Used for alerts, tray notifications, tab headers, and dialog messages.
+        /// </summary>
+        [JsonIgnore]
+        public string DisplayNameWithIntent => ReadOnlyIntent ? $"{DisplayName} (Read-Only)" : DisplayName;
 
         /// <summary>
         /// Display-only property for showing authentication type in UI.
@@ -105,6 +119,7 @@ namespace PerformanceMonitorDashboard.Models
                         "Strict" => SqlConnectionEncryptOption.Strict,
                         _ => SqlConnectionEncryptOption.Mandatory
                     },
+                    ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
                     Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive
                 };
 
@@ -135,7 +150,8 @@ namespace PerformanceMonitorDashboard.Models
                 username,
                 password,
                 EncryptMode,
-                TrustServerCertificate
+                TrustServerCertificate,
+                ReadOnlyIntent
             ).ConnectionString;
         }
 

--- a/Dashboard/Models/ServerHealthStatus.cs
+++ b/Dashboard/Models/ServerHealthStatus.cs
@@ -78,7 +78,7 @@ namespace PerformanceMonitorDashboard.Models
 
         public ServerConnection Server => _server;
         public string ServerId => _server.Id;
-        public string DisplayName => _server.DisplayName;
+        public string DisplayName => _server.DisplayNameWithIntent;
         public string ServerName => _server.ServerName;
 
         public bool IsLoading

--- a/Dashboard/Models/ServerListItem.cs
+++ b/Dashboard/Models/ServerListItem.cs
@@ -54,7 +54,7 @@ namespace PerformanceMonitorDashboard.Models
 
         // Convenience properties for binding
         public string Id => Server.Id;
-        public string DisplayName => Server.DisplayName;
+        public string DisplayName => Server.DisplayNameWithIntent;
         public string ServerName => Server.ServerName;
 
         /// <summary>

--- a/Dashboard/Services/DatabaseService.cs
+++ b/Dashboard/Services/DatabaseService.cs
@@ -85,7 +85,8 @@ namespace PerformanceMonitorDashboard.Services
             string? username = null,
             string? password = null,
             string encryptMode = "Mandatory",
-            bool trustServerCertificate = false)
+            bool trustServerCertificate = false,
+            bool readOnlyIntent = false)
         {
             var builder = new SqlConnectionStringBuilder
             {
@@ -93,7 +94,8 @@ namespace PerformanceMonitorDashboard.Services
                 InitialCatalog = "PerformanceMonitor",
                 TrustServerCertificate = trustServerCertificate,
                 IntegratedSecurity = useWindowsAuth,
-                MultipleActiveResultSets = true
+                MultipleActiveResultSets = true,
+                ApplicationIntent = readOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite
             };
 
             // Set encryption mode


### PR DESCRIPTION
## Summary
- Adds per-server `ReadOnlyIntent` checkbox to the Add/Edit Server dialog, matching the existing Lite implementation
- Sets `ApplicationIntent=ReadOnly` on connection strings for AG listener routing to readable secondaries
- All user-visible surfaces differentiate read-only connections: tab headers show "(RO)", sidebar/NOC show "(Read-Only)", tray notifications, alert history, MCP tools tag with `[Read-Only]`
- 10 files across model, services, UI, and MCP layers

This was already implemented and tested in Lite (used against Azure SQL readable replicas). Dashboard port follows identical patterns.

## Test plan
- [ ] Add Server dialog shows "Read-only intent" checkbox in Connection Options
- [ ] Edit Server dialog loads existing ReadOnlyIntent state
- [ ] Server sidebar shows "(Read-Only)" suffix when enabled
- [ ] Tab headers show "(RO)" suffix
- [ ] Alert history records server name with "(Read-Only)" suffix
- [ ] MCP `list_servers` output includes `[Read-Only]` tag
- [ ] Connections to AG listener readable secondaries route correctly (requires AG environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)