### PR TITLE
Fix Dashboard auto-refresh stalling with stop/start timer

### DIFF
--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -27,7 +27,6 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     private DatabaseService? _dataService;
     private SqlServerBaselineProvider? _baselineProvider;
     private CorrelatedCrosshairManager? _crosshairManager;
-    private bool _isRefreshing;
 
     public CorrelatedTimelineLanesControl()
     {
@@ -66,176 +65,168 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     public async Task RefreshAsync(int hoursBack, DateTime? fromDate, DateTime? toDate,
         (DateTime From, DateTime To)? comparisonRange = null)
     {
-        if (_dataService == null || _isRefreshing) return;
-        _isRefreshing = true;
+        if (_dataService == null) return;
+
+        _crosshairManager?.PrepareForRefresh();
+
+        var cpuTask = _dataService.GetCpuUtilizationAsync(hoursBack, fromDate, toDate);
+        var waitTask = _dataService.GetTotalWaitStatsTrendAsync(hoursBack, fromDate, toDate);
+        var blockingTask = _dataService.GetBlockedSessionTrendAsync(hoursBack, fromDate, toDate);
+        var deadlockTask = _dataService.GetDeadlockTrendAsync(hoursBack, fromDate, toDate);
+        var memoryTask = _dataService.GetMemoryStatsAsync(hoursBack, fromDate, toDate);
+        var fileIoTask = _dataService.GetFileIoLatencyTimeSeriesAsync(false, hoursBack, fromDate, toDate);
+
+        // Fetch baselines for band rendering if provider is available
+        var referenceTime = fromDate ?? DateTime.UtcNow.AddHours(-hoursBack);
+        Task<BaselineBucket?>? cpuBaselineTask = null;
+        Task<BaselineBucket?>? waitBaselineTask = null;
+        Task<BaselineBucket?>? ioBaselineTask = null;
+        Task<BaselineBucket?>? blockingBaselineTask = null;
+        Task<BaselineBucket?>? deadlockBaselineTask = null;
+
+        if (_baselineProvider != null)
+        {
+            cpuBaselineTask = GetBaselineAsync(SqlServerMetricNames.Cpu, referenceTime);
+            waitBaselineTask = GetBaselineAsync(SqlServerMetricNames.WaitStats, referenceTime);
+            ioBaselineTask = GetBaselineAsync(SqlServerMetricNames.IoLatency, referenceTime);
+            blockingBaselineTask = GetBaselineAsync(SqlServerMetricNames.Blocking, referenceTime);
+            deadlockBaselineTask = GetBaselineAsync(SqlServerMetricNames.Deadlock, referenceTime);
+        }
 
         try
         {
-            _crosshairManager?.PrepareForRefresh();
+            var tasks = new List<Task> { cpuTask, waitTask, blockingTask, deadlockTask, memoryTask, fileIoTask };
+            if (cpuBaselineTask != null) tasks.Add(cpuBaselineTask);
+            if (waitBaselineTask != null) tasks.Add(waitBaselineTask);
+            if (ioBaselineTask != null) tasks.Add(ioBaselineTask);
+            if (blockingBaselineTask != null) tasks.Add(blockingBaselineTask);
+            if (deadlockBaselineTask != null) tasks.Add(deadlockBaselineTask);
+            await Task.WhenAll(tasks);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"CorrelatedLanes: Data fetch failed: {ex.Message}");
+        }
 
-            var cpuTask = _dataService.GetCpuUtilizationAsync(hoursBack, fromDate, toDate);
-            var waitTask = _dataService.GetTotalWaitStatsTrendAsync(hoursBack, fromDate, toDate);
-            var blockingTask = _dataService.GetBlockedSessionTrendAsync(hoursBack, fromDate, toDate);
-            var deadlockTask = _dataService.GetDeadlockTrendAsync(hoursBack, fromDate, toDate);
-            var memoryTask = _dataService.GetMemoryStatsAsync(hoursBack, fromDate, toDate);
-            var fileIoTask = _dataService.GetFileIoLatencyTimeSeriesAsync(false, hoursBack, fromDate, toDate);
+        var cpuBaseline = cpuBaselineTask is { IsCompletedSuccessfully: true } ? cpuBaselineTask.Result : null;
+        var waitBaseline = waitBaselineTask is { IsCompletedSuccessfully: true } ? waitBaselineTask.Result : null;
+        var ioBaseline = ioBaselineTask is { IsCompletedSuccessfully: true } ? ioBaselineTask.Result : null;
+        var blockingBaseline = blockingBaselineTask is { IsCompletedSuccessfully: true } ? blockingBaselineTask.Result : null;
+        var deadlockBaseline = deadlockBaselineTask is { IsCompletedSuccessfully: true } ? deadlockBaselineTask.Result : null;
+        var blockingLaneBaseline = blockingBaseline ?? deadlockBaseline;
 
-            // Fetch baselines for band rendering if provider is available
-            var referenceTime = fromDate ?? DateTime.UtcNow.AddHours(-hoursBack);
-            Task<BaselineBucket?>? cpuBaselineTask = null;
-            Task<BaselineBucket?>? waitBaselineTask = null;
-            Task<BaselineBucket?>? ioBaselineTask = null;
-            Task<BaselineBucket?>? blockingBaselineTask = null;
-            Task<BaselineBucket?>? deadlockBaselineTask = null;
+        // minAnomalyValue: absolute floor below which dots/arrows are suppressed even if outside band.
+        // Prevents "1% CPU above 0.5% baseline" false alarms on idle servers.
+        if (cpuTask.IsCompletedSuccessfully)
+            UpdateLane(CpuChart, "CPU %",
+                cpuTask.Result.OrderBy(d => d.SampleTime)
+                    .Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(),
+                "#4FC3F7", 0, 105, cpuBaseline, minAnomalyValue: 10);
+        else
+            ShowEmpty(CpuChart, "CPU %");
 
-            if (_baselineProvider != null)
-            {
-                cpuBaselineTask = GetBaselineAsync(SqlServerMetricNames.Cpu, referenceTime);
-                waitBaselineTask = GetBaselineAsync(SqlServerMetricNames.WaitStats, referenceTime);
-                ioBaselineTask = GetBaselineAsync(SqlServerMetricNames.IoLatency, referenceTime);
-                blockingBaselineTask = GetBaselineAsync(SqlServerMetricNames.Blocking, referenceTime);
-                deadlockBaselineTask = GetBaselineAsync(SqlServerMetricNames.Deadlock, referenceTime);
-            }
+        if (waitTask.IsCompletedSuccessfully)
+            UpdateLane(WaitStatsChart, "Wait ms/sec",
+                waitTask.Result.Select(d => (d.CollectionTime.ToOADate(), (double)d.WaitTimeMsPerSecond)).ToList(),
+                "#FFB74D", baseline: waitBaseline, minAnomalyValue: 100);
+        else
+            ShowEmpty(WaitStatsChart, "Wait ms/sec");
 
-            try
-            {
-                var tasks = new List<Task> { cpuTask, waitTask, blockingTask, deadlockTask, memoryTask, fileIoTask };
-                if (cpuBaselineTask != null) tasks.Add(cpuBaselineTask);
-                if (waitBaselineTask != null) tasks.Add(waitBaselineTask);
-                if (ioBaselineTask != null) tasks.Add(ioBaselineTask);
-                if (blockingBaselineTask != null) tasks.Add(blockingBaselineTask);
-                if (deadlockBaselineTask != null) tasks.Add(deadlockBaselineTask);
-                await Task.WhenAll(tasks);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"CorrelatedLanes: Data fetch failed: {ex.Message}");
-            }
-
-            var cpuBaseline = cpuBaselineTask is { IsCompletedSuccessfully: true } ? cpuBaselineTask.Result : null;
-            var waitBaseline = waitBaselineTask is { IsCompletedSuccessfully: true } ? waitBaselineTask.Result : null;
-            var ioBaseline = ioBaselineTask is { IsCompletedSuccessfully: true } ? ioBaselineTask.Result : null;
-            var blockingBaseline = blockingBaselineTask is { IsCompletedSuccessfully: true } ? blockingBaselineTask.Result : null;
-            var deadlockBaseline = deadlockBaselineTask is { IsCompletedSuccessfully: true } ? deadlockBaselineTask.Result : null;
-            var blockingLaneBaseline = blockingBaseline ?? deadlockBaseline;
-
-            // minAnomalyValue: absolute floor below which dots/arrows are suppressed even if outside band.
-            // Prevents "1% CPU above 0.5% baseline" false alarms on idle servers.
-            if (cpuTask.IsCompletedSuccessfully)
-                UpdateLane(CpuChart, "CPU %",
-                    cpuTask.Result.OrderBy(d => d.SampleTime)
-                        .Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(),
-                    "#4FC3F7", 0, 105, cpuBaseline, minAnomalyValue: 10);
-            else
-                ShowEmpty(CpuChart, "CPU %");
-
-            if (waitTask.IsCompletedSuccessfully)
-                UpdateLane(WaitStatsChart, "Wait ms/sec",
-                    waitTask.Result.Select(d => (d.CollectionTime.ToOADate(), (double)d.WaitTimeMsPerSecond)).ToList(),
-                    "#FFB74D", baseline: waitBaseline, minAnomalyValue: 100);
-            else
-                ShowEmpty(WaitStatsChart, "Wait ms/sec");
-
-            try
-            {
-                var blockingData = blockingTask.IsCompletedSuccessfully
-                    ? blockingTask.Result
-                        .GroupBy(d => d.CollectionTime)
-                        .OrderBy(g => g.Key)
-                        .Select(g => (g.Key.ToOADate(), (double)g.Sum(x => x.BlockedCount)))
-                        .ToList()
-                    : new List<(double, double)>();
-                var deadlockData = deadlockTask.IsCompletedSuccessfully
-                    ? deadlockTask.Result
-                        .Select(d => (d.CollectionTime.ToOADate(), (double)d.BlockedCount))
-                        .ToList()
-                    : new List<(double, double)>();
-                UpdateBlockingLane(blockingData, deadlockData, blockingLaneBaseline);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"CorrelatedLanes: Blocking lane failed: {ex}");
-                ShowEmpty(BlockingChart, "Blocking & Deadlocking");
-            }
-
-            if (memoryTask.IsCompletedSuccessfully)
-                UpdateLane(MemoryChart, "Buffer Pool MB",
-                    memoryTask.Result.Select(d => (d.CollectionTime.ToOADate(), (double)d.TotalMemoryMb)).ToList(),
-                    "#CE93D8");
-            else
-                ShowEmpty(MemoryChart, "Buffer Pool MB");
-
-            if (fileIoTask.IsCompletedSuccessfully)
-            {
-                var ioGrouped = fileIoTask.Result
+        try
+        {
+            var blockingData = blockingTask.IsCompletedSuccessfully
+                ? blockingTask.Result
                     .GroupBy(d => d.CollectionTime)
                     .OrderBy(g => g.Key)
-                    .Select(g => (g.Key.ToOADate(), (double)g.Average(x => x.ReadLatencyMs)))
-                    .ToList();
-                UpdateLane(FileIoChart, "I/O ms", ioGrouped, "#81C784", baseline: ioBaseline, minAnomalyValue: 2);
-            }
-            else
-                ShowEmpty(FileIoChart, "I/O ms");
-
-            // Comparison overlay — fetch reference period data and render as ghost lines
-            if (comparisonRange.HasValue)
-            {
-                var refFrom = comparisonRange.Value.From;
-                var refTo = comparisonRange.Value.To;
-                var timeShift = (fromDate ?? DateTime.UtcNow.AddHours(-hoursBack)) - refFrom;
-
-                var refCpuTask = _dataService.GetCpuUtilizationAsync(0, refFrom, refTo);
-                var refWaitTask = _dataService.GetTotalWaitStatsTrendAsync(0, refFrom, refTo);
-                var refBlockingTask = _dataService.GetBlockedSessionTrendAsync(0, refFrom, refTo);
-                var refMemoryTask = _dataService.GetMemoryStatsAsync(0, refFrom, refTo);
-                var refIoTask = _dataService.GetFileIoLatencyTimeSeriesAsync(false, 0, refFrom, refTo);
-
-                try { await Task.WhenAll(refCpuTask, refWaitTask, refBlockingTask, refMemoryTask, refIoTask); }
-                catch (Exception ex) { Debug.WriteLine($"CorrelatedLanes: Comparison fetch failed: {ex.Message}"); }
-
-                if (refCpuTask.IsCompletedSuccessfully)
-                    AddGhostLine(CpuChart, refCpuTask.Result
-                        .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(), "#4FC3F7");
-
-                if (refWaitTask.IsCompletedSuccessfully)
-                    AddGhostLine(WaitStatsChart, refWaitTask.Result
-                        .Select(d => (d.CollectionTime.Add(timeShift).ToOADate(), (double)d.WaitTimeMsPerSecond)).ToList(), "#FFB74D");
-
-                if (refBlockingTask.IsCompletedSuccessfully)
-                {
-                    var refBlocking = refBlockingTask.Result
-                        .GroupBy(d => d.CollectionTime)
-                        .OrderBy(g => g.Key)
-                        .Select(g => (g.Key.Add(timeShift).ToOADate(), (double)g.Sum(x => x.BlockedCount)))
-                        .ToList();
-                    if (refBlocking.Count > 0)
-                        AddGhostLine(BlockingChart, refBlocking, "#E57373");
-                }
-
-                if (refMemoryTask.IsCompletedSuccessfully)
-                    AddGhostLine(MemoryChart, refMemoryTask.Result
-                        .Select(d => (d.CollectionTime.Add(timeShift).ToOADate(), (double)d.TotalMemoryMb)).ToList(), "#CE93D8");
-
-                if (refIoTask.IsCompletedSuccessfully)
-                {
-                    var refIo = refIoTask.Result
-                        .GroupBy(d => d.CollectionTime)
-                        .OrderBy(g => g.Key)
-                        .Select(g => (g.Key.Add(timeShift).ToOADate(), (double)g.Average(x => x.ReadLatencyMs)))
-                        .ToList();
-                    AddGhostLine(FileIoChart, refIo, "#81C784");
-                }
-
-                _crosshairManager?.SetComparisonLabel(ComparisonLabel(comparisonRange.Value, fromDate, hoursBack));
-            }
-
-            _crosshairManager?.ReattachVLines();
-            SyncXAxes(hoursBack, fromDate, toDate);
+                    .Select(g => (g.Key.ToOADate(), (double)g.Sum(x => x.BlockedCount)))
+                    .ToList()
+                : new List<(double, double)>();
+            var deadlockData = deadlockTask.IsCompletedSuccessfully
+                ? deadlockTask.Result
+                    .Select(d => (d.CollectionTime.ToOADate(), (double)d.BlockedCount))
+                    .ToList()
+                : new List<(double, double)>();
+            UpdateBlockingLane(blockingData, deadlockData, blockingLaneBaseline);
         }
-        finally
+        catch (Exception ex)
         {
-            _isRefreshing = false;
+            Debug.WriteLine($"CorrelatedLanes: Blocking lane failed: {ex}");
+            ShowEmpty(BlockingChart, "Blocking & Deadlocking");
         }
+
+        if (memoryTask.IsCompletedSuccessfully)
+            UpdateLane(MemoryChart, "Buffer Pool MB",
+                memoryTask.Result.Select(d => (d.CollectionTime.ToOADate(), (double)d.TotalMemoryMb)).ToList(),
+                "#CE93D8");
+        else
+            ShowEmpty(MemoryChart, "Buffer Pool MB");
+
+        if (fileIoTask.IsCompletedSuccessfully)
+        {
+            var ioGrouped = fileIoTask.Result
+                .GroupBy(d => d.CollectionTime)
+                .OrderBy(g => g.Key)
+                .Select(g => (g.Key.ToOADate(), (double)g.Average(x => x.ReadLatencyMs)))
+                .ToList();
+            UpdateLane(FileIoChart, "I/O ms", ioGrouped, "#81C784", baseline: ioBaseline, minAnomalyValue: 2);
+        }
+        else
+            ShowEmpty(FileIoChart, "I/O ms");
+
+        // Comparison overlay — fetch reference period data and render as ghost lines
+        if (comparisonRange.HasValue)
+        {
+            var refFrom = comparisonRange.Value.From;
+            var refTo = comparisonRange.Value.To;
+            var timeShift = (fromDate ?? DateTime.UtcNow.AddHours(-hoursBack)) - refFrom;
+
+            var refCpuTask = _dataService.GetCpuUtilizationAsync(0, refFrom, refTo);
+            var refWaitTask = _dataService.GetTotalWaitStatsTrendAsync(0, refFrom, refTo);
+            var refBlockingTask = _dataService.GetBlockedSessionTrendAsync(0, refFrom, refTo);
+            var refMemoryTask = _dataService.GetMemoryStatsAsync(0, refFrom, refTo);
+            var refIoTask = _dataService.GetFileIoLatencyTimeSeriesAsync(false, 0, refFrom, refTo);
+
+            try { await Task.WhenAll(refCpuTask, refWaitTask, refBlockingTask, refMemoryTask, refIoTask); }
+            catch (Exception ex) { Debug.WriteLine($"CorrelatedLanes: Comparison fetch failed: {ex.Message}"); }
+
+            if (refCpuTask.IsCompletedSuccessfully)
+                AddGhostLine(CpuChart, refCpuTask.Result
+                    .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(), "#4FC3F7");
+
+            if (refWaitTask.IsCompletedSuccessfully)
+                AddGhostLine(WaitStatsChart, refWaitTask.Result
+                    .Select(d => (d.CollectionTime.Add(timeShift).ToOADate(), (double)d.WaitTimeMsPerSecond)).ToList(), "#FFB74D");
+
+            if (refBlockingTask.IsCompletedSuccessfully)
+            {
+                var refBlocking = refBlockingTask.Result
+                    .GroupBy(d => d.CollectionTime)
+                    .OrderBy(g => g.Key)
+                    .Select(g => (g.Key.Add(timeShift).ToOADate(), (double)g.Sum(x => x.BlockedCount)))
+                    .ToList();
+                if (refBlocking.Count > 0)
+                    AddGhostLine(BlockingChart, refBlocking, "#E57373");
+            }
+
+            if (refMemoryTask.IsCompletedSuccessfully)
+                AddGhostLine(MemoryChart, refMemoryTask.Result
+                    .Select(d => (d.CollectionTime.Add(timeShift).ToOADate(), (double)d.TotalMemoryMb)).ToList(), "#CE93D8");
+
+            if (refIoTask.IsCompletedSuccessfully)
+            {
+                var refIo = refIoTask.Result
+                    .GroupBy(d => d.CollectionTime)
+                    .OrderBy(g => g.Key)
+                    .Select(g => (g.Key.Add(timeShift).ToOADate(), (double)g.Average(x => x.ReadLatencyMs)))
+                    .ToList();
+                AddGhostLine(FileIoChart, refIo, "#81C784");
+            }
+
+            _crosshairManager?.SetComparisonLabel(ComparisonLabel(comparisonRange.Value, fromDate, hoursBack));
+        }
+
+        _crosshairManager?.ReattachVLines();
+        SyncXAxes(hoursBack, fromDate, toDate);
     }
 
     /// <summary>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -47,6 +47,7 @@ namespace PerformanceMonitorDashboard
         private readonly UserPreferencesService _preferencesService;
         private DispatcherTimer? _autoRefreshTimer;
         private bool _isRefreshing;
+        private DateTime _refreshStartedUtc;
         private bool _suppressPickerUpdates;
 
         // Filter state dictionaries for each DataGrid
@@ -344,7 +345,22 @@ namespace PerformanceMonitorDashboard
                 };
                 _autoRefreshTimer.Tick += async (s, e) =>
                 {
-                    await LoadDataAsync(fullRefresh: false);
+                    _autoRefreshTimer?.Stop();
+                    try
+                    {
+                        await RefreshVisibleTabAsync();
+                        StatusText.Text = "Ready";
+                        FooterText.Text = $"Last refresh: {DateTime.Now:yyyy-MM-dd HH:mm:ss} | Server: {_serverConnection.DisplayName}";
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Auto-refresh error: {ex.Message}", ex);
+                        StatusText.Text = "Auto-refresh error";
+                    }
+                    finally
+                    {
+                        _autoRefreshTimer?.Start();
+                    }
                 };
                 _autoRefreshTimer.Start();
                 AutoRefreshToggle.IsChecked = true;
@@ -400,7 +416,22 @@ namespace PerformanceMonitorDashboard
                 };
                 _autoRefreshTimer.Tick += async (s, e) =>
                 {
-                    await LoadDataAsync(fullRefresh: false);
+                    _autoRefreshTimer?.Stop();
+                    try
+                    {
+                        await RefreshVisibleTabAsync();
+                        StatusText.Text = "Ready";
+                        FooterText.Text = $"Last refresh: {DateTime.Now:yyyy-MM-dd HH:mm:ss} | Server: {_serverConnection.DisplayName}";
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Auto-refresh error: {ex.Message}", ex);
+                        StatusText.Text = "Auto-refresh error";
+                    }
+                    finally
+                    {
+                        _autoRefreshTimer?.Start();
+                    }
                 };
                 _autoRefreshTimer.Start();
                 AutoRefreshToggle.IsChecked = true;
@@ -434,7 +465,22 @@ namespace PerformanceMonitorDashboard
                 };
                 _autoRefreshTimer.Tick += async (s, args) =>
                 {
-                    await LoadDataAsync(fullRefresh: false);
+                    _autoRefreshTimer?.Stop();
+                    try
+                    {
+                        await RefreshVisibleTabAsync();
+                        StatusText.Text = "Ready";
+                        FooterText.Text = $"Last refresh: {DateTime.Now:yyyy-MM-dd HH:mm:ss} | Server: {_serverConnection.DisplayName}";
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Auto-refresh error: {ex.Message}", ex);
+                        StatusText.Text = "Auto-refresh error";
+                    }
+                    finally
+                    {
+                        _autoRefreshTimer?.Start();
+                    }
                 };
                 _autoRefreshTimer.Start();
                 AutoRefreshToggle.Content = $"Auto-Refresh: {prefs.AutoRefreshIntervalSeconds}s";
@@ -1084,8 +1130,14 @@ namespace PerformanceMonitorDashboard
         /// </summary>
         private async Task LoadDataAsync(bool fullRefresh = true)
         {
-            if (_isRefreshing) return;
+            if (_isRefreshing)
+            {
+                // If a previous refresh has been running for over 2 minutes, it's stuck — allow a new one
+                if ((DateTime.UtcNow - _refreshStartedUtc).TotalMinutes < 2) return;
+                Logger.Error($"Previous refresh appears stuck (started {_refreshStartedUtc:HH:mm:ss}), allowing new refresh");
+            }
             _isRefreshing = true;
+            _refreshStartedUtc = DateTime.UtcNow;
 
             using var _ = Helpers.MethodProfiler.StartTiming("ServerTab");
             try
@@ -1616,9 +1668,11 @@ namespace PerformanceMonitorDashboard
             UpdateCompareDropdownState();
 
             // Don't refresh during initial load or if already refreshing
-            if (_isRefreshing || !IsLoaded) return;
+            if (!IsLoaded) return;
+            if (_isRefreshing && (DateTime.UtcNow - _refreshStartedUtc).TotalMinutes < 2) return;
 
             _isRefreshing = true;
+            _refreshStartedUtc = DateTime.UtcNow;
             try
             {
                 await RefreshVisibleTabAsync();


### PR DESCRIPTION
## Summary
- Auto-refresh timer ticks now use stop/start pattern instead of `_isRefreshing` guard — timer stops before each tick, restarts in `finally`, guaranteeing it always resumes
- Timer ticks call `RefreshVisibleTabAsync` directly, bypassing `LoadDataAsync` and its `_isRefreshing` gate that could get permanently stuck on hung SQL queries
- Removed redundant `_isRefreshing` guard from `CorrelatedTimelineLanesControl.RefreshAsync` that was independently causing Server Trends charts to silently skip updates
- Supersedes #833 which fixed the symptom but not the root cause

## Test plan
- [x] Build clean, 0 errors
- [x] Verified auto-refresh ticks fire on schedule via profiler log
- [x] Verified charts update on each tick (not just grids)
- [x] Verified user-selected time ranges are preserved across auto-refresh ticks
- [ ] Leave running overnight to confirm no stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)