### PR TITLE
Fix Lite FinOps Enterprise features query for missing database_id column

### DIFF
--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -1569,11 +1569,18 @@ ORDER BY CAST(collection_time AS DATE)";
 
             if (edition.Contains("Enterprise", StringComparison.OrdinalIgnoreCase))
             {
-                using var featCmd = new SqlCommand(@"
-SELECT
-    DB_NAME(database_id) AS database_name,
-    feature_name
-FROM sys.dm_db_persisted_sku_features", sqlConn);
+                var hasDatabaseId = false;
+                using (var colCheck = new SqlCommand(
+                    "SELECT COL_LENGTH('sys.dm_db_persisted_sku_features', 'database_id')", sqlConn))
+                {
+                    colCheck.CommandTimeout = 10;
+                    hasDatabaseId = await colCheck.ExecuteScalarAsync() is not null and not DBNull;
+                }
+
+                var featSql = hasDatabaseId
+                    ? "SELECT DB_NAME(database_id) AS database_name, feature_name FROM sys.dm_db_persisted_sku_features"
+                    : "SELECT N'(unknown)' AS database_name, feature_name FROM sys.dm_db_persisted_sku_features";
+                using var featCmd = new SqlCommand(featSql, sqlConn);
                 featCmd.CommandTimeout = 30;
 
                 var features = new List<string>();


### PR DESCRIPTION
## Summary
- Port the `COL_LENGTH` check from Dashboard (#766) to Lite — `sys.dm_db_persisted_sku_features` doesn't have `database_id` on all SQL Server builds
- Falls back to `N'(unknown)'` when column is absent, preserving database name on servers that have it
- Supersedes community PR #777 which simply removed the column

## Test plan
- [x] Builds clean
- [x] Matches the proven Dashboard approach from #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)