### PR TITLE
Add before/after comparison mode for query grids (#687)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -572,10 +572,15 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <local:TimeRangeSlicerControl x:Name="QueryStatsSlicer" Grid.Row="0"/>
-            <DataGrid Grid.Row="1" x:Name="QueryStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                <TextBlock x:Name="QueryStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                           Padding="8,4" FontWeight="Bold"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           Background="#2244AAFF"/>
+            <DataGrid Grid.Row="2" x:Name="QueryStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
@@ -862,6 +867,44 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
+            <DataGrid Grid.Row="2" x:Name="QueryStatsComparisonGrid" Visibility="Collapsed"
+                      AutoGenerateColumns="False" IsReadOnly="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowStyle="{DynamicResource DefaultRowStyle}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock"><Setter Property="FontWeight" Value="Bold"/><Setter Property="HorizontalAlignment" Value="Center"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsNew}" Value="True"><Setter Property="Foreground" Value="#FF6B6B"/></DataTrigger>
+                                    <DataTrigger Binding="{Binding IsGone}" Value="True"><Setter Property="Foreground" Value="#888888"/></DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120"><DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"><DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"><DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding QueryHash}" Width="140"><DataGridTextColumn.Header><TextBlock Text="Query Hash" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTemplateColumn Width="500"><DataGridTemplateColumn.Header><TextBlock Text="Query Text" FontWeight="Bold"/></DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate><DataTemplate><TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/></DataTemplate></DataGridTemplateColumn.CellTemplate></DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
             <TextBlock x:Name="QueryStatsNoDataMessage" Style="{StaticResource EmptyStateMessage}"
                        Text="No query statistics in selected time range"/>
             <local:LoadingOverlay x:Name="QueryStatsLoading"/>
@@ -873,10 +916,15 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <local:TimeRangeSlicerControl x:Name="ProcStatsSlicer" Grid.Row="0"/>
-            <DataGrid Grid.Row="1" x:Name="ProcStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                <TextBlock x:Name="ProcStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                           Padding="8,4" FontWeight="Bold"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           Background="#2244AAFF"/>
+            <DataGrid Grid.Row="2" x:Name="ProcStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
@@ -1134,6 +1182,42 @@
                     </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
+            <DataGrid Grid.Row="2" x:Name="ProcStatsComparisonGrid" Visibility="Collapsed"
+                      AutoGenerateColumns="False" IsReadOnly="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowStyle="{DynamicResource DefaultRowStyle}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock"><Setter Property="FontWeight" Value="Bold"/><Setter Property="HorizontalAlignment" Value="Center"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsNew}" Value="True"><Setter Property="Foreground" Value="#FF6B6B"/></DataTrigger>
+                                    <DataTrigger Binding="{Binding IsGone}" Value="True"><Setter Property="Foreground" Value="#888888"/></DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120"><DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding FullName}" Width="200"><DataGridTextColumn.Header><TextBlock Text="Procedure" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"><DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"><DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                </DataGrid.Columns>
+            </DataGrid>
             <TextBlock x:Name="ProcStatsNoDataMessage" Style="{StaticResource NoDataMessage}"/>
             </Grid>
         </TabItem>
@@ -1143,10 +1227,15 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <local:TimeRangeSlicerControl x:Name="QueryStoreSlicer" Grid.Row="0"/>
-            <DataGrid Grid.Row="1" x:Name="QueryStoreDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                <TextBlock x:Name="QueryStoreComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                           Padding="8,4" FontWeight="Bold"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           Background="#2244AAFF"/>
+            <DataGrid Grid.Row="2" x:Name="QueryStoreDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
                       RowStyle="{DynamicResource DefaultRowStyle}"
@@ -1543,6 +1632,44 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+            <DataGrid Grid.Row="2" x:Name="QueryStoreComparisonGrid" Visibility="Collapsed"
+                      AutoGenerateColumns="False" IsReadOnly="True"
+                      GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                      RowStyle="{DynamicResource DefaultRowStyle}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock"><Setter Property="FontWeight" Value="Bold"/><Setter Property="HorizontalAlignment" Value="Center"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsNew}" Value="True"><Setter Property="Foreground" Value="#FF6B6B"/></DataTrigger>
+                                    <DataTrigger Binding="{Binding IsGone}" Value="True"><Setter Property="Foreground" Value="#888888"/></DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120"><DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"><DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"><DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"><DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80"><DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle></DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding QueryHash}" Width="140"><DataGridTextColumn.Header><TextBlock Text="Query Hash" FontWeight="Bold"/></DataGridTextColumn.Header></DataGridTextColumn>
+                    <DataGridTemplateColumn Width="500"><DataGridTemplateColumn.Header><TextBlock Text="Query Text" FontWeight="Bold"/></DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate><DataTemplate><TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2" ToolTip="{Binding QueryText}"/></DataTemplate></DataGridTemplateColumn.CellTemplate></DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock x:Name="QueryStoreNoDataMessage" Style="{StaticResource NoDataMessage}"/>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -60,6 +60,9 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>Raised when a drill-down needs the parent to set custom time pickers. Args: (fromUtc, toUtc)</summary>
         public event Action<DateTime, DateTime>? DrillDownTimeRangeRequested;
 
+        /// <summary>Fired when the Queries sub-tab changes, so the global Compare dropdown can update.</summary>
+        public event Action? SubTabChanged;
+
         private CancellationTokenSource? _actualPlanCts;
 
         /// <summary>Cancels the in-flight actual plan execution, if any.</summary>
@@ -157,7 +160,14 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartSaveMenus();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-            SubTabControl.SelectionChanged += (s, e) => { if (e.Source == SubTabControl) _isDrillDownActive = false; };
+            SubTabControl.SelectionChanged += (s, e) =>
+            {
+                if (e.Source == SubTabControl)
+                {
+                    _isDrillDownActive = false;
+                    SubTabChanged?.Invoke();
+                }
+            };
             Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
 
             _queryDurationHover = new Helpers.ChartHoverHelper(QueryPerfTrendsQueryChart, "ms/sec");
@@ -722,6 +732,140 @@ namespace PerformanceMonitorDashboard.Controls
         /// Sets the time range for all sub-tabs.
         /// </summary>
         public void SelectSubTab(int index) => SubTabControl.SelectedIndex = index;
+
+        private (DateTime From, DateTime To)? _comparisonRange;
+
+        public void SetComparisonRange((DateTime From, DateTime To)? range)
+        {
+            _comparisonRange = range;
+        }
+
+        public async Task RefreshComparisonAsync()
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                var currentEnd = _queryStatsToDate ?? DateTime.UtcNow;
+                var currentStart = _queryStatsFromDate ?? currentEnd.AddHours(-_queryStatsHoursBack);
+
+                await RefreshQueryStatsComparisonAsync(currentStart, currentEnd);
+                await RefreshProcStatsComparisonAsync(currentStart, currentEnd);
+                await RefreshQueryStoreComparisonAsync(currentStart, currentEnd);
+            }
+            catch (Exception ex)
+            {
+                _statusCallback?.Invoke($"Comparison failed: {ex.Message}");
+            }
+        }
+
+        private void SetQueryStatsComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+        {
+            QueryStatsDataGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+            QueryStatsComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+            QueryStatsComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+            if (active && baselineRange.HasValue)
+            {
+                var from = baselineRange.Value.From.ToString("yyyy-MM-dd HH:mm");
+                var to = baselineRange.Value.To.ToString("yyyy-MM-dd HH:mm");
+                QueryStatsComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+            }
+        }
+
+        private async Task RefreshQueryStatsComparisonAsync(DateTime currentStart, DateTime currentEnd)
+        {
+            if (_comparisonRange == null)
+            {
+                SetQueryStatsComparisonMode(false);
+                return;
+            }
+
+            SetQueryStatsComparisonMode(true, _comparisonRange);
+
+            var items = await _databaseService!.GetQueryStatsComparisonAsync(
+                currentStart, currentEnd,
+                _comparisonRange.Value.From, _comparisonRange.Value.To);
+
+            var sorted = items
+                .OrderBy(x => x.SortGroup)
+                .ThenByDescending(x => x.SortableDurationDelta)
+                .ToList();
+
+            QueryStatsComparisonGrid.ItemsSource = sorted;
+        }
+
+        private void SetProcStatsComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+        {
+            ProcStatsDataGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+            ProcStatsComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+            ProcStatsComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+            if (active && baselineRange.HasValue)
+            {
+                var from = baselineRange.Value.From.ToString("yyyy-MM-dd HH:mm");
+                var to = baselineRange.Value.To.ToString("yyyy-MM-dd HH:mm");
+                ProcStatsComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+            }
+        }
+
+        private async Task RefreshProcStatsComparisonAsync(DateTime currentStart, DateTime currentEnd)
+        {
+            if (_comparisonRange == null)
+            {
+                SetProcStatsComparisonMode(false);
+                return;
+            }
+
+            SetProcStatsComparisonMode(true, _comparisonRange);
+
+            var items = await _databaseService!.GetProcedureStatsComparisonAsync(
+                currentStart, currentEnd,
+                _comparisonRange.Value.From, _comparisonRange.Value.To);
+
+            var sorted = items
+                .OrderBy(x => x.SortGroup)
+                .ThenByDescending(x => x.SortableDurationDelta)
+                .ToList();
+
+            ProcStatsComparisonGrid.ItemsSource = sorted;
+        }
+
+        private void SetQueryStoreComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+        {
+            QueryStoreDataGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+            QueryStoreComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+            QueryStoreComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+            if (active && baselineRange.HasValue)
+            {
+                var from = baselineRange.Value.From.ToString("yyyy-MM-dd HH:mm");
+                var to = baselineRange.Value.To.ToString("yyyy-MM-dd HH:mm");
+                QueryStoreComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+            }
+        }
+
+        private async Task RefreshQueryStoreComparisonAsync(DateTime currentStart, DateTime currentEnd)
+        {
+            if (_comparisonRange == null)
+            {
+                SetQueryStoreComparisonMode(false);
+                return;
+            }
+
+            SetQueryStoreComparisonMode(true, _comparisonRange);
+
+            var items = await _databaseService!.GetQueryStoreComparisonAsync(
+                currentStart, currentEnd,
+                _comparisonRange.Value.From, _comparisonRange.Value.To);
+
+            var sorted = items
+                .OrderBy(x => x.SortGroup)
+                .ThenByDescending(x => x.SortableDurationDelta)
+                .ToList();
+
+            QueryStoreComparisonGrid.ItemsSource = sorted;
+        }
 
         public void SetTimeRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
         {

--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -29,18 +29,6 @@
         <!-- Server Trends Sub-Tab — Correlated Timeline Lanes -->
         <TabItem Header="Server Trends">
             <DockPanel>
-                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="8,4,8,0">
-                    <TextBlock Text="Compare:" VerticalAlignment="Center" Margin="0,0,4,0"
-                               Foreground="{DynamicResource ForegroundBrush}"/>
-                    <ComboBox x:Name="CompareToCombo" SelectedIndex="0" Width="150"
-                              SelectionChanged="CompareToCombo_SelectionChanged"
-                              ToolTip="Overlay a reference period on the timeline charts">
-                        <ComboBoxItem Content="None"/>
-                        <ComboBoxItem Content="Yesterday"/>
-                        <ComboBoxItem Content="Last week"/>
-                        <ComboBoxItem Content="Same day last week"/>
-                    </ComboBox>
-                </StackPanel>
                 <local:CorrelatedTimelineLanesControl x:Name="CorrelatedLanes"/>
             </DockPanel>
         </TabItem>

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -1025,33 +1025,15 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Server Trends Tab
 
-        private async void CompareToCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (!IsLoaded) return;
-            ComparisonRange = GetComparisonRange();
-            await RefreshServerTrendsAsync();
-        }
-
         private (DateTime From, DateTime To)? ComparisonRange { get; set; }
 
         /// <summary>
-        /// Computes the reference time range for the comparison overlay.
-        /// Returns null if "None" is selected.
+        /// Sets the comparison range from the global Compare dropdown and refreshes Server Trends.
         /// </summary>
-        private (DateTime From, DateTime To)? GetComparisonRange()
+        public async Task SetComparisonRangeAsync((DateTime From, DateTime To)? range)
         {
-            if (CompareToCombo == null || CompareToCombo.SelectedIndex <= 0) return null;
-
-            var currentEnd = _serverTrendsToDate ?? DateTime.UtcNow;
-            var currentStart = _serverTrendsFromDate ?? currentEnd.AddHours(-_serverTrendsHoursBack);
-
-            return CompareToCombo.SelectedIndex switch
-            {
-                1 => (currentStart.AddDays(-1), currentEnd.AddDays(-1)),   // Yesterday
-                2 => (currentStart.AddDays(-7), currentEnd.AddDays(-7)),   // Last week
-                3 => (currentStart.AddDays(-7), currentEnd.AddDays(-7)),   // Same day last week
-                _ => null
-            };
+            ComparisonRange = range;
+            await RefreshServerTrendsAsync();
         }
 
         private async Task RefreshServerTrendsAsync()

--- a/Dashboard/Models/ComparisonItemBase.cs
+++ b/Dashboard/Models/ComparisonItemBase.cs
@@ -1,0 +1,80 @@
+using System.Windows.Media;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    public abstract class ComparisonItemBase
+    {
+        public string DatabaseName { get; set; } = "";
+
+        // Current period
+        public long ExecutionCount { get; set; }
+        public double AvgDurationMs { get; set; }
+        public double AvgCpuMs { get; set; }
+        public double AvgReads { get; set; }
+
+        // Baseline period
+        public long BaselineExecutionCount { get; set; }
+        public double BaselineAvgDurationMs { get; set; }
+        public double BaselineAvgCpuMs { get; set; }
+        public double BaselineAvgReads { get; set; }
+
+        // Flags
+        public bool IsNew => ExecutionCount > 0 && BaselineExecutionCount == 0;
+        public bool IsGone => ExecutionCount == 0 && BaselineExecutionCount > 0;
+
+        // Delta percentages (null when baseline is zero or item is new/gone)
+        public double? DurationDeltaPct => ComputeDelta(AvgDurationMs, BaselineAvgDurationMs);
+        public double? CpuDeltaPct => ComputeDelta(AvgCpuMs, BaselineAvgCpuMs);
+        public double? ReadsDeltaPct => ComputeDelta(AvgReads, BaselineAvgReads);
+        public double? ExecutionDeltaPct => ComputeDelta(ExecutionCount, BaselineExecutionCount);
+
+        // Display helpers for grid binding
+        public string DurationDeltaDisplay => FormatDelta(DurationDeltaPct);
+        public string CpuDeltaDisplay => FormatDelta(CpuDeltaPct);
+        public string ReadsDeltaDisplay => FormatDelta(ReadsDeltaPct);
+        public string ExecutionDeltaDisplay => FormatDelta(ExecutionDeltaPct);
+
+        public string StatusBadge => IsNew ? "NEW" : IsGone ? "GONE" : "";
+
+        // Sort key: NEW at top (0), normal by delta (1), GONE at bottom (2)
+        public int SortGroup => IsNew ? 0 : IsGone ? 2 : 1;
+        public double SortableDurationDelta => DurationDeltaPct ?? (IsNew ? double.MaxValue : double.MinValue);
+
+        // Color brushes for delta columns (red = regression, green = improvement)
+        public Brush DurationDeltaBrush => GetDeltaBrush(DurationDeltaPct, 25);
+        public Brush CpuDeltaBrush => GetDeltaBrush(CpuDeltaPct, 25);
+        public Brush ReadsDeltaBrush => GetDeltaBrush(ReadsDeltaPct, 50, 25);
+        public Brush ExecutionDeltaBrush => GetDeltaBrush(ExecutionDeltaPct, 100, 50);
+
+        private static readonly Brush RedBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x6B, 0x6B));
+        private static readonly Brush GreenBrush = new SolidColorBrush(Color.FromRgb(0x4E, 0xC9, 0xB0));
+        private static readonly Brush NeutralBrush = Brushes.Transparent;
+
+        static ComparisonItemBase()
+        {
+            RedBrush.Freeze();
+            GreenBrush.Freeze();
+        }
+
+        private static Brush GetDeltaBrush(double? delta, double redThreshold, double greenThreshold = 25)
+        {
+            if (!delta.HasValue) return NeutralBrush;
+            if (delta.Value > redThreshold) return RedBrush;
+            if (delta.Value < -greenThreshold) return GreenBrush;
+            return NeutralBrush;
+        }
+
+        private static double? ComputeDelta(double current, double baseline)
+        {
+            if (baseline == 0) return null;
+            return (current - baseline) / baseline * 100.0;
+        }
+
+        private static string FormatDelta(double? delta)
+        {
+            if (!delta.HasValue) return "\u2014";
+            var sign = delta.Value >= 0 ? "+" : "";
+            return $"{sign}{delta.Value:N1}%";
+        }
+    }
+}

--- a/Dashboard/Models/ProcedureStatsComparisonItem.cs
+++ b/Dashboard/Models/ProcedureStatsComparisonItem.cs
@@ -1,0 +1,9 @@
+namespace PerformanceMonitorDashboard.Models
+{
+    public class ProcedureStatsComparisonItem : ComparisonItemBase
+    {
+        public string SchemaName { get; set; } = "";
+        public string ObjectName { get; set; } = "";
+        public string FullName => string.IsNullOrEmpty(SchemaName) ? ObjectName : $"{SchemaName}.{ObjectName}";
+    }
+}

--- a/Dashboard/Models/QueryStatsComparisonItem.cs
+++ b/Dashboard/Models/QueryStatsComparisonItem.cs
@@ -1,0 +1,11 @@
+namespace PerformanceMonitorDashboard.Models
+{
+    public class QueryStatsComparisonItem : ComparisonItemBase
+    {
+        public string QueryHash { get; set; } = "";
+        public string? ObjectName { get; set; }
+        public string? SchemaName { get; set; }
+        public string? ObjectType { get; set; }
+        public string QueryText { get; set; } = "";
+    }
+}

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -105,6 +105,16 @@
                         <ToggleButton x:Name="AutoRefreshToggle" Content="Auto-Refresh: Off" Click="AutoRefreshToggle_Click" Margin="8,0,2,0" Padding="12,5" MinWidth="130" ToolTip="Toggle auto-refresh on/off. Configure interval in Settings."/>
                         <Button Content="Edit Schedules" Click="EditSchedules_Click" Margin="8,0,2,0" Padding="12,5" Style="{DynamicResource AccentButton}" ToolTip="Edit collector schedules (frequency, retention, enabled/disabled)"/>
                         <TextBlock Text="|" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <TextBlock Text="Compare:" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ComboBox x:Name="CompareToCombo" SelectedIndex="0" Width="130" Margin="0,0,8,0"
+                                  SelectionChanged="CompareToCombo_SelectionChanged"
+                                  ToolTip="Compare current period against a baseline">
+                            <ComboBoxItem Content="None"/>
+                            <ComboBoxItem Content="Yesterday"/>
+                            <ComboBoxItem Content="Last week"/>
+                            <ComboBoxItem Content="Same day last week"/>
+                        </ComboBox>
+                        <TextBlock Text="|" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
                         <TextBlock Text="Times:" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
                         <ComboBox x:Name="TimeDisplayModeBox" Width="120" SelectionChanged="TimeDisplayMode_SelectionChanged" ToolTip="How timestamps are displayed across all tabs">
                             <ComboBoxItem Content="Server Time" Tag="ServerTime"/>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -157,6 +157,7 @@ namespace PerformanceMonitorDashboard
             {
                 SetDrillDownGlobalRange(from, to);
             };
+            PerformanceTab.SubTabChanged += () => UpdateCompareDropdownState();
             SystemEventsContent.Initialize(_databaseService);
             var baselineProvider = new Analysis.SqlServerBaselineProvider(_databaseService.ConnectionString);
             ResourceMetricsContent.Initialize(_databaseService, baselineProvider);
@@ -1639,6 +1640,8 @@ namespace PerformanceMonitorDashboard
             // Only handle events from the main DataTabControl, not from nested sub-tab controls
             if (e.Source != DataTabControl) return;
 
+            UpdateCompareDropdownState();
+
             // Don't refresh during initial load or if already refreshing
             if (_isRefreshing || !IsLoaded) return;
 
@@ -1677,6 +1680,76 @@ namespace PerformanceMonitorDashboard
             scheduleWindow.Owner = Window.GetWindow(this);
             scheduleWindow.ShowDialog();
         }
+
+        #region Global Compare Dropdown
+
+        private async void CompareToCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!IsLoaded || _isRefreshing) return;
+
+            var comparisonRange = GetComparisonRange();
+
+            try
+            {
+                // Feed comparison to Resource Metrics (Server Trends overlay)
+                await ResourceMetricsContent.SetComparisonRangeAsync(comparisonRange);
+
+                // Feed comparison to Query Performance grids
+                PerformanceTab.SetComparisonRange(comparisonRange);
+                await PerformanceTab.RefreshComparisonAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Comparison refresh failed: {ex.Message}", ex);
+            }
+        }
+
+        private (DateTime From, DateTime To)? GetComparisonRange()
+        {
+            if (CompareToCombo == null || CompareToCombo.SelectedIndex <= 0) return null;
+
+            var currentEnd = _globalToDate ?? DateTime.UtcNow;
+            var currentStart = _globalFromDate ?? currentEnd.AddHours(-_globalHoursBack);
+
+            return CompareToCombo.SelectedIndex switch
+            {
+                1 => (currentStart.AddDays(-1), currentEnd.AddDays(-1)),   // Yesterday
+                2 => (currentStart.AddDays(-7), currentEnd.AddDays(-7)),   // Last week
+                3 => (currentStart.AddDays(-7), currentEnd.AddDays(-7)),   // Same day last week
+                _ => null
+            };
+        }
+
+        private bool IsComparisonSupportedOnCurrentTab()
+        {
+            return DataTabControl.SelectedIndex switch
+            {
+                1 => PerformanceTab.SubTabControl.SelectedIndex is 3 or 4 or 5, // Query Stats / Proc Stats / Query Store
+                3 => true, // Resource Metrics — Server Trends overlay
+                _ => false
+            };
+        }
+
+        private void UpdateCompareDropdownState()
+        {
+            var supported = IsComparisonSupportedOnCurrentTab();
+
+            if (supported)
+            {
+                CompareToCombo.IsEnabled = true;
+                CompareToCombo.Opacity = 1.0;
+                CompareToCombo.ToolTip = "Compare current period against a baseline";
+            }
+            else
+            {
+                CompareToCombo.SelectedIndex = 0;
+                CompareToCombo.IsEnabled = false;
+                CompareToCombo.Opacity = 0.5;
+                CompareToCombo.ToolTip = "Comparison is not available for this tab";
+            }
+        }
+
+        #endregion
 
         private void TimeDisplayMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -3810,5 +3810,340 @@ ORDER BY
                 CellDetails = cellDetails
             };
         }
+
+        /// <summary>
+        /// Gets query stats comparison between a current time range and a baseline range.
+        /// Uses delta columns for accurate period-level aggregation.
+        /// </summary>
+        public async Task<List<Models.QueryStatsComparisonItem>> GetQueryStatsComparisonAsync(
+            DateTime currentStart, DateTime currentEnd,
+            DateTime baselineStart, DateTime baselineEnd)
+        {
+            var items = new List<Models.QueryStatsComparisonItem>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+;WITH top_hashes AS (
+    SELECT DISTINCT query_hash, database_name, object_name, schema_name, object_type
+    FROM (
+        SELECT TOP 100 query_hash, database_name, object_name, schema_name, object_type
+        FROM collect.query_stats
+        WHERE collection_time >= @currentStart AND collection_time <= @currentEnd
+        AND   execution_count_delta > 0
+        GROUP BY query_hash, database_name, object_name, schema_name, object_type
+        ORDER BY SUM(execution_count_delta) DESC
+        UNION
+        SELECT TOP 100 query_hash, database_name, object_name, schema_name, object_type
+        FROM collect.query_stats
+        WHERE collection_time >= @baselineStart AND collection_time <= @baselineEnd
+        AND   execution_count_delta > 0
+        GROUP BY query_hash, database_name, object_name, schema_name, object_type
+        ORDER BY SUM(execution_count_delta) DESC
+    ) AS combined
+),
+current_period AS (
+    SELECT th.database_name,
+           CONVERT(nvarchar(20), th.query_hash, 1) AS query_hash,
+           th.object_name, th.schema_name, th.object_type,
+           SUM(qs.execution_count_delta) AS exec_count,
+           SUM(qs.total_elapsed_time_delta) / NULLIF(SUM(qs.execution_count_delta), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.total_worker_time_delta) / NULLIF(SUM(qs.execution_count_delta), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.total_physical_reads_delta) / NULLIF(SUM(qs.execution_count_delta), 0) AS avg_reads,
+           LEFT(CAST(DECOMPRESS(MAX(qs.query_text)) AS nvarchar(max)), 500) AS query_text
+    FROM top_hashes th
+    INNER JOIN collect.query_stats qs
+      ON  qs.query_hash = th.query_hash
+      AND qs.database_name = th.database_name
+      AND ISNULL(qs.object_name, N'') = ISNULL(th.object_name, N'')
+    WHERE qs.collection_time >= @currentStart AND qs.collection_time <= @currentEnd
+    AND   qs.execution_count_delta > 0
+    GROUP BY th.database_name, th.query_hash, th.object_name, th.schema_name, th.object_type
+),
+baseline_period AS (
+    SELECT th.database_name,
+           CONVERT(nvarchar(20), th.query_hash, 1) AS query_hash,
+           th.object_name, th.schema_name, th.object_type,
+           SUM(qs.execution_count_delta) AS exec_count,
+           SUM(qs.total_elapsed_time_delta) / NULLIF(SUM(qs.execution_count_delta), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.total_worker_time_delta) / NULLIF(SUM(qs.execution_count_delta), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.total_physical_reads_delta) / NULLIF(SUM(qs.execution_count_delta), 0) AS avg_reads,
+           LEFT(CAST(DECOMPRESS(MAX(qs.query_text)) AS nvarchar(max)), 500) AS query_text
+    FROM top_hashes th
+    INNER JOIN collect.query_stats qs
+      ON  qs.query_hash = th.query_hash
+      AND qs.database_name = th.database_name
+      AND ISNULL(qs.object_name, N'') = ISNULL(th.object_name, N'')
+    WHERE qs.collection_time >= @baselineStart AND qs.collection_time <= @baselineEnd
+    AND   qs.execution_count_delta > 0
+    GROUP BY th.database_name, th.query_hash, th.object_name, th.schema_name, th.object_type
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.query_hash, b.query_hash) AS query_hash,
+       COALESCE(c.object_name, b.object_name) AS object_name,
+       COALESCE(c.schema_name, b.schema_name) AS schema_name,
+       COALESCE(c.object_type, b.object_type) AS object_type,
+       COALESCE(c.query_text, b.query_text) AS query_text,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  ISNULL(c.database_name, N'') = ISNULL(b.database_name, N'')
+  AND ISNULL(c.query_hash, N'') = ISNULL(b.query_hash, N'')
+  AND ISNULL(c.object_name, N'') = ISNULL(b.object_name, N'')
+  AND ISNULL(c.schema_name, N'') = ISNULL(b.schema_name, N'')
+  AND ISNULL(c.object_type, N'') = ISNULL(b.object_type, N'');";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+            command.Parameters.Add(new SqlParameter("@currentStart", SqlDbType.DateTime2) { Value = currentStart });
+            command.Parameters.Add(new SqlParameter("@currentEnd", SqlDbType.DateTime2) { Value = currentEnd });
+            command.Parameters.Add(new SqlParameter("@baselineStart", SqlDbType.DateTime2) { Value = baselineStart });
+            command.Parameters.Add(new SqlParameter("@baselineEnd", SqlDbType.DateTime2) { Value = baselineEnd });
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                items.Add(new Models.QueryStatsComparisonItem
+                {
+                    DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    QueryHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    ObjectName = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    SchemaName = reader.IsDBNull(3) ? null : reader.GetString(3),
+                    ObjectType = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    QueryText = reader.IsDBNull(5) ? "" : reader.GetString(5),
+                    ExecutionCount = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                    AvgDurationMs = reader.IsDBNull(7) ? 0 : Convert.ToDouble(reader.GetValue(7), CultureInfo.InvariantCulture),
+                    AvgCpuMs = reader.IsDBNull(8) ? 0 : Convert.ToDouble(reader.GetValue(8), CultureInfo.InvariantCulture),
+                    AvgReads = reader.IsDBNull(9) ? 0 : Convert.ToDouble(reader.GetValue(9), CultureInfo.InvariantCulture),
+                    BaselineExecutionCount = reader.IsDBNull(10) ? 0 : reader.GetInt64(10),
+                    BaselineAvgDurationMs = reader.IsDBNull(11) ? 0 : Convert.ToDouble(reader.GetValue(11), CultureInfo.InvariantCulture),
+                    BaselineAvgCpuMs = reader.IsDBNull(12) ? 0 : Convert.ToDouble(reader.GetValue(12), CultureInfo.InvariantCulture),
+                    BaselineAvgReads = reader.IsDBNull(13) ? 0 : Convert.ToDouble(reader.GetValue(13), CultureInfo.InvariantCulture),
+                });
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets procedure stats comparison between a current time range and a baseline range.
+        /// </summary>
+        public async Task<List<Models.ProcedureStatsComparisonItem>> GetProcedureStatsComparisonAsync(
+            DateTime currentStart, DateTime currentEnd,
+            DateTime baselineStart, DateTime baselineEnd)
+        {
+            var items = new List<Models.ProcedureStatsComparisonItem>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+;WITH top_procs AS (
+    SELECT DISTINCT database_name, schema_name, object_name
+    FROM (
+        SELECT TOP 100 database_name, schema_name, object_name
+        FROM collect.procedure_stats
+        WHERE collection_time >= @currentStart AND collection_time <= @currentEnd
+        AND   execution_count_delta > 0
+        GROUP BY database_name, schema_name, object_name
+        ORDER BY SUM(execution_count_delta) DESC
+        UNION
+        SELECT TOP 100 database_name, schema_name, object_name
+        FROM collect.procedure_stats
+        WHERE collection_time >= @baselineStart AND collection_time <= @baselineEnd
+        AND   execution_count_delta > 0
+        GROUP BY database_name, schema_name, object_name
+        ORDER BY SUM(execution_count_delta) DESC
+    ) AS combined
+),
+current_period AS (
+    SELECT tp.database_name, tp.schema_name, tp.object_name,
+           SUM(ps.execution_count_delta) AS exec_count,
+           SUM(ps.total_elapsed_time_delta) / NULLIF(SUM(ps.execution_count_delta), 0) / 1000.0 AS avg_duration_ms,
+           SUM(ps.total_worker_time_delta) / NULLIF(SUM(ps.execution_count_delta), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(ps.total_physical_reads_delta) / NULLIF(SUM(ps.execution_count_delta), 0) AS avg_reads
+    FROM top_procs tp
+    INNER JOIN collect.procedure_stats ps
+      ON  ps.database_name = tp.database_name
+      AND ISNULL(ps.schema_name, N'') = ISNULL(tp.schema_name, N'')
+      AND ps.object_name = tp.object_name
+    WHERE ps.collection_time >= @currentStart AND ps.collection_time <= @currentEnd
+    AND   ps.execution_count_delta > 0
+    GROUP BY tp.database_name, tp.schema_name, tp.object_name
+),
+baseline_period AS (
+    SELECT tp.database_name, tp.schema_name, tp.object_name,
+           SUM(ps.execution_count_delta) AS exec_count,
+           SUM(ps.total_elapsed_time_delta) / NULLIF(SUM(ps.execution_count_delta), 0) / 1000.0 AS avg_duration_ms,
+           SUM(ps.total_worker_time_delta) / NULLIF(SUM(ps.execution_count_delta), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(ps.total_physical_reads_delta) / NULLIF(SUM(ps.execution_count_delta), 0) AS avg_reads
+    FROM top_procs tp
+    INNER JOIN collect.procedure_stats ps
+      ON  ps.database_name = tp.database_name
+      AND ISNULL(ps.schema_name, N'') = ISNULL(tp.schema_name, N'')
+      AND ps.object_name = tp.object_name
+    WHERE ps.collection_time >= @baselineStart AND ps.collection_time <= @baselineEnd
+    AND   ps.execution_count_delta > 0
+    GROUP BY tp.database_name, tp.schema_name, tp.object_name
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.schema_name, b.schema_name) AS schema_name,
+       COALESCE(c.object_name, b.object_name) AS object_name,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  ISNULL(c.database_name, N'') = ISNULL(b.database_name, N'')
+  AND ISNULL(c.schema_name, N'') = ISNULL(b.schema_name, N'')
+  AND ISNULL(c.object_name, N'') = ISNULL(b.object_name, N'');";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+            command.Parameters.Add(new SqlParameter("@currentStart", SqlDbType.DateTime2) { Value = currentStart });
+            command.Parameters.Add(new SqlParameter("@currentEnd", SqlDbType.DateTime2) { Value = currentEnd });
+            command.Parameters.Add(new SqlParameter("@baselineStart", SqlDbType.DateTime2) { Value = baselineStart });
+            command.Parameters.Add(new SqlParameter("@baselineEnd", SqlDbType.DateTime2) { Value = baselineEnd });
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                items.Add(new Models.ProcedureStatsComparisonItem
+                {
+                    DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    ObjectName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                    ExecutionCount = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                    AvgDurationMs = reader.IsDBNull(4) ? 0 : Convert.ToDouble(reader.GetValue(4), CultureInfo.InvariantCulture),
+                    AvgCpuMs = reader.IsDBNull(5) ? 0 : Convert.ToDouble(reader.GetValue(5), CultureInfo.InvariantCulture),
+                    AvgReads = reader.IsDBNull(6) ? 0 : Convert.ToDouble(reader.GetValue(6), CultureInfo.InvariantCulture),
+                    BaselineExecutionCount = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                    BaselineAvgDurationMs = reader.IsDBNull(8) ? 0 : Convert.ToDouble(reader.GetValue(8), CultureInfo.InvariantCulture),
+                    BaselineAvgCpuMs = reader.IsDBNull(9) ? 0 : Convert.ToDouble(reader.GetValue(9), CultureInfo.InvariantCulture),
+                    BaselineAvgReads = reader.IsDBNull(10) ? 0 : Convert.ToDouble(reader.GetValue(10), CultureInfo.InvariantCulture),
+                });
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Gets query store comparison between a current time range and a baseline range.
+        /// Reuses QueryStatsComparisonItem model (same identity: database + query_hash).
+        /// </summary>
+        public async Task<List<Models.QueryStatsComparisonItem>> GetQueryStoreComparisonAsync(
+            DateTime currentStart, DateTime currentEnd,
+            DateTime baselineStart, DateTime baselineEnd)
+        {
+            var items = new List<Models.QueryStatsComparisonItem>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+;WITH top_hashes AS (
+    SELECT DISTINCT database_name, query_hash
+    FROM (
+        SELECT TOP 100 database_name, query_hash
+        FROM collect.query_store_stats
+        WHERE collection_time >= @currentStart AND collection_time <= @currentEnd
+        AND   execution_count > 0
+        GROUP BY database_name, query_hash
+        ORDER BY SUM(execution_count) DESC
+        UNION
+        SELECT TOP 100 database_name, query_hash
+        FROM collect.query_store_stats
+        WHERE collection_time >= @baselineStart AND collection_time <= @baselineEnd
+        AND   execution_count > 0
+        GROUP BY database_name, query_hash
+        ORDER BY SUM(execution_count) DESC
+    ) AS combined
+),
+current_period AS (
+    SELECT th.database_name,
+           CONVERT(nvarchar(20), th.query_hash, 1) AS query_hash,
+           SUM(qs.execution_count) AS exec_count,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_duration_us) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_cpu_time_us) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_logical_io_reads) / NULLIF(SUM(qs.execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN collect.query_store_stats qs
+      ON  qs.query_hash = th.query_hash
+      AND qs.database_name = th.database_name
+    WHERE qs.collection_time >= @currentStart AND qs.collection_time <= @currentEnd
+    AND   qs.execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+),
+baseline_period AS (
+    SELECT th.database_name,
+           CONVERT(nvarchar(20), th.query_hash, 1) AS query_hash,
+           SUM(qs.execution_count) AS exec_count,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_duration_us) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_cpu_time_us) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(CAST(qs.execution_count AS bigint) * qs.avg_logical_io_reads) / NULLIF(SUM(qs.execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN collect.query_store_stats qs
+      ON  qs.query_hash = th.query_hash
+      AND qs.database_name = th.database_name
+    WHERE qs.collection_time >= @baselineStart AND qs.collection_time <= @baselineEnd
+    AND   qs.execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.query_hash, b.query_hash) AS query_hash,
+       COALESCE(c.query_text, b.query_text) AS query_text,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  ISNULL(c.database_name, N'') = ISNULL(b.database_name, N'')
+  AND ISNULL(c.query_hash, N'') = ISNULL(b.query_hash, N'');";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+            command.Parameters.Add(new SqlParameter("@currentStart", SqlDbType.DateTime2) { Value = currentStart });
+            command.Parameters.Add(new SqlParameter("@currentEnd", SqlDbType.DateTime2) { Value = currentEnd });
+            command.Parameters.Add(new SqlParameter("@baselineStart", SqlDbType.DateTime2) { Value = baselineStart });
+            command.Parameters.Add(new SqlParameter("@baselineEnd", SqlDbType.DateTime2) { Value = baselineEnd });
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                items.Add(new Models.QueryStatsComparisonItem
+                {
+                    DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    QueryHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                    ExecutionCount = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                    AvgDurationMs = reader.IsDBNull(4) ? 0 : Convert.ToDouble(reader.GetValue(4), CultureInfo.InvariantCulture),
+                    AvgCpuMs = reader.IsDBNull(5) ? 0 : Convert.ToDouble(reader.GetValue(5), CultureInfo.InvariantCulture),
+                    AvgReads = reader.IsDBNull(6) ? 0 : Convert.ToDouble(reader.GetValue(6), CultureInfo.InvariantCulture),
+                    BaselineExecutionCount = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                    BaselineAvgDurationMs = reader.IsDBNull(8) ? 0 : Convert.ToDouble(reader.GetValue(8), CultureInfo.InvariantCulture),
+                    BaselineAvgCpuMs = reader.IsDBNull(9) ? 0 : Convert.ToDouble(reader.GetValue(9), CultureInfo.InvariantCulture),
+                    BaselineAvgReads = reader.IsDBNull(10) ? 0 : Convert.ToDouble(reader.GetValue(10), CultureInfo.InvariantCulture),
+                });
+            }
+
+            return items;
+        }
     }
 }

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -107,7 +107,7 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                     <ComboBox x:Name="CompareToCombo" SelectedIndex="0" Width="130" Margin="0,0,8,0"
                               SelectionChanged="CompareToCombo_SelectionChanged"
-                              ToolTip="Overlay a reference period on the Overview charts">
+                              ToolTip="Compare current period against a baseline">
                         <ComboBoxItem Content="None"/>
                         <ComboBoxItem Content="Yesterday"/>
                         <ComboBoxItem Content="Last week"/>
@@ -349,10 +349,15 @@
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
                                 <controls:TimeRangeSlicerControl x:Name="QueryStatsSlicer" Grid.Row="0"/>
-                            <DataGrid Grid.Row="1" x:Name="QueryStatsGrid"
+                                <TextBlock x:Name="QueryStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                                           Padding="8,4" FontWeight="Bold"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           Background="#2244AAFF"/>
+                            <DataGrid Grid.Row="2" x:Name="QueryStatsGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -477,16 +482,129 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            <DataGrid Grid.Row="2" x:Name="QueryStatsComparisonGrid" Visibility="Collapsed"
+                                      AutoGenerateColumns="False" IsReadOnly="True"
+                                      RowStyle="{StaticResource GridRowStyle}"
+                                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                                      CanUserSortColumns="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="FontWeight" Value="Bold"/>
+                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsNew}" Value="True">
+                                                        <Setter Property="Foreground" Value="#FF6B6B"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsGone}" Value="True">
+                                                        <Setter Property="Foreground" Value="#888888"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                                        <DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                        <DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                <Setter Property="Padding" Value="0,0,5,0"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                <Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                <Setter Property="Padding" Value="0,0,5,0"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                <Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                <Setter Property="Padding" Value="0,0,5,0"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                <Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                <Setter Property="Padding" Value="0,0,5,0"/>
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                <Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding QueryHash}" Width="140">
+                                        <DataGridTextColumn.Header><TextBlock Text="Query Hash" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn Width="500">
+                                        <DataGridTemplateColumn.Header><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
+                                                           ToolTip="{Binding QueryText}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
                             </Grid>
                         </TabItem>
                         <TabItem Header="Top Procedures by Duration">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
                                 <controls:TimeRangeSlicerControl x:Name="ProcStatsSlicer" Grid.Row="0"/>
-                            <DataGrid Grid.Row="1" x:Name="ProcedureStatsGrid"
+                                <TextBlock x:Name="ProcStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                                           Padding="8,4" FontWeight="Bold"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           Background="#2244AAFF"/>
+                            <DataGrid Grid.Row="2" x:Name="ProcedureStatsGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -590,16 +708,88 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
+                            <DataGrid Grid.Row="2" x:Name="ProcStatsComparisonGrid" Visibility="Collapsed"
+                                      AutoGenerateColumns="False" IsReadOnly="True"
+                                      RowStyle="{StaticResource GridRowStyle}"
+                                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                                      CanUserSortColumns="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="FontWeight" Value="Bold"/>
+                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsNew}" Value="True"><Setter Property="Foreground" Value="#FF6B6B"/></DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsGone}" Value="True"><Setter Property="Foreground" Value="#888888"/></DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                                        <DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding FullName}" Width="200">
+                                        <DataGridTextColumn.Header><TextBlock Text="Procedure" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                        <DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
                             </Grid>
                         </TabItem>
                         <TabItem Header="Query Store by Duration">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
                                 <controls:TimeRangeSlicerControl x:Name="QueryStoreSlicer" Grid.Row="0"/>
-                            <DataGrid Grid.Row="1" x:Name="QueryStoreGrid"
+                                <TextBlock x:Name="QueryStoreComparisonBanner" Grid.Row="1" Visibility="Collapsed"
+                                           Padding="8,4" FontWeight="Bold"
+                                           Foreground="{DynamicResource ForegroundBrush}"
+                                           Background="#2244AAFF"/>
+                            <DataGrid Grid.Row="2" x:Name="QueryStoreGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
@@ -698,6 +888,82 @@
                                     <DataGridTemplateColumn Width="500">
                                         <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryText" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Text" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
                                                                                 <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
+                                                           ToolTip="{Binding QueryText}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <DataGrid Grid.Row="2" x:Name="QueryStoreComparisonGrid" Visibility="Collapsed"
+                                      AutoGenerateColumns="False" IsReadOnly="True"
+                                      RowStyle="{StaticResource GridRowStyle}"
+                                      HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                                      CanUserSortColumns="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding StatusBadge}" Width="55">
+                                        <DataGridTextColumn.Header><TextBlock Text="" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="FontWeight" Value="Bold"/>
+                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsNew}" Value="True"><Setter Property="Foreground" Value="#FF6B6B"/></DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsGone}" Value="True"><Setter Property="Foreground" Value="#888888"/></DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
+                                        <DataGridTextColumn.Header><TextBlock Text="Database" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                        <DataGridTextColumn.Header><TextBlock Text="Executions" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Execs" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Exec &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ExecutionDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Dur (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DurationDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Dur &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding DurationDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base CPU (ms)" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding CpuDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="CPU &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding CpuDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                                        <DataGridTextColumn.Header><TextBlock Text="Avg Reads" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding BaselineAvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                                        <DataGridTextColumn.Header><TextBlock Text="Base Reads" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ReadsDeltaDisplay}" Width="80">
+                                        <DataGridTextColumn.Header><TextBlock Text="Reads &#x0394;" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/><Setter Property="Padding" Value="0,0,5,0"/><Setter Property="FontWeight" Value="SemiBold"/><Setter Property="Foreground" Value="{Binding ReadsDeltaBrush}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding QueryHash}" Width="140">
+                                        <DataGridTextColumn.Header><TextBlock Text="Query Hash" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn Width="500">
+                                        <DataGridTemplateColumn.Header><TextBlock Text="Query Text" FontWeight="Bold"/></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <TextBlock Text="{Binding QueryText}" TextWrapping="Wrap" MaxHeight="90" Margin="5,2"
                                                            ToolTip="{Binding QueryText}"/>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -636,6 +636,20 @@ public partial class ServerTab : UserControl
         }
 
         await RefreshOverviewAsync(hoursBack, fromDate, toDate);
+
+        // Also refresh comparison grids
+        try
+        {
+            var currentEnd = toDate ?? DateTime.UtcNow;
+            var currentStart = fromDate ?? currentEnd.AddHours(-hoursBack);
+            await RefreshQueryStatsComparisonAsync(currentStart, currentEnd);
+            await RefreshProcStatsComparisonAsync(currentStart, currentEnd);
+            await RefreshQueryStoreComparisonAsync(currentStart, currentEnd);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] Comparison refresh failed: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -960,12 +974,27 @@ public partial class ServerTab : UserControl
         LiveSnapshotIndicator.Text = "";
         _queryStatsFilterMgr!.UpdateData(queryStatsTask.Result);
         SetDefaultSortIfNone(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+        {
+            var cEnd = toDate ?? DateTime.UtcNow;
+            var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
+            await RefreshQueryStatsComparisonAsync(cStart, cEnd);
+        }
         _procStatsFilterMgr!.UpdateData(procStatsTask.Result);
         SetDefaultSortIfNone(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
+        {
+            var cEnd2 = toDate ?? DateTime.UtcNow;
+            var cStart2 = fromDate ?? cEnd2.AddHours(-hoursBack);
+            await RefreshProcStatsComparisonAsync(cStart2, cEnd2);
+        }
         _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
         _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(deadlockTask.Result));
         _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
         SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
+        {
+            var cEnd3 = toDate ?? DateTime.UtcNow;
+            var cStart3 = fromDate ?? cEnd3.AddHours(-hoursBack);
+            await RefreshQueryStoreComparisonAsync(cStart3, cEnd3);
+        }
         _serverConfigFilterMgr!.UpdateData(serverConfigTask.Result);
         _databaseConfigFilterMgr!.UpdateData(databaseConfigTask.Result);
         _dbScopedConfigFilterMgr!.UpdateData(databaseScopedConfigTask.Result);
@@ -1076,18 +1105,33 @@ public partial class ServerTab : UserControl
                         _queryStatsFilterMgr!.UpdateData(queryStats);
                         SetDefaultSortIfNone(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
                         _ = LoadQueryStatsSlicerAsync();
+                        {
+                            var cEnd = toDate ?? DateTime.UtcNow;
+                            var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
+                            await RefreshQueryStatsComparisonAsync(cStart, cEnd);
+                        }
                         break;
                     case 3: // Top Procedures by Duration
                         var procStats = await _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes);
                         _procStatsFilterMgr!.UpdateData(procStats);
                         SetDefaultSortIfNone(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
                         _ = LoadProcStatsSlicerAsync();
+                        {
+                            var cEnd = toDate ?? DateTime.UtcNow;
+                            var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
+                            await RefreshProcStatsComparisonAsync(cStart, cEnd);
+                        }
                         break;
                     case 4: // Query Store by Duration
                         var qsData = await _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate);
                         _queryStoreFilterMgr!.UpdateData(qsData);
                         SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
                         _ = LoadQueryStoreSlicerAsync();
+                        {
+                            var cEnd = toDate ?? DateTime.UtcNow;
+                            var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
+                            await RefreshQueryStoreComparisonAsync(cStart, cEnd);
+                        }
                         break;
                     case 5: // Query Heatmap
                         var hmMetric = (HeatmapMetric)HeatmapMetricCombo.SelectedIndex;
@@ -1127,12 +1171,27 @@ public partial class ServerTab : UserControl
             _queryStatsFilterMgr!.UpdateData(queryStatsTask.Result);
             SetDefaultSortIfNone(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
             _ = LoadQueryStatsSlicerAsync();
+            {
+                var cEnd = toDate ?? DateTime.UtcNow;
+                var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
+                await RefreshQueryStatsComparisonAsync(cStart, cEnd);
+            }
             _procStatsFilterMgr!.UpdateData(procStatsTask.Result);
             SetDefaultSortIfNone(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
             _ = LoadProcStatsSlicerAsync();
+            {
+                var cEnd2 = toDate ?? DateTime.UtcNow;
+                var cStart2 = fromDate ?? cEnd2.AddHours(-hoursBack);
+                await RefreshProcStatsComparisonAsync(cStart2, cEnd2);
+            }
             _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
             SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
             _ = LoadQueryStoreSlicerAsync();
+            {
+                var cEnd3 = toDate ?? DateTime.UtcNow;
+                var cStart3 = fromDate ?? cEnd3.AddHours(-hoursBack);
+                await RefreshQueryStoreComparisonAsync(cStart3, cEnd3);
+            }
 
             UpdateQueryDurationTrendChart(queryDurationTrendTask.Result);
             UpdateProcDurationTrendChart(procDurationTrendTask.Result);
@@ -1144,6 +1203,120 @@ public partial class ServerTab : UserControl
         {
             AppLogger.Info("ServerTab", $"[{_server.DisplayName}] RefreshQueriesAsync failed: {ex.Message}");
         }
+    }
+
+    private bool IsQueryStatsComparisonActive => GetComparisonRange() != null;
+
+    private void SetQueryStatsComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+    {
+        QueryStatsGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+        QueryStatsComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+        QueryStatsComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+        if (active && baselineRange.HasValue)
+        {
+            var from = ServerTimeHelper.FormatServerTime(baselineRange.Value.From);
+            var to = ServerTimeHelper.FormatServerTime(baselineRange.Value.To);
+            QueryStatsComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+        }
+    }
+
+    private async System.Threading.Tasks.Task RefreshQueryStatsComparisonAsync(DateTime currentStart, DateTime currentEnd)
+    {
+        var baselineRange = GetComparisonRange();
+        if (baselineRange == null)
+        {
+            SetQueryStatsComparisonMode(false);
+            return;
+        }
+
+        SetQueryStatsComparisonMode(true, baselineRange);
+
+        var items = await _dataService.GetQueryStatsComparisonAsync(
+            _serverId, currentStart, currentEnd,
+            baselineRange.Value.From, baselineRange.Value.To);
+
+        // Sort: NEW first, then by duration delta descending, GONE last
+        var sorted = items
+            .OrderBy(x => x.SortGroup)
+            .ThenByDescending(x => x.SortableDurationDelta)
+            .ToList();
+
+        QueryStatsComparisonGrid.ItemsSource = sorted;
+    }
+
+    private void SetProcStatsComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+    {
+        ProcedureStatsGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+        ProcStatsComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+        ProcStatsComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+        if (active && baselineRange.HasValue)
+        {
+            var from = ServerTimeHelper.FormatServerTime(baselineRange.Value.From);
+            var to = ServerTimeHelper.FormatServerTime(baselineRange.Value.To);
+            ProcStatsComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+        }
+    }
+
+    private async System.Threading.Tasks.Task RefreshProcStatsComparisonAsync(DateTime currentStart, DateTime currentEnd)
+    {
+        var baselineRange = GetComparisonRange();
+        if (baselineRange == null)
+        {
+            SetProcStatsComparisonMode(false);
+            return;
+        }
+
+        SetProcStatsComparisonMode(true, baselineRange);
+
+        var items = await _dataService.GetProcedureStatsComparisonAsync(
+            _serverId, currentStart, currentEnd,
+            baselineRange.Value.From, baselineRange.Value.To);
+
+        var sorted = items
+            .OrderBy(x => x.SortGroup)
+            .ThenByDescending(x => x.SortableDurationDelta)
+            .ToList();
+
+        ProcStatsComparisonGrid.ItemsSource = sorted;
+    }
+
+    private void SetQueryStoreComparisonMode(bool active, (DateTime From, DateTime To)? baselineRange = null)
+    {
+        QueryStoreGrid.Visibility = active ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+        QueryStoreComparisonGrid.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+        QueryStoreComparisonBanner.Visibility = active ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+        if (active && baselineRange.HasValue)
+        {
+            var from = ServerTimeHelper.FormatServerTime(baselineRange.Value.From);
+            var to = ServerTimeHelper.FormatServerTime(baselineRange.Value.To);
+            QueryStoreComparisonBanner.Text = $"Comparing against baseline: {from} \u2192 {to}";
+        }
+    }
+
+    private async System.Threading.Tasks.Task RefreshQueryStoreComparisonAsync(DateTime currentStart, DateTime currentEnd)
+    {
+        var baselineRange = GetComparisonRange();
+        if (baselineRange == null)
+        {
+            SetQueryStoreComparisonMode(false);
+            return;
+        }
+
+        SetQueryStoreComparisonMode(true, baselineRange);
+
+        var items = await _dataService.GetQueryStoreComparisonAsync(
+            _serverId, currentStart, currentEnd,
+            baselineRange.Value.From, baselineRange.Value.To);
+
+        var sorted = items
+            .OrderBy(x => x.SortGroup)
+            .ThenByDescending(x => x.SortableDurationDelta)
+            .ToList();
+
+        QueryStoreComparisonGrid.ItemsSource = sorted;
     }
 
     /// <summary>Tab 3 — CPU</summary>
@@ -1591,6 +1764,8 @@ public partial class ServerTab : UserControl
         if (e.Source != MainTabControl && e.Source != QueriesSubTabControl
             && e.Source != MemorySubTabControl && e.Source != BlockingSubTabControl) return;
 
+        UpdateCompareDropdownState();
+
         var hoursBack = GetHoursBack();
         DateTime? fromDate = null, toDate = null;
         if (IsCustomRange)
@@ -1604,6 +1779,35 @@ public partial class ServerTab : UserControl
             }
         }
         await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
+    }
+
+    private bool IsComparisonSupportedOnCurrentTab()
+    {
+        return MainTabControl.SelectedIndex switch
+        {
+            0 => true, // Overview — correlated timeline lanes
+            2 => QueriesSubTabControl.SelectedIndex is 2 or 3 or 4, // Top Queries / Top Procedures / Query Store
+            _ => false
+        };
+    }
+
+    private void UpdateCompareDropdownState()
+    {
+        var supported = IsComparisonSupportedOnCurrentTab();
+
+        if (supported)
+        {
+            CompareToCombo.IsEnabled = true;
+            CompareToCombo.Opacity = 1.0;
+            CompareToCombo.ToolTip = "Compare current period against a baseline";
+        }
+        else
+        {
+            CompareToCombo.SelectedIndex = 0;
+            CompareToCombo.IsEnabled = false;
+            CompareToCombo.Opacity = 0.5;
+            CompareToCombo.ToolTip = "Comparison is not available for this tab";
+        }
     }
 
     /// <summary>
@@ -4681,6 +4885,7 @@ public partial class ServerTab : UserControl
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
             var queryStats = await _dataService.GetTopQueriesByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
             _queryStatsFilterMgr!.UpdateData(queryStats);
+            await RefreshQueryStatsComparisonAsync(fromServer, toServer);
         }
         catch (Exception ex)
         {
@@ -4779,6 +4984,7 @@ public partial class ServerTab : UserControl
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
             var qsData = await _dataService.GetQueryStoreTopQueriesAsync(_serverId, 0, 50, fromServer, toServer);
             _queryStoreFilterMgr!.UpdateData(qsData);
+            await RefreshQueryStoreComparisonAsync(fromServer, toServer);
         }
         catch (Exception ex)
         {
@@ -4875,6 +5081,7 @@ public partial class ServerTab : UserControl
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
             var procStats = await _dataService.GetTopProceduresByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
             _procStatsFilterMgr!.UpdateData(procStats);
+            await RefreshProcStatsComparisonAsync(fromServer, toServer);
         }
         catch (Exception ex)
         {

--- a/Lite/Models/ComparisonItemBase.cs
+++ b/Lite/Models/ComparisonItemBase.cs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows.Media;
+
+namespace PerformanceMonitorLite.Models;
+
+public abstract class ComparisonItemBase
+{
+    public string DatabaseName { get; set; } = "";
+
+    // Current period
+    public long ExecutionCount { get; set; }
+    public double AvgDurationMs { get; set; }
+    public double AvgCpuMs { get; set; }
+    public double AvgReads { get; set; }
+
+    // Baseline period
+    public long BaselineExecutionCount { get; set; }
+    public double BaselineAvgDurationMs { get; set; }
+    public double BaselineAvgCpuMs { get; set; }
+    public double BaselineAvgReads { get; set; }
+
+    // Flags
+    public bool IsNew => ExecutionCount > 0 && BaselineExecutionCount == 0;
+    public bool IsGone => ExecutionCount == 0 && BaselineExecutionCount > 0;
+
+    // Delta percentages (null when baseline is zero or item is new/gone)
+    public double? DurationDeltaPct => ComputeDelta(AvgDurationMs, BaselineAvgDurationMs);
+    public double? CpuDeltaPct => ComputeDelta(AvgCpuMs, BaselineAvgCpuMs);
+    public double? ReadsDeltaPct => ComputeDelta(AvgReads, BaselineAvgReads);
+    public double? ExecutionDeltaPct => ComputeDelta(ExecutionCount, BaselineExecutionCount);
+
+    // Display helpers for grid binding
+    public string DurationDeltaDisplay => FormatDelta(DurationDeltaPct);
+    public string CpuDeltaDisplay => FormatDelta(CpuDeltaPct);
+    public string ReadsDeltaDisplay => FormatDelta(ReadsDeltaPct);
+    public string ExecutionDeltaDisplay => FormatDelta(ExecutionDeltaPct);
+
+    public string StatusBadge => IsNew ? "NEW" : IsGone ? "GONE" : "";
+
+    // Sort key: NEW at top (0), normal by delta (1), GONE at bottom (2)
+    public int SortGroup => IsNew ? 0 : IsGone ? 2 : 1;
+    public double SortableDurationDelta => DurationDeltaPct ?? (IsNew ? double.MaxValue : double.MinValue);
+
+    // Color brushes for delta columns (red = regression, green = improvement)
+    public Brush DurationDeltaBrush => GetDeltaBrush(DurationDeltaPct, 25);
+    public Brush CpuDeltaBrush => GetDeltaBrush(CpuDeltaPct, 25);
+    public Brush ReadsDeltaBrush => GetDeltaBrush(ReadsDeltaPct, 50, 25);
+    public Brush ExecutionDeltaBrush => GetDeltaBrush(ExecutionDeltaPct, 100, 50);
+
+    private static readonly Brush RedBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x6B, 0x6B));
+    private static readonly Brush GreenBrush = new SolidColorBrush(Color.FromRgb(0x4E, 0xC9, 0xB0));
+    private static readonly Brush NeutralBrush = Brushes.Transparent;
+
+    static ComparisonItemBase()
+    {
+        RedBrush.Freeze();
+        GreenBrush.Freeze();
+    }
+
+    private static Brush GetDeltaBrush(double? delta, double redThreshold, double greenThreshold = 25)
+    {
+        if (!delta.HasValue) return NeutralBrush;
+        if (delta.Value > redThreshold) return RedBrush;
+        if (delta.Value < -greenThreshold) return GreenBrush;
+        return NeutralBrush;
+    }
+
+    private static double? ComputeDelta(double current, double baseline)
+    {
+        if (baseline == 0) return null;
+        return (current - baseline) / baseline * 100.0;
+    }
+
+    private static string FormatDelta(double? delta)
+    {
+        if (!delta.HasValue) return "\u2014";
+        var sign = delta.Value >= 0 ? "+" : "";
+        return $"{sign}{delta.Value:N1}%";
+    }
+}

--- a/Lite/Models/ProcedureStatsComparisonItem.cs
+++ b/Lite/Models/ProcedureStatsComparisonItem.cs
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorLite.Models;
+
+public class ProcedureStatsComparisonItem : ComparisonItemBase
+{
+    public string SchemaName { get; set; } = "";
+    public string ObjectName { get; set; } = "";
+    public string FullName => string.IsNullOrEmpty(SchemaName) ? ObjectName : $"{SchemaName}.{ObjectName}";
+}

--- a/Lite/Models/QueryStatsComparisonItem.cs
+++ b/Lite/Models/QueryStatsComparisonItem.cs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorLite.Models;
+
+public class QueryStatsComparisonItem : ComparisonItemBase
+{
+    public string QueryHash { get; set; } = "";
+    public string QueryText { get; set; } = "";
+}

--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -189,6 +189,19 @@ public class CollectionLogRow
 
 public class CollectorHealthRow
 {
+    /// <summary>
+    /// On-load collectors run once per tab open, not on the scheduled loop.
+    /// Staleness thresholds don't apply to them.
+    /// </summary>
+    private static readonly HashSet<string> OnLoadCollectors = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "server_config",
+        "database_config",
+        "database_scoped_config",
+        "trace_flags",
+        "server_properties"
+    };
+
     public string CollectorName { get; set; } = "";
     public long TotalRuns { get; set; }
     public long SuccessCount { get; set; }
@@ -211,6 +224,11 @@ public class CollectorHealthRow
         {
             if (TotalRuns == 0) return "NEVER_RUN";
             if (PermissionDeniedCount > 0 && ErrorCount == 0 && SuccessCount == 0) return "NO_PERMISSIONS";
+            if (OnLoadCollectors.Contains(CollectorName))
+            {
+                if (FailureRatePercent > 20) return "WARNING";
+                return "HEALTHY";
+            }
             if (HoursSinceLastSuccess > 24) return "FAILING";
             if (HoursSinceLastSuccess > 4) return "STALE";
             if (FailureRatePercent > 20) return "WARNING";

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -185,6 +185,122 @@ LIMIT $4";
     }
 
     /// <summary>
+    /// Gets query stats comparison between a current time range and a baseline range.
+    /// Returns delta percentages for duration, CPU, reads, and execution count.
+    /// </summary>
+    public async Task<List<Models.QueryStatsComparisonItem>> GetQueryStatsComparisonAsync(
+        int serverId,
+        DateTime currentStart, DateTime currentEnd,
+        DateTime baselineStart, DateTime baselineEnd)
+    {
+        using var _q = TimeQuery("GetQueryStatsComparisonAsync", "v_query_stats comparison");
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+WITH top_current AS (
+    SELECT query_hash, database_name
+    FROM v_query_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2 AND collection_time <= $3
+    AND   delta_execution_count > 0
+    GROUP BY query_hash, database_name
+    ORDER BY SUM(delta_execution_count) DESC
+    LIMIT 100
+),
+top_baseline AS (
+    SELECT query_hash, database_name
+    FROM v_query_stats
+    WHERE server_id = $1
+    AND   collection_time >= $4 AND collection_time <= $5
+    AND   delta_execution_count > 0
+    GROUP BY query_hash, database_name
+    ORDER BY SUM(delta_execution_count) DESC
+    LIMIT 100
+),
+top_hashes AS (
+    SELECT DISTINCT query_hash, database_name
+    FROM (
+        SELECT * FROM top_current
+        UNION ALL
+        SELECT * FROM top_baseline
+    ) combined
+),
+current_period AS (
+    SELECT th.database_name, th.query_hash,
+           SUM(qs.delta_execution_count) AS exec_count,
+           SUM(qs.delta_elapsed_time)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.delta_worker_time)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.delta_physical_reads)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN v_query_stats qs
+      ON  qs.query_hash IS NOT DISTINCT FROM th.query_hash
+      AND qs.database_name IS NOT DISTINCT FROM th.database_name
+    WHERE qs.server_id = $1
+    AND   qs.collection_time >= $2 AND qs.collection_time <= $3
+    AND   qs.delta_execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+),
+baseline_period AS (
+    SELECT th.database_name, th.query_hash,
+           SUM(qs.delta_execution_count) AS exec_count,
+           SUM(qs.delta_elapsed_time)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.delta_worker_time)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.delta_physical_reads)::DOUBLE / NULLIF(SUM(qs.delta_execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN v_query_stats qs
+      ON  qs.query_hash IS NOT DISTINCT FROM th.query_hash
+      AND qs.database_name IS NOT DISTINCT FROM th.database_name
+    WHERE qs.server_id = $1
+    AND   qs.collection_time >= $4 AND qs.collection_time <= $5
+    AND   qs.delta_execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.query_hash, b.query_hash) AS query_hash,
+       COALESCE(c.query_text, b.query_text) AS query_text,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  c.database_name IS NOT DISTINCT FROM b.database_name
+  AND c.query_hash IS NOT DISTINCT FROM b.query_hash;";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = currentStart });
+        command.Parameters.Add(new DuckDBParameter { Value = currentEnd });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineStart });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineEnd });
+
+        var items = new List<Models.QueryStatsComparisonItem>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.QueryStatsComparisonItem
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                QueryHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ExecutionCount = reader.IsDBNull(3) ? 0 : ToInt64(reader.GetValue(3)),
+                AvgDurationMs = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                AvgCpuMs = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                AvgReads = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
+                BaselineExecutionCount = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+                BaselineAvgDurationMs = reader.IsDBNull(8) ? 0 : ToDouble(reader.GetValue(8)),
+                BaselineAvgCpuMs = reader.IsDBNull(9) ? 0 : ToDouble(reader.GetValue(9)),
+                BaselineAvgReads = reader.IsDBNull(10) ? 0 : ToDouble(reader.GetValue(10)),
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
     /// Gets collection-level history for a specific query hash (for drilldown).
     /// </summary>
     public async Task<List<QueryStatsHistoryRow>> GetQueryStatsHistoryAsync(int serverId, string databaseName, string queryHash, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
@@ -574,6 +690,123 @@ LIMIT $4";
 
         return items;
     }
+
+    /// <summary>
+    /// Gets procedure stats comparison between a current time range and a baseline range.
+    /// </summary>
+    public async Task<List<Models.ProcedureStatsComparisonItem>> GetProcedureStatsComparisonAsync(
+        int serverId,
+        DateTime currentStart, DateTime currentEnd,
+        DateTime baselineStart, DateTime baselineEnd)
+    {
+        using var _q = TimeQuery("GetProcedureStatsComparisonAsync", "v_procedure_stats comparison");
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+WITH top_current AS (
+    SELECT database_name, schema_name, object_name
+    FROM v_procedure_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2 AND collection_time <= $3
+    AND   delta_execution_count > 0
+    GROUP BY database_name, schema_name, object_name
+    ORDER BY SUM(delta_execution_count) DESC
+    LIMIT 100
+),
+top_baseline AS (
+    SELECT database_name, schema_name, object_name
+    FROM v_procedure_stats
+    WHERE server_id = $1
+    AND   collection_time >= $4 AND collection_time <= $5
+    AND   delta_execution_count > 0
+    GROUP BY database_name, schema_name, object_name
+    ORDER BY SUM(delta_execution_count) DESC
+    LIMIT 100
+),
+top_procs AS (
+    SELECT DISTINCT database_name, schema_name, object_name
+    FROM (
+        SELECT * FROM top_current
+        UNION ALL
+        SELECT * FROM top_baseline
+    ) combined
+),
+current_period AS (
+    SELECT tp.database_name, tp.schema_name, tp.object_name,
+           SUM(ps.delta_execution_count) AS exec_count,
+           SUM(ps.delta_elapsed_time)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(ps.delta_worker_time)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(ps.delta_physical_reads)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) AS avg_reads
+    FROM top_procs tp
+    INNER JOIN v_procedure_stats ps
+      ON  ps.database_name IS NOT DISTINCT FROM tp.database_name
+      AND ps.schema_name IS NOT DISTINCT FROM tp.schema_name
+      AND ps.object_name IS NOT DISTINCT FROM tp.object_name
+    WHERE ps.server_id = $1
+    AND   ps.collection_time >= $2 AND ps.collection_time <= $3
+    AND   ps.delta_execution_count > 0
+    GROUP BY tp.database_name, tp.schema_name, tp.object_name
+),
+baseline_period AS (
+    SELECT tp.database_name, tp.schema_name, tp.object_name,
+           SUM(ps.delta_execution_count) AS exec_count,
+           SUM(ps.delta_elapsed_time)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(ps.delta_worker_time)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(ps.delta_physical_reads)::DOUBLE / NULLIF(SUM(ps.delta_execution_count), 0) AS avg_reads
+    FROM top_procs tp
+    INNER JOIN v_procedure_stats ps
+      ON  ps.database_name IS NOT DISTINCT FROM tp.database_name
+      AND ps.schema_name IS NOT DISTINCT FROM tp.schema_name
+      AND ps.object_name IS NOT DISTINCT FROM tp.object_name
+    WHERE ps.server_id = $1
+    AND   ps.collection_time >= $4 AND ps.collection_time <= $5
+    AND   ps.delta_execution_count > 0
+    GROUP BY tp.database_name, tp.schema_name, tp.object_name
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.schema_name, b.schema_name) AS schema_name,
+       COALESCE(c.object_name, b.object_name) AS object_name,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  c.database_name IS NOT DISTINCT FROM b.database_name
+  AND c.schema_name IS NOT DISTINCT FROM b.schema_name
+  AND c.object_name IS NOT DISTINCT FROM b.object_name;";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = currentStart });
+        command.Parameters.Add(new DuckDBParameter { Value = currentEnd });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineStart });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineEnd });
+
+        var items = new List<Models.ProcedureStatsComparisonItem>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.ProcedureStatsComparisonItem
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                ObjectName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ExecutionCount = reader.IsDBNull(3) ? 0 : ToInt64(reader.GetValue(3)),
+                AvgDurationMs = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                AvgCpuMs = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                AvgReads = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
+                BaselineExecutionCount = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+                BaselineAvgDurationMs = reader.IsDBNull(8) ? 0 : ToDouble(reader.GetValue(8)),
+                BaselineAvgCpuMs = reader.IsDBNull(9) ? 0 : ToDouble(reader.GetValue(9)),
+                BaselineAvgReads = reader.IsDBNull(10) ? 0 : ToDouble(reader.GetValue(10)),
+            });
+        }
+
+        return items;
+    }
+
     /// <summary>
     /// Gets query duration trend — total elapsed time per collection snapshot.
     /// </summary>

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -162,6 +162,122 @@ LIMIT $4";
     }
 
     /// <summary>
+    /// Gets query store comparison between a current time range and a baseline range.
+    /// Uses weighted averages (execution_count * avg_metric) for accurate aggregation.
+    /// </summary>
+    public async Task<List<Models.QueryStatsComparisonItem>> GetQueryStoreComparisonAsync(
+        int serverId,
+        DateTime currentStart, DateTime currentEnd,
+        DateTime baselineStart, DateTime baselineEnd)
+    {
+        using var _q = TimeQuery("GetQueryStoreComparisonAsync", "v_query_store_stats comparison");
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+WITH top_current AS (
+    SELECT database_name, query_hash
+    FROM v_query_store_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2 AND collection_time <= $3
+    AND   execution_count > 0
+    GROUP BY database_name, query_hash
+    ORDER BY SUM(execution_count) DESC
+    LIMIT 100
+),
+top_baseline AS (
+    SELECT database_name, query_hash
+    FROM v_query_store_stats
+    WHERE server_id = $1
+    AND   collection_time >= $4 AND collection_time <= $5
+    AND   execution_count > 0
+    GROUP BY database_name, query_hash
+    ORDER BY SUM(execution_count) DESC
+    LIMIT 100
+),
+top_hashes AS (
+    SELECT DISTINCT database_name, query_hash
+    FROM (
+        SELECT * FROM top_current
+        UNION ALL
+        SELECT * FROM top_baseline
+    ) combined
+),
+current_period AS (
+    SELECT th.database_name, th.query_hash,
+           SUM(qs.execution_count) AS exec_count,
+           SUM(qs.execution_count * qs.avg_duration_us::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.execution_count * qs.avg_cpu_time_us::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.execution_count * qs.avg_logical_io_reads::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN v_query_store_stats qs
+      ON  qs.query_hash IS NOT DISTINCT FROM th.query_hash
+      AND qs.database_name IS NOT DISTINCT FROM th.database_name
+    WHERE qs.server_id = $1
+    AND   qs.collection_time >= $2 AND qs.collection_time <= $3
+    AND   qs.execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+),
+baseline_period AS (
+    SELECT th.database_name, th.query_hash,
+           SUM(qs.execution_count) AS exec_count,
+           SUM(qs.execution_count * qs.avg_duration_us::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_duration_ms,
+           SUM(qs.execution_count * qs.avg_cpu_time_us::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) / 1000.0 AS avg_cpu_ms,
+           SUM(qs.execution_count * qs.avg_logical_io_reads::DOUBLE) / NULLIF(SUM(qs.execution_count), 0) AS avg_reads,
+           MAX(qs.query_text) AS query_text
+    FROM top_hashes th
+    INNER JOIN v_query_store_stats qs
+      ON  qs.query_hash IS NOT DISTINCT FROM th.query_hash
+      AND qs.database_name IS NOT DISTINCT FROM th.database_name
+    WHERE qs.server_id = $1
+    AND   qs.collection_time >= $4 AND qs.collection_time <= $5
+    AND   qs.execution_count > 0
+    GROUP BY th.database_name, th.query_hash
+)
+SELECT COALESCE(c.database_name, b.database_name) AS database_name,
+       COALESCE(c.query_hash, b.query_hash) AS query_hash,
+       COALESCE(c.query_text, b.query_text) AS query_text,
+       c.exec_count, c.avg_duration_ms, c.avg_cpu_ms, c.avg_reads,
+       b.exec_count AS baseline_exec_count,
+       b.avg_duration_ms AS baseline_avg_duration_ms,
+       b.avg_cpu_ms AS baseline_avg_cpu_ms,
+       b.avg_reads AS baseline_avg_reads
+FROM current_period c
+FULL OUTER JOIN baseline_period b
+  ON  c.database_name IS NOT DISTINCT FROM b.database_name
+  AND c.query_hash IS NOT DISTINCT FROM b.query_hash;";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = currentStart });
+        command.Parameters.Add(new DuckDBParameter { Value = currentEnd });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineStart });
+        command.Parameters.Add(new DuckDBParameter { Value = baselineEnd });
+
+        var items = new List<Models.QueryStatsComparisonItem>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new Models.QueryStatsComparisonItem
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                QueryHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                QueryText = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ExecutionCount = reader.IsDBNull(3) ? 0 : ToInt64(reader.GetValue(3)),
+                AvgDurationMs = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                AvgCpuMs = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
+                AvgReads = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
+                BaselineExecutionCount = reader.IsDBNull(7) ? 0 : ToInt64(reader.GetValue(7)),
+                BaselineAvgDurationMs = reader.IsDBNull(8) ? 0 : ToDouble(reader.GetValue(8)),
+                BaselineAvgCpuMs = reader.IsDBNull(9) ? 0 : ToDouble(reader.GetValue(9)),
+                BaselineAvgReads = reader.IsDBNull(10) ? 0 : ToDouble(reader.GetValue(10)),
+            });
+        }
+
+        return items;
+    }
+
+    /// <summary>
     /// Gets collection-level history for a specific Query Store query (for drilldown).
     /// </summary>
     public async Task<List<QueryStoreHistoryRow>> GetQueryStoreHistoryAsync(int serverId, string databaseName, long queryId, long planId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)


### PR DESCRIPTION
## Summary
- Extends the global Compare dropdown in Lite to support query stats, procedure stats, and query store tabs with delta columns (current vs baseline)
- Color-coded delta columns: red for regressions, green for improvements, NEW/GONE badges
- Compare dropdown is disabled with visual feedback on unsupported tabs, resets to "None" on tab switch
- Fix on-load collector health status (server_config etc. not flagged as stale)

## Test plan
- [ ] Select a time range with data, toggle Compare to Yesterday/Last week on Top Queries tab
- [ ] Verify comparison grid shows delta columns with color coding
- [ ] Verify NEW/GONE badges appear for queries only in one period
- [ ] Test Compare on Top Procedures and Query Store tabs
- [ ] Verify Compare dropdown disables on unsupported tabs (Wait Stats, CPU, etc.)
- [ ] Verify selecting "None" restores the normal grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)