### PR TITLE
Skip version-bump check for documentation-only PRs

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -12,7 +12,22 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v5
 
+      # Documentation-only PRs (e.g. a CHANGELOG correction) do not bump the
+      # version. The workflow still runs so the required check reports a result
+      # — using paths-ignore would skip the run entirely and leave the check
+      # stuck pending. Instead, the version comparison below is gated on whether
+      # any non-*.md file changed.
+      - name: Detect non-documentation changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+
       - name: Get PR version
+        if: steps.changes.outputs.code == 'true'
         id: pr
         shell: pwsh
         run: |
@@ -21,12 +36,14 @@ jobs:
           Write-Host "PR version: $version"
 
       - name: Checkout main
+        if: steps.changes.outputs.code == 'true'
         uses: actions/checkout@v5
         with:
           ref: main
           path: main-branch
 
       - name: Get main version
+        if: steps.changes.outputs.code == 'true'
         id: main
         shell: pwsh
         run: |
@@ -35,6 +52,7 @@ jobs:
           Write-Host "Main version: $version"
 
       - name: Compare versions
+        if: steps.changes.outputs.code == 'true'
         env:
           PR_VERSION: ${{ steps.pr.outputs.VERSION }}
           MAIN_VERSION: ${{ steps.main.outputs.VERSION }}
@@ -46,3 +64,7 @@ jobs:
             exit 1
           fi
           echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"
+
+      - name: Skip notice
+        if: steps.changes.outputs.code != 'true'
+        run: echo "Only documentation (*.md) files changed — version bump check skipped."


### PR DESCRIPTION
## Summary

Documentation-only `dev → main` PRs (e.g. the v2.11.0 CHANGELOG correction in #967) don't bump the version, so `check-version-bump` failed and needed an admin override to merge — and threw a failure email each time.

This gates the version comparison on whether any non-`*.md` file changed, using `dorny/paths-filter` (already used in `build.yml`).

- **Code PRs** — version comparison runs exactly as before.
- **Doc-only PRs** — comparison steps are skipped, a "Skip notice" step runs instead, the job completes successfully.

Deliberately **not** using `paths-ignore` at the trigger level: `check-version` gates merges, so skipping the run entirely would leave the required check stuck pending. Keeping the workflow running and conditionally skipping the failing step means the check still reports — green — for doc-only PRs.

## Note

The `dev → main` PR that carries this fix to main will *itself* still fail `check-version` once (it changes a workflow file, not a doc file, with no version bump) and needs one admin merge to bootstrap. Every doc-only PR after that is clean.

## Test plan

- [x] YAML structure mirrors the existing `dorny/paths-filter` usage in `build.yml`
- [ ] Confirm on first doc-only PR after merge that `check-version` reports green

🤖 Generated with [Claude Code](https://claude.com/claude-code)