### PR TITLE
Add nonclustered indexes for query/procedure/query store lookups

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -1123,7 +1123,7 @@ ORDER BY bucket_hour;";
 
         SELECT TOP (500)
             database_name = pl.database_name,
-            query_hash = CONVERT(nvarchar(20), pl.query_hash, 1),
+            query_hash = pl.query_hash,
             object_type = MAX(pl.object_type),
             object_name =
                 CASE MAX(pl.object_type)
@@ -1180,7 +1180,7 @@ ORDER BY bucket_hour;";
         /*Phase 3: hydrate text and plan XML for the TOP 500 winners only*/
         SELECT
             tr.database_name,
-            tr.query_hash,
+            query_hash = CONVERT(nvarchar(20), tr.query_hash, 1),
             tr.object_type,
             tr.object_name,
             tr.first_execution_time,
@@ -1224,7 +1224,7 @@ ORDER BY bucket_hour;";
             SELECT TOP (1)
                 query_text = CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max))
             FROM collect.query_stats AS qs2
-            WHERE qs2.query_hash = CONVERT(binary(8), tr.query_hash, 1)
+            WHERE qs2.query_hash = tr.query_hash
             AND   qs2.database_name = tr.database_name
             ORDER BY qs2.collection_time DESC
         ) AS qt
@@ -1233,7 +1233,7 @@ ORDER BY bucket_hour;";
             SELECT TOP (1)
                 query_plan_xml = CAST(DECOMPRESS(qs3.query_plan_text) AS nvarchar(max))
             FROM collect.query_stats AS qs3
-            WHERE qs3.query_hash = CONVERT(binary(8), tr.query_hash, 1)
+            WHERE qs3.query_hash = tr.query_hash
             AND   qs3.database_name = tr.database_name
             AND   qs3.query_plan_text IS NOT NULL
             ORDER BY qs3.collection_time DESC
@@ -4379,7 +4379,7 @@ DROP TABLE IF EXISTS #top_ranked;
 
 SELECT TOP (@top + 5)
     database_name = pl.database_name,
-    query_hash = CONVERT(nvarchar(20), pl.query_hash, 1),
+    query_hash = pl.query_hash,
     object_type = MAX(pl.object_type),
     object_name =
         CASE MAX(pl.object_type)
@@ -4438,7 +4438,7 @@ OPTION
 /*Phase 3: hydrate text for winners only, apply WAITFOR filter*/
 SELECT TOP (@top)
     tr.database_name,
-    tr.query_hash,
+    query_hash = CONVERT(nvarchar(20), tr.query_hash, 1),
     tr.object_type,
     tr.object_name,
     tr.first_execution_time,
@@ -4481,7 +4481,7 @@ OUTER APPLY
     SELECT TOP (1)
         query_text = CAST(DECOMPRESS(qs2.query_text) AS nvarchar(max))
     FROM collect.query_stats AS qs2
-    WHERE qs2.query_hash = CONVERT(binary(8), tr.query_hash, 1)
+    WHERE qs2.query_hash = tr.query_hash
     AND   qs2.database_name = tr.database_name
     ORDER BY qs2.collection_time DESC
 ) AS qt

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1495,5 +1495,83 @@ BEGIN
     PRINT 'Created collect.server_properties table';
 END;
 
+/*
+Nonclustered indexes to support OUTER APPLY lookups in the Dashboard's
+query/procedure/query store grid queries. Without these, the optimizer builds
+an Eager Index Spool over the entire table to service the lookups, which can
+take minutes on large installations (see #835).
+
+ONLINE = ON is only supported on Enterprise/Developer/Azure editions. The
+options string is built dynamically based on SERVERPROPERTY('EngineEdition').
+*/
+DECLARE @online_option nvarchar(20) =
+    CASE
+        WHEN CAST(SERVERPROPERTY(N'EngineEdition') AS integer) IN (3, 5, 8)
+        THEN N', ONLINE = ON'
+        ELSE N''
+    END;
+
+DECLARE @index_sql nvarchar(max);
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.query_stats')
+    AND   name = N'IX_query_stats_hash_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_query_stats_hash_lookup
+    ON collect.query_stats
+        (query_hash, database_name, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.query_stats.IX_query_stats_hash_lookup index';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.procedure_stats')
+    AND   name = N'IX_procedure_stats_name_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_procedure_stats_name_lookup
+    ON collect.procedure_stats
+        (database_name, schema_name, object_name, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.procedure_stats.IX_procedure_stats_name_lookup index';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.query_store_data')
+    AND   name = N'IX_query_store_data_id_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_query_store_data_id_lookup
+    ON collect.query_store_data
+        (database_name, query_id, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.query_store_data.IX_query_store_data_id_lookup index';
+END;
+
 PRINT 'All collection tables created successfully';
 GO

--- a/upgrades/2.7.0-to-2.8.0/01_add_query_lookup_indexes.sql
+++ b/upgrades/2.7.0-to-2.8.0/01_add_query_lookup_indexes.sql
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 2.7.0 to 2.8.0
+
+Add nonclustered indexes on collect.query_stats, collect.procedure_stats, and
+collect.query_store_data to support OUTER APPLY lookups in the Dashboard's
+grid queries. Without these, the optimizer builds an Eager Index Spool over
+the entire table to service the lookups, which can take minutes on large
+installations (see #835).
+
+ONLINE = ON is only supported on Enterprise/Developer/Azure editions. The
+options string is built dynamically based on SERVERPROPERTY('EngineEdition').
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+DECLARE @online_option nvarchar(20) =
+    CASE
+        WHEN CAST(SERVERPROPERTY(N'EngineEdition') AS integer) IN (3, 5, 8)
+        THEN N', ONLINE = ON'
+        ELSE N''
+    END;
+
+DECLARE @index_sql nvarchar(max);
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.query_stats')
+    AND   name = N'IX_query_stats_hash_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_query_stats_hash_lookup
+    ON collect.query_stats
+        (query_hash, database_name, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.query_stats.IX_query_stats_hash_lookup index';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.procedure_stats')
+    AND   name = N'IX_procedure_stats_name_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_procedure_stats_name_lookup
+    ON collect.procedure_stats
+        (database_name, schema_name, object_name, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.procedure_stats.IX_procedure_stats_name_lookup index';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.query_store_data')
+    AND   name = N'IX_query_store_data_id_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_query_store_data_id_lookup
+    ON collect.query_store_data
+        (database_name, query_id, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.query_store_data.IX_query_store_data_id_lookup index';
+END;

--- a/upgrades/2.7.0-to-2.8.0/upgrade.txt
+++ b/upgrades/2.7.0-to-2.8.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_add_query_lookup_indexes.sql


### PR DESCRIPTION
## Summary
- **SARGability fix**: Remove `CONVERT(binary(8), nvarchar, 1)` from OUTER APPLY WHERE clauses in the Phase 3 hydration queries (`GetQueryStatsAsync` + MCP equivalent). `query_hash` now stays as native `binary(8)` through the temp tables and is only converted to `nvarchar(20)` in the final output.
- **Three new nonclustered indexes** to back the OUTER APPLY lookups:
  - `IX_query_stats_hash_lookup (query_hash, database_name, collection_time DESC)`
  - `IX_procedure_stats_name_lookup (database_name, schema_name, object_name, collection_time DESC)`
  - `IX_query_store_data_id_lookup (database_name, query_id, collection_time DESC)`
- Indexes use `SORT_IN_TEMPDB = ON` and `DATA_COMPRESSION = PAGE`.
- `ONLINE = ON` is applied conditionally via dynamic SQL based on `SERVERPROPERTY('EngineEdition')` — Enterprise/Developer/Azure only.
- Added to both `install/02_create_tables.sql` (new installs) and `upgrades/2.7.0-to-2.8.0/01_add_query_lookup_indexes.sql` (existing installs).

## Background
CADelete's execution plan (#835) showed a 104-second Eager Index Spool on the Phase 3 OUTER APPLY. No nonclustered index existed to service the lookup by `(query_hash, database_name)`, so SQL Server built a temporary index over the entire 781K-row table on every query.

After testing locally and on CADelete's server: Phase 3 dropped from 104s to effectively 0 (key lookups for 500 rows). Total query went from 1m 37s to 5s on their 742K-row table.

Fixes #835

## Test plan
- [x] Builds clean
- [x] Install script tested against local SQL2022 — indexes created with PAGE compression
- [x] Upgrade script is idempotent (re-running skips via `IF NOT EXISTS`)
- [x] Dynamic SQL for ONLINE option works on Developer Edition
- [ ] Test upgrade path from 2.7.0 against a populated database
- [ ] Verify plan picks up index at scale (CADelete's server showed natural seek at 742K rows without hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)