### PR TITLE
Cap DuckDB compaction memory at 2 GB (#758)

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -309,6 +309,14 @@ COPY (
         using var con = new DuckDBConnection("DataSource=:memory:");
         con.Open();
 
+        /* Cap memory to avoid multi-GB spikes decompressing large parquet archives.
+           DuckDB will spill excess to its temp directory automatically. */
+        using (var pragma = con.CreateCommand())
+        {
+            pragma.CommandText = "SET memory_limit = '2GB'; SET preserve_insertion_order = false;";
+            pragma.ExecuteNonQuery();
+        }
+
         var totalMerged = 0;
         var totalRemoved = 0;
 


### PR DESCRIPTION
## Summary
- Set `memory_limit = '2GB'` on the in-memory DuckDB connection used for parquet archive compaction
- Set `preserve_insertion_order = false` to further reduce memory during COPY operations
- DuckDB automatically spills to disk when the limit is hit, so compaction still works correctly

Root cause: the default `memory_limit` is 80% of physical RAM. Decompressing 800 MB of parquet archives (user reported 230 MB query_store_stats alone) easily expands to 5-7 GB in memory.

Companion to #760 which fixed the long-running event handler and delta cache leaks.

## Test plan
- [x] Builds clean
- [x] Launched Lite, startup footprint dropped from 349 MB to 258 MB
- [x] Open/close tabs stable, no growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)