### PR TITLE
Bump ModelContextProtocol to 1.2.0

### DIFF
--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -40,8 +40,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />
-    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -63,8 +63,8 @@
     <PackageReference Include="System.Text.Json" Version="10.0.7" />
 
     <!-- MCP server for LLM tool access -->
-    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Moves `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` in Dashboard and Lite from **0.7.0-preview.1 → 1.2.0** — getting off the preview tag and onto a stable 1.x.

The C# SDK landed 1.0 between these two points, but our codebase happens to use only the stable subset of the surface that survived 1.0 stabilization unchanged:
- `[McpServerTool]` / `[McpServerToolType]` attributes — every site already specifies `Name = "..."`
- `AddMcpServer(...)` → `.WithHttpTransport().WithTools<T>()` chains
- `_app.MapMcp()`
- DI-bound tool method parameters

None of the actually-breaking APIs across 0.7→1.2 are referenced anywhere in this repo: filter API rename (`Add*Filter` → `WithMessageFilters`/`WithRequestFilters`), `RequestContext` ctor signature, `RunSessionHandler`, `ImageContentBlock.Data` / `AudioContentBlock.Data` / `FromImage` / `FromAudio`, `McpServerHandlers`, legacy SSE endpoints. **154** `[McpServerTool]` sites + **39** `[McpServerToolType]` sites compile unchanged. Zero source code changes — packaging only.

### Behavioral changes worth knowing
- Streamable-HTTP session handling is stricter (returns 400 for stateful POSTs without a session ID, or invalid `Protocol-Version` headers).
- Legacy `/sse` and `/message` endpoints are off by default. Server-side is fine since we already use `WithHttpTransport()` — but any consumer pinned to the old SSE endpoints needs to switch to Streamable HTTP.

## Test plan
- [x] Dashboard builds clean (0 errors)
- [x] Lite builds clean (0 errors)
- [x] Lite launches — in-process MCP server starts on the configured port (default 5151)
- [x] `POST /` `initialize` against the new Streamable HTTP transport returns the full server capabilities and tool list (verified via curl, `serverInfo.version = "1.2.0"`)
- [ ] **Manual: connect Claude Code (or any MCP client) to both Dashboard and Lite and run a couple of tools (e.g. `list_servers`, `get_collection_health`) end-to-end**

🤖 Generated with [Claude Code](https://claude.com/claude-code)