### PR TITLE
Fix #916 — chart tooltips break after tab switch (real root cause)

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -106,11 +106,10 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartContextMenus();
             Loaded += OnLoaded;
             Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
-            Unloaded += (_, _) =>
-            {
-                Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
-                DisposeChartHelpers();
-            };
+            /* WPF fires Unloaded on every TabControl tab switch, not just on destruction.
+               Tearing down chart hover helpers here unsubscribes their MouseMove handlers
+               and they are never re-registered when the user returns — this is the
+               root cause of #916. Final disposal happens via ServerTab.CleanupOnClose. */
 
             // Apply dark theme immediately so charts don't flash white before data loads
             TabHelpers.ApplyThemeToChart(MemoryStatsOverviewChart);
@@ -136,6 +135,7 @@ namespace PerformanceMonitorDashboard.Controls
             _memoryClerksHover?.Dispose();
             _planCacheHover?.Dispose();
             _memoryPressureEventsHover?.Dispose();
+            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -241,8 +241,10 @@ namespace PerformanceMonitorDashboard.Controls
             _qsRegressionsUnfilteredData = null;
             _lrqPatternsUnfilteredData = null;
 
-            DisposeChartHelpers();
-            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
+            /* WPF fires Unloaded on every TabControl tab switch, not just on destruction.
+               Tearing down chart hover helpers or unsubscribing ThemeManager here breaks
+               tooltips and theme refresh after a tab switch (#916). Final cleanup happens
+               via ServerTab.CleanupOnClose → DisposeChartHelpers. */
         }
 
         public void DisposeChartHelpers()
@@ -251,6 +253,7 @@ namespace PerformanceMonitorDashboard.Controls
             _procDurationHover?.Dispose();
             _qsDurationHover?.Dispose();
             _execTrendsHover?.Dispose();
+            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
         }
 
         private void OnThemeChanged(string _)

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -130,11 +130,10 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartContextMenus();
             Loaded += OnLoaded;
             Helpers.ThemeManager.ThemeChanged += OnThemeChanged;
-            Unloaded += (_, _) =>
-            {
-                Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
-                DisposeChartHelpers();
-            };
+            /* WPF fires Unloaded on every TabControl tab switch, not just on destruction.
+               Tearing down chart hover helpers here unsubscribes their MouseMove handlers
+               and they are never re-registered when the user returns — this is the
+               root cause of #916. Final disposal happens via ServerTab.CleanupOnClose. */
 
             // Apply dark theme immediately so charts don't flash white before data loads
             TabHelpers.ApplyThemeToChart(LatchStatsChart);
@@ -175,6 +174,7 @@ namespace PerformanceMonitorDashboard.Controls
             _waitStatsHover?.Dispose();
             _tempdbStatsHover?.Dispose();
             _tempDbLatencyHover?.Dispose();
+            Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/Dashboard/Controls/SystemEventsContent.xaml.cs
+++ b/Dashboard/Controls/SystemEventsContent.xaml.cs
@@ -175,19 +175,39 @@ namespace PerformanceMonitorDashboard.Controls
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            /* Unsubscribe from filter popup events to prevent memory leaks */
+            /* WPF fires Unloaded on every TabControl tab switch, not just on destruction.
+               Unsubscribing ThemeManager or filter-popup events here breaks them on
+               return to the tab (#916 family). Final cleanup happens via
+               ServerTab.CleanupOnClose → DisposeChartHelpers. */
+        }
+
+        public void DisposeChartHelpers()
+        {
+            _badPagesHover?.Dispose();
+            _dumpRequestsHover?.Dispose();
+            _accessViolationsHover?.Dispose();
+            _writeAccessViolationsHover?.Dispose();
+            _nonYieldingTasksHover?.Dispose();
+            _latchWarningsHover?.Dispose();
+            _sickSpinlocksHover?.Dispose();
+            _cpuComparisonHover?.Dispose();
+            _severeErrorsHover?.Dispose();
+            _ioIssuesHover?.Dispose();
+            _longestPendingIoHover?.Dispose();
+            _schedulerIssuesHover?.Dispose();
+            _memoryConditionsHover?.Dispose();
+            _cpuTasksHover?.Dispose();
+            _memoryBrokerHover?.Dispose();
+            _memoryBrokerRatioHover?.Dispose();
+            _memoryNodeOomHover?.Dispose();
+            _memoryNodeOomUtilHover?.Dispose();
+            _memoryNodeOomMemoryHover?.Dispose();
+
             if (_filterPopupContent != null)
             {
                 _filterPopupContent.FilterApplied -= FilterPopup_FilterApplied;
                 _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
             }
-
-            /* Clear large data collections to free memory */
-            _systemHealthUnfilteredData = null;
-            _severeErrorsUnfilteredData = null;
-            _ioIssuesUnfilteredData = null;
-            _memoryBrokerUnfilteredData = null;
-            _memoryNodeOOMUnfilteredData = null;
 
             Helpers.ThemeManager.ThemeChanged -= OnThemeChanged;
         }

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -275,6 +275,7 @@ namespace PerformanceMonitorDashboard
             MemoryTab.DisposeChartHelpers();
             ResourceMetricsContent.DisposeChartHelpers();
             PerformanceTab.DisposeChartHelpers();
+            SystemEventsContent.DisposeChartHelpers();
         }
 
         public void RefreshAutoRefreshSettings()


### PR DESCRIPTION
## Summary
- Reporter on #916 confirmed the bug still reproduces in v2.10.0 after PR #919 / #921 / #922 shipped. Those PRs fixed the WPF Popup wedge but missed the underlying bug.
- `MemoryContent`, `ResourceMetricsContent`, and `QueryPerformanceContent` all call `DisposeChartHelpers()` from their per-control `Unloaded` event handler. WPF fires `Unloaded` on every `TabControl` tab switch, not just on destruction — so switching away from the Memory tab unsubscribes every chart's `MouseMove` handlers, and they're never re-registered when the user comes back. The popup-wedge fixes were running inside helpers that had already torn themselves down.
- `ServerTab_Unloaded` already had a comment warning maintainers about exactly this trap; the inner `UserControl`s just didn't follow the same rule.

## Changes
- `MemoryContent` / `ResourceMetricsContent` / `QueryPerformanceContent`: drop `DisposeChartHelpers()` and `ThemeManager` unsubscribe from the tab-switch `Unloaded` handler. Move the `ThemeManager` unsubscribe into `DisposeChartHelpers()` so it runs only on real cleanup.
- `SystemEventsContent`: same family of bug. Add a `DisposeChartHelpers()` method that disposes the 19 hover helpers, unsubscribes filter-popup events, and unsubscribes `ThemeManager`. Empty out `OnUnloaded`.
- `ServerTab.CleanupOnClose`: add `SystemEventsContent.DisposeChartHelpers()` to the cleanup chain — those 19 hovers were leaking on tab close before this.

Final disposal still happens correctly via `ServerTab.CleanupOnClose`, which only fires when a server tab is actually removed from `MainTabControl`. Lite is unaffected — its `Unloaded` handler only unsubscribes `ThemeManager` and never disposed chart hovers.

## Test plan
- [ ] Build Dashboard
- [ ] Open Dashboard → Overview → Resource Overview → confirm tooltip appears
- [ ] Switch to Memory → Memory Overview → confirm tooltip appears
- [ ] Switch back to Overview → tooltip still works
- [ ] Switch back to Memory → tooltip still works (the original #916 repro)
- [ ] Repeat across all five Memory sub-tabs (Memory Overview, Memory Grants, Memory Clerks, Plan Cache, Memory Pressure Events)
- [ ] Repeat for Resource Metrics tab (the #922 follow-up scenario)
- [ ] Repeat for Query Performance tab
- [ ] Repeat for System Events tab
- [ ] Switch theme (light/dark) after a tab switch — chart colors should still update
- [ ] Close the server tab — no exceptions, no leaked subscriptions

Fixes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)