### PR TITLE
Bump safe NuGet packages: M.Extensions 10.0.7, System.Text.Json 10.0.7, ScottPlot 5.1.58

### DIFF
--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -36,12 +36,12 @@
     <PackageReference Include="CredentialManagement" Version="1.0.2" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-    <PackageReference Include="ScottPlot.WPF" Version="5.1.57" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -44,22 +44,22 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
 
     <!-- Charting -->
-    <PackageReference Include="ScottPlot.WPF" Version="5.1.57" />
+    <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />
 
     <!-- Windows Credential Manager for secure credential storage -->
     <PackageReference Include="CredentialManagement" Version="1.0.2" />
 
     <!-- Background service hosting -->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
 
     <!-- Logging -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
 
     <!-- System tray -->
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
 
     <!-- JSON configuration -->
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
 
     <!-- MCP server for LLM tool access -->
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />


### PR DESCRIPTION
## Summary
Patch-level NuGet bumps with no expected behavioral change:
- `Microsoft.Extensions.Configuration` / `Configuration.Json` / `Hosting` / `Logging`: 10.0.5 → 10.0.7 (Dashboard, Lite)
- `System.Text.Json`: 10.0.5 → 10.0.7 (Lite)
- `ScottPlot.WPF`: 5.1.57 → 5.1.58 (Dashboard, Lite)

`Microsoft.Data.SqlClient` (6.1.4 → 7.0.1) and `ModelContextProtocol` (0.7.0-preview.1 → 1.2.0) deliberately left out — both need their own PR after dedicated review.

## Test plan
- [x] `dotnet build Dashboard/Dashboard.csproj -c Debug` — 0 errors
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 errors
- [x] `dotnet build Installer/PerformanceMonitorInstaller.csproj -c Debug` — 0 errors (no diff to Installer)
- [x] Dashboard launches
- [x] Lite launches and resumes collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)