### PR TITLE
Refine Rule 3: TRIVIAL, 0ms elapsed, severity demotion

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -38,9 +38,12 @@ public static partial class PlanAnalyzer
     private static void AnalyzeStatement(PlanStatement stmt)
     {
         // Rule 3: Serial plan with reason
-        // Skip trivial statements (e.g., variable assignments, constant scans) — not worth warning about
+        // Skip: trivial cost (< 0.01), TRIVIAL optimization (can't go parallel anyway),
+        // and 0ms actual elapsed time (not worth flagging).
         if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason)
-            && stmt.StatementSubTreeCost >= 0.01)
+            && stmt.StatementSubTreeCost >= 0.01
+            && stmt.StatementOptmLevel != "TRIVIAL"
+            && !(stmt.QueryTimeStats != null && stmt.QueryTimeStats.ElapsedTimeMs == 0))
         {
             var reason = stmt.NonParallelPlanReason switch
             {
@@ -52,11 +55,13 @@ public static partial class PlanAnalyzer
                 _ => stmt.NonParallelPlanReason
             };
 
+            var isExplicit = stmt.NonParallelPlanReason is "MaxDOPSetToOne" or "QueryHintNoParallelSet";
+
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "Serial Plan",
                 Message = $"Query running serially: {reason}.",
-                Severity = PlanWarningSeverity.Warning
+                Severity = isExplicit ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
             });
         }
 

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -38,9 +38,12 @@ public static partial class PlanAnalyzer
     private static void AnalyzeStatement(PlanStatement stmt)
     {
         // Rule 3: Serial plan with reason
-        // Skip trivial statements (e.g., variable assignments, constant scans) — not worth warning about
+        // Skip: trivial cost (< 0.01), TRIVIAL optimization (can't go parallel anyway),
+        // and 0ms actual elapsed time (not worth flagging).
         if (!string.IsNullOrEmpty(stmt.NonParallelPlanReason)
-            && stmt.StatementSubTreeCost >= 0.01)
+            && stmt.StatementSubTreeCost >= 0.01
+            && stmt.StatementOptmLevel != "TRIVIAL"
+            && !(stmt.QueryTimeStats != null && stmt.QueryTimeStats.ElapsedTimeMs == 0))
         {
             var reason = stmt.NonParallelPlanReason switch
             {
@@ -52,11 +55,13 @@ public static partial class PlanAnalyzer
                 _ => stmt.NonParallelPlanReason
             };
 
+            var isExplicit = stmt.NonParallelPlanReason is "MaxDOPSetToOne" or "QueryHintNoParallelSet";
+
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "Serial Plan",
                 Message = $"Query running serially: {reason}.",
-                Severity = PlanWarningSeverity.Warning
+                Severity = isExplicit ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
             });
         }
 


### PR DESCRIPTION
## Summary
- Suppress serial plan warning for TRIVIAL optimization (can't go parallel anyway)
- Suppress when actual elapsed is 0ms (not worth flagging)
- Demote to Info unless user explicitly forced serial (MAXDOP 1 / query hint)

Ported from PerformanceStudio #178 round 2 feedback.

## Test plan
- [x] Build succeeds (0 errors)
- [x] Dashboard and Lite copies identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)