### PR TITLE
Release: v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.9.0] - TBD
+## [2.10.0] - TBD
+
+### Fixed
+
+- **Memory tab tooltip** stops working after switching away and returning to the tab. Both Dashboard and Lite Memory tab crosshair tooltip handlers now reattach correctly on tab re-entry; the same popup-wedge fix is also applied to `CorrelatedCrosshairManager` ([#916])
+- **FinOps memory recommendation** now bases sizing on a 7-day P95 of memory samples instead of a single snapshot, so recommendations no longer swing based on instantaneous workload state. Applied in both Dashboard and Lite ([#917])
+
+### Changed
+
+- **Per-database grants for FinOps Index Analysis** documented in the README — sp_IndexCleanup-backed Index Analysis requires per-database `EXECUTE` grants on each user database you want to analyze ([#915])
+
+[#915]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/915
+[#916]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/916
+[#917]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/917
+
+## [2.9.0] - 2026-04-29
 
 ### Important
 

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -7,10 +7,10 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>2.9.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
-    <InformationalVersion>2.9.0</InformationalVersion>
+    <Version>2.10.0</Version>
+    <AssemblyVersion>2.10.0.0</AssemblyVersion>
+    <FileVersion>2.10.0.0</FileVersion>
+    <InformationalVersion>2.10.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -94,7 +94,7 @@ namespace PerformanceMonitorDashboard.Models
         /// <summary>
         /// Installed PerformanceMonitor version on this server. Populated asynchronously
         /// by the Manage Servers window. Not persisted — runtime-only display field.
-        /// Conventional values: null (not yet probed), a 3-part version like "2.9.0",
+        /// Conventional values: null (not yet probed), a 3-part version like "2.10.0",
         /// "Not installed", or "Unavailable" when the probe fails.
         /// </summary>
         [JsonIgnore]

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,10 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>2.9.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
-    <InformationalVersion>2.9.0</InformationalVersion>
+    <Version>2.10.0</Version>
+    <AssemblyVersion>2.10.0.0</AssemblyVersion>
+    <FileVersion>2.10.0.0</FileVersion>
+    <InformationalVersion>2.10.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>2.9.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
-    <InformationalVersion>2.9.0</InformationalVersion>
+    <Version>2.10.0</Version>
+    <AssemblyVersion>2.10.0.0</AssemblyVersion>
+    <FileVersion>2.10.0.0</FileVersion>
+    <InformationalVersion>2.10.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -168,7 +168,7 @@ public class ServerConnection : INotifyPropertyChanged
     private string? _installedVersion;
 
     /// <summary>
-    /// PerformanceMonitor Lite app version monitoring this server (e.g., "2.9.0").
+    /// PerformanceMonitor Lite app version monitoring this server (e.g., "2.10.0").
     /// Populated by the Manage Servers window. Not persisted — runtime-only display field.
     /// Same value for every row since one Lite process monitors all servers.
     /// </summary>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -8,10 +8,10 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>2.9.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
-    <InformationalVersion>2.9.0</InformationalVersion>
+    <Version>2.10.0</Version>
+    <AssemblyVersion>2.10.0.0</AssemblyVersion>
+    <FileVersion>2.10.0.0</FileVersion>
+    <InformationalVersion>2.10.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Lightweight SQL Server performance monitoring - no installation required on target servers</Description>


### PR DESCRIPTION
## Summary
- Bump versions to **2.10.0** in all 4 csproj files (Dashboard, Lite, Installer, Installer.Core)
- CHANGELOG entry for 2.10.0; backfill 2.9.0 release date (2026-04-29)
- No schema changes since v2.9.0 — no upgrade folder

## What's in 2.10.0
- **Fix #916** — Memory tab tooltip stops working after tab switch (Dashboard + Lite); same popup-wedge fix extended to `CorrelatedCrosshairManager`
- **Fix #917** — FinOps memory recommendation now bases sizing on a 7-day P95 of memory samples, not a single snapshot (Dashboard + Lite)
- **Docs #915** — README: per-database `EXECUTE` grants required for FinOps Index Analysis

## Validation
- [x] `dotnet build -c Debug` — 0 errors
- [x] `Installer.Tests` — 46/46 passing
- [x] sql2022 upgrade 2.9.0 → 2.10.0 — clean (54/54 scripts, 23s)
- [x] sql2022 idempotent re-run — clean
- [x] Data survival on sql2022 — all key tables grew, none zeroed
- [x] `installation_history` shows UPGRADE 2.9.0→2.10.0 SUCCESS, then REINSTALL 2.10.0→2.10.0 SUCCESS
- [x] `collection_log` last hour: 1164 SUCCESS, 13 NO_RESULTS, 4 SKIPPED, **0 ERROR**

## Test plan
- [ ] Smoke test #916 in Dashboard + Lite (Memory tab → switch tabs → return → tooltip works)
- [ ] Smoke test #917 in Dashboard + Lite (FinOps recommendation reflects 7-day P95)

After this lands in dev, follow-up PR dev → main, then tag v2.10.0 and create the GitHub Release to trigger the build workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)