### PR TITLE
Speed up Lite tests: enable parallelization + share DuckDB in FinOpsTests

### DIFF
--- a/Lite.Tests/AnomalyDetectorTests.cs
+++ b/Lite.Tests/AnomalyDetectorTests.cs
@@ -15,6 +15,7 @@ namespace PerformanceMonitorLite.Tests;
 /// methods (batch requests, sessions, query duration, memory), per-metric thresholds,
 /// and baseline context metadata.
 /// </summary>
+[Collection(BaselineProviderCollection.Name)]
 public class AnomalyDetectorTests : IDisposable
 {
     private readonly string _tempDir;

--- a/Lite.Tests/BaselineProviderCollection.cs
+++ b/Lite.Tests/BaselineProviderCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/* BaselineProviderTests and AnomalyDetectorTests both mutate the static
+   BaselineProvider.CacheTtl field. With assembly-level parallelization
+   enabled, those two classes must share a collection so they don't run
+   concurrently and stomp on each other's TTL writes. */
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class BaselineProviderCollection
+{
+    public const string Name = "BaselineProvider";
+}

--- a/Lite.Tests/BaselineProviderTests.cs
+++ b/Lite.Tests/BaselineProviderTests.cs
@@ -13,6 +13,7 @@ namespace PerformanceMonitorLite.Tests;
 /// Tests for BaselineProvider: time-bucketed baseline computation, bucket collapse
 /// with hysteresis, restart poisoning exclusion, and division-by-zero handling.
 /// </summary>
+[Collection(BaselineProviderCollection.Name)]
 public class BaselineProviderTests : IDisposable
 {
     private readonly string _tempDir;

--- a/Lite.Tests/FinOpsDuckDbFixture.cs
+++ b/Lite.Tests/FinOpsDuckDbFixture.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using PerformanceMonitorLite.Database;
+
+namespace PerformanceMonitorLite.Tests;
+
+/* Shared DuckDB fixture for FinOpsTests. xUnit instantiates this once per
+   test class (via IClassFixture<>), so all tests in the class share a
+   single DuckDB file. Each test seeder calls ClearTestDataAsync first
+   (via the *Async helpers in TestDataSeeder), so cross-test pollution
+   is prevented without paying the schema-init cost on every test. */
+public sealed class FinOpsDuckDbFixture : IDisposable
+{
+    public string TempDir { get; }
+    public string DbPath { get; }
+    public DuckDbInitializer DuckDb { get; }
+
+    public FinOpsDuckDbFixture()
+    {
+        TempDir = Path.Combine(Path.GetTempPath(), "FinOpsTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(TempDir);
+        DbPath = Path.Combine(TempDir, "test.duckdb");
+        DuckDb = new DuckDbInitializer(DbPath);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(TempDir))
+                Directory.Delete(TempDir, recursive: true);
+        }
+        catch { /* Best-effort cleanup */ }
+    }
+}

--- a/Lite.Tests/FinOpsTests.cs
+++ b/Lite.Tests/FinOpsTests.cs
@@ -15,28 +15,13 @@ namespace PerformanceMonitorLite.Tests;
 /// Each test seeds a specific server profile into DuckDB, runs the recommendation or
 /// scoring engine, and validates the output (categories, findings, severity, savings).
 /// </summary>
-public class FinOpsTests : IDisposable
+public class FinOpsTests : IClassFixture<FinOpsDuckDbFixture>
 {
-    private readonly string _tempDir;
-    private readonly string _dbPath;
     private readonly DuckDbInitializer _duckDb;
 
-    public FinOpsTests()
+    public FinOpsTests(FinOpsDuckDbFixture fixture)
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "FinOpsTests_" + Guid.NewGuid().ToString("N")[..8]);
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "test.duckdb");
-        _duckDb = new DuckDbInitializer(_dbPath);
-    }
-
-    public void Dispose()
-    {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch { /* Best-effort cleanup */ }
+        _duckDb = fixture.DuckDb;
     }
 
     /* ── Over-Provisioned Enterprise ── */

--- a/Lite.Tests/Lite.Tests.csproj
+++ b/Lite.Tests/Lite.Tests.csproj
@@ -20,4 +20,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Lite\PerformanceMonitorLite.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/Lite.Tests/xunit.runner.json
+++ b/Lite.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/v3/xunit.runner.schema.json",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "parallelAlgorithm": "aggressive"
+}


### PR DESCRIPTION
## Summary
The CI test step was averaging ~7 minutes for 257 Lite tests because xUnit's default parallelization was implicit and slow classes (FactCollectorTests, ScenarioTests) blocked the pipeline. Local runs of the full suite drop to **~2m21s** with explicit parallelization config.

## Changes
- **`Lite.Tests/xunit.runner.json`**: explicit parallelization settings (`parallelizeAssembly=true`, `parallelizeTestCollections=true`, `maxParallelThreads=-1`, `parallelAlgorithm=aggressive`), with `CopyToOutputDirectory` wired up in the csproj.
- **`BaselineProviderCollection`**: serialize `BaselineProviderTests` and `AnomalyDetectorTests` into a shared collection (`DisableParallelization=true`). Both mutate the static `BaselineProvider.CacheTtl` field, so they must run sequentially relative to each other or they'd race on the static state.
- **`FinOpsTests` → `IClassFixture<FinOpsDuckDbFixture>`**: shares one DuckDB across the class. Every seeder in `TestDataSeeder.Seed*` already calls `ClearTestDataAsync` first, so cross-test pollution is prevented without rewriting test code. Saves the schema-init cost on each test.

This is a pilot for the IClassFixture approach. Converting other classes (`FactCollectorTests` etc.) would require adding `ClearTestDataAsync` calls to many tests, so leaving those for a follow-up. The bigger win is parallel execution across classes, which is fully covered by the runner.json settings.

## Test plan
- [x] `dotnet test Lite.Tests` — 257 passed, 0 failed, 2m 21s locally
- [ ] Confirm CI's "Run Lite tests" step drops noticeably below the prior ~7 min baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)