### PR TITLE
Skip live query plans on Azure SQL DB (#857)

### DIFF
--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -5365,7 +5365,9 @@ public partial class ServerTab : UserControl
                 ConnectTimeout = 15
             };
 
-            var query = RemoteCollectorService.BuildQuerySnapshotsQuery(supportsLiveQueryPlan: true, isAzureSqlDatabase: _isAzureSqlDatabase);
+            // Live query plans require VIEW SERVER PERFORMANCE STATE on Azure SQL DB,
+            // which DB-scoped logins don't have — skip them there. See #857.
+            var query = RemoteCollectorService.BuildQuerySnapshotsQuery(supportsLiveQueryPlan: !_isAzureSqlDatabase, isAzureSqlDatabase: _isAzureSqlDatabase);
 
             await using var connection = new SqlConnection(builder.ConnectionString);
             await connection.OpenAsync();

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -217,11 +217,18 @@ DROP TABLE #req;
     /// </summary>
     private async Task<int> CollectQuerySnapshotsAsync(ServerConnection server, CancellationToken cancellationToken)
     {
-        // dm_exec_query_statistics_xml requires SQL Server 2016 SP1+ (version 13)
+        /*
+         * sys.dm_exec_query_statistics_xml requires SQL Server 2016 SP1+ (version 13)
+         * on boxed, and VIEW SERVER PERFORMANCE STATE on Azure SQL Database regardless
+         * of tier. DB-scoped logins (e.g. D365FO) don't have the server-level grant
+         * and the DMF raises error 300 even when only called for current-DB sessions,
+         * so we disable live query plans on Azure SQL DB entirely. See #857.
+         */
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
-        var supportsLiveQueryPlan = serverStatus.SqlMajorVersion >= 13 || serverStatus.SqlMajorVersion == 0
-            || serverStatus.SqlEngineEdition == 5 || serverStatus.SqlEngineEdition == 8;
         var isAzureSqlDatabase = serverStatus.SqlEngineEdition == 5;
+        var supportsLiveQueryPlan = !isAzureSqlDatabase
+            && (serverStatus.SqlMajorVersion >= 13 || serverStatus.SqlMajorVersion == 0
+                || serverStatus.SqlEngineEdition == 8);
 
         var query = BuildQuerySnapshotsQuery(supportsLiveQueryPlan, isAzureSqlDatabase);
 


### PR DESCRIPTION
## Summary

Third follow-up to #857. @TrudAX confirmed the `#temp` pre-filter from #869 didn't resolve the Live Snapshot error for his D365FO database — same SQL 300 (`VIEW SERVER PERFORMANCE STATE permission was denied`).

His working SSMS query uses `sys.dm_exec_sql_text` and `sys.dm_exec_query_plan` but **not** `sys.dm_exec_query_statistics_xml` — that's the signal. Per MS docs, `sys.dm_exec_query_statistics_xml` requires `VIEW SERVER PERFORMANCE STATE` on Azure SQL Database regardless of service tier or scope. Even with the `#temp` pre-filter only feeding it current-DB session IDs, the DMF does a server-level permission check before returning, so it fails for DB-scoped logins.

Fix: disable live query plans on Azure SQL Database in both the collector and the Live Snapshot button. Users lose the animated in-progress query plan on Azure SQL DB but get working current-activity visibility — which they don't have at all today. Boxed SQL Server and Azure Managed Instance (edition 8) still get live plans.

- `CollectQuerySnapshotsAsync`: `supportsLiveQueryPlan = !isAzureSqlDatabase && (version >= 13 || version == 0 || edition == 8)`
- `LiveSnapshot_Click`: pass `!_isAzureSqlDatabase` instead of hardcoded `true`
- No SQL template changes — when `supportsLiveQueryPlan` is false the existing `BuildQuerySnapshotsQuery` already emits `live_query_plan = CONVERT(xml, NULL),` and omits the OUTER APPLY

## Test plan

- [x] Build: `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 errors
- [x] Boxed SQL Server smoke test (SQL2022): live plans still emitted, behaviour unchanged
- [ ] D365FO confirmation (deferred to @TrudAX): Live Snapshot returns rows without the permission error; `live_query_plan` column will be NULL on Azure SQL DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)