### PR TITLE
fix/numeric columns sorting as text instead of numbers

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -139,7 +139,7 @@
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding EstMonthlySavingsDisplay}" MinWidth="110" Width="Auto">
+                        <DataGridTextColumn Binding="{Binding EstMonthlySavingsDisplay}" MinWidth="110" Width="Auto" SortMemberPath="EstMonthlySavings">
                             <DataGridTextColumn.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EstMonthlySavingsDisplay" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1162,7 +1162,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SpaceSavedGb}" Width="110">
+                            <DataGridTextColumn Binding="{Binding SpaceSavedGb}" Width="110" SortMemberPath="SpaceSavedGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SpaceSavedGb" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1171,7 +1171,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SpaceReductionPercent}" Width="95">
+                            <DataGridTextColumn Binding="{Binding SpaceReductionPercent}" Width="95" SortMemberPath="SpaceReductionPercentSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SpaceReductionPercent" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1180,7 +1180,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding RemovableIndexes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding RemovableIndexes}" Width="90" SortMemberPath="RemovableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RemovableIndexes" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1189,7 +1189,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CurrentSizeGb}" Width="115">
+                            <DataGridTextColumn Binding="{Binding CurrentSizeGb}" Width="115" SortMemberPath="CurrentSizeGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CurrentSizeGb" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1198,7 +1198,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                            <DataGridTextColumn Binding="{Binding SizeAfterCleanupGb}" Width="125" SortMemberPath="SizeAfterCleanupGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SizeAfterCleanupGb" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1208,7 +1208,7 @@
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <!-- Index counts -->
-                            <DataGridTextColumn Binding="{Binding TotalIndexes}" Width="100">
+                            <DataGridTextColumn Binding="{Binding TotalIndexes}" Width="100" SortMemberPath="TotalIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalIndexes" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1217,7 +1217,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding MergeableIndexes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding MergeableIndexes}" Width="90" SortMemberPath="MergeableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MergeableIndexes" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1226,7 +1226,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CompressableIndexes}" Width="100">
+                            <DataGridTextColumn Binding="{Binding CompressableIndexes}" Width="100" SortMemberPath="CompressableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompressableIndexes" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1235,7 +1235,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PercentRemovable}" Width="95">
+                            <DataGridTextColumn Binding="{Binding PercentRemovable}" Width="95" SortMemberPath="PercentRemovableSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentRemovable" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1315,7 +1315,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TotalRows}" Width="100">
+                            <DataGridTextColumn Binding="{Binding TotalRows}" Width="100" SortMemberPath="TotalRowsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1332,7 +1332,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding Writes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding Writes}" Width="90" SortMemberPath="WritesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1341,7 +1341,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyWriteOpsSaved}" Width="130">
+                            <DataGridTextColumn Binding="{Binding DailyWriteOpsSaved}" Width="130" SortMemberPath="DailyWriteOpsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyWriteOpsSaved" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1350,7 +1350,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LockWaitCount}" Width="95">
+                            <DataGridTextColumn Binding="{Binding LockWaitCount}" Width="95" SortMemberPath="LockWaitCountSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LockWaitCount" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1359,7 +1359,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyLockWaitsSaved}" Width="150">
+                            <DataGridTextColumn Binding="{Binding DailyLockWaitsSaved}" Width="150" SortMemberPath="DailyLockWaitsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyLockWaitsSaved" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1368,7 +1368,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AvgLockWaitMs}" Width="120">
+                            <DataGridTextColumn Binding="{Binding AvgLockWaitMs}" Width="120" SortMemberPath="AvgLockWaitMsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLockWaitMs" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1377,7 +1377,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LatchWaitCount}" Width="95">
+                            <DataGridTextColumn Binding="{Binding LatchWaitCount}" Width="95" SortMemberPath="LatchWaitCountSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LatchWaitCount" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1386,7 +1386,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyLatchWaitsSaved}" Width="155">
+                            <DataGridTextColumn Binding="{Binding DailyLatchWaitsSaved}" Width="155" SortMemberPath="DailyLatchWaitsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyLatchWaitsSaved" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1395,7 +1395,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AvgLatchWaitMs}" Width="130">
+                            <DataGridTextColumn Binding="{Binding AvgLatchWaitMs}" Width="130" SortMemberPath="AvgLatchWaitMsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLatchWaitMs" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1490,7 +1490,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexSizeGb}" Width="80">
+                            <DataGridTextColumn Binding="{Binding IndexSizeGb}" Width="80" SortMemberPath="IndexSizeGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexSizeGb" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1499,7 +1499,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexRows}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexRows}" Width="90" SortMemberPath="IndexRowsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexRows" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1508,7 +1508,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexReads}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexReads}" Width="90" SortMemberPath="IndexReadsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexReads" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
@@ -1517,7 +1517,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexWrites}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexWrites}" Width="90" SortMemberPath="IndexWritesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexWrites" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -106,7 +106,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding Duration}" Width="100">
+                    <DataGridTextColumn Binding="{Binding Duration}" Width="100" SortMemberPath="DurationSort">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Duration" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -210,7 +210,7 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="TranLogWritesSort">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogWrites" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
@@ -382,7 +382,7 @@
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding ElapsedTimeFormatted}" Width="120">
+                        <DataGridTextColumn Binding="{Binding ElapsedTimeFormatted}" Width="120" SortMemberPath="TotalElapsedTimeMs">
                             <DataGridTextColumn.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ElapsedTimeFormatted" Click="CurrentActiveFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Models/QuerySnapshotItem.cs
+++ b/Dashboard/Models/QuerySnapshotItem.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Globalization;
 
 namespace PerformanceMonitorDashboard.Models
 {
@@ -48,5 +49,37 @@ namespace PerformanceMonitorDashboard.Models
 
         // Chain mode — set by WaitDrillDownWindow when showing head blockers
         public string ChainBlockingPath { get; set; } = "";
+
+        /// <summary>
+        /// Parses sp_WhoIsActive duration format ("dd hh:mm:ss.mmm" or "hh:mm:ss.mmm") to total milliseconds for numeric sorting.
+        /// </summary>
+        public double DurationSort
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(Duration)) return -1;
+                var s = Duration.Trim();
+                int days = 0;
+                int spaceIdx = s.IndexOf(' ');
+                if (spaceIdx > 0 && int.TryParse(s.AsSpan(0, spaceIdx), out var d))
+                {
+                    days = d;
+                    s = s.Substring(spaceIdx + 1);
+                }
+                if (TimeSpan.TryParse(s, CultureInfo.InvariantCulture, out var ts))
+                    return ts.TotalMilliseconds + days * 86_400_000.0;
+                return -1;
+            }
+        }
+
+        public decimal TranLogWritesSort
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(TranLogWrites)) return -1m;
+                var cleaned = TranLogWrites.Replace(",", "").Trim();
+                return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out var v) ? v : -1m;
+            }
+        }
     }
 }

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -366,12 +366,12 @@
                                             <TextBlock Text="Start Time" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding CurrentDurationFormatted}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding CurrentDurationFormatted}" Width="120" SortMemberPath="CurrentDurationSeconds">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="Current Duration" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="120">
+                                    <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="120" SortMemberPath="AvgDurationSeconds">
                                         <DataGridTextColumn.Header>
                                             <TextBlock Text="Avg Duration" FontWeight="Bold"/>
                                         </DataGridTextColumn.Header>

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -2674,6 +2674,11 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
         public string IndexWrites { get; set; } = "";
         public string OriginalIndexDefinition { get; set; } = "";
         public string Script { get; set; } = "";
+
+        public decimal IndexSizeGbSort => NumericSortHelper.Parse(IndexSizeGb);
+        public decimal IndexRowsSort => NumericSortHelper.Parse(IndexRows);
+        public decimal IndexReadsSort => NumericSortHelper.Parse(IndexReads);
+        public decimal IndexWritesSort => NumericSortHelper.Parse(IndexWrites);
     }
 
     public class FinOpsProvisioningTrend
@@ -2768,6 +2773,25 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
         public string LatchWaitCount { get; set; } = "";
         public string DailyLatchWaitsSaved { get; set; } = "";
         public string AvgLatchWaitMs { get; set; } = "";
+
+        public decimal TotalIndexesSort => NumericSortHelper.Parse(TotalIndexes);
+        public decimal RemovableIndexesSort => NumericSortHelper.Parse(RemovableIndexes);
+        public decimal MergeableIndexesSort => NumericSortHelper.Parse(MergeableIndexes);
+        public decimal CompressableIndexesSort => NumericSortHelper.Parse(CompressableIndexes);
+        public decimal PercentRemovableSort => NumericSortHelper.Parse(PercentRemovable);
+        public decimal CurrentSizeGbSort => NumericSortHelper.Parse(CurrentSizeGb);
+        public decimal SizeAfterCleanupGbSort => NumericSortHelper.Parse(SizeAfterCleanupGb);
+        public decimal SpaceSavedGbSort => NumericSortHelper.Parse(SpaceSavedGb);
+        public decimal SpaceReductionPercentSort => NumericSortHelper.Parse(SpaceReductionPercent);
+        public decimal TotalRowsSort => NumericSortHelper.Parse(TotalRows);
+        public decimal WritesSort => NumericSortHelper.Parse(Writes);
+        public decimal DailyWriteOpsSavedSort => NumericSortHelper.Parse(DailyWriteOpsSaved);
+        public decimal LockWaitCountSort => NumericSortHelper.Parse(LockWaitCount);
+        public decimal DailyLockWaitsSavedSort => NumericSortHelper.Parse(DailyLockWaitsSaved);
+        public decimal AvgLockWaitMsSort => NumericSortHelper.Parse(AvgLockWaitMs);
+        public decimal LatchWaitCountSort => NumericSortHelper.Parse(LatchWaitCount);
+        public decimal DailyLatchWaitsSavedSort => NumericSortHelper.Parse(DailyLatchWaitsSaved);
+        public decimal AvgLatchWaitMsSort => NumericSortHelper.Parse(AvgLatchWaitMs);
     }
 
     public class FinOpsRecommendation
@@ -2807,5 +2831,16 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
             >= 60 => "#F39C12",
             _ => "#27AE60"
         };
+    }
+
+    internal static class NumericSortHelper
+    {
+        internal static decimal Parse(string? s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return -1m;
+            var cleaned = s.Replace(",", "").Replace("%", "").Trim();
+            return decimal.TryParse(cleaned, System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : -1m;
+        }
     }
 }

--- a/Dashboard/WaitDrillDownWindow.xaml
+++ b/Dashboard/WaitDrillDownWindow.xaml
@@ -80,7 +80,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Duration}" Width="100">
+                <DataGridTextColumn Binding="{Binding Duration}" Width="100" SortMemberPath="DurationSort">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Duration" Click="Filter_Click" Margin="0,0,4,0"/>
@@ -184,7 +184,7 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="TranLogWritesSort">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogWrites" Click="Filter_Click" Margin="0,0,4,0"/>

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -104,7 +104,7 @@
                         <DataGridTextColumn Header="Confidence" Binding="{Binding Confidence}" MinWidth="90" Width="Auto"/>
                         <DataGridTextColumn Header="Finding" Binding="{Binding Finding}" MinWidth="250" Width="Auto"/>
                         <DataGridTextColumn Header="Detail" Binding="{Binding Detail}" MinWidth="400" Width="*"/>
-                        <DataGridTextColumn Header="Est. Savings ($/mo)" Binding="{Binding EstMonthlySavingsDisplay}" MinWidth="110" Width="Auto">
+                        <DataGridTextColumn Header="Est. Savings ($/mo)" Binding="{Binding EstMonthlySavingsDisplay}" MinWidth="110" Width="Auto" SortMemberPath="EstMonthlySavings">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="HorizontalAlignment" Value="Right"/>
@@ -1113,7 +1113,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SpaceSavedGb}" Width="110">
+                            <DataGridTextColumn Binding="{Binding SpaceSavedGb}" Width="110" SortMemberPath="SpaceSavedGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SpaceSavedGb" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1122,7 +1122,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SpaceReductionPercent}" Width="95">
+                            <DataGridTextColumn Binding="{Binding SpaceReductionPercent}" Width="95" SortMemberPath="SpaceReductionPercentSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SpaceReductionPercent" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1131,7 +1131,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding RemovableIndexes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding RemovableIndexes}" Width="90" SortMemberPath="RemovableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RemovableIndexes" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1140,7 +1140,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CurrentSizeGb}" Width="115">
+                            <DataGridTextColumn Binding="{Binding CurrentSizeGb}" Width="115" SortMemberPath="CurrentSizeGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CurrentSizeGb" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1149,7 +1149,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding SizeAfterCleanupGb}" Width="125">
+                            <DataGridTextColumn Binding="{Binding SizeAfterCleanupGb}" Width="125" SortMemberPath="SizeAfterCleanupGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SizeAfterCleanupGb" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1159,7 +1159,7 @@
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <!-- Index counts -->
-                            <DataGridTextColumn Binding="{Binding TotalIndexes}" Width="100">
+                            <DataGridTextColumn Binding="{Binding TotalIndexes}" Width="100" SortMemberPath="TotalIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalIndexes" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1168,7 +1168,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding MergeableIndexes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding MergeableIndexes}" Width="90" SortMemberPath="MergeableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MergeableIndexes" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1177,7 +1177,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CompressableIndexes}" Width="100">
+                            <DataGridTextColumn Binding="{Binding CompressableIndexes}" Width="100" SortMemberPath="CompressableIndexesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompressableIndexes" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1186,7 +1186,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PercentRemovable}" Width="95">
+                            <DataGridTextColumn Binding="{Binding PercentRemovable}" Width="95" SortMemberPath="PercentRemovableSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentRemovable" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1266,7 +1266,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TotalRows}" Width="100">
+                            <DataGridTextColumn Binding="{Binding TotalRows}" Width="100" SortMemberPath="TotalRowsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1283,7 +1283,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding Writes}" Width="90">
+                            <DataGridTextColumn Binding="{Binding Writes}" Width="90" SortMemberPath="WritesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1292,7 +1292,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyWriteOpsSaved}" Width="130">
+                            <DataGridTextColumn Binding="{Binding DailyWriteOpsSaved}" Width="130" SortMemberPath="DailyWriteOpsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyWriteOpsSaved" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1301,7 +1301,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LockWaitCount}" Width="95">
+                            <DataGridTextColumn Binding="{Binding LockWaitCount}" Width="95" SortMemberPath="LockWaitCountSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LockWaitCount" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1310,7 +1310,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyLockWaitsSaved}" Width="150">
+                            <DataGridTextColumn Binding="{Binding DailyLockWaitsSaved}" Width="150" SortMemberPath="DailyLockWaitsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyLockWaitsSaved" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1319,7 +1319,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AvgLockWaitMs}" Width="120">
+                            <DataGridTextColumn Binding="{Binding AvgLockWaitMs}" Width="120" SortMemberPath="AvgLockWaitMsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLockWaitMs" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1328,7 +1328,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding LatchWaitCount}" Width="95">
+                            <DataGridTextColumn Binding="{Binding LatchWaitCount}" Width="95" SortMemberPath="LatchWaitCountSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LatchWaitCount" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1337,7 +1337,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DailyLatchWaitsSaved}" Width="155">
+                            <DataGridTextColumn Binding="{Binding DailyLatchWaitsSaved}" Width="155" SortMemberPath="DailyLatchWaitsSavedSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DailyLatchWaitsSaved" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1346,7 +1346,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding AvgLatchWaitMs}" Width="130">
+                            <DataGridTextColumn Binding="{Binding AvgLatchWaitMs}" Width="130" SortMemberPath="AvgLatchWaitMsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLatchWaitMs" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1440,7 +1440,7 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexSizeGb}" Width="80">
+                            <DataGridTextColumn Binding="{Binding IndexSizeGb}" Width="80" SortMemberPath="IndexSizeGbSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexSizeGb" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1449,7 +1449,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexRows}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexRows}" Width="90" SortMemberPath="IndexRowsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexRows" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1458,7 +1458,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexReads}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexReads}" Width="90" SortMemberPath="IndexReadsSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexReads" Click="FilterButton_Click" Margin="0,0,4,0"/>
@@ -1467,7 +1467,7 @@
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style></DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding IndexWrites}" Width="90">
+                            <DataGridTextColumn Binding="{Binding IndexWrites}" Width="90" SortMemberPath="IndexWritesSort">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexWrites" Click="FilterButton_Click" Margin="0,0,4,0"/>

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="PerformanceMonitorLite.Controls.ServerTab"
+<UserControl x:Class="PerformanceMonitorLite.Controls.ServerTab"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
@@ -1149,7 +1149,7 @@
                                     <DataGridTextColumn Binding="{Binding WaitResource}" Width="200">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitResource" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Wait Resource" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding WaitTimeFormatted}" Width="80">
+                                    <DataGridTextColumn Binding="{Binding WaitTimeFormatted}" Width="80" SortMemberPath="WaitTime">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Wait (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding IsolationLevel}" Width="120">
@@ -1285,7 +1285,7 @@
                             <DataGridTextColumn Binding="{Binding P95DurationFormatted}" Width="110" SortMemberPath="P95DurationSeconds">
                                 <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="P95DurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="P95 Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding PercentOfAverageFormatted}" Width="100">
+                            <DataGridTextColumn Binding="{Binding PercentOfAverageFormatted}" Width="100" SortMemberPath="PercentOfAverage">
                                 <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentOfAverageFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="% of Average" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                             </DataGridTextColumn>
                             <DataGridTextColumn Binding="{Binding RunningLongDisplay}" Width="90">

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -2442,6 +2442,11 @@ public class IndexCleanupResultRow
     public string IndexWrites { get; set; } = "";
     public string OriginalIndexDefinition { get; set; } = "";
     public string Script { get; set; } = "";
+
+    public decimal IndexSizeGbSort => NumericSortHelper.Parse(IndexSizeGb);
+    public decimal IndexRowsSort => NumericSortHelper.Parse(IndexRows);
+    public decimal IndexReadsSort => NumericSortHelper.Parse(IndexReads);
+    public decimal IndexWritesSort => NumericSortHelper.Parse(IndexWrites);
 }
 
 public class IndexCleanupSummaryRow
@@ -2475,6 +2480,25 @@ public class IndexCleanupSummaryRow
     public string LatchWaitCount { get; set; } = "";
     public string DailyLatchWaitsSaved { get; set; } = "";
     public string AvgLatchWaitMs { get; set; } = "";
+
+    public decimal TotalIndexesSort => NumericSortHelper.Parse(TotalIndexes);
+    public decimal RemovableIndexesSort => NumericSortHelper.Parse(RemovableIndexes);
+    public decimal MergeableIndexesSort => NumericSortHelper.Parse(MergeableIndexes);
+    public decimal CompressableIndexesSort => NumericSortHelper.Parse(CompressableIndexes);
+    public decimal PercentRemovableSort => NumericSortHelper.Parse(PercentRemovable);
+    public decimal CurrentSizeGbSort => NumericSortHelper.Parse(CurrentSizeGb);
+    public decimal SizeAfterCleanupGbSort => NumericSortHelper.Parse(SizeAfterCleanupGb);
+    public decimal SpaceSavedGbSort => NumericSortHelper.Parse(SpaceSavedGb);
+    public decimal SpaceReductionPercentSort => NumericSortHelper.Parse(SpaceReductionPercent);
+    public decimal TotalRowsSort => NumericSortHelper.Parse(TotalRows);
+    public decimal WritesSort => NumericSortHelper.Parse(Writes);
+    public decimal DailyWriteOpsSavedSort => NumericSortHelper.Parse(DailyWriteOpsSaved);
+    public decimal LockWaitCountSort => NumericSortHelper.Parse(LockWaitCount);
+    public decimal DailyLockWaitsSavedSort => NumericSortHelper.Parse(DailyLockWaitsSaved);
+    public decimal AvgLockWaitMsSort => NumericSortHelper.Parse(AvgLockWaitMs);
+    public decimal LatchWaitCountSort => NumericSortHelper.Parse(LatchWaitCount);
+    public decimal DailyLatchWaitsSavedSort => NumericSortHelper.Parse(DailyLatchWaitsSaved);
+    public decimal AvgLatchWaitMsSort => NumericSortHelper.Parse(AvgLatchWaitMs);
 }
 
 public class RecommendationRow
@@ -2589,4 +2613,15 @@ public class HighImpactQueryRow
         >= 60 => "#F39C12",
         _ => "#27AE60"
     };
+}
+
+internal static class NumericSortHelper
+{
+    internal static decimal Parse(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return -1m;
+        var cleaned = s.Replace(",", "").Replace("%", "").Trim();
+        return decimal.TryParse(cleaned, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : -1m;
+    }
 }


### PR DESCRIPTION
## What does this PR do?

DataGrid columns displaying sizes, row counts, durations, and percentages were stored as formatted strings, causing lexicographic sort order (e.g. "9.8" before "87"). Added numeric SortMemberPath companion properties using the same pattern as the existing AutoGrowthSort/VlfCountSort, and wired them up in XAML across both Dashboard and Lite editions.

- IndexCleanup summary/detail grids: 22 columns each (Size GB, Rows, etc.)
- FinOps recommendations: EstMonthlySavingsDisplay
- Query snapshots: Duration, TranLogWrites
- Live queries: ElapsedTimeFormatted
- Running jobs: CurrentDurationFormatted, AvgDurationFormatted
- Deadlock details: WaitTimeFormatted
- Running jobs: PercentOfAverageFormatted


DataGrid columns that display numeric values (sizes, row counts, durations, percentages, costs) were stored as formatted strings, so WPF sorted them lexicographically instead of numerically - e.g., "9.8" sorted before "87.9" because "9" > "8" as a character. This adds numeric companion properties and wires them via SortMemberPath, following the existing AutoGrowthSort / VlfCountSort pattern.

## Which component(s) does this affect?

- [X] Full Dashboard
- [X] Lite Dashboard
- [ ] Lite Tests
- [ ] SQL collection scripts
- [ ] CLI Installer
- [ ] GUI Installer
- [ ] Documentation

## How was this tested?

- Both projects build with zero errors (dotnet build Dashboard/Dashboard.csproj and dotnet build Lite/PerformanceMonitorLite.csproj)
- Verified sort behavior by clicking Size GB and Rows column headers - values now order numerically (e.g., 7.0, 8.4, 9.8, 68.6, 78.8, 87.9, 99.5) instead of alphabetically

## Checklist

- [X] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [X] My code builds with zero warnings (`dotnet build -c Debug`)
- [X] I have tested my changes against at least one SQL Server version
- [X] I have not introduced any hardcoded credentials or server names
