### PR TITLE
Encrypt webhook URLs with DPAPI via Credential Manager

### DIFF
--- a/Dashboard/Services/WebhookAlertService.cs
+++ b/Dashboard/Services/WebhookAlertService.cs
@@ -24,7 +24,10 @@ namespace PerformanceMonitorDashboard.Services
     public class WebhookAlertService
     {
         private const string EditionName = "Performance Monitor Dashboard";
+        private const string TeamsWebhookCredentialKey = "TeamsWebhook";
+        private const string SlackWebhookCredentialKey = "SlackWebhook";
         private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
+        private static readonly CredentialService s_credentialService = new();
 
         private readonly UserPreferencesService _preferencesService;
         private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
@@ -41,6 +44,50 @@ namespace PerformanceMonitorDashboard.Services
             _preferencesService = preferencesService;
             Current = this;
         }
+
+        /// <summary>
+        /// Gets a webhook URL from Windows Credential Manager.
+        /// </summary>
+        public static string GetWebhookUrl(string credentialKey)
+        {
+            try
+            {
+                var cred = s_credentialService.GetCredential(credentialKey);
+                return cred?.Password ?? "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to retrieve webhook URL for {credentialKey}: {ex.Message}");
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Saves a webhook URL to Windows Credential Manager.
+        /// </summary>
+        public static void SaveWebhookUrl(string credentialKey, string url)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(url))
+                {
+                    s_credentialService.DeleteCredential(credentialKey);
+                }
+                else
+                {
+                    s_credentialService.SaveCredential(credentialKey, "webhook", url);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to save webhook URL for {credentialKey}: {ex.Message}");
+            }
+        }
+
+        public static string GetTeamsWebhookUrl() => GetWebhookUrl(TeamsWebhookCredentialKey);
+        public static string GetSlackWebhookUrl() => GetWebhookUrl(SlackWebhookCredentialKey);
+        public static void SaveTeamsWebhookUrl(string url) => SaveWebhookUrl(TeamsWebhookCredentialKey, url);
+        public static void SaveSlackWebhookUrl(string url) => SaveWebhookUrl(SlackWebhookCredentialKey, url);
 
         /// <summary>
         /// Sends webhook alerts to all configured channels (Teams and/or Slack).
@@ -67,12 +114,14 @@ namespace PerformanceMonitorDashboard.Services
 
                 bool sent = false;
 
-                if (prefs.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(prefs.TeamsWebhookUrl))
+                var teamsUrl = GetTeamsWebhookUrl();
+                if (prefs.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(teamsUrl))
                 {
                     sent |= await TrySendTeamsAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
                 }
 
-                if (prefs.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(prefs.SlackWebhookUrl))
+                var slackUrl = GetSlackWebhookUrl();
+                if (prefs.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(slackUrl))
                 {
                     sent |= await TrySendSlackAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
                 }
@@ -148,7 +197,7 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, context: context);
-                var error = await PostWebhookAsync(prefs.TeamsWebhookUrl, payload, prefs.TeamsProxyAddress);
+                var error = await PostWebhookAsync(GetTeamsWebhookUrl(), payload, prefs.TeamsProxyAddress);
 
                 if (error != null)
                 {
@@ -268,7 +317,7 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, context: context);
-                var error = await PostWebhookAsync(prefs.SlackWebhookUrl, payload, prefs.SlackProxyAddress);
+                var error = await PostWebhookAsync(GetSlackWebhookUrl(), payload, prefs.SlackProxyAddress);
 
                 if (error != null)
                 {

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -210,11 +210,27 @@ namespace PerformanceMonitorDashboard
 
             // Webhook settings (Teams / Slack)
             TeamsWebhookEnabledCheckBox.IsChecked = prefs.TeamsWebhookEnabled;
-            TeamsWebhookUrlTextBox.Text = prefs.TeamsWebhookUrl;
             TeamsProxyAddressTextBox.Text = prefs.TeamsProxyAddress;
             SlackWebhookEnabledCheckBox.IsChecked = prefs.SlackWebhookEnabled;
-            SlackWebhookUrlTextBox.Text = prefs.SlackWebhookUrl;
             SlackProxyAddressTextBox.Text = prefs.SlackProxyAddress;
+
+            /* Migrate legacy plaintext webhook URLs to Credential Manager */
+            if (!string.IsNullOrWhiteSpace(prefs.TeamsWebhookUrl))
+            {
+                WebhookAlertService.SaveTeamsWebhookUrl(prefs.TeamsWebhookUrl);
+                prefs.TeamsWebhookUrl = "";
+                _preferencesService.SavePreferences(prefs);
+            }
+            if (!string.IsNullOrWhiteSpace(prefs.SlackWebhookUrl))
+            {
+                WebhookAlertService.SaveSlackWebhookUrl(prefs.SlackWebhookUrl);
+                prefs.SlackWebhookUrl = "";
+                _preferencesService.SavePreferences(prefs);
+            }
+
+            /* Load webhook URLs from Credential Manager */
+            TeamsWebhookUrlTextBox.Text = WebhookAlertService.GetTeamsWebhookUrl();
+            SlackWebhookUrlTextBox.Text = WebhookAlertService.GetSlackWebhookUrl();
             UpdateTeamsControlStates();
             UpdateSlackControlStates();
 
@@ -705,11 +721,15 @@ namespace PerformanceMonitorDashboard
 
             // Save webhook settings (Teams / Slack)
             prefs.TeamsWebhookEnabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
-            prefs.TeamsWebhookUrl = TeamsWebhookUrlTextBox.Text?.Trim() ?? "";
+            prefs.TeamsWebhookUrl = "";  /* URLs stored in Credential Manager, not preferences */
             prefs.TeamsProxyAddress = TeamsProxyAddressTextBox.Text?.Trim() ?? "";
             prefs.SlackWebhookEnabled = SlackWebhookEnabledCheckBox.IsChecked == true;
-            prefs.SlackWebhookUrl = SlackWebhookUrlTextBox.Text?.Trim() ?? "";
+            prefs.SlackWebhookUrl = "";  /* URLs stored in Credential Manager, not preferences */
             prefs.SlackProxyAddress = SlackProxyAddressTextBox.Text?.Trim() ?? "";
+
+            /* Save webhook URLs to Credential Manager */
+            WebhookAlertService.SaveTeamsWebhookUrl(TeamsWebhookUrlTextBox.Text?.Trim() ?? "");
+            WebhookAlertService.SaveSlackWebhookUrl(SlackWebhookUrlTextBox.Text?.Trim() ?? "");
 
             // Save MCP server settings
             bool mcpWasEnabled = prefs.McpEnabled;

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -128,6 +128,50 @@ public partial class App : Application
     public static string SlackWebhookUrl { get; set; } = "";
     public static string SlackProxyAddress { get; set; } = "";
 
+    private const string TeamsWebhookCredentialKey = "TeamsWebhook";
+    private const string SlackWebhookCredentialKey = "SlackWebhook";
+
+    /// <summary>
+    /// Gets a webhook URL from Windows Credential Manager.
+    /// </summary>
+    public static string GetWebhookUrl(string credentialKey)
+    {
+        try
+        {
+            var credService = new Services.CredentialService();
+            var cred = credService.GetCredential(credentialKey);
+            return cred?.Password ?? "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("App", $"Failed to retrieve webhook URL for {credentialKey}: {ex.Message}");
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// Saves a webhook URL to Windows Credential Manager.
+    /// </summary>
+    public static void SaveWebhookUrl(string credentialKey, string url)
+    {
+        try
+        {
+            var credService = new Services.CredentialService();
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                credService.DeleteCredential(credentialKey);
+            }
+            else
+            {
+                credService.SaveCredential(credentialKey, "webhook", url);
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("App", $"Failed to save webhook URL for {credentialKey}: {ex.Message}");
+        }
+    }
+
     /* SMTP email alert settings */
     public static bool SmtpEnabled { get; set; } = false;
     public static string SmtpServer { get; set; } = "";
@@ -356,13 +400,33 @@ public partial class App : Application
 
             /* Teams webhook settings */
             if (root.TryGetProperty("teams_webhook_enabled", out v)) TeamsWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("teams_webhook_url", out v)) TeamsWebhookUrl = v.GetString() ?? "";
             if (root.TryGetProperty("teams_proxy_address", out v)) TeamsProxyAddress = v.GetString() ?? "";
 
             /* Slack webhook settings */
             if (root.TryGetProperty("slack_webhook_enabled", out v)) SlackWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("slack_webhook_url", out v)) SlackWebhookUrl = v.GetString() ?? "";
             if (root.TryGetProperty("slack_proxy_address", out v)) SlackProxyAddress = v.GetString() ?? "";
+
+            /* Migrate webhook URLs from plaintext settings.json to Credential Manager */
+            if (root.TryGetProperty("teams_webhook_url", out v))
+            {
+                var legacyUrl = v.GetString() ?? "";
+                if (!string.IsNullOrWhiteSpace(legacyUrl))
+                {
+                    SaveWebhookUrl(TeamsWebhookCredentialKey, legacyUrl);
+                }
+            }
+            if (root.TryGetProperty("slack_webhook_url", out v))
+            {
+                var legacyUrl = v.GetString() ?? "";
+                if (!string.IsNullOrWhiteSpace(legacyUrl))
+                {
+                    SaveWebhookUrl(SlackWebhookCredentialKey, legacyUrl);
+                }
+            }
+
+            /* Load webhook URLs from Credential Manager */
+            TeamsWebhookUrl = GetWebhookUrl(TeamsWebhookCredentialKey);
+            SlackWebhookUrl = GetWebhookUrl(SlackWebhookCredentialKey);
 
             /* SMTP settings */
             if (root.TryGetProperty("smtp_enabled", out v)) SmtpEnabled = v.GetBoolean();

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -983,6 +983,10 @@ public partial class SettingsWindow : Window
         App.SlackWebhookUrl = SlackWebhookUrlBox.Text?.Trim() ?? "";
         App.SlackProxyAddress = SlackProxyAddressBox.Text?.Trim() ?? "";
 
+        /* Save webhook URLs to Credential Manager instead of settings.json */
+        App.SaveWebhookUrl("TeamsWebhook", App.TeamsWebhookUrl);
+        App.SaveWebhookUrl("SlackWebhook", App.SlackWebhookUrl);
+
         var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
         try
         {
@@ -998,11 +1002,16 @@ public partial class SettingsWindow : Window
             }
 
             root["teams_webhook_enabled"] = App.TeamsWebhookEnabled;
-            root["teams_webhook_url"] = App.TeamsWebhookUrl;
             root["teams_proxy_address"] = App.TeamsProxyAddress;
             root["slack_webhook_enabled"] = App.SlackWebhookEnabled;
-            root["slack_webhook_url"] = App.SlackWebhookUrl;
             root["slack_proxy_address"] = App.SlackProxyAddress;
+
+            /* Remove legacy plaintext webhook URLs from settings.json */
+            if (root is JsonObject obj)
+            {
+                obj.Remove("teams_webhook_url");
+                obj.Remove("slack_webhook_url");
+            }
 
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(settingsPath, root.ToJsonString(options));


### PR DESCRIPTION
## Summary
- Moves Teams and Slack webhook URLs from plaintext `settings.json` / `preferences.json` to Windows Credential Manager (DPAPI-encrypted)
- Follows the existing pattern used for SMTP passwords and SQL Server credentials
- Automatic migration: on first settings load, any plaintext URLs are moved to Credential Manager and stripped from the JSON file
- Both Dashboard and Lite editions updated

Closes #848

## Test plan
- [x] Both editions build with 0 warnings, 0 errors
- [ ] **Migration**: With an existing webhook URL in settings.json/preferences.json, open Settings — URL should appear in the textbox and be removed from the JSON file
- [ ] **Save**: Enter a new webhook URL, save settings, verify it persists across app restarts
- [ ] **Send**: Verify Teams/Slack test messages still send successfully
- [ ] **Clean install**: Fresh install with no prior webhook config — settings should load cleanly

cc @jakemorgangit — you built the webhook feature (#725), could you help test this with your Teams/Slack setup?

🤖 Generated with [Claude Code](https://claude.com/claude-code)