### PR TITLE
Fix embedded resource upgrade discovery and add server version UX

### DIFF
--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -2,15 +2,20 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Add SQL Server"
-        SizeToContent="Height" Width="500" MaxHeight="1050"
+        Height="750" Width="500"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize"
+        ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource BackgroundBrush}"
         Foreground="{DynamicResource ForegroundBrush}">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Grid Margin="20">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+        <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -217,14 +222,17 @@
                        Foreground="{DynamicResource ForegroundMutedBrush}"
                        TextWrapping="Wrap" Margin="0,8,0,0" Visibility="Collapsed"/>
 
-            <!-- Buttons -->
-            <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
-                <Button x:Name="ViewReportButton" Content="View Report" Margin="0,0,8,0"
-                        Click="ViewReport_Click" Visibility="Collapsed"/>
-                <Button x:Name="TestConnectionButton" Content="Test Connection" Margin="0,0,8,0" Click="TestConnection_Click"/>
-                <Button x:Name="SaveButton" Content="Save" MinWidth="80" Height="30" Padding="12,0" Margin="0,0,10,0" Click="Save_Click" IsDefault="True" Style="{StaticResource AccentButton}"/>
-                <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click" IsCancel="True"/>
-            </StackPanel>
         </Grid>
-    </ScrollViewer>
+        </ScrollViewer>
+
+        <!-- Buttons pinned to bottom -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+            <Button x:Name="ViewReportButton" Content="View Report" Margin="0,0,8,0"
+                    Click="ViewReport_Click" Visibility="Collapsed"/>
+            <Button x:Name="CheckForUpdatesButton" Content="Check for Updates" Margin="0,0,8,0" Click="CheckForUpdates_Click"/>
+            <Button x:Name="TestConnectionButton" Content="Test Connection" Margin="0,0,8,0" Click="TestConnection_Click"/>
+            <Button x:Name="SaveButton" Content="Save" MinWidth="80" Height="30" Padding="12,0" Margin="0,0,10,0" Click="Save_Click" IsDefault="True" Style="{StaticResource AccentButton}"/>
+            <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -313,6 +313,24 @@ namespace PerformanceMonitorDashboard
             return (connected, errorMessage, mfaCancelled, serverVersion);
         }
 
+        private async void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        {
+            if (!ValidateInputs()) return;
+
+            CheckForUpdatesButton.IsEnabled = false;
+            CheckForUpdatesButton.Content = "Checking...";
+
+            try
+            {
+                await DetectDatabaseStatusAsync();
+            }
+            finally
+            {
+                CheckForUpdatesButton.IsEnabled = true;
+                CheckForUpdatesButton.Content = "Check for Updates";
+            }
+        }
+
         private async void TestConnection_Click(object sender, RoutedEventArgs e)
         {
             if (!ValidateInputs()) return;

--- a/Dashboard/Controls/LandingPage.xaml
+++ b/Dashboard/Controls/LandingPage.xaml
@@ -74,7 +74,9 @@
                     <DataTemplate>
                         <local:ServerHealthCard Width="300"
                                                 Height="220"
-                                                CardClicked="ServerHealthCard_CardClicked"/>
+                                                CardClicked="ServerHealthCard_CardClicked"
+                                                EditServerRequested="ServerHealthCard_EditServerRequested"
+                                                CheckVersionRequested="ServerHealthCard_CheckVersionRequested"/>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/Dashboard/Controls/LandingPage.xaml.cs
+++ b/Dashboard/Controls/LandingPage.xaml.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -168,6 +169,10 @@ namespace PerformanceMonitorDashboard.Controls
                 // and the UI updates automatically via data binding
                 await databaseService.RefreshNocHealthStatusAsync(status);
 
+                // Populate installed monitor version from connectivity check
+                var connStatus = _serverManager.GetConnectionStatus(server.Id);
+                status.MonitorVersion = connStatus.InstalledMonitorVersion;
+
                 // Update tab badges in MainWindow
                 UpdateTabBadges(status);
             }
@@ -219,6 +224,80 @@ namespace PerformanceMonitorDashboard.Controls
         private void ServerHealthCard_CardClicked(object? sender, ServerHealthStatus status)
         {
             ServerCardClicked?.Invoke(this, status.Server);
+        }
+
+        private void ServerHealthCard_EditServerRequested(object? sender, ServerHealthStatus status)
+        {
+            var server = status.Server;
+            var dialog = new AddServerDialog(server);
+            dialog.Owner = Window.GetWindow(this);
+
+            if (dialog.ShowDialog() == true)
+            {
+                try
+                {
+                    _serverManager.UpdateServer(dialog.ServerConnection, dialog.Username, dialog.Password);
+                    _ = ReloadServersAsync();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Failed to update server:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
+        private async void ServerHealthCard_CheckVersionRequested(object? sender, ServerHealthStatus status)
+        {
+            var server = status.Server;
+
+            try
+            {
+                string? installedVersion = await _serverManager.GetInstalledVersionAsync(server);
+
+                if (installedVersion == null)
+                {
+                    MessageBox.Show(
+                        $"No PerformanceMonitor installation found on '{server.DisplayNameWithIntent}'.",
+                        "Not Installed", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                string appVersion = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                    ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+                int plusIndex = appVersion.IndexOf('+');
+                if (plusIndex >= 0) appVersion = appVersion[..plusIndex];
+
+                static string Normalize(string v) =>
+                    Version.TryParse(v, out var p) ? new Version(p.Major, p.Minor, p.Build).ToString() : v;
+
+                string normalizedInstalled = Normalize(installedVersion);
+                string normalizedApp = Normalize(appVersion);
+
+                if (Version.TryParse(normalizedInstalled, out var installed) &&
+                    Version.TryParse(normalizedApp, out var app) &&
+                    installed < app)
+                {
+                    var result = MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' has v{normalizedInstalled} installed.\n\nv{normalizedApp} is available. Open the server editor to upgrade?",
+                        "Update Available", MessageBoxButton.YesNo, MessageBoxImage.Information);
+
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        ServerHealthCard_EditServerRequested(sender, status);
+                    }
+                }
+                else
+                {
+                    MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' is up to date (v{normalizedInstalled}).",
+                        "No Updates", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to check version:\n\n{ex.Message}", "Connection Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         /// <summary>

--- a/Dashboard/Controls/ServerHealthCard.xaml
+++ b/Dashboard/Controls/ServerHealthCard.xaml
@@ -8,6 +8,19 @@
              Background="Transparent"
              MouseLeftButtonDown="Card_MouseLeftButtonDown"
              Cursor="Hand">
+    <UserControl.ContextMenu>
+        <ContextMenu>
+            <MenuItem Header="Open in New Tab" Click="OpenInNewTab_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F5C2;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Edit Server..." Click="EditServer_Click">
+                <MenuItem.Icon><TextBlock Text="&#x270F;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Check Server Version" Click="CheckVersion_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F504;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+    </UserControl.ContextMenu>
     <UserControl.Resources>
         <ResourceDictionary>
             <!-- Severity to color converter -->

--- a/Dashboard/Controls/ServerHealthCard.xaml.cs
+++ b/Dashboard/Controls/ServerHealthCard.xaml.cs
@@ -25,6 +25,8 @@ namespace PerformanceMonitorDashboard.Controls
         private static readonly SolidColorBrush UnknownBrush = new(Color.FromRgb(0x88, 0x88, 0x88));   // Gray
 
         public event EventHandler<ServerHealthStatus>? CardClicked;
+        public event EventHandler<ServerHealthStatus>? EditServerRequested;
+        public event EventHandler<ServerHealthStatus>? CheckVersionRequested;
 
         public ServerHealthCard()
         {
@@ -166,6 +168,24 @@ namespace PerformanceMonitorDashboard.Controls
             {
                 CardClicked?.Invoke(this, status);
             }
+        }
+
+        private void OpenInNewTab_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ServerHealthStatus status)
+                CardClicked?.Invoke(this, status);
+        }
+
+        private void EditServer_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ServerHealthStatus status)
+                EditServerRequested?.Invoke(this, status);
+        }
+
+        private void CheckVersion_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ServerHealthStatus status)
+                CheckVersionRequested?.Invoke(this, status);
         }
     }
 }

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -118,6 +118,12 @@
                                                Foreground="{Binding StatusColor}"
                                                Margin="0,-1,0,0"
                                                Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <!-- Monitor Version -->
+                                    <TextBlock Text="{Binding MonitorVersionDisplay, Mode=OneWay}"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource ForegroundMutedBrush}"
+                                               Margin="0,-1,0,0"
+                                               Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                     <!-- Last Checked Timestamp -->
                                     <TextBlock FontSize="12" Foreground="{DynamicResource ForegroundDimBrush}" Margin="0,-1,0,0">
                                         <Run Text="{Binding LastCheckedDisplay, Mode=OneWay}"/>
@@ -136,6 +142,9 @@
                             </MenuItem>
                             <MenuItem Header="Edit Server..." Click="EditServer_Click">
                                 <MenuItem.Icon><TextBlock Text="&#x270F;"/></MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="Check Server Version" Click="CheckServerVersion_Click">
+                                <MenuItem.Icon><TextBlock Text="&#x1F504;"/></MenuItem.Icon>
                             </MenuItem>
                             <Separator/>
                             <MenuItem x:Name="ToggleFavoriteMenuItem" Header="Set as Favorite" Click="ToggleFavorite_Click">

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitorDashboard.Mcp;
 using PerformanceMonitorDashboard.Models;
+using System.Reflection;
 using PerformanceMonitorDashboard.Controls;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Services;
@@ -975,6 +976,76 @@ namespace PerformanceMonitorDashboard
                         );
                     }
                 }
+            }
+        }
+
+        private async void CheckServerVersion_Click(object sender, RoutedEventArgs e)
+        {
+            if (ServerListView.SelectedItem is not ServerListItem item) return;
+            var server = item.Server;
+
+            try
+            {
+                string? installedVersion = await _serverManager.GetInstalledVersionAsync(server);
+
+                if (installedVersion == null)
+                {
+                    MessageBox.Show(
+                        $"No PerformanceMonitor installation found on '{server.DisplayNameWithIntent}'.",
+                        "Not Installed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                    return;
+                }
+
+                string appVersion = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                    ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+                int plusIndex = appVersion.IndexOf('+');
+                if (plusIndex >= 0) appVersion = appVersion[..plusIndex];
+
+                static string Normalize(string v) =>
+                    Version.TryParse(v, out var p) ? new Version(p.Major, p.Minor, p.Build).ToString() : v;
+
+                string normalizedInstalled = Normalize(installedVersion);
+                string normalizedApp = Normalize(appVersion);
+
+                if (Version.TryParse(normalizedInstalled, out var installed) &&
+                    Version.TryParse(normalizedApp, out var app) &&
+                    installed < app)
+                {
+                    var result = MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' has v{normalizedInstalled} installed.\n\nv{normalizedApp} is available. Open the server editor to upgrade?",
+                        "Update Available",
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Information);
+
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        var dialog = new AddServerDialog(server);
+                        if (dialog.ShowDialog() == true)
+                        {
+                            _serverManager.UpdateServer(dialog.ServerConnection, dialog.Username, dialog.Password);
+                            await LoadServerListAsync();
+                        }
+                    }
+                }
+                else
+                {
+                    MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' is up to date (v{normalizedInstalled}).",
+                        "No Updates",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to check version:\n\n{ex.Message}",
+                    "Connection Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
             }
         }
 

--- a/Dashboard/ManageServersWindow.xaml
+++ b/Dashboard/ManageServersWindow.xaml
@@ -90,6 +90,7 @@
                 <Button Content="Add Server..." Width="100" Height="30" Margin="0,0,8,0" Click="AddServer_Click"/>
                 <Button Content="Edit..." Width="80" Height="30" Margin="0,0,8,0" Click="EditServer_Click"/>
                 <Button x:Name="ToggleFavoriteButton" Content="Toggle Favorite" Width="110" Height="30" Margin="0,0,8,0" Click="ToggleFavorite_Click"/>
+                <Button x:Name="CheckUpdatesButton" Content="Check Server Version" Width="140" Height="30" Margin="0,0,8,0" Click="CheckForUpdates_Click"/>
                 <Button Content="Remove" Width="80" Height="30" Margin="0,0,8,0" Click="RemoveServer_Click"
                         Foreground="{DynamicResource ErrorBrush}"/>
             </StackPanel>

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -8,9 +8,11 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Installer.Core;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
@@ -187,6 +189,111 @@ namespace PerformanceMonitorDashboard
                     MessageBoxButton.OK,
                     MessageBoxImage.Information
                 );
+            }
+        }
+
+        private async void CheckForUpdates_Click(object sender, RoutedEventArgs e)
+        {
+            if (ServersDataGrid.SelectedItem is not ServerConnection server)
+            {
+                MessageBox.Show(
+                    "Please select a server to check for updates.",
+                    "No Server Selected",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            CheckUpdatesButton.IsEnabled = false;
+            CheckUpdatesButton.Content = "Checking...";
+
+            try
+            {
+                string? installedVersion = await _serverManager.GetInstalledVersionAsync(server);
+
+                if (installedVersion == null)
+                {
+                    MessageBox.Show(
+                        $"No PerformanceMonitor installation found on '{server.DisplayNameWithIntent}'.\n\nUse Edit to install.",
+                        "Not Installed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                    return;
+                }
+
+                string appVersion = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                    ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+                /* Strip git hash suffix if present (e.g., "2.5.0+abc123" → "2.5.0") */
+                int plusIndex = appVersion.IndexOf('+');
+                if (plusIndex >= 0) appVersion = appVersion[..plusIndex];
+
+                /* Normalize both to 3-part for comparison */
+                string Normalize(string v)
+                {
+                    if (Version.TryParse(v, out var parsed))
+                        return new Version(parsed.Major, parsed.Minor, parsed.Build).ToString();
+                    return v;
+                }
+
+                string normalizedInstalled = Normalize(installedVersion);
+                string normalizedApp = Normalize(appVersion);
+
+                if (Version.TryParse(normalizedInstalled, out var installed) &&
+                    Version.TryParse(normalizedApp, out var app) &&
+                    installed < app)
+                {
+                    var result = MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' has v{normalizedInstalled} installed.\n\nv{normalizedApp} is available. Open the server editor to upgrade?",
+                        "Update Available",
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Information);
+
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        var dialog = new AddServerDialog(server);
+                        dialog.Owner = this;
+
+                        if (dialog.ShowDialog() == true)
+                        {
+                            try
+                            {
+                                _serverManager.UpdateServer(dialog.ServerConnection, dialog.Username, dialog.Password);
+                                LoadServers();
+                                ServersModified = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                MessageBox.Show(
+                                    $"Failed to update server:\n\n{ex.Message}",
+                                    "Error",
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Error);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    MessageBox.Show(
+                        $"'{server.DisplayNameWithIntent}' is up to date (v{normalizedInstalled}).",
+                        "No Updates",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to check for updates:\n\n{ex.Message}",
+                    "Connection Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            finally
+            {
+                CheckUpdatesButton.IsEnabled = true;
+                CheckUpdatesButton.Content = "Check Server Version";
             }
         }
 

--- a/Dashboard/Models/ServerConnectionStatus.cs
+++ b/Dashboard/Models/ServerConnectionStatus.cs
@@ -81,6 +81,12 @@ namespace PerformanceMonitorDashboard.Models
         public int? UtcOffsetMinutes { get; set; }
 
         /// <summary>
+        /// The installed PerformanceMonitor version on the server (e.g., "2.5.0").
+        /// Null if the PerformanceMonitor database is not installed.
+        /// </summary>
+        public string? InstalledMonitorVersion { get; set; }
+
+        /// <summary>
         /// Gets the status display text for the UI.
         /// </summary>
         public string StatusText

--- a/Dashboard/Models/ServerHealthStatus.cs
+++ b/Dashboard/Models/ServerHealthStatus.cs
@@ -71,6 +71,9 @@ namespace PerformanceMonitorDashboard.Models
         private string? _topWaitType;
         private decimal _topWaitDurationSeconds;
 
+        // Installed version
+        private string? _monitorVersion;
+
         public ServerHealthStatus(ServerConnection server)
         {
             _server = server;
@@ -533,13 +536,28 @@ namespace PerformanceMonitorDashboard.Models
             }
         }
 
+        public string? MonitorVersion
+        {
+            get => _monitorVersion;
+            set { _monitorVersion = value; OnPropertyChanged(); OnPropertyChanged(nameof(ConnectionStatusText)); }
+        }
+
         public string ConnectionStatusText
         {
             get
             {
                 if (!_isOnline.HasValue) return "Unknown";
+                if (_isOnline.Value && _monitorVersion != null)
+                    return $"Online — Monitor v{NormalizeVersion(_monitorVersion)}";
                 return _isOnline.Value ? "Online" : "Offline";
             }
+        }
+
+        private static string NormalizeVersion(string version)
+        {
+            if (Version.TryParse(version, out var parsed))
+                return new Version(parsed.Major, parsed.Minor, parsed.Build).ToString();
+            return version;
         }
 
         // Overall health - worst severity across all metrics

--- a/Dashboard/Models/ServerListItem.cs
+++ b/Dashboard/Models/ServerListItem.cs
@@ -48,6 +48,7 @@ namespace PerformanceMonitorDashboard.Models
                     OnPropertyChanged(nameof(StatusDurationDisplay));
                     OnPropertyChanged(nameof(IsOnline));
                     OnPropertyChanged(nameof(HasBeenChecked));
+                    OnPropertyChanged(nameof(MonitorVersionDisplay));
                 }
             }
         }
@@ -102,6 +103,22 @@ namespace PerformanceMonitorDashboard.Models
         /// Whether the server has been checked at least once.
         /// </summary>
         public bool HasBeenChecked => _status.LastChecked.HasValue;
+
+        /// <summary>
+        /// Display text for the installed monitor version (e.g., "Monitor v2.5.0").
+        /// Empty string if not installed or not yet checked.
+        /// </summary>
+        public string MonitorVersionDisplay
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_status.InstalledMonitorVersion))
+                    return string.Empty;
+                if (System.Version.TryParse(_status.InstalledMonitorVersion, out var v))
+                    return $"Monitor v{new System.Version(v.Major, v.Minor, v.Build)}";
+                return $"Monitor v{_status.InstalledMonitorVersion}";
+            }
+        }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -15,6 +15,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Data.SqlClient;
+using Installer.Core;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Models;
@@ -323,6 +324,36 @@ namespace PerformanceMonitorDashboard.Services
                 {
                     Logger.Info($"Connectivity check passed for server '{server.DisplayName}'");
                     status.UserCancelledMfa = false; // Clear any previous cancellation flag
+
+                    /* Query installed PerformanceMonitor version */
+                    try
+                    {
+                        using var versionCmd = new SqlCommand(@"
+                            IF DB_ID(N'PerformanceMonitor') IS NOT NULL
+                            AND EXISTS (
+                                SELECT 1
+                                FROM PerformanceMonitor.sys.tables AS t
+                                JOIN PerformanceMonitor.sys.schemas AS s
+                                    ON t.schema_id = s.schema_id
+                                WHERE s.name = N'config'
+                                AND   t.name = N'installation_history'
+                            )
+                            BEGIN
+                                SELECT TOP (1)
+                                    installer_version
+                                FROM PerformanceMonitor.config.installation_history
+                                WHERE installation_status = N'SUCCESS'
+                                ORDER BY installation_date DESC;
+                            END;", connection);
+                        versionCmd.CommandTimeout = ConnectionCheckTimeoutSeconds;
+                        var versionResult = await versionCmd.ExecuteScalarAsync();
+                        status.InstalledMonitorVersion = versionResult is string v ? v : null;
+                    }
+                    catch (SqlException)
+                    {
+                        /* Non-critical — don't fail the connectivity check */
+                        status.InstalledMonitorVersion = null;
+                    }
                 }
             }
             catch (SqlException ex)
@@ -381,6 +412,17 @@ namespace PerformanceMonitorDashboard.Services
             var servers = GetAllServers();
             var tasks = servers.Select(s => CheckConnectionAsync(s.Id));
             await Task.WhenAll(tasks);
+        }
+
+        public async Task<string?> GetInstalledVersionAsync(ServerConnection server)
+        {
+            var connectionString = server.GetConnectionString(_credentialService);
+            var builder = new SqlConnectionStringBuilder(connectionString)
+            {
+                InitialCatalog = "master",
+                ConnectTimeout = ConnectionCheckTimeoutSeconds
+            };
+            return await InstallationService.GetInstalledVersionAsync(builder.ConnectionString);
         }
 
         private void LoadServers()

--- a/Installer.Core/Patterns.cs
+++ b/Installer.Core/Patterns.cs
@@ -28,6 +28,14 @@ public static partial class Patterns
         RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
     /// <summary>
+    /// Matches MSBuild-mangled upgrade folder names from embedded resource names.
+    /// MSBuild converts "2.2.0-to-2.3.0" to "_2._2._0_to_2._3._0" (dots become namespace
+    /// separators, hyphens become underscores, digit-leading segments get underscore prefix).
+    /// </summary>
+    [GeneratedRegex(@"^(_\d+\._\d+\._\d+_to_\d+\._\d+\._\d+)\.")]
+    public static partial Regex EmbeddedUpgradeFolderPattern();
+
+    /// <summary>
     /// Prefixes that indicate excluded scripts (uninstall, test, troubleshooting).
     /// </summary>
     public static readonly string[] ExcludedPrefixes = ["00_", "97_", "99_"];

--- a/Installer.Core/ScriptProvider.cs
+++ b/Installer.Core/ScriptProvider.cs
@@ -330,15 +330,28 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
     {
         string upgradesPrefix = $"{_resourcePrefix}.Resources.upgrades.";
 
-        var folderNames = _assembly.GetManifestResourceNames()
+        /*
+        MSBuild mangles embedded resource names: folder "2.2.0-to-2.3.0" becomes
+        "_2._2._0_to_2._3._0" (dots → namespace separators, hyphens → underscores,
+        digit-leading segments → underscore prefix). Extract the mangled name and
+        recover the original for version parsing. Store mangled name in Path for
+        resource lookups; original in FolderName for display/version parsing.
+        */
+        var mangledNames = _assembly.GetManifestResourceNames()
             .Where(r => r.StartsWith(upgradesPrefix, StringComparison.Ordinal))
             .Select(r => r[upgradesPrefix.Length..])
-            .Select(r => r.Split('.')[0])
+            .Select(r => Patterns.EmbeddedUpgradeFolderPattern().Match(r))
+            .Where(m => m.Success)
+            .Select(m => m.Groups[1].Value)
             .Distinct()
             .ToList();
 
-        var allUpgrades = folderNames
-            .Select(f => ParseUpgradeFolderName(f, f))
+        var allUpgrades = mangledNames
+            .Select(mangled =>
+            {
+                string original = UnmangleUpgradeFolderName(mangled);
+                return ParseUpgradeFolderName(original, mangled);
+            })
             .Where(x => x != null)
             .Cast<UpgradeInfo>()
             .ToList();
@@ -348,7 +361,7 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
         var result = new List<UpgradeInfo>();
         foreach (var upgrade in filtered)
         {
-            string manifestResource = $"{upgradesPrefix}{upgrade.FolderName}.upgrade.txt";
+            string manifestResource = $"{upgradesPrefix}{upgrade.Path}.upgrade.txt";
             if (_assembly.GetManifestResourceNames().Contains(manifestResource))
             {
                 result.Add(upgrade);
@@ -364,7 +377,7 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
     public override List<string> GetUpgradeManifest(UpgradeInfo upgrade)
     {
         string upgradesPrefix = $"{_resourcePrefix}.Resources.upgrades.";
-        string manifestResource = $"{upgradesPrefix}{upgrade.FolderName}.upgrade.txt";
+        string manifestResource = $"{upgradesPrefix}{upgrade.Path}.upgrade.txt";
         string content = ReadResource(manifestResource);
         return ParseUpgradeManifest(content.Split('\n'));
     }
@@ -372,7 +385,7 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
     public override string ReadUpgradeScript(UpgradeInfo upgrade, string scriptName)
     {
         string upgradesPrefix = $"{_resourcePrefix}.Resources.upgrades.";
-        string resource = $"{upgradesPrefix}{upgrade.FolderName}.{scriptName}";
+        string resource = $"{upgradesPrefix}{upgrade.Path}.{scriptName}";
         return ReadResource(resource);
     }
 
@@ -383,8 +396,32 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
     public override bool UpgradeScriptExists(UpgradeInfo upgrade, string scriptName)
     {
         string upgradesPrefix = $"{_resourcePrefix}.Resources.upgrades.";
-        string resource = $"{upgradesPrefix}{upgrade.FolderName}.{scriptName}";
+        string resource = $"{upgradesPrefix}{upgrade.Path}.{scriptName}";
         return _assembly.GetManifestResourceNames().Contains(resource);
+    }
+
+    /// <summary>
+    /// Reverses MSBuild's resource name mangling for upgrade folder names.
+    /// "_2._2._0_to_2._3._0" → "2.2.0-to-2.3.0"
+    /// </summary>
+    private static string UnmangleUpgradeFolderName(string mangled)
+    {
+        /*
+        MSBuild mangling:
+        - dots in folder names become namespace separator dots
+        - hyphens become underscores
+        - segments starting with a digit get an underscore prefix
+        Reverse: remove leading underscores from digit segments,
+        rejoin with dots, then restore the hyphen in "-to-".
+        */
+        var segments = mangled.Split('.');
+        for (int i = 0; i < segments.Length; i++)
+        {
+            if (segments[i].Length > 1 && segments[i][0] == '_' && char.IsDigit(segments[i][1]))
+                segments[i] = segments[i][1..];
+        }
+        string result = string.Join(".", segments);
+        return result.Replace("_to_", "-to-");
     }
 
     public override string? ReadTroubleshootingScript()

--- a/Installer.Tests/UpgradeOrderingTests.cs
+++ b/Installer.Tests/UpgradeOrderingTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Installer.Core;
 using Installer.Core.Models;
 using Installer.Tests.Helpers;
@@ -145,5 +146,39 @@ public class UpgradeOrderingTests
 
         Assert.Equal(2, upgrades.Count);
         Assert.DoesNotContain(upgrades, u => u.FolderName == "2.2.0-to-2.3.0");
+    }
+
+    [Fact]
+    public void EmbeddedResources_FindsUpgradeFolders()
+    {
+        // Regression test for #772: MSBuild mangles embedded resource names
+        // (e.g., "2.2.0-to-2.3.0" → "_2._2._0_to_2._3._0"), which broke
+        // upgrade discovery when using Split('.')[0].
+        var provider = ScriptProvider.FromEmbeddedResources();
+        var upgrades = provider.GetApplicableUpgrades("2.2.0", "2.5.0");
+
+        Assert.NotEmpty(upgrades);
+        Assert.Contains(upgrades, u => u.FolderName == "2.2.0-to-2.3.0");
+    }
+
+    [Theory]
+    [InlineData("_2._2._0_to_2._3._0.upgrade.txt", "_2._2._0_to_2._3._0")]
+    [InlineData("_2._2._0_to_2._3._0.03_add_growth_vlf_columns.sql", "_2._2._0_to_2._3._0")]
+    [InlineData("_10._1._0_to_10._2._0.01_schema.sql", "_10._1._0_to_10._2._0")]
+    public void EmbeddedUpgradeFolderPattern_ExtractsMangledName(string resourceSuffix, string expectedMangled)
+    {
+        var match = Patterns.EmbeddedUpgradeFolderPattern().Match(resourceSuffix);
+
+        Assert.True(match.Success);
+        Assert.Equal(expectedMangled, match.Groups[1].Value);
+    }
+
+    [Theory]
+    [InlineData("not-a-version")]
+    [InlineData("readme.txt")]
+    [InlineData("README.md")]
+    public void EmbeddedUpgradeFolderPattern_RejectsNonVersionStrings(string input)
+    {
+        Assert.False(Patterns.EmbeddedUpgradeFolderPattern().Match(input).Success);
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause fix for #772**: MSBuild mangles embedded resource names for upgrade folders (e.g., `2.2.0-to-2.3.0` → `_2._2._0_to_2._3._0`), which broke `EmbeddedResourceScriptProvider` — all Dashboard upgrades silently returned zero results
- **Server version visibility**: Show installed Monitor version in NOC health cards, sidebar server list, and Manage Servers
- **Check for Updates UX**: Added "Check for Updates" button to Edit Server dialog, "Check Server Version" to sidebar right-click and NOC card right-click menus
- **Dialog layout fix**: Pin Save/Cancel buttons outside scroll area so they stay visible during long install/upgrade operations; allow dialog resizing

## Test plan
- [x] Unit tests: 17 upgrade ordering tests pass (including new embedded resource regression test)
- [x] Integration test: Downloaded v2.2.0 release installer, installed on SQL2022, upgraded via Dashboard Edit Server — all 3 missing columns added, upgrade recorded as SUCCESS
- [x] Verified NOC cards show "Online — Monitor v2.5.0"
- [x] Verified sidebar shows "Monitor v2.5.0" for online servers
- [x] Verified right-click menus work from sidebar and NOC cards
- [x] Verified Edit Server "Check for Updates" detects version mismatch and offers upgrade
- [x] Verified buttons stay visible after upgrade completes

Fixes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)