### PR TITLE
Fix #945 — clean up build warnings (Lite 190→0, Dashboard 3→0)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.cs]
+
+# CA1873: Avoid potentially expensive logging
+#
+# This rule fires on any non-literal argument to a logging method (including
+# trivial field accesses like `_logger.LogInformation("X: {Path}", _path)`),
+# on the theory that the argument might be expensive to evaluate when the
+# level is disabled. In this codebase the cost is consistently negligible —
+# the proper fix is migrating to LoggerMessage source generators, which is
+# a larger separate effort. Until then, this rule is pure noise.
+dotnet_diagnostic.CA1873.severity = none

--- a/Dashboard/ServerTab.Plans.cs
+++ b/Dashboard/ServerTab.Plans.cs
@@ -341,7 +341,7 @@ namespace PerformanceMonitorDashboard
 
                     int stmtStart = 0;
                     int stmtEnd = -1;
-                    int.TryParse(frame.Attribute("stmtstart")?.Value, out stmtStart);
+                    _ = int.TryParse(frame.Attribute("stmtstart")?.Value, out stmtStart);
                     if (int.TryParse(frame.Attribute("stmtend")?.Value, out var se)) stmtEnd = se;
 
                     frames.Add((handle!, stmtStart, stmtEnd));
@@ -426,7 +426,7 @@ namespace PerformanceMonitorDashboard
                     !string.Equals(procHandle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase))
                 {
                     int ps = 0, pe = -1;
-                    int.TryParse(process.Attribute("stmtstart")?.Value, out ps);
+                    _ = int.TryParse(process.Attribute("stmtstart")?.Value, out ps);
                     if (int.TryParse(process.Attribute("stmtend")?.Value, out var peParsed)) pe = peParsed;
                     frames.Add((procHandle!, ps, pe));
                 }
@@ -441,7 +441,7 @@ namespace PerformanceMonitorDashboard
                         if (string.Equals(handle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase)) continue;
 
                         int fs = 0, fe = -1;
-                        int.TryParse(frame.Attribute("stmtstart")?.Value, out fs);
+                        _ = int.TryParse(frame.Attribute("stmtstart")?.Value, out fs);
                         if (int.TryParse(frame.Attribute("stmtend")?.Value, out var feParsed)) fe = feParsed;
                         frames.Add((handle!, fs, fe));
                     }

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -174,11 +174,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                     $"Comparison: refFrom={refFrom:o}, refTo={refTo:o}, shift={timeShift.TotalHours:F1}h, " +
                     $"cpuRows={refCpuTask.Result?.Count ?? 0}, waitRows={refWaitTask.Result?.Count ?? 0}");
 
-                if (refCpuTask.IsCompletedSuccessfully)
+                if (refCpuTask.IsCompletedSuccessfully && refCpuTask.Result != null)
                     AddGhostLine(CpuChart, refCpuTask.Result
                         .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.SqlServerCpu)).ToList(), "#4FC3F7");
 
-                if (refWaitTask.IsCompletedSuccessfully)
+                if (refWaitTask.IsCompletedSuccessfully && refWaitTask.Result != null)
                     AddGhostLine(WaitStatsChart, refWaitTask.Result
                         .Select(d => (d.CollectionTime.AddMinutes(utcOffset).Add(timeShift).ToOADate(), d.WaitTimeMsPerSecond)).ToList(), "#FFB74D");
 

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -840,7 +840,7 @@ internal static class ToolRecommendations
     /// Formats baseline context from anomaly fact metadata into a human-readable object
     /// for MCP output. Example: "4.1σ above baseline for Tue 14:00, mean 68.2"
     /// </summary>
-    private static object? FormatBaselineContext(Dictionary<string, double> metadata)
+    private static Dictionary<string, object>? FormatBaselineContext(Dictionary<string, double> metadata)
     {
         var result = new Dictionary<string, object>();
 


### PR DESCRIPTION
## Summary

Reduces full-rebuild warning counts to **0** across all three projects.

| Project | Before | After |
|---|---|---|
| Lite | 190 | 0 |
| Dashboard | 3 | 0 |
| Installer | 0 | 0 |

## Files

### ``.editorconfig`` (new, repo root)

Suppresses **CA1873** ("Avoid potentially expensive logging") globally with a justifying comment. This rule fires on any non-literal argument to a logging method — including trivial field accesses like ``_logger.LogInformation(""X: {Path}"", _path)`` — and accounted for ~97% of Lite's warning count. The cost the rule warns about is consistently negligible in this codebase. Real fix would be migrating to ``LoggerMessage`` source generators across the codebase, which is a separate effort.

### ``Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs`` (CS8604 ×2)

The comparison-data fetch path passed possibly-null ``Task<T>.Result`` directly to ``.Select(...)`` after only checking ``IsCompletedSuccessfully``. The same file does ``?.Count ?? 0`` for these exact fields elsewhere, so null was anticipated — the ``.Select`` lines just missed the guard. Added ``&& Result != null`` to the conditions on both lines.

### ``Lite/Mcp/McpAnalysisTools.cs`` (CA1859 ×1)

``FormatBaselineContext`` already builds and returns a ``Dictionary<string, object>``, but the declared return type was ``object?``, forcing boxing. Tightened to ``Dictionary<string, object>?``.

### ``Dashboard/ServerTab.Plans.cs`` (CA1806 ×3)

Three sites called ``int.TryParse(..., out X)`` and discarded the bool return, relying on TryParse setting the out param to default on failure. Behavior is correct, but the analyzer can't see the intent. Replaced with ``_ = int.TryParse(...)`` to make the discard explicit. Behavior unchanged.

## Notes

Static analyzers fire on the WPF temp-project compilation step, so each warning shows up twice in the raw output. The 187 / 3 unique counts above match the deduplicated tallies.

CS8019 / CS8933 (redundant ``using`` directives covered by global usings) appear in IDE diagnostics but are not surfaced by ``dotnet build``, so they don't affect the build warning count and aren't addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)