### PR TITLE
Enable upgrade detection in Edit Server dialog

### DIFF
--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -331,11 +331,8 @@ namespace PerformanceMonitorDashboard
                     MessageBoxImage.Information
                 );
 
-                /* After successful connection in Add mode, check database status */
-                if (!_isEditMode)
-                {
-                    await DetectDatabaseStatusAsync();
-                }
+                /* After successful connection, check database status */
+                await DetectDatabaseStatusAsync();
             }
             else if (mfaCancelled)
             {


### PR DESCRIPTION
## Summary
- Removes the `_isEditMode` guard so Test Connection calls `DetectDatabaseStatusAsync()` in both Add and Edit modes
- Users can now detect and trigger database upgrades from the Edit Server dialog without re-adding the server

Partial fix for #771 (Edit Server flow; Manage Servers version column is a separate effort)

## Test plan
- [ ] Open Manage Servers → Edit an existing server
- [ ] Click Test Connection against a server with an older PM database version
- [ ] Verify the "Upgrade Now" button appears
- [ ] Run the upgrade and confirm it completes successfully
- [ ] Verify Edit Server still saves correctly after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)