### PR TITLE
Fix doomed transaction error handling (#756)

### DIFF
--- a/install/05_delta_framework.sql
+++ b/install/05_delta_framework.sql
@@ -1202,38 +1202,43 @@ BEGIN
 
     END TRY
     BEGIN CATCH
+        DECLARE
+            @error_message nvarchar(4000) = ERROR_MESSAGE();
+
         /*
         Only rollback if we started the transaction
         Otherwise let the caller handle it
         */
-        IF  @trancount_at_entry = 0 
+        IF  @trancount_at_entry = 0
         AND @@TRANCOUNT > 0
         BEGIN
             ROLLBACK TRANSACTION;
         END;
 
-        DECLARE
-            @error_message nvarchar(4000) = ERROR_MESSAGE();
-        
         /*
-        Log the error
+        Log the error only if the transaction is not doomed
+        When called inside a caller's transaction that is doomed (XACT_STATE = -1),
+        we cannot write to the log — the caller must rollback first
         */
-        INSERT INTO
-            config.collection_log
-        (
-            collector_name,
-            collection_status,
-            duration_ms,
-            error_message
-        )
-        VALUES
-        (
-            N'calculate_deltas_' + @table_name,
-            N'ERROR',
-            DATEDIFF(MILLISECOND, @start_time, SYSDATETIME()),
-            @error_message
-        );
-        
+        IF XACT_STATE() <> -1
+        BEGIN
+            INSERT INTO
+                config.collection_log
+            (
+                collector_name,
+                collection_status,
+                duration_ms,
+                error_message
+            )
+            VALUES
+            (
+                N'calculate_deltas_' + @table_name,
+                N'ERROR',
+                DATEDIFF(MILLISECOND, @start_time, SYSDATETIME()),
+                @error_message
+            );
+        END;
+
         RAISERROR(N'Error calculating deltas for %s: %s', 16, 1, @table_name, @error_message);
     END CATCH;
 END;

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -1206,8 +1206,14 @@ BEGIN
     BEGIN CATCH
         SET @error_message = ERROR_MESSAGE();
 
+        IF @@TRANCOUNT > 0
+        BEGIN
+            ROLLBACK;
+        END;
+
         /*
         Log errors to collection log
+        Must happen after rollback to avoid doomed transaction writes
         */
         INSERT INTO
             config.collection_log
@@ -1228,11 +1234,6 @@ BEGIN
             DATEDIFF(MILLISECOND, @start_time, SYSDATETIME()),
             @error_message
         );
-
-        IF @@TRANCOUNT > 0
-        BEGIN
-            ROLLBACK;
-        END;
 
         THROW;
     END CATCH;


### PR DESCRIPTION
## Summary
- **`calculate_deltas`**: CATCH block tried to INSERT into `collection_log` while inside a caller's doomed transaction (`XACT_STATE = -1`). Added XACT_STATE check and moved error message capture before ROLLBACK.
- **`ensure_collection_table`**: CATCH block did INSERT before ROLLBACK. Reordered to ROLLBACK first.

Fixes #756 — the "cannot be committed" error was masking the real underlying failure during installation validation.

## Test plan
- [x] Deployed fixed procs to sql2022, ran collector successfully
- [x] Simulated doomed transaction by renaming table mid-collection — real error now propagates correctly
- [x] OP confirmed clean install passes 45/45 collectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)