### PR TITLE
Fix #916 (Lite) — Memory tab tooltip stops working after returning to tab

### DIFF
--- a/Lite/Helpers/ChartHoverHelper.cs
+++ b/Lite/Helpers/ChartHoverHelper.cs
@@ -53,6 +53,16 @@ internal sealed class ChartHoverHelper
 
         chart.MouseMove += OnMouseMove;
         chart.MouseLeave += OnMouseLeave;
+
+        /* Tab switching can leave the popup wedged: WPF unloads the parent TabItem
+           without firing MouseLeave, so IsOpen stays true with a stale anchor.
+           When the chart becomes visible again, OnMouseMove sets IsOpen = true
+           but it is already true, so the popup never re-anchors and never shows.
+           Force-close on every visibility/load transition so the next mouse move
+           re-opens cleanly. */
+        chart.IsVisibleChanged += OnChartVisibilityChanged;
+        chart.Unloaded += OnChartUnloaded;
+        chart.Loaded += OnChartLoaded;
     }
 
     public string Unit { get => _unit; set => _unit = value; }
@@ -61,10 +71,22 @@ internal sealed class ChartHoverHelper
     {
         _chart.MouseMove -= OnMouseMove;
         _chart.MouseLeave -= OnMouseLeave;
+        _chart.IsVisibleChanged -= OnChartVisibilityChanged;
+        _chart.Unloaded -= OnChartUnloaded;
+        _chart.Loaded -= OnChartLoaded;
         _popup.IsOpen = false;
         _scatters.Clear();
         _barPlots.Clear();
     }
+
+    private void OnChartVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e) =>
+        _popup.IsOpen = false;
+
+    private void OnChartUnloaded(object sender, RoutedEventArgs e) =>
+        _popup.IsOpen = false;
+
+    private void OnChartLoaded(object sender, RoutedEventArgs e) =>
+        _popup.IsOpen = false;
 
     public void Clear()
     {
@@ -193,6 +215,11 @@ internal sealed class ChartHoverHelper
             _text.Text = $"{bestLabel}\n{valueFormatted} {_unit}\n{time:HH:mm:ss}";
             _popup.HorizontalOffset = pos.X + 15;
             _popup.VerticalOffset = pos.Y + 15;
+            /* Toggle if already open so WPF re-evaluates the placement target.
+               Without this, a popup that was IsOpen = true when its TabItem was
+               unloaded stays "open" with a stale anchor and never appears on
+               return — the assignment below is a no-op. */
+            if (_popup.IsOpen) _popup.IsOpen = false;
             _popup.IsOpen = true;
         }
         else


### PR DESCRIPTION
## Summary
- Mirrors Dashboard PR #919 for the Lite collector. WPF `Popup` (used by Lite's `ChartHoverHelper`) can wedge when the user navigates away from a `TabItem` mid-hover: WPF unloads the parent without firing `MouseLeave`, so `IsOpen` stays `true` with a stale placement anchor. On return, `OnMouseMove` sets `IsOpen = true` again, but since it's already `true` the assignment is a no-op and the popup never re-anchors or appears.
- Lite has the same nested-TabControl shape (parent Memory tab → Memory Overview / Memory Clerks / Memory Grants / Memory Pressure Events sub-tabs), so the bug surfaces identically to the Full Dashboard.
- Force-close the popup on chart `Loaded` / `Unloaded` / `IsVisibleChanged`, and toggle `IsOpen` off→on inside `OnMouseMove` so WPF re-evaluates placement even when the popup believes it's already open.

Related to #916

## Test plan
- [ ] Build Lite
- [ ] Switch between top-level tabs that own charts and verify tooltip still appears on return
- [ ] Repeat across all Memory sub-tabs (Memory Overview, Memory Clerks, Memory Grants, Memory Pressure Events)
- [ ] Sanity-check tooltips still behave on other Lite tabs that use ChartHoverHelper

🤖 Generated with [Claude Code](https://claude.com/claude-code)