### PR TITLE
Fix: skip tempdb_stats collector on Azure SQL DB

### DIFF
--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -810,6 +810,7 @@ WHERE server_id = $3";
                 case "server_config":     /* sys.configurations not available */
                 case "trace_flags":       /* DBCC TRACESTATUS not available */
                 case "running_jobs":      /* msdb.dbo.sysjobs not available */
+                case "tempdb_stats":      /* cross-database tempdb access not available */
                     return false;
             }
         }


### PR DESCRIPTION
## Summary

- Adds `tempdb_stats` to the Azure SQL DB edition gate in `IsCollectorSupported`, preventing the collector from running on Azure SQL DB (engine edition 5)
- Azure SQL DB does not allow cross-database access to `tempdb`, causing `VIEW DATABASE PERFORMANCE STATE permission denied in database 'tempdb'` errors on every collection cycle
- Follows the existing blocklist pattern already used for `server_config`, `trace_flags`, and `running_jobs`

Closes #737

## Test plan

- [x] `dotnet build Lite/PerformanceMonitorLite.csproj` — compiles with 0 errors
- [x] `dotnet test Lite.Tests/` — 225 tests passed, 0 failed
- [x] Live tested against Azure SQL Database — confirmed tempdb_stats collector no longer runs and the permission denied error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)