### PR TITLE
Switch to SignPath release-signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Dashboard'
           github-artifact-id: '${{ steps.upload-dashboard.outputs.artifact-id }}'
           wait-for-completion: true
@@ -127,7 +127,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Lite'
           github-artifact-id: '${{ steps.upload-lite.outputs.artifact-id }}'
           wait-for-completion: true
@@ -140,7 +140,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Installers'
           github-artifact-id: '${{ steps.upload-installer.outputs.artifact-id }}'
           wait-for-completion: true

--- a/README.md
+++ b/README.md
@@ -693,6 +693,17 @@ See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for complete license texts.
 
 ---
 
+## Sponsors
+
+<table>
+  <tr>
+    <td><a href="https://signpath.io"><img src="https://about.signpath.io/wp-content/uploads/2024/01/signpath_logo_blue.svg" alt="SignPath" width="40"></a></td>
+    <td>Free code signing on Windows provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a></td>
+  </tr>
+</table>
+
+---
+
 ## License
 
 Copyright (c) 2026 Darling Data, LLC. Licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Switch all 3 signing steps (Dashboard, Lite, Installer) from `test-signing` to `release-signing` policy
- Add SignPath sponsor attribution to README per their FOSS terms

SignPath production certificate has been issued.

## Test plan
- [ ] Verify signing works on next release build
- [ ] Confirm sponsor section renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)