### PR TITLE
Port warning rule improvements from PerformanceStudio

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -38,7 +38,9 @@ public static partial class PlanAnalyzer
     private static void AnalyzeStatement(PlanStatement stmt)
     {
         // Rule 3: Serial plan with reason
-        if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason))
+        // Skip trivial statements (e.g., variable assignments, constant scans) — not worth warning about
+        if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason)
+            && stmt.StatementSubTreeCost >= 0.01)
         {
             var reason = stmt.NonParallelPlanReason switch
             {
@@ -140,7 +142,7 @@ public static partial class PlanAnalyzer
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF cost in this statement: {stmt.QueryUdfElapsedTimeMs:N0}ms elapsed, {stmt.QueryUdfCpuTimeMs:N0}ms CPU. Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump results to a #temp table and apply the UDF only to the final result set.",
+                Message = $"Scalar UDF cost in this statement: {stmt.QueryUdfElapsedTimeMs:N0}ms elapsed, {stmt.QueryUdfCpuTimeMs:N0}ms CPU. Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = stmt.QueryUdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
@@ -148,7 +150,8 @@ public static partial class PlanAnalyzer
         // Rule 20: Local variables without RECOMPILE
         // Parameters with no CompiledValue are likely local variables — the optimizer
         // cannot sniff their values and uses density-based ("unknown") estimates.
-        if (stmt.Parameters.Count > 0)
+        // Skip trivial statements (simple variable assignments) where estimate quality doesn't matter.
+        if (stmt.Parameters.Count > 0 && stmt.StatementSubTreeCost >= 0.01)
         {
             var unsnifffedParams = stmt.Parameters
                 .Where(p => string.IsNullOrEmpty(p.CompiledValue))
@@ -352,21 +355,42 @@ public static partial class PlanAnalyzer
     {
         // Rule 1: Filter operators — rows survived the tree just to be discarded
         // Quantify the impact by summing child subtree cost (reads, CPU, time).
-        if (node.PhysicalOp == "Filter" && !string.IsNullOrEmpty(node.Predicate))
+        // Suppress when the filter's child subtree is trivial (low I/O, fast, cheap).
+        if (node.PhysicalOp == "Filter" && !string.IsNullOrEmpty(node.Predicate)
+            && node.Children.Count > 0)
         {
-            var impact = QuantifyFilterImpact(node);
-            var predicate = Truncate(node.Predicate, 200);
-            var message = "Filter operator discarding rows late in the plan.";
-            if (!string.IsNullOrEmpty(impact))
-                message += $"\n{impact}";
-            message += $"\nPredicate: {predicate}";
-
-            node.Warnings.Add(new PlanWarning
+            // Gate: skip trivial filters based on actual stats or estimated cost
+            bool isTrivial;
+            if (node.HasActualStats)
             {
-                WarningType = "Filter Operator",
-                Message = message,
-                Severity = PlanWarningSeverity.Warning
-            });
+                long childReads = 0;
+                foreach (var child in node.Children)
+                    childReads += SumSubtreeReads(child);
+                var childElapsed = node.Children.Max(c => c.ActualElapsedMs);
+                isTrivial = childReads < 128 && childElapsed < 10;
+            }
+            else
+            {
+                var childCost = node.Children.Sum(c => c.EstimatedTotalSubtreeCost);
+                isTrivial = childCost < 1.0;
+            }
+
+            if (!isTrivial)
+            {
+                var impact = QuantifyFilterImpact(node);
+                var predicate = Truncate(node.Predicate, 200);
+                var message = "Filter operator discarding rows late in the plan.";
+                if (!string.IsNullOrEmpty(impact))
+                    message += $"\n{impact}";
+                message += $"\nPredicate: {predicate}";
+
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Filter Operator",
+                    Message = message,
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
         }
 
         // Rule 2: Eager Index Spools — optimizer building temporary indexes on the fly
@@ -391,7 +415,7 @@ public static partial class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF executing on this operator ({node.UdfElapsedTimeMs:N0}ms elapsed, {node.UdfCpuTimeMs:N0}ms CPU). Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump the query results to a #temp table first and apply the UDF only to the final result set.",
+                Message = $"Scalar UDF executing on this operator ({node.UdfElapsedTimeMs:N0}ms elapsed, {node.UdfCpuTimeMs:N0}ms CPU). Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = node.UdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
@@ -451,7 +475,7 @@ public static partial class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Scalar UDF",
-                Message = $"Scalar {type} UDF: {udf.FunctionName}. Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump results to a #temp table and apply the UDF only to the final result set.",
+                Message = $"Scalar {type} UDF: {udf.FunctionName}. Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -830,12 +854,17 @@ public static partial class PlanAnalyzer
             node.EstimateRowsWithoutRowGoal > node.EstimateRows)
         {
             var reduction = node.EstimateRowsWithoutRowGoal / node.EstimateRows;
-            node.Warnings.Add(new PlanWarning
+            // Require at least a 2x reduction to be worth mentioning — "1 to 1" or
+            // tiny floating-point differences that display identically are noise
+            if (reduction >= 2.0)
             {
-                WarningType = "Row Goal",
-                Message = $"Row goal active: estimate reduced from {node.EstimateRowsWithoutRowGoal:N0} to {node.EstimateRows:N0} ({reduction:N0}x reduction) due to TOP, EXISTS, IN, or FAST hint. The optimizer chose this plan shape expecting to stop reading early. If the query reads all rows anyway, the plan choice may be suboptimal.",
-                Severity = PlanWarningSeverity.Info
-            });
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Row Goal",
+                    Message = $"Row goal active: estimate reduced from {node.EstimateRowsWithoutRowGoal:N0} to {node.EstimateRows:N0} ({reduction:N0}x reduction) due to TOP, EXISTS, IN, or FAST hint. The optimizer chose this plan shape expecting to stop reading early. If the query reads all rows anyway, the plan choice may be suboptimal.",
+                    Severity = PlanWarningSeverity.Info
+                });
+            }
         }
 
         // Rule 28: Row Count Spool — NOT IN with nullable column
@@ -1065,6 +1094,13 @@ public static partial class PlanAnalyzer
         // Walk up to Nested Loops
         parent = parent.Parent;
         if (parent == null || parent.PhysicalOp != "Nested Loops")
+            return false;
+
+        // If this Nested Loops is inside an Anti/Semi Join, this is a NOT IN/IN
+        // subquery pattern (Merge Interval optimizing range lookups), not an OR expansion
+        var nlParent = parent.Parent;
+        if (nlParent != null && nlParent.LogicalOp != null &&
+            nlParent.LogicalOp.Contains("Semi"))
             return false;
 
         return true;

--- a/Dashboard/Services/ShowPlanParser.cs
+++ b/Dashboard/Services/ShowPlanParser.cs
@@ -1632,7 +1632,8 @@ public static class ShowPlanParser
             });
         }
 
-        // Memory grant warning
+        // Memory grant warning (from plan XML) — gate at 1 GB to avoid noise on small grants
+        // All values are in KB, consistent with MemoryGrantInfo element
         var memWarnEl = warningsEl.Element(Ns + "MemoryGrantWarning");
         if (memWarnEl != null)
         {
@@ -1640,12 +1641,17 @@ public static class ShowPlanParser
             var requested = ParseLong(memWarnEl.Attribute("RequestedMemory")?.Value);
             var granted = ParseLong(memWarnEl.Attribute("GrantedMemory")?.Value);
             var maxUsed = ParseLong(memWarnEl.Attribute("MaxUsedMemory")?.Value);
-            result.Add(new PlanWarning
+            if (granted >= 1048576) // 1 GB in KB
             {
-                WarningType = "Memory Grant",
-                Message = $"{kind}: Requested {requested:N0} KB, Granted {granted:N0} KB, Used {maxUsed:N0} KB",
-                Severity = PlanWarningSeverity.Warning
-            });
+                var grantedMB = granted / 1024.0;
+                var usedMB = maxUsed / 1024.0;
+                result.Add(new PlanWarning
+                {
+                    WarningType = "Memory Grant",
+                    Message = $"{kind}: Granted {grantedMB:N0} MB, Used {usedMB:N0} MB",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
         }
 
         // Implicit conversions

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -38,7 +38,9 @@ public static partial class PlanAnalyzer
     private static void AnalyzeStatement(PlanStatement stmt)
     {
         // Rule 3: Serial plan with reason
-        if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason))
+        // Skip trivial statements (e.g., variable assignments, constant scans) — not worth warning about
+        if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason)
+            && stmt.StatementSubTreeCost >= 0.01)
         {
             var reason = stmt.NonParallelPlanReason switch
             {
@@ -140,7 +142,7 @@ public static partial class PlanAnalyzer
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF cost in this statement: {stmt.QueryUdfElapsedTimeMs:N0}ms elapsed, {stmt.QueryUdfCpuTimeMs:N0}ms CPU. Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump results to a #temp table and apply the UDF only to the final result set.",
+                Message = $"Scalar UDF cost in this statement: {stmt.QueryUdfElapsedTimeMs:N0}ms elapsed, {stmt.QueryUdfCpuTimeMs:N0}ms CPU. Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = stmt.QueryUdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
@@ -148,7 +150,8 @@ public static partial class PlanAnalyzer
         // Rule 20: Local variables without RECOMPILE
         // Parameters with no CompiledValue are likely local variables — the optimizer
         // cannot sniff their values and uses density-based ("unknown") estimates.
-        if (stmt.Parameters.Count > 0)
+        // Skip trivial statements (simple variable assignments) where estimate quality doesn't matter.
+        if (stmt.Parameters.Count > 0 && stmt.StatementSubTreeCost >= 0.01)
         {
             var unsnifffedParams = stmt.Parameters
                 .Where(p => string.IsNullOrEmpty(p.CompiledValue))
@@ -352,21 +355,42 @@ public static partial class PlanAnalyzer
     {
         // Rule 1: Filter operators — rows survived the tree just to be discarded
         // Quantify the impact by summing child subtree cost (reads, CPU, time).
-        if (node.PhysicalOp == "Filter" && !string.IsNullOrEmpty(node.Predicate))
+        // Suppress when the filter's child subtree is trivial (low I/O, fast, cheap).
+        if (node.PhysicalOp == "Filter" && !string.IsNullOrEmpty(node.Predicate)
+            && node.Children.Count > 0)
         {
-            var impact = QuantifyFilterImpact(node);
-            var predicate = Truncate(node.Predicate, 200);
-            var message = "Filter operator discarding rows late in the plan.";
-            if (!string.IsNullOrEmpty(impact))
-                message += $"\n{impact}";
-            message += $"\nPredicate: {predicate}";
-
-            node.Warnings.Add(new PlanWarning
+            // Gate: skip trivial filters based on actual stats or estimated cost
+            bool isTrivial;
+            if (node.HasActualStats)
             {
-                WarningType = "Filter Operator",
-                Message = message,
-                Severity = PlanWarningSeverity.Warning
-            });
+                long childReads = 0;
+                foreach (var child in node.Children)
+                    childReads += SumSubtreeReads(child);
+                var childElapsed = node.Children.Max(c => c.ActualElapsedMs);
+                isTrivial = childReads < 128 && childElapsed < 10;
+            }
+            else
+            {
+                var childCost = node.Children.Sum(c => c.EstimatedTotalSubtreeCost);
+                isTrivial = childCost < 1.0;
+            }
+
+            if (!isTrivial)
+            {
+                var impact = QuantifyFilterImpact(node);
+                var predicate = Truncate(node.Predicate, 200);
+                var message = "Filter operator discarding rows late in the plan.";
+                if (!string.IsNullOrEmpty(impact))
+                    message += $"\n{impact}";
+                message += $"\nPredicate: {predicate}";
+
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Filter Operator",
+                    Message = message,
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
         }
 
         // Rule 2: Eager Index Spools — optimizer building temporary indexes on the fly
@@ -391,7 +415,7 @@ public static partial class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "UDF Execution",
-                Message = $"Scalar UDF executing on this operator ({node.UdfElapsedTimeMs:N0}ms elapsed, {node.UdfCpuTimeMs:N0}ms CPU). Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump the query results to a #temp table first and apply the UDF only to the final result set.",
+                Message = $"Scalar UDF executing on this operator ({node.UdfElapsedTimeMs:N0}ms elapsed, {node.UdfCpuTimeMs:N0}ms CPU). Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = node.UdfElapsedTimeMs >= 1000 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
@@ -451,7 +475,7 @@ public static partial class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Scalar UDF",
-                Message = $"Scalar {type} UDF: {udf.FunctionName}. Scalar UDFs run once per row and prevent parallelism. Rewrite as an inline table-valued function, or dump results to a #temp table and apply the UDF only to the final result set.",
+                Message = $"Scalar {type} UDF: {udf.FunctionName}. Scalar UDFs run once per row and prevent parallelism. Options: rewrite as an inline table-valued function, assign the result to a variable if only one row is needed, dump results to a #temp table and apply the UDF to the final result set, or on SQL Server 2019+ check if the UDF is eligible for automatic scalar UDF inlining.",
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -829,12 +853,17 @@ public static partial class PlanAnalyzer
             node.EstimateRowsWithoutRowGoal > node.EstimateRows)
         {
             var reduction = node.EstimateRowsWithoutRowGoal / node.EstimateRows;
-            node.Warnings.Add(new PlanWarning
+            // Require at least a 2x reduction to be worth mentioning — "1 to 1" or
+            // tiny floating-point differences that display identically are noise
+            if (reduction >= 2.0)
             {
-                WarningType = "Row Goal",
-                Message = $"Row goal active: estimate reduced from {node.EstimateRowsWithoutRowGoal:N0} to {node.EstimateRows:N0} ({reduction:N0}x reduction) due to TOP, EXISTS, IN, or FAST hint. The optimizer chose this plan shape expecting to stop reading early. If the query reads all rows anyway, the plan choice may be suboptimal.",
-                Severity = PlanWarningSeverity.Info
-            });
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Row Goal",
+                    Message = $"Row goal active: estimate reduced from {node.EstimateRowsWithoutRowGoal:N0} to {node.EstimateRows:N0} ({reduction:N0}x reduction) due to TOP, EXISTS, IN, or FAST hint. The optimizer chose this plan shape expecting to stop reading early. If the query reads all rows anyway, the plan choice may be suboptimal.",
+                    Severity = PlanWarningSeverity.Info
+                });
+            }
         }
 
         // Rule 28: Row Count Spool — NOT IN with nullable column
@@ -1064,6 +1093,13 @@ public static partial class PlanAnalyzer
         // Walk up to Nested Loops
         parent = parent.Parent;
         if (parent == null || parent.PhysicalOp != "Nested Loops")
+            return false;
+
+        // If this Nested Loops is inside an Anti/Semi Join, this is a NOT IN/IN
+        // subquery pattern (Merge Interval optimizing range lookups), not an OR expansion
+        var nlParent = parent.Parent;
+        if (nlParent != null && nlParent.LogicalOp != null &&
+            nlParent.LogicalOp.Contains("Semi"))
             return false;
 
         return true;

--- a/Lite/Services/ShowPlanParser.cs
+++ b/Lite/Services/ShowPlanParser.cs
@@ -1632,7 +1632,8 @@ public static class ShowPlanParser
             });
         }
 
-        // Memory grant warning
+        // Memory grant warning (from plan XML) — gate at 1 GB to avoid noise on small grants
+        // All values are in KB, consistent with MemoryGrantInfo element
         var memWarnEl = warningsEl.Element(Ns + "MemoryGrantWarning");
         if (memWarnEl != null)
         {
@@ -1640,12 +1641,17 @@ public static class ShowPlanParser
             var requested = ParseLong(memWarnEl.Attribute("RequestedMemory")?.Value);
             var granted = ParseLong(memWarnEl.Attribute("GrantedMemory")?.Value);
             var maxUsed = ParseLong(memWarnEl.Attribute("MaxUsedMemory")?.Value);
-            result.Add(new PlanWarning
+            if (granted >= 1048576) // 1 GB in KB
             {
-                WarningType = "Memory Grant",
-                Message = $"{kind}: Requested {requested:N0} KB, Granted {granted:N0} KB, Used {maxUsed:N0} KB",
-                Severity = PlanWarningSeverity.Warning
-            });
+                var grantedMB = granted / 1024.0;
+                var usedMB = maxUsed / 1024.0;
+                result.Add(new PlanWarning
+                {
+                    WarningType = "Memory Grant",
+                    Message = $"{kind}: Granted {grantedMB:N0} MB, Used {usedMB:N0} MB",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
         }
 
         // Implicit conversions


### PR DESCRIPTION
## Summary
Ports false positive fixes and warning improvements from PerformanceStudio issue #178 (community feedback).

**Rule changes (applied identically to Dashboard and Lite):**
- Rule 1 (Filter): Suppress trivial filters — actual: < 128 reads AND < 10ms; estimated: cost < 1.0
- Rule 3 (Serial Plan): Skip trivial statements (cost < 0.01) — stops warning on 0ms variable assignments
- Rule 15 (Join OR): Exclude Merge Interval inside anti/semi joins — fixes NOT IN false positive
- Rule 20 (Local Variables): Skip trivial statements (cost < 0.01)
- Rule 26 (Row Goal): Require >= 2x reduction — suppresses "1 to 1 (1x reduction)" noise
- ShowPlanParser: Gate XML MemoryGrantWarning at 1 GB — stops noise on small grants
- Scalar UDF: Expanded advice — variable assignment, SQL 2019+ automatic inlining

## Test plan
- [x] Build succeeds (0 errors)
- [x] 257/257 Lite tests pass
- [x] Dashboard and Lite copies are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)