### PR TITLE
Bump Microsoft.Data.SqlClient to 7.0.1 (+ Extensions.Azure for Entra)

### DIFF
--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -35,7 +35,8 @@
   <ItemGroup>
     <PackageReference Include="CredentialManagement" Version="1.0.2" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -19,7 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
   </ItemGroup>
 
   <!-- Embed SQL scripts as assembly resources for Dashboard consumption -->

--- a/Installer.Tests/Installer.Tests.csproj
+++ b/Installer.Tests/Installer.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/InstallerGui/InstallerGui.csproj
+++ b/InstallerGui/InstallerGui.csproj
@@ -27,7 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -41,7 +41,8 @@
     <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.5.2" />
 
     <!-- SQL Server connectivity -->
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
 
     <!-- Charting -->
     <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />


### PR DESCRIPTION
## Summary

Major-version bump of `Microsoft.Data.SqlClient` from **6.1.4 → 7.0.1**. The breaking change in 7.0 is that Azure/Entra dependencies were split out of the core package — anything using `SqlAuthenticationMethod.ActiveDirectory*` now requires the separate `Microsoft.Data.SqlClient.Extensions.Azure` package, or it throws at runtime (compile still succeeds, so the regression is silent without it).

We use `ActiveDirectoryInteractive` in five places (Dashboard/Lite/Installer.Core), so this PR adds `Microsoft.Data.SqlClient.Extensions.Azure 1.0.0` to those projects. Pure-SQL-auth projects (`Installer`, `Installer.Tests`) get the SqlClient bump only.

7.0.1 specifically (not 7.0.0): patches a `SqlBulkCopy` regression against SQL 2016 — we don't use `SqlBulkCopy`, but no reason to land on 7.0.0.

### Why this is low-risk for us
- All connection-string builders already set `Encrypt` explicitly (the only behavioral default flip in recent SqlClient history) — no silent change.
- SqlClient 7.0 still supports SQL Server 2012+, so 2016/2017/2019/2022/2025 stay reachable.
- No usage of `SqlBulkCopy`, `SqlDependency`, `ColumnEncryption`, custom `SqlAuthenticationProvider`, or `ServerCertificateValidationCallback`.
- No source code changes — packaging only.

## Test plan
- [x] All six projects build clean (Dashboard, Lite, Installer, Installer.Core, InstallerGui, Installer.Tests, Lite.Tests)
- [x] `Installer.Tests`: 46/46 passing (exercises real SqlClient against test SQL servers)
- [x] `Lite.Tests`: 257/257 passing (exercises real SqlClient)
- [x] Dashboard launches, stays running
- [x] Lite launches, stays running, resumes collection
- [ ] **Manual: add a SQL 2016 server with `Encrypt=Mandatory, TrustServerCertificate=true` and confirm a collection cycle completes**
- [ ] **Manual: add an Entra MFA server in both Dashboard and Lite — this is where a missing `Extensions.Azure` would silently regress**
- [ ] **Manual: run `Installer` end-to-end against a fresh database**

🤖 Generated with [Claude Code](https://claude.com/claude-code)