### PR TITLE
Fix Dashboard auto-refresh: async loop, tab close, legend duplication

### DIFF
--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -375,6 +375,7 @@ namespace PerformanceMonitorDashboard
                 {
                     await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), cts.Token);
                     if (cts.Token.IsCancellationRequested) break;
+                    if (_isRefreshing) continue;
 
                     try
                     {
@@ -383,6 +384,11 @@ namespace PerformanceMonitorDashboard
                         StatusText.Text = "Ready";
                         FooterText.Text = $"Last refresh: {DateTime.Now:yyyy-MM-dd HH:mm:ss} | Server: {_serverConnection.DisplayName}";
                         Logger.Info($"Auto-refresh completed in {sw.ElapsedMilliseconds}ms for {_serverConnection.DisplayName}");
+                    }
+                    catch (OperationCanceledException) when (!cts.Token.IsCancellationRequested)
+                    {
+                        // SQL query cancelled or timed out, but our loop CTS is still alive — keep going
+                        Logger.Error($"Auto-refresh query cancelled for {_serverConnection.DisplayName}, continuing loop");
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -393,13 +399,15 @@ namespace PerformanceMonitorDashboard
             }
             catch (OperationCanceledException)
             {
-                // Normal shutdown
+                Logger.Info($"Auto-refresh loop stopped for {_serverConnection.DisplayName}");
             }
         }
 
         private void ServerTab_Unloaded(object sender, RoutedEventArgs e)
         {
-            _autoRefreshCts?.Cancel();
+            // Don't cancel auto-refresh on tab switch — WPF fires Unloaded when
+            // a TabItem is deselected, not just when the control is destroyed.
+            // The loop is lightweight and should keep ticking in the background.
             _autoRefreshTimer?.Stop();
             _autoRefreshTimer = null;
 


### PR DESCRIPTION
## Summary

- Replace DispatcherTimer with async Task.Delay loop — immune to Dispatcher priority starvation under heavy chart rendering
- Don't cancel auto-refresh on `Unloaded` — WPF fires this on tab switch/close, not just destruction
- Catch `OperationCanceledException` from SQL queries without killing the loop
- Skip auto-refresh ticks while a full refresh is in progress to prevent concurrent chart rendering that duplicates legends

## Test plan

- [x] Auto-refresh ticks every 60s verified in log
- [x] Closing other server tabs does not kill the remaining tab's auto-refresh
- [x] Chart legends remain single instance across multiple refreshes
- [x] Slicer-narrowed query grids still respect slicer range on auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)