### PR TITLE
Fix upgrade script executing against master instead of PerformanceMonitor

### DIFF
--- a/upgrades/2.4.0-to-2.5.0/01_widen_version_columns.sql
+++ b/upgrades/2.4.0-to-2.5.0/01_widen_version_columns.sql
@@ -3,6 +3,20 @@ Widen sql_server_version and sql_server_edition columns in config.installation_h
 Some @@VERSION strings exceed 255 characters (#712)
 */
 
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
 IF EXISTS
 (
     SELECT

--- a/upgrades/README.md
+++ b/upgrades/README.md
@@ -36,30 +36,49 @@ The installer:
 
 ## Upgrade Script Guidelines
 
-1. **Always check before altering**: Use `IF NOT EXISTS` checks before adding columns/indexes
-2. **Be idempotent**: Scripts should be safe to run multiple times
-3. **Preserve data**: Never DROP tables with data (use ALTER/UPDATE instead)
-4. **Add comments**: Document why each change is being made
-5. **Test upgrade paths**: Test upgrading from each previous version
+1. **Start from `_template.sql`**: Copy the template for every new upgrade script — it has the required SET options and `USE PerformanceMonitor` that the installer depends on
+2. **Always check before altering**: Use `IF NOT EXISTS` / `IF EXISTS` checks before adding or modifying columns/indexes
+3. **Be idempotent**: Scripts should be safe to run multiple times
+4. **Preserve data**: Never DROP tables with data (use ALTER/UPDATE instead)
+5. **Add comments**: Document why each change is being made
+6. **Test upgrade paths**: Test upgrading from each previous version
 
 ## Example Upgrade Script
 
 ```sql
 /*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
 Upgrade from 1.0.0 to 1.1.0
 Adds execution context tracking to query_stats
 */
 
--- Add new column if it doesn't exist
-IF NOT EXISTS (
-    SELECT 1/0
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
     FROM sys.columns
-    WHERE object_id = OBJECT_ID('collect.query_stats')
-    AND name = 'execution_context'
+    WHERE object_id = OBJECT_ID(N'collect.query_stats')
+    AND   name = N'execution_context'
 )
 BEGIN
     ALTER TABLE collect.query_stats
-    ADD execution_context nvarchar(128) NULL;
+        ADD execution_context nvarchar(128) NULL;
 
     PRINT 'Added execution_context column to collect.query_stats';
 END;

--- a/upgrades/_template.sql
+++ b/upgrades/_template.sql
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from X.Y.Z to X.Y.Z
+<describe what this upgrade does and why>
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+/* upgrade logic here — must be idempotent */


### PR DESCRIPTION
## Summary
- `01_widen_version_columns.sql` (added in PR #722) was missing `USE PerformanceMonitor;` and the standard `SET` options preamble
- The installer connects with `InitialCatalog = "master"`, so the script's `OBJECT_ID(N'config.installation_history')` resolved against `master`, found nothing, skipped both ALTERs, and reported success — leaving columns at `nvarchar(255)`
- Every other upgrade script in `upgrades/` has the `USE` statement; this one was the only exception

## How it was found
User in #828 upgraded from v2.2.0 to v2.6.0. The install log showed `01_widen_version_columns.sql - Success` but the `LogInstallationHistoryAsync` INSERT then failed with string truncation because the columns were never actually widened.

## Test plan
- [x] Verified all other upgrade scripts have `USE PerformanceMonitor;` — this was the only one missing it
- [ ] Test upgrade from pre-2.5.0 to current on a test server

Fixes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)