### PR TITLE
Fix FinOps severity sort order in Dashboard (#872)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -90,7 +90,7 @@
                                 </StackPanel>
                             </DataGridTextColumn.Header>
                         </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Severity}" MinWidth="80" Width="Auto">
+                        <DataGridTextColumn Binding="{Binding Severity}" SortMemberPath="SeveritySort" MinWidth="80" Width="Auto">
                             <DataGridTextColumn.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>

--- a/Dashboard/Services/DatabaseService.FinOps.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.cs
@@ -2470,7 +2470,7 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
                 Logger.Error($"[{ServerLabel}] Recommendation check failed (Reserved capacity): {ex.Message}", ex);
             }
 
-            return recommendations;
+            return recommendations.OrderBy(r => r.SeveritySort).ToList();
         }
 
         private static string FormatDuration(long seconds)
@@ -2873,6 +2873,14 @@ OPTION(MAXDOP 1, RECOMPILE);", connection);
         public string Detail { get; set; } = "";
         public decimal? EstMonthlySavings { get; set; }
         public string EstMonthlySavingsDisplay => EstMonthlySavings.HasValue ? $"${EstMonthlySavings.Value:N0}" : "";
+
+        public int SeveritySort => Severity switch
+        {
+            "High" => 1,
+            "Medium" => 2,
+            "Low" => 3,
+            _ => 4
+        };
     }
 
     public class FinOpsHighImpactQuery


### PR DESCRIPTION
## Summary
- Ports the Lite fix from PR #874 to Dashboard.
- Sort FinOps recommendations by severity rank (High=1, Medium=2, Low=3) instead of alphabetically.
- Adds `SeveritySort` to `FinOpsRecommendation` and wires `SortMemberPath="SeveritySort"` on the Severity column so header-click sort matches.
- Display strings unchanged.

Follow-up to #872 / #874 — same bug existed in Dashboard, caught during post-merge review.

## Test plan
- [x] Dashboard builds clean (0 errors)
- [ ] Eyeball FinOps tab — severity now orders High → Medium → Low

🤖 Generated with [Claude Code](https://claude.com/claude-code)