### PR TITLE
Add GitHub Sponsors funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: erikdarlingdata


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to enable the Sponsor button on the repo page
- Links to GitHub Sponsors profile for erikdarlingdata

🤖 Generated with [Claude Code](https://claude.com/claude-code)