### PR TITLE
Scope query snapshots to current database on Azure SQL DB (#857)

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -112,6 +112,7 @@ public partial class ServerTab : UserControl
 
     public int UtcOffsetMinutes { get; }
     private readonly bool _hasMsdbAccess;
+    private readonly bool _isAzureSqlDatabase;
 
     /// <summary>
     /// Raised after each data refresh with alert counts for tab badge display.
@@ -120,7 +121,7 @@ public partial class ServerTab : UserControl
     public event Action<int>? ApplyTimeRangeRequested; /* selectedIndex */
     public event Func<Task>? ManualRefreshRequested;
 
-    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialService credentialService, int utcOffsetMinutes = 0, bool hasMsdbAccess = true)
+    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialService credentialService, int utcOffsetMinutes = 0, bool hasMsdbAccess = true, bool isAzureSqlDatabase = false)
     {
         InitializeComponent();
 
@@ -130,6 +131,7 @@ public partial class ServerTab : UserControl
         _credentialService = credentialService;
         UtcOffsetMinutes = utcOffsetMinutes;
         _hasMsdbAccess = hasMsdbAccess;
+        _isAzureSqlDatabase = isAzureSqlDatabase;
         ServerTimeHelper.UtcOffsetMinutes = utcOffsetMinutes;
 
         ServerNameText.Text = server.ReadOnlyIntent ? $"{server.DisplayName} (Read-Only)" : server.DisplayName;
@@ -5137,7 +5139,7 @@ public partial class ServerTab : UserControl
                 ConnectTimeout = 15
             };
 
-            var query = RemoteCollectorService.BuildQuerySnapshotsQuery(supportsLiveQueryPlan: true);
+            var query = RemoteCollectorService.BuildQuerySnapshotsQuery(supportsLiveQueryPlan: true, isAzureSqlDatabase: _isAzureSqlDatabase);
 
             await using var connection = new SqlConnection(builder.ConnectionString);
             await connection.OpenAsync();

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -523,7 +523,7 @@ public partial class MainWindow : Window
         }
 
         var utcOffset = status.UtcOffsetMinutes ?? 0;
-        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialService, utcOffset, status.HasMsdbAccess);
+        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialService, utcOffset, status.HasMsdbAccess, status.SqlEngineEdition == 5);
         var tabHeader = CreateTabHeader(server);
         var tabItem = new TabItem
         {

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -81,6 +81,7 @@ WHERE der.session_id <> @@SPID
 AND   der.session_id >= 50
 AND   dest.text IS NOT NULL
 AND   der.database_id <> ISNULL(DB_ID(N'PerformanceMonitor'), 0)
+{2}
 ORDER BY der.cpu_time DESC, der.parallel_worker_count DESC
 OPTION(MAXDOP 1, RECOMPILE);
 """;
@@ -89,12 +90,21 @@ OPTION(MAXDOP 1, RECOMPILE);
     /// <summary>
     /// Builds the query snapshots SQL with or without live query plan support.
     /// Used by both the collector and the live snapshot button.
+    /// On Azure SQL Database the result set is scoped to the current database only,
+    /// because logins without access to master can't resolve cross-database requests (see #857).
     /// </summary>
-    internal static string BuildQuerySnapshotsQuery(bool supportsLiveQueryPlan)
+    internal static string BuildQuerySnapshotsQuery(bool supportsLiveQueryPlan, bool isAzureSqlDatabase)
     {
-        return supportsLiveQueryPlan
-            ? string.Format(null, QuerySnapshotsBaseFormat, "live_query_plan = deqs.query_plan,", "OUTER APPLY sys.dm_exec_query_statistics_xml(der.session_id) AS deqs")
-            : string.Format(null, QuerySnapshotsBaseFormat, "live_query_plan = CONVERT(xml, NULL),", "");
+        var liveQueryPlanColumn = supportsLiveQueryPlan
+            ? "live_query_plan = deqs.query_plan,"
+            : "live_query_plan = CONVERT(xml, NULL),";
+        var liveQueryPlanApply = supportsLiveQueryPlan
+            ? "OUTER APPLY sys.dm_exec_query_statistics_xml(der.session_id) AS deqs"
+            : "";
+        var azureScopePredicate = isAzureSqlDatabase
+            ? "AND   der.database_id = DB_ID()"
+            : "";
+        return string.Format(null, QuerySnapshotsBaseFormat, liveQueryPlanColumn, liveQueryPlanApply, azureScopePredicate);
     }
 
     /// <summary>
@@ -106,8 +116,9 @@ OPTION(MAXDOP 1, RECOMPILE);
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         var supportsLiveQueryPlan = serverStatus.SqlMajorVersion >= 13 || serverStatus.SqlMajorVersion == 0
             || serverStatus.SqlEngineEdition == 5 || serverStatus.SqlEngineEdition == 8;
+        var isAzureSqlDatabase = serverStatus.SqlEngineEdition == 5;
 
-        var query = BuildQuerySnapshotsQuery(supportsLiveQueryPlan);
+        var query = BuildQuerySnapshotsQuery(supportsLiveQueryPlan, isAzureSqlDatabase);
 
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;


### PR DESCRIPTION
## Summary

Follow-up to #858. @TrudAX reported that the Live Snapshot button still errored on his D365FO Azure SQL Database after the collector fallback shipped. Root cause: `sys.dm_exec_requests` can surface rows for databases the login can't resolve (typically master-scoped activity), and the subsequent `OUTER APPLY`s to `sys.dm_exec_sql_text` / `sys.dm_exec_text_query_plan` blow up.

On Azure SQL DB, scoping the query snapshots result set to the current database is both correct and sufficient — `sys.dm_exec_requests` on Azure SQL DB is already per-connection and the user DB is the only DB the login is guaranteed to access.

- `BuildQuerySnapshotsQuery` takes a new `isAzureSqlDatabase` flag and emits `AND der.database_id = DB_ID()` only when true
- Collector path pulls `SqlEngineEdition` from the cached `ServerConnectionStatus` (already did — just added the flag derivation)
- Live Snapshot button path gets the flag through a new `ServerTab` constructor parameter wired from `MainWindow`
- Boxed SQL Server, Managed Instance, and elastic pool behavior is unchanged

Verified on a fresh Azure SQL DB (`GP_S_Gen5`) — `DB_ID()` (no args) returns the current DB, the scoped query runs cleanly, and activity from the current DB shows up in Live Snapshot.

## Test plan
- [x] Build: `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 errors
- [x] Azure SQL DB smoke test: Live Snapshot button returns results for testdb-scoped activity only, no master rows
- [x] Boxed SQL Server: unchanged behavior, no new predicate emitted
- [ ] D365FO environment confirmation (deferred to @TrudAX when merged to dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)