### PR TITLE
Fall back to single-DB mode when Azure master is inaccessible (#857)

### DIFF
--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -102,6 +102,14 @@ public partial class RemoteCollectorService
     private int _logInsertFailures;
     private string? _lastLogInsertError;
 
+    /// <summary>
+    /// Per-server flag indicating that master DB enumeration has failed with an access-denied
+    /// error and should not be retried. Used on Azure SQL DB where per-database logins may not
+    /// have master access (e.g. Microsoft Dynamics 365 FO). See issue #857.
+    /// </summary>
+    private readonly Dictionary<int, bool> _azureMasterInaccessible = new();
+    private readonly object _azureMasterInaccessibleLock = new();
+
     public RemoteCollectorService(
         DuckDbInitializer duckDb,
         ServerManager serverManager,
@@ -561,10 +569,30 @@ WHERE server_id = $3";
     /// Enumerates online databases on an Azure SQL DB logical server.
     /// HAS_DBACCESS() returns false for user databases from master on Azure SQL DB,
     /// so we skip that filter — inaccessible databases should be handled by callers via try/catch.
+    ///
+    /// On Azure SQL DB, logins are sometimes granted access only to a specific user database and
+    /// not to master (e.g. Microsoft Dynamics 365 FO). In that case, master enumeration fails with
+    /// an access/login error; we fall back to returning the connection's initial catalog as a
+    /// single-database list, and cache that decision per server so we don't retry master each cycle.
+    /// See issue #857.
     /// </summary>
     protected async Task<List<string>> GetAzureDatabaseListAsync(ServerConnection server, CancellationToken cancellationToken)
     {
+        var serverId = GetServerId(server);
         var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+        var targetDb = new SqlConnectionStringBuilder(baseConnStr).InitialCatalog;
+
+        bool knownInaccessible;
+        lock (_azureMasterInaccessibleLock)
+        {
+            _azureMasterInaccessible.TryGetValue(serverId, out knownInaccessible);
+        }
+
+        if (knownInaccessible)
+        {
+            return SingleDbOrEmpty(targetDb);
+        }
+
         var connStr = new SqlConnectionStringBuilder(baseConnStr)
         {
             ConnectTimeout = ConnectionTimeoutSeconds,
@@ -572,16 +600,63 @@ WHERE server_id = $3";
         }.ConnectionString;
 
         var databases = new List<string>();
-        using var conn = new SqlConnection(connStr);
-        await conn.OpenAsync(cancellationToken);
-        using var cmd = new SqlCommand(
-            "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
-            conn)
-        { CommandTimeout = CommandTimeoutSeconds };
-        using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
-            databases.Add(reader.GetString(0));
-        return databases;
+        try
+        {
+            using var conn = new SqlConnection(connStr);
+            await conn.OpenAsync(cancellationToken);
+            using var cmd = new SqlCommand(
+                "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
+                conn)
+            { CommandTimeout = CommandTimeoutSeconds };
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                databases.Add(reader.GetString(0));
+            return databases;
+        }
+        catch (SqlException ex) when (IsMasterAccessDeniedError(ex))
+        {
+            lock (_azureMasterInaccessibleLock)
+            {
+                _azureMasterInaccessible[serverId] = true;
+            }
+
+            var fallback = SingleDbOrEmpty(targetDb);
+            if (fallback.Count > 0)
+            {
+                AppLogger.Info("Collector", $"  [{server.DisplayName}] master DB inaccessible (SQL error {ex.Number}) — collecting from '{targetDb}' only.");
+            }
+            else
+            {
+                AppLogger.Warn("Collector", $"  [{server.DisplayName}] master DB inaccessible (SQL error {ex.Number}) and no target database in connection string — no data will be collected for database-scoped collectors.");
+            }
+            return fallback;
+        }
+    }
+
+    private static List<string> SingleDbOrEmpty(string? targetDb)
+    {
+        if (string.IsNullOrEmpty(targetDb) || string.Equals(targetDb, "master", StringComparison.OrdinalIgnoreCase))
+            return new List<string>();
+        return new List<string> { targetDb };
+    }
+
+    /// <summary>
+    /// Error numbers indicating the login cannot open or read from master on Azure SQL DB.
+    /// Trigger a fallback to single-database mode when we see one of these.
+    /// </summary>
+    private static bool IsMasterAccessDeniedError(SqlException ex)
+    {
+        return ex.Number switch
+        {
+            229   => true, // Permission denied on object
+            230   => true, // Permission denied on column
+            916   => true, // Server principal is not able to access the database under the current security context
+            4060  => true, // Cannot open database requested by the login
+            18456 => true, // Login failed for user
+            40613 => true, // Database 'master' on server is not currently available
+            40615 => true, // Cannot open server — login denied (firewall/auth)
+            _     => false
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fixes #857 — Lite failed and showed an empty screen when connecting to an Azure SQL DB login that lacks master access (common with Microsoft Dynamics 365 FO and other single-tenant logins).
- `GetAzureDatabaseListAsync` now catches known access-denied/login-failed SQL errors from the master connection, caches the per-server decision, and returns the connection's `InitialCatalog` as a single-element list.
- The three callers (`query_stats`, `database_size_stats`, `file_io_stats`) already iterate per-database — single-DB mode works without further changes.
- Users with master access retain today's full-server enumeration behavior.

## Behavior matrix
| InitialCatalog | Master accessible | Result |
|---|---|---|
| empty | yes | enumerate all DBs (unchanged) |
| empty | no | nothing collected, warning logged |
| set to a DB | yes | enumerate all DBs (unchanged) |
| set to a DB | no | collect from that one DB (new, fixes #857) |

## Test plan
- [ ] Connect Lite to an Azure SQL DB login with master access — enumeration still works, all DBs appear.
- [ ] Connect Lite to an Azure SQL DB login without master access and a specified target DB — no error popup, data collected for target DB only, info log line appears.
- [ ] Connect Lite to an Azure SQL DB login without master access and no target DB — warning log line appears, no crash.
- [ ] Confirm the fallback decision is cached: subsequent cycles don't retry master (check logs don't show repeated fallback messages).
- [ ] Boxed SQL Server and Azure MI unaffected (they don't call `GetAzureDatabaseListAsync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)