### PR TITLE
Fix #933: cap main DuckDB memory_limit, per-pair compaction exclude detection

### DIFF
--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -124,10 +124,17 @@ public class DuckDbInitializer
 
     /// <summary>
     /// Gets the connection string for the DuckDB database.
-    /// Disables automatic WAL checkpoints to prevent 2-3s stop-the-world stalls
-    /// during collector writes. Manual CHECKPOINT runs between collection cycles instead.
+    /// - checkpoint_threshold=1GB: disables automatic WAL checkpoints to prevent
+    ///   2-3s stop-the-world stalls during collector writes. Manual CHECKPOINT
+    ///   runs between collection cycles instead.
+    /// - memory_limit=1GB: caps the resting buffer pool so it doesn't grow
+    ///   unbounded as the archive directory fills with parquet files (the
+    ///   ".tmp dir caching" path is the actual driver of #933's titled
+    ///   complaint — uncapped, buffer pool grows toward 80% of system RAM).
+    ///   ArchiveService raises this temporarily for parquet COPY operations,
+    ///   which need more headroom due to a DuckDB pre-reservation behavior.
     /// </summary>
-    public string ConnectionString => $"Data Source={_databasePath};checkpoint_threshold=1GB";
+    public string ConnectionString => $"Data Source={_databasePath};memory_limit=1GB;checkpoint_threshold=1GB";
 
     /// <summary>
     /// Ensures the database exists and all tables are created.

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -204,6 +204,35 @@ COPY (
         ["query_store_stats"] = ["query_plan_text"]
     };
 
+    /* Build the SELECT clause for a compaction COPY, excluding only the
+       CompactionExcludeColumns actually present in THIS set of files.
+       Detection must be per-merge-set, not global: archive files predating a
+       schema change lack the column, so a globally-computed "* EXCLUDE (col)"
+       fails the binder on a pair where neither file has it. query_plan_text
+       was added to query_store_stats in migration v13 (2026-02-23), so a
+       reporter's pre-v13 archives don't carry it. (#933) */
+    private static string BuildSelectClause(string table, IReadOnlyList<string> paths)
+    {
+        if (!CompactionExcludeColumns.TryGetValue(table, out var excludeCols))
+        {
+            return "*";
+        }
+
+        using var schemaCon = new DuckDBConnection("DataSource=:memory:");
+        schemaCon.Open();
+        var pathList = string.Join(", ", paths.Select(p => $"'{EscapeSqlPath(p)}'"));
+        using var schemaCmd = schemaCon.CreateCommand();
+        schemaCmd.CommandText = $"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet([{pathList}], union_by_name=true))";
+        using var reader = schemaCmd.ExecuteReader();
+        var existingCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (reader.Read()) existingCols.Add(reader.GetString(0));
+
+        var colsToExclude = excludeCols.Where(c => existingCols.Contains(c)).ToArray();
+        return colsToExclude.Length > 0
+            ? $"* EXCLUDE ({string.Join(", ", colsToExclude)})"
+            : "*";
+    }
+
     /// <summary>
     /// Compacts all per-cycle parquet files into monthly files (YYYYMM_tablename.parquet).
     /// This keeps the archive directory small (~75 files for 3 months of 25 tables)
@@ -371,26 +400,6 @@ COPY (
                     .Select(f => Path.Combine(_archivePath, f).Replace("\\", "/"))
                     .ToList();
 
-                /* Determine column exclusions up front using all source files */
-                var selectClause = "*";
-                if (CompactionExcludeColumns.TryGetValue(table, out var excludeCols))
-                {
-                    using var schemaCon = new DuckDBConnection("DataSource=:memory:");
-                    schemaCon.Open();
-                    var allPathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
-                    using var schemaCmd = schemaCon.CreateCommand();
-                    schemaCmd.CommandText = $"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet([{allPathList}], union_by_name=true))";
-                    using var reader = schemaCmd.ExecuteReader();
-                    var existingCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    while (reader.Read()) existingCols.Add(reader.GetString(0));
-
-                    var colsToExclude = excludeCols.Where(c => existingCols.Contains(c)).ToArray();
-                    if (colsToExclude.Length > 0)
-                    {
-                        selectClause = $"* EXCLUDE ({string.Join(", ", colsToExclude)})";
-                    }
-                }
-
                 if (sourcePaths.Count <= 2)
                 {
                     /* Small group — single-pass merge.
@@ -416,6 +425,7 @@ COPY (
                         pragma.ExecuteNonQuery();
                     }
 
+                    var selectClause = BuildSelectClause(table, sourcePaths);
                     var pathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
                     using var cmd = con.CreateCommand();
                     cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pathList}], union_by_name=true)) " +
@@ -447,6 +457,7 @@ COPY (
                             pragma.ExecuteNonQuery();
                         }
 
+                        var selectClause = BuildSelectClause(table, new[] { currentPath, sorted[i] });
                         var pairList = $"'{EscapeSqlPath(currentPath)}', '{EscapeSqlPath(sorted[i])}'";
                         using var cmd = con.CreateCommand();
                         cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pairList}], union_by_name=true)) " +

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -187,16 +187,64 @@ public class ArchiveService
 
     private static async Task ExportToParquet(DuckDBConnection connection, string table, string timeColumn, DateTime cutoff, string filePath)
     {
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = $@"
+        await WithRaisedCopyMemoryLimit(connection, async () =>
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
 COPY (
     SELECT * FROM {table} WHERE {timeColumn} < $1
 ) TO '{EscapeSqlPath(filePath)}' (FORMAT PARQUET, COMPRESSION ZSTD)";
-        cmd.Parameters.Add(new DuckDBParameter { Value = cutoff });
-        await cmd.ExecuteNonQueryAsync();
+            cmd.Parameters.Add(new DuckDBParameter { Value = cutoff });
+            await cmd.ExecuteNonQueryAsync();
+        });
     }
 
     private static string EscapeSqlPath(string path) => DuckDbInitializer.EscapeSqlPath(path);
+
+    /* Resting and COPY memory_limit values for the main DuckDB connection.
+       The resting value is also set in DuckDbInitializer.ConnectionString so
+       newly-opened connections start at the resting cap; the COPY value is
+       applied transiently around parquet COPY operations and restored after.
+       See WithRaisedCopyMemoryLimit and the comment block on ConnectionString. */
+    private const string MainConnectionRestingMemoryLimit = "1GB";
+    private const string MainConnectionCopyMemoryLimit = "4GB";
+
+    /// <summary>
+    /// Runs <paramref name="action"/> with the connection's memory_limit raised
+    /// to <see cref="MainConnectionCopyMemoryLimit"/>, restoring to
+    /// <see cref="MainConnectionRestingMemoryLimit"/> after. Use around parquet
+    /// COPY operations on the main connection — those hit a DuckDB
+    /// pre-reservation behavior that needs more headroom than the resting cap
+    /// (#933). memory_limit is instance-level; concurrent operations briefly
+    /// see the raised cap.
+    /// </summary>
+    private static async Task WithRaisedCopyMemoryLimit(DuckDBConnection connection, Func<Task> action)
+    {
+        using (var raiseCmd = connection.CreateCommand())
+        {
+            raiseCmd.CommandText = $"SET memory_limit = '{MainConnectionCopyMemoryLimit}'";
+            await raiseCmd.ExecuteNonQueryAsync();
+        }
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            try
+            {
+                using var restoreCmd = connection.CreateCommand();
+                restoreCmd.CommandText = $"SET memory_limit = '{MainConnectionRestingMemoryLimit}'";
+                await restoreCmd.ExecuteNonQueryAsync();
+            }
+            catch
+            {
+                /* Best-effort restore. If this fails the connection is in a bad
+                   state and will be disposed by the caller's `using` shortly. */
+            }
+        }
+    }
 
     /* Columns to exclude during compaction — dead weight from legacy archives */
     private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
@@ -573,9 +621,12 @@ COPY (
                         var parquetPath = Path.Combine(_archivePath, $"{timestamp}_{table}.parquet")
                             .Replace("\\", "/");
 
-                        using var exportCmd = connection.CreateCommand();
-                        exportCmd.CommandText = $"COPY (SELECT * FROM {table}) TO '{EscapeSqlPath(parquetPath)}' (FORMAT PARQUET, COMPRESSION ZSTD)";
-                        await exportCmd.ExecuteNonQueryAsync();
+                        await WithRaisedCopyMemoryLimit(connection, async () =>
+                        {
+                            using var exportCmd = connection.CreateCommand();
+                            exportCmd.CommandText = $"COPY (SELECT * FROM {table}) TO '{EscapeSqlPath(parquetPath)}' (FORMAT PARQUET, COMPRESSION ZSTD)";
+                            await exportCmd.ExecuteNonQueryAsync();
+                        });
 
                         _logger?.LogInformation("Archived {Count} rows from {Table}", rowCount, table);
                     }
@@ -598,9 +649,12 @@ COPY (
                         if (rowCount == 0) continue;
 
                         var preservePath = Path.Combine(preserveDir, $"{table}.parquet").Replace("\\", "/");
-                        using var exportCmd = connection.CreateCommand();
-                        exportCmd.CommandText = $"COPY (SELECT * FROM {table}) TO '{EscapeSqlPath(preservePath)}' (FORMAT PARQUET)";
-                        await exportCmd.ExecuteNonQueryAsync();
+                        await WithRaisedCopyMemoryLimit(connection, async () =>
+                        {
+                            using var exportCmd = connection.CreateCommand();
+                            exportCmd.CommandText = $"COPY (SELECT * FROM {table}) TO '{EscapeSqlPath(preservePath)}' (FORMAT PARQUET)";
+                            await exportCmd.ExecuteNonQueryAsync();
+                        });
                         preservedFiles[table] = preservePath;
 
                         _logger?.LogInformation("Preserved {Count} rows from {Table} for restoration after reset", rowCount, table);


### PR DESCRIPTION
## Summary

Two related fixes for #933, on top of [#952](https://github.com/erikdarlingdata/PerformanceMonitor/pull/952):

1. **Cap the main DuckDB connection's `memory_limit` at 1 GB** (raised transiently to 4 GB around parquet COPY operations).
2. **Detect compaction exclude-columns per merge step** instead of once globally — fixes a `Binder Error` on `query_store_stats` archives that span the v13 schema change.

## Why this is the right fix

We re-read #933 carefully and realized **the titled complaint is "Memory usage on client"** — the reporter says Lite uses 2.7-2.9 GB after 10 minutes with 4 servers. The compaction OOMs we've been chasing are downstream symptoms: by the time compaction runs, the app already holds 2.7 GB, leaving little headroom on a 16 GB / 1.6 GB-free machine. The compaction tunings in #942 / #952 were treating symptoms.

**Root cause:** `DuckDbInitializer.ConnectionString` set no `memory_limit`, so the buffer pool ran at DuckDB's default ceiling of 80% of system RAM (~12.8 GB). With archive parquet files accumulating, every UI query over archive views caches parquet pages — the buffer pool grows freely. That's the 2.7-2.9 GB the reporter is seeing.

## The wrinkle

We can't just cap the main connection at 1 GB statically. DuckDB v1.5.2 parquet `COPY` has a buffer-manager-bypass pre-reservation that needs 2-4 GB headroom (validated against DuckDB CLI v1.5.2 standalone — same OOM in both .NET binding and CLI; tracked upstream at [duckdb#16482](https://github.com/duckdb/duckdb/issues/16482)). So:

- **Resting**: `memory_limit=1GB` in the ConnectionString — caps the archive-page cache, addresses the actual complaint.
- **Around each parquet COPY on the main connection**: `SET memory_limit='4GB'`, run COPY, restore to `1GB`. Factored into a `WithRaisedCopyMemoryLimit` helper. Three call sites: `ExportToParquet` and the two `COPY` paths in `ArchiveAllAndResetAsync`.
- **Compaction connections** (separate `:memory:` instances): keep 4 GB cap from #952.

## Separate Binder fix

`CompactParquetFiles` detected `CompactionExcludeColumns` once across the global union of files, then applied `* EXCLUDE (col)` to each pair. `query_plan_text` was added to `query_store_stats` in migration v13 (2026-02-23), so the reporter's mix of pre-v13 and post-v13 archives lets the global detector see the column, but a pair of two pre-v13 files hits `Binder Error: Column "query_plan_text" in EXCLUDE list not found in FROM clause`. Fixed by detecting exclude-columns per merge-set in a new `BuildSelectClause` helper.

## Validation

DuckDB CLI v1.5.2 against synthetic query_snapshots-shaped data:

| Operation | 256 MB | 512 MB | 1 GB | 2 GB | 4 GB |
|---|---|---|---|---|---|
| INSERT (Appender, 1000 wide rows) | ✅ | ✅ | ✅ | ✅ | — |
| SELECT recent / GROUP BY | ✅ | ✅ | ✅ | ✅ | — |
| **COPY table → parquet** | ❌ pre-resv | ❌ pre-resv | ❌ pre-resv | ✅ | ✅ |
| **COPY read_parquet → parquet** (compaction) | ❌ | ❌ | ❌ | ✅* | ✅ |

`*` succeeds on 200 MB synthetic; OOMs on 1.5 GB. The 4 GB raise covers both.

Binder fix reproduced and verified against the DuckDB CLI on a 1-file-with-column + 1-file-without pair.

## Tradeoff (named, not hidden)

The resting 1 GB cap forces eviction of cached archive parquet pages. Long-range historical UI queries that re-scan many parquet files will do more disk I/O. Live/recent-data queries against the hot DB are unaffected — hot DB is small enough to fit in 1 GB easily.

## Test plan

- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Release` clean
- [x] DuckDB CLI validation matrix above
- [x] Binder fix verified end-to-end (mixed-schema parquet pair)
- [ ] Local hands-on with 4 SQL servers — confirm resting RSS drops materially from 2.7-2.9 GB baseline, UI feels normal, archival/compaction cycle completes
- [ ] Reporter confirms on next nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)