### PR TITLE
Add plans/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ nul
 Lite/config/servers.json
 Lite/servers.json
 Lite/collection_schedule.json
+
+# Plans directory
+plans/


### PR DESCRIPTION
## Summary
- Adds `plans/` directory to `.gitignore` so it stops showing as untracked

## Test plan
- [x] Verify `git status` no longer shows `plans/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)