### PR TITLE
Skip build/test/publish for documentation-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,16 @@ jobs:
               - 'Installer.Tests/**'
               - 'install/**'
               - 'upgrades/**'
+            # True when any non-documentation file changed. Documentation-only
+            # changes (e.g. a CHANGELOG or README edit) skip the build/test/
+            # publish steps below — there is nothing to compile. The job still
+            # runs so the required 'build' check reports a result.
+            code:
+              - '**'
+              - '!**/*.md'
 
       - name: Setup .NET 10.0
+        if: steps.filter.outputs.code != 'false'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -53,6 +61,7 @@ jobs:
           cache-dependency-path: '**/packages.lock.json'
 
       - name: Restore dependencies
+        if: steps.filter.outputs.code != 'false'
         run: |
           dotnet restore Dashboard/Dashboard.csproj --locked-mode
           dotnet restore Lite/PerformanceMonitorLite.csproj --locked-mode
@@ -61,12 +70,15 @@ jobs:
           dotnet restore Installer.Tests/Installer.Tests.csproj --locked-mode
 
       - name: Build Lite.Tests
+        if: steps.filter.outputs.code != 'false'
         run: dotnet build Lite.Tests/Lite.Tests.csproj -c Release --no-restore
 
       - name: Build Installer.Tests
+        if: steps.filter.outputs.code != 'false'
         run: dotnet build Installer.Tests/Installer.Tests.csproj -c Release --no-restore
 
       - name: Run Lite fast tests
+        if: steps.filter.outputs.code != 'false'
         run: dotnet test Lite.Tests/Lite.Tests.csproj -c Release --no-build --verbosity normal --filter "FullyQualifiedName!~AnomalyDetectorTests&FullyQualifiedName!~FactCollectorTests&FullyQualifiedName!~FactCollectorMiseryTests&FullyQualifiedName!~BaselineProviderTests&FullyQualifiedName!~InferenceEngineTests&FullyQualifiedName!~ScenarioTests&FullyQualifiedName!~AnalysisServiceTests"
 
       - name: Run Lite analysis-heavy tests
@@ -78,6 +90,7 @@ jobs:
         run: dotnet test Installer.Tests/Installer.Tests.csproj -c Release --no-build --verbosity normal --filter "FullyQualifiedName!~VersionDetectionTests&FullyQualifiedName!~IdempotencyTests&FullyQualifiedName!~AdversarialTests"
 
       - name: Get version
+        if: steps.filter.outputs.code != 'false'
         id: version
         shell: pwsh
         run: |
@@ -85,6 +98,7 @@ jobs:
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
 
       - name: Publish Dashboard
+        if: steps.filter.outputs.code != 'false'
         run: dotnet publish Dashboard/Dashboard.csproj -c Release -o publish/Dashboard
 
       - name: Publish Dashboard (self-contained for Velopack)
@@ -92,6 +106,7 @@ jobs:
         run: dotnet publish Dashboard/Dashboard.csproj -c Release -r win-x64 --self-contained -o publish/Dashboard-velopack
 
       - name: Publish Lite
+        if: steps.filter.outputs.code != 'false'
         run: dotnet publish Lite/PerformanceMonitorLite.csproj -c Release -o publish/Lite
 
       - name: Publish Lite (self-contained for Velopack)
@@ -99,6 +114,7 @@ jobs:
         run: dotnet publish Lite/PerformanceMonitorLite.csproj -c Release -r win-x64 --self-contained -o publish/Lite-velopack
 
       - name: Publish CLI Installer
+        if: steps.filter.outputs.code != 'false'
         run: dotnet publish Installer/PerformanceMonitorInstaller.csproj -c Release
 
       - name: Package release artifacts


### PR DESCRIPTION
## Summary

A documentation-only change (CHANGELOG, README, etc.) triggered a full ~15-minute compile of Dashboard, Lite, and the Installer — pointless, since nothing compilable changed.

The existing `dorny/paths-filter` step now also computes a `code` output (true when any non-`*.md` file changed). The Setup/Restore/Build/Test/Publish steps are gated on `steps.filter.outputs.code != 'false'`.

- **Code PRs / pushes** — build runs exactly as before.
- **Doc-only PRs / pushes** — build/test/publish steps skip; the job runs only checkout + the filter and finishes in seconds. The `build` check still reports (green) because the job runs — not skipped at the workflow level, which would leave the required check stuck pending.
- **Release builds** — unaffected. The filter step doesn't run on `release` events, so `code` is empty and the gate (`code != 'false'`) treats empty as "run".

Same pattern as #968 (check-version-bump).

## Bootstrap note

The `dev → main` PR carrying this fix changes a workflow file (not a doc), so `check-version` runs and fails once — needs one admin merge. (After this, doc-only PRs are clean on both checks.)

## Test plan

- [x] `yaml.safe_load` parses clean
- [x] Release path traced: filter skipped on release → `code` empty → `'' != 'false'` → all build steps run
- [ ] Confirm on first doc-only PR after merge that `build` reports green in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)