### PR TITLE
Re-run installation_history widen for pre-v2.7.0 no-op upgrades (#828)

### DIFF
--- a/upgrades/2.10.0-to-2.11.0/01_rewiden_version_columns.sql
+++ b/upgrades/2.10.0-to-2.11.0/01_rewiden_version_columns.sql
@@ -1,0 +1,68 @@
+/*
+Re-run installation_history version-column widening from the 2.4.0-to-2.5.0 upgrade.
+
+Scope (release-notes guidance — keep this quiet):
+    Servers that crossed 2.4 -> 2.5 BEFORE PR #828's fix shipped in v2.7.0 ran the
+    widen script as a no-op (it executed against master, not PerformanceMonitor)
+    and then advanced their installer_version past 2.5. The upgrade filter only
+    selects folders where ToVersion > currentVersion, so the now-fixed script is
+    never re-applied on those servers and their sql_server_version /
+    sql_server_edition columns stay at nvarchar(255) -- which truncates SQL 2022+
+    @@VERSION strings (~260 chars) on every install attempt.
+
+    This is a silent remediation for that long tail. The body is identical to
+    upgrades/2.4.0-to-2.5.0/01_widen_version_columns.sql and is idempotent: the
+    IF EXISTS guard checks max_length = 510 (nvarchar(255) in bytes) so servers
+    that are already widened, or that ran the fixed 2.4->2.5 upgrade cleanly,
+    skip both ALTERs.
+
+    For changelog purposes this is a one-line "fix": "Re-run installation_history
+    column widening for servers that hit the no-op pre-v2.7.0 upgrade (#828)."
+    Do not promote it as a new feature.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'config.installation_history')
+    AND   c.name = N'sql_server_version'
+    AND   c.max_length = 510 /* nvarchar(255) = 510 bytes */
+)
+BEGIN
+    ALTER TABLE config.installation_history
+        ALTER COLUMN sql_server_version nvarchar(512) NOT NULL;
+
+    PRINT 'Widened config.installation_history.sql_server_version to nvarchar(512)';
+END;
+
+IF EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'config.installation_history')
+    AND   c.name = N'sql_server_edition'
+    AND   c.max_length = 510
+)
+BEGIN
+    ALTER TABLE config.installation_history
+        ALTER COLUMN sql_server_edition nvarchar(512) NOT NULL;
+
+    PRINT 'Widened config.installation_history.sql_server_edition to nvarchar(512)';
+END;

--- a/upgrades/2.10.0-to-2.11.0/upgrade.txt
+++ b/upgrades/2.10.0-to-2.11.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_rewiden_version_columns.sql


### PR DESCRIPTION
## Summary

- Adds `upgrades/2.10.0-to-2.11.0/01_rewiden_version_columns.sql` to re-run the installation_history version-column widening for servers stranded by the original #828 bug.
- The 2.4.0-to-2.5.0 widen script was originally missing `USE PerformanceMonitor;` (fixed in #828, shipped v2.7.0). Servers that crossed 2.4 → 2.5 *before* v2.7.0 silently no-op'd the ALTERs against `master`, advanced past 2.5, and the upgrade filter (`ToVersion > currentVersion`) permanently skips the now-fixed script. Result: `sql_server_version` / `sql_server_edition` stay at `nvarchar(255)` and truncate SQL 2022+ `@@VERSION` strings (~260 chars).
- Body is identical to the 2.4.0-to-2.5.0 widen and idempotent — `IF EXISTS … max_length = 510` guards skip already-widened servers.
- Confirmed by `ghauan` on #828 hitting this on a SQL 2025 server upgrading 2.8 → 2.10. Issue stays closed; commented there.

## Test plan

- [ ] Verify on a server still at `nvarchar(255)`: run installer upgrade, confirm both columns become `nvarchar(512)` and the install record inserts without truncation warning.
- [ ] Verify on an already-widened server: upgrade runs the script as a no-op (no ALTERs printed) and completes cleanly.
- [ ] Confirm `upgrade.txt` is picked up by `ScriptProvider.GetApplicableUpgrades` for current → 2.11.0 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)