### PR TITLE
Skip historical sweep when collectors resume after a gap (closes #892)

### DIFF
--- a/install/08_collect_query_stats.sql
+++ b/install/08_collect_query_stats.sql
@@ -158,6 +158,42 @@ BEGIN
                         @last_collection_time,
                         DATEADD(MINUTE, -ISNULL(@frequency_minutes, 15), SYSDATETIME())
                     );
+
+            /*
+            Resume detection: if this collector hasn't successfully run in a long time
+            (Off preset, Agent stoppage, server reboot, manual disable), skip the
+            historical sweep so we don't dump the entire plan cache into our deltas.
+            Threshold: 5x the configured frequency, floored at 30 minutes.
+            */
+            DECLARE
+                @last_successful_run_time datetime2(7),
+                @resume_threshold_minutes integer;
+
+            SELECT
+                @last_successful_run_time = MAX(cl.collection_time)
+            FROM config.collection_log AS cl
+            WHERE cl.collector_name = N'query_stats_collector'
+            AND   cl.collection_status = N'SUCCESS';
+
+            SET @resume_threshold_minutes =
+                CASE
+                    WHEN ISNULL(@frequency_minutes, 0) <= 0 THEN 30
+                    WHEN @frequency_minutes * 5 > 30 THEN @frequency_minutes * 5
+                    ELSE 30
+                END;
+
+            IF @last_successful_run_time IS NOT NULL
+            AND DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME()) > @resume_threshold_minutes
+            BEGIN
+                IF @debug = 1
+                BEGIN
+                    DECLARE @gap_minutes integer = DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME());
+                    RAISERROR(N'Resume detected: %d-minute gap exceeds %d-minute threshold. Skipping historical sweep.', 0, 1,
+                              @gap_minutes, @resume_threshold_minutes) WITH NOWAIT;
+                END;
+
+                SET @cutoff_time = SYSDATETIME();
+            END;
         END;
 
         IF @debug = 1

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -192,6 +192,44 @@ BEGIN
                         ),
                         0
                     );
+
+            /*
+            Resume detection: if this collector hasn't successfully run in a long time
+            (Off preset, Agent stoppage, server reboot, manual disable), skip the
+            historical sweep so we don't dump the entire Query Store window into our deltas.
+            Note: @last_collection_time above tracks the latest captured query execution time,
+            not the collector's run time, so we need a separate lookup against config.collection_log.
+            Threshold: 5x the configured frequency, floored at 30 minutes.
+            */
+            DECLARE
+                @last_successful_run_time datetime2(7),
+                @resume_threshold_minutes integer;
+
+            SELECT
+                @last_successful_run_time = MAX(cl.collection_time)
+            FROM config.collection_log AS cl
+            WHERE cl.collector_name = N'query_store_collector'
+            AND   cl.collection_status = N'SUCCESS';
+
+            SET @resume_threshold_minutes =
+                CASE
+                    WHEN ISNULL(@collection_interval_minutes, 0) <= 0 THEN 30
+                    WHEN @collection_interval_minutes * 5 > 30 THEN @collection_interval_minutes * 5
+                    ELSE 30
+                END;
+
+            IF @last_successful_run_time IS NOT NULL
+            AND DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME()) > @resume_threshold_minutes
+            BEGIN
+                IF @debug = 1
+                BEGIN
+                    DECLARE @gap_minutes integer = DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME());
+                    RAISERROR(N'Resume detected: %d-minute gap exceeds %d-minute threshold. Skipping historical sweep.', 0, 1,
+                              @gap_minutes, @resume_threshold_minutes) WITH NOWAIT;
+                END;
+
+                SET @cutoff_time = TODATETIMEOFFSET(SYSUTCDATETIME(), 0);
+            END;
         END;
 
         IF @debug = 1

--- a/install/10_collect_procedure_stats.sql
+++ b/install/10_collect_procedure_stats.sql
@@ -157,6 +157,42 @@ BEGIN
             SELECT
                 @cutoff_time = ISNULL(@last_collection_time,
                     DATEADD(MINUTE, -ISNULL(@frequency_minutes, 15), SYSDATETIME()));
+
+            /*
+            Resume detection: if this collector hasn't successfully run in a long time
+            (Off preset, Agent stoppage, server reboot, manual disable), skip the
+            historical sweep so we don't dump cumulative procedure stats into our deltas.
+            Threshold: 5x the configured frequency, floored at 30 minutes.
+            */
+            DECLARE
+                @last_successful_run_time datetime2(7),
+                @resume_threshold_minutes integer;
+
+            SELECT
+                @last_successful_run_time = MAX(cl.collection_time)
+            FROM config.collection_log AS cl
+            WHERE cl.collector_name = N'procedure_stats_collector'
+            AND   cl.collection_status = N'SUCCESS';
+
+            SET @resume_threshold_minutes =
+                CASE
+                    WHEN ISNULL(@frequency_minutes, 0) <= 0 THEN 30
+                    WHEN @frequency_minutes * 5 > 30 THEN @frequency_minutes * 5
+                    ELSE 30
+                END;
+
+            IF @last_successful_run_time IS NOT NULL
+            AND DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME()) > @resume_threshold_minutes
+            BEGIN
+                IF @debug = 1
+                BEGIN
+                    DECLARE @gap_minutes integer = DATEDIFF(MINUTE, @last_successful_run_time, SYSDATETIME());
+                    RAISERROR(N'Resume detected: %d-minute gap exceeds %d-minute threshold. Skipping historical sweep.', 0, 1,
+                              @gap_minutes, @resume_threshold_minutes) WITH NOWAIT;
+                END;
+
+                SET @cutoff_time = SYSDATETIME();
+            END;
         END;
 
         IF @debug = 1


### PR DESCRIPTION
## Summary
After an Off preset, Agent stoppage, or server reboot, the first run of \`query_stats\` / \`procedure_stats\` / \`query_store\` would historically sweep the entire backlog of cumulative state into the delta tables in one shot. On \`query_stats\` that was enough to blow tempdb overnight (the original pain in #885).

These three collectors now do a lightweight check after computing their normal cutoff: if \`MAX(config.collection_log.collection_time)\` for their own \`collector_name\` (status \`SUCCESS\`) is older than 5× the configured \`frequency_minutes\` (floored at 30 min), the cutoff is clamped to \`SYSDATETIME()\` so only forward-going data is collected on the resume run.

## What's NOT touched
- **XE-backed collectors** (\`blocked_process_xml\`, \`deadlock_xml\`, \`system_health\`, \`default_trace\`, \`trace_analysis\`) are already bounded by their \`@minutes_back\` / \`@hours_back\` parameters — verified by reading each. No catch-up problem.
- **Snapshot collectors** (\`wait_stats\`, \`file_io_stats\`, \`memory_grant_stats\`, \`plan_cache_stats\`, etc.) insert one row per run regardless of gap.
- **No schema changes.** No new column on \`config.collection_schedule\`, no upgrade folder needed.

## Threshold logic
\`\`\`
threshold_minutes = MAX(@frequency_minutes * 5, 30)
                    -- with NULL/0 frequency safely defaulting to 30
\`\`\`

| Configured freq | Threshold |
|---:|---:|
| 1–5 min | 30 min (floor) |
| 10 min | 50 min |
| 30 min | 150 min |
| 60 min (custom) | 300 min |

5× breathes room for slipped cycles; 30-min floor protects 1-min collectors from false-firing on Agent restarts.

## Test plan
- [x] All three procs apply cleanly on sql2016/2017/2019/2022/2025.
- [x] On sql2019, synthetic 3-hour gap (achieved by transactionally backdating collection_log + ROLLBACK) → heuristic fires for all three: \"Resume detected: 182-minute gap exceeds 30-minute threshold. Skipping historical sweep.\"
- [x] Normal run with no gap → heuristic stays silent.
- [x] Verified XE collectors and snapshot collectors are not affected.

Closes #892.