### PR TITLE
Retire InstallerGui from solution and build pipeline (#755 Phase 3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
           dotnet restore Dashboard/Dashboard.csproj
           dotnet restore Lite/PerformanceMonitorLite.csproj
           dotnet restore Installer/PerformanceMonitorInstaller.csproj
-          dotnet restore InstallerGui/InstallerGui.csproj
 
       - name: Get version
         id: version
@@ -56,9 +55,6 @@ jobs:
       - name: Publish CLI Installer
         run: dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
 
-      - name: Publish GUI Installer
-        run: dotnet publish InstallerGui/InstallerGui.csproj -c Release
-
       - name: Package release artifacts
         if: github.event_name == 'release'
         shell: pwsh
@@ -72,14 +68,13 @@ jobs:
           # Lite ZIP
           Compress-Archive -Path 'publish/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
 
-          # Installer ZIP (CLI + GUI + SQL scripts)
+          # Installer ZIP (CLI + SQL scripts)
           $instDir = 'publish/Installer'
           New-Item -ItemType Directory -Force -Path $instDir
           New-Item -ItemType Directory -Force -Path "$instDir/install"
           New-Item -ItemType Directory -Force -Path "$instDir/upgrades"
 
           Copy-Item 'Installer/bin/Release/net8.0/win-x64/publish/PerformanceMonitorInstaller.exe' $instDir
-          Copy-Item 'InstallerGui/bin/Release/net8.0-windows/win-x64/publish/PerformanceMonitorInstallerGui.exe' $instDir -ErrorAction SilentlyContinue
           Copy-Item 'install/*.sql' "$instDir/install/"
           if (Test-Path 'upgrades') { Copy-Item 'upgrades/*' "$instDir/upgrades/" -Recurse -ErrorAction SilentlyContinue }
           if (Test-Path 'README.md') { Copy-Item 'README.md' $instDir }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           dotnet restore Dashboard/Dashboard.csproj
           dotnet restore Lite/PerformanceMonitorLite.csproj
           dotnet restore Installer/PerformanceMonitorInstaller.csproj
-          dotnet restore InstallerGui/InstallerGui.csproj
           dotnet restore Lite.Tests/Lite.Tests.csproj
 
       - name: Build all projects
@@ -31,7 +30,6 @@ jobs:
           dotnet build Dashboard/Dashboard.csproj -c Release --no-restore
           dotnet build Lite/PerformanceMonitorLite.csproj -c Release --no-restore
           dotnet build Installer/PerformanceMonitorInstaller.csproj -c Release --no-restore
-          dotnet build InstallerGui/InstallerGui.csproj -c Release --no-restore
           dotnet build Lite.Tests/Lite.Tests.csproj -c Release --no-restore
 
       - name: Run tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,6 @@ jobs:
           dotnet restore Dashboard/Dashboard.csproj
           dotnet restore Lite/PerformanceMonitorLite.csproj
           dotnet restore Installer/PerformanceMonitorInstaller.csproj
-          dotnet restore InstallerGui/InstallerGui.csproj
           dotnet restore Lite.Tests/Lite.Tests.csproj
 
       - name: Run tests
@@ -76,9 +75,6 @@ jobs:
 
       - name: Publish CLI Installer
         run: dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
-
-      - name: Publish GUI Installer
-        run: dotnet publish InstallerGui/InstallerGui.csproj -c Release
 
       - name: Package artifacts
         shell: pwsh
@@ -95,7 +91,6 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$instDir/upgrades"
 
           Copy-Item 'Installer/bin/Release/net8.0/win-x64/publish/PerformanceMonitorInstaller.exe' $instDir
-          Copy-Item 'InstallerGui/bin/Release/net8.0-windows/win-x64/publish/PerformanceMonitorInstallerGui.exe' $instDir -ErrorAction SilentlyContinue
           Copy-Item 'install/*.sql' "$instDir/install/"
           if (Test-Path 'install/templates') { Copy-Item 'install/templates' "$instDir/install/templates" -Recurse -ErrorAction SilentlyContinue }
           if (Test-Path 'upgrades') { Copy-Item 'upgrades/*' "$instDir/upgrades/" -Recurse -ErrorAction SilentlyContinue }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ This repository contains two editions of the SQL Server Performance Monitor:
 |--------|-------------|
 | `install/` | 50+ T-SQL scripts that create the PerformanceMonitor database |
 | `Installer/` | CLI installer for the Full Edition database and collectors |
-| `InstallerGui/` | GUI installer (same functionality as the CLI installer) |
-| `Dashboard/` | WPF dashboard that connects to the installed PerformanceMonitor database |
+| `Installer.Core/` | Shared installation library (used by CLI installer and Dashboard) |
+| `Dashboard/` | WPF dashboard — connects to PerformanceMonitor database, can also install/upgrade via Add Server |
 
 **Lite Edition** — standalone desktop app, nothing installed on the target server:
 
@@ -61,8 +61,6 @@ dotnet build Lite/PerformanceMonitorLite.csproj
 # Build CLI Installer (self-contained)
 dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
 
-# Build GUI Installer
-dotnet publish InstallerGui/InstallerGui.csproj -c Release -r win-x64 --self-contained
 ```
 
 ### Running the Applications

--- a/PerformanceMonitor.sln
+++ b/PerformanceMonitor.sln
@@ -7,8 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dashboard", "Dashboard\Dash
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceMonitorLite", "Lite\PerformanceMonitorLite.csproj", "{48718A1C-3679-AB80-1D5F-A9C20CC7EF9A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstallerGui", "InstallerGui\InstallerGui.csproj", "{B9F4D012-5FA6-6773-E3A5-63482B482B9A}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lite.Tests", "Lite.Tests\Lite.Tests.csproj", "{C4E76DA8-A115-7291-3AD0-12C648E24FF2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceMonitorInstaller", "Installer\PerformanceMonitorInstaller.csproj", "{0F1EFD0D-61B6-D475-3A2E-ED7FD83BCE6E}"
@@ -31,10 +29,6 @@ Global
 		{48718A1C-3679-AB80-1D5F-A9C20CC7EF9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48718A1C-3679-AB80-1D5F-A9C20CC7EF9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48718A1C-3679-AB80-1D5F-A9C20CC7EF9A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B9F4D012-5FA6-6773-E3A5-63482B482B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B9F4D012-5FA6-6773-E3A5-63482B482B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B9F4D012-5FA6-6773-E3A5-63482B482B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B9F4D012-5FA6-6773-E3A5-63482B482B9A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C4E76DA8-A115-7291-3AD0-12C648E24FF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C4E76DA8-A115-7291-3AD0-12C648E24FF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4E76DA8-A115-7291-3AD0-12C648E24FF2}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ PerformanceMonitorInstaller.exe YourServerName --uninstall
 PerformanceMonitorInstaller.exe YourServerName sa YourPassword --uninstall
 ```
 
-The installer automatically tests the connection, checks the SQL Server version (2016+ required), executes SQL scripts, downloads community dependencies, creates SQL Agent jobs, and runs initial data collection. A GUI installer (`InstallerGui/`) is also available with the same functionality.
+The installer automatically tests the connection, checks the SQL Server version (2016+ required), executes SQL scripts, downloads community dependencies, creates SQL Agent jobs, and runs initial data collection. You can also install directly from the Dashboard's Add Server dialog.
 
 ### CLI Installer Options
 
@@ -599,8 +599,8 @@ Monitor/
 ├── install/          # 58 SQL installation scripts
 ├── upgrades/         # Version-specific upgrade scripts
 ├── Installer/        # CLI installer for Full Edition database (C#)
-├── InstallerGui/     # GUI installer for Full Edition database (WPF)
-├── Dashboard/        # Full Edition dashboard application (WPF)
+├── Installer.Core/   # Shared installation library (CLI + Dashboard)
+├── Dashboard/        # Full Edition dashboard application (WPF, includes installer)
 │
 │   Lite Edition (standalone desktop app, nothing installed on server)
 ├── Lite/             # Lite Edition desktop application (WPF)
@@ -624,9 +624,6 @@ dotnet build Lite/PerformanceMonitorLite.csproj
 
 # CLI Installer (self-contained)
 dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
-
-# GUI Installer
-dotnet publish InstallerGui/InstallerGui.csproj -c Release -r win-x64 --self-contained
 ```
 
 ---

--- a/build-dashboard.cmd
+++ b/build-dashboard.cmd
@@ -36,25 +36,12 @@ echo.
 :: ----------------------------------------
 :: CLI Installer
 :: ----------------------------------------
-echo [2/3] Publishing CLI Installer...
+echo [2/2] Publishing CLI Installer...
 dotnet publish Installer\PerformanceMonitorInstaller.csproj -c Release
 
 if %ERRORLEVEL% neq 0 (
     echo.
     echo ERROR: CLI Installer build failed!
-    exit /b 1
-)
-echo.
-
-:: ----------------------------------------
-:: GUI Installer
-:: ----------------------------------------
-echo [3/3] Publishing GUI Installer...
-dotnet publish InstallerGui\InstallerGui.csproj -c Release -r win-x64 --self-contained
-
-if %ERRORLEVEL% neq 0 (
-    echo.
-    echo ERROR: GUI Installer build failed!
     exit /b 1
 )
 echo.
@@ -70,7 +57,6 @@ mkdir "%INST_DIR%\install"
 mkdir "%INST_DIR%\upgrades"
 
 copy "Installer\bin\Release\net8.0\win-x64\publish\PerformanceMonitorInstaller.exe" "%INST_DIR%\" >nul
-copy "InstallerGui\bin\Release\net8.0\win-x64\publish\InstallerGui.exe" "%INST_DIR%\" >nul 2>&1
 copy "install\*.sql" "%INST_DIR%\install\" >nul
 xcopy "upgrades" "%INST_DIR%\upgrades\" /E /I /Q >nul 2>&1
 if exist README.md copy README.md "%INST_DIR%\" >nul

--- a/install/README.md
+++ b/install/README.md
@@ -1,6 +1,6 @@
 # Install Scripts
 
-SQL scripts that create and configure the PerformanceMonitor database for the Full Edition. The CLI installer (`Installer/`) and GUI installer (`InstallerGui/`) execute these scripts in order against the target SQL Server instance.
+SQL scripts that create and configure the PerformanceMonitor database for the Full Edition. The CLI installer (`Installer/`) and Dashboard's Add Server dialog execute these scripts in order against the target SQL Server instance.
 
 Scripts create the database, collection tables, configuration tables, stored procedures for each collector, SQL Agent jobs, reporting views, and data retention logic. Each script is idempotent — tables use `IF NOT EXISTS` guards and procedures use `CREATE OR ALTER`, so re-running the installer on an existing installation is safe and preserves collected data.
 


### PR DESCRIPTION
## Summary

- Removed InstallerGui project from solution and all CI/CD workflows
- Updated build-dashboard.cmd to only publish CLI installer
- Updated README, CONTRIBUTING, install/README docs
- InstallerGui/ directory left in place for reference but no longer built or signed

Final phase of #755. Installation is now available via Dashboard's Add Server dialog or the CLI installer.

## Test plan

- [x] All 4 active projects build (Installer.Core, Dashboard, CLI Installer, Installer.Tests)
- [x] InstallerGui no longer referenced in solution, CI, or build scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)