### PR TITLE
Release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - TBD
+## [2.11.0] - 2026-05-19
+
+### Important
+
+- **.NET 10 upgrade** — Dashboard, Lite, Installer, and Installer.Core now target `net10.0` (Windows projects target `net10.0-windows`). Building from source now requires the .NET 10 SDK; CI is pinned to 10.0.204 via `global.json` for reproducible builds. End users running prebuilt Velopack installers do not need to install anything separately — runtime is bundled ([#958])
+- **Dashboard and Lite ship via Setup.exe only** — portable ZIP artifacts have been dropped from the Dashboard and Lite release pipeline. Velopack `Setup.exe` is the only Dashboard/Lite release artifact and now correctly registers the apps under Apps & Features and creates Start Menu shortcuts. The Installer ZIP (CLI installer + SQL scripts) is unchanged. Users upgrading from a portable ZIP install should uninstall the ZIP version and reinstall via `Setup.exe`
+- **Shared `servers.json` location** — Dashboard and Lite now store `servers.json` under `%ProgramData%\PerformanceMonitor{Dashboard,Lite}\` so every Windows user on the same machine shares one server list. First run migrates an existing per-user `servers.json` to the new location and grants Authenticated Users Modify on the directory. SQL credentials remain per-user in Windows Credential Manager — each DBA re-enters SQL passwords on first connect; Windows Auth works with no re-entry
+
+### Added
+
+- **One-click snooze from the alert tray popup** in Lite — snooze an alert directly from the tray notification balloon without opening the main window ([#944])
+- **Snooze hint in email and Teams/Slack alert payloads** — alert messages now show the snooze duration / scheduled wake time when an alert is fired while a snooze is active ([#944])
+- **Process memory logging per collection cycle** in Lite — the collector now logs working set and private bytes at the end of each cycle, making it easier to track memory growth in long-running sessions
+
+### Changed
+
+- **Lite compaction memory tuning** ([#933]) — multiple changes to make parquet compaction robust on wide-row tables and large datasets:
+    - Cap the main collector connection's `memory_limit` and raise it transiently only for the `COPY` step
+    - Detect compaction `EXCLUDE` columns per merge step instead of once up front
+    - Raise the compaction `memory_limit` floor to 4 GB
+    - Set DuckDB `temp_directory` explicitly so spill files don't blow the OS temp drive
+    - Compact parquet in size-budgeted batches instead of one mega-batch
+- **Trace collectors honor `config.collector_database_exclusions`** ([#887] follow-up) — the trace-file based collectors now filter against the exclusions table, matching the behavior of the eight DMV-based per-database collectors shipped in v2.9.0
+- **InstallerGui project directory removed** — the WPF InstallerGui was retired in v2.9.0 in favor of the Dashboard's integrated Add Server dialog. The project directory has now been deleted from the repo
+- **Build warnings cleaned up** across Lite, Dashboard, and Installer ([#945])
+- **GitHub Actions runners bumped** to Node 24-compatible major versions to silence deprecation warnings
+
+### Fixed
+
+- **Re-run `installation_history` column widening** for servers that crossed v2.4.0 → v2.5.0 before PR #828's fix shipped in v2.7.0. Those servers ran the original widen script as a no-op against `master`, then advanced their installer_version past 2.5, so the now-fixed script never reapplied. Adds an idempotent ALTER under an `IF EXISTS` guard checking `max_length = 510` ([#828])
+- **Mute rules preserved across size-triggered DuckDB reset** in Lite — when the local DuckDB exceeded the configured size budget and was reset, mute rules were being lost. They now survive the reset ([#938])
+- **Chart tooltips break after tab switch** — root-cause fix for the popup-wedge issue first patched in v2.10.0. Both the Memory tab handlers and `CorrelatedCrosshairManager` are now resilient to tab churn ([#916], [#937])
+- **Stale `Monitor_LongQueries_*.trc` files cleaned up** by `config.data_retention` — the trace-file cleanup step previously left old `.trc` files behind on disk ([#951])
+- **Nullability guards** added to the remaining comparison overlay tasks that were producing CS86xx warnings
+
+[#828]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/828
+[#887]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/887
+[#916]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/916
+[#933]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/933
+[#937]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/937
+[#938]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/938
+[#944]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/944
+[#945]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/945
+[#951]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/951
+[#958]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/958
+
+## [2.10.0] - 2026-05-04
 
 ### Fixed
 
@@ -17,7 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-database grants for FinOps Index Analysis** documented in the README — sp_IndexCleanup-backed Index Analysis requires per-database `EXECUTE` grants on each user database you want to analyze ([#915])
 
 [#915]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/915
-[#916]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/916
 [#917]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/917
 
 ## [2.9.0] - 2026-04-29

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -7,10 +7,10 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>2.10.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
-    <InformationalVersion>2.10.0</InformationalVersion>
+    <Version>2.11.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
+    <InformationalVersion>2.11.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <ApplicationIcon>EDD.ico</ApplicationIcon>

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,10 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>2.10.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
-    <InformationalVersion>2.10.0</InformationalVersion>
+    <Version>2.11.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
+    <InformationalVersion>2.11.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>2.10.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
-    <InformationalVersion>2.10.0</InformationalVersion>
+    <Version>2.11.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
+    <InformationalVersion>2.11.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -8,10 +8,10 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>2.10.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
-    <InformationalVersion>2.10.0</InformationalVersion>
+    <Version>2.11.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
+    <InformationalVersion>2.11.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Lightweight SQL Server performance monitoring - no installation required on target servers</Description>


### PR DESCRIPTION
## Summary

Release prep for v2.11.0:

- Bumps Dashboard, Lite, Installer, Installer.Core to **2.11.0**
- Drafts v2.11.0 changelog covering 42 commits since v2.10.0
- Stamps v2.10.0 with its actual release date (2026-05-04)

### Highlights of v2.11.0

**Important**
- .NET 10 upgrade (#958)
- Dashboard and Lite ship via Setup.exe only — portable ZIPs dropped
- `servers.json` moved to `%ProgramData%\PerformanceMonitor{Dashboard,Lite}\` for shared per-machine server lists

**Added**
- One-click snooze from alert tray popup (#944)
- Snooze hint in email and Teams/Slack alert payloads (#944)
- Process memory logging at end of each Lite collection cycle

**Changed**
- Lite compaction memory tuning bundle (#933) — temp_directory, 4 GB floor, size-budgeted batches, per-step exclude-column detection
- Trace collectors honor `config.collector_database_exclusions` (#887 follow-up)
- InstallerGui project directory removed (retired in v2.9.0)
- Build warnings cleanup (#945)

**Fixed**
- Re-run `installation_history` column widening for pre-v2.7.0 no-op upgrades (#828)
- Mute rules preserved across size-triggered DuckDB reset (#938)
- Chart tooltips after tab switch — root-cause fix (#916/#937)
- Stale `Monitor_LongQueries_*.trc` files cleaned up by data_retention (#951)

## Test plan

- [x] Build clean (`dotnet build -c Debug` — 0 warnings, 0 errors)
- [x] 46 adversarial Installer.Tests pass
- [x] Fresh install on sql2016 (`--reinstall` from v2.9.0 baseline)
- [x] Upgrade test on sql2017 (v2.9.0 → v2.11.0, two-hop) — data survived
- [x] Upgrade test on sql2019 (v2.9.0 → v2.11.0)
- [x] Upgrade + idempotency on sql2022 (v2.10.0 → v2.11.0, then re-run) — data survived
- [x] Upgrade test on sql2025 (v2.9.0 → v2.11.0)
- [x] Uninstall path on sql2016 — DB dropped, Agent jobs removed, XE sessions cleared; fresh install after uninstall worked
- [x] `installation_history` shows 2.11.0 SUCCESS on every server, version columns at nvarchar(512) (1024 bytes)
- [x] Cloud: Lite collecting from Azure SQL DB (eastus2) and AWS RDS (us-east-1) for 30 min — 0 errors, 12+ collector types per server, platform-specific skips working (running_jobs SKIPPED on both)
- [x] Cloud: Dashboard installed PerformanceMonitor on RDS via Add Server flow (148 runs / 0 errors / 5 skipped — embedded-resource install path, #772-class)
- [x] New process-memory-per-cycle log lines observed in Lite
- [x] Nightly build green; no open bug reports against nightly in last 48h
- [ ] **Manual UI smoke remaining**: snooze from tray (#944), chart tooltips after tab switch (#916/#937), visual theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)