### PR TITLE
Add nullability guards to comparison overlay tasks

### DIFF
--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -182,7 +182,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                     AddGhostLine(WaitStatsChart, refWaitTask.Result
                         .Select(d => (d.CollectionTime.AddMinutes(utcOffset).Add(timeShift).ToOADate(), d.WaitTimeMsPerSecond)).ToList(), "#FFB74D");
 
-                if (refBlockingTask.IsCompletedSuccessfully)
+                if (refBlockingTask.IsCompletedSuccessfully && refBlockingTask.Result != null)
                 {
                     var refBlocking = refBlockingTask.Result
                         .Select(d => (d.Time.AddMinutes(utcOffset).Add(timeShift).ToOADate(), (double)d.Count)).ToList();
@@ -190,11 +190,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                         AddGhostLine(BlockingChart, refBlocking, "#E57373");
                 }
 
-                if (refMemoryTask.IsCompletedSuccessfully)
+                if (refMemoryTask.IsCompletedSuccessfully && refMemoryTask.Result != null)
                     AddGhostLine(MemoryChart, refMemoryTask.Result
                         .Select(d => (d.CollectionTime.AddMinutes(utcOffset).Add(timeShift).ToOADate(), d.BufferPoolMb)).ToList(), "#CE93D8");
 
-                if (refIoTask.IsCompletedSuccessfully)
+                if (refIoTask.IsCompletedSuccessfully && refIoTask.Result != null)
                 {
                     var refIo = refIoTask.Result
                         .GroupBy(d => d.CollectionTime)


### PR DESCRIPTION
## Summary
Three `.Result.Select` / `.GroupBy` calls in `CorrelatedTimelineLanesControl.xaml.cs` (Blocking line 187, Memory line 194, IO line 199) were missing the `&& Result != null` guard the CPU and Wait branches at lines 177/181 already had.

Without the guard, a null result from `_dataService.Get*TrendAsync` would NRE on the subsequent `.Select` / `.GroupBy`. CS8604 only fired on two of the five because of how generic types differ; these three were latent.

Pick one nullability contract (the existing CPU/Wait pattern) and apply uniformly.

## Test plan
- [ ] Build Lite, open the correlated timeline panel
- [ ] Drag the slicer to invoke a comparison range that previously rendered
- [ ] Confirm Blocking, Memory, and File I/O ghost lines still render
- [ ] If reachable: simulate a null result from one of the trend APIs and confirm no NRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)