### PR TITLE
Drop sys.dm_os_schedulers from memory_stats on Azure SQL DB (#857)

### DIFF
--- a/Lite/Services/RemoteCollectorService.Memory.cs
+++ b/Lite/Services/RemoteCollectorService.Memory.cs
@@ -30,6 +30,14 @@ public partial class RemoteCollectorService
            Azure MI (edition 8) HAS dm_os_sys_memory, sql_memory_model_desc, and behaves like on-prem. */
         bool isAzureSqlDb = serverStatus.SqlEngineEdition == 5;
 
+        /*
+         * Azure SQL Database in an elastic pool (e.g. D365FO tenants) enforces
+         * VIEW SERVER PERFORMANCE STATE on sys.dm_os_schedulers regardless of
+         * the login's DB-scoped grants, so we skip the schedulers subquery on
+         * Azure SQL DB and report current_workers_count as NULL. The rest of
+         * the row — memory sizes from sys.dm_os_sys_info and the perf counters
+         * — succeeds for contained DB users. See #857.
+         */
         string query = isAzureSqlDb
             ? @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -46,7 +54,7 @@ SELECT
     buffer_pool_mb = CONVERT(decimal(18,2), pc_buffer.cntr_value / 1024.0),
     plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0),
     max_workers_count = osi.max_workers_count,
-    current_workers_count = w.current_workers
+    current_workers_count = CONVERT(int, NULL)
 FROM sys.dm_os_sys_info AS osi
 CROSS JOIN
 (
@@ -73,12 +81,6 @@ CROSS JOIN
     WHERE counter_name = N'Cache Pages'
       AND object_name LIKE N'%:Plan Cache%'
 ) AS pc_plan
-CROSS JOIN
-(
-    SELECT current_workers = SUM(active_workers_count)
-    FROM sys.dm_os_schedulers
-    WHERE status = N'VISIBLE ONLINE'
-) AS w
 OPTION(RECOMPILE);"
             : @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;


### PR DESCRIPTION
## Summary

Fourth follow-up to #857. Reproduced @TrudAX's environment by provisioning a standard Azure SQL Database **elastic pool** and adding a contained DB user with just `VIEW DATABASE STATE` + `VIEW DATABASE PERFORMANCE STATE`. That reproduces his failure pattern **exactly**:

| DMV | Standalone Azure SQL DB | **Elastic pool** | TrudAX |
|---|---|---|---|
| `sys.dm_os_sys_info` | ✓ | ✓ | ✓ |
| `sys.dm_os_performance_counters` | ✓ | ✓ | ✓ |
| `sys.dm_exec_requests WHERE database_id = DB_ID()` | ✓ | ✓ | ✓ |
| `sys.dm_os_memory_clerks` | ✓ | **FAIL 300** | FAIL 300 |
| `sys.dm_os_schedulers` | ✓ | **FAIL 300** | (not probed, but inferred) |
| `sys.dm_os_waiting_tasks` | ✓ | **FAIL 300** | FAIL 300 |
| `tempdb.sys.dm_db_file_space_usage` | FAIL 262 | FAIL 300 | FAIL 300 |

So D365FO customer tenants really do live in elastic pools, and pools enforce `VIEW SERVER PERFORMANCE STATE` on those DMVs regardless of DB-scoped grants. Microsoft docs currently say `VIEW DATABASE PERFORMANCE STATE` should suffice for these DMVs on non-Basic tiers — the docs are wrong for elastic pool.

`memory_stats` is the one collector we can partially recover: the `sys.dm_os_schedulers` CROSS JOIN is the only piece that hits the permission wall. Dropping it and reporting `current_workers_count = NULL` lets the collector succeed with all the memory metrics populated.

- Azure branch of `memory_stats` now emits `current_workers_count = CONVERT(int, NULL)` and drops the `sys.dm_os_schedulers` CROSS JOIN
- Reader (`Memory.cs:164`) already coerces `IsDBNull(11)` to `0`, so DuckDB gets 0 instead of NULL — no schema change needed, and the existing on-prem / Azure MI path is untouched
- Verified against the elastic pool repro: all remaining fields populate, query runs clean

`memory_clerks`, `waiting_tasks`, and `tempdb_stats` stay permission-denied for elastic pool users — no DB-scoped alternative exists. They'll remain skip-gated by #870 (silent, no log churn).

## Test plan

- [x] Build: `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 errors
- [x] Elastic pool repro: full query succeeds as `d365pool` user (only `VIEW DATABASE STATE` + `VIEW DATABASE PERFORMANCE STATE`)
- [x] Boxed SQL Server path (`isAzureSqlDb = false`): unchanged, still populates `current_workers_count`
- [ ] D365FO confirmation (deferred to @TrudAX on next nightly): `memory_stats` collector goes green, `current_workers_count` reported as 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)