### PR TITLE
Integrate installation into Dashboard Add Server dialog (#755 Phase 2)

### DIFF
--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -2,136 +2,229 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Add SQL Server"
-        SizeToContent="Height" Width="450" MaxHeight="850"
+        SizeToContent="Height" Width="500" MaxHeight="1050"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Background="{DynamicResource BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}">
-    <Grid Margin="20">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-        <!-- Header -->
-        <TextBlock Grid.Row="0" Text="Add SQL Server Connection" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"
-                   Foreground="{DynamicResource ForegroundBrush}"/>
-
-        <!-- Form Fields -->
-        <StackPanel Grid.Row="1">
-            <!-- Server Name/Address -->
-            <TextBlock Text="Server Name/Address:" FontWeight="Bold" Margin="0,0,0,4"
+            <!-- Header -->
+            <TextBlock Grid.Row="0" Text="Add SQL Server Connection" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"
                        Foreground="{DynamicResource ForegroundBrush}"/>
-            <TextBox x:Name="ServerNameTextBox" Margin="0,0,0,12"
-                     ToolTip="e.g., localhost, server.domain.com, 192.168.1.100, server\instance"/>
 
-            <!-- Display Name -->
-            <TextBlock Text="Display Name (optional):" FontWeight="Bold" Margin="0,0,0,4"
-                       Foreground="{DynamicResource ForegroundBrush}"/>
-            <TextBox x:Name="DisplayNameTextBox" Margin="0,0,0,12"
-                     ToolTip="Friendly name to display in the server list"/>
-
-            <!-- Authentication Type -->
-            <TextBlock Text="Authentication:" FontWeight="Bold" Margin="0,0,0,4"
-                       Foreground="{DynamicResource ForegroundBrush}"/>
-            <StackPanel Margin="0,0,0,12">
-                <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication"
-                             GroupName="Auth" IsChecked="True"
-                             Foreground="{DynamicResource ForegroundBrush}"
-                             Checked="AuthType_Changed" Margin="0,0,0,4"/>
-                <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication"
-                             GroupName="Auth"
-                             Foreground="{DynamicResource ForegroundBrush}"
-                             Checked="AuthType_Changed" Margin="0,0,0,4"/>
-                <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA"
-                             GroupName="Auth"
-                             Foreground="{DynamicResource ForegroundBrush}"
-                             Checked="AuthType_Changed"
-                             ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
-            </StackPanel>
-
-            <!-- SQL Authentication Fields -->
-            <StackPanel x:Name="SqlAuthPanel" Visibility="Collapsed" Margin="0,0,0,12">
-                <TextBlock Text="Username:" Margin="0,0,0,4"
+            <!-- Form Fields -->
+            <StackPanel Grid.Row="1">
+                <!-- Server Name/Address -->
+                <TextBlock Text="Server Name/Address:" FontWeight="Bold" Margin="0,0,0,4"
                            Foreground="{DynamicResource ForegroundBrush}"/>
-                <TextBox x:Name="UsernameTextBox" Margin="0,0,0,8"/>
+                <TextBox x:Name="ServerNameTextBox" Margin="0,0,0,12"
+                         ToolTip="e.g., localhost, server.domain.com, 192.168.1.100, server\instance"/>
 
-                <TextBlock Text="Password:" Margin="0,0,0,4"
+                <!-- Display Name -->
+                <TextBlock Text="Display Name (optional):" FontWeight="Bold" Margin="0,0,0,4"
                            Foreground="{DynamicResource ForegroundBrush}"/>
-                <PasswordBox x:Name="PasswordBox"/>
-            </StackPanel>
+                <TextBox x:Name="DisplayNameTextBox" Margin="0,0,0,12"
+                         ToolTip="Friendly name to display in the server list"/>
 
-            <!-- Microsoft Entra MFA Fields -->
-            <StackPanel x:Name="EntraMfaPanel" Visibility="Collapsed" Margin="0,0,0,12">
-                <TextBlock Text="Username (optional):" Margin="0,0,0,4"
+                <!-- Authentication Type -->
+                <TextBlock Text="Authentication:" FontWeight="Bold" Margin="0,0,0,4"
                            Foreground="{DynamicResource ForegroundBrush}"/>
-                <TextBox x:Name="EntraMfaUsernameBox"
-                         ToolTip="Optional: Pre-populate the authentication dialog with this email address"/>
-            </StackPanel>
-
-            <!-- Connection Options -->
-            <TextBlock Text="Connection Options:" FontWeight="Bold" Margin="0,0,0,4"
-                       Foreground="{DynamicResource ForegroundBrush}"/>
-            <StackPanel Margin="0,0,0,12">
-                <!-- Encryption Mode -->
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                    <TextBlock Text="Encryption:" Width="80" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}"/>
-                    <ComboBox x:Name="EncryptModeComboBox" Width="150"
-                              SelectedIndex="1"
-                              ToolTip="Optional: Encrypt if server supports it&#x0a;Mandatory: Always encrypt (fails if not supported)&#x0a;Strict: Full validation required">
-                        <ComboBoxItem Content="Optional"/>
-                        <ComboBoxItem Content="Mandatory"/>
-                        <ComboBoxItem Content="Strict"/>
-                    </ComboBox>
+                <StackPanel Margin="0,0,0,12">
+                    <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication"
+                                 GroupName="Auth" IsChecked="True"
+                                 Foreground="{DynamicResource ForegroundBrush}"
+                                 Checked="AuthType_Changed" Margin="0,0,0,4"/>
+                    <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication"
+                                 GroupName="Auth"
+                                 Foreground="{DynamicResource ForegroundBrush}"
+                                 Checked="AuthType_Changed" Margin="0,0,0,4"/>
+                    <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA"
+                                 GroupName="Auth"
+                                 Foreground="{DynamicResource ForegroundBrush}"
+                                 Checked="AuthType_Changed"
+                                 ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
                 </StackPanel>
 
-                <!-- Trust Server Certificate -->
-                <CheckBox x:Name="TrustServerCertificateCheckBox"
-                          Content="Trust server certificate (skip certificate validation)"
-                          IsChecked="False"
-                          Foreground="{DynamicResource ForegroundBrush}"
-                          ToolTip="When checked, accepts any server certificate without validation.&#x0a;Uncheck for stricter security (requires valid certificate)."
-                          Margin="0,0,0,6"/>
-
-                <!-- Read-Only Intent -->
-                <CheckBox x:Name="ReadOnlyIntentCheckBox"
-                          Content="Read-only intent (for AG listeners and readable replicas)"
-                          Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
-                          ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
-
-                <!-- Is Favorite -->
-                <CheckBox x:Name="IsFavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
-                          Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>
-
-                <!-- Monthly Cost -->
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                    <TextBlock Text="Monthly Cost ($):" Width="110" VerticalAlignment="Center"
+                <!-- SQL Authentication Fields -->
+                <StackPanel x:Name="SqlAuthPanel" Visibility="Collapsed" Margin="0,0,0,12">
+                    <TextBlock Text="Username:" Margin="0,0,0,4"
                                Foreground="{DynamicResource ForegroundBrush}"/>
-                    <TextBox x:Name="MonthlyCostTextBox" Width="100" TextAlignment="Right" Text="0"
-                             ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
+                    <TextBox x:Name="UsernameTextBox" Margin="0,0,0,8"/>
+
+                    <TextBlock Text="Password:" Margin="0,0,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <PasswordBox x:Name="PasswordBox"/>
                 </StackPanel>
 
-                <!-- Description -->
-                <TextBlock Text="Description (optional):" Margin="0,4,0,4"
+                <!-- Microsoft Entra MFA Fields -->
+                <StackPanel x:Name="EntraMfaPanel" Visibility="Collapsed" Margin="0,0,0,12">
+                    <TextBlock Text="Username (optional):" Margin="0,0,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="EntraMfaUsernameBox"
+                             ToolTip="Optional: Pre-populate the authentication dialog with this email address"/>
+                </StackPanel>
+
+                <!-- Connection Options -->
+                <TextBlock Text="Connection Options:" FontWeight="Bold" Margin="0,0,0,4"
                            Foreground="{DynamicResource ForegroundBrush}"/>
-                <TextBox x:Name="DescriptionTextBox" Height="60" TextWrapping="Wrap"
-                         AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                <StackPanel Margin="0,0,0,12">
+                    <!-- Encryption Mode -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="Encryption:" Width="80" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ComboBox x:Name="EncryptModeComboBox" Width="150"
+                                  SelectedIndex="1"
+                                  ToolTip="Optional: Encrypt if server supports it&#x0a;Mandatory: Always encrypt (fails if not supported)&#x0a;Strict: Full validation required">
+                            <ComboBoxItem Content="Optional"/>
+                            <ComboBoxItem Content="Mandatory"/>
+                            <ComboBoxItem Content="Strict"/>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <!-- Trust Server Certificate -->
+                    <CheckBox x:Name="TrustServerCertificateCheckBox"
+                              Content="Trust server certificate (skip certificate validation)"
+                              IsChecked="False"
+                              Foreground="{DynamicResource ForegroundBrush}"
+                              ToolTip="When checked, accepts any server certificate without validation.&#x0a;Uncheck for stricter security (requires valid certificate)."
+                              Margin="0,0,0,6"/>
+
+                    <!-- Read-Only Intent -->
+                    <CheckBox x:Name="ReadOnlyIntentCheckBox"
+                              Content="Read-only intent (for AG listeners and readable replicas)"
+                              Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
+                              ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
+
+                    <!-- Is Favorite -->
+                    <CheckBox x:Name="IsFavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
+                              Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>
+
+                    <!-- Monthly Cost -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="Monthly Cost ($):" Width="110" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                        <TextBox x:Name="MonthlyCostTextBox" Width="100" TextAlignment="Right" Text="0"
+                                 ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
+                    </StackPanel>
+
+                    <!-- Description -->
+                    <TextBlock Text="Description (optional):" Margin="0,4,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="DescriptionTextBox" Height="60" TextWrapping="Wrap"
+                             AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                </StackPanel>
             </StackPanel>
-        </StackPanel>
 
-        <!-- Status -->
-        <TextBlock x:Name="StatusText" Grid.Row="2"
-                   Foreground="{DynamicResource ForegroundMutedBrush}"
-                   TextWrapping="Wrap" Margin="0,8,0,0" Visibility="Collapsed"/>
+            <!-- Database Status Panel -->
+            <Border x:Name="DatabaseStatusPanel" Grid.Row="2" Visibility="Collapsed"
+                    Background="{DynamicResource BackgroundLightBrush}"
+                    CornerRadius="4" Padding="12" Margin="0,0,0,10">
+                <StackPanel>
+                    <TextBlock x:Name="DatabaseStatusText" TextWrapping="Wrap" Margin="0,0,0,8"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                        <Button x:Name="InstallUpgradeButton" Content="Install Now"
+                                Style="{StaticResource AccentButton}"
+                                Click="InstallOrUpgrade_Click" Margin="0,0,12,0"/>
+                        <TextBlock x:Name="SkipInstallText" Text="Skip, just add server"
+                                   VerticalAlignment="Center" Cursor="Hand"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}"
+                                   MouseLeftButtonUp="SkipInstall_Click">
+                            <TextBlock.TextDecorations>
+                                <TextDecoration Location="Underline"/>
+                            </TextBlock.TextDecorations>
+                        </TextBlock>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
 
-        <!-- Buttons -->
-        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
-            <Button x:Name="TestConnectionButton" Content="Test Connection" Margin="0,0,8,0" Click="TestConnection_Click"/>
-            <Button x:Name="SaveButton" Content="Save" Width="80" Height="30" Margin="0,0,10,0" Click="Save_Click" IsDefault="True" Style="{StaticResource AccentButton}"/>
-            <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click" IsCancel="True"/>
-        </StackPanel>
-    </Grid>
+            <!-- Installation Progress Panel -->
+            <StackPanel x:Name="InstallationPanel" Grid.Row="3" Visibility="Collapsed" Margin="0,0,0,10">
+                <!-- Advanced Options Expander (shown before install starts) -->
+                <Expander x:Name="AdvancedOptionsExpander" Header="Advanced Options" IsExpanded="False"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8">
+                    <StackPanel Margin="16,8,0,0">
+                        <CheckBox x:Name="CleanInstallCheckBox"
+                                  Content="Perform clean install (drops existing database)"
+                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                        <CheckBox x:Name="ResetScheduleCheckBox"
+                                  Content="Reset collection schedule to defaults"
+                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                        <CheckBox x:Name="ValidationCheckBox"
+                                  Content="Run validation after install" IsChecked="True"
+                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                        <CheckBox x:Name="InstallDepsCheckBox"
+                                  Content="Install community dependencies" IsChecked="True"
+                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                    </StackPanel>
+                </Expander>
+
+                <ProgressBar x:Name="InstallProgressBar" Height="6" Margin="0,0,0,6"
+                             Minimum="0" Maximum="100" Value="0"
+                             Foreground="{DynamicResource AccentBrush}"
+                             Background="{DynamicResource BackgroundLighterBrush}"/>
+                <TextBlock x:Name="InstallStatusText" TextWrapping="Wrap" Margin="0,0,0,6"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBox x:Name="InstallLogTextBox" FontFamily="Consolas" FontSize="11"
+                         MaxHeight="180" IsReadOnly="True" TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         Background="{DynamicResource BackgroundDarkBrush}"
+                         Foreground="{DynamicResource ForegroundBrush}"
+                         BorderBrush="{DynamicResource BorderBrush}"
+                         Margin="0,0,0,6"/>
+                <Button x:Name="CancelInstallButton" Content="Cancel" Click="CancelInstall_Click"
+                        HorizontalAlignment="Left" Margin="0,0,0,4"/>
+            </StackPanel>
+
+            <!-- Monitoring Credentials Panel -->
+            <Border x:Name="MonitoringCredsPanel" Grid.Row="4" Visibility="Collapsed"
+                    Background="{DynamicResource BackgroundLightBrush}"
+                    CornerRadius="4" Padding="12" Margin="0,0,0,10">
+                <StackPanel>
+                    <TextBlock Text="The installer used your credentials to set up the database. You can use different credentials for ongoing Dashboard monitoring if needed."
+                               TextWrapping="Wrap" Margin="0,0,0,8"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <CheckBox x:Name="UseSameCredsCheckBox"
+                              Content="Use same credentials for monitoring" IsChecked="True"
+                              Foreground="{DynamicResource ForegroundBrush}"
+                              Checked="UseSameCredsCheckBox_Changed"
+                              Unchecked="UseSameCredsCheckBox_Changed"
+                              Margin="0,0,0,8"/>
+                    <StackPanel x:Name="MonitorCredsFieldsPanel" Visibility="Collapsed">
+                        <TextBlock Text="Monitoring Username:" Margin="0,0,0,4"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                        <TextBox x:Name="MonitorUsernameTextBox" Margin="0,0,0,8"/>
+                        <TextBlock Text="Monitoring Password:" Margin="0,0,0,4"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                        <PasswordBox x:Name="MonitorPasswordBox"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Status -->
+            <TextBlock x:Name="StatusText" Grid.Row="5"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"
+                       TextWrapping="Wrap" Margin="0,8,0,0" Visibility="Collapsed"/>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+                <Button x:Name="ViewReportButton" Content="View Report" Margin="0,0,8,0"
+                        Click="ViewReport_Click" Visibility="Collapsed"/>
+                <Button x:Name="TestConnectionButton" Content="Test Connection" Margin="0,0,8,0" Click="TestConnection_Click"/>
+                <Button x:Name="SaveButton" Content="Save" MinWidth="80" Height="30" Padding="12,0" Margin="0,0,10,0" Click="Save_Click" IsDefault="True" Style="{StaticResource AccentButton}"/>
+                <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click" IsCancel="True"/>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Window>

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -7,8 +7,15 @@
  */
 
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using Installer.Core;
+using Installer.Core.Models;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
@@ -18,10 +25,28 @@ namespace PerformanceMonitorDashboard
 {
     public partial class AddServerDialog : Window
     {
+        private enum DialogState
+        {
+            Initial,
+            Connected_NoDatabase,
+            Connected_NeedsUpgrade,
+            Connected_Current,
+            Installing,
+            InstallComplete,
+            MonitoringCredentials
+        }
+
         public ServerConnection ServerConnection { get; private set; }
         public string? Username { get; private set; }
         public string? Password { get; private set; }
         private bool _isEditMode;
+
+        private CancellationTokenSource? _installCts;
+        private Installer.Core.Models.ServerInfo? _coreServerInfo;
+        private string? _installedVersion;
+        private InstallationResult? _installResult;
+        private string? _reportPath;
+        private DialogState _currentState = DialogState.Initial;
 
         public AddServerDialog()
         {
@@ -154,6 +179,67 @@ namespace PerformanceMonitorDashboard
             return builder;
         }
 
+        private string BuildInstallerConnectionString()
+        {
+            string server = ServerNameTextBox.Text.Trim();
+            bool useWindowsAuth = WindowsAuthRadio.IsChecked == true;
+            bool useEntraAuth = EntraMfaAuthRadio.IsChecked == true;
+            string? username = null;
+            string? password = null;
+
+            if (SqlAuthRadio.IsChecked == true)
+            {
+                username = UsernameTextBox.Text.Trim();
+                password = PasswordBox.Password;
+            }
+            else if (useEntraAuth)
+            {
+                username = EntraMfaUsernameBox.Text.Trim();
+            }
+
+            return InstallationService.BuildConnectionString(
+                server,
+                useWindowsAuth,
+                username,
+                password,
+                GetSelectedEncryptMode(),
+                TrustServerCertificateCheckBox.IsChecked == true,
+                useEntraAuth);
+        }
+
+        private static string GetAppVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrEmpty(infoVersion))
+            {
+                /* Strip any +metadata suffix (e.g. "2.4.1+abc123" -> "2.4.1") */
+                int plusIndex = infoVersion.IndexOf('+');
+                return plusIndex >= 0 ? infoVersion[..plusIndex] : infoVersion;
+            }
+
+            var version = assembly.GetName().Version;
+            if (version != null)
+            {
+                /* Normalize 4-part to 3-part: "2.4.1.0" -> "2.4.1" */
+                return $"{version.Major}.{version.Minor}.{version.Build}";
+            }
+
+            return "0.0.0";
+        }
+
+        /// <summary>
+        /// Normalize a version string to 3-part for comparison (e.g., "2.4.1.0" -> "2.4.1").
+        /// </summary>
+        private static string NormalizeVersion(string version)
+        {
+            if (Version.TryParse(version, out var parsed))
+            {
+                return $"{parsed.Major}.{parsed.Minor}.{parsed.Build}";
+            }
+            return version;
+        }
+
         private bool ValidateInputs()
         {
             if (string.IsNullOrWhiteSpace(ServerNameTextBox.Text))
@@ -197,7 +283,12 @@ namespace PerformanceMonitorDashboard
             string? serverVersion = null;
             try
             {
-                await using var connection = new SqlConnection(BuildConnectionBuilder().ConnectionString);
+                /* Connect to master (not PerformanceMonitor) so the test succeeds
+                   even when the database doesn't exist yet — installation detection
+                   happens after the connection test in DetectDatabaseStatusAsync() */
+                var builder = BuildConnectionBuilder();
+                builder.InitialCatalog = "master";
+                await using var connection = new SqlConnection(builder.ConnectionString);
                 await connection.OpenAsync();
                 using var cmd = new SqlCommand("SELECT @@VERSION", connection);
                 var version = await cmd.ExecuteScalarAsync() as string;
@@ -239,6 +330,12 @@ namespace PerformanceMonitorDashboard
                     MessageBoxButton.OK,
                     MessageBoxImage.Information
                 );
+
+                /* After successful connection in Add mode, check database status */
+                if (!_isEditMode)
+                {
+                    await DetectDatabaseStatusAsync();
+                }
             }
             else if (mfaCancelled)
             {
@@ -266,36 +363,493 @@ namespace PerformanceMonitorDashboard
             }
         }
 
+        private async System.Threading.Tasks.Task DetectDatabaseStatusAsync()
+        {
+            try
+            {
+                StatusText.Text = "Checking database status...";
+                StatusText.Visibility = Visibility.Visible;
+
+                string installerConnStr = BuildInstallerConnectionString();
+                string appVersion = GetAppVersion();
+
+                /* Test connection via Installer.Core to get ServerInfo */
+                _coreServerInfo = await InstallationService.TestConnectionAsync(installerConnStr);
+
+                if (_coreServerInfo == null || !_coreServerInfo.IsConnected)
+                {
+                    StatusText.Text = string.Empty;
+                    StatusText.Visibility = Visibility.Collapsed;
+                    return;
+                }
+
+                if (!_coreServerInfo.IsSupportedVersion)
+                {
+                    DatabaseStatusText.Text = $"Warning: {_coreServerInfo.ProductMajorVersionName} is not supported. SQL Server 2016+ is required.";
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    InstallUpgradeButton.Visibility = Visibility.Collapsed;
+                    SkipInstallText.Visibility = Visibility.Collapsed;
+                    StatusText.Text = string.Empty;
+                    StatusText.Visibility = Visibility.Collapsed;
+                    return;
+                }
+
+                /* Check installed version */
+                _installedVersion = await InstallationService.GetInstalledVersionAsync(installerConnStr);
+
+                if (_installedVersion == null)
+                {
+                    TransitionToState(DialogState.Connected_NoDatabase);
+                }
+                else
+                {
+                    string normalizedInstalled = NormalizeVersion(_installedVersion);
+                    string normalizedApp = NormalizeVersion(appVersion);
+
+                    if (Version.TryParse(normalizedInstalled, out var installedVer) &&
+                        Version.TryParse(normalizedApp, out var appVer))
+                    {
+                        if (installedVer < appVer)
+                        {
+                            TransitionToState(DialogState.Connected_NeedsUpgrade);
+                        }
+                        else
+                        {
+                            TransitionToState(DialogState.Connected_Current);
+                        }
+                    }
+                    else
+                    {
+                        TransitionToState(DialogState.Connected_Current);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                StatusText.Text = $"Could not check database status: {ex.Message}";
+                StatusText.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void TransitionToState(DialogState newState)
+        {
+            _currentState = newState;
+            string appVersion = GetAppVersion();
+
+            /* Reset panel visibility */
+            DatabaseStatusPanel.Visibility = Visibility.Collapsed;
+            InstallationPanel.Visibility = Visibility.Collapsed;
+            MonitoringCredsPanel.Visibility = Visibility.Collapsed;
+            ViewReportButton.Visibility = Visibility.Collapsed;
+            StatusText.Text = string.Empty;
+            StatusText.Visibility = Visibility.Collapsed;
+            InstallUpgradeButton.Visibility = Visibility.Visible;
+            SkipInstallText.Visibility = Visibility.Visible;
+
+            switch (newState)
+            {
+                case DialogState.Connected_NoDatabase:
+                    DatabaseStatusText.Text = $"No PerformanceMonitor database found on this server. Install v{appVersion}?";
+                    InstallUpgradeButton.Content = "Install Now";
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    SaveButton.IsEnabled = false;
+                    break;
+
+                case DialogState.Connected_NeedsUpgrade:
+                    string normalizedInstalled = NormalizeVersion(_installedVersion!);
+                    DatabaseStatusText.Text = $"v{normalizedInstalled} installed — v{appVersion} available";
+                    InstallUpgradeButton.Content = "Upgrade Now";
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    SaveButton.IsEnabled = true;
+                    break;
+
+                case DialogState.Connected_Current:
+                    string normalizedCurrent = NormalizeVersion(_installedVersion!);
+                    DatabaseStatusText.Text = $"PerformanceMonitor v{normalizedCurrent} is up to date.";
+                    InstallUpgradeButton.Visibility = Visibility.Collapsed;
+                    SkipInstallText.Visibility = Visibility.Collapsed;
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    SaveButton.IsEnabled = true;
+                    break;
+
+                case DialogState.Installing:
+                    DatabaseStatusPanel.Visibility = Visibility.Collapsed;
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    AdvancedOptionsExpander.IsEnabled = false;
+                    CancelInstallButton.IsEnabled = true;
+                    SetFormEnabled(false);
+                    break;
+
+                case DialogState.InstallComplete:
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    AdvancedOptionsExpander.IsEnabled = false;
+                    CancelInstallButton.IsEnabled = false;
+                    SetFormEnabled(true);
+                    if (_reportPath != null)
+                    {
+                        ViewReportButton.Visibility = Visibility.Visible;
+                    }
+                    /* Transition to monitoring credentials if using SQL auth */
+                    if (SqlAuthRadio.IsChecked == true)
+                    {
+                        TransitionToState(DialogState.MonitoringCredentials);
+                        return;
+                    }
+                    SaveButton.IsEnabled = true;
+                    SaveButton.Content = "Save & Connect";
+                    break;
+
+                case DialogState.MonitoringCredentials:
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    AdvancedOptionsExpander.IsEnabled = false;
+                    CancelInstallButton.IsEnabled = false;
+                    MonitoringCredsPanel.Visibility = Visibility.Visible;
+                    if (_reportPath != null)
+                    {
+                        ViewReportButton.Visibility = Visibility.Visible;
+                    }
+                    SetFormEnabled(true);
+                    SaveButton.IsEnabled = true;
+                    SaveButton.Content = "Save & Connect";
+                    break;
+
+                case DialogState.Initial:
+                default:
+                    SetFormEnabled(true);
+                    SaveButton.IsEnabled = true;
+                    SaveButton.Content = "Save";
+                    break;
+            }
+        }
+
+        private async void InstallOrUpgrade_Click(object sender, RoutedEventArgs e)
+        {
+            TransitionToState(DialogState.Installing);
+            InstallLogTextBox.Clear();
+            InstallProgressBar.Value = 0;
+            InstallStatusText.Text = "Preparing installation...";
+
+            _installCts = new CancellationTokenSource();
+            var cancellationToken = _installCts.Token;
+
+            try
+            {
+                var provider = ScriptProvider.FromEmbeddedResources();
+                string installerConnStr = BuildInstallerConnectionString();
+                string appVersion = GetAppVersion();
+                bool cleanInstall = CleanInstallCheckBox.IsChecked == true;
+                bool resetSchedule = ResetScheduleCheckBox.IsChecked == true;
+                bool runValidation = ValidationCheckBox.IsChecked == true;
+                bool installDeps = InstallDepsCheckBox.IsChecked == true;
+
+                var progress = new Progress<InstallationProgress>(p =>
+                {
+                    Dispatcher.Invoke(() =>
+                    {
+                        /* Update progress bar */
+                        if (p.ProgressPercent.HasValue)
+                        {
+                            InstallProgressBar.Value = p.ProgressPercent.Value;
+                        }
+
+                        /* Update status text */
+                        if (!string.IsNullOrEmpty(p.Message))
+                        {
+                            InstallStatusText.Text = p.Message;
+                        }
+
+                        /* Append to log (filter out Debug messages) */
+                        if (p.Status != "Debug")
+                        {
+                            AppendInstallLog(p.Message, p.Status);
+                        }
+                    });
+                });
+
+                /* Run upgrades if applicable (existing database, not clean install) */
+                if (!cleanInstall && _installedVersion != null)
+                {
+                    AppendInstallLog($"Checking for upgrades from v{NormalizeVersion(_installedVersion)} to v{appVersion}...", "Info");
+
+                    var (upgradeSuccess, upgradeFailure, upgradeCount) = await InstallationService.ExecuteAllUpgradesAsync(
+                        provider,
+                        installerConnStr,
+                        _installedVersion,
+                        appVersion,
+                        progress,
+                        cancellationToken);
+
+                    if (upgradeCount > 0)
+                    {
+                        AppendInstallLog($"Upgrades complete: {upgradeSuccess} succeeded, {upgradeFailure} failed", upgradeFailure == 0 ? "Success" : "Warning");
+                    }
+
+                    if (upgradeFailure > 0)
+                    {
+                        AppendInstallLog("Upgrade failures detected. Continuing with full installation to ensure consistency...", "Warning");
+                    }
+                }
+
+                /* Run main installation */
+                AppendInstallLog("Starting main installation...", "Info");
+
+                Func<System.Threading.Tasks.Task>? preValidationAction = null;
+                if (installDeps)
+                {
+                    preValidationAction = async () =>
+                    {
+                        AppendInstallLog("Installing community dependencies...", "Info");
+                        using var depInstaller = new DependencyInstaller();
+                        await depInstaller.InstallDependenciesAsync(installerConnStr, progress, cancellationToken);
+                    };
+                }
+
+                _installResult = await InstallationService.ExecuteInstallationAsync(
+                    installerConnStr,
+                    provider,
+                    cleanInstall,
+                    resetSchedule,
+                    progress,
+                    preValidationAction,
+                    cancellationToken);
+
+                /* Log installation history */
+                try
+                {
+                    AppendInstallLog("Recording installation history...", "Info");
+                    await InstallationService.LogInstallationHistoryAsync(
+                        installerConnStr,
+                        appVersion,
+                        appVersion,
+                        _installResult.StartTime,
+                        _installResult.FilesSucceeded,
+                        _installResult.FilesFailed,
+                        _installResult.Success,
+                        progress);
+                    AppendInstallLog("Installation history recorded", "Success");
+                }
+                catch (Exception ex)
+                {
+                    AppendInstallLog($"Could not record installation history: {ex.Message}", "Warning");
+                }
+
+                /* Run validation if requested */
+                if (runValidation && _installResult.Success)
+                {
+                    try
+                    {
+                        AppendInstallLog("Running post-install validation...", "Info");
+                        var (collectorsSucceeded, collectorsFailed) = await InstallationService.RunValidationAsync(
+                            installerConnStr,
+                            progress,
+                            cancellationToken);
+                        AppendInstallLog($"Validation: {collectorsSucceeded} collectors succeeded, {collectorsFailed} failed",
+                            collectorsFailed == 0 ? "Success" : "Warning");
+                    }
+                    catch (Exception ex)
+                    {
+                        AppendInstallLog($"Validation failed: {ex.Message}", "Warning");
+                    }
+                }
+
+                /* Generate summary report */
+                try
+                {
+                    _reportPath = InstallationService.GenerateSummaryReport(
+                        ServerNameTextBox.Text.Trim(),
+                        _coreServerInfo?.SqlServerVersion ?? "",
+                        _coreServerInfo?.SqlServerEdition ?? "",
+                        appVersion,
+                        _installResult);
+                    AppendInstallLog($"Report saved: {_reportPath}", "Info");
+                }
+                catch (Exception ex)
+                {
+                    AppendInstallLog($"Could not generate report: {ex.Message}", "Warning");
+                }
+
+                /* Update final status */
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    InstallProgressBar.Value = 100;
+                    if (_installResult.Success)
+                    {
+                        InstallStatusText.Text = "Installation completed successfully!";
+                        AppendInstallLog("Installation completed successfully!", "Success");
+                    }
+                    else
+                    {
+                        InstallStatusText.Text = $"Installation completed with {_installResult.FilesFailed} error(s).";
+                        AppendInstallLog($"Installation completed with {_installResult.FilesFailed} error(s).", "Error");
+                    }
+
+                    TransitionToState(DialogState.InstallComplete);
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    InstallStatusText.Text = "Installation cancelled.";
+                    AppendInstallLog("Installation was cancelled by user.", "Warning");
+                    InstallProgressBar.Value = 0;
+                    TransitionToState(DialogState.Initial);
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    AdvancedOptionsExpander.IsEnabled = true;
+                });
+            }
+            catch (Exception ex)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    InstallStatusText.Text = $"Installation failed: {ex.Message}";
+                    AppendInstallLog($"Fatal error: {ex.Message}", "Error");
+                    TransitionToState(DialogState.Initial);
+                    DatabaseStatusPanel.Visibility = Visibility.Visible;
+                    InstallationPanel.Visibility = Visibility.Visible;
+                    AdvancedOptionsExpander.IsEnabled = true;
+                });
+            }
+            finally
+            {
+                _installCts?.Dispose();
+                _installCts = null;
+            }
+        }
+
+        private void CancelInstall_Click(object sender, RoutedEventArgs e)
+        {
+            _installCts?.Cancel();
+            CancelInstallButton.IsEnabled = false;
+            InstallStatusText.Text = "Cancelling...";
+        }
+
+        private void AppendInstallLog(string message, string status)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => AppendInstallLog(message, status));
+                return;
+            }
+
+            string prefix = status switch
+            {
+                "Success" => "[OK] ",
+                "Error" => "[ERROR] ",
+                "Warning" => "[WARN] ",
+                _ => ""
+            };
+
+            InstallLogTextBox.AppendText($"{prefix}{message}\n");
+            InstallLogTextBox.ScrollToEnd();
+        }
+
+        private void SkipInstall_Click(object sender, MouseButtonEventArgs e)
+        {
+            DatabaseStatusPanel.Visibility = Visibility.Collapsed;
+            InstallationPanel.Visibility = Visibility.Collapsed;
+            SaveButton.IsEnabled = true;
+            SaveButton.Content = "Save";
+            _currentState = DialogState.Initial;
+        }
+
+        private void ViewReport_Click(object sender, RoutedEventArgs e)
+        {
+            if (_reportPath != null && File.Exists(_reportPath))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = _reportPath,
+                        UseShellExecute = true
+                    });
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Could not open report: {ex.Message}",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
+                }
+            }
+        }
+
+        private void UseSameCredsCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (MonitorCredsFieldsPanel != null)
+            {
+                MonitorCredsFieldsPanel.Visibility = UseSameCredsCheckBox.IsChecked == true
+                    ? Visibility.Collapsed
+                    : Visibility.Visible;
+            }
+        }
+
+        private void SetFormEnabled(bool enabled)
+        {
+            ServerNameTextBox.IsEnabled = enabled;
+            DisplayNameTextBox.IsEnabled = enabled;
+            WindowsAuthRadio.IsEnabled = enabled;
+            SqlAuthRadio.IsEnabled = enabled;
+            EntraMfaAuthRadio.IsEnabled = enabled;
+            UsernameTextBox.IsEnabled = enabled;
+            PasswordBox.IsEnabled = enabled;
+            EntraMfaUsernameBox.IsEnabled = enabled;
+            EncryptModeComboBox.IsEnabled = enabled;
+            TrustServerCertificateCheckBox.IsEnabled = enabled;
+            ReadOnlyIntentCheckBox.IsEnabled = enabled;
+            IsFavoriteCheckBox.IsEnabled = enabled;
+            MonthlyCostTextBox.IsEnabled = enabled;
+            DescriptionTextBox.IsEnabled = enabled;
+            TestConnectionButton.IsEnabled = enabled;
+            SaveButton.IsEnabled = enabled;
+        }
+
         private async void Save_Click(object sender, RoutedEventArgs e)
         {
             if (!ValidateInputs()) return;
 
-            var (connected, errorMessage, mfaCancelled, _) = await RunConnectionTestAsync(SaveButton);
+            /* If we just finished installing, skip re-testing the connection */
+            bool skipConnectionTest = _currentState == DialogState.InstallComplete ||
+                                       _currentState == DialogState.MonitoringCredentials;
 
-            if (!connected)
+            if (!skipConnectionTest)
             {
-                if (mfaCancelled)
+                var (connected, errorMessage, mfaCancelled, _) = await RunConnectionTestAsync(SaveButton);
+
+                if (!connected)
                 {
-                    MessageBox.Show(
-                        "Authentication was cancelled. Click Save to try again, or Cancel to abort.",
-                        "Authentication Cancelled",
-                        MessageBoxButton.OK,
+                    if (mfaCancelled)
+                    {
+                        MessageBox.Show(
+                            "Authentication was cancelled. Click Save to try again, or Cancel to abort.",
+                            "Authentication Cancelled",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning
+                        );
+                        return;
+                    }
+
+                    var detail = errorMessage != null ? $"\n\nError: {errorMessage}" : string.Empty;
+                    var result = MessageBox.Show(
+                        $"Could not connect to {ServerNameTextBox.Text}.{detail}\n\n" +
+                        "Do you still want to save this connection?",
+                        "Connection Failed",
+                        MessageBoxButton.YesNo,
                         MessageBoxImage.Warning
                     );
-                    return;
+
+                    if (result != MessageBoxResult.Yes)
+                        return;
                 }
-
-                var detail = errorMessage != null ? $"\n\nError: {errorMessage}" : string.Empty;
-                var result = MessageBox.Show(
-                    $"Could not connect to {ServerNameTextBox.Text}.{detail}\n\n" +
-                    "Do you still want to save this connection?",
-                    "Connection Failed",
-                    MessageBoxButton.YesNo,
-                    MessageBoxImage.Warning
-                );
-
-                if (result != MessageBoxResult.Yes)
-                    return;
             }
 
             // Determine authentication type and credentials
@@ -315,8 +869,20 @@ namespace PerformanceMonitorDashboard
             else
             {
                 authenticationType = AuthenticationTypes.SqlServer;
-                Username = UsernameTextBox.Text.Trim();
-                Password = PasswordBox.Password;
+
+                /* Use monitoring credentials if provided */
+                if (_currentState == DialogState.MonitoringCredentials &&
+                    UseSameCredsCheckBox.IsChecked == false &&
+                    !string.IsNullOrWhiteSpace(MonitorUsernameTextBox.Text))
+                {
+                    Username = MonitorUsernameTextBox.Text.Trim();
+                    Password = MonitorPasswordBox.Password;
+                }
+                else
+                {
+                    Username = UsernameTextBox.Text.Trim();
+                    Password = PasswordBox.Password;
+                }
             }
 
             // Use server name as display name if not provided
@@ -365,6 +931,7 @@ namespace PerformanceMonitorDashboard
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
+            _installCts?.Cancel();
             DialogResult = false;
             Close();
         }

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -46,6 +46,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Installer.Core\Installer.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary

- Add Server dialog now detects PerformanceMonitor database state after Test Connection
- Offers **Install Now** (no DB) or **Upgrade** (old version) inline with progress bar and log
- Credential separation: post-install prompt for lower-privilege monitoring credentials
- Advanced options: clean install, reset schedule, validation, community dependencies
- Uses `ScriptProvider.FromEmbeddedResources()` — SQL scripts embedded in Installer.Core assembly

Phase 2 of #755. Phase 3 (retire InstallerGui) will follow.

## Test plan

- [x] Clean install via Dashboard on SQL2016 (no existing DB) — 54/54 scripts
- [x] "Up to date" detection on servers with current version
- [x] Save & Connect button sizing fixed
- [x] Thread safety: all UI updates via Dispatcher.Invoke
- [x] Connection test targets master (works when DB doesn't exist)
- [ ] Upgrade path testing deferred to release testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)