### PR TITLE
Fix FinOps recommendation severity sort order (#872)

### DIFF
--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -82,7 +82,7 @@
                           AlternatingRowBackground="{DynamicResource DataGridAlternatingRowBrush}">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Category" Binding="{Binding Category}" MinWidth="120" Width="Auto"/>
-                        <DataGridTextColumn Header="Severity" Binding="{Binding Severity}" MinWidth="80" Width="Auto">
+                        <DataGridTextColumn Header="Severity" Binding="{Binding Severity}" MinWidth="80" Width="Auto" SortMemberPath="SeveritySort">
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Style.Triggers>

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -2176,7 +2176,7 @@ HAVING COUNT(*) >= 24";
             AppLogger.Error("FinOps", $"Recommendation check failed (Reserved capacity): {ex.Message}");
         }
 
-        return recommendations;
+        return recommendations.OrderBy(r => r.SeveritySort).ToList();
     }
 
     private static string FormatDuration(long seconds)
@@ -2578,6 +2578,13 @@ public class RecommendationRow
     public string Detail { get; set; } = "";
     public decimal? EstMonthlySavings { get; set; }
     public string EstMonthlySavingsDisplay => EstMonthlySavings.HasValue ? $"${EstMonthlySavings.Value:N0}" : "";
+    public int SeveritySort => Severity switch
+    {
+        "High" => 1,
+        "Medium" => 2,
+        "Low" => 3,
+        _ => 4
+    };
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Sort FinOps recommendations by severity rank (High=1, Medium=2, Low=3) instead of alphabetically.
- Adds `SeveritySort` to `RecommendationRow` and wires `SortMemberPath="SeveritySort"` on the Severity column so header-click sort matches.
- Display strings unchanged.

Closes #872.

## Test plan
- [x] Lite builds clean (0 errors)
- [ ] Eyeball FinOps Recommendations tab — severity now orders High → Medium → Low

🤖 Generated with [Claude Code](https://claude.com/claude-code)