### PR TITLE
CI: bump actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Detect changed paths
         id: filter
@@ -46,7 +46,7 @@ jobs:
               - 'upgrades/**'
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
           cache: true
@@ -132,7 +132,7 @@ jobs:
       - name: Upload Dashboard for signing
         if: github.event_name == 'release'
         id: upload-dashboard
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Dashboard-unsigned
           path: publish/Dashboard/
@@ -140,7 +140,7 @@ jobs:
       - name: Upload Lite for signing
         if: github.event_name == 'release'
         id: upload-lite
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Lite-unsigned
           path: publish/Lite/
@@ -148,14 +148,14 @@ jobs:
       - name: Upload Installer for signing
         if: github.event_name == 'release'
         id: upload-installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Installer-unsigned
           path: publish/Installer/
 
       - name: Sign Dashboard
         if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
@@ -168,7 +168,7 @@ jobs:
 
       - name: Sign Lite
         if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
@@ -181,7 +181,7 @@ jobs:
 
       - name: Sign Installer
         if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get PR version
         id: pr
@@ -21,7 +21,7 @@ jobs:
           Write-Host "PR version: $version"
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           path: main-branch

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: dev
           fetch-depth: 0
@@ -38,12 +38,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: dev
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
           cache: true

--- a/.github/workflows/sql-validation.yml
+++ b/.github/workflows/sql-validation.yml
@@ -41,7 +41,7 @@ jobs:
           --health-retries 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install sqlcmd
         run: |


### PR DESCRIPTION
## Summary
GitHub will force JS actions to Node 24 on **June 2nd, 2026**, and remove Node 20 from runners on **September 16th, 2026**. Bumps the four actions GitHub's runner deprecation warning called out:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v6** |
| `signpath/github-action-submit-signing-request` | v1 | **v2** |

Matches the bump PerformanceStudio just made for the same reason. `dorny/paths-filter@v3` was not in the deprecation warning — left as-is.

Files touched:
- `.github/workflows/build.yml`
- `.github/workflows/nightly.yml`
- `.github/workflows/check-version-bump.yml`
- `.github/workflows/sql-validation.yml`

## Test plan
- [ ] CI checks pass on this PR (build, check-pr-branch)
- [ ] Verify the runner no longer emits the `Node.js 20 actions are deprecated` warning on the next workflow run
- [ ] Next nightly + next release build complete cleanly with the new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)