### PR TITLE
Lite: fix compaction OOM by setting DuckDB temp_directory (#933)

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -322,6 +322,14 @@ COPY (
         var totalMerged = 0;
         var totalRemoved = 0;
 
+        /* Spill directory for the in-memory compaction connections. Without this,
+           the memory_limit pragma is a hard wall — DuckDB has nowhere to spill and
+           OOMs the moment the cap is hit. Co-locating with the archive keeps the
+           write on the same volume the parquet files already live on. */
+        var spillDir = Path.Combine(_archivePath, "duckdb_tmp");
+        Directory.CreateDirectory(spillDir);
+        var spillDirSql = spillDir.Replace("\\", "/");
+
         foreach (var ((month, table), files) in groups)
         {
             /* If there's exactly one file and it's already in monthly format, skip */
@@ -376,7 +384,7 @@ COPY (
                     con.Open();
                     using (var pragma = con.CreateCommand())
                     {
-                        pragma.CommandText = "SET memory_limit = '4GB'; SET preserve_insertion_order = false;";
+                        pragma.CommandText = $"SET memory_limit = '4GB'; SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";
                         pragma.ExecuteNonQuery();
                     }
 
@@ -407,7 +415,7 @@ COPY (
                         con.Open();
                         using (var pragma = con.CreateCommand())
                         {
-                            pragma.CommandText = "SET memory_limit = '4GB'; SET preserve_insertion_order = false;";
+                            pragma.CommandText = $"SET memory_limit = '4GB'; SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";
                             pragma.ExecuteNonQuery();
                         }
 


### PR DESCRIPTION
## Summary
- The in-memory DuckDB connections used for parquet compaction had a 4 GB `memory_limit` pragma but no `temp_directory`, so the cap acted as a hard wall — DuckDB had nowhere to spill and OOM'd the moment it was hit.
- Set `temp_directory` to `<archive>/duckdb_tmp/` on both compaction connections (small-group and incremental pair-merge). Co-locating with the archive keeps spill writes on the same volume as the parquet files.

## Verification
Tested end-to-end against 4 monitored SQL Servers under HammerDB load:
- First 512 MB reset (single-file groups) — 26 groups compacted, no errors.
- Second 512 MB reset (multi-file groups, the path that OOM'd in #933) — 21 groups merged with 2 source files each, completed in ~3.5s, `duckdb_tmp/` cleaned up on connection close, no OOM.

Closes #933.

## Test plan
- [x] Builds clean (0 errors / 0 warnings on incremental build)
- [x] First reset (single-file compaction) succeeds with new code path
- [x] Second reset (multi-file pair-merge) succeeds — the actual OOM-prone path from #933
- [x] `duckdb_tmp/` directory created on first archive cycle and cleaned by DuckDB on connection close
- [x] No regression in collector health during archive cycles
- [ ] Reporter (000al000) confirms fix on their 4-server environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)