### PR TITLE
Bump DuckDB.NET to 1.5.2

### DIFF
--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -37,8 +37,8 @@
 
   <ItemGroup>
     <!-- DuckDB for local data storage -->
-    <PackageReference Include="DuckDB.NET.Data" Version="1.5.0" />
-    <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.5.0" />
+    <PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
+    <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.5.2" />
 
     <!-- SQL Server connectivity -->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />


### PR DESCRIPTION
## Summary
- Bumps `DuckDB.NET.Data` and `DuckDB.NET.Bindings.Full` from 1.5.0 to 1.5.2 in `Lite/PerformanceMonitorLite.csproj`.
- Pulls in two upstream bugfix releases relevant to Lite's collector pattern:
  - **1.5.2** fixes unbounded row group growth on indexed tables under repeated load+insert cycles, and memory leaks/race conditions in prepared statements.
  - **1.5.1** hardens WAL checkpoint marking, prevents memory corruption in concurrent `TrimFreeBlocks`, and improves Windows UTF-8/UTF-16 handling.
- No storage version change within the 1.5.x line — drop-in upgrade.

## Test plan
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` succeeds (0 warnings, 0 errors)
- [x] Lite launches and connects to its existing 1.5.0 DuckDB file without migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)