### PR TITLE
Ship via Setup.exe only and share servers.json across users

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,13 +108,11 @@ jobs:
           $version = "${{ steps.version.outputs.VERSION }}"
           New-Item -ItemType Directory -Force -Path releases
 
-          # Dashboard ZIP
-          Compress-Archive -Path 'publish/Dashboard/*' -DestinationPath "releases/PerformanceMonitorDashboard-$version.zip" -Force
+          # Dashboard and Lite ship via Velopack Setup.exe only (see "Create Velopack release" step).
+          # The portable ZIPs were removed because they skipped Start Menu shortcuts and
+          # Apps & Features registration, leaving testers unable to find the app after install.
 
-          # Lite ZIP
-          Compress-Archive -Path 'publish/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
-
-          # Installer ZIP (CLI + SQL scripts)
+          # Installer ZIP (CLI + SQL scripts) — still shipped for server-side install
           $instDir = 'publish/Installer'
           New-Item -ItemType Directory -Force -Path $instDir
           New-Item -ItemType Directory -Force -Path "$instDir/install"
@@ -129,22 +127,6 @@ jobs:
 
           Compress-Archive -Path 'publish/Installer/*' -DestinationPath "releases/PerformanceMonitorInstaller-$version.zip" -Force
 
-      - name: Upload Dashboard for signing
-        if: github.event_name == 'release'
-        id: upload-dashboard
-        uses: actions/upload-artifact@v6
-        with:
-          name: Dashboard-unsigned
-          path: publish/Dashboard/
-
-      - name: Upload Lite for signing
-        if: github.event_name == 'release'
-        id: upload-lite
-        uses: actions/upload-artifact@v6
-        with:
-          name: Lite-unsigned
-          path: publish/Lite/
-
       - name: Upload Installer for signing
         if: github.event_name == 'release'
         id: upload-installer
@@ -152,32 +134,6 @@ jobs:
         with:
           name: Installer-unsigned
           path: publish/Installer/
-
-      - name: Sign Dashboard
-        if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
-          project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'release-signing'
-          artifact-configuration-slug: 'Dashboard'
-          github-artifact-id: '${{ steps.upload-dashboard.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed/Dashboard'
-
-      - name: Sign Lite
-        if: github.event_name == 'release'
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
-          project-slug: 'PerformanceMonitor'
-          signing-policy-slug: 'release-signing'
-          artifact-configuration-slug: 'Lite'
-          github-artifact-id: '${{ steps.upload-lite.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed/Lite'
 
       - name: Sign Installer
         if: github.event_name == 'release'
@@ -197,11 +153,6 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.VERSION }}"
-          # Re-zip signed files into release archives
-          Remove-Item "releases/PerformanceMonitorDashboard-$version.zip" -ErrorAction SilentlyContinue
-          Compress-Archive -Path 'signed/Dashboard/*' -DestinationPath "releases/PerformanceMonitorDashboard-$version.zip" -Force
-          Remove-Item "releases/PerformanceMonitorLite-$version.zip" -ErrorAction SilentlyContinue
-          Compress-Archive -Path 'signed/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
           Remove-Item "releases/PerformanceMonitorInstaller-$version.zip" -ErrorAction SilentlyContinue
           Compress-Archive -Path 'signed/Installer/*' -DestinationPath "releases/PerformanceMonitorInstaller-$version.zip" -Force
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,9 +108,13 @@ jobs:
           $version = "${{ steps.version.outputs.VERSION }}"
           New-Item -ItemType Directory -Force -Path releases
 
-          # Dashboard and Lite ship via Velopack Setup.exe only (see "Create Velopack release" step).
-          # The portable ZIPs were removed because they skipped Start Menu shortcuts and
-          # Apps & Features registration, leaving testers unable to find the app after install.
+          # Dashboard ZIP — portable artifact for advanced/air-gapped users.
+          # The README points end users at Setup.exe (Velopack) because it sets up Start Menu
+          # shortcuts and Apps & Features registration; this ZIP is the explicit fallback.
+          Compress-Archive -Path 'publish/Dashboard/*' -DestinationPath "releases/PerformanceMonitorDashboard-$version.zip" -Force
+
+          # Lite ZIP — same rationale.
+          Compress-Archive -Path 'publish/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
 
           # Installer ZIP (CLI + SQL scripts) — still shipped for server-side install
           $instDir = 'publish/Installer'
@@ -127,6 +131,22 @@ jobs:
 
           Compress-Archive -Path 'publish/Installer/*' -DestinationPath "releases/PerformanceMonitorInstaller-$version.zip" -Force
 
+      - name: Upload Dashboard for signing
+        if: github.event_name == 'release'
+        id: upload-dashboard
+        uses: actions/upload-artifact@v6
+        with:
+          name: Dashboard-unsigned
+          path: publish/Dashboard/
+
+      - name: Upload Lite for signing
+        if: github.event_name == 'release'
+        id: upload-lite
+        uses: actions/upload-artifact@v6
+        with:
+          name: Lite-unsigned
+          path: publish/Lite/
+
       - name: Upload Installer for signing
         if: github.event_name == 'release'
         id: upload-installer
@@ -134,6 +154,32 @@ jobs:
         with:
           name: Installer-unsigned
           path: publish/Installer/
+
+      - name: Sign Dashboard
+        if: github.event_name == 'release'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
+          project-slug: 'PerformanceMonitor'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'Dashboard'
+          github-artifact-id: '${{ steps.upload-dashboard.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'signed/Dashboard'
+
+      - name: Sign Lite
+        if: github.event_name == 'release'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
+          project-slug: 'PerformanceMonitor'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'Lite'
+          github-artifact-id: '${{ steps.upload-lite.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'signed/Lite'
 
       - name: Sign Installer
         if: github.event_name == 'release'
@@ -153,6 +199,11 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.VERSION }}"
+          # Re-zip signed files into release archives
+          Remove-Item "releases/PerformanceMonitorDashboard-$version.zip" -ErrorAction SilentlyContinue
+          Compress-Archive -Path 'signed/Dashboard/*' -DestinationPath "releases/PerformanceMonitorDashboard-$version.zip" -Force
+          Remove-Item "releases/PerformanceMonitorLite-$version.zip" -ErrorAction SilentlyContinue
+          Compress-Archive -Path 'signed/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
           Remove-Item "releases/PerformanceMonitorInstaller-$version.zip" -ErrorAction SilentlyContinue
           Compress-Archive -Path 'signed/Installer/*' -DestinationPath "releases/PerformanceMonitorInstaller-$version.zip" -Force
 

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -11,6 +11,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -38,18 +40,85 @@ namespace PerformanceMonitorDashboard.Services
 
         public ServerManager()
         {
-            string appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "PerformanceMonitorDashboard"
-            );
-
-            Directory.CreateDirectory(appDataPath);
-            _configFilePath = Path.Combine(appDataPath, "servers.json");
+            _configFilePath = ResolveSharedServersJsonPath();
             _credentialService = new CredentialService();
             _servers = new List<ServerConnection>();
             _connectionStatuses = new ConcurrentDictionary<string, ServerConnectionStatus>();
 
             LoadServers();
+        }
+
+        /// <summary>
+        /// Resolves the path to the machine-wide servers.json under %ProgramData% so multiple
+        /// Windows users on the same machine see the same server list. On first directory
+        /// creation, grants Authenticated Users Modify so any user can edit the file.
+        /// One-time migrates an existing per-user %APPDATA% servers.json if no shared file
+        /// is present yet (the old file is left in place as a backup).
+        /// Credentials remain per-user in Windows Credential Manager.
+        /// </summary>
+        private static string ResolveSharedServersJsonPath()
+        {
+            string sharedDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "PerformanceMonitorDashboard");
+            string sharedPath = Path.Combine(sharedDir, "servers.json");
+
+            bool directoryCreated = !Directory.Exists(sharedDir);
+            Directory.CreateDirectory(sharedDir);
+
+            if (directoryCreated)
+            {
+                TryGrantAuthenticatedUsersModify(sharedDir);
+            }
+
+            if (!File.Exists(sharedPath))
+            {
+                string legacyPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "PerformanceMonitorDashboard",
+                    "servers.json");
+
+                if (File.Exists(legacyPath))
+                {
+                    try
+                    {
+                        File.Copy(legacyPath, sharedPath);
+                        Logger.Info($"Migrated servers.json from '{legacyPath}' to '{sharedPath}'. " +
+                                    "The old file was left in place as a backup. " +
+                                    "Passwords in Windows Credential Manager remain per-user — other users on this machine will need to re-enter SQL passwords for each server.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"Failed to migrate servers.json from '{legacyPath}': {ex.Message}");
+                    }
+                }
+            }
+
+            return sharedPath;
+        }
+
+        private static void TryGrantAuthenticatedUsersModify(string directoryPath)
+        {
+            try
+            {
+                var dirInfo = new DirectoryInfo(directoryPath);
+                var security = dirInfo.GetAccessControl();
+                var authenticatedUsers = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+
+                security.AddAccessRule(new FileSystemAccessRule(
+                    authenticatedUsers,
+                    FileSystemRights.Modify | FileSystemRights.Synchronize,
+                    InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                    PropagationFlags.None,
+                    AccessControlType.Allow));
+
+                dirInfo.SetAccessControl(security);
+                Logger.Info($"Granted Authenticated Users Modify on '{directoryPath}' so other Windows users on this machine can edit the shared server list.");
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Could not set shared ACL on '{directoryPath}': {ex.Message}. Other Windows users may be unable to edit the server list until permissions are fixed manually.");
+            }
         }
 
         public List<ServerConnection> GetAllServers()

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -9,6 +9,8 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -60,9 +62,19 @@ public partial class App : Application
     public static string DatabasePath { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Gets the config directory path.
+    /// Gets the per-user config directory path. Holds settings.json, schedules, and
+    /// other per-user preferences. Stays in %LOCALAPPDATA% so Velopack updates can
+    /// replace the app directory without losing data.
     /// </summary>
     public static string ConfigDirectory { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the machine-wide config directory under %ProgramData% used for files that
+    /// should be shared across Windows users on the same machine — currently just
+    /// servers.json (the list of monitored servers). Credentials remain per-user in
+    /// Windows Credential Manager.
+    /// </summary>
+    public static string SharedConfigDirectory { get; private set; } = string.Empty;
 
     /// <summary>
     /// Gets the archive directory path for Parquet files.
@@ -274,6 +286,9 @@ public partial class App : Application
         // Initialize logging
         var logDirectory = Path.Combine(appDataRoot, "logs");
         AppLogger.Initialize(logDirectory);
+
+        // Resolve shared (machine-wide) config directory AFTER logger init so migration/ACL events are logged
+        SharedConfigDirectory = ResolveSharedConfigDirectory(ConfigDirectory);
         Helpers.MethodProfiler.Initialize(logDirectory);
         Helpers.QueryLogger.Initialize(logDirectory);
         AppLogger.Info("App", $"Starting PerformanceMonitorLite v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
@@ -301,6 +316,81 @@ public partial class App : Application
         _singleInstanceMutex?.Dispose();
 
         base.OnExit(e);
+    }
+
+    /// <summary>
+    /// Resolves the machine-wide config directory under %ProgramData% (currently used
+    /// only for servers.json) so multiple Windows users on the same machine see the
+    /// same server list. On first directory creation, grants Authenticated Users
+    /// Modify so any user can edit the file. One-time migrates an existing
+    /// per-user servers.json from <paramref name="perUserConfigDirectory"/> if no
+    /// shared servers.json exists yet; the old file is left in place as a backup.
+    /// Credentials remain per-user in Windows Credential Manager.
+    /// </summary>
+    private static string ResolveSharedConfigDirectory(string perUserConfigDirectory)
+    {
+        string sharedDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "PerformanceMonitorLite",
+            "config");
+
+        bool directoryCreated = !Directory.Exists(sharedDir);
+        Directory.CreateDirectory(sharedDir);
+
+        if (directoryCreated)
+        {
+            TryGrantAuthenticatedUsersModify(sharedDir);
+        }
+
+        string sharedServers = Path.Combine(sharedDir, "servers.json");
+        if (!File.Exists(sharedServers))
+        {
+            string legacyServers = Path.Combine(perUserConfigDirectory, "servers.json");
+            if (File.Exists(legacyServers))
+            {
+                try
+                {
+                    File.Copy(legacyServers, sharedServers);
+                    AppLogger.Info("App",
+                        $"Migrated servers.json from '{legacyServers}' to '{sharedServers}'. " +
+                        "The old file was left in place as a backup. " +
+                        "Passwords in Windows Credential Manager remain per-user — other users on this machine will need to re-enter SQL passwords for each server.");
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Warn("App",
+                        $"Failed to migrate servers.json from '{legacyServers}': {ex.Message}");
+                }
+            }
+        }
+
+        return sharedDir;
+    }
+
+    private static void TryGrantAuthenticatedUsersModify(string directoryPath)
+    {
+        try
+        {
+            var dirInfo = new DirectoryInfo(directoryPath);
+            var security = dirInfo.GetAccessControl();
+            var authenticatedUsers = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+
+            security.AddAccessRule(new FileSystemAccessRule(
+                authenticatedUsers,
+                FileSystemRights.Modify | FileSystemRights.Synchronize,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+
+            dirInfo.SetAccessControl(security);
+            AppLogger.Info("App",
+                $"Granted Authenticated Users Modify on '{directoryPath}' so other Windows users on this machine can edit the shared server list.");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warn("App",
+                $"Could not set shared ACL on '{directoryPath}': {ex.Message}. Other Windows users may be unable to edit the server list until permissions are fixed manually.");
+        }
     }
 
     private static void LoadDefaultTimeRange()

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -70,7 +70,7 @@ public partial class MainWindow : Window
         _databaseInitializer = new DuckDbInitializer(App.DatabasePath, new AppLoggerAdapter<DuckDbInitializer>());
         _emailAlertService = new EmailAlertService(_databaseInitializer);
         _muteRuleService = new MuteRuleService(_databaseInitializer);
-        _serverManager = new ServerManager(App.ConfigDirectory, logger: new AppLoggerAdapter<ServerManager>());
+        _serverManager = new ServerManager(App.SharedConfigDirectory, logger: new AppLoggerAdapter<ServerManager>());
         _scheduleManager = new ScheduleManager(App.ConfigDirectory);
 
         // Status bar update timer

--- a/README.md
+++ b/README.md
@@ -144,14 +144,14 @@ All data is stored in `%LOCALAPPDATA%\PerformanceMonitorLite\` — separate from
 
 ### Lite Configuration
 
-All configuration lives in the `config/` folder:
+| File | Location | Purpose |
+|---|---|---|
+| `servers.json` | `%ProgramData%\PerformanceMonitorLite\config\` (machine-wide) | Server connections, shared across all Windows users on the machine. Passwords stay per-user in Windows Credential Manager. Optional **Utility Database** per server for community procs installed outside master. |
+| `settings.json` | `%LOCALAPPDATA%\PerformanceMonitorLite\config\` (per-user) | Retention, MCP server, startup behavior, alert thresholds, SMTP configuration |
+| `collection_schedule.json` | `%LOCALAPPDATA%\PerformanceMonitorLite\config\` (per-user) | Per-collector enable/disable and frequency |
+| `ignored_wait_types.json` | `%LOCALAPPDATA%\PerformanceMonitorLite\config\` (per-user) | 144 benign wait types excluded by default |
 
-| File | Purpose |
-|---|---|
-| `servers.json` | Server connections (passwords in Windows Credential Manager). Optional **Utility Database** per server for community procs installed outside master. |
-| `settings.json` | Retention, MCP server, startup behavior, alert thresholds, SMTP configuration |
-| `collection_schedule.json` | Per-collector enable/disable and frequency |
-| `ignored_wait_types.json` | 144 benign wait types excluded by default |
+When a second Windows user on the same machine launches Lite, they see the shared `servers.json` immediately. SQL Auth and Entra MFA passwords are scoped to each user's own Credential Manager, so they'll be prompted once per server; Windows Auth works without any prompt.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ All release binaries are digitally signed via [SignPath](https://signpath.io) �
 
 ## Quick Start — Lite Edition
 
-1. Download and extract **[PerformanceMonitorLite](https://github.com/erikdarlingdata/PerformanceMonitor/releases/latest)** (requires [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/10.0))
-2. Run `PerformanceMonitorLite.exe`
-3. Click **+ Add Server**, enter connection details, test, save
-4. Double-click the server in the sidebar to connect
+1. Download **[`PerformanceMonitorLite-win-Setup.exe`](https://github.com/erikdarlingdata/PerformanceMonitor/releases/latest)** (requires [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/10.0))
+2. Run the installer — it installs to `%LocalAppData%\PerformanceMonitorLite`, adds **Start Menu** and **Desktop** shortcuts, and registers the app under **Apps & Features** so it shows up in Windows search and can be uninstalled normally. Auto-update is wired in.
+3. Launch from the Start Menu or Desktop shortcut.
+4. Click **+ Add Server**, enter connection details, test, save.
+5. Double-click the server in the sidebar to connect.
 
 Data starts flowing within 1–5 minutes. That's it. No installation on your server, no Agent jobs, no sysadmin required.
 
@@ -238,7 +239,7 @@ FROM PerformanceMonitor.config.collection_log
 ORDER BY collection_time DESC;
 ```
 
-3. Launch the Dashboard (`Dashboard/` folder — build with `dotnet build` or use the release package). The Dashboard is a separate WPF application that runs on your workstation and connects to any SQL Server where the PerformanceMonitor database is installed. Add your server, enter credentials, and data appears immediately.
+3. Install the Dashboard. Download **[`PerformanceMonitorDashboard-win-Setup.exe`](https://github.com/erikdarlingdata/PerformanceMonitor/releases/latest)** (requires [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)). Setup.exe installs to `%LocalAppData%\PerformanceMonitorDashboard`, adds **Start Menu** and **Desktop** shortcuts, registers the app under **Apps & Features**, and wires up auto-update. Launch from the Start Menu, add your server, enter credentials, and data appears immediately.
 
 ### What Gets Installed
 

--- a/build-dashboard.cmd
+++ b/build-dashboard.cmd
@@ -18,7 +18,7 @@ if not exist "releases" mkdir releases
 :: ----------------------------------------
 :: Dashboard
 :: ----------------------------------------
-echo [1/2] Publishing Dashboard...
+echo [1/3] Publishing Dashboard...
 dotnet publish Dashboard\Dashboard.csproj -c Release -o publish\Dashboard
 
 if %ERRORLEVEL% neq 0 (
@@ -27,14 +27,18 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 
-:: Dashboard ships via Setup.exe (Velopack), not a portable ZIP — see .github/workflows/build.yml.
-:: Local dev iterates against publish\Dashboard\ directly.
+:: Portable ZIP for advanced / air-gapped users. README points end users at Setup.exe (Velopack)
+:: because that registers shortcuts + Apps & Features; this is the explicit fallback.
+echo Creating Dashboard ZIP...
+set DASH_ZIP=PerformanceMonitorDashboard-%VERSION%.zip
+if exist "releases\%DASH_ZIP%" del "releases\%DASH_ZIP%"
+powershell -Command "Compress-Archive -Path 'publish\Dashboard\*' -DestinationPath 'releases\%DASH_ZIP%' -Force"
 echo.
 
 :: ----------------------------------------
 :: CLI Installer
 :: ----------------------------------------
-echo [2/2] Publishing CLI Installer...
+echo [2/3] Publishing CLI Installer...
 dotnet publish Installer\PerformanceMonitorInstaller.csproj -c Release
 
 if %ERRORLEVEL% neq 0 (
@@ -71,10 +75,11 @@ echo  Build Complete!
 echo ========================================
 echo.
 echo Output:
-echo   publish\Dashboard\        (run PerformanceMonitorDashboard.exe directly for dev)
+echo   releases\%DASH_ZIP%       (portable Dashboard ZIP)
 echo   releases\%INST_ZIP%       (CLI installer + SQL scripts)
 echo.
 
+for %%A in ("releases\%DASH_ZIP%") do echo Dashboard size:  %%~zA bytes
 for %%A in ("releases\%INST_ZIP%") do echo Installer size:  %%~zA bytes
 
 endlocal

--- a/build-dashboard.cmd
+++ b/build-dashboard.cmd
@@ -18,7 +18,7 @@ if not exist "releases" mkdir releases
 :: ----------------------------------------
 :: Dashboard
 :: ----------------------------------------
-echo [1/3] Publishing Dashboard...
+echo [1/2] Publishing Dashboard...
 dotnet publish Dashboard\Dashboard.csproj -c Release -o publish\Dashboard
 
 if %ERRORLEVEL% neq 0 (
@@ -27,10 +27,8 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 
-echo Creating Dashboard ZIP...
-set DASH_ZIP=PerformanceMonitorDashboard-%VERSION%.zip
-if exist "releases\%DASH_ZIP%" del "releases\%DASH_ZIP%"
-powershell -Command "Compress-Archive -Path 'publish\Dashboard\*' -DestinationPath 'releases\%DASH_ZIP%' -Force"
+:: Dashboard ships via Setup.exe (Velopack), not a portable ZIP — see .github/workflows/build.yml.
+:: Local dev iterates against publish\Dashboard\ directly.
 echo.
 
 :: ----------------------------------------
@@ -73,11 +71,10 @@ echo  Build Complete!
 echo ========================================
 echo.
 echo Output:
-echo   releases\%DASH_ZIP%
-echo   releases\%INST_ZIP%
+echo   publish\Dashboard\        (run PerformanceMonitorDashboard.exe directly for dev)
+echo   releases\%INST_ZIP%       (CLI installer + SQL scripts)
 echo.
 
-for %%A in ("releases\%DASH_ZIP%") do echo Dashboard size:  %%~zA bytes
 for %%A in ("releases\%INST_ZIP%") do echo Installer size:  %%~zA bytes
 
 endlocal

--- a/build-lite.cmd
+++ b/build-lite.cmd
@@ -23,15 +23,26 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 
-:: Lite ships via Setup.exe (Velopack), not a portable ZIP — see .github/workflows/build.yml.
-:: Local dev iterates against publish\Lite\ directly.
+:: Portable ZIP for advanced / air-gapped users. README points end users at Setup.exe (Velopack)
+:: because that registers shortcuts + Apps & Features; this is the explicit fallback.
+echo.
+echo Creating ZIP package...
+set ZIPNAME=PerformanceMonitorLite-%VERSION%.zip
+
+if exist "releases\%ZIPNAME%" del "releases\%ZIPNAME%"
+if not exist "releases" mkdir releases
+
+powershell -Command "Compress-Archive -Path 'publish\Lite\*' -DestinationPath 'releases\%ZIPNAME%' -Force"
 
 echo.
 echo ========================================
 echo  Build Complete!
 echo ========================================
 echo.
-echo Output: publish\Lite\  (run PerformanceMonitorLite.exe directly for dev)
+echo Output: releases\%ZIPNAME%
 echo.
+
+:: Show size
+for %%A in ("releases\%ZIPNAME%") do echo Size: %%~zA bytes
 
 endlocal

--- a/build-lite.cmd
+++ b/build-lite.cmd
@@ -23,25 +23,15 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 
-:: Create ZIP
-echo.
-echo Creating ZIP package...
-set ZIPNAME=PerformanceMonitorLite-%VERSION%.zip
-
-if exist "releases\%ZIPNAME%" del "releases\%ZIPNAME%"
-if not exist "releases" mkdir releases
-
-powershell -Command "Compress-Archive -Path 'publish\Lite\*' -DestinationPath 'releases\%ZIPNAME%' -Force"
+:: Lite ships via Setup.exe (Velopack), not a portable ZIP — see .github/workflows/build.yml.
+:: Local dev iterates against publish\Lite\ directly.
 
 echo.
 echo ========================================
 echo  Build Complete!
 echo ========================================
 echo.
-echo Output: releases\%ZIPNAME%
+echo Output: publish\Lite\  (run PerformanceMonitorLite.exe directly for dev)
 echo.
-
-:: Show size
-for %%A in ("releases\%ZIPNAME%") do echo Size: %%~zA bytes
 
 endlocal


### PR DESCRIPTION
## Summary

Two tester-reported issues, fixed in one PR.

**Issue 1 — App didn't appear in Apps & Features / Start Menu.** The tester downloaded the bare ZIP, extracted it, and pinned the EXE to the taskbar; nothing registered with Windows so the app was effectively invisible after install. Velopack's `Setup.exe` already does the right thing (Start Menu + Desktop shortcuts, registers under HKCU\…\Uninstall, install location, auto-update), so this PR makes Setup.exe the README-promoted install path. The portable ZIPs continue to ship as an explicit fallback for advanced and air-gapped users.

**Issue 2 — Second DBA on the same Windows machine couldn't see the first DBA's server list.** `servers.json` lived in per-user `%APPDATA%` / `%LOCALAPPDATA%`. Moves it to `%ProgramData%\PerformanceMonitor{Dashboard,Lite}\`, grants Authenticated Users Modify on first directory creation, and migrates an existing per-user file in if no shared file exists yet (legacy file left in place as a backup).

## Changes

### Installer / packaging
- `README.md` — Quick Start now describes `Setup.exe`, what it does (shortcuts, Apps & Features registration, auto-update), and where it installs (`%LocalAppData%`). The portable ZIPs are intentionally not advertised in Quick Start.
- `.github/workflows/build.yml`, `build-dashboard.cmd`, `build-lite.cmd` — unchanged in behavior; only comments added documenting that the portable ZIP is a deliberate fallback and the README points users at Setup.exe.

### Shared server list (Dashboard)
- `Dashboard/Services/ServerManager.cs` — `_configFilePath` now resolves to `%ProgramData%\PerformanceMonitorDashboard\servers.json`. New private helpers `ResolveSharedServersJsonPath` and `TryGrantAuthenticatedUsersModify` handle directory creation, ACL grant (`FileSystemRights.Modify | Synchronize`, `ContainerInherit | ObjectInherit`), and one-time migration from `%APPDATA%`. Other Dashboard services (`EmailAlertService`, `MuteRuleService`, `UserPreferencesService`) keep their per-user paths.

### Shared server list (Lite)
- `Lite/App.xaml.cs` — new `SharedConfigDirectory` static, resolved after `AppLogger.Initialize` (so migration and ACL events are logged). Same `ResolveSharedConfigDirectory` + `TryGrantAuthenticatedUsersModify` pattern as Dashboard. Per-user `ConfigDirectory` (settings.json, schedules, perfmon_counters.json, MCP settings) stays in `%LOCALAPPDATA%`. DuckDB, archive, and logs also stay per-user.
- `Lite/MainWindow.xaml.cs:73` — pass `App.SharedConfigDirectory` to `ServerManager` instead of `App.ConfigDirectory`.

## Velopack defaults confirmed

`vpk pack` for Windows defaults `--shortcuts` to `Desktop,StartMenuRoot` and `--instLocation` to `Either` (per [`WindowsPackCommand.cs`](https://github.com/velopack/velopack/blob/develop/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs)). No new flags are needed; the current `vpk pack -u … -e …` invocations already produce a properly-registered installer. The `--channel dashboard` / `--channel lite` structure that auto-update depends on is unchanged.

## Caveat — passwords

Credentials remain per-user in Windows Credential Manager (that store is Windows-bounded to the user profile and not something this PR moves). Effect for the tester's two-DBA scenario:

- **Windows Auth servers** — work for each DBA immediately, using their own token.
- **SQL Auth / Entra MFA servers** — DBA #2 sees the server but will be prompted to re-enter the password the first time they connect; the password is then saved in their own Credential Manager.

Cross-machine sharing (network share, DB-backed config) is intentionally out of scope here.

## Test plan

- [x] `dotnet build Dashboard/Dashboard.csproj -c Debug` — clean
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — clean
- [ ] Tag a pre-release / run a release on a branch to confirm both the Dashboard/Lite portable ZIPs **and** the Velopack Setup.exe assets upload
- [ ] Install `Setup.exe` on a clean VM (or fresh Windows profile); confirm Start Menu + Desktop shortcuts appear and the app is listed under Apps & Features
- [ ] First-launch confirms `%ProgramData%\PerformanceMonitor{Dashboard,Lite}\servers.json` is created with Authenticated Users Modify
- [ ] On a host with a pre-existing `%APPDATA%\PerformanceMonitorDashboard\servers.json` (or `%LOCALAPPDATA%\PerformanceMonitorLite\config\servers.json`), confirm migration kicks in and the legacy file is left behind as a backup
- [ ] Switch to a second Windows account on the same machine, launch the app, confirm the same server list appears; Windows-Auth servers connect immediately, SQL-Auth servers prompt for the password and persist it per-user

🤖 Generated with [Claude Code](https://claude.com/claude-code)