### PR TITLE
Fix deadlock count not resetting between collections (#803)

### DIFF
--- a/install/26_blocking_deadlock_analyzer.sql
+++ b/install/26_blocking_deadlock_analyzer.sql
@@ -178,6 +178,8 @@ BEGIN
             Aggregate deadlock data by database
             Update rows if database already exists from blocking aggregation
             Otherwise insert new rows
+            Include databases from previous collection with zero counts so
+            deltas reset to 0 when no new events occur (#803)
             */
             WITH
                 deadlock_aggregates AS
@@ -192,9 +194,41 @@ BEGIN
                 AND   bl.collection_time < @start_time
                 GROUP BY
                     bl.database_name
+            ),
+                combined_source AS
+            (
+                SELECT
+                    da.database_name,
+                    da.deadlock_count,
+                    da.total_deadlock_wait_time_ms,
+                    da.victim_count
+                FROM deadlock_aggregates AS da
+
+                UNION ALL
+
+                /*
+                Carry forward databases from previous collection with zero
+                counts so delta calculation can reset them to 0
+                */
+                SELECT DISTINCT
+                    bds.database_name,
+                    0,
+                    0,
+                    0
+                FROM collect.blocking_deadlock_stats AS bds
+                WHERE bds.collection_time >= @last_deadlock_collection
+                AND   bds.collection_time < @start_time
+                AND   bds.database_name <> N'(none)'
+                AND   NOT EXISTS
+                (
+                    SELECT
+                        1/0
+                    FROM deadlock_aggregates AS da
+                    WHERE da.database_name = bds.database_name
+                )
             )
             MERGE collect.blocking_deadlock_stats WITH (SERIALIZABLE) AS target
-            USING deadlock_aggregates AS source
+            USING combined_source AS source
                 ON  target.database_name = source.database_name
                 AND target.collection_time >= @start_time
             WHEN MATCHED 


### PR DESCRIPTION
## Summary
- When no new deadlocks occurred for a database, the MERGE source was empty — no row was created, so stale `deadlock_count_delta` values persisted in the last row
- Expanded the MERGE source with a `combined_source` CTE that carries forward databases from the previous collection with zero counts
- The delta calculation now properly resets to 0 on the next cycle

## Test plan
- [x] Deployed to SQL2022, created a deadlock, verified `deadlock_count = 1` appeared
- [x] Ran analyzer again with no new deadlocks — confirmed carry-forward row with `deadlock_count = 0, deadlock_count_delta = 0`
- [x] Without the fix, no row would be created and the stale delta persists

Fixes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)