### PR TITLE
Fix Rule 2: eager table spools no longer flagged as eager index spools

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -371,7 +371,7 @@ public static partial class PlanAnalyzer
 
         // Rule 2: Eager Index Spools — optimizer building temporary indexes on the fly
         if (node.LogicalOp == "Eager Spool" &&
-            node.PhysicalOp.Contains("Spool", StringComparison.OrdinalIgnoreCase))
+            node.PhysicalOp.Contains("Index", StringComparison.OrdinalIgnoreCase))
         {
             var message = "SQL Server is building a temporary index in TempDB at runtime because no suitable permanent index exists. This is expensive — it builds the index from scratch on every execution. Create a permanent index on the underlying table to eliminate this operator entirely.";
             if (!string.IsNullOrEmpty(node.SuggestedIndex))

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -371,7 +371,7 @@ public static partial class PlanAnalyzer
 
         // Rule 2: Eager Index Spools — optimizer building temporary indexes on the fly
         if (node.LogicalOp == "Eager Spool" &&
-            node.PhysicalOp.Contains("Spool", StringComparison.OrdinalIgnoreCase))
+            node.PhysicalOp.Contains("Index", StringComparison.OrdinalIgnoreCase))
         {
             var message = "SQL Server is building a temporary index in TempDB at runtime because no suitable permanent index exists. This is expensive — it builds the index from scratch on every execution. Create a permanent index on the underlying table to eliminate this operator entirely.";
             if (!string.IsNullOrEmpty(node.SuggestedIndex))


### PR DESCRIPTION
## Summary
- Rule 2 checked `PhysicalOp.Contains("Spool")` which matched both "Index Spool" and "Table Spool"
- Changed to `PhysicalOp.Contains("Index")` to only match eager index spools
- Synced in both Dashboard and Lite PlanAnalyzer copies

Same fix applied to PerformanceStudio (with test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)