### PR TITLE
Fix heatmap colorbar stacking on refresh

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -2602,6 +2602,7 @@ namespace PerformanceMonitorDashboard.Controls
             colorBar.LabelStyle.ForeColor = QueryHeatmapChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor;
             colorBar.Axis.TickLabelStyle.ForeColor = QueryHeatmapChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor;
             QueryHeatmapChart.Plot.Axes.AddPanel(colorBar);
+            _legendPanels[QueryHeatmapChart] = colorBar;
 
             var metricName = ((ComboBoxItem)HeatmapMetricCombo.SelectedItem).Content?.ToString() ?? "Duration (ms)";
             QueryHeatmapChart.Plot.Title($"Query Distribution by {metricName}");

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -41,7 +41,7 @@ public partial class ServerTab : UserControl
     private readonly CredentialService _credentialService;
     private readonly DispatcherTimer _refreshTimer;
     private bool _isRefreshing;
-    private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.Panels.LegendPanel?> _legendPanels = new();
+    private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.IPanel?> _legendPanels = new();
     private List<SelectableItem> _waitTypeItems = new();
     private List<SelectableItem> _perfmonCounterItems = new();
     private Helpers.ChartHoverHelper? _waitStatsHover;
@@ -2819,6 +2819,7 @@ public partial class ServerTab : UserControl
         cbTicks.AddMajor(Math.Log(1 + maxRaw), ((int)maxRaw).ToString("N0"));
         colorBar.Axis.TickGenerator = cbTicks;
         QueryHeatmapChart.Plot.Axes.AddPanel(colorBar);
+        _legendPanels[QueryHeatmapChart] = colorBar;
 
         var metricName = ((ComboBoxItem)HeatmapMetricCombo.SelectedItem).Content?.ToString() ?? "Duration (ms)";
         QueryHeatmapChart.Plot.Title($"Query Distribution by {metricName}");


### PR DESCRIPTION
## Summary
- Track colorbar panel in `_legendPanels` so it gets removed before re-adding on refresh
- Widen Lite's `_legendPanels` type from `LegendPanel?` to `IPanel?` to support `ColorBar`

## Test plan
- [ ] Dashboard: stay on Query Heatmap, wait for several auto-refresh cycles — only one colorbar should appear
- [ ] Lite: same test

🤖 Generated with [Claude Code](https://claude.com/claude-code)