### PR TITLE
Apply #916 popup-wedge fix to CorrelatedCrosshairManager

### DIFF
--- a/Dashboard/Helpers/CorrelatedCrosshairManager.cs
+++ b/Dashboard/Helpers/CorrelatedCrosshairManager.cs
@@ -74,8 +74,27 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         chart.MouseMove += (s, e) => OnMouseMove(lane, e);
         chart.MouseLeave += (s, e) => OnMouseLeave();
 
+        /* Tab switching can leave the popup wedged: WPF unloads the parent TabItem
+           without firing MouseLeave, so IsOpen stays true with a stale anchor.
+           When a chart becomes visible again, OnMouseMove sets IsOpen = true but
+           it is already true, so the popup never re-anchors. Force-close on every
+           visibility/load transition for any lane so the next mouse move re-opens
+           cleanly. */
+        chart.IsVisibleChanged += OnLaneVisibilityChanged;
+        chart.Unloaded += OnLaneUnloaded;
+        chart.Loaded += OnLaneLoaded;
+
         _lanes.Add(lane);
     }
+
+    private void OnLaneVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e) =>
+        _tooltip.IsOpen = false;
+
+    private void OnLaneUnloaded(object sender, RoutedEventArgs e) =>
+        _tooltip.IsOpen = false;
+
+    private void OnLaneLoaded(object sender, RoutedEventArgs e) =>
+        _tooltip.IsOpen = false;
 
     /// <summary>
     /// Sets the expected baseline range for a lane (upper/lower bounds).
@@ -287,6 +306,11 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         _tooltip.PlacementTarget = sourceLane.Chart;
         _tooltip.HorizontalOffset = pos.X + 15;
         _tooltip.VerticalOffset = pos.Y + 15;
+        /* Toggle if already open so WPF re-evaluates the placement target.
+           Without this, a popup that was IsOpen = true when its TabItem was
+           unloaded stays "open" with a stale anchor and never appears on
+           return — the assignment below is a no-op. */
+        if (_tooltip.IsOpen) _tooltip.IsOpen = false;
         _tooltip.IsOpen = true;
     }
 
@@ -373,6 +397,9 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         _tooltip.IsOpen = false;
         foreach (var lane in _lanes)
         {
+            lane.Chart.IsVisibleChanged -= OnLaneVisibilityChanged;
+            lane.Chart.Unloaded -= OnLaneUnloaded;
+            lane.Chart.Loaded -= OnLaneLoaded;
             lane.Series.Clear();
             lane.VLine = null;
         }

--- a/Lite/Helpers/CorrelatedCrosshairManager.cs
+++ b/Lite/Helpers/CorrelatedCrosshairManager.cs
@@ -74,8 +74,27 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         chart.MouseMove += (s, e) => OnMouseMove(lane, e);
         chart.MouseLeave += (s, e) => OnMouseLeave();
 
+        /* Tab switching can leave the popup wedged: WPF unloads the parent TabItem
+           without firing MouseLeave, so IsOpen stays true with a stale anchor.
+           When a chart becomes visible again, OnMouseMove sets IsOpen = true but
+           it is already true, so the popup never re-anchors. Force-close on every
+           visibility/load transition for any lane so the next mouse move re-opens
+           cleanly. */
+        chart.IsVisibleChanged += OnLaneVisibilityChanged;
+        chart.Unloaded += OnLaneUnloaded;
+        chart.Loaded += OnLaneLoaded;
+
         _lanes.Add(lane);
     }
+
+    private void OnLaneVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e) =>
+        _tooltip.IsOpen = false;
+
+    private void OnLaneUnloaded(object sender, RoutedEventArgs e) =>
+        _tooltip.IsOpen = false;
+
+    private void OnLaneLoaded(object sender, RoutedEventArgs e) =>
+        _tooltip.IsOpen = false;
 
     /// <summary>
     /// Sets the expected baseline range for a lane (upper/lower bounds).
@@ -287,6 +306,11 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         _tooltip.PlacementTarget = sourceLane.Chart;
         _tooltip.HorizontalOffset = pos.X + 15;
         _tooltip.VerticalOffset = pos.Y + 15;
+        /* Toggle if already open so WPF re-evaluates the placement target.
+           Without this, a popup that was IsOpen = true when its TabItem was
+           unloaded stays "open" with a stale anchor and never appears on
+           return — the assignment below is a no-op. */
+        if (_tooltip.IsOpen) _tooltip.IsOpen = false;
         _tooltip.IsOpen = true;
     }
 
@@ -373,6 +397,9 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         _tooltip.IsOpen = false;
         foreach (var lane in _lanes)
         {
+            lane.Chart.IsVisibleChanged -= OnLaneVisibilityChanged;
+            lane.Chart.Unloaded -= OnLaneUnloaded;
+            lane.Chart.Loaded -= OnLaneLoaded;
             lane.Series.Clear();
             lane.VLine = null;
         }


### PR DESCRIPTION
## Summary
Sweep for repeats of the WPF Popup wedge bug from #916 found `CorrelatedCrosshairManager` has the same shape as `ChartHoverHelper` — multiple charts feed a single tooltip popup, `IsOpen = true` is set on every mouse move with no re-anchor toggle, and no `Loaded` / `Unloaded` / `IsVisibleChanged` subscriptions on the chart lanes.

`CorrelatedTimelineLanesControl` is hosted inside Resource Metrics → Server Trends (a `TabItem` inside a `TabItem`), so the same wedge applies: WPF unloads the parent on tab switch without firing `MouseLeave`, leaving `_tooltip.IsOpen` stuck at `true` with a stale anchor.

Both Dashboard and Lite copies updated in lockstep per the file's own `SYNC WARNING`.

- Subscribe to chart `Loaded` / `Unloaded` / `IsVisibleChanged` in `AddLane` and force `_tooltip.IsOpen = false` on each event.
- In `OnMouseMove`, toggle `IsOpen` off then on so WPF re-evaluates placement even when the popup believes it is already open.
- Unhook the new event handlers in `Dispose`.

Related to #916

## Test plan
- [ ] Build Dashboard and Lite
- [ ] In Dashboard: open a server, navigate to Resource Metrics → Server Trends, hover the timeline lanes, switch to another top-level tab, switch back → tooltip should still appear on hover
- [ ] Same scenario in Lite
- [ ] Sanity-check the existing chart hover tooltips still behave on Memory tab and elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)