### PR TITLE
Add Open Log Folder sidebar button in Lite (#873)

### DIFF
--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -191,6 +191,13 @@
                                 <TextBlock Text="View Log" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
+                        <Button Click="OpenLogFolderButton_Click" Margin="0,8,0,0"
+                                ToolTip="Open the log folder in Explorer (for grabbing logs to attach to bug reports)">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE838;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Open Log Folder" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <Button x:Name="SettingsButton" Click="SettingsButton_Click" Margin="0,8,0,0">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12" VerticalAlignment="Center" Margin="0,0,6,0"/>

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -909,6 +909,25 @@ public partial class MainWindow : Window
         }
     }
 
+    private void OpenLogFolderButton_Click(object sender, RoutedEventArgs e)
+    {
+        var logDir = AppLogger.GetLogDirectory();
+        try
+        {
+            System.IO.Directory.CreateDirectory(logDir);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = logDir,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not open log folder: {ex.Message}", "Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
     private void ImportSettingsButton_Click(object sender, RoutedEventArgs e)
     {
         var dialog = new Microsoft.Win32.OpenFolderDialog


### PR DESCRIPTION
## Summary
- Adds **Open Log Folder** sidebar button right below **View Log** in Lite
- Opens `%LocalAppData%\PerformanceMonitorLite\logs\` in Explorer for grabbing historical logs to attach to bug reports
- View Log retains existing behavior (opens today's log file)

Closes #873 (first bullet only — copyable error text and diagnostic report remain).

## Test plan
- [x] Build clean
- [x] Click Open Log Folder → Explorer opens at the Lite logs directory
- [ ] Verify on a fresh install where the logs folder may not exist yet (handler calls `Directory.CreateDirectory` defensively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)