### PR TITLE
Make custom range pickers respect display mode

### DIFF
--- a/Dashboard/Helpers/ServerTimeHelper.cs
+++ b/Dashboard/Helpers/ServerTimeHelper.cs
@@ -71,6 +71,16 @@ namespace PerformanceMonitorDashboard.Helpers
         };
 
         /// <summary>
+        /// Converts a display-mode DateTime back to server time. Reverse of ConvertForDisplay.
+        /// </summary>
+        public static DateTime DisplayTimeToServerTime(DateTime displayTime, TimeDisplayMode mode) => mode switch
+        {
+            TimeDisplayMode.LocalTime => ToServerTime(displayTime),
+            TimeDisplayMode.UTC => displayTime.AddMinutes(_utcOffsetMinutes),
+            _ => displayTime
+        };
+
+        /// <summary>
         /// Returns a short timezone label for the current display mode (e.g., "UTC", "PST", "UTC-8:00").
         /// </summary>
         public static string GetTimezoneLabel(TimeDisplayMode mode) => mode switch

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -47,6 +47,7 @@ namespace PerformanceMonitorDashboard
         private readonly UserPreferencesService _preferencesService;
         private DispatcherTimer? _autoRefreshTimer;
         private bool _isRefreshing;
+        private bool _suppressPickerUpdates;
 
         // Filter state dictionaries for each DataGrid
 
@@ -663,11 +664,13 @@ namespace PerformanceMonitorDashboard
 
         private async void GlobalCustomDateTime_Changed(object sender, SelectionChangedEventArgs e)
         {
+            if (_suppressPickerUpdates) return;
             await UpdateGlobalDateTimeRange();
         }
 
         private async void GlobalTimeCombo_Changed(object sender, SelectionChangedEventArgs e)
         {
+            if (_suppressPickerUpdates) return;
             // Only update if both dates are selected (time change alone isn't meaningful without dates)
             if (GlobalFromDate.SelectedDate.HasValue && GlobalToDate.SelectedDate.HasValue)
             {
@@ -684,10 +687,10 @@ namespace PerformanceMonitorDashboard
 
                 if (fromDateTime.HasValue && toDateTime.HasValue)
                 {
-                    /* Convert local dates/times to server time - user picks in their timezone,
-                       but database stores collection_time in server's timezone */
-                    _globalFromDate = Helpers.ServerTimeHelper.ToServerTime(fromDateTime.Value);
-                    _globalToDate = Helpers.ServerTimeHelper.ToServerTime(toDateTime.Value);
+                    /* Convert display-mode time back to server time — pickers show time
+                       in the current display mode (server, local, or UTC) */
+                    _globalFromDate = Helpers.ServerTimeHelper.DisplayTimeToServerTime(fromDateTime.Value, Helpers.ServerTimeHelper.CurrentDisplayMode);
+                    _globalToDate = Helpers.ServerTimeHelper.DisplayTimeToServerTime(toDateTime.Value, Helpers.ServerTimeHelper.CurrentDisplayMode);
 
                     if (_globalFromDate > _globalToDate)
                     {
@@ -1686,7 +1689,27 @@ namespace PerformanceMonitorDashboard
             };
             if (mode == ServerTimeHelper.CurrentDisplayMode) return;
 
-            ServerTimeHelper.CurrentDisplayMode = mode;
+            // Re-convert custom range pickers from old display mode to new.
+            // Suppress picker change handlers to avoid validation errors and cascading refreshes.
+            var oldMode = ServerTimeHelper.CurrentDisplayMode;
+            var fromPicker = GetDateTimeFromPickers(GlobalFromDate, GlobalFromHour, GlobalFromMinute);
+            var toPicker = GetDateTimeFromPickers(GlobalToDate, GlobalToHour, GlobalToMinute);
+            _suppressPickerUpdates = true;
+            try
+            {
+                ServerTimeHelper.CurrentDisplayMode = mode;
+                if (fromPicker.HasValue && toPicker.HasValue)
+                {
+                    var fromServer = Helpers.ServerTimeHelper.DisplayTimeToServerTime(fromPicker.Value, oldMode);
+                    var toServer = Helpers.ServerTimeHelper.DisplayTimeToServerTime(toPicker.Value, oldMode);
+                    SetPickersFromDateTime(fromServer, GlobalFromDate, GlobalFromHour, GlobalFromMinute);
+                    SetPickersFromDateTime(toServer, GlobalToDate, GlobalToHour, GlobalToMinute);
+                }
+            }
+            finally
+            {
+                _suppressPickerUpdates = false;
+            }
 
             // Persist preference
             var prefs = _preferencesService.GetPreferences();

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -429,11 +429,11 @@ public partial class ServerTab : UserControl
 
     private void SetPickersFromDateTime(DateTime serverTime, DatePicker datePicker, ComboBox hourCombo, ComboBox minuteCombo)
     {
-        /* Convert server time to local time for display in UI */
-        var localTime = ServerTimeHelper.ToLocalTime(serverTime);
-        datePicker.SelectedDate = localTime.Date;
-        hourCombo.SelectedIndex = localTime.Hour;
-        minuteCombo.SelectedIndex = localTime.Minute / 15;
+        /* Convert server time to the current display mode for UI */
+        var displayTime = ServerTimeHelper.ConvertForDisplay(serverTime, ServerTimeHelper.CurrentDisplayMode);
+        datePicker.SelectedDate = displayTime.Date;
+        hourCombo.SelectedIndex = displayTime.Hour;
+        minuteCombo.SelectedIndex = displayTime.Minute / 15;
     }
 
     /// <summary>
@@ -549,7 +549,44 @@ public partial class ServerTab : UserControl
         };
         if (mode == ServerTimeHelper.CurrentDisplayMode) return;
 
-        ServerTimeHelper.CurrentDisplayMode = mode;
+        // Re-convert custom range pickers from old display mode to new.
+        // Suppress refreshes while updating pickers to avoid cascading queries.
+        var oldMode = ServerTimeHelper.CurrentDisplayMode;
+        _isRefreshing = true;
+        try
+        {
+            if (IsCustomRange)
+            {
+                var fromPicker = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+                var toPicker = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+                if (fromPicker.HasValue && toPicker.HasValue)
+                {
+                    var fromServer = ServerTimeHelper.DisplayTimeToServerTime(fromPicker.Value, oldMode);
+                    var toServer = ServerTimeHelper.DisplayTimeToServerTime(toPicker.Value, oldMode);
+                    ServerTimeHelper.CurrentDisplayMode = mode;
+                    var fromNew = ServerTimeHelper.ConvertForDisplay(fromServer, mode);
+                    var toNew = ServerTimeHelper.ConvertForDisplay(toServer, mode);
+                    FromDatePicker.SelectedDate = fromNew.Date;
+                    FromHourCombo.SelectedIndex = fromNew.Hour;
+                    FromMinuteCombo.SelectedIndex = fromNew.Minute / 15;
+                    ToDatePicker.SelectedDate = toNew.Date;
+                    ToHourCombo.SelectedIndex = toNew.Hour;
+                    ToMinuteCombo.SelectedIndex = toNew.Minute / 15;
+                }
+                else
+                {
+                    ServerTimeHelper.CurrentDisplayMode = mode;
+                }
+            }
+            else
+            {
+                ServerTimeHelper.CurrentDisplayMode = mode;
+            }
+        }
+        finally
+        {
+            _isRefreshing = false;
+        }
 
         // Refresh all DataGrid bindings so ServerTimeConverter re-evaluates
         QuerySnapshotsGrid.Items.Refresh();
@@ -742,8 +779,8 @@ public partial class ServerTab : UserControl
             var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
             if (fromLocal.HasValue && toLocal.HasValue)
             {
-                fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
             }
         }
 
@@ -1435,8 +1472,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -1522,8 +1559,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -1667,8 +1704,8 @@ public partial class ServerTab : UserControl
             var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
             if (fromLocal.HasValue && toLocal.HasValue)
             {
-                fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
             }
         }
         await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
@@ -2578,8 +2615,8 @@ public partial class ServerTab : UserControl
             var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
             var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
             if (fromLocal.HasValue && toLocal.HasValue)
-                return (ServerTimeHelper.LocalToServerTime(fromLocal.Value),
-                        ServerTimeHelper.LocalToServerTime(toLocal.Value));
+                return (ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode),
+                        ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode));
         }
         return (null, null);
     }
@@ -2908,8 +2945,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
             var metric = (HeatmapMetric)HeatmapMetricCombo.SelectedIndex;
@@ -3205,7 +3242,8 @@ public partial class ServerTab : UserControl
     /// </summary>
     private void SetDrillDownTimeRange(DateTime fromServer, DateTime toServer)
     {
-        // Display in the current time mode (server time, local time, or UTC)
+        // Pickers store time in the current display mode. Downstream reads use
+        // DisplayTimeToServerTime() to convert back.
         var fromDisplay = ServerTimeHelper.ConvertForDisplay(fromServer, ServerTimeHelper.CurrentDisplayMode);
         var toDisplay = ServerTimeHelper.ConvertForDisplay(toServer, ServerTimeHelper.CurrentDisplayMode);
 
@@ -3261,8 +3299,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
             double globalMax = 0;
@@ -3411,8 +3449,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -3621,8 +3659,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
             double globalMax = 0;
@@ -4615,8 +4653,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -4720,8 +4758,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -4818,8 +4856,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 
@@ -4914,8 +4952,8 @@ public partial class ServerTab : UserControl
                 var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
                 if (fromLocal.HasValue && toLocal.HasValue)
                 {
-                    fromDate = ServerTimeHelper.LocalToServerTime(fromLocal.Value);
-                    toDate = ServerTimeHelper.LocalToServerTime(toLocal.Value);
+                    fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                    toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
             }
 

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -68,6 +68,16 @@ public static class ServerTimeHelper
     };
 
     /// <summary>
+    /// Converts a display-mode DateTime back to server time. Reverse of ConvertForDisplay.
+    /// </summary>
+    public static DateTime DisplayTimeToServerTime(DateTime displayTime, Helpers.TimeDisplayMode mode) => mode switch
+    {
+        Helpers.TimeDisplayMode.LocalTime => LocalToServerTime(displayTime),
+        Helpers.TimeDisplayMode.UTC => displayTime.AddMinutes(_utcOffsetMinutes),
+        _ => displayTime
+    };
+
+    /// <summary>
     /// Returns a short timezone label for the current display mode.
     /// </summary>
     public static string GetTimezoneLabel(Helpers.TimeDisplayMode mode) => mode switch


### PR DESCRIPTION
## Summary
- Custom range pickers now display time in the current display mode (Server Time / Local / UTC) instead of always showing local time
- Switching display mode re-converts picker values without triggering validation errors or cascading data refreshes
- Added `DisplayTimeToServerTime()` to both apps' ServerTimeHelper as the reverse of `ConvertForDisplay()`

## Test plan
- [ ] Both apps: do a drill-down, verify pickers show time matching the display mode
- [ ] Both apps: switch between Server Time / Local / UTC — pickers should update, no errors, no data changes
- [ ] Both apps: manually set a custom range, switch display mode, verify it converts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)