### PR TITLE
Fix Lite long-running query alerts firing on stale DuckDB snapshots

### DIFF
--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -418,6 +418,7 @@ LIMIT 2000";
                 FROM v_query_snapshots AS r
                 WHERE r.server_id = $1
                     AND r.collection_time = (SELECT MAX(vqs.collection_time) FROM v_query_snapshots AS vqs WHERE vqs.server_id = $1)
+                    AND r.collection_time >= NOW() - INTERVAL '10 MINUTES'
                     AND r.session_id > 50
                     {spServerDiagnosticsFilter}
                     {waitForFilter}


### PR DESCRIPTION
## Summary
- Lite's long-running query alert reads from `v_query_snapshots` (DuckDB) using `MAX(collection_time)` to find the latest snapshot
- When the collector captures 0 active queries, no new rows are inserted, so `MAX(collection_time)` still returns the old snapshot — alerts re-fire indefinitely on queries that finished hours ago
- Added a 10-minute recency check so stale snapshots are ignored

## Test plan
- [x] Confirmed alerts were firing every 5 minutes on a session that no longer existed
- [x] After fix, alerts stopped immediately
- [x] Verified collector is running and writing fresh snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)