### PR TITLE
Fix Lite auto-refresh silently skipping every tick (#824)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -2459,7 +2459,7 @@
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuCount" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
-                                        <TextBlock Text="CPUs" FontWeight="Bold" VerticalAlignment="Center"/>
+                                        <TextBlock Text="Logical CPUs" FontWeight="Bold" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle>

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -2246,7 +2246,7 @@
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuCount" Click="FilterButton_Click" Margin="0,0,4,0"/>
-                                        <TextBlock Text="CPUs" FontWeight="Bold" VerticalAlignment="Center"/>
+                                        <TextBlock Text="Logical CPUs" FontWeight="Bold" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                                 <DataGridTextColumn.ElementStyle>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -153,16 +153,7 @@ public partial class ServerTab : UserControl
         };
         _refreshTimer.Tick += async (s, e) =>
         {
-            if (_isRefreshing) return;
-            _isRefreshing = true;
-            try
-            {
-                await RefreshAllDataAsync(fullRefresh: false);
-            }
-            finally
-            {
-                _isRefreshing = false;
-            }
+            await RefreshAllDataAsync(fullRefresh: false);
         };
         _refreshTimer.Start();
 


### PR DESCRIPTION
## Summary
- **Fixed auto-refresh bug**: The timer tick handler set `_isRefreshing = true` before calling `RefreshAllDataAsync`, which also checked that flag and returned immediately — every auto-refresh cycle was a silent no-op
- **Renamed "CPUs" to "Logical CPUs"** in the FinOps server inventory tab (both Dashboard and Lite) to clarify the distinction from the Cores/Socket column which shows physical cores

Closes #824

## Test plan
- [x] Verified auto-refresh ticks fire and complete successfully (4 consecutive 60s cycles observed)
- [x] Confirmed `_isRefreshing=False` at each tick, meaning refreshes complete before the next cycle
- [ ] Verify "Logical CPUs" column header displays correctly in both Dashboard and Lite FinOps tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)