### PR TITLE
Honor collector_database_exclusions in default trace and trace analysis collectors (#887 follow-up)

### DIFF
--- a/install/29_collect_default_trace.sql
+++ b/install/29_collect_default_trace.sql
@@ -369,6 +369,15 @@ BEGIN
         AND   ft.StartTime >= @cutoff_time
         AND   ISNULL(ft.DatabaseID, 0) NOT IN (DB_ID(N'PerformanceMonitor'), 1, 3, 4)
         AND   ISNULL(ft.DatabaseID, 0) < 32761 /*exclude contained AG system databases*/
+        AND   NOT EXISTS
+        (
+            SELECT
+                1/0
+            FROM config.collector_database_exclusions AS e
+            JOIN sys.databases AS d
+              ON d.name = e.database_name
+            WHERE d.database_id = ISNULL(ft.DatabaseID, 0)
+        )
         /*
         Filter for useful system events, excluding login failures
         */

--- a/install/31_collect_trace_analysis.sql
+++ b/install/31_collect_trace_analysis.sql
@@ -284,6 +284,13 @@ BEGIN
                 AND   trc.DatabaseName NOT IN (N'master', N'msdb', N'model', N'tempdb', N'PerformanceMonitor')
                 AND   trc.DatabaseName NOT LIKE N'%[_]master' /*exclude contained AG system databases*/
                 AND   trc.DatabaseName NOT LIKE N'%[_]msdb' /*exclude contained AG system databases*/
+                AND   NOT EXISTS
+                (
+                    SELECT
+                        1/0
+                    FROM config.collector_database_exclusions AS e
+                    WHERE e.database_name = trc.DatabaseName
+                )
                 ORDER BY
                     trc.StartTime DESC;
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #905. `default_trace_collector` and `trace_analysis_collector` were skipped in the original per-database exclusion work because they filter trace events by `DatabaseID` / `DatabaseName` rather than iterating `sys.databases`, so the `NOT EXISTS (... d.name)` pattern from #905 didn't drop in directly.
- Both collectors now honor `config.collector_database_exclusions`, matching the behavior of the other 8 per-database collectors.

## Changes
- `install/29_collect_default_trace.sql` — `NOT EXISTS` against `config.collector_database_exclusions` joined to `sys.databases` to translate the exclusion list (by name) into ids matching `ft.DatabaseID` from `sys.fn_trace_gettable`.
- `install/31_collect_trace_analysis.sql` — `NOT EXISTS` directly on `trc.DatabaseName` (the .trc file exposes the name, no translation needed).

## Scope check
Re-audited every Dashboard `install/*collect*.sql` and every Lite collector class. Confirmed:
- These two were the only Dashboard collectors missing the filter.
- Lite is fully covered — all 9 per-database collectors apply `BuildDatabaseExclusionFilter()` from `RemoteCollectorService.cs`. No Lite changes needed.

## Test plan
- [ ] Run the CLI installer end-to-end against a test instance and confirm 54/54 install scripts succeed.
- [ ] Verify both procs reference `config.collector_database_exclusions` after install.
- [ ] Smoke test: exclude a database that's currently producing trace/audit events (e.g. distribution), confirm `default_trace_collector` and `trace_analysis_collector` skip its events while a non-excluded DB still produces rows. Wrap in a transaction and roll back.

Addresses the follow-up question on https://github.com/erikdarlingdata/PerformanceMonitor/issues/887#issuecomment-4380323068.