### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - TBD
+
+### Important
+
+- **New nonclustered indexes** on `collect.query_stats`, `collect.procedure_stats`, and `collect.query_store_data` to eliminate Eager Index Spools in Dashboard grid queries. On large installations these indexes may take several minutes to build; the upgrade script uses `ONLINE = ON` on Enterprise/Developer/Azure editions and falls back to offline on Standard/Web ([#835])
+
+### Added
+
+- **Memory Pressure Events in Lite** — the collector, chart, and `get_memory_pressure_events` MCP tool previously only in the Full Edition are now available in Lite ([#865])
+- **Grid auto-scrolling** in Lite and Dashboard ([#843]) — thanks [@ClaudioESSilva](https://github.com/ClaudioESSilva)
+
+### Changed
+
+- **PlanAnalyzer and BenefitScorer** synced with PerformanceStudio's Apr 9–16 improvements
+- **Query/Procedure/Query Store stats** refactored to a phased DECOMPRESS approach; removed unhelpful `WAITFOR DECOMPRESS` filters
+- **Query/Procedure/Query Store grids** capped to TOP 500 to prevent UI freezes on large datasets
+- **Server tabs lazy-load** — only the visible server tab loads on startup; remaining tabs load on first visit
+- **Webhook URLs** encrypted with DPAPI via Windows Credential Manager
+- **DuckDB queries hardened** — parameterized values, escaped paths, fixed `IsArchiving` race
+- **Lite chart axes and sub-tab styling** polished, then ported to Dashboard
+
+### Fixed
+
+- **Memory Pressure Events chart filter** was dropping valid rows; added MCP interpretation guidance ([#865])
+- **FinOps recommendation severity sort order** in Lite and Dashboard ([#872])
+- **Overview crosshair** disappearing after tab switches or layout passes
+- **Blocked process report plan lookup** returning the wrong plan ([#867])
+- **FinOps TDE recommendation** flagging Standard edition on SQL Server 2019+ where TDE is free ([#854])
+- **Azure SQL DB collector** falls back to single-database mode when `master` is inaccessible ([#857])
+- **Azure SQL DB query snapshots** scoped to the current database ([#857])
+- **Azure SQL DB query snapshot prefilter** — request set is narrowed into `#temp` before joining DMVs to avoid Azure-specific execution plan issues ([#857])
+- **Azure SQL DB live query plans** — now skipped gracefully instead of erroring ([#857])
+- **Azure SQL DB memory_stats collector** — dropped `sys.dm_os_schedulers` which is blocked on elastic-pool contained users regardless of DB-scoped grants ([#857])
+- **Non-transient permission denials** now stop collector retries instead of looping forever ([#857])
+
+[#835]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/835
+[#843]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/843
+[#854]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/854
+[#857]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/857
+[#865]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/865
+[#867]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/867
+[#872]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/872
+
 ## [2.7.0] - 2026-04-13
 
 ### Added

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -7,10 +7,10 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>2.8.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,10 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>2.8.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>2.8.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -8,10 +8,10 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>2.8.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Lightweight SQL Server performance monitoring - no installation required on target servers</Description>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Data starts flowing within 1–5 minutes. That's it. No installation on your ser
 
 ### Lite Collectors
 
-23 collectors run on independent, configurable schedules:
+24 collectors run on independent, configurable schedules:
 
 | Collector | Default | Source |
 |---|---|---|
@@ -122,6 +122,7 @@ Data starts flowing within 1–5 minutes. That's it. No installation on your ser
 | deadlocks | 1 min | `system_health` Extended Events session |
 | session_stats | 1 min | `sys.dm_exec_sessions` active session tracking |
 | memory_clerks | 5 min | `sys.dm_os_memory_clerks` |
+| memory_pressure_events | 5 min | `sys.dm_os_ring_buffers` RING_BUFFER_RESOURCE_MONITOR |
 | query_store | 5 min | Query Store DMVs (per database) |
 | running_jobs | 5 min | `msdb` job history with duration vs avg/p95 |
 | database_size_stats | 15 min | `sys.master_files` + `FILEPROPERTY` + `dm_os_volume_stats` |
@@ -312,7 +313,7 @@ The Full Edition supports Azure SQL Managed Instance and AWS RDS for SQL Server 
 | AWS RDS for SQL Server | Supported | Supported |
 | Azure SQL Database | Not supported | Supported |
 | Multi-server from one seat | Per-server install | Built-in |
-| Collectors | 32 | 23 |
+| Collectors | 32 | 24 |
 | Agent job monitoring | Duration vs historical avg/p95 | Duration vs historical avg/p95 |
 | Data storage | SQL Server (on target) | DuckDB + Parquet (local) |
 | Execution plans | Collected and stored (can be disabled per-collector) | Download on demand |
@@ -323,7 +324,7 @@ The Full Edition supports Azure SQL Managed Instance and AWS RDS for SQL Server 
 | Dashboard | Separate app | Built-in |
 | Themes | Dark and light | Dark and light |
 | Portability | Server-bound | Single executable |
-| MCP server (LLM integration) | Built into Dashboard (63 tools) | Built-in (51 tools) |
+| MCP server (LLM integration) | Built into Dashboard (63 tools) | Built-in (52 tools) |
 
 ---
 
@@ -350,7 +351,7 @@ Plus a NOC-style landing page with server health cards (green/yellow/red severit
 | **Active Queries** | Running queries with session details, wait types, blocking, DOP, memory grants |
 | **Wait Stats** | Filterable wait statistics chart with delta calculations |
 | **CPU** | SQL Server CPU vs Other Processes over time |
-| **Memory** | Physical memory overview, SQL Server memory trend, memory clerk breakdown |
+| **Memory** | Physical memory overview, SQL Server memory trend, memory clerk breakdown, memory pressure events |
 | **Queries** | Performance trends, top queries and procedures by duration, Query Store integration, query heatmap |
 | **File I/O** | Read/write I/O trends per database file |
 | **TempDB** | Space usage breakdown and TempDB file I/O |
@@ -453,7 +454,7 @@ claude mcp add --transport http --scope user sql-monitor http://localhost:5151/
 
 ### Available Tools
 
-Full Edition exposes 63 tools, Lite Edition exposes 51. Core tools are shared across both editions.
+Full Edition exposes 63 tools, Lite Edition exposes 52. Core tools are shared across both editions.
 
 | Category | Tools |
 |---|---|
@@ -477,7 +478,7 @@ Full Edition exposes 63 tools, Lite Edition exposes 51. Core tools are shared ac
 | Scheduler | `get_cpu_scheduler_pressure`\*\* |
 | Latch/Spinlock | `get_latch_stats`\*\*, `get_spinlock_stats`\*\* |
 | Diagnostics | `get_plan_cache_bloat`\*\*, `get_critical_issues`\*\* |
-| System Events | `get_default_trace_events`\*\*, `get_trace_analysis`\*\*, `get_memory_pressure_events`\*\* |
+| System Events | `get_default_trace_events`\*\*, `get_trace_analysis`\*\*, `get_memory_pressure_events` |
 | Health Parser | `get_health_parser_system_health`\*\*, `get_health_parser_severe_errors`\*\*, `get_health_parser_io_issues`\*\*, `get_health_parser_scheduler_issues`\*\*, `get_health_parser_memory_conditions`\*\*, `get_health_parser_cpu_tasks`\*\*, `get_health_parser_memory_broker`\*\*, `get_health_parser_memory_node_oom`\*\* |
 | Plan Analysis | `analyze_query_plan`, `analyze_procedure_plan`, `analyze_query_store_plan`, `analyze_plan_xml`, `get_plan_xml` |
 | Diagnostic Analysis | `analyze_server`\*, `get_analysis_facts`\*, `compare_analysis`\*, `audit_config`\*, `get_analysis_findings`\*, `mute_analysis_finding`\* |


### PR DESCRIPTION
## Summary

- **Indexes** — new nonclustered indexes on `collect.query_stats`, `procedure_stats`, `query_store_data` to eliminate Eager Index Spools in Dashboard grid lookups (#835)
- **Memory Pressure Events in Lite** — collector, chart, and `get_memory_pressure_events` MCP tool ported from Dashboard (#865)
- **Grid auto-scrolling** in Lite and Dashboard (#843 — thanks @ClaudioESSilva)
- **FinOps severity sort order** fix in both Lite and Dashboard (#872)
- **Azure SQL DB collector** improvements under #857 — single-database fallback when master is inaccessible, current-DB scoped snapshots, #temp prefilter, live plan skip, memory_stats drops `sys.dm_os_schedulers` for elastic-pool contained users, non-transient permission denials stop retries
- **Blocked process report** plan lookup fix (#867)
- **FinOps TDE** no longer flagged on SQL Server 2019+ where it's free on Standard (#854)
- **Performance polish** — phased DECOMPRESS, TOP 500 grid caps, lazy server tab loading, DuckDB query hardening, DPAPI webhook encryption

## Test plan

- [x] `Installer.Tests` — 46/46 passed
- [x] `dotnet build -c Debug` — 0 errors
- [x] Fresh install on sql2016 (`--reinstall`) — 54/54 scripts, 48 HEALTHY, 0 errors
- [x] Upgrade install on sql2017 (2.7.0→2.8.0) — 3 new indexes present, data survived
- [x] Upgrade install on sql2022 (2.7.0→2.8.0) + idempotency re-run
- [x] Multi-hop upgrade on sql2019 — v2.5.0→2.8.0 and v2.6.0→2.8.0 via CLI (filesystem provider)
- [x] Dashboard GUI upgrade on sql2025 (2.6.0→2.8.0, embedded-resource provider — #772 regression surface)
- [x] Cloud platform testing — Azure SQL DB + AWS RDS, fresh installs, 60-min burn-in clean (0 errors)
- [x] `installation_history` SUCCESS with correct `previous_version` across all paths
- [x] Data survival verified via row-count diffs before/after each upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)