### PR TITLE
Fix drill-down timezone mismatches and slicer state

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -2680,9 +2680,16 @@ namespace PerformanceMonitorDashboard.Controls
         {
             if (_databaseService == null) return;
             _isDrillDownActive = true;
+
+            // Update active queries state so slicer loads matching data
+            _activeQueriesHoursBack = 0;
+            _activeQueriesFromDate = from;
+            _activeQueriesToDate = to;
+
             var snapshots = await _databaseService.GetQuerySnapshotsAsync(0, from, to);
             SetItemsSourcePreservingSort(ActiveQueriesDataGrid, snapshots);
             ActiveQueriesNoDataMessage.Visibility = snapshots.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            LoadActiveQueriesSlicerAsync().ConfigureAwait(false);
         }
 
         #endregion

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -3120,7 +3120,7 @@ public partial class ServerTab : UserControl
         QueriesSubTabControl.SelectedIndex = 1; // Active Queries
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
-        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
     }
 
@@ -3134,7 +3134,7 @@ public partial class ServerTab : UserControl
         QueriesSubTabControl.SelectedIndex = 1; // Active Queries
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
-        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
     }
 
@@ -3149,7 +3149,7 @@ public partial class ServerTab : UserControl
         QueriesSubTabControl.SelectedIndex = 1; // Active Queries
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
-        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
     }
 
@@ -3190,7 +3190,7 @@ public partial class ServerTab : UserControl
         QueriesSubTabControl.SelectedIndex = 1; // Active Queries
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
-        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate, "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate, "HH:mm")}";
+        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
     }
 


### PR DESCRIPTION
## Summary
- **Lite**: Fixed drill-down label showing UTC instead of display time (e.g. "01:40" → "08:40"). `FormatServerTime` expects UTC but was receiving server time.
- **Dashboard**: Heatmap drill-down now updates Active Queries state fields and refreshes slicer so it shows the drill-down window instead of stale 24h.

## Test plan
- [ ] Lite: right-click heatmap > Show Active Queries — drill-down label time should match slicer time
- [ ] Lite: same test from CPU/Memory charts — label should show correct server/local time
- [ ] Dashboard: right-click heatmap > Show Active Queries — slicer should narrow to the drill-down window

Fixes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)