### PR TITLE
Fix blocked process report plan lookup (#867)

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -32,12 +32,38 @@
                 </MenuItem>
             </ContextMenu>
 
+            <!-- Context menu for Blocked Process Reports: separate Blocked/Blocking plan
+                 actions; no Get Actual Plan because re-executing a blocked query is a foot-gun. -->
+            <ContextMenu x:Key="BlockedProcessContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Blocked Plan" Click="ViewBlockedSidePlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="View Blocking Plan" Click="ViewBlockingSidePlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+
             <Style x:Key="GridRowStyle" TargetType="DataGridRow">
                 <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
             </Style>
 
             <!-- Row style for blocking grid - highlight long-duration blocks -->
-            <Style x:Key="BlockingRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource GridRowStyle}">
+            <Style x:Key="BlockingRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource BlockedProcessContextMenu}"/>
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding IsLongBlock}" Value="True">
                         <Setter Property="Background" Value="#33FF6B6B"/>

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -4861,6 +4861,104 @@ public partial class ServerTab : UserControl
         catch { return null; }
     }
 
+    // ── Blocked Process Report plan lookup ──
+
+    /* SQL Server writes this 42-byte all-zero handle into executionStack frames
+       for dynamic SQL / system contexts where no persistent sql_handle exists.
+       Filter matches sp_HumanEventsBlockViewer's XPath exclusion. */
+    private static readonly string ZeroSqlHandle = "0x" + new string('0', 84);
+
+    private async void ViewBlockedSidePlan_Click(object sender, RoutedEventArgs e)
+        => await ShowBlockedProcessPlanAsync(sender, blockingSide: false);
+
+    private async void ViewBlockingSidePlan_Click(object sender, RoutedEventArgs e)
+        => await ShowBlockedProcessPlanAsync(sender, blockingSide: true);
+
+    private async System.Threading.Tasks.Task ShowBlockedProcessPlanAsync(object sender, bool blockingSide)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is not BlockedProcessReportRow row) return;
+
+        var sideLabel = blockingSide ? "Blocking" : "Blocked";
+        var spid = blockingSide ? row.BlockingSpid : row.BlockedSpid;
+        var queryText = blockingSide ? row.BlockingSqlText : row.BlockedSqlText;
+        var label = $"Est Plan - {sideLabel} SPID {spid}";
+
+        var frames = ExtractBlockedProcessFrames(row.BlockedProcessReportXml, blockingSide);
+        if (frames.Count == 0)
+        {
+            MessageBox.Show(
+                $"The {sideLabel.ToLowerInvariant()} process report has no resolvable sql_handle. " +
+                "This usually means the query ran as dynamic SQL or a system context — " +
+                "SQL Server records a zero handle in that case and the plan can't be recovered.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        string? planXml = null;
+        try
+        {
+            var connStr = _server.GetConnectionString(_credentialService);
+            foreach (var f in frames)
+            {
+                planXml = await LocalDataService.FetchPlanBySqlHandleAsync(
+                    connStr, row.DatabaseName, f.SqlHandle, f.StmtStart, f.StmtEnd);
+                if (!string.IsNullOrEmpty(planXml)) break;
+            }
+        }
+        catch { }
+
+        if (!string.IsNullOrEmpty(planXml))
+        {
+            OpenPlanTab(planXml, label, queryText);
+            PlanViewerTabItem.IsSelected = true;
+        }
+        else
+        {
+            MessageBox.Show(
+                $"The plan for the {sideLabel.ToLowerInvariant()} query is no longer in the plan cache on {_server.ServerName}. " +
+                "Blocked process reports only give us a sql_handle — if that plan has been evicted, we can't recover it.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+    }
+
+    private static IReadOnlyList<(string SqlHandle, int StmtStart, int StmtEnd)> ExtractBlockedProcessFrames(
+        string bprXml, bool blockingSide)
+    {
+        var empty = Array.Empty<(string, int, int)>();
+        if (string.IsNullOrWhiteSpace(bprXml)) return empty;
+        try
+        {
+            var doc = System.Xml.Linq.XElement.Parse(bprXml);
+            var processContainer = blockingSide
+                ? doc.Element("blocking-process")
+                : doc.Element("blocked-process");
+            var stack = processContainer?.Element("process")?.Element("executionStack");
+            if (stack == null) return empty;
+
+            var frames = new List<(string, int, int)>();
+            foreach (var frame in stack.Elements("frame"))
+            {
+                var handle = frame.Attribute("sqlhandle")?.Value;
+                if (string.IsNullOrWhiteSpace(handle)) continue;
+                if (string.Equals(handle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase)) continue;
+
+                int stmtStart = 0;
+                int stmtEnd = -1;
+                int.TryParse(frame.Attribute("stmtstart")?.Value, out stmtStart);
+                if (int.TryParse(frame.Attribute("stmtend")?.Value, out var se)) stmtEnd = se;
+
+                frames.Add((handle!, stmtStart, stmtEnd));
+            }
+            return frames;
+        }
+        catch
+        {
+            return empty;
+        }
+    }
+
     // ── Active Queries Slicer ──
 
     private async System.Threading.Tasks.Task LoadActiveQueriesSlicerAsync()

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -570,6 +570,72 @@ OPTION(RECOMPILE);',
     }
 
     /// <summary>
+    /// Fetches a query plan on-demand by sql_handle + statement offsets.
+    /// Used for Blocked Process Reports, where query_hash is not present in the
+    /// XE event payload — only the sql_handle and offsets from executionStack frames.
+    /// </summary>
+    public static async Task<string?> FetchPlanBySqlHandleAsync(
+        string connectionString,
+        string databaseName,
+        string sqlHandleHex,
+        int statementStartOffset,
+        int statementEndOffset)
+    {
+        if (string.IsNullOrWhiteSpace(sqlHandleHex)) return null;
+        var handleBytes = HexStringToBytes(sqlHandleHex);
+        if (handleBytes == null || handleBytes.Length == 0) return null;
+
+        using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        var quotedDbName = await GetValidatedDatabaseNameAsync(connection, databaseName)
+                           ?? "[master]";
+
+        var query = $@"
+EXECUTE {quotedDbName}.sys.sp_executesql
+    N'
+SELECT TOP (1)
+    query_plan_text = tqp.query_plan
+FROM sys.dm_exec_query_stats AS qs
+OUTER APPLY sys.dm_exec_text_query_plan(qs.plan_handle, qs.statement_start_offset, qs.statement_end_offset) AS tqp
+WHERE qs.sql_handle = @h
+AND   qs.statement_start_offset = @stmt_start
+AND   qs.statement_end_offset = @stmt_end
+AND   tqp.query_plan IS NOT NULL
+ORDER BY
+    qs.last_execution_time DESC
+OPTION(RECOMPILE);',
+    N'@h varbinary(64), @stmt_start int, @stmt_end int',
+    @h, @stmt_start, @stmt_end;";
+
+        using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };
+        command.Parameters.Add(new SqlParameter("@h", SqlDbType.VarBinary, 64) { Value = handleBytes });
+        command.Parameters.Add(new SqlParameter("@stmt_start", SqlDbType.Int) { Value = statementStartOffset });
+        command.Parameters.Add(new SqlParameter("@stmt_end", SqlDbType.Int) { Value = statementEndOffset });
+        var result = await command.ExecuteScalarAsync();
+        return result as string;
+    }
+
+    private static byte[]? HexStringToBytes(string hex)
+    {
+        var start = hex.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? 2 : 0;
+        var len = hex.Length - start;
+        if (len <= 0 || (len % 2) != 0) return null;
+        var bytes = new byte[len / 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (!byte.TryParse(hex.AsSpan(start + i * 2, 2),
+                               System.Globalization.NumberStyles.HexNumber,
+                               System.Globalization.CultureInfo.InvariantCulture,
+                               out bytes[i]))
+            {
+                return null;
+            }
+        }
+        return bytes;
+    }
+
+    /// <summary>
     /// Gets top procedures by CPU for a server.
     /// </summary>
     public async Task<List<Models.TimeSliceBucket>> GetProcStatsSlicerDataAsync(


### PR DESCRIPTION
## Summary
- Right-click on a Blocked Process Reports row now offers **View Blocked Plan** and **View Blocking Plan**; shared context menu previously fell through with no handler case
- Removed **Get Actual Plan** from this grid — re-executing a query that was mid-transaction holding locks is a foot-gun
- Added `FetchPlanBySqlHandleAsync` keyed on `sql_handle` + statement offsets against `sys.dm_exec_query_stats` (query_hash isn't in the XE event payload, so the existing hash-based path couldn't reach these plans)
- Frame extraction enumerates every `<frame>` in `executionStack`, filters the 42-byte all-zero placeholder handle (dynamic SQL / system contexts), and defaults `stmtstart=0` / `stmtend=-1` per the `dm_exec_text_query_plan` convention — matches sp_HumanEventsBlockViewer's XPath and join shape

Fixes #867.

Not addressed here: the truncated SQL text the reporter noted — that's SQL Server's own cap on `<inputbuf>` inside the `blocked_process_report` XE event, nothing we can do from the collector side. Related master-DB concern is tracked separately on #857.

## Test plan
- [x] Build clean (0 errors)
- [x] Manual smoke test — right-click a BPR row, both View Blocked/Blocking Plan resolve when the plan is still in cache
- [ ] Verify "no longer in cache" message when the plan has been evicted
- [ ] Verify the all-zero-handle path (dynamic SQL blocker) shows the "no resolvable sql_handle" message instead of churning round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)