### PR TITLE
Fix drill-down timezone and picker display issues

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -57,6 +57,9 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>Raised when actual plan execution finishes (success or failure).</summary>
         public event Action? ActualPlanFinished;
 
+        /// <summary>Raised when a drill-down needs the parent to set custom time pickers. Args: (fromUtc, toUtc)</summary>
+        public event Action<DateTime, DateTime>? DrillDownTimeRangeRequested;
+
         private CancellationTokenSource? _actualPlanCts;
 
         /// <summary>Cancels the in-flight actual plan execution, if any.</summary>
@@ -219,10 +222,16 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 if (heatmapDrillDown.Tag is DateTime bucketTime)
                 {
-                    var fromDate = bucketTime.AddMinutes(-5);
-                    var toDate = bucketTime.AddMinutes(10);
+                    // bucketTime is already server time (SQL Server stores collection_time in server local time)
+                    var serverFrom = bucketTime.AddMinutes(-5);
+                    var serverTo = bucketTime.AddMinutes(10);
+                    DrillDownTimeRangeRequested?.Invoke(serverFrom, serverTo);
+
+                    // Query also uses server time (same as collection_time in SQL Server)
+                    var queryFrom = serverFrom;
+                    var queryTo = serverTo;
                     SubTabControl.SelectedIndex = 1; // Active Queries
-                    await RefreshActiveQueriesWithRangeAsync(fromDate, toDate);
+                    await RefreshActiveQueriesWithRangeAsync(queryFrom, queryTo);
                 }
             };
         }
@@ -324,9 +333,19 @@ namespace PerformanceMonitorDashboard.Controls
             if (_databaseService == null) return;
             try
             {
+                // For narrow time ranges (drill-downs), pad the query by ±1 hour
+                // so hourly slicer buckets overlap the display range
+                var queryFrom = _activeQueriesFromDate;
+                var queryTo = _activeQueriesToDate;
+                if (queryFrom.HasValue && queryTo.HasValue && (queryTo.Value - queryFrom.Value).TotalHours < 2)
+                {
+                    queryFrom = queryFrom.Value.AddHours(-1);
+                    queryTo = queryTo.Value.AddHours(1);
+                }
+
                 var data = await _databaseService.GetActiveQuerySlicerDataAsync(
-                    _activeQueriesHoursBack, _activeQueriesFromDate, _activeQueriesToDate);
-                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_activeQueriesHoursBack, _activeQueriesFromDate, _activeQueriesToDate);
+                    _activeQueriesHoursBack, queryFrom, queryTo);
+                var (slicerStart, slicerEnd) = GetSlicerTimeRange(_activeQueriesHoursBack, queryFrom, queryTo);
                 if (data.Count > 0)
                     ActiveQueriesSlicer.LoadData(data, "Sessions", slicerStart, slicerEnd);
             }

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -152,6 +152,10 @@ namespace PerformanceMonitorDashboard
             {
                 HidePlanLoading();
             };
+            PerformanceTab.DrillDownTimeRangeRequested += (from, to) =>
+            {
+                SetDrillDownGlobalRange(from, to);
+            };
             SystemEventsContent.Initialize(_databaseService);
             ResourceMetricsContent.Initialize(_databaseService);
             ResourceMetricsContent.ChartDrillDownRequested += OnChildChartDrillDown;
@@ -318,11 +322,11 @@ namespace PerformanceMonitorDashboard
 
         private void SetPickersFromDateTime(DateTime serverTime, DatePicker datePicker, ComboBox hourCombo, ComboBox minuteCombo)
         {
-            // Convert server time to local time for display in UI pickers
-            var localTime = Helpers.ServerTimeHelper.ToLocalTime(serverTime);
-            datePicker.SelectedDate = localTime.Date;
-            hourCombo.SelectedIndex = localTime.Hour;
-            minuteCombo.SelectedIndex = localTime.Minute / 15; // Round down to nearest 15-min interval
+            // Display in the current time mode (server time, local time, or UTC)
+            var displayTime = Helpers.ServerTimeHelper.ConvertForDisplay(serverTime, Helpers.ServerTimeHelper.CurrentDisplayMode);
+            datePicker.SelectedDate = displayTime.Date;
+            hourCombo.SelectedIndex = displayTime.Hour;
+            minuteCombo.SelectedIndex = displayTime.Minute / 15;
         }
 
         private void SetupAutoRefresh()

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -3179,18 +3179,23 @@ public partial class ServerTab : UserControl
 
     private async void OnHeatmapDrillDown(DateTime bucketTimeUtc)
     {
-        // The time bucket is in UTC — convert to server time for the drill-down
         var serverTime = bucketTimeUtc.AddMinutes(UtcOffsetMinutes);
         var fromDate = serverTime.AddMinutes(-5);
-        var toDate = serverTime.AddMinutes(10); // 5-min bucket + 5-min padding
+        var toDate = serverTime.AddMinutes(10);
+
+        AppLogger.Info("DrillDown", $"OnHeatmapDrillDown: bucketTimeUtc={bucketTimeUtc:O}, UtcOffsetMinutes={UtcOffsetMinutes}, serverTime={serverTime:O}, fromDate={fromDate:O}, toDate={toDate:O}");
 
         SetDrillDownTimeRange(fromDate, toDate);
 
         MainTabControl.SelectedIndex = 2; // Queries
         QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+
+        AppLogger.Info("DrillDown", $"Calling GetLatestQuerySnapshotsAsync with fromDate={fromDate:O}, toDate={toDate:O}");
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
+        AppLogger.Info("DrillDown", $"Got {snapshots.Count} snapshots");
+
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
-        LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} \u2192 {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
+        LiveSnapshotIndicator.Text = $"Drill-down: {fromDate:HH:mm} \u2192 {toDate:HH:mm} (server time)";
         _ = LoadActiveQueriesSlicerAsync();
     }
 
@@ -3200,21 +3205,21 @@ public partial class ServerTab : UserControl
     /// </summary>
     private void SetDrillDownTimeRange(DateTime fromServer, DateTime toServer)
     {
-        // Convert server time to local time for the pickers
-        var fromLocal = ServerTimeHelper.ToLocalTime(fromServer);
-        var toLocal = ServerTimeHelper.ToLocalTime(toServer);
+        // Display in the current time mode (server time, local time, or UTC)
+        var fromDisplay = ServerTimeHelper.ConvertForDisplay(fromServer, ServerTimeHelper.CurrentDisplayMode);
+        var toDisplay = ServerTimeHelper.ConvertForDisplay(toServer, ServerTimeHelper.CurrentDisplayMode);
 
         // Switch to Custom without triggering a refresh
         _isRefreshing = true;
         try
         {
             TimeRangeCombo.SelectedIndex = 5; // Custom
-            FromDatePicker.SelectedDate = fromLocal.Date;
-            FromHourCombo.SelectedIndex = fromLocal.Hour;
-            FromMinuteCombo.SelectedIndex = fromLocal.Minute / 15;
-            ToDatePicker.SelectedDate = toLocal.Date;
-            ToHourCombo.SelectedIndex = toLocal.Hour;
-            ToMinuteCombo.SelectedIndex = toLocal.Minute / 15;
+            FromDatePicker.SelectedDate = fromDisplay.Date;
+            FromHourCombo.SelectedIndex = fromDisplay.Hour;
+            FromMinuteCombo.SelectedIndex = fromDisplay.Minute / 15;
+            ToDatePicker.SelectedDate = toDisplay.Date;
+            ToHourCombo.SelectedIndex = toDisplay.Hour;
+            ToMinuteCombo.SelectedIndex = toDisplay.Minute / 15;
 
             // Make pickers visible
             var visibility = Visibility.Visible;
@@ -4615,10 +4620,19 @@ public partial class ServerTab : UserControl
                 }
             }
 
-            var data = await _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            // For narrow time ranges (drill-downs), pad the query by ±1 hour
+            // so hourly slicer buckets overlap the display range
+            DateTime? queryFrom = fromDate, queryTo = toDate;
+            if (fromDate.HasValue && toDate.HasValue && (toDate.Value - fromDate.Value).TotalHours < 2)
+            {
+                queryFrom = fromDate.Value.AddHours(-1);
+                queryTo = toDate.Value.AddHours(1);
+            }
+
+            var data = await _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, queryFrom, queryTo);
             _activeQueriesSlicerData = data;
             _activeQueriesSlicerMetric = "Sessions";
-            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
+            var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, queryFrom, queryTo);
             if (data.Count > 0)
                 ActiveQueriesSlicer.LoadData(data, "Sessions", slicerStart, slicerEnd);
         }


### PR DESCRIPTION
## Summary
- **Both apps**: Drill-down pickers now respect the display mode (Server Time / Local / UTC) instead of always showing local time
- **Both apps**: Slicer query pads ±1 hour for narrow drill-down windows so hourly buckets appear
- **Lite**: Drill-down label converts correctly (fixes double-offset)
- **Dashboard**: Heatmap drill-down populates custom range pickers via new `DrillDownTimeRangeRequested` event. Bucket time treated as server time (not UTC).

## Test plan
- [ ] Dashboard: right-click heatmap > Show Active Queries — pickers show server time, slicer has data
- [ ] Lite: same test — pickers and slicer align
- [ ] Switch display mode to Local Time or UTC — pickers should adjust accordingly

Fixes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)