### PR TITLE
Release v2.9.0: Manage Servers version column, Lite-style indicators in Full, prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.8.0] - TBD
+## [2.9.0] - TBD
+
+### Important
+
+- **Breaking change to `config.data_retention`** — the `@truncate_all` parameter has been removed. Pass `@retention_days = 0` for the same behavior. `@retention_days = NULL` (default) respects per-collector retention from `config.collection_schedule` with a 30-day fallback for unscheduled tables; `@retention_days = N > 0` overrides every table to N days. Any existing Agent jobs or scripts calling `data_retention @truncate_all = 1` need to be updated ([#900])
+- **New `config.collector_database_exclusions` table** for per-database collector exclusions. Eight per-database collectors filter against this table; system databases remain hard-skipped by the collectors themselves. Existing installs get the table on the next upgrade — `install/01_install_database.sql` and `config.ensure_config_tables` both create it under an `IF OBJECT_ID … IS NULL` guard ([#887])
+
+### Added
+
+- **Per-database collector exclusions** — exclude noisy or unimportant databases from per-database collectors. Dashboard side adds `config.collector_database_exclusions` and filters 8 collectors (`query_stats`, `query_store`, `procedure_stats`, `file_io_stats`, `waiting_tasks`, `database_configuration`, `database_size_stats`, `server_properties`). Lite side adds an `ExcludedDatabases` list per server in `servers.json` and filters 9 collectors ([#887])
+- **`Off` collection preset** — `EXECUTE config.apply_collection_preset @preset_name = N'Off'` disables every collector in one call. Pair with a second Agent job that applies a non-`Off` preset at the start of your active window for overnight / quiet-hours scoping. Non-`Off` presets now also set `enabled = 1` across the board so the switch from `Off → Balanced` reliably resumes collection ([#888])
+- **Purge Now action** in Manage Servers — confirm dialog with a mode picker (Use configured / 1 / 3 / 7 / Custom / All) drives `config.data_retention`; right-click menu on the Manage Servers grid mirrors every per-row action (Edit, Toggle Favorite, Check Server Version, Purge Now, Remove) ([#900])
+- **Total non-idle CPU on Lite Overview** — headline value shows total CPU with the SQL-only value alongside (e.g. `64% (SQL 60%)`); new `CpuAlertMode` dropdown in Settings → Alerts (Total / SqlOnly) drives both the alert evaluator and headline color; tray notifications and email alerts label the value as "Total CPU" or "SQL CPU" ([#899])
+- **Resume gap detection** — `query_stats`, `procedure_stats`, and `query_store` collectors skip the historical sweep on first run after an Off preset, Agent stoppage, or server reboot. When the last successful run is older than 5× the configured `frequency_minutes` (floored at 30 minutes), the cutoff clamps to `SYSDATETIME()` so only forward-going data is collected on resume — preventing the tempdb blowout that hit the original reporter ([#892])
+- **Right-click View Plan** on Dashboard Blocked Process Reports (View Blocked Plan + View Blocking Plan), Dashboard Deadlocks, and Lite Deadlocks grids. Plan lookup hits `sys.dm_exec_query_stats` + `sys.dm_exec_text_query_plan` on the monitored server, falling back to `executionStack/frame` entries when the process-level `sql_handle` is empty or evicted ([#880])
+- **Open Log Folder** sidebar button in Lite — opens `%LocalAppData%\PerformanceMonitorLite\logs\` in Explorer for grabbing historical logs to attach to bug reports. Sits below View Log, which retains its existing behavior of opening today's log file ([#873])
+- **Installed Version column** in the Manage Servers grid for both Dashboard and Lite. Dashboard shows the PerformanceMonitor database version on each server (probed in parallel via `GetInstalledVersionAsync`, with `Not installed` / `Unavailable` fallbacks). Lite shows the running app's own version on every row, mirroring Full's column header for consistency.
+- **Lite-style server card indicators in Full** — back-ported the Ellipse-with-DataTriggers status dot (Online/Offline/Warning/Unknown) and the right-aligned favorite star from Lite to the Full Dashboard's server list, matching Lite's visual treatment.
+- **Architecture overview** at `docs/how-collection-works.md` covering the minute loop, dispatcher, collector shape, `config.collection_schedule`, retention, and the Dashboard read path
+
+### Changed
+
+- **PlanIconMapper synced** with PerformanceStudio v1.9.0 improvements — columnstore storage type on scan/delete/insert/update/merge operators routes to `columnstore_index_*` icons (covers CCI and NCCI); `Parallelism` operator subtypes (Repartition Streams, Distribute Streams, Gather Streams) get their own icons
+- **`Microsoft.Data.SqlClient` 6.1.4 → 7.0.1** — major-version bump. Azure/Entra dependencies were split out of the core package in 7.0; `Microsoft.Data.SqlClient.Extensions.Azure 1.0.0` added to Dashboard, Lite, and Installer.Core for `ActiveDirectoryInteractive` connections
+- **`ModelContextProtocol` 0.7.0-preview.1 → 1.2.0** — off the preview tag and onto stable 1.x in Dashboard and Lite
+- **`DuckDB.NET` 1.5.0 → 1.5.2** in Lite — fixes unbounded row group growth on indexed tables under repeated load+insert cycles, memory leaks and race conditions in prepared statements, WAL checkpoint marking, and Windows UTF-8/UTF-16 handling
+- **`Microsoft.Extensions.*` 10.0.5 → 10.0.7**, **`System.Text.Json` 10.0.5 → 10.0.7**, **`ScottPlot.WPF` 5.1.57 → 5.1.58** — patch-level bumps with no expected behavioral change
+- **Theme polish** on grids and plan viewer in Dashboard and Lite — thanks [@ClaudioESSilva](https://github.com/ClaudioESSilva) ([#889])
+
+### Fixed
+
+- **Install loop timeout** raised from 5 minutes to 1 hour. `install/98_validate_installation.sql` runs every enabled collector with `@debug = 1` in a single batch; on large databases (reporter had 7.2M rows in `collect.query_stats`, 4.4M in `collect.query_store_data`) this took ~9 minutes and was blowing the 5-minute timeout, failing the install or upgrade ([#884])
+
+[#873]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/873
+[#880]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/880
+[#884]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/884
+[#887]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/887
+[#888]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/888
+[#889]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/889
+[#892]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/892
+[#899]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/899
+[#900]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/900
+
+## [2.8.0] - 2026-04-22
 
 ### Important
 
@@ -15,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Memory Pressure Events in Lite** — the collector, chart, and `get_memory_pressure_events` MCP tool previously only in the Full Edition are now available in Lite ([#865])
 - **Grid auto-scrolling** in Lite and Dashboard ([#843]) — thanks [@ClaudioESSilva](https://github.com/ClaudioESSilva)
-- **`Off` collection preset** — `config.apply_collection_preset @preset_name = N'Off'` disables every collector in one call. Pair it with a second Agent job that applies a non-`Off` preset at the start of your active window to get overnight / quiet-hours scoping without writing scheduler code. Non-`Off` presets now also set `enabled = 1` across the board so the switch reliably resumes collection ([#888])
 
 ### Changed
 
@@ -48,7 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#865]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/865
 [#867]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/867
 [#872]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/872
-[#888]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/888
 
 ## [2.7.0] - 2026-04-13
 

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -7,10 +7,10 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>2.8.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
-    <InformationalVersion>2.8.0</InformationalVersion>
+    <Version>2.9.0</Version>
+    <AssemblyVersion>2.9.0.0</AssemblyVersion>
+    <FileVersion>2.9.0.0</FileVersion>
+    <InformationalVersion>2.9.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/Dashboard/MainWindow.xaml
+++ b/Dashboard/MainWindow.xaml
@@ -88,47 +88,75 @@
                           BorderThickness="0">
                     <ListView.ItemTemplate>
                         <DataTemplate>
-                            <Border BorderBrush="{DynamicResource BorderBrush}" 
-                                    BorderThickness="1" 
-                                    CornerRadius="4" 
-                                    Padding="8,6" 
+                            <Border BorderBrush="{DynamicResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    Padding="8,6"
                                     Margin="2">
-                                <StackPanel>
-                                    <!-- Server Name Row with Status Icon -->
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding StatusIcon}"
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- Status Indicator (back-ported from Lite: Ellipse + DataTriggers) -->
+                                    <Ellipse Grid.Column="0"
+                                             Width="10" Height="10"
+                                             Margin="0,6,8,0"
+                                             VerticalAlignment="Top"
+                                             ToolTip="{Binding Status.ErrorMessage}">
+                                        <Ellipse.Style>
+                                            <Style TargetType="Ellipse">
+                                                <Setter Property="Fill" Value="{DynamicResource ForegroundMutedBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Online">
+                                                        <Setter Property="Fill" Value="{DynamicResource SuccessBrush}"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Offline">
+                                                        <Setter Property="Fill" Value="{DynamicResource ErrorBrush}"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Warning">
+                                                        <Setter Property="Fill" Value="{DynamicResource WarningBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Ellipse.Style>
+                                    </Ellipse>
+
+                                    <!-- Server detail stack -->
+                                    <StackPanel Grid.Column="1">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource ForegroundBrush}"/>
+                                        <TextBlock Text="{Binding ServerName}" FontSize="13" Foreground="{DynamicResource AccentBrush}" Margin="0,-2,0,0" />
+                                        <TextBlock Text="{Binding Description}" FontSize="10" Foreground="{DynamicResource ForegroundDimBrush}"
+                                                   TextWrapping="Wrap" Margin="0,-1,0,0"/>
+                                        <!-- Status Duration (Online for X / Offline for X) -->
+                                        <TextBlock Text="{Binding StatusDurationDisplay, Mode=OneWay}"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold"
                                                    Foreground="{Binding StatusColor}"
-                                                   FontSize="14"
-                                                   FontWeight="Bold"
-                                                   VerticalAlignment="Center"
-                                                   Margin="0,0,4,0"
-                                                   ToolTip="{Binding Status.ErrorMessage}"/>
-                                        <TextBlock Text="&#x2605;" FontSize="13" Foreground="#FFD700" Margin="0,0,4,0"
-                                                   VerticalAlignment="Center"
-                                                   Visibility="{Binding IsFavorite, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="13" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                                                   Margin="0,-1,0,0"
+                                                   Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                        <!-- Monitor Version -->
+                                        <TextBlock Text="{Binding MonitorVersionDisplay, Mode=OneWay}"
+                                                   FontSize="11"
+                                                   Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                   Margin="0,-1,0,0"
+                                                   Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                        <!-- Last Checked Timestamp -->
+                                        <TextBlock FontSize="12" Foreground="{DynamicResource ForegroundDimBrush}" Margin="0,-1,0,0">
+                                            <Run Text="{Binding LastCheckedDisplay, Mode=OneWay}"/>
+                                        </TextBlock>
                                     </StackPanel>
-                                    <TextBlock Text="{Binding ServerName}" FontSize="13" Foreground="{DynamicResource AccentBrush}" Margin="0,-2,0,0" />
-                                    <TextBlock Text="{Binding Description}" FontSize="10" Foreground="{DynamicResource ForegroundDimBrush}"
-                                               TextWrapping="Wrap" Margin="0,-1,0,0"/>
-                                    <!-- Status Duration (Online for X / Offline for X) -->
-                                    <TextBlock Text="{Binding StatusDurationDisplay, Mode=OneWay}"
-                                               FontSize="13"
-                                               FontWeight="SemiBold"
-                                               Foreground="{Binding StatusColor}"
-                                               Margin="0,-1,0,0"
-                                               Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <!-- Monitor Version -->
-                                    <TextBlock Text="{Binding MonitorVersionDisplay, Mode=OneWay}"
-                                               FontSize="11"
-                                               Foreground="{DynamicResource ForegroundMutedBrush}"
-                                               Margin="0,-1,0,0"
-                                               Visibility="{Binding HasBeenChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <!-- Last Checked Timestamp -->
-                                    <TextBlock FontSize="12" Foreground="{DynamicResource ForegroundDimBrush}" Margin="0,-1,0,0">
-                                        <Run Text="{Binding LastCheckedDisplay, Mode=OneWay}"/>
-                                    </TextBlock>
-                                </StackPanel>
+
+                                    <!-- Favorite Star (right-aligned, back-ported from Lite) -->
+                                    <TextBlock Grid.Column="2"
+                                               Text="&#x2605;" FontSize="16"
+                                               VerticalAlignment="Top"
+                                               Foreground="#FFD700"
+                                               Margin="4,2,0,0"
+                                               Visibility="{Binding IsFavorite, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                </Grid>
                             </Border>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/Dashboard/ManageServersWindow.xaml
+++ b/Dashboard/ManageServersWindow.xaml
@@ -74,6 +74,7 @@
                     <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayName}" Width="150"/>
                     <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" Width="180"/>
                     <DataGridTextColumn Header="Authentication" Binding="{Binding AuthenticationDisplay}" Width="120"/>
+                    <DataGridTextColumn Header="Installed Version" Binding="{Binding InstalledVersion}" Width="130"/>
                     <DataGridTextColumn Header="Monthly Cost ($)" Binding="{Binding MonthlyCostUsd, StringFormat='{}{0:N0}'}" Width="120">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -7,12 +7,13 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Installer.Core;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
@@ -29,11 +30,45 @@ namespace PerformanceMonitorDashboard
             _serverManager = serverManager;
             ServersModified = false;
             LoadServers();
+            _ = LoadInstalledVersionsAsync();
         }
 
         private void LoadServers()
         {
             ServersDataGrid.ItemsSource = _serverManager.GetAllServers();
+        }
+
+        private async Task LoadInstalledVersionsAsync()
+        {
+            if (ServersDataGrid.ItemsSource is not IEnumerable<ServerConnection> source) return;
+
+            /* Snapshot the list so subsequent LoadServers() calls don't race us. */
+            var servers = source.ToList();
+
+            /* Probe in parallel — each call opens its own SqlConnection to master. */
+            var tasks = servers.Select(async s =>
+            {
+                try
+                {
+                    string? version = await _serverManager.GetInstalledVersionAsync(s);
+                    s.InstalledVersion = string.IsNullOrEmpty(version) ? "Not installed" : NormalizeVersion(version);
+                }
+                catch
+                {
+                    s.InstalledVersion = "Unavailable";
+                }
+            });
+
+            await Task.WhenAll(tasks);
+        }
+
+        private static string NormalizeVersion(string version)
+        {
+            int plusIndex = version.IndexOf('+');
+            string trimmed = plusIndex >= 0 ? version[..plusIndex] : version;
+            return Version.TryParse(trimmed, out var v)
+                ? new Version(v.Major, v.Minor, v.Build).ToString()
+                : trimmed;
         }
 
         private void ServersDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Text.Json.Serialization;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorDashboard.Interfaces;
@@ -14,7 +15,7 @@ using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard.Models
 {
-    public class ServerConnection
+    public class ServerConnection : INotifyPropertyChanged
     {
         public string Id { get; set; } = Guid.NewGuid().ToString();
         public string ServerName { get; set; } = string.Empty;
@@ -87,6 +88,28 @@ namespace PerformanceMonitorDashboard.Models
         /// </summary>
         [JsonIgnore]
         public string DisplayNameWithIntent => ReadOnlyIntent ? $"{DisplayName} (Read-Only)" : DisplayName;
+
+        private string? _installedVersion;
+
+        /// <summary>
+        /// Installed PerformanceMonitor version on this server. Populated asynchronously
+        /// by the Manage Servers window. Not persisted — runtime-only display field.
+        /// Conventional values: null (not yet probed), a 3-part version like "2.9.0",
+        /// "Not installed", or "Unavailable" when the probe fails.
+        /// </summary>
+        [JsonIgnore]
+        public string? InstalledVersion
+        {
+            get => _installedVersion;
+            set
+            {
+                if (_installedVersion == value) return;
+                _installedVersion = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InstalledVersion)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         /// <summary>
         /// Display-only property for showing authentication type in UI.

--- a/Dashboard/Models/ServerListItem.cs
+++ b/Dashboard/Models/ServerListItem.cs
@@ -44,6 +44,7 @@ namespace PerformanceMonitorDashboard.Models
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(StatusIcon));
                     OnPropertyChanged(nameof(StatusColor));
+                    OnPropertyChanged(nameof(DotStatus));
                     OnPropertyChanged(nameof(LastCheckedDisplay));
                     OnPropertyChanged(nameof(StatusDurationDisplay));
                     OnPropertyChanged(nameof(IsOnline));
@@ -69,6 +70,20 @@ namespace PerformanceMonitorDashboard.Models
         /// Status icon: ✓ for online, ✗ for offline, ? for unknown.
         /// </summary>
         public string StatusIcon => _status.StatusIcon;
+
+        /// <summary>
+        /// Symbolic status used by the sidebar Ellipse indicator's DataTriggers.
+        /// Returns "Online", "Offline", or "Unknown".
+        /// </summary>
+        public string DotStatus
+        {
+            get
+            {
+                if (!_status.LastChecked.HasValue)
+                    return "Unknown";
+                return _status.IsOnline == true ? "Online" : "Offline";
+            }
+        }
 
         /// <summary>
         /// Color for the status icon: green for online, red for offline, gray for unknown.

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,10 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>2.8.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
-    <InformationalVersion>2.8.0</InformationalVersion>
+    <Version>2.9.0</Version>
+    <AssemblyVersion>2.9.0.0</AssemblyVersion>
+    <FileVersion>2.9.0.0</FileVersion>
+    <InformationalVersion>2.9.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>2.8.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
-    <InformationalVersion>2.8.0</InformationalVersion>
+    <Version>2.9.0</Version>
+    <AssemblyVersion>2.9.0.0</AssemblyVersion>
+    <FileVersion>2.9.0.0</FileVersion>
+    <InformationalVersion>2.9.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -7,13 +7,14 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Text.Json.Serialization;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Models;
 
-public class ServerConnection
+public class ServerConnection : INotifyPropertyChanged
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public string ServerName { get; set; } = string.Empty;
@@ -163,6 +164,27 @@ public class ServerConnection
     /// </summary>
     [JsonIgnore]
     public string StatusDisplay => IsEnabled ? "Enabled" : "Disabled";
+
+    private string? _installedVersion;
+
+    /// <summary>
+    /// PerformanceMonitor Lite app version monitoring this server (e.g., "2.9.0").
+    /// Populated by the Manage Servers window. Not persisted — runtime-only display field.
+    /// Same value for every row since one Lite process monitors all servers.
+    /// </summary>
+    [JsonIgnore]
+    public string? InstalledVersion
+    {
+        get => _installedVersion;
+        set
+        {
+            if (_installedVersion == value) return;
+            _installedVersion = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InstalledVersion)));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
     /// Builds and returns a connection string for this server.

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -8,10 +8,10 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>2.8.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
-    <InformationalVersion>2.8.0</InformationalVersion>
+    <Version>2.9.0</Version>
+    <AssemblyVersion>2.9.0.0</AssemblyVersion>
+    <FileVersion>2.9.0.0</FileVersion>
+    <InformationalVersion>2.9.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Lightweight SQL Server performance monitoring - no installation required on target servers</Description>

--- a/Lite/Windows/ManageServersWindow.xaml
+++ b/Lite/Windows/ManageServersWindow.xaml
@@ -55,6 +55,7 @@
                 <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayNameWithIntent}" Width="150"/>
                 <DataGridTextColumn Header="Server" Binding="{Binding ServerNameDisplay}" Width="200"/>
                 <DataGridTextColumn Header="Auth" Binding="{Binding AuthenticationDisplay}" Width="100"/>
+                <DataGridTextColumn Header="Installed Version" Binding="{Binding InstalledVersion}" Width="130"/>
                 <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="80"/>
                 <DataGridTextColumn Header="Monthly Cost ($)" Binding="{Binding MonthlyCostUsd, StringFormat='{}{0:N0}'}" Width="120">
                     <DataGridTextColumn.ElementStyle>

--- a/Lite/Windows/ManageServersWindow.xaml.cs
+++ b/Lite/Windows/ManageServersWindow.xaml.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
 using PerformanceMonitorLite.Models;
@@ -32,7 +33,27 @@ public partial class ManageServersWindow : Window
     private void RefreshGrid()
     {
         ServersGrid.ItemsSource = null;
-        ServersGrid.ItemsSource = _serverManager.GetAllServers();
+        var servers = _serverManager.GetAllServers();
+        string appVersion = GetAppVersion();
+        foreach (var s in servers)
+        {
+            s.InstalledVersion = appVersion;
+        }
+        ServersGrid.ItemsSource = servers;
+    }
+
+    private static string GetAppVersion()
+    {
+        string raw = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "0.0.0";
+
+        int plusIndex = raw.IndexOf('+');
+        string trimmed = plusIndex >= 0 ? raw[..plusIndex] : raw;
+        return System.Version.TryParse(trimmed, out var v)
+            ? new System.Version(v.Major, v.Minor, v.Build).ToString()
+            : trimmed;
     }
 
     private void AddButton_Click(object sender, RoutedEventArgs e)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Data starts flowing within 1–5 minutes. That's it. No installation on your ser
 
 All data is stored in `%LOCALAPPDATA%\PerformanceMonitorLite\` — separate from the executable, so auto-updates don't affect your data.
 
-- **Hot data** in DuckDB 1.5.0 — non-blocking checkpoints, free block reuse, stable file size without periodic resets
+- **Hot data** in DuckDB 1.5.2 — non-blocking checkpoints, free block reuse, stable file size without periodic resets
 - **Archive** to Parquet with ZSTD compression (~10x reduction) — automatic monthly compaction keeps file count low (~75 files vs thousands)
 - **Retention**: 3-month calendar-month rolling window
 - Typical size: ~50–200 MB per server per week


### PR DESCRIPTION
## Summary
Bundles the v2.9.0 release prep with two related Manage Servers UI improvements that landed during release testing:

- **Installed Version column** in Manage Servers for both Dashboard and Lite.
  - Full: queries `config.installation_history` per server in parallel via `ServerManager.GetInstalledVersionAsync`. Falls back to `Not installed` (no install detected) or `Unavailable` (probe failed). Versions normalize to 3-part by stripping the `+gitsha` suffix.
  - Lite: shows the running Lite app's `AssemblyInformationalVersion` on every row. Same column header as Full so the UX matches across editions, even though Lite has no per-server installed version concept.
  - Both use `INotifyPropertyChanged` on `ServerConnection.InstalledVersion` so async population (Full) and post-load population (Lite) update each row in place without reloading the grid.

- **Lite-style server card indicators back-ported to Full**. The Full Dashboard's server list now uses Lite's Ellipse-with-DataTriggers status dot (Online / Offline / Warning / Unknown) and a right-aligned favorite star, matching Lite's visual treatment.

## Release prep also bundled here
- Version bumps to **2.9.0** / **2.9.0.0** in all four csproj files (Dashboard, Lite, Installer, Installer.Core).
- CHANGELOG rewrite:
  - Fixed the 2.8.0 entry's date from `TBD` to `2026-04-22` (was a release-time bug).
  - Moved the `Off` collection preset (#888) out of 2.8.0 into 2.9.0 since #891 landed after the v2.8.0 tag.
  - Added the full 2.9.0 entry covering Important / Added / Changed / Fixed for the post-2.8.0 PR set.
- README: bumped DuckDB version reference 1.5.0 → 1.5.2 (only factual mismatch — collector counts, MCP tool counts, install script count all still match).

## Test plan
Already exercised on dev during this release pass:
- [x] `dotnet build` clean (0 errors).
- [x] `Installer.Tests` 46/46 pass.
- [x] sql2016 fresh install (`--reinstall`), 54/54 scripts, 45 collectors validated, 0 errors.
- [x] sql2017 upgrade 2.8.0 → 2.9.0, all 26 tables preserved, row counts grew, exclusions table created.
- [x] sql2022 upgrade 2.8.0 → 2.9.0 + idempotency re-run, 1.5M+ row tables preserved across both runs.
- [x] Multi-hop on sql2016: v2.6.0 → 2.9.0, v2.7.0 → 2.9.0, v2.8.0 → 2.9.0, all clean.
- [x] sql2016 uninstall — DB / Agent jobs / XE sessions removed.
- [x] Manage Servers Installed Version column verified in both apps.
- [ ] sql2019 + sql2025 via Dashboard Add Server (Erik driving).
- [ ] Cloud Lite (Azure SQL DB + AWS RDS provisioned, Erik driving).
- [ ] Lite/Dashboard smoke tests of new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)