### PR TITLE
CI: fix paths-filter to compare against previous commit on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ jobs:
         if: github.event_name != 'release'
         uses: dorny/paths-filter@v3
         with:
+          # On push events, compare against the previous commit on this branch
+          # (github.event.before). Without this, the action defaults to comparing
+          # against the default branch on non-default branch pushes, which would
+          # match every accumulated change and defeat the filter.
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
           filters: |
             lite_analysis:
               - 'Lite/Analysis/**'


### PR DESCRIPTION
## Summary
PR #927's path filter worked correctly on the PR build (compared against the PR base, dev) but fired the heavy Lite lane on the resulting dev push. Root cause from the run log:

\`\`\`
Changes will be detected between main and dev
git merge-base refs/remotes/origin/main refs/remotes/origin/dev
Detected 106 changed files
\`\`\`

dorny/paths-filter@v3 defaults to comparing against the default branch on push events to non-default branches. dev is ~1200 commits ahead of main, so every push effectively saw the entire backlog, including all the FinOps/LocalDataService work, and \`lite_analysis = true\`.

This sets \`base: github.event.before\` for push events explicitly, while leaving it empty on pull_request so the action keeps its PR-base default.

## Expected behavior after this PR
- **Push to dev** with no analysis paths changed → heavy lane skips, total ~3-4 min.
- **Push to dev** that touches \`Lite/Services/**\` etc. → heavy lane runs.
- **Pull request** → unchanged, still compares against the PR base.
- **Release** → unchanged, force-runs everything.

## Test plan
- [ ] On this PR build (a pull_request event), the heavy lane should still run because the workflow file is the only change — wait, the workflow file isn't in the lite_analysis filter, so heavy lane should SKIP. Confirm in the run log.
- [ ] After merging, the dev push should compare \`github.event.before\` (the merge commit's parent on dev) against HEAD. The diff is just \`.github/workflows/build.yml\`. Heavy lane should SKIP.
- [ ] Total dev push time should drop to ~3-4 min vs the ~10 min baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)