### PR TITLE
Fix drill-down navigation bugs in Dashboard and Lite

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -97,6 +97,7 @@ namespace PerformanceMonitorDashboard.Controls
         private int _activeQueriesHoursBack = 1;
         private DateTime? _activeQueriesFromDate;
         private DateTime? _activeQueriesToDate;
+        private bool _isDrillDownActive;
 
         // Query Stats state
         private int _queryStatsHoursBack = 24;
@@ -153,6 +154,7 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartSaveMenus();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            SubTabControl.SelectionChanged += (s, e) => { if (e.Source == SubTabControl) _isDrillDownActive = false; };
             Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
 
             _queryDurationHover = new Helpers.ChartHoverHelper(QueryPerfTrendsQueryChart, "ms/sec");
@@ -704,6 +706,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         public void SetTimeRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
         {
+            _isDrillDownActive = false;
             _activeQueriesHoursBack = hoursBack;
             _activeQueriesFromDate = fromDate;
             _activeQueriesToDate = toDate;
@@ -1064,6 +1067,7 @@ namespace PerformanceMonitorDashboard.Controls
         {
             using var _ = Helpers.MethodProfiler.StartTiming("QueryPerf-ActiveQueries");
             if (_databaseService == null) return;
+            if (_isDrillDownActive) return;
 
             try
             {
@@ -2674,6 +2678,7 @@ namespace PerformanceMonitorDashboard.Controls
         private async Task RefreshActiveQueriesWithRangeAsync(DateTime from, DateTime to)
         {
             if (_databaseService == null) return;
+            _isDrillDownActive = true;
             var snapshots = await _databaseService.GetQuerySnapshotsAsync(0, from, to);
             SetItemsSourcePreservingSort(ActiveQueriesDataGrid, snapshots);
             ActiveQueriesNoDataMessage.Visibility = snapshots.Count == 0 ? Visibility.Visible : Visibility.Collapsed;

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -3120,6 +3120,7 @@ public partial class ServerTab : UserControl
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        _ = LoadActiveQueriesSlicerAsync();
     }
 
     private async void OnMemoryDrillDown(DateTime time)
@@ -3133,6 +3134,7 @@ public partial class ServerTab : UserControl
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        _ = LoadActiveQueriesSlicerAsync();
     }
 
     private async void OnTempDbDrillDown(DateTime time)
@@ -3147,6 +3149,7 @@ public partial class ServerTab : UserControl
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        _ = LoadActiveQueriesSlicerAsync();
     }
 
     private async void OnBlockingDrillDown(DateTime time)
@@ -3187,6 +3190,7 @@ public partial class ServerTab : UserControl
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        _ = LoadActiveQueriesSlicerAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- **Dashboard (#741)**: Auto-refresh timer no longer overwrites Active Queries after a drill-down. Added `_isDrillDownActive` flag that's set on drill-down and cleared on sub-tab switch or time range change.
- **Lite (#742)**: Drill-down handlers now call `LoadActiveQueriesSlicerAsync()` so the slicer updates to match the drill-down time window.

## Test plan
- [ ] Dashboard: right-click a chart > "Show Active Queries at This Time" — data should persist through refresh cycles
- [ ] Dashboard: after drill-down, switch to a different sub-tab and back — refresh should resume normally
- [ ] Dashboard: after drill-down, change time range — refresh should resume normally
- [ ] Lite: right-click a chart > "Show Active Queries at This Time" — slicer should align to the drill-down time window

Fixes #741, Fixes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)