### PR TITLE
Add Query Heatmap sub-tab to Dashboard

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -1833,5 +1833,27 @@
             <TextBlock x:Name="LongRunningQueryPatternsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
             </Grid>
         </TabItem>
+        <!-- Query Heatmap Sub-Tab -->
+        <TabItem Header="Query Heatmap">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,4,0,4">
+                    <TextBlock Text="Metric:" VerticalAlignment="Center" Margin="0,0,6,0" FontSize="11"/>
+                    <ComboBox x:Name="HeatmapMetricCombo" SelectedIndex="0" SelectionChanged="HeatmapMetric_SelectionChanged" FontSize="11" Padding="4,2">
+                        <ComboBoxItem Content="Duration (ms)"/>
+                        <ComboBoxItem Content="CPU (ms)"/>
+                        <ComboBoxItem Content="Logical Reads"/>
+                        <ComboBoxItem Content="Logical Writes"/>
+                        <ComboBoxItem Content="Execution Count"/>
+                    </ComboBox>
+                </StackPanel>
+                <ScottPlot:WpfPlot Grid.Row="1" x:Name="QueryHeatmapChart"
+                                    MouseMove="HeatmapChart_MouseMove"
+                                    MouseLeave="HeatmapChart_MouseLeave"/>
+            </Grid>
+        </TabItem>
     </TabControl>
 </UserControl>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -137,6 +137,16 @@ namespace PerformanceMonitorDashboard.Controls
         private Helpers.ChartHoverHelper? _qsDurationHover;
         private Helpers.ChartHoverHelper? _execTrendsHover;
 
+        // Query heatmap
+        private HeatmapResult? _lastHeatmapResult;
+        private ScottPlot.Plottables.Heatmap? _heatmapPlottable;
+        private int _heatmapHoursBack = 24;
+        private DateTime? _heatmapFromDate;
+        private DateTime? _heatmapToDate;
+        private Popup? _heatmapPopup;
+        private System.Windows.Controls.TextBlock? _heatmapPopupText;
+        private DateTime _lastHeatmapHoverUpdate;
+
         public QueryPerformanceContent()
         {
             InitializeComponent();
@@ -149,6 +159,70 @@ namespace PerformanceMonitorDashboard.Controls
             _procDurationHover = new Helpers.ChartHoverHelper(QueryPerfTrendsProcChart, "ms/sec");
             _qsDurationHover = new Helpers.ChartHoverHelper(QueryPerfTrendsQsChart, "ms/sec");
             _execTrendsHover = new Helpers.ChartHoverHelper(QueryPerfTrendsExecChart, "/sec");
+
+            // Heatmap popup tooltip
+            _heatmapPopupText = new System.Windows.Controls.TextBlock
+            {
+                Foreground = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xE0, 0xE0, 0xE0)),
+                FontSize = 13,
+                MaxWidth = 450,
+                TextTrimming = TextTrimming.CharacterEllipsis
+            };
+            _heatmapPopup = new Popup
+            {
+                PlacementTarget = QueryHeatmapChart,
+                Placement = PlacementMode.Relative,
+                IsHitTestVisible = false,
+                AllowsTransparency = true,
+                Child = new System.Windows.Controls.Border
+                {
+                    Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x33, 0x33, 0x33)),
+                    BorderBrush = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x55, 0x55, 0x55)),
+                    BorderThickness = new Thickness(1),
+                    CornerRadius = new CornerRadius(3),
+                    Padding = new Thickness(8, 4, 8, 4),
+                    Child = _heatmapPopupText
+                }
+            };
+            TabHelpers.ApplyThemeToChart(QueryHeatmapChart);
+
+            // Heatmap right-click drill-down
+            var heatmapMenu = TabHelpers.SetupChartContextMenu(QueryHeatmapChart, "Query_Heatmap");
+            var heatmapDrillDown = new MenuItem { Header = "Show Active Queries at This Time" };
+            heatmapMenu.Items.Insert(0, heatmapDrillDown);
+            heatmapMenu.Items.Insert(1, new Separator());
+            heatmapMenu.Opened += (s, _) =>
+            {
+                if (_lastHeatmapResult == null || _heatmapPlottable == null || _lastHeatmapResult.TimeBuckets.Length == 0)
+                {
+                    heatmapDrillDown.IsEnabled = false;
+                    return;
+                }
+                var mpos = Mouse.GetPosition(QueryHeatmapChart);
+                var mdpi = System.Windows.Media.VisualTreeHelper.GetDpi(QueryHeatmapChart);
+                var mpixel = new ScottPlot.Pixel((float)(mpos.X * mdpi.DpiScaleX), (float)(mpos.Y * mdpi.DpiScaleY));
+                var mcoords = QueryHeatmapChart.Plot.GetCoordinates(mpixel);
+                var (mCol, _) = _heatmapPlottable.GetIndexes(mcoords);
+                if (mCol >= 0 && mCol < _lastHeatmapResult.TimeBuckets.Length)
+                {
+                    heatmapDrillDown.Tag = _lastHeatmapResult.TimeBuckets[mCol];
+                    heatmapDrillDown.IsEnabled = true;
+                }
+                else
+                {
+                    heatmapDrillDown.IsEnabled = false;
+                }
+            };
+            heatmapDrillDown.Click += async (s, _) =>
+            {
+                if (heatmapDrillDown.Tag is DateTime bucketTime)
+                {
+                    var fromDate = bucketTime.AddMinutes(-5);
+                    var toDate = bucketTime.AddMinutes(10);
+                    SubTabControl.SelectedIndex = 1; // Active Queries
+                    await RefreshActiveQueriesWithRangeAsync(fromDate, toDate);
+                }
+            };
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -657,6 +731,10 @@ namespace PerformanceMonitorDashboard.Controls
             _perfTrendsHoursBack = hoursBack;
             _perfTrendsFromDate = fromDate;
             _perfTrendsToDate = toDate;
+
+            _heatmapHoursBack = hoursBack;
+            _heatmapFromDate = fromDate;
+            _heatmapToDate = toDate;
         }
 
         /// <summary>
@@ -683,6 +761,7 @@ namespace PerformanceMonitorDashboard.Controls
                         case 5: await RefreshQueryStoreGridAsync(); break;
                         case 6: await RefreshQueryStoreRegressionsAsync(); break;
                         case 7: await RefreshLongRunningPatternsAsync(); break;
+                        case 8: await RefreshQueryHeatmapAsync(); break;
                     }
                     return;
                 }
@@ -757,6 +836,9 @@ namespace PerformanceMonitorDashboard.Controls
                 LoadDurationChart(QueryPerfTrendsProcChart, await procDurationTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate, "Duration (ms/sec)", TabHelpers.ChartColors[1], _procDurationHover);
                 LoadDurationChart(QueryPerfTrendsQsChart, await qsDurationTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate, "Duration (ms/sec)", TabHelpers.ChartColors[4], _qsDurationHover);
                 LoadExecChart(await execTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate);
+
+                // Heatmap
+                await RefreshQueryHeatmapAsync();
             }
             catch (Exception ex)
             {
@@ -2412,6 +2494,189 @@ namespace PerformanceMonitorDashboard.Controls
                     }
                 }
             }
+        }
+
+        #endregion
+
+        #region Query Heatmap
+
+        private async Task RefreshQueryHeatmapAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var metric = (HeatmapMetric)HeatmapMetricCombo.SelectedIndex;
+                var result = await _databaseService.GetQueryHeatmapAsync(metric, _heatmapHoursBack, _heatmapFromDate, _heatmapToDate);
+                UpdateQueryHeatmapChart(result);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error refreshing heatmap: {ex.Message}", ex);
+            }
+        }
+
+        private void UpdateQueryHeatmapChart(HeatmapResult result)
+        {
+            if (_legendPanels.TryGetValue(QueryHeatmapChart, out var existingPanel) && existingPanel != null)
+            {
+                QueryHeatmapChart.Plot.Axes.Remove(existingPanel);
+                _legendPanels[QueryHeatmapChart] = null;
+            }
+            QueryHeatmapChart.Plot.Clear();
+            TabHelpers.ApplyThemeToChart(QueryHeatmapChart);
+
+            _lastHeatmapResult = result;
+
+            if (result.TimeBuckets.Length == 0 || result.BucketLabels.Length == 0)
+            {
+                QueryHeatmapChart.Plot.Title("Query Heatmap — No Data");
+                QueryHeatmapChart.Refresh();
+                return;
+            }
+
+            int numRows = result.Intensities.GetLength(0);
+            int numCols = result.Intensities.GetLength(1);
+
+            // Log1p scaling; NaN for empty cells so they render as background.
+            var scaled = new double[numRows, numCols];
+            for (int r = 0; r < numRows; r++)
+            {
+                for (int c = 0; c < numCols; c++)
+                {
+                    scaled[r, c] = result.Intensities[r, c] > 0
+                        ? Math.Log(1 + result.Intensities[r, c])
+                        : double.NaN;
+                }
+            }
+
+            var heatmap = QueryHeatmapChart.Plot.Add.Heatmap(scaled);
+            _heatmapPlottable = heatmap;
+            heatmap.FlipVertically = true;
+            heatmap.Colormap = new ScottPlot.Colormaps.Viridis();
+            heatmap.NaNCellColor = QueryHeatmapChart.Plot.DataBackground.Color;
+
+            // X-axis: time labels at column positions
+            var xTicks = new ScottPlot.TickGenerators.NumericManual();
+            int xStep = Math.Max(1, numCols / 12);
+            for (int i = 0; i < numCols; i += xStep)
+            {
+                var t = result.TimeBuckets[i];
+                xTicks.AddMajor(i, t.ToString("M/d\nh:mm tt"));
+            }
+            QueryHeatmapChart.Plot.Axes.Bottom.TickGenerator = xTicks;
+
+            // Y-axis: bucket labels
+            var yTicks = new ScottPlot.TickGenerators.NumericManual();
+            for (int i = 0; i < result.BucketLabels.Length; i++)
+            {
+                yTicks.AddMajor(i, result.BucketLabels[i]);
+            }
+            QueryHeatmapChart.Plot.Axes.Left.TickGenerator = yTicks;
+
+            QueryHeatmapChart.Plot.Axes.SetLimitsX(-0.5, numCols - 0.5);
+            QueryHeatmapChart.Plot.Axes.SetLimitsY(-0.5, numRows - 0.5);
+
+            TabHelpers.ReapplyAxisColors(QueryHeatmapChart);
+
+            // Colorbar with whole-number ticks
+            double maxRaw = 0;
+            for (int r = 0; r < numRows; r++)
+                for (int c = 0; c < numCols; c++)
+                    if (result.Intensities[r, c] > maxRaw) maxRaw = result.Intensities[r, c];
+            var colorBar = new ScottPlot.Panels.ColorBar(heatmap, ScottPlot.Edge.Right);
+            colorBar.Label = "Query Count";
+            var cbTicks = new ScottPlot.TickGenerators.NumericManual();
+            cbTicks.AddMajor(0, "0");
+            int[] niceValues = { 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000 };
+            foreach (var n in niceValues)
+            {
+                if (n > maxRaw) break;
+                cbTicks.AddMajor(Math.Log(1 + n), n.ToString("N0"));
+            }
+            cbTicks.AddMajor(Math.Log(1 + maxRaw), ((int)maxRaw).ToString("N0"));
+            colorBar.Axis.TickGenerator = cbTicks;
+            colorBar.LabelStyle.ForeColor = QueryHeatmapChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor;
+            colorBar.Axis.TickLabelStyle.ForeColor = QueryHeatmapChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor;
+            QueryHeatmapChart.Plot.Axes.AddPanel(colorBar);
+
+            var metricName = ((ComboBoxItem)HeatmapMetricCombo.SelectedItem).Content?.ToString() ?? "Duration (ms)";
+            QueryHeatmapChart.Plot.Title($"Query Distribution by {metricName}");
+
+            QueryHeatmapChart.Refresh();
+        }
+
+        private void HeatmapChart_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (_heatmapPopup != null) _heatmapPopup.IsOpen = false;
+        }
+
+        private void HeatmapChart_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (_heatmapPopup == null || _heatmapPopupText == null || _heatmapPlottable == null) return;
+            if (_lastHeatmapResult == null || _lastHeatmapResult.TimeBuckets.Length == 0) return;
+
+            var now = DateTime.UtcNow;
+            if ((now - _lastHeatmapHoverUpdate).TotalMilliseconds < 50) return;
+            _lastHeatmapHoverUpdate = now;
+
+            var pos = e.GetPosition(QueryHeatmapChart);
+            var dpi = System.Windows.Media.VisualTreeHelper.GetDpi(QueryHeatmapChart);
+            var pixel = new ScottPlot.Pixel(
+                (float)(pos.X * dpi.DpiScaleX),
+                (float)(pos.Y * dpi.DpiScaleY));
+            var coords = QueryHeatmapChart.Plot.GetCoordinates(pixel);
+
+            int numRows = _lastHeatmapResult.Intensities.GetLength(0);
+            int numCols = _lastHeatmapResult.Intensities.GetLength(1);
+
+            var (col, rowIdx) = _heatmapPlottable.GetIndexes(coords);
+            int row = (numRows - 1) - rowIdx;
+
+            if (row < 0 || row >= numRows || col < 0 || col >= numCols)
+            {
+                _heatmapPopup.IsOpen = false;
+                return;
+            }
+
+            long count = (long)_lastHeatmapResult.Intensities[row, col];
+            if (count == 0)
+            {
+                _heatmapPopup.IsOpen = false;
+                return;
+            }
+
+            var cell = _lastHeatmapResult.CellDetails[row, col];
+            var time = _lastHeatmapResult.TimeBuckets[col];
+            var bucketLabel = row < _lastHeatmapResult.BucketLabels.Length
+                ? _lastHeatmapResult.BucketLabels[row]
+                : "?";
+
+            var tipText = $"{time:HH:mm:ss}  |  {bucketLabel}  |  {count:N0} queries";
+            if (cell != null && !string.IsNullOrEmpty(cell.TopQueryText))
+            {
+                var flat = System.Text.RegularExpressions.Regex.Replace(cell.TopQueryText, @"\s+", " ").Trim();
+                if (flat.Length > 60) flat = flat[..60] + "...";
+                tipText += $"\n{flat}";
+            }
+            _heatmapPopupText.Text = tipText;
+
+            _heatmapPopup.HorizontalOffset = pos.X + 15;
+            _heatmapPopup.VerticalOffset = pos.Y + 15;
+            _heatmapPopup.IsOpen = true;
+        }
+
+        private async void HeatmapMetric_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _databaseService == null) return;
+            await RefreshQueryHeatmapAsync();
+        }
+
+        private async Task RefreshActiveQueriesWithRangeAsync(DateTime from, DateTime to)
+        {
+            if (_databaseService == null) return;
+            var snapshots = await _databaseService.GetQuerySnapshotsAsync(0, from, to);
+            SetItemsSourcePreservingSort(ActiveQueriesDataGrid, snapshots);
+            ActiveQueriesNoDataMessage.Visibility = snapshots.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         }
 
         #endregion

--- a/Dashboard/Models/HeatmapModels.cs
+++ b/Dashboard/Models/HeatmapModels.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public enum HeatmapMetric
+    {
+        Duration,
+        Cpu,
+        LogicalReads,
+        LogicalWrites,
+        ExecutionCount
+    }
+
+    public class HeatmapCell
+    {
+        public DateTime TimeBucket { get; set; }
+        public int BucketIndex { get; set; }
+        public long Count { get; set; }
+        public string TopQueryHash { get; set; } = "";
+        public string TopQueryText { get; set; } = "";
+    }
+
+    public class HeatmapResult
+    {
+        public double[,] Intensities { get; set; } = new double[0, 0];
+        public DateTime[] TimeBuckets { get; set; } = Array.Empty<DateTime>();
+        public string[] BucketLabels { get; set; } = Array.Empty<string>();
+        public HeatmapCell[,] CellDetails { get; set; } = new HeatmapCell[0, 0];
+    }
+}

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -3586,5 +3586,167 @@ OPTION(MAXDOP 1, RECOMPILE);";
 
             return items;
         }
+
+        private static string GetHeatmapMetricExpr(Models.HeatmapMetric metric) => metric switch
+        {
+            Models.HeatmapMetric.Duration => "(qs.total_elapsed_time_delta / 1000.0) / NULLIF(qs.execution_count_delta, 0)",
+            Models.HeatmapMetric.Cpu => "(qs.total_worker_time_delta / 1000.0) / NULLIF(qs.execution_count_delta, 0)",
+            Models.HeatmapMetric.LogicalReads => "CAST(qs.total_logical_reads_delta AS float) / NULLIF(qs.execution_count_delta, 0)",
+            Models.HeatmapMetric.LogicalWrites => "CAST(qs.total_logical_writes_delta AS float) / NULLIF(qs.execution_count_delta, 0)",
+            Models.HeatmapMetric.ExecutionCount => "CAST(qs.execution_count_delta AS float)",
+            _ => "(qs.total_elapsed_time_delta / 1000.0) / NULLIF(qs.execution_count_delta, 0)"
+        };
+
+        private static readonly string[] HeatmapDurationLabels = { "0-1ms", "1-10ms", "10-100ms", "100ms-1s", "1-10s", "10-100s", ">100s" };
+        private static readonly string[] HeatmapCountLabels = { "0-1", "1-10", "10-100", "100-1K", "1K-10K", "10K-100K", ">100K" };
+
+        public async Task<Models.HeatmapResult> GetQueryHeatmapAsync(Models.HeatmapMetric metric, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+        {
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            var metricExpr = GetHeatmapMetricExpr(metric);
+
+            string timeFilter;
+            if (fromDate.HasValue && toDate.HasValue)
+            {
+                timeFilter = "AND qs.collection_time >= @from_date AND qs.collection_time <= @to_date";
+            }
+            else
+            {
+                timeFilter = $"AND qs.collection_time >= DATEADD(HOUR, -{hoursBack}, GETDATE())";
+            }
+
+            var query = $@"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH per_query AS
+(
+    SELECT
+        time_bin = DATEADD(MINUTE, DATEDIFF(MINUTE, 0, qs.collection_time) / 5 * 5, 0),
+        metric_value = {metricExpr},
+        qs.query_hash,
+        query_preview = LEFT(CAST(DECOMPRESS(qs.query_text) AS nvarchar(max)), 120),
+        qs.execution_count_delta
+    FROM collect.query_stats AS qs
+    WHERE qs.execution_count_delta > 0
+    AND   {metricExpr} IS NOT NULL
+    {timeFilter}
+)
+SELECT
+    pq.time_bin,
+    bucket_index =
+        CASE
+            WHEN pq.metric_value < 1 THEN 0
+            WHEN pq.metric_value < 10 THEN 1
+            WHEN pq.metric_value < 100 THEN 2
+            WHEN pq.metric_value < 1000 THEN 3
+            WHEN pq.metric_value < 10000 THEN 4
+            WHEN pq.metric_value < 100000 THEN 5
+            ELSE 6
+        END,
+    query_count = COUNT(*),
+    top_query_hash = CONVERT(varchar(20), MAX(CASE WHEN pq.execution_count_delta = m.max_exec THEN pq.query_hash END), 1),
+    top_query_text = MAX(CASE WHEN pq.execution_count_delta = m.max_exec THEN pq.query_preview END)
+FROM per_query AS pq
+CROSS APPLY
+(
+    SELECT max_exec = MAX(pq2.execution_count_delta)
+    FROM per_query AS pq2
+    WHERE pq2.time_bin = pq.time_bin
+    AND   CASE
+            WHEN pq2.metric_value < 1 THEN 0
+            WHEN pq2.metric_value < 10 THEN 1
+            WHEN pq2.metric_value < 100 THEN 2
+            WHEN pq2.metric_value < 1000 THEN 3
+            WHEN pq2.metric_value < 10000 THEN 4
+            WHEN pq2.metric_value < 100000 THEN 5
+            ELSE 6
+          END =
+          CASE
+            WHEN pq.metric_value < 1 THEN 0
+            WHEN pq.metric_value < 10 THEN 1
+            WHEN pq.metric_value < 100 THEN 2
+            WHEN pq.metric_value < 1000 THEN 3
+            WHEN pq.metric_value < 10000 THEN 4
+            WHEN pq.metric_value < 100000 THEN 5
+            ELSE 6
+          END
+) AS m
+GROUP BY
+    pq.time_bin,
+    CASE
+        WHEN pq.metric_value < 1 THEN 0
+        WHEN pq.metric_value < 10 THEN 1
+        WHEN pq.metric_value < 100 THEN 2
+        WHEN pq.metric_value < 1000 THEN 3
+        WHEN pq.metric_value < 10000 THEN 4
+        WHEN pq.metric_value < 100000 THEN 5
+        ELSE 6
+    END
+ORDER BY
+    pq.time_bin,
+    bucket_index;";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+            if (fromDate.HasValue && toDate.HasValue)
+            {
+                command.Parameters.AddWithValue("@from_date", fromDate.Value);
+                command.Parameters.AddWithValue("@to_date", toDate.Value);
+            }
+
+            var rawCells = new System.Collections.Generic.List<Models.HeatmapCell>();
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                rawCells.Add(new Models.HeatmapCell
+                {
+                    TimeBucket = reader.GetDateTime(0),
+                    BucketIndex = reader.GetInt32(1),
+                    Count = Convert.ToInt64(reader.GetValue(2), CultureInfo.InvariantCulture),
+                    TopQueryHash = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                    TopQueryText = reader.IsDBNull(4) ? "" : reader.GetString(4)
+                });
+            }
+
+            if (rawCells.Count == 0)
+                return new Models.HeatmapResult();
+
+            var times = new System.Collections.Generic.List<DateTime>();
+            var timeIndex = new System.Collections.Generic.Dictionary<DateTime, int>();
+            foreach (var cell in rawCells)
+            {
+                if (!timeIndex.ContainsKey(cell.TimeBucket))
+                {
+                    timeIndex[cell.TimeBucket] = times.Count;
+                    times.Add(cell.TimeBucket);
+                }
+            }
+
+            int numBuckets = 7;
+            var intensities = new double[numBuckets, times.Count];
+            var cellDetails = new Models.HeatmapCell[numBuckets, times.Count];
+
+            foreach (var cell in rawCells)
+            {
+                if (!timeIndex.TryGetValue(cell.TimeBucket, out int col)) continue;
+                int row = Math.Clamp(cell.BucketIndex, 0, numBuckets - 1);
+                intensities[row, col] = cell.Count;
+                cellDetails[row, col] = cell;
+            }
+
+            var labels = metric == Models.HeatmapMetric.LogicalReads || metric == Models.HeatmapMetric.LogicalWrites || metric == Models.HeatmapMetric.ExecutionCount
+                ? HeatmapCountLabels
+                : HeatmapDurationLabels;
+
+            return new Models.HeatmapResult
+            {
+                Intensities = intensities,
+                TimeBuckets = times.ToArray(),
+                BucketLabels = labels,
+                CellDetails = cellDetails
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Port of Lite's Query Heatmap to the full Dashboard (SQL Server backend)
- New sub-tab under Query Performance with metric selector, ScottPlot heatmap, colorbar, hover tooltips, right-click drill-down
- Uses `DECOMPRESS` for compressed query text in `collect.query_stats`
- Same UX patterns as Lite: Viridis colormap, FlipVertically, manual tick labels, whole-number colorbar

## Test plan
- [ ] Connect to a server, navigate to Query Performance > Query Heatmap
- [ ] Verify heatmap renders with data and correct Y-axis labels
- [ ] Switch metric dropdown — heatmap refreshes
- [ ] Hover over colored cells — tooltip shows time, bucket, count, query text
- [ ] Right-click > "Show Active Queries at This Time" — navigates to Active Queries with correct time filter
- [ ] Change time range — heatmap updates

Addresses #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)