### PR TITLE
Fix duplicate release builds: trigger on published only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, dev]
   release:
-    types: [created, published]
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Remove `created` from release trigger types, keeping only `published`
- `gh release create` fires both `created` and `published` events, causing two identical builds that conflict on Velopack asset uploads

## Test plan
- [ ] Next release should trigger exactly one build run

🤖 Generated with [Claude Code](https://claude.com/claude-code)