### PR TITLE
Add trust-cert and encryption prompts to CLI installer interactive mode

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -231,6 +231,24 @@ namespace PerformanceMonitorInstaller
                     return (int)InstallationResultCode.InvalidArguments;
                 }
 
+                Console.Write("Trust server certificate? (Y/N, default Y): ");
+                string? trustResponse = Console.ReadLine()?.Trim();
+                trustCert = string.IsNullOrWhiteSpace(trustResponse)
+                    || trustResponse.Equals("Y", StringComparison.OrdinalIgnoreCase);
+
+                Console.WriteLine("Encryption level:");
+                Console.WriteLine("  [O] Optional (default)");
+                Console.WriteLine("  [M] Mandatory");
+                Console.WriteLine("  [S] Strict");
+                Console.Write("Choice (O/M/S, default O): ");
+                string? encryptResponse = Console.ReadLine()?.Trim();
+                encryptionLevel = encryptResponse?.ToUpperInvariant() switch
+                {
+                    "M" => "Mandatory",
+                    "S" => "Strict",
+                    _ => "Optional"
+                };
+
                 Console.WriteLine("Authentication type:");
                 Console.WriteLine("  [W] Windows Authentication (default)");
                 Console.WriteLine("  [S] SQL Server Authentication");


### PR DESCRIPTION
## Summary
- CLI installer interactive mode defaulted to Mandatory encryption with no cert trust, causing connection failures on servers with self-signed certificates
- The retired GUI installer defaulted to Optional encryption + trust cert, which worked
- Now interactive mode prompts for both settings with sensible defaults (trust cert = Y, encryption = Optional)

Fixes #784

## Test plan
- [x] Builds clean
- [x] Interactive mode flow verified: prompts appear in correct order before auth type selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)