### PR TITLE
Fix legend duplication on tab switch

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -886,6 +886,7 @@ namespace PerformanceMonitorDashboard
                             serverTab.AlertAcknowledged -= handler;
                             _alertAcknowledgedHandlers.Remove(tabId);
                         }
+                        serverTab.CleanupOnClose();
                     }
                     _openTabs.Remove(tabId);
                     _tabBadges.Remove(tabId);
@@ -1092,6 +1093,7 @@ namespace PerformanceMonitorDashboard
 
                     if (_openTabs.TryGetValue(server.Id, out var tabItem))
                     {
+                        if (tabItem.Content is ServerTab st) st.CleanupOnClose();
                         _openTabs.Remove(server.Id);
                         ServerTabControl.Items.Remove(tabItem);
                     }

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -377,6 +377,8 @@ namespace PerformanceMonitorDashboard
                     if (cts.Token.IsCancellationRequested) break;
                     if (_isRefreshing) continue;
 
+                    _isRefreshing = true;
+                    _refreshStartedUtc = DateTime.UtcNow;
                     try
                     {
                         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -387,13 +389,16 @@ namespace PerformanceMonitorDashboard
                     }
                     catch (OperationCanceledException) when (!cts.Token.IsCancellationRequested)
                     {
-                        // SQL query cancelled or timed out, but our loop CTS is still alive — keep going
                         Logger.Error($"Auto-refresh query cancelled for {_serverConnection.DisplayName}, continuing loop");
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         Logger.Error($"Auto-refresh error: {ex.Message}", ex);
                         StatusText.Text = "Auto-refresh error";
+                    }
+                    finally
+                    {
+                        _isRefreshing = false;
                     }
                 }
             }
@@ -405,9 +410,18 @@ namespace PerformanceMonitorDashboard
 
         private void ServerTab_Unloaded(object sender, RoutedEventArgs e)
         {
-            // Don't cancel auto-refresh on tab switch — WPF fires Unloaded when
-            // a TabItem is deselected, not just when the control is destroyed.
-            // The loop is lightweight and should keep ticking in the background.
+            // WPF fires Unloaded on tab switch, not just destruction.
+            // Don't tear down state here — the auto-refresh loop and chart
+            // state must survive tab switches. Cleanup happens when the tab
+            // is actually removed from the TabControl (via CleanupOnClose).
+        }
+
+        /// <summary>
+        /// Full cleanup — call when the server tab is permanently removed, not on tab switch.
+        /// </summary>
+        public void CleanupOnClose()
+        {
+            _autoRefreshCts?.Cancel();
             _autoRefreshTimer?.Stop();
             _autoRefreshTimer = null;
 


### PR DESCRIPTION
## Summary

Move teardown logic from `ServerTab_Unloaded` to a new `CleanupOnClose` method. WPF fires `Unloaded` on tab switch (not just destruction), which was clearing `_legendPanels`, disposing chart helpers, and unsubscribing events while the auto-refresh loop was still running. This caused duplicate legends on every tab switch.

Now `Unloaded` is a no-op. `CleanupOnClose` is called from `MainWindow` only when a tab is actually closed/removed.

## Test plan

- [x] Switch between sql2022 and sql2019 tabs — legends remain single instance
- [x] Manual refresh on each tab after switching — no duplicates
- [x] Auto-refresh keeps ticking through tab switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)