### PR TITLE
Per-database exclusions for collectors — Lite side (closes #887)

### DIFF
--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -96,6 +96,13 @@ public class ServerConnection
     public bool MultiSubnetFailover { get; set; } = false;
 
     /// <summary>
+    /// User databases to skip in per-database collectors (query_store, file_io_stats, etc.).
+    /// System databases (master/tempdb/model/msdb) and the connection database itself are always
+    /// excluded by the collectors and aren't represented here.
+    /// </summary>
+    public System.Collections.Generic.List<string> ExcludedDatabases { get; set; } = new();
+
+    /// <summary>
     /// Server name with "(Read-Only)" suffix when ReadOnlyIntent is enabled.
     /// Used for sidebar subtitle and status text.
     /// </summary>

--- a/Lite/Services/RemoteCollectorService.DatabaseSize.cs
+++ b/Lite/Services/RemoteCollectorService.DatabaseSize.cs
@@ -30,7 +30,7 @@ public partial class RemoteCollectorService
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
 
-        const string onPremQuery = @"
+        string onPremQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET NOCOUNT ON;
 
@@ -52,6 +52,7 @@ DECLARE db_cursor CURSOR LOCAL FAST_FORWARD FOR
     WHERE d.state_desc = N'ONLINE'
     AND   d.database_id > 0
     AND   HAS_DBACCESS(d.name) = 1
+    /*EXCLUSION_FILTER_CURSOR*/
     ORDER BY
         d.name;
 
@@ -131,10 +132,18 @@ LEFT JOIN #file_space AS fs
   ON  fs.database_id = mf.database_id
   AND fs.file_id = mf.file_id
 WHERE d.state_desc = N'ONLINE'
+/*EXCLUSION_FILTER_OUTER*/
 ORDER BY
     d.name,
     mf.file_id
 OPTION(RECOMPILE);";
+
+        /* Both filter sites (cursor SELECT and final SELECT) are in outer T-SQL, not nested dynamic SQL,
+           so parameter bindings work fine and the same @excl_db_N can be referenced twice. */
+        var (dbSizeExclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        onPremQuery = onPremQuery
+            .Replace("/*EXCLUSION_FILTER_CURSOR*/", dbSizeExclusionClause)
+            .Replace("/*EXCLUSION_FILTER_OUTER*/", dbSizeExclusionClause);
 
         const string azureSqlDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -231,6 +240,8 @@ OPTION(RECOMPILE);";
             using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
             using var command = new SqlCommand(onPremQuery, sqlConnection);
             command.CommandTimeout = CommandTimeoutSeconds;
+            var (_, dbSizeExclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+            foreach (var p in dbSizeExclusionParams) command.Parameters.Add(p);
 
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))

--- a/Lite/Services/RemoteCollectorService.FileIo.cs
+++ b/Lite/Services/RemoteCollectorService.FileIo.cs
@@ -83,7 +83,12 @@ LEFT JOIN sys.databases AS d
 WHERE (vfs.database_id > 4 OR vfs.database_id = 2)
 AND   vfs.database_id < 32761
 AND   vfs.database_id <> ISNULL(DB_ID(N'PerformanceMonitor'), 0)
+/*EXCLUSION_FILTER*/
 OPTION(RECOMPILE);";
+
+        /* Azure path filters via GetAzureDatabaseListAsync; on-prem path injects here */
+        var (fileIoExclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        query = query.Replace("/*EXCLUSION_FILTER*/", isAzureSqlDb ? string.Empty : fileIoExclusionClause);
 
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
@@ -125,6 +130,8 @@ OPTION(RECOMPILE);";
         {
             using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
             using var command = new SqlCommand(query, sqlConnection) { CommandTimeout = CommandTimeoutSeconds };
+            var (_, fileIoExclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+            foreach (var p in fileIoExclusionParams) command.Parameters.Add(p);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
                 fileStats.Add(ReadFileIoRow(reader));

--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -32,7 +32,7 @@ public partial class RemoteCollectorService
         /* total_spills/min_spills/max_spills exist in dm_exec_procedure_stats and dm_exec_trigger_stats
            on all supported versions, but do NOT exist in dm_exec_function_stats on any version.
            Use dynamic SQL to handle this. */
-        const string standardQuery = @"
+        string standardQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 DECLARE
@@ -81,6 +81,7 @@ INNER JOIN sys.databases AS d
 WHERE d.state = 0
 AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+/*EXCLUSION_FILTER*/
 
 UNION ALL
 
@@ -136,6 +137,7 @@ INNER JOIN sys.databases AS d
 WHERE d.state = 0
 AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+/*EXCLUSION_FILTER*/
 
 UNION ALL
 
@@ -178,6 +180,7 @@ INNER JOIN sys.databases AS d
 WHERE d.state = 0
 AND   pa.dbid NOT IN (1, 3, 4, 32761, 32767, ISNULL(DB_ID(N''PerformanceMonitor''), 0))
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+/*EXCLUSION_FILTER*/
 ) AS combined
 ORDER BY total_elapsed_time DESC
 OPTION(RECOMPILE);' AS nvarchar(max));
@@ -220,8 +223,18 @@ SELECT /* PerformanceMonitorLite */ TOP (150)
 FROM sys.dm_exec_procedure_stats AS s
 WHERE s.database_id = DB_ID()
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+/*EXCLUSION_FILTER*/
 ORDER BY s.total_elapsed_time DESC
 OPTION(RECOMPILE);";
+
+        /* Standard query is dynamic SQL (built into @sql then passed to sp_executesql), so the
+           exclusion filter is interpolated as literal N'...' values rather than parameter bindings.
+           Names come from a user-picked checklist of existing DBs, escaped against single-quote
+           injection. forNestedDynamicSql=true doubles the escape because @sql is itself a
+           single-quoted T-SQL string at the outer layer. */
+        string standardExclusionClause = BuildDatabaseExclusionLiteralClause(
+            server.ExcludedDatabases, "d.name", forNestedDynamicSql: true);
+        standardQuery = standardQuery.Replace("/*EXCLUSION_FILTER*/", standardExclusionClause);
 
         string query = isAzureSqlDb ? azureSqlDbQuery : standardQuery;
 

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -232,6 +232,18 @@ DROP TABLE #req;
 
         var query = BuildQuerySnapshotsQuery(supportsLiveQueryPlan, isAzureSqlDatabase);
 
+        /* Append the per-database exclusion filter to the WHERE clause. The base query joins
+           sys.databases AS d, so we filter on d.name. When ExcludedDatabases is empty the
+           clause is "" so nothing changes. */
+        var (qsExclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        if (!string.IsNullOrEmpty(qsExclusionClause))
+        {
+            /* Inject just before the OPTION clause so it lands inside the WHERE. */
+            query = query.Replace(
+                "ORDER BY der.cpu_time DESC",
+                qsExclusionClause + "\nORDER BY der.cpu_time DESC");
+        }
+
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
         var rowsCollected = 0;
@@ -242,6 +254,8 @@ DROP TABLE #req;
         using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
         using var command = new SqlCommand(query, sqlConnection);
         command.CommandTimeout = CommandTimeoutSeconds;
+        var (_, qsExclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        foreach (var p in qsExclusionParams) command.Parameters.Add(p);
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken);
         sqlSw.Stop();

--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -31,7 +31,7 @@ public partial class RemoteCollectorService
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         bool isAzureSqlDb = serverStatus.SqlEngineEdition == 5;
 
-        const string standardQuery = @"
+        string standardQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT /* PerformanceMonitorLite */ TOP (200)
@@ -106,9 +106,13 @@ INNER JOIN sys.databases AS d
 WHERE pa.dbid NOT IN (1, 2, 3, 4, 32761, 32767, ISNULL(DB_ID(N'PerformanceMonitor'), 0))
 AND   st.text NOT LIKE N'%PerformanceMonitorLite%'
 AND   qs.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())
+/*EXCLUSION_FILTER*/
 ORDER BY
     qs.total_elapsed_time DESC
 OPTION(RECOMPILE);";
+
+        var (exclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        standardQuery = standardQuery.Replace("/*EXCLUSION_FILTER*/", exclusionClause);
 
         /* Azure SQL DB: skip plan_attributes, use DB_NAME() for the single database context */
         const string azureSqlDbQuery = @"
@@ -229,6 +233,11 @@ OPTION(RECOMPILE);";
                 {
                 using var command = new SqlCommand(query, sqlConnection);
                 command.CommandTimeout = CommandTimeoutSeconds;
+                if (!isAzureSqlDb)
+                {
+                    var (_, freshParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+                    foreach (var p in freshParams) command.Parameters.Add(p);
+                }
 
                 using var reader = await command.ExecuteReaderAsync(cancellationToken);
 

--- a/Lite/Services/RemoteCollectorService.QueryStore.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStore.cs
@@ -32,7 +32,7 @@ public partial class RemoteCollectorService
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
 
-        const string onPremDbQuery = @"
+        string onPremDbQuery = @"
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -60,6 +60,7 @@ DECLARE db_check CURSOR LOCAL FAST_FORWARD FOR
         drs.database_id IS NULL          /*not in any AG*/
         OR drs.is_primary_replica = 1    /*primary replica*/
     )
+    /*EXCLUSION_FILTER*/
     OPTION(RECOMPILE);
 
 OPEN db_check;
@@ -103,7 +104,7 @@ FROM @result
 ORDER BY
     name;";
 
-        const string azureDbQuery = @"
+        string azureDbQuery = @"
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -123,6 +124,7 @@ DECLARE db_check CURSOR LOCAL FAST_FORWARD FOR
     AND   d.database_id < 32761
     AND   d.state_desc = N'ONLINE'
     AND   d.name <> N'PerformanceMonitor'
+    /*EXCLUSION_FILTER*/
     OPTION(RECOMPILE);
 
 OPEN db_check;
@@ -165,6 +167,10 @@ SELECT
 FROM @result
 ORDER BY
     name;";
+
+        var (exclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        onPremDbQuery = onPremDbQuery.Replace("/*EXCLUSION_FILTER*/", exclusionClause);
+        azureDbQuery = azureDbQuery.Replace("/*EXCLUSION_FILTER*/", exclusionClause);
 
         string dbQuery = isAzureSqlDb ? azureDbQuery : onPremDbQuery;
 
@@ -187,6 +193,8 @@ ORDER BY
         using (var dbCommand = new SqlCommand(dbQuery, sqlConnection))
         {
             dbCommand.CommandTimeout = CommandTimeoutSeconds;
+            var (_, exclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+            foreach (var p in exclusionParams) dbCommand.Parameters.Add(p);
             using var dbReader = await dbCommand.ExecuteReaderAsync(cancellationToken);
             while (await dbReader.ReadAsync(cancellationToken))
             {

--- a/Lite/Services/RemoteCollectorService.ServerConfig.cs
+++ b/Lite/Services/RemoteCollectorService.ServerConfig.cs
@@ -149,6 +149,8 @@ OPTION(RECOMPILE);";
     is_optimized_locking_on = d.is_optimized_locking_on";
         }
 
+        var (dbConfigExclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+
         var query = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -158,6 +160,7 @@ FROM sys.databases AS d
 WHERE (d.database_id > 4 OR d.database_id = 2)
 AND   d.database_id < 32761
 AND   d.name <> N'PerformanceMonitor'
+{dbConfigExclusionClause}
 ORDER BY d.name
 OPTION(RECOMPILE);";
 
@@ -173,6 +176,8 @@ OPTION(RECOMPILE);";
         using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
         using var command = new SqlCommand(query, sqlConnection);
         command.CommandTimeout = CommandTimeoutSeconds;
+        var (_, dbConfigExclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        foreach (var p in dbConfigExclusionParams) command.Parameters.Add(p);
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -329,7 +334,7 @@ OPTION(RECOMPILE);";
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
 
-        const string onPremDbQuery = @"
+        string onPremDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
@@ -347,10 +352,11 @@ AND
     drs.database_id IS NULL          /*not in any AG*/
     OR drs.is_primary_replica = 1    /*primary replica*/
 )
+/*EXCLUSION_FILTER*/
 ORDER BY d.name
 OPTION(RECOMPILE);";
 
-        const string azureDbQuery = @"
+        string azureDbQuery = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
@@ -360,8 +366,13 @@ WHERE (d.database_id > 4 OR d.database_id = 2)
 AND   d.database_id < 32761
 AND   d.name <> N'PerformanceMonitor'
 AND   d.state_desc = N'ONLINE'
+/*EXCLUSION_FILTER*/
 ORDER BY d.name
 OPTION(RECOMPILE);";
+
+        var (scopedExclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        onPremDbQuery = onPremDbQuery.Replace("/*EXCLUSION_FILTER*/", scopedExclusionClause);
+        azureDbQuery = azureDbQuery.Replace("/*EXCLUSION_FILTER*/", scopedExclusionClause);
 
         string dbQuery = isAzureSqlDb ? azureDbQuery : onPremDbQuery;
 
@@ -379,6 +390,8 @@ OPTION(RECOMPILE);";
         using (var dbCommand = new SqlCommand(dbQuery, sqlConnection))
         {
             dbCommand.CommandTimeout = CommandTimeoutSeconds;
+            var (_, scopedExclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+            foreach (var p in scopedExclusionParams) dbCommand.Parameters.Add(p);
             using var dbReader = await dbCommand.ExecuteReaderAsync(cancellationToken);
             while (await dbReader.ReadAsync(cancellationToken))
             {

--- a/Lite/Services/RemoteCollectorService.WaitingTasks.cs
+++ b/Lite/Services/RemoteCollectorService.WaitingTasks.cs
@@ -24,7 +24,7 @@ public partial class RemoteCollectorService
     /// </summary>
     private async Task<int> CollectWaitingTasksAsync(ServerConnection server, CancellationToken cancellationToken)
     {
-        const string query = @"
+        string query = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT /* PerformanceMonitorLite */
@@ -42,7 +42,11 @@ WHERE wt.session_id >= 50
 AND   wt.session_id <> @@SPID
 AND   wt.wait_type IS NOT NULL
 AND   er.database_id <> ISNULL(DB_ID(N'PerformanceMonitor'), 0)
+/*EXCLUSION_FILTER*/
 OPTION(RECOMPILE);";
+
+        var (exclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        query = query.Replace("/*EXCLUSION_FILTER*/", exclusionClause);
 
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;
@@ -54,6 +58,8 @@ OPTION(RECOMPILE);";
         using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
         using var command = new SqlCommand(query, sqlConnection);
         command.CommandTimeout = CommandTimeoutSeconds;
+        var (_, exclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        foreach (var p in exclusionParams) command.Parameters.Add(p);
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken);
         sqlSw.Stop();

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -634,15 +634,18 @@ WHERE server_id = $3";
             InitialCatalog = "master"
         }.ConnectionString;
 
+        var (exclusionClause, exclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "name");
+
         var databases = new List<string>();
         try
         {
             using var conn = new SqlConnection(connStr);
             await conn.OpenAsync(cancellationToken);
             using var cmd = new SqlCommand(
-                "SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 ORDER BY name;",
+                $"SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 {exclusionClause} ORDER BY name;",
                 conn)
             { CommandTimeout = CommandTimeoutSeconds };
+            foreach (var p in exclusionParams) cmd.Parameters.Add(p);
             using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
                 databases.Add(reader.GetString(0));
@@ -666,6 +669,54 @@ WHERE server_id = $3";
             }
             return fallback;
         }
+    }
+
+    /// <summary>
+    /// Builds a SQL fragment and matching SqlParameters for excluding the supplied database names.
+    /// When the list is empty, returns ("", []) so callers can splice without effect.
+    /// Each name is parameterized — works on every supported SQL Server version (no STRING_SPLIT/OPENJSON
+    /// compatibility-level dependency).
+    /// </summary>
+    /// <param name="excludedDatabaseNames">Names from server.ExcludedDatabases.</param>
+    /// <param name="columnExpression">SQL column to filter, e.g. "d.name".</param>
+    internal static (string Clause, List<SqlParameter> Parameters) BuildDatabaseExclusionFilter(
+        IList<string>? excludedDatabaseNames, string columnExpression)
+    {
+        if (excludedDatabaseNames is null || excludedDatabaseNames.Count == 0)
+            return (string.Empty, new List<SqlParameter>());
+
+        var paramNames = new List<string>(excludedDatabaseNames.Count);
+        var sqlParams = new List<SqlParameter>(excludedDatabaseNames.Count);
+        for (int i = 0; i < excludedDatabaseNames.Count; i++)
+        {
+            string p = $"@excl_db_{i}";
+            paramNames.Add(p);
+            sqlParams.Add(new SqlParameter(p, System.Data.SqlDbType.NVarChar, 128) { Value = excludedDatabaseNames[i] });
+        }
+        return ($"AND {columnExpression} NOT IN ({string.Join(", ", paramNames)})", sqlParams);
+    }
+
+    /// <summary>
+    /// Builds a SQL fragment with database names interpolated as literal N'...' values.
+    /// Use this for dynamic SQL paths where parameter binding is awkward (e.g. inside
+    /// a string passed to sp_executesql). Names come from user-picked checklists of
+    /// existing databases, so literal interpolation with single-quote escaping is safe.
+    /// When forNestedDynamicSql=true, doubles the escape for use inside an outer T-SQL
+    /// string that itself becomes a dynamic-SQL @sql variable.
+    /// </summary>
+    internal static string BuildDatabaseExclusionLiteralClause(
+        IList<string>? excludedDatabaseNames, string columnExpression, bool forNestedDynamicSql = false)
+    {
+        if (excludedDatabaseNames is null || excludedDatabaseNames.Count == 0)
+            return string.Empty;
+
+        string escapedQuote = forNestedDynamicSql ? "''" : "'";
+        string Escape(string s) => forNestedDynamicSql
+            ? s.Replace("'", "''''")
+            : s.Replace("'", "''");
+
+        var quoted = excludedDatabaseNames.Select(n => $"N{escapedQuote}{Escape(n)}{escapedQuote}");
+        return $"AND {columnExpression} NOT IN ({string.Join(", ", quoted)})";
     }
 
     private static List<string> SingleDbOrEmpty(string? targetDb)

--- a/Lite/Windows/ExcludedDatabasesDialog.xaml
+++ b/Lite/Windows/ExcludedDatabasesDialog.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="PerformanceMonitorLite.Windows.ExcludedDatabasesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Excluded Databases"
+        Height="500" Width="500"
+        WindowStartupLocation="CenterOwner"
+        Icon="/EDD.ico"
+        ResizeMode="CanResizeWithGrip"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" x:Name="HeaderText" FontWeight="Bold" FontSize="14"
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" TextWrapping="Wrap" FontSize="11"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,12"
+                   Text="Databases marked here are skipped by per-database collectors (query_store, file_io_stats, etc.) on this server. System databases (master/tempdb/model/msdb) are always excluded."/>
+
+        <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="4">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="8">
+                <ItemsControl x:Name="DatabasesItemsControl">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Content="{Binding DisplayName}"
+                                      IsChecked="{Binding IsExcluded, Mode=TwoWay}"
+                                      IsEnabled="{Binding IsEnabled}"
+                                      Foreground="{Binding ForegroundBrush}"
+                                      Margin="2,3"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <TextBlock Grid.Row="3" x:Name="StatusText" FontSize="10" FontStyle="Italic"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,8,0,0"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Save" Width="80" Height="28" Margin="0,0,8,0" Click="Save_Click" Style="{StaticResource AccentButton}"/>
+            <Button Content="Cancel" Width="80" Height="28" Click="Cancel_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Lite/Windows/ExcludedDatabasesDialog.xaml.cs
+++ b/Lite/Windows/ExcludedDatabasesDialog.xaml.cs
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Windows;
+
+public partial class ExcludedDatabasesDialog : Window
+{
+    private readonly ServerManager _serverManager;
+    private readonly ServerConnection _server;
+    private ObservableCollection<DatabaseExclusionItem> _items = new();
+
+    public bool ExclusionsModified { get; private set; }
+
+    public ExcludedDatabasesDialog(ServerManager serverManager, ServerConnection server)
+    {
+        InitializeComponent();
+        _serverManager = serverManager;
+        _server = server;
+        HeaderText.Text = $"Excluded Databases — {server.DisplayNameWithIntent}";
+        Loaded += async (_, _) => await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        StatusText.Text = "Loading databases…";
+        DatabasesItemsControl.ItemsSource = null;
+
+        try
+        {
+            var liveDatabases = await GetUserDatabasesAsync();
+            var existingExclusions = _server.ExcludedDatabases ?? new List<string>();
+
+            var liveSet = new HashSet<string>(liveDatabases, StringComparer.OrdinalIgnoreCase);
+
+            _items = new ObservableCollection<DatabaseExclusionItem>();
+
+            foreach (var name in liveDatabases.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            {
+                _items.Add(new DatabaseExclusionItem
+                {
+                    Name = name,
+                    DisplayName = name,
+                    IsExcluded = existingExclusions.Contains(name, StringComparer.OrdinalIgnoreCase),
+                    IsEnabled = true,
+                    IsStale = false
+                });
+            }
+
+            /* Stale entries: in exclusion list but not present on the server. Greyed, disabled, pre-checked. */
+            foreach (var name in existingExclusions
+                         .Where(n => !liveSet.Contains(n))
+                         .OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            {
+                _items.Add(new DatabaseExclusionItem
+                {
+                    Name = name,
+                    DisplayName = $"{name}  (missing)",
+                    IsExcluded = true,
+                    IsEnabled = false,
+                    IsStale = true
+                });
+            }
+
+            DatabasesItemsControl.ItemsSource = _items;
+            StatusText.Text = $"{liveDatabases.Count} database(s) on this server, {existingExclusions.Count} currently excluded.";
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Failed to load: {ex.Message}";
+            MessageBox.Show(this,
+                $"Could not read database list from '{_server.DisplayNameWithIntent}':\n\n{ex.Message}",
+                "Load Failed",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+    }
+
+    private async Task<List<string>> GetUserDatabasesAsync()
+    {
+        var connectionString = _server.GetConnectionString(_serverManager.CredentialService);
+        var builder = new SqlConnectionStringBuilder(connectionString)
+        {
+            InitialCatalog = "master",
+            ConnectTimeout = 10
+        };
+
+        using var connection = new SqlConnection(builder.ConnectionString);
+        await connection.OpenAsync();
+
+        using var cmd = new SqlCommand(@"
+SELECT d.name
+FROM sys.databases AS d
+WHERE d.database_id > 4
+AND   d.state_desc = N'ONLINE'
+AND   d.database_id < 32761 /*exclude contained AG system databases*/
+ORDER BY d.name;", connection);
+        cmd.CommandTimeout = 30;
+
+        var names = new List<string>();
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            names.Add(reader.GetString(0));
+        }
+        return names;
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            _server.ExcludedDatabases = _items
+                .Where(i => i.IsExcluded)
+                .Select(i => i.Name)
+                .ToList();
+
+            _serverManager.UpdateServer(_server);
+            ExclusionsModified = true;
+            DialogResult = true;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this,
+                $"Failed to save exclusions:\n\n{ex.Message}",
+                "Save Failed",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}
+
+public class DatabaseExclusionItem : INotifyPropertyChanged
+{
+    public string Name { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    private bool _isExcluded;
+    public bool IsExcluded
+    {
+        get => _isExcluded;
+        set { _isExcluded = value; OnPropertyChanged(nameof(IsExcluded)); }
+    }
+    public bool IsEnabled { get; set; } = true;
+    public bool IsStale { get; set; }
+
+    public Brush ForegroundBrush => IsStale
+        ? (Brush)Application.Current.FindResource("ForegroundMutedBrush")
+        : (Brush)Application.Current.FindResource("ForegroundBrush");
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Lite/Windows/ManageServersWindow.xaml
+++ b/Lite/Windows/ManageServersWindow.xaml
@@ -9,6 +9,11 @@
     <Window.Resources>
         <ResourceDictionary>
             <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Edit" Click="EditMenuItem_Click"/>
+                <MenuItem Header="Excluded Databases" Click="ExcludedDatabases_Click"/>
+                <MenuItem Header="Delete" Click="DeleteMenuItem_Click"
+                          Foreground="{DynamicResource ErrorBrush}"/>
+                <Separator/>
                 <MenuItem Header="Copy Cell" Click="CopyCell_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
                 </MenuItem>
@@ -66,6 +71,7 @@
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button Content="Add Server" Click="AddButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
             <Button Content="Edit" Click="EditButton_Click" Margin="0,0,8,0"/>
+            <Button Content="Excluded Databases" Click="ExcludedDatabases_Click" Margin="0,0,8,0"/>
             <Button Content="Delete" Click="DeleteButton_Click" Margin="0,0,8,0"/>
             <Button Content="Close" Click="CloseButton_Click"/>
         </StackPanel>

--- a/Lite/Windows/ManageServersWindow.xaml.cs
+++ b/Lite/Windows/ManageServersWindow.xaml.cs
@@ -70,6 +70,25 @@ public partial class ManageServersWindow : Window
         }
     }
 
+    private void EditMenuItem_Click(object sender, RoutedEventArgs e) => EditSelected();
+
+    private void DeleteMenuItem_Click(object sender, RoutedEventArgs e) => DeleteButton_Click(sender, e);
+
+    private void ExcludedDatabases_Click(object sender, RoutedEventArgs e)
+    {
+        if (ServersGrid.SelectedItem is not ServerConnection selected)
+        {
+            return;
+        }
+
+        var dialog = new ExcludedDatabasesDialog(_serverManager, selected) { Owner = this };
+        if (dialog.ShowDialog() == true && dialog.ExclusionsModified)
+        {
+            ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
     private void DeleteButton_Click(object sender, RoutedEventArgs e)
     {
         if (ServersGrid.SelectedItem is not ServerConnection selected)


### PR DESCRIPTION
## Summary
Lite-side companion to PR #905. Gives Lite users the same per-server "skip these databases" feature now available in the Dashboard — but stored client-side since Lite doesn't install on targets.

## Storage
- New \`ExcludedDatabases\` (List<string>) on \`ServerConnection\`, persisted via the existing \`servers.json\` round-trip.

## Collector wiring (9 collectors)
\`query_stats\`, \`query_store\`, \`procedure_stats\`, \`query_snapshots\`, \`file_io_stats\`, \`waiting_tasks\`, \`database_configuration\`, \`database_scoped_configurations\`, \`database_size\`. Azure-mode collectors that route through \`GetAzureDatabaseListAsync\` get exclusions automatically since the helper now applies the filter centrally.

## Two SQL helpers on \`RemoteCollectorService\`
- \`BuildDatabaseExclusionFilter\` — parameterized \`AND <col> NOT IN (@excl_db_N)\`. Used by every collector whose query is plain (non-dynamic) T-SQL. Deliberately avoids \`OPENJSON\` / \`STRING_SPLIT\` because both require compat 130+ on the connection database (e.g. \`master\` often lags).
- \`BuildDatabaseExclusionLiteralClause\` — \`N'name'\` literals with single-quote escaping (and a \`forNestedDynamicSql=true\` mode that doubles the escape). Used by \`procedure_stats\` which builds \`@sql\` and passes it to \`sp_executesql\`. Names come from a user-picked checklist of existing DBs, escaped against \`'\` injection.

## UI
- \`ManageServersWindow\`: new **Excluded Databases** button between Edit and Delete.
- Right-click menu now mirrors the buttons: Edit / Excluded Databases / Delete (red) on top, then a separator, then existing Copy / Export items.
- New \`ExcludedDatabasesDialog\` matches the Dashboard version: live-queries \`sys.databases\`, hides system DBs, pre-checks current exclusions, shows stale entries greyed with \`(missing)\` tag. Save calls \`ServerManager.UpdateServer\` to persist via \`servers.json\`.

## Test plan
- [x] Lite builds clean.
- [x] Manage Servers window: button visible, context menu reorganized.
- [x] Excluded Databases dialog: opens, lists user DBs, hides system DBs.
- [x] Save round-trips to \`servers.json\`.
- [ ] Manual: add an exclusion, watch the next collection cycle skip the DB in the local DuckDB tables.

Closes #887 (paired with #905 for Dashboard).