### PR TITLE
Fix CSV and clipboard exports writing StackPanel type name as column headers (#805)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Dashboard'
           github-artifact-id: '${{ steps.upload-dashboard.outputs.artifact-id }}'
           wait-for-completion: true
@@ -127,7 +127,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Lite'
           github-artifact-id: '${{ steps.upload-lite.outputs.artifact-id }}'
           wait-for-completion: true
@@ -140,7 +140,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
           project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'Installers'
           github-artifact-id: '${{ steps.upload-installer.outputs.artifact-id }}'
           wait-for-completion: true

--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -19,6 +19,7 @@ using System.Windows.Threading;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Controls;
 using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Controls;
@@ -419,7 +420,7 @@ public partial class AlertsHistoryTab : UserControl
 
         foreach (var col in grid.Columns)
         {
-            sb.Append(col.Header?.ToString() ?? "");
+            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
             sb.Append('\t');
         }
         sb.AppendLine();
@@ -456,7 +457,7 @@ public partial class AlertsHistoryTab : UserControl
 
         var headers = new List<string>();
         foreach (var col in grid.Columns)
-            headers.Add(CsvEscape(col.Header?.ToString() ?? ""));
+            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col)));
         sb.AppendLine(string.Join(",", headers));
 
         foreach (var item in grid.Items)

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Controls;
@@ -884,7 +885,7 @@ public partial class FinOpsTab : UserControl
 
         foreach (var col in grid.Columns)
         {
-            sb.Append(col.Header?.ToString() ?? "");
+            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
             sb.Append('\t');
         }
         sb.AppendLine();
@@ -930,7 +931,7 @@ public partial class FinOpsTab : UserControl
 
         var headers = new List<string>();
         foreach (var col in grid.Columns)
-            headers.Add(CsvEscape(col.Header?.ToString() ?? ""));
+            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col)));
         sb.AppendLine(string.Join(",", headers));
 
         foreach (var item in grid.Items)

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -4213,7 +4213,7 @@ public partial class ServerTab : UserControl
         var headers = new List<string>();
         foreach (var col in grid.Columns)
         {
-            headers.Add(CsvEscape(col.Header?.ToString() ?? "", sep));
+            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col), sep));
         }
         sb.AppendLine(string.Join(sep, headers));
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,17 @@ See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for complete license texts.
 
 ---
 
+## Sponsors
+
+<table>
+  <tr>
+    <td><a href="https://signpath.io"><img src="https://about.signpath.io/wp-content/uploads/2024/01/signpath_logo_blue.svg" alt="SignPath" width="40"></a></td>
+    <td>Free code signing on Windows provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a></td>
+  </tr>
+</table>
+
+---
+
 ## License
 
 Copyright (c) 2026 Darling Data, LLC. Licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Fix grid CSV and clipboard exports outputting `System.Windows.Controls.StackPanel` as column headers instead of actual header text
- Resolves #805

## Test plan
- [ ] Export any grid to CSV, verify column headers match the UI
- [ ] Copy grid rows to clipboard, verify headers are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)