### PR TITLE
Lazy-load server tabs and cap query grid results to TOP 500

### DIFF
--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -101,7 +101,7 @@
                 <StackPanel Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Vertical" Margin="15,0,0,0">
                     <StackPanel Orientation="Horizontal">
                         <Button x:Name="ApplyToAllButton" Content="Apply to All Tabs" Click="ApplyToAllTabs_Click" Margin="2,0" Padding="12,5" Style="{DynamicResource AccentButton}"/>
-                        <Button x:Name="RefreshButton" Content="Refresh Tab" Click="RefreshButton_Click" Margin="2,0" Padding="12,5" Style="{DynamicResource SuccessButton}"/>
+                        <Button x:Name="RefreshButton" Content="Refresh Tab" Click="RefreshButton_Click" Margin="2,0" Padding="12,5" Style="{DynamicResource SuccessButton}" ToolTip="Refresh the current tab. Ctrl+Click to refresh all tabs."/>
                         <ToggleButton x:Name="AutoRefreshToggle" Content="Auto-Refresh: Off" Click="AutoRefreshToggle_Click" Margin="8,0,2,0" Padding="12,5" MinWidth="130" ToolTip="Toggle auto-refresh on/off. Configure interval in Settings."/>
                         <Button Content="Edit Schedules" Click="EditSchedules_Click" Margin="8,0,2,0" Padding="12,5" Style="{DynamicResource AccentButton}" ToolTip="Edit collector schedules (frequency, retention, enabled/disabled)"/>
                         <TextBlock Text="|" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -51,6 +51,7 @@ namespace PerformanceMonitorDashboard
         private bool _isRefreshing;
         private DateTime _refreshStartedUtc;
         private bool _suppressPickerUpdates;
+        private readonly HashSet<string> _initializedTabs = new();
 
         // Filter state dictionaries for each DataGrid
 
@@ -424,6 +425,7 @@ namespace PerformanceMonitorDashboard
             _autoRefreshCts?.Cancel();
             _autoRefreshTimer?.Stop();
             _autoRefreshTimer = null;
+            _initializedTabs.Clear();
 
             Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
             Loaded -= ServerTab_Loaded;
@@ -549,7 +551,8 @@ namespace PerformanceMonitorDashboard
                 if (e.Key == System.Windows.Input.Key.F5)
                 {
                     e.Handled = true;
-                    await LoadDataAsync();
+                    bool fullRefresh = System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control);
+                    await LoadDataAsync(fullRefresh);
                 }
                 else if (e.Key == System.Windows.Input.Key.V &&
                          System.Windows.Input.Keyboard.Modifiers == System.Windows.Input.ModifierKeys.Control &&
@@ -640,7 +643,7 @@ namespace PerformanceMonitorDashboard
                 CriticalIssuesTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                 DefaultTraceTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
 
-                await LoadDataAsync();
+                await LoadDataAsync(fullRefresh: false);
                 SetupAutoRefresh();
             }
             catch (Exception ex)
@@ -654,7 +657,8 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                await LoadDataAsync();
+                bool fullRefresh = System.Windows.Input.Keyboard.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control);
+                await LoadDataAsync(fullRefresh);
             }
             catch (Exception ex)
             {
@@ -1271,7 +1275,9 @@ namespace PerformanceMonitorDashboard
         }
 
         /// <summary>
-        /// Refreshes only the currently visible tab — used on auto-refresh timer tick.
+        /// Refreshes only the currently visible tab. On first visit to a tab,
+        /// does a full refresh so all sub-tabs are populated. Subsequent visits
+        /// only refresh the active sub-tab for speed.
         /// </summary>
         private async Task RefreshVisibleTabAsync()
         {
@@ -1279,6 +1285,7 @@ namespace PerformanceMonitorDashboard
             if (selectedTab == null) return;
 
             var tabHeader = GetTabHeaderText(selectedTab);
+            bool firstVisit = _initializedTabs.Add(tabHeader);
 
             switch (tabHeader)
             {
@@ -1286,19 +1293,19 @@ namespace PerformanceMonitorDashboard
                     await RefreshOverviewTabAsync();
                     break;
                 case "Queries":
-                    await RefreshQueriesTabAsync(fullRefresh: false);
+                    await RefreshQueriesTabAsync(fullRefresh: firstVisit);
                     break;
                 case "Resource Metrics":
-                    await RefreshResourceMetricsTabAsync(fullRefresh: false);
+                    await RefreshResourceMetricsTabAsync(fullRefresh: firstVisit);
                     break;
                 case "Memory":
-                    await RefreshMemoryTabAsync(fullRefresh: false);
+                    await RefreshMemoryTabAsync(fullRefresh: firstVisit);
                     break;
                 case "Locking":
                     await RefreshLockingTabAsync();
                     break;
                 case "System Events":
-                    await RefreshSystemEventsTabAsync(fullRefresh: false);
+                    await RefreshSystemEventsTabAsync(fullRefresh: firstVisit);
                     break;
                 // Plan Viewer has no data to refresh
             }

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -1110,7 +1110,7 @@ ORDER BY bucket_hour;";
                 qs.query_hash,
                 qs.creation_time
         )
-        SELECT
+        SELECT TOP (500)
             database_name = pl.database_name,
             query_hash = CONVERT(nvarchar(20), pl.query_hash, 1),
             object_type = MAX(pl.object_type),
@@ -1345,7 +1345,7 @@ ORDER BY bucket_hour;";
                 ps.object_name,
                 ps.cached_time
         )
-        SELECT
+        SELECT TOP (500)
             database_name = pl.database_name,
             object_id = MAX(pl.object_id),
             object_name = QUOTENAME(pl.schema_name) + N'.' + QUOTENAME(pl.object_name),
@@ -1520,7 +1520,7 @@ ORDER BY bucket_hour;";
                     string query = @"
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-        SELECT
+        SELECT TOP (500)
             database_name = qsd.database_name,
             query_id = qsd.query_id,
             execution_type_desc = MAX(qsd.execution_type_desc),


### PR DESCRIPTION
## Summary
- **Lazy-load tabs**: Opening a server tab now only loads the visible tab (Overview). Other tabs load on first switch. This prevents heavy queries like `GetQueryStatsAsync` from running when the user just wants Overview.
- **First-visit full load**: First switch to any tab does a full refresh (all sub-tabs). Subsequent auto-refreshes only hit the active sub-tab.
- **Ctrl+Click / Ctrl+F5**: Refreshes all tabs at once for users who want the old behavior. Tooltip on Refresh Tab button documents this.
- **TOP 500 cap**: `GetQueryStatsAsync`, `GetProcedureStatsAsync`, and `GetQueryStoreDataAsync` now return at most 500 rows (ordered by avg CPU desc). Prevents unbounded memory consumption on large installations.

Fixes #835 — tested against a report from a user with 49 databases and 742K rows in `query_stats` after 3 days, where the queries were timing out after 120 seconds and consuming 4GB+ memory.

## Test plan
- [x] Both commits build with 0 warnings, 0 errors
- [x] Opening a server tab loads fast (Overview only)
- [x] Switching to Queries tab loads all sub-tabs on first visit
- [x] Subsequent Refresh Tab only refreshes visible tab
- [x] Ctrl+Click on Refresh Tab refreshes all tabs
- [x] Apply to All Tabs still does full refresh
- [ ] Verify TOP 500 doesn't truncate meaningful data for typical installations

🤖 Generated with [Claude Code](https://claude.com/claude-code)