### PR TITLE
Add Host OS column to Server Inventory (#748)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -2447,6 +2447,14 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding HostOsVersion}" Width="200">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostOsVersion" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                        <TextBlock Text="Host OS" FontWeight="Bold" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -391,6 +391,20 @@ OPTION(MAXDOP 1, RECOMPILE);";
             await connection.OpenAsync();
 
             const string query = @"
+DECLARE @host_os nvarchar(256);
+IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
+    EXEC sys.sp_executesql N'SELECT @os = host_distribution FROM sys.dm_os_host_info',
+        N'@os nvarchar(256) OUTPUT', @os = @host_os OUTPUT;
+
+IF @host_os IS NULL
+BEGIN
+    /* SQL 2016 or Azure SQL DB: parse OS from @@VERSION */
+    DECLARE @ver nvarchar(4000) = @@VERSION;
+    DECLARE @on_pos int = CHARINDEX(N' on ', @ver);
+    IF @on_pos > 0
+        SET @host_os = LTRIM(SUBSTRING(@ver, @on_pos + 4, LEN(@ver)));
+END;
+
 SELECT
     edition =
         CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
@@ -417,7 +431,9 @@ SELECT
     is_hadr_enabled =
         CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
     is_clustered =
-        CONVERT(int, SERVERPROPERTY('IsClustered'))
+        CONVERT(int, SERVERPROPERTY('IsClustered')),
+    host_os =
+        @host_os
 FROM sys.dm_os_sys_info AS si;";
 
             using var command = new SqlCommand(query, connection);
@@ -446,6 +462,7 @@ FROM sys.dm_os_sys_info AS si;";
                     EngineEdition = reader.IsDBNull(10) ? null : Convert.ToInt32(reader.GetValue(10)),
                     IsHadrEnabled = reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)) == 1,
                     IsClustered = reader.IsDBNull(12) ? null : Convert.ToInt32(reader.GetValue(12)) == 1,
+                    HostOsVersion = reader.IsDBNull(13) ? "" : reader.GetString(13),
                     LastUpdated = DateTime.Now
                 };
             }
@@ -2496,6 +2513,7 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
         public string ServerName { get; set; } = "";
         public string Edition { get; set; } = "";
         public string SqlVersion { get; set; } = "";
+        public string HostOsVersion { get; set; } = "";
         public int CpuCount { get; set; }
         public long PhysicalMemoryMb { get; set; }
         public int? SocketCount { get; set; }

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -2234,6 +2234,14 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding HostOsVersion}" Width="200">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostOsVersion" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                        <TextBlock Text="Host OS" FontWeight="Bold" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Binding="{Binding CpuCount, StringFormat='{}{0:N0}'}" Width="70">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -93,9 +93,22 @@ DECLARE
             THEN N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.database_files'
             ELSE N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files'
         END,
-    @storage_gb decimal(19,2);
+    @storage_gb decimal(19,2),
+    @host_os nvarchar(256);
 
 EXEC sys.sp_executesql @storage_sql, N'@gb decimal(19,2) OUTPUT', @gb = @storage_gb OUTPUT;
+
+IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
+    EXEC sys.sp_executesql N'SELECT @os = host_distribution FROM sys.dm_os_host_info',
+        N'@os nvarchar(256) OUTPUT', @os = @host_os OUTPUT;
+
+IF @host_os IS NULL
+BEGIN
+    DECLARE @ver nvarchar(4000) = @@VERSION;
+    DECLARE @on_pos int = CHARINDEX(N' on ', @ver);
+    IF @on_pos > 0
+        SET @host_os = LTRIM(SUBSTRING(@ver, @on_pos + 4, LEN(@ver)));
+END;
 
 SELECT
     CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
@@ -110,7 +123,8 @@ SELECT
     si.cores_per_socket,
     CONVERT(int, SERVERPROPERTY('EngineEdition')),
     CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
-    CONVERT(int, SERVERPROPERTY('IsClustered'))
+    CONVERT(int, SERVERPROPERTY('IsClustered')),
+    @host_os
 FROM sys.dm_os_sys_info AS si;";
 
         using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };
@@ -137,6 +151,7 @@ FROM sys.dm_os_sys_info AS si;";
                 EngineEdition = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
                 IsHadrEnabled = reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)) == 1,
                 IsClustered = reader.IsDBNull(12) ? null : Convert.ToInt32(reader.GetValue(12)) == 1,
+                HostOsVersion = reader.IsDBNull(13) ? "" : reader.GetString(13),
                 LastUpdated = DateTime.Now
             };
         }
@@ -2295,6 +2310,7 @@ public class ServerPropertyRow
     public string ServerName { get; set; } = "";
     public string Edition { get; set; } = "";
     public string ProductVersion { get; set; } = "";
+    public string HostOsVersion { get; set; } = "";
     public string? ProductLevel { get; set; }
     public string? ProductUpdateLevel { get; set; }
     public int EngineEdition { get; set; }


### PR DESCRIPTION
## Summary
- Adds "Host OS" column to Server Inventory in both Dashboard and Lite
- Uses `sys.dm_os_host_info` (SQL 2017+), falls back to parsing `@@VERSION` for SQL 2016 and Azure SQL DB
- No schema changes — data is queried live alongside existing server properties
- Column placed between Version and CPUs, with filter button

## Test plan
- [x] Dashboard and Lite build clean
- [x] Verified on SQL 2022: returns `Windows Server 2016 Datacenter` from `sys.dm_os_host_info`
- [x] Verified on SQL 2016: falls back to `@@VERSION` parsing, returns full OS string
- [ ] Visual check in both Dashboard and Lite Server Inventory tabs

Fixes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)