### PR TITLE
Fix Overview crosshair disappearing after tab switches / layout passes

### DIFF
--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -31,7 +31,12 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     public CorrelatedTimelineLanesControl()
     {
         InitializeComponent();
-        Unloaded += (_, _) => _crosshairManager?.Dispose();
+        /* No Unloaded → Dispose() handler: WPF fires Unloaded for transient
+           reasons (tab virtualization, layout rebuilds) and Dispose() clears
+           the crosshair manager's lane list, permanently breaking the crosshair
+           until the ServerTab is rebuilt. The manager holds only managed state
+           (a Popup + lane references) — letting GC clean it up with the control
+           is fine. */
     }
 
     /// <summary>
@@ -68,6 +73,9 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         if (_dataService == null) return;
 
         _crosshairManager?.PrepareForRefresh();
+
+        try
+        {
 
         var cpuTask = _dataService.GetCpuUtilizationAsync(hoursBack, fromDate, toDate);
         var waitTask = _dataService.GetTotalWaitStatsTrendAsync(hoursBack, fromDate, toDate);
@@ -225,8 +233,18 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             _crosshairManager?.SetComparisonLabel(ComparisonLabel(comparisonRange.Value, fromDate, hoursBack));
         }
 
+        /* VLines must be re-attached before SyncXAxes so they're part of
+           the render set when the chart refreshes. */
         _crosshairManager?.ReattachVLines();
         SyncXAxes(hoursBack, fromDate, toDate);
+        }
+        finally
+        {
+            /* Safety net: if something threw between PrepareForRefresh() and the
+               ReattachVLines() call above, VLines are still null. EnsureVLinesAttached
+               creates them only for lanes where VLine is null, so it's idempotent. */
+            _crosshairManager?.EnsureVLinesAttached();
+        }
     }
 
     /// <summary>

--- a/Dashboard/Helpers/CorrelatedCrosshairManager.cs
+++ b/Dashboard/Helpers/CorrelatedCrosshairManager.cs
@@ -33,7 +33,6 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
     private readonly Popup _tooltip;
     private readonly TextBlock _tooltipText;
     private DateTime _lastUpdate;
-    private bool _isRefreshing;
 
     public CorrelatedCrosshairManager()
     {
@@ -144,10 +143,11 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
 
     /// <summary>
     /// Clears data and VLines. Call before re-populating charts.
+    /// The OnMouseMove guard relies on lane.VLine == null to detect "not ready",
+    /// so this is self-healing: once ReattachVLines runs, crosshairs resume.
     /// </summary>
     public void PrepareForRefresh()
     {
-        _isRefreshing = true;
         _tooltip.IsOpen = false;
         _comparisonLabel = null;
         foreach (var lane in _lanes)
@@ -162,25 +162,54 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
 
     /// <summary>
     /// Creates fresh VLine plottables on each lane's chart.
-    /// Must be called AFTER chart data is populated.
+    /// Must be called AFTER chart data is populated. Safe to call in a finally
+    /// block — if chart state is invalid, a failure on one lane won't prevent
+    /// the others from recovering.
     /// </summary>
     public void ReattachVLines()
     {
         foreach (var lane in _lanes)
         {
-            var vline = lane.Chart.Plot.Add.VerticalLine(0);
+            lane.VLine = CreateVLine(lane.Chart);
+        }
+    }
+
+    /// <summary>
+    /// Creates VLines only for lanes that don't already have one. Idempotent —
+    /// safe to call from a finally block as a recovery path after an exception
+    /// in the main refresh flow.
+    /// </summary>
+    public void EnsureVLinesAttached()
+    {
+        foreach (var lane in _lanes)
+        {
+            if (lane.VLine != null) continue;
+            lane.VLine = CreateVLine(lane.Chart);
+        }
+    }
+
+    private static ScottPlot.Plottables.VerticalLine? CreateVLine(ScottPlot.WPF.WpfPlot chart)
+    {
+        try
+        {
+            var vline = chart.Plot.Add.VerticalLine(0);
             vline.Color = ScottPlot.Color.FromHex("#FFFFFF").WithAlpha(100);
             vline.LineWidth = 1;
             vline.LinePattern = ScottPlot.LinePattern.Dashed;
             vline.IsVisible = false;
-            lane.VLine = vline;
+            return vline;
         }
-        _isRefreshing = false;
+        catch
+        {
+            /* If attach fails, return null so OnMouseMove skips this lane.
+               Next refresh will try again. */
+            return null;
+        }
     }
 
     private void OnMouseMove(LaneInfo sourceLane, MouseEventArgs e)
     {
-        if (_isRefreshing || sourceLane.VLine == null) return;
+        if (sourceLane.VLine == null) return;
 
         var now = DateTime.UtcNow;
         if ((now - _lastUpdate).TotalMilliseconds < 16) return;

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -31,7 +31,12 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     public CorrelatedTimelineLanesControl()
     {
         InitializeComponent();
-        Unloaded += (_, _) => _crosshairManager?.Dispose();
+        /* No Unloaded → Dispose() handler: WPF fires Unloaded for transient
+           reasons (tab virtualization, layout rebuilds) and Dispose() clears
+           the crosshair manager's lane list, permanently breaking the crosshair
+           until the ServerTab is rebuilt. The manager holds only managed state
+           (a Popup + lane references) — letting GC clean it up with the control
+           is fine. */
     }
 
     /// <summary>
@@ -203,11 +208,17 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 _crosshairManager?.SetComparisonLabel(ComparisonLabel(comparisonRange.Value, fromDate, hoursBack));
             }
 
+            /* VLines must be re-attached before SyncXAxes so they're part of
+               the render set when the chart refreshes. */
             _crosshairManager?.ReattachVLines();
             SyncXAxes(hoursBack, fromDate, toDate, utcOffset);
         }
         finally
         {
+            /* Safety net: if something threw between PrepareForRefresh() and the
+               ReattachVLines() call above, VLines are still null. EnsureVLinesAttached
+               creates them only for lanes where VLine is null, so it's idempotent. */
+            _crosshairManager?.EnsureVLinesAttached();
             _isRefreshing = false;
         }
     }

--- a/Lite/Helpers/CorrelatedCrosshairManager.cs
+++ b/Lite/Helpers/CorrelatedCrosshairManager.cs
@@ -33,7 +33,6 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
     private readonly Popup _tooltip;
     private readonly TextBlock _tooltipText;
     private DateTime _lastUpdate;
-    private bool _isRefreshing;
 
     public CorrelatedCrosshairManager()
     {
@@ -144,10 +143,11 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
 
     /// <summary>
     /// Clears data and VLines. Call before re-populating charts.
+    /// The OnMouseMove guard relies on lane.VLine == null to detect "not ready",
+    /// so this is self-healing: once ReattachVLines runs, crosshairs resume.
     /// </summary>
     public void PrepareForRefresh()
     {
-        _isRefreshing = true;
         _tooltip.IsOpen = false;
         _comparisonLabel = null;
         foreach (var lane in _lanes)
@@ -162,25 +162,54 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
 
     /// <summary>
     /// Creates fresh VLine plottables on each lane's chart.
-    /// Must be called AFTER chart data is populated.
+    /// Must be called AFTER chart data is populated. Safe to call in a finally
+    /// block — if chart state is invalid, a failure on one lane won't prevent
+    /// the others from recovering.
     /// </summary>
     public void ReattachVLines()
     {
         foreach (var lane in _lanes)
         {
-            var vline = lane.Chart.Plot.Add.VerticalLine(0);
+            lane.VLine = CreateVLine(lane.Chart);
+        }
+    }
+
+    /// <summary>
+    /// Creates VLines only for lanes that don't already have one. Idempotent —
+    /// safe to call from a finally block as a recovery path after an exception
+    /// in the main refresh flow.
+    /// </summary>
+    public void EnsureVLinesAttached()
+    {
+        foreach (var lane in _lanes)
+        {
+            if (lane.VLine != null) continue;
+            lane.VLine = CreateVLine(lane.Chart);
+        }
+    }
+
+    private static ScottPlot.Plottables.VerticalLine? CreateVLine(ScottPlot.WPF.WpfPlot chart)
+    {
+        try
+        {
+            var vline = chart.Plot.Add.VerticalLine(0);
             vline.Color = ScottPlot.Color.FromHex("#FFFFFF").WithAlpha(100);
             vline.LineWidth = 1;
             vline.LinePattern = ScottPlot.LinePattern.Dashed;
             vline.IsVisible = false;
-            lane.VLine = vline;
+            return vline;
         }
-        _isRefreshing = false;
+        catch
+        {
+            /* If attach fails, return null so OnMouseMove skips this lane.
+               Next refresh will try again. */
+            return null;
+        }
     }
 
     private void OnMouseMove(LaneInfo sourceLane, MouseEventArgs e)
     {
-        if (_isRefreshing || sourceLane.VLine == null) return;
+        if (sourceLane.VLine == null) return;
 
         var now = DateTime.UtcNow;
         if ((now - _lastUpdate).TotalMilliseconds < 16) return;


### PR DESCRIPTION
## Summary
Crosshair on the Overview tab's correlated timeline lanes was working on first open but disappearing after some combination of auto-refreshes, tab switches, or layout events. Diagnosed via logging: the manager's lane list was going from 5 to 0 unexpectedly.

**Root cause:** the control had `Unloaded += ...Dispose()` on the crosshair manager. WPF fires `Unloaded` for transient reasons (tab virtualization, layout rebuilds) — not just when the control is truly going away. `Dispose()` clears the lane list, after which `ReattachVLines` runs over an empty list and the crosshair is permanently gone.

## Changes
- **Remove the `Unloaded → Dispose()` handler** in both Lite and Dashboard copies. The manager holds only managed state (a Popup + lane references) — GC will clean it up with the control.
- **Remove the redundant `_isRefreshing` flag** from `CorrelatedCrosshairManager`. The `lane.VLine == null` check in `OnMouseMove` is a sufficient "not ready" guard and is self-healing once VLines are recreated.
- **Wrap `ReattachVLines` in a try/finally** on the control side, with a new idempotent `EnsureVLinesAttached()` safety net that only creates VLines for lanes where they're still null.
- **Per-lane exception handling** in `CreateVLine` so one failing chart can't prevent the others from recovering.

## Test plan
- [x] Builds clean (Lite + Dashboard)
- [x] Crosshair survives multiple auto-refresh cycles on Lite (verified with logging before commit)
- [ ] Crosshair survives tab switches (Overview → Queries → back to Overview)
- [ ] Crosshair works on manual time range changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)