### PR TITLE
Raise install loop timeout from 5 minutes to 1 hour (#884)

### DIFF
--- a/Installer.Core/InstallationService.cs
+++ b/Installer.Core/InstallationService.cs
@@ -432,7 +432,7 @@ END;";
                     batchNumber++;
 
                     using var command = new SqlCommand(trimmedBatch, connection);
-                    command.CommandTimeout = StandardTimeoutSeconds;
+                    command.CommandTimeout = UpgradeTimeoutSeconds;
 
                     try
                     {


### PR DESCRIPTION
## Summary
- `ExecuteInstallationAsync` applied `StandardTimeoutSeconds` (300s) to every batch in the main install script list. `install/98_validate_installation.sql` contains a cursor that runs every enabled collector with `@debug = 1` inside a single batch; on large databases (reporter had 7.2M rows in `collect.query_stats`, 4.4M in `collect.query_store_data`) this takes ~9 minutes and blows the 5-minute timeout, failing the install/upgrade.
- `ExecuteAllUpgradesAsync` already uses `UpgradeTimeoutSeconds` (3600s) for `upgrades/{from}-to-{to}/` scripts (cfd7d6e, #538/#539). That fix only covered the upgrade folder. The main install loop — which also runs during every upgrade after the versioned scripts, via `CREATE OR ALTER` — was left on 5 minutes.
- Apply the existing 1-hour constant to the main install loop too. One-line change.

Fixes #884.

## Test plan
- [ ] Upgrade an existing v2.4.1 install on a database with multi-million-row `collect.query_stats` and confirm `98_validate_installation.sql` completes.
- [ ] Fresh install on a small database still succeeds (sanity).
- [ ] Cancellation token still aborts mid-batch promptly (the install's overall cancellation path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)