### PR TITLE
Add MultiSubnetFailover connection option (#813)

### DIFF
--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -111,6 +111,12 @@
                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
                               ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
 
+                    <!-- Multi-Subnet Failover -->
+                    <CheckBox x:Name="MultiSubnetFailoverCheckBox"
+                              Content="Multi-subnet failover (for AG listeners and FCIs)"
+                              Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
+                              ToolTip="Sets MultiSubnetFailover=true. Connects to all IPs in parallel during failover. Recommended for AG listeners and failover cluster instances spanning multiple subnets."/>
+
                     <!-- Is Favorite -->
                     <CheckBox x:Name="IsFavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -78,6 +78,7 @@ namespace PerformanceMonitorDashboard
             };
             TrustServerCertificateCheckBox.IsChecked = existingServer.TrustServerCertificate;
             ReadOnlyIntentCheckBox.IsChecked = existingServer.ReadOnlyIntent;
+            MultiSubnetFailoverCheckBox.IsChecked = existingServer.MultiSubnetFailover;
 
             if (existingServer.AuthenticationType == AuthenticationTypes.EntraMFA)
             {
@@ -154,7 +155,8 @@ namespace PerformanceMonitorDashboard
                 Encrypt = ParseEncryptOption(GetSelectedEncryptMode()),
                 ApplicationIntent = ReadOnlyIntentCheckBox.IsChecked == true
                     ? ApplicationIntent.ReadOnly
-                    : ApplicationIntent.ReadWrite
+                    : ApplicationIntent.ReadWrite,
+                MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true
             };
 
             if (WindowsAuthRadio.IsChecked == true)
@@ -821,6 +823,7 @@ namespace PerformanceMonitorDashboard
             EncryptModeComboBox.IsEnabled = enabled;
             TrustServerCertificateCheckBox.IsEnabled = enabled;
             ReadOnlyIntentCheckBox.IsEnabled = enabled;
+            MultiSubnetFailoverCheckBox.IsEnabled = enabled;
             IsFavoriteCheckBox.IsEnabled = enabled;
             MonthlyCostTextBox.IsEnabled = enabled;
             DescriptionTextBox.IsEnabled = enabled;
@@ -915,6 +918,7 @@ namespace PerformanceMonitorDashboard
                 ServerConnection.EncryptMode = GetSelectedEncryptMode();
                 ServerConnection.TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true;
                 ServerConnection.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
+                ServerConnection.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostTextBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     ServerConnection.MonthlyCostUsd = editCost;
             }
@@ -936,6 +940,7 @@ namespace PerformanceMonitorDashboard
                     EncryptMode = GetSelectedEncryptMode(),
                     TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true,
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
+                    MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
                     MonthlyCostUsd = monthlyCost
                 };
             }

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -70,6 +70,12 @@ namespace PerformanceMonitorDashboard.Models
         public bool ReadOnlyIntent { get; set; } = false;
 
         /// <summary>
+        /// When true, sets MultiSubnetFailover=true on the connection string.
+        /// Recommended for AG listeners and FCIs spanning multiple subnets.
+        /// </summary>
+        public bool MultiSubnetFailover { get; set; } = false;
+
+        /// <summary>
         /// Monthly cost of this server in USD, used for FinOps cost attribution.
         /// Set to 0 to hide cost columns. All FinOps costs are proportional to this budget.
         /// </summary>
@@ -120,6 +126,7 @@ namespace PerformanceMonitorDashboard.Models
                         _ => SqlConnectionEncryptOption.Mandatory
                     },
                     ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
+                    MultiSubnetFailover = MultiSubnetFailover,
                     Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive
                 };
 
@@ -151,7 +158,8 @@ namespace PerformanceMonitorDashboard.Models
                 password,
                 EncryptMode,
                 TrustServerCertificate,
-                ReadOnlyIntent
+                ReadOnlyIntent,
+                MultiSubnetFailover
             ).ConnectionString;
         }
 

--- a/Dashboard/Services/DatabaseService.cs
+++ b/Dashboard/Services/DatabaseService.cs
@@ -92,7 +92,8 @@ namespace PerformanceMonitorDashboard.Services
             string? password = null,
             string encryptMode = "Mandatory",
             bool trustServerCertificate = false,
-            bool readOnlyIntent = false)
+            bool readOnlyIntent = false,
+            bool multiSubnetFailover = false)
         {
             var builder = new SqlConnectionStringBuilder
             {
@@ -101,7 +102,8 @@ namespace PerformanceMonitorDashboard.Services
                 TrustServerCertificate = trustServerCertificate,
                 IntegratedSecurity = useWindowsAuth,
                 MultipleActiveResultSets = true,
-                ApplicationIntent = readOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite
+                ApplicationIntent = readOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
+                MultiSubnetFailover = multiSubnetFailover
             };
 
             // Set encryption mode

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -90,6 +90,12 @@ public class ServerConnection
     public bool ReadOnlyIntent { get; set; } = false;
 
     /// <summary>
+    /// When true, sets MultiSubnetFailover=true on the connection string.
+    /// Recommended for AG listeners and FCIs spanning multiple subnets.
+    /// </summary>
+    public bool MultiSubnetFailover { get; set; } = false;
+
+    /// <summary>
     /// Server name with "(Read-Only)" suffix when ReadOnlyIntent is enabled.
     /// Used for sidebar subtitle and status text.
     /// </summary>
@@ -205,7 +211,8 @@ public class ServerConnection
             CommandTimeout = 60,
             TrustServerCertificate = TrustServerCertificate,
             MultipleActiveResultSets = true,
-            ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite
+            ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
+            MultiSubnetFailover = MultiSubnetFailover
         };
 
         // Set encryption mode

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -96,6 +96,9 @@
             <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="Read-only intent (for AG listeners and readable replicas)"
                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
                       ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
+            <CheckBox x:Name="MultiSubnetFailoverCheckBox" Content="Multi-subnet failover (for AG listeners and FCIs)"
+                      Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
+                      ToolTip="Sets MultiSubnetFailover=true. Connects to all IPs in parallel during failover. Recommended for AG listeners and failover cluster instances spanning multiple subnets."/>
             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                 <TextBlock Text="Monthly Cost ($):" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
                 <TextBox x:Name="MonthlyCostBox" Width="100" TextAlignment="Right" Text="0"

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -61,6 +61,7 @@ public partial class AddServerDialog : Window
         DatabaseNameBox.Text = existing.DatabaseName ?? "";
         UtilityDatabaseBox.Text = existing.UtilityDatabase ?? "";
         ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
+        MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
         MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         // Set authentication mode
@@ -146,7 +147,8 @@ public partial class AddServerDialog : Window
             Encrypt = ParseEncryptOption(GetSelectedEncryptMode()),
             ApplicationIntent = ReadOnlyIntentCheckBox.IsChecked == true
                 ? ApplicationIntent.ReadOnly
-                : ApplicationIntent.ReadWrite
+                : ApplicationIntent.ReadWrite,
+            MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true
         };
 
         if (WindowsAuthRadio.IsChecked == true)
@@ -350,6 +352,7 @@ public partial class AddServerDialog : Window
                 AddedServer.DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
                 AddedServer.UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim();
                 AddedServer.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
+                AddedServer.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     AddedServer.MonthlyCostUsd = editCost;
 
@@ -375,6 +378,7 @@ public partial class AddServerDialog : Window
                     DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim(),
                     UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim(),
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
+                    MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
                     MonthlyCostUsd = monthlyCost
                 };
 


### PR DESCRIPTION
## Summary
- Adds `MultiSubnetFailover` boolean property to `ServerConnection` model in both Dashboard and Lite
- Checkbox in Add/Edit Server dialogs: "Multi-subnet failover (for AG listeners and FCIs)"
- Sets `MultiSubnetFailover=true` on `SqlConnectionStringBuilder` when checked
- Flows through to all connection paths: Dashboard UI, Lite collector, test connection, installer

## Test plan
- [x] Dashboard builds clean (0 errors)
- [x] Lite builds clean (0 errors)
- [x] Installer tests pass (18/18)
- [ ] Verify checkbox appears and persists in both Dashboard and Lite Add Server dialogs
- [ ] Verify existing servers.json without the field loads correctly (defaults to false)

Fixes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)