### PR TITLE
Skip retrying collectors after permission denial (#857)

### DIFF
--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -39,6 +39,15 @@ public class CollectorHealthEntry
     public int ConsecutiveErrors { get; set; }
     public int TotalErrors { get; set; }
     public int TotalSuccesses { get; set; }
+
+    /*
+     * Set when a collector hits a non-transient permission error
+     * (SQL errors 229 / 297 / 300). The scheduler skips the collector
+     * for the rest of the app session so we don't churn the log with
+     * identical denials every interval. Cleared on app restart — if
+     * permissions get granted later, the next launch retries once.
+     */
+    public bool IsPermissionRestricted { get; set; }
 }
 
 /// <summary>
@@ -225,9 +234,12 @@ public partial class RemoteCollectorService
             {
                 /* Permission errors are not transient — don't count as failures
                    (which would show FAILING) but don't count as success either.
-                   Record the error message so the user can see what's wrong. */
+                   Record the error message so the user can see what's wrong,
+                   and flag the collector so the scheduler stops retrying for
+                   the rest of the app session. */
                 entry.LastErrorTime = DateTime.UtcNow;
                 entry.LastErrorMessage = errorMessage;
+                entry.IsPermissionRestricted = true;
             }
             else
             {
@@ -236,6 +248,19 @@ public partial class RemoteCollectorService
                 entry.ConsecutiveErrors++;
                 entry.TotalErrors++;
             }
+        }
+    }
+
+    /// <summary>
+    /// Returns true if a collector has hit a permission denial this session
+    /// and should be skipped without re-running. See <see cref="CollectorHealthEntry.IsPermissionRestricted"/>.
+    /// </summary>
+    private bool IsCollectorPermissionRestricted(int serverId, string collectorName)
+    {
+        lock (_healthLock)
+        {
+            return _collectorHealth.TryGetValue((serverId, collectorName), out var entry)
+                && entry.IsPermissionRestricted;
         }
     }
 
@@ -376,6 +401,15 @@ public partial class RemoteCollectorService
             {
                 AppLogger.Info("Collector", $"  [{server.DisplayName}] {collectorName} SKIPPED - MFA authentication cancelled by user");
                 _logger?.LogDebug("Skipping collector '{Collector}' for server '{Server}' - user cancelled MFA",
+                    collectorName, server.DisplayName);
+                return;
+            }
+
+            // Skip collectors that have already hit a non-transient permission denial
+            // this session. Flag is in-memory — next app start retries once (see #857).
+            if (IsCollectorPermissionRestricted(GetServerId(server), collectorName))
+            {
+                _logger?.LogDebug("Skipping collector '{Collector}' for server '{Server}' - permission denied this session",
                     collectorName, server.DisplayName);
                 return;
             }


### PR DESCRIPTION
## Summary

Follow-up to #857. @TrudAX's Collection Health screenshot showed five collectors (`memory_clerks`, `memory_stats`, `tempdb_stats`, `query_snapshots`, `waiting_tasks`) all stuck at "10 runs, 0 success" — each re-running every collection interval, hitting the same SQL error 300 (`VIEW SERVER PERFORMANCE STATE permission was denied`) every time, and logging a fresh identical denial row into the collection log.

The denial isn't transient. A DB-scoped login (D365FO) will never grow server-level permission mid-session. Retrying just churns the log.

This PR flags the collector on first denial and short-circuits `RunCollectorAsync` so we skip the round-trip and the log entry entirely.

- New `CollectorHealthEntry.IsPermissionRestricted` bool set when `RecordCollectorResult` sees status `PERMISSIONS`
- New `IsCollectorPermissionRestricted(serverId, collectorName)` helper read under the existing `_healthLock`
- Early-return in `RunCollectorAsync` right after the existing MFA-cancelled skip, logging at Debug level
- Flag is in-memory per (server, collector) — app restart retries once. If perms are still missing the flag re-applies after the first attempt

Collection Health's `NO_PERMISSIONS` status logic is unchanged — it still renders correctly from the single recorded denial row.

Per-collector DB-scoped fallback queries (e.g. `sys.dm_db_resource_stats` for memory_stats) were considered but deliberately out of scope — their semantics differ from the boxed DMVs and each is its own decision.

## Test plan

- [x] Build: `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 errors
- [ ] Boxed SQL Server smoke test: no behavioural change expected (no permission errors normally)
- [ ] D365FO confirmation (deferred to @TrudAX once the nightly lands): collectors should hit denial once then stop; Collection Health shows `NO_PERMISSIONS` instead of `10 runs, 0 success` growing unbounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)