### PR TITLE
Fix upgrade filter skipping patch versions (#817)

### DIFF
--- a/Installer.Core/ScriptProvider.cs
+++ b/Installer.Core/ScriptProvider.cs
@@ -152,7 +152,7 @@ public abstract class ScriptProvider
 
         return candidates
             .Where(x => x.FromVersion != null && x.ToVersion != null)
-            .Where(x => x.FromVersion >= current)
+            .Where(x => x.ToVersion > current)
             .Where(x => x.ToVersion <= target)
             .OrderBy(x => x.FromVersion)
             .ToList();

--- a/Installer.Tests/UpgradeOrderingTests.cs
+++ b/Installer.Tests/UpgradeOrderingTests.cs
@@ -149,6 +149,23 @@ public class UpgradeOrderingTests
     }
 
     [Fact]
+    public void PatchVersion_GetsUpgradeFromPriorMinor()
+    {
+        // Regression test for #817: user on v2.4.1 should still get the
+        // 2.4.0-to-2.5.0 upgrade applied (patch version within range)
+        using var dir = new TempDirectoryBuilder()
+            .WithUpgrade("2.3.0", "2.4.0", "01_a.sql")
+            .WithUpgrade("2.4.0", "2.5.0", "01_b.sql")
+            .WithUpgrade("2.5.0", "2.6.0", "01_c.sql");
+
+        var upgrades = ScriptProvider.FromDirectory(dir.RootPath).GetApplicableUpgrades("2.4.1", "2.6.0");
+
+        Assert.Equal(2, upgrades.Count);
+        Assert.Equal("2.4.0-to-2.5.0", upgrades[0].FolderName);
+        Assert.Equal("2.5.0-to-2.6.0", upgrades[1].FolderName);
+    }
+
+    [Fact]
     public void EmbeddedResources_FindsUpgradeFolders()
     {
         // Regression test for #772: MSBuild mangles embedded resource names


### PR DESCRIPTION
## Summary
- `FilterUpgrades` used `FromVersion >= current` which excluded upgrades when the user was on a patch release (e.g., v2.4.1 skipped the 2.4.0-to-2.5.0 upgrade because 2.4.0 < 2.4.1)
- Changed to `ToVersion > current` so any upgrade the user hasn't reached is included
- Adds regression test for the patch version scenario

## Test plan
- [x] All 18 `UpgradeOrderingTests` pass (including new `PatchVersion_GetsUpgradeFromPriorMinor`)
- [ ] Verify on a test server with v2.4.1 installed that upgrade to v2.6.0 now applies the 2.4.0-to-2.5.0 scripts

Fixes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)