### PR TITLE
Fix Rule 3: CouldNotGenerateValidParallelPlan stays Warning

### DIFF
--- a/Dashboard/Services/PlanAnalyzer.cs
+++ b/Dashboard/Services/PlanAnalyzer.cs
@@ -55,13 +55,14 @@ public static partial class PlanAnalyzer
                 _ => stmt.NonParallelPlanReason
             };
 
-            var isExplicit = stmt.NonParallelPlanReason is "MaxDOPSetToOne" or "QueryHintNoParallelSet";
+            var isActionable = stmt.NonParallelPlanReason is "MaxDOPSetToOne"
+                or "QueryHintNoParallelSet" or "CouldNotGenerateValidParallelPlan";
 
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "Serial Plan",
                 Message = $"Query running serially: {reason}.",
-                Severity = isExplicit ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
+                Severity = isActionable ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
             });
         }
 

--- a/Lite/Services/PlanAnalyzer.cs
+++ b/Lite/Services/PlanAnalyzer.cs
@@ -55,13 +55,14 @@ public static partial class PlanAnalyzer
                 _ => stmt.NonParallelPlanReason
             };
 
-            var isExplicit = stmt.NonParallelPlanReason is "MaxDOPSetToOne" or "QueryHintNoParallelSet";
+            var isActionable = stmt.NonParallelPlanReason is "MaxDOPSetToOne"
+                or "QueryHintNoParallelSet" or "CouldNotGenerateValidParallelPlan";
 
             stmt.PlanWarnings.Add(new PlanWarning
             {
                 WarningType = "Serial Plan",
                 Message = $"Query running serially: {reason}.",
-                Severity = isExplicit ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
+                Severity = isActionable ? PlanWarningSeverity.Warning : PlanWarningSeverity.Info
             });
         }
 


### PR DESCRIPTION
CouldNotGenerateValidParallelPlan is actionable (scalar UDFs, table variable inserts block parallelism). Should be Warning, not Info.