### PR TITLE
Bring existing window to foreground on second launch instead of error

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -137,9 +137,10 @@ namespace PerformanceMonitorDashboard
         {
             if (msg == NativeMethods.WM_SHOWMONITOR)
             {
-                // Another instance tried to start - bring this window to front
+                // Another instance tried to start - bring this window to front (#769)
                 Show();
-                WindowState = WindowState.Normal;
+                if (WindowState == WindowState.Minimized)
+                    WindowState = WindowState.Normal;
                 Activate();
                 Topmost = true;  // Temporarily set topmost to ensure visibility
                 Topmost = false;

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -22,6 +22,21 @@ public partial class App : Application
     [DllImport("shell32.dll", SetLastError = true)]
     private static extern void SetCurrentProcessExplicitAppUserModelID([MarshalAs(UnmanagedType.LPWStr)] string appId);
 
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr FindWindow(string? lpClassName, string lpWindowName);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    private const int SW_RESTORE = 9;
+
     private const string MutexName = "PerformanceMonitorLite_SingleInstance";
     private Mutex? _singleInstanceMutex;
     private bool _ownsMutex;
@@ -167,11 +182,14 @@ public partial class App : Application
 
         if (!_ownsMutex)
         {
-            MessageBox.Show(
-                "Performance Monitor Lite is already running.",
-                "Already Running",
-                MessageBoxButton.OK,
-                MessageBoxImage.Information);
+            /* Bring the existing instance's window to the foreground instead of showing an error (#769) */
+            var hWnd = FindWindow(null, "Performance Monitor Lite");
+            if (hWnd != IntPtr.Zero)
+            {
+                if (IsIconic(hWnd))
+                    ShowWindow(hWnd, SW_RESTORE);
+                SetForegroundWindow(hWnd);
+            }
             Shutdown();
             return;
         }


### PR DESCRIPTION
## Summary
- **Lite**: Replace "already running" error dialog with `FindWindow`/`SetForegroundWindow` to activate the existing instance. Uses `IsIconic` check to only call `SW_RESTORE` when minimized, preserving maximized state.
- **Dashboard**: Fix `WndProc` handler to only reset `WindowState` when minimized, preserving maximized state on second-launch activation.
- Minimize-to-tray setting preserved as a user option in both apps.

Fixes #769

## Test plan
- [x] Lite: Launch maximized, double-click exe again — brings to foreground, stays maximized
- [x] Lite: Launch minimized, double-click exe again — restores window
- [x] Dashboard: Launch maximized, double-click exe again — brings to foreground, stays maximized
- [x] Minimize-to-tray setting still works when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)