### PR TITLE
Fix Lite memory leaks: delta cache, event handlers, chart helpers (#758)

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -5243,6 +5243,37 @@ public partial class ServerTab : UserControl
         _refreshTimer.Stop();
     }
 
+    public void DisposeChartHelpers()
+    {
+        _waitStatsHover?.Dispose();
+        _perfmonHover?.Dispose();
+        _overviewCpuHover?.Dispose();
+        _overviewMemoryHover?.Dispose();
+        _overviewFileIoHover?.Dispose();
+        _overviewWaitStatsHover?.Dispose();
+        _cpuHover?.Dispose();
+        _memoryHover?.Dispose();
+        _tempDbHover?.Dispose();
+        _tempDbFileIoHover?.Dispose();
+        _fileIoReadHover?.Dispose();
+        _fileIoWriteHover?.Dispose();
+        _fileIoReadThroughputHover?.Dispose();
+        _fileIoWriteThroughputHover?.Dispose();
+        _collectorDurationHover?.Dispose();
+        _queryDurationTrendHover?.Dispose();
+        _procDurationTrendHover?.Dispose();
+        _queryStoreDurationTrendHover?.Dispose();
+        _executionCountTrendHover?.Dispose();
+        _lockWaitTrendHover?.Dispose();
+        _blockingTrendHover?.Dispose();
+        _deadlockTrendHover?.Dispose();
+        _memoryClerksHover?.Dispose();
+        _memoryGrantSizingHover?.Dispose();
+        _memoryGrantActivityHover?.Dispose();
+        _currentWaitsDurationHover?.Dispose();
+        _currentWaitsBlockedHover?.Dispose();
+    }
+
     /* ========== Column Filtering ========== */
 
     private void InitializeFilterManagers()

--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -56,6 +56,14 @@ internal sealed class ChartHoverHelper
 
     public string Unit { get => _unit; set => _unit = value; }
 
+    public void Dispose()
+    {
+        _chart.MouseMove -= OnMouseMove;
+        _chart.MouseLeave -= OnMouseLeave;
+        _popup.IsOpen = false;
+        _scatters.Clear();
+    }
+
     public void Clear() => _scatters.Clear();
 
     public void Add(ScottPlot.Plottables.Scatter scatter, string label) =>

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ public partial class MainWindow : Window
     private CancellationTokenSource? _backgroundCts;
     private SystemTrayService? _trayService;
     private readonly Dictionary<string, TabItem> _openServerTabs = new();
+    private readonly Dictionary<string, (Action<int, int, DateTime?> AlertCounts, Action<int> ApplyTimeRange, Func<Task> ManualRefresh)> _tabEventHandlers = new();
     private readonly Dictionary<string, bool> _previousConnectionStates = new();
     private readonly Dictionary<string, bool> _previousCollectorErrorStates = new();
     private readonly Dictionary<string, DateTime> _lastCpuAlert = new();
@@ -530,15 +531,13 @@ public partial class MainWindow : Window
             Content = serverTab
         };
 
-        /* Subscribe to alert counts for badge updates */
+        /* Subscribe to events — store handlers so we can unsubscribe on tab close */
         var serverId = server.Id;
-        serverTab.AlertCountsChanged += (blockingCount, deadlockCount, latestEventTime) =>
+        Action<int, int, DateTime?> alertHandler = (blockingCount, deadlockCount, latestEventTime) =>
         {
             Dispatcher.Invoke(() => UpdateTabBadge(tabHeader, serverId, blockingCount, deadlockCount, latestEventTime));
         };
-
-        /* Subscribe to "Apply to All" time range propagation */
-        serverTab.ApplyTimeRangeRequested += (selectedIndex) =>
+        Action<int> timeRangeHandler = (selectedIndex) =>
         {
             Dispatcher.Invoke(() =>
             {
@@ -551,9 +550,7 @@ public partial class MainWindow : Window
                 }
             });
         };
-
-        /* Re-collect on-load data (config, trace flags) when refresh button is clicked */
-        serverTab.ManualRefreshRequested += async () =>
+        Func<Task> refreshHandler = async () =>
         {
             if (_collectorService != null)
             {
@@ -571,6 +568,11 @@ public partial class MainWindow : Window
                 }
             }
         };
+
+        serverTab.AlertCountsChanged += alertHandler;
+        serverTab.ApplyTimeRangeRequested += timeRangeHandler;
+        serverTab.ManualRefreshRequested += refreshHandler;
+        _tabEventHandlers[server.Id] = (alertHandler, timeRangeHandler, refreshHandler);
 
         _openServerTabs[server.Id] = tabItem;
         ServerTabControl.Items.Add(tabItem);
@@ -793,7 +795,20 @@ public partial class MainWindow : Window
         {
             if (tab.Content is ServerTab serverTab)
             {
+                /* Unsubscribe event handlers to prevent memory leaks */
+                if (_tabEventHandlers.TryGetValue(serverId, out var handlers))
+                {
+                    serverTab.AlertCountsChanged -= handlers.AlertCounts;
+                    serverTab.ApplyTimeRangeRequested -= handlers.ApplyTimeRange;
+                    serverTab.ManualRefreshRequested -= handlers.ManualRefresh;
+                    _tabEventHandlers.Remove(serverId);
+                }
+
                 serverTab.StopRefresh();
+                serverTab.DisposeChartHelpers();
+
+                /* Clear delta cache for this server to free memory */
+                _collectorService?.DeltaCalculator?.ClearServer(serverTab.ServerId);
             }
 
             ServerTabControl.Items.Remove(tab);

--- a/Lite/Services/DeltaCalculator.cs
+++ b/Lite/Services/DeltaCalculator.cs
@@ -60,6 +60,15 @@ public class DeltaCalculator
     }
 
     /// <summary>
+    /// Removes all cached entries for a server (e.g., when the server tab is closed).
+    /// Next collection will re-seed from database if needed.
+    /// </summary>
+    public void ClearServer(int serverId)
+    {
+        _cache.TryRemove(serverId, out _);
+    }
+
+    /// <summary>
     /// Calculates the delta between the current value and the previous cached value.
     /// First-ever sighting (no baseline): returns currentValue so single-execution queries appear.
     /// Counter reset (value decreased): returns 0 to avoid inflated deltas from plan cache churn.

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -59,6 +59,7 @@ public partial class RemoteCollectorService
     private readonly ScheduleManager _scheduleManager;
     private readonly ILogger<RemoteCollectorService>? _logger;
     private readonly DeltaCalculator _deltaCalculator;
+    public DeltaCalculator DeltaCalculator => _deltaCalculator;
     private static long s_idCounter = DateTime.UtcNow.Ticks;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- **DeltaCalculator**: Added `ClearServer()` to evict all cached entries when a server tab is closed. Previously the cache grew unbounded for the lifetime of the process.
- **MainWindow event handlers**: Three event handler lambdas per tab (`AlertCountsChanged`, `ApplyTimeRangeRequested`, `ManualRefreshRequested`) were subscribed but never unsubscribed on close. Now stored as named delegates and unsubscribed in `CloseServerTab`.
- **ChartHoverHelper**: Added `Dispose()` to unsubscribe `MouseMove`/`MouseLeave` from chart controls. 27 instances per tab were keeping the entire visual tree alive via event references.
- **ServerTab**: Added `DisposeChartHelpers()` called from `CloseServerTab`.

Addresses #758 - high memory consumption (5+ GB) when running Lite over extended periods.

## Test plan
- [x] Builds clean (0 errors)
- [ ] Run Lite, connect to server, close tab, verify memory drops in Task Manager
- [ ] Run Lite for extended period, verify memory stabilizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)