### PR TITLE
Fix query_snapshots compaction OOM with per-table tuning (#933)

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -246,150 +246,6 @@ COPY (
         }
     }
 
-    /* Columns to exclude during compaction — dead weight from legacy archives */
-    private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
-    {
-        ["query_store_stats"] = ["query_plan_text"]
-    };
-
-    /* Maximum total on-disk parquet bytes per compaction merge batch. Wide-VARCHAR
-       tables (query_snapshots) expand 5-10x on read; this cap keeps the in-memory
-       working set during a COPY well below the 4 GB compaction memory_limit even
-       on the worst data shapes. Groups exceeding this budget produce multiple
-       _ptNNN.parquet output files. See #933 followup — a 72-file query_snapshots
-       backlog at 4 GB OOM'd on real allocation pressure during the final merge. */
-    private const long MaxBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
-
-    /* Greedily group <paramref name="sortedPaths"/> (smallest-first) into batches
-       whose total on-disk bytes don't exceed <paramref name="maxBytes"/>. A single
-       file larger than the cap becomes its own one-element batch — that's the
-       degenerate case (the cap can't split an individual file) and the caller
-       handles it as a single-file pass-through merge. */
-    private static List<List<string>> BuildSizeBudgetedBatches(IReadOnlyList<string> sortedPaths, long maxBytes)
-    {
-        var batches = new List<List<string>>();
-        var current = new List<string>();
-        long currentBytes = 0;
-
-        foreach (var p in sortedPaths)
-        {
-            var size = new FileInfo(p.Replace("/", "\\")).Length;
-            if (currentBytes + size > maxBytes && current.Count > 0)
-            {
-                batches.Add(current);
-                current = new List<string>();
-                currentBytes = 0;
-            }
-            current.Add(p);
-            currentBytes += size;
-        }
-        if (current.Count > 0)
-        {
-            batches.Add(current);
-        }
-
-        return batches;
-    }
-
-    /* Merge one size-budgeted batch into <paramref name="outputPath"/>. The pragma
-       block matches the compaction tuning from #933:
-         - memory_limit = 4GB: parquet COPY does allocations that bypass the buffer
-           manager and can't be spilled. The cap is a hard ceiling for those, not
-           a spill trigger. 4GB leaves real headroom for wide-VARCHAR data within
-           the batch-size budget. Aligns with DuckDB's OOM guide (50-60% of RAM).
-         - threads = 2: fewer per-thread row-group buffers in flight.
-         - ROW_GROUP_SIZE 8192: smaller buffered batch per row group.
-         - preserve_insertion_order = false: lets DuckDB stream.
-       See tools/CompactionRepro for the stress reproducer. */
-    private void MergeBatchToFile(string table, List<string> sourcePaths, string outputPath, string spillDirSql)
-    {
-        if (sourcePaths.Count <= 2)
-        {
-            /* Small batch — single-pass merge (also covers the degenerate 1-file case). */
-            using var con = new DuckDBConnection("DataSource=:memory:");
-            con.Open();
-            using (var pragma = con.CreateCommand())
-            {
-                pragma.CommandText = $"SET memory_limit = '4GB'; SET threads = 2; SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";
-                pragma.ExecuteNonQuery();
-            }
-
-            var selectClause = BuildSelectClause(table, sourcePaths);
-            var pathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
-            using var cmd = con.CreateCommand();
-            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pathList}], union_by_name=true)) " +
-                              $"TO '{EscapeSqlPath(outputPath)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 8192)";
-            cmd.ExecuteNonQuery();
-            return;
-        }
-
-        /* Larger batch — incremental pairwise merge. Caller has already sorted
-           smallest-first across the whole group; within a batch we preserve that
-           order so the accumulator grows steadily and small files are folded in
-           early when memory is cheapest. */
-        var currentPath = sourcePaths[0];
-        var intermediateFiles = new List<string>();
-
-        for (var i = 1; i < sourcePaths.Count; i++)
-        {
-            var stepOutput = i < sourcePaths.Count - 1
-                ? outputPath + $".step{i}.tmp"
-                : outputPath;
-
-            using var con = new DuckDBConnection("DataSource=:memory:");
-            con.Open();
-            using (var pragma = con.CreateCommand())
-            {
-                pragma.CommandText = $"SET memory_limit = '4GB'; SET threads = 2; SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";
-                pragma.ExecuteNonQuery();
-            }
-
-            var selectClause = BuildSelectClause(table, new[] { currentPath, sourcePaths[i] });
-            var pairList = $"'{EscapeSqlPath(currentPath)}', '{EscapeSqlPath(sourcePaths[i])}'";
-            using var cmd = con.CreateCommand();
-            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pairList}], union_by_name=true)) " +
-                              $"TO '{EscapeSqlPath(stepOutput)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 8192)";
-            cmd.ExecuteNonQuery();
-
-            if (intermediateFiles.Count > 0)
-            {
-                var prev = intermediateFiles[^1];
-                try { File.Delete(prev); } catch { /* best effort */ }
-            }
-            intermediateFiles.Add(stepOutput);
-            currentPath = stepOutput;
-        }
-    }
-
-    /* Build the SELECT clause for a compaction COPY, excluding only the
-       CompactionExcludeColumns actually present in THIS set of files.
-       Detection must be per-merge-set, not global: archive files predating a
-       schema change lack the column, so a globally-computed "* EXCLUDE (col)"
-       fails the binder on a pair where neither file has it. query_plan_text
-       was added to query_store_stats in migration v13 (2026-02-23), so a
-       reporter's pre-v13 archives don't carry it. (#933) */
-    private static string BuildSelectClause(string table, IReadOnlyList<string> paths)
-    {
-        if (!CompactionExcludeColumns.TryGetValue(table, out var excludeCols))
-        {
-            return "*";
-        }
-
-        using var schemaCon = new DuckDBConnection("DataSource=:memory:");
-        schemaCon.Open();
-        var pathList = string.Join(", ", paths.Select(p => $"'{EscapeSqlPath(p)}'"));
-        using var schemaCmd = schemaCon.CreateCommand();
-        schemaCmd.CommandText = $"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet([{pathList}], union_by_name=true))";
-        using var reader = schemaCmd.ExecuteReader();
-        var existingCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        while (reader.Read()) existingCols.Add(reader.GetString(0));
-
-        var colsToExclude = excludeCols.Where(c => existingCols.Contains(c)).ToArray();
-        return colsToExclude.Length > 0
-            ? $"* EXCLUDE ({string.Join(", ", colsToExclude)})"
-            : "*";
-    }
-
     /// <summary>
     /// Compacts all per-cycle parquet files into monthly files (YYYYMM_tablename.parquet).
     /// This keeps the archive directory small (~75 files for 3 months of 25 tables)
@@ -580,7 +436,7 @@ COPY (
                    (not pre-reservation) — see #933 followup. The cap is sized so
                    that even with ~10x expansion the in-memory load stays well under
                    4 GB. Narrow tables fit one batch with hundreds of files in it. */
-                var batches = BuildSizeBudgetedBatches(sorted, MaxBatchInputBytes);
+                var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, ParquetCompaction.MaxBatchInputBytes);
 
                 /* Plan the output names. With one batch we keep the existing
                    YYYYMM_table.parquet name (backward compatible). With multiple
@@ -601,7 +457,7 @@ COPY (
                    place for next cycle's retry. */
                 for (var i = 0; i < batches.Count; i++)
                 {
-                    MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql);
+                    ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql);
                 }
 
                 /* All batches succeeded — delete originals, promote temps. */

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -428,15 +428,13 @@ COPY (
                     .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
                     .ToList();
 
-                /* Bucket files into size-budgeted batches. Cap each batch's on-disk
-                   parquet bytes so a single COPY doesn't try to merge an unbounded
-                   amount of expanded VARCHAR data. Wide-row tables (query_snapshots'
-                   plan XML) expand ~5-10x in memory on read; a 72-file backlog at
-                   the 4 GB compaction memory_limit OOM'd on real allocation pressure
-                   (not pre-reservation) — see #933 followup. The cap is sized so
-                   that even with ~10x expansion the in-memory load stays well under
-                   4 GB. Narrow tables fit one batch with hundreds of files in it. */
-                var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, ParquetCompaction.MaxBatchInputBytes);
+                /* Bucket files into size-budgeted batches so a single COPY never
+                   merges an unbounded amount of expanded VARCHAR data. The budget
+                   and row-group size are per-table: query_snapshots' plan XML
+                   expands ~30x on read and OOMs a 4 GB connection at the defaults,
+                   so it gets a tighter budget (see ParquetCompaction.PerTableCompaction
+                   and #933). Narrow tables fit one batch with hundreds of files. */
+                var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, ParquetCompaction.BatchBudgetFor(table));
 
                 /* Plan the output names. With one batch we keep the existing
                    YYYYMM_table.parquet name (backward compatible). With multiple
@@ -457,7 +455,8 @@ COPY (
                    place for next cycle's retry. */
                 for (var i = 0; i < batches.Count; i++)
                 {
-                    ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql);
+                    ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql,
+                        rowGroupSize: ParquetCompaction.RowGroupSizeFor(table));
                 }
 
                 /* All batches succeeded — delete originals, promote temps. */

--- a/Lite/Services/ParquetCompaction.cs
+++ b/Lite/Services/ParquetCompaction.cs
@@ -152,6 +152,36 @@ public static class ParquetCompaction
         }
     }
 
+    /* Single-pass merge: one COPY over the whole batch. Unlike the pairwise path
+       in MergeBatchToFile, this never materializes a growing accumulator and
+       never re-reads re-packed row groups — DuckDB streams the multi-file parquet
+       scan straight into the writer. Under evaluation for #933; tools/CompactionRepro
+       --merge-mode single exercises it. */
+    public static void MergeBatchSingleCopy(
+        string table,
+        List<string> sourcePaths,
+        string outputPath,
+        string spillDirSql,
+        string memoryLimit = DefaultMemoryLimit,
+        int threads = DefaultThreads,
+        int rowGroupSize = DefaultRowGroupSize)
+    {
+        using var con = new DuckDBConnection("DataSource=:memory:");
+        con.Open();
+        using (var pragmaCmd = con.CreateCommand())
+        {
+            pragmaCmd.CommandText = BuildPragma(memoryLimit, threads, spillDirSql);
+            pragmaCmd.ExecuteNonQuery();
+        }
+
+        var selectClause = BuildSelectClause(table, sourcePaths);
+        var pathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pathList}], union_by_name=true)) " +
+                          $"TO '{EscapeSqlPath(outputPath)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
+        cmd.ExecuteNonQuery();
+    }
+
     private static string BuildPragma(string memoryLimit, int threads, string spillDirSql) =>
         $"SET memory_limit = '{memoryLimit}'; SET threads = {threads}; " +
         $"SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";

--- a/Lite/Services/ParquetCompaction.cs
+++ b/Lite/Services/ParquetCompaction.cs
@@ -1,0 +1,187 @@
+/*
+ * ParquetCompaction — the parquet merge logic used by ArchiveService.CompactParquetFiles.
+ *
+ * Extracted into a standalone, dependency-free static class so the standalone
+ * reproducer (tools/CompactionRepro) can link this exact source and exercise
+ * the *real* production merge path. Before this extraction the reproducer kept
+ * its own hand-copied merge loops, which silently drifted from production —
+ * fixes "passed the repro" while still OOMing on real installs (see #933).
+ *
+ * This file must stay free of DI, logging, and project dependencies: it is
+ * compiled into both the Lite assembly and the CompactionRepro assembly.
+ */
+
+using System.IO;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public static class ParquetCompaction
+{
+    /* Production tuning for the compaction merge connections (#933 followup).
+       The reproducer overrides these to sweep values; ArchiveService uses the
+       defaults so the production knobs live in exactly one place. */
+    public const string DefaultMemoryLimit = "4GB";
+    public const int DefaultThreads = 2;
+    public const int DefaultRowGroupSize = 8192;
+
+    /* Maximum total on-disk parquet bytes per compaction merge batch. Wide-VARCHAR
+       tables (query_snapshots) expand 5-10x on read; this cap keeps the in-memory
+       working set during a COPY well below the 4 GB compaction memory_limit even
+       on the worst data shapes. Groups exceeding this budget produce multiple
+       _ptNNN.parquet output files. See #933 followup — a 72-file query_snapshots
+       backlog at 4 GB OOM'd on real allocation pressure during the final merge. */
+    public const long MaxBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
+
+    /* Columns to exclude during compaction — dead weight from legacy archives */
+    private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
+    {
+        ["query_store_stats"] = ["query_plan_text"]
+    };
+
+    private static string EscapeSqlPath(string path) => path.Replace("'", "''");
+
+    /* Greedily group <paramref name="sortedPaths"/> (smallest-first) into batches
+       whose total on-disk bytes don't exceed <paramref name="maxBytes"/>. A single
+       file larger than the cap becomes its own one-element batch — that's the
+       degenerate case (the cap can't split an individual file) and the caller
+       handles it as a single-file pass-through merge. */
+    public static List<List<string>> BuildSizeBudgetedBatches(IReadOnlyList<string> sortedPaths, long maxBytes)
+    {
+        var batches = new List<List<string>>();
+        var current = new List<string>();
+        long currentBytes = 0;
+
+        foreach (var p in sortedPaths)
+        {
+            var size = new FileInfo(p.Replace("/", "\\")).Length;
+            if (currentBytes + size > maxBytes && current.Count > 0)
+            {
+                batches.Add(current);
+                current = new List<string>();
+                currentBytes = 0;
+            }
+            current.Add(p);
+            currentBytes += size;
+        }
+        if (current.Count > 0)
+        {
+            batches.Add(current);
+        }
+
+        return batches;
+    }
+
+    /* Merge one size-budgeted batch into <paramref name="outputPath"/>. The pragma
+       block matches the compaction tuning from #933:
+         - memory_limit = 4GB: parquet COPY does allocations that bypass the buffer
+           manager and can't be spilled. The cap is a hard ceiling for those, not
+           a spill trigger. 4GB leaves real headroom for wide-VARCHAR data within
+           the batch-size budget. Aligns with DuckDB's OOM guide (50-60% of RAM).
+         - threads = 2: fewer per-thread row-group buffers in flight.
+         - ROW_GROUP_SIZE 8192: smaller buffered batch per row group.
+         - preserve_insertion_order = false: lets DuckDB stream.
+       The memoryLimit/threads/rowGroupSize parameters exist so tools/CompactionRepro
+       can sweep them; production callers omit them and get the defaults above. */
+    public static void MergeBatchToFile(
+        string table,
+        List<string> sourcePaths,
+        string outputPath,
+        string spillDirSql,
+        string memoryLimit = DefaultMemoryLimit,
+        int threads = DefaultThreads,
+        int rowGroupSize = DefaultRowGroupSize)
+    {
+        var pragma = BuildPragma(memoryLimit, threads, spillDirSql);
+
+        if (sourcePaths.Count <= 2)
+        {
+            /* Small batch — single-pass merge (also covers the degenerate 1-file case). */
+            using var con = new DuckDBConnection("DataSource=:memory:");
+            con.Open();
+            using (var pragmaCmd = con.CreateCommand())
+            {
+                pragmaCmd.CommandText = pragma;
+                pragmaCmd.ExecuteNonQuery();
+            }
+
+            var selectClause = BuildSelectClause(table, sourcePaths);
+            var pathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pathList}], union_by_name=true)) " +
+                              $"TO '{EscapeSqlPath(outputPath)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
+            cmd.ExecuteNonQuery();
+            return;
+        }
+
+        /* Larger batch — incremental pairwise merge. Caller has already sorted
+           smallest-first across the whole group; within a batch we preserve that
+           order so the accumulator grows steadily and small files are folded in
+           early when memory is cheapest. */
+        var currentPath = sourcePaths[0];
+        var intermediateFiles = new List<string>();
+
+        for (var i = 1; i < sourcePaths.Count; i++)
+        {
+            var stepOutput = i < sourcePaths.Count - 1
+                ? outputPath + $".step{i}.tmp"
+                : outputPath;
+
+            using var con = new DuckDBConnection("DataSource=:memory:");
+            con.Open();
+            using (var pragmaCmd = con.CreateCommand())
+            {
+                pragmaCmd.CommandText = pragma;
+                pragmaCmd.ExecuteNonQuery();
+            }
+
+            var selectClause = BuildSelectClause(table, new[] { currentPath, sourcePaths[i] });
+            var pairList = $"'{EscapeSqlPath(currentPath)}', '{EscapeSqlPath(sourcePaths[i])}'";
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pairList}], union_by_name=true)) " +
+                              $"TO '{EscapeSqlPath(stepOutput)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
+            cmd.ExecuteNonQuery();
+
+            if (intermediateFiles.Count > 0)
+            {
+                var prev = intermediateFiles[^1];
+                try { File.Delete(prev); } catch { /* best effort */ }
+            }
+            intermediateFiles.Add(stepOutput);
+            currentPath = stepOutput;
+        }
+    }
+
+    private static string BuildPragma(string memoryLimit, int threads, string spillDirSql) =>
+        $"SET memory_limit = '{memoryLimit}'; SET threads = {threads}; " +
+        $"SET preserve_insertion_order = false; SET temp_directory = '{EscapeSqlPath(spillDirSql)}';";
+
+    /* Build the SELECT clause for a compaction COPY, excluding only the
+       CompactionExcludeColumns actually present in THIS set of files.
+       Detection must be per-merge-set, not global: archive files predating a
+       schema change lack the column, so a globally-computed "* EXCLUDE (col)"
+       fails the binder on a pair where neither file has it. query_plan_text
+       was added to query_store_stats in migration v13 (2026-02-23), so a
+       reporter's pre-v13 archives don't carry it. (#933) */
+    private static string BuildSelectClause(string table, IReadOnlyList<string> paths)
+    {
+        if (!CompactionExcludeColumns.TryGetValue(table, out var excludeCols))
+        {
+            return "*";
+        }
+
+        using var schemaCon = new DuckDBConnection("DataSource=:memory:");
+        schemaCon.Open();
+        var pathList = string.Join(", ", paths.Select(p => $"'{EscapeSqlPath(p)}'"));
+        using var schemaCmd = schemaCon.CreateCommand();
+        schemaCmd.CommandText = $"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet([{pathList}], union_by_name=true))";
+        using var reader = schemaCmd.ExecuteReader();
+        var existingCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (reader.Read()) existingCols.Add(reader.GetString(0));
+
+        var colsToExclude = excludeCols.Where(c => existingCols.Contains(c)).ToArray();
+        return colsToExclude.Length > 0
+            ? $"* EXCLUDE ({string.Join(", ", colsToExclude)})"
+            : "*";
+    }
+}

--- a/Lite/Services/ParquetCompaction.cs
+++ b/Lite/Services/ParquetCompaction.cs
@@ -18,20 +18,39 @@ namespace PerformanceMonitorLite.Services;
 
 public static class ParquetCompaction
 {
-    /* Production tuning for the compaction merge connections (#933 followup).
-       The reproducer overrides these to sweep values; ArchiveService uses the
-       defaults so the production knobs live in exactly one place. */
+    /* Production tuning for the compaction merge connections (#933).
+       memoryLimit/threads/rowGroupSize are exposed as MergeBatchToFile parameters
+       so tools/CompactionRepro can sweep them; production callers pass the
+       per-table values from BatchBudgetFor / RowGroupSizeFor below. */
     public const string DefaultMemoryLimit = "4GB";
     public const int DefaultThreads = 2;
     public const int DefaultRowGroupSize = 8192;
 
-    /* Maximum total on-disk parquet bytes per compaction merge batch. Wide-VARCHAR
-       tables (query_snapshots) expand 5-10x on read; this cap keeps the in-memory
-       working set during a COPY well below the 4 GB compaction memory_limit even
-       on the worst data shapes. Groups exceeding this budget produce multiple
-       _ptNNN.parquet output files. See #933 followup — a 72-file query_snapshots
-       backlog at 4 GB OOM'd on real allocation pressure during the final merge. */
-    public const long MaxBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
+    /* Default on-disk parquet bytes per compaction merge batch. A group whose
+       files exceed this budget is merged in multiple passes, each producing a
+       _ptNNN.parquet output file. */
+    public const long DefaultBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
+
+    /* Per-table compaction overrides. query_snapshots stores query-plan XML that
+       expands ~30x on read; at the default 200 MB batch / 8192 row-group size the
+       merge OOMs a 4 GB connection (#933). Validated on a real 100-file / 15 GB-
+       uncompressed backlog: 100 MB batches at ROW_GROUP_SIZE 2048 compact it in
+       ~27 s with ~1.8 GB headroom under the cap, producing ~6 monthly part files.
+       Only wide-XML tables need this; numeric tables merge fine at the defaults. */
+    private static readonly Dictionary<string, (long BatchBytes, int RowGroupSize)> PerTableCompaction = new()
+    {
+        ["query_snapshots"] = (100L * 1024 * 1024, 2048)
+    };
+
+    /* On-disk batch budget for <paramref name="table"/> — the per-table override
+       if one exists, otherwise the default. */
+    public static long BatchBudgetFor(string table) =>
+        PerTableCompaction.TryGetValue(table, out var c) ? c.BatchBytes : DefaultBatchInputBytes;
+
+    /* Output ROW_GROUP_SIZE for <paramref name="table"/> — the per-table override
+       if one exists, otherwise the default. */
+    public static int RowGroupSizeFor(string table) =>
+        PerTableCompaction.TryGetValue(table, out var c) ? c.RowGroupSize : DefaultRowGroupSize;
 
     /* Columns to exclude during compaction — dead weight from legacy archives */
     private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
@@ -72,92 +91,27 @@ public static class ParquetCompaction
         return batches;
     }
 
-    /* Merge one size-budgeted batch into <paramref name="outputPath"/>. The pragma
-       block matches the compaction tuning from #933:
-         - memory_limit = 4GB: parquet COPY does allocations that bypass the buffer
-           manager and can't be spilled. The cap is a hard ceiling for those, not
-           a spill trigger. 4GB leaves real headroom for wide-VARCHAR data within
-           the batch-size budget. Aligns with DuckDB's OOM guide (50-60% of RAM).
+    /* Merge one size-budgeted batch into <paramref name="outputPath"/> with a
+       single COPY over the whole batch. DuckDB streams the multi-file parquet
+       scan straight into the writer — no growing accumulator, no re-reading
+       re-packed row groups.
+
+       #933 replaced an incremental pairwise merge here: on a real 100-file
+       backlog the pairwise path was ~5x slower (it re-read an ever-larger
+       accumulator file every step) and OOM-prone. A sweep on the reporter's
+       actual data confirmed a single COPY at the per-table row-group size is
+       both faster and stays within the memory cap.
+
+       Pragma tuning:
+         - memory_limit = 4GB: parquet COPY makes allocations that bypass the
+           buffer manager and can't spill; the cap is a hard ceiling, not a
+           spill trigger. Pair it with the per-table batch budget (BatchBudgetFor)
+           and row-group size (RowGroupSizeFor) so the working set stays under it.
          - threads = 2: fewer per-thread row-group buffers in flight.
-         - ROW_GROUP_SIZE 8192: smaller buffered batch per row group.
          - preserve_insertion_order = false: lets DuckDB stream.
-       The memoryLimit/threads/rowGroupSize parameters exist so tools/CompactionRepro
-       can sweep them; production callers omit them and get the defaults above. */
+       The memoryLimit/threads/rowGroupSize parameters let tools/CompactionRepro
+       sweep them; production passes the per-table values. */
     public static void MergeBatchToFile(
-        string table,
-        List<string> sourcePaths,
-        string outputPath,
-        string spillDirSql,
-        string memoryLimit = DefaultMemoryLimit,
-        int threads = DefaultThreads,
-        int rowGroupSize = DefaultRowGroupSize)
-    {
-        var pragma = BuildPragma(memoryLimit, threads, spillDirSql);
-
-        if (sourcePaths.Count <= 2)
-        {
-            /* Small batch — single-pass merge (also covers the degenerate 1-file case). */
-            using var con = new DuckDBConnection("DataSource=:memory:");
-            con.Open();
-            using (var pragmaCmd = con.CreateCommand())
-            {
-                pragmaCmd.CommandText = pragma;
-                pragmaCmd.ExecuteNonQuery();
-            }
-
-            var selectClause = BuildSelectClause(table, sourcePaths);
-            var pathList = string.Join(", ", sourcePaths.Select(p => $"'{EscapeSqlPath(p)}'"));
-            using var cmd = con.CreateCommand();
-            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pathList}], union_by_name=true)) " +
-                              $"TO '{EscapeSqlPath(outputPath)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
-            cmd.ExecuteNonQuery();
-            return;
-        }
-
-        /* Larger batch — incremental pairwise merge. Caller has already sorted
-           smallest-first across the whole group; within a batch we preserve that
-           order so the accumulator grows steadily and small files are folded in
-           early when memory is cheapest. */
-        var currentPath = sourcePaths[0];
-        var intermediateFiles = new List<string>();
-
-        for (var i = 1; i < sourcePaths.Count; i++)
-        {
-            var stepOutput = i < sourcePaths.Count - 1
-                ? outputPath + $".step{i}.tmp"
-                : outputPath;
-
-            using var con = new DuckDBConnection("DataSource=:memory:");
-            con.Open();
-            using (var pragmaCmd = con.CreateCommand())
-            {
-                pragmaCmd.CommandText = pragma;
-                pragmaCmd.ExecuteNonQuery();
-            }
-
-            var selectClause = BuildSelectClause(table, new[] { currentPath, sourcePaths[i] });
-            var pairList = $"'{EscapeSqlPath(currentPath)}', '{EscapeSqlPath(sourcePaths[i])}'";
-            using var cmd = con.CreateCommand();
-            cmd.CommandText = $"COPY (SELECT {selectClause} FROM read_parquet([{pairList}], union_by_name=true)) " +
-                              $"TO '{EscapeSqlPath(stepOutput)}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
-            cmd.ExecuteNonQuery();
-
-            if (intermediateFiles.Count > 0)
-            {
-                var prev = intermediateFiles[^1];
-                try { File.Delete(prev); } catch { /* best effort */ }
-            }
-            intermediateFiles.Add(stepOutput);
-            currentPath = stepOutput;
-        }
-    }
-
-    /* Single-pass merge: one COPY over the whole batch. Unlike the pairwise path
-       in MergeBatchToFile, this never materializes a growing accumulator and
-       never re-reads re-packed row groups — DuckDB streams the multi-file parquet
-       scan straight into the writer. Under evaluation for #933; tools/CompactionRepro
-       --merge-mode single exercises it. */
-    public static void MergeBatchSingleCopy(
         string table,
         List<string> sourcePaths,
         string outputPath,

--- a/tools/CompactionRepro/CompactionRepro.csproj
+++ b/tools/CompactionRepro/CompactionRepro.csproj
@@ -14,4 +14,12 @@
     <PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
     <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.5.2" />
   </ItemGroup>
+
+  <!-- Link the real production compaction code so the reproducer exercises the
+       exact merge path ArchiveService runs. Do NOT re-copy this logic here —
+       the whole point of #933's repro rework is that the repro stops drifting
+       from production. -->
+  <ItemGroup>
+    <Compile Include="..\..\Lite\Services\ParquetCompaction.cs" Link="ParquetCompaction.cs" />
+  </ItemGroup>
 </Project>

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -1,47 +1,52 @@
 using System.Diagnostics;
 using DuckDB.NET.Data;
+using PerformanceMonitorLite.Services;
 
 /*
  * CompactionRepro — standalone reproducer for issue #933.
  *
- * Splits an existing monthly parquet file (like 202604_query_snapshots.parquet)
- * into N per-cycle-shaped chunks, then runs ArchiveService.CompactParquetFiles'
- * merge logic with knobs you can flip on the command line. The split chunks
- * have the exact row shape that caused the user's OOM in #933.
+ * Runs the *real* production compaction merge code against a set of parquet
+ * files and reports memory behavior + pass/fail.
  *
- * Two merge strategies:
- *   accumulator (current prod) — sort smallest-first, fold each next file
- *                                into a growing accumulator. Peak input size
- *                                grows linearly with file count.
- *   tournament  (proposed fix) — pair files in rounds; each round halves the
- *                                file count. Each merge step's inputs stay
- *                                balanced. Final round still merges ~all the
- *                                data but every intermediate step is smaller.
+ * IMPORTANT: this tool does NOT reimplement the merge. It links the actual
+ * production source (Lite/Services/ParquetCompaction.cs, via a <Compile Link>
+ * in the csproj) and calls ParquetCompaction.BuildSizeBudgetedBatches +
+ * MergeBatchToFile directly — the same calls ArchiveService.CompactParquetFiles
+ * makes. Earlier versions of this repro kept hand-copied merge loops that
+ * silently drifted from production; fixes "passed the repro" and still OOM'd on
+ * real installs. If you change the merge algorithm, change it in
+ * ParquetCompaction.cs and this tool picks it up automatically.
  *
- * Usage:
- *   dotnet run -- --source-file <path> [options]
+ * Input sources (pick one):
+ *   --source-file <path>   Split an existing monthly parquet into N per-cycle
+ *                          chunks, then compact. Closest to a real backlog.
+ *   --merge-files <a,b,..> Compact the given files directly (no split). Use this
+ *                          to run against a reporter's actual archive files.
+ *   --synthetic            Generate a query_snapshots-shaped source, then split.
  *
- * Options:
- *   --source-file <path>     Required. Path to a monthly parquet file to split & merge.
- *   --strategy <str>         accumulator | tournament. Default: tournament
- *   --memory-limit <str>     DuckDB memory_limit (e.g. "1GB", "4GB"). Default: 1GB
- *   --threads <int>          DuckDB threads. 0 = DuckDB default. Default: 1
- *   --row-group-size <int>   Output ROW_GROUP_SIZE. Default: 8192
- *   --num-files <int>        Number of split chunks. Default: 15
- *   --keep                   Don't delete temp dir after run (for inspection)
+ * Tuning knobs (defaults = current production values from ParquetCompaction):
+ *   --memory-limit <str>   DuckDB memory_limit per merge connection. Default: 4GB
+ *   --threads <int>        DuckDB threads per merge connection. Default: 2
+ *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: 8192
+ *   --max-batch-mb <int>   Per-batch on-disk input budget (MB). Default: 200
+ *   --table <name>         Table name (drives exclude-column logic). Default: query_snapshots
+ *
+ * Other options:
+ *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
+ *   --synthetic-rows <int> Synthetic row count. Default: 30000
+ *   --synthetic-plan-kb <n> Synthetic plan XML KB per row. Default: 100
+ *   --cycles <int>         Re-run the full compaction N times (memory-release test). Default: 1
+ *   --keep                 Don't delete the temp dir after the run.
  *
  * Examples:
- *   # Proposed fix: tournament merge, threads=1
- *   dotnet run -- --source-file "$LOCALAPPDATA/PerformanceMonitorLite/archive/202604_query_snapshots.parquet" \
- *                 --strategy tournament --threads 1
+ *   # Run against a reporter's actual failing files
+ *   dotnet run -c Release -- --merge-files "C:/archive/20260501_query_snapshots.parquet,C:/archive/202605_query_snapshots.parquet"
  *
- *   # Reproduce the current OOM: accumulator + threads=2 (matches prod after #942)
- *   dotnet run -- --source-file "$LOCALAPPDATA/PerformanceMonitorLite/archive/202604_query_snapshots.parquet" \
- *                 --strategy accumulator --threads 2
+ *   # Reproduce the production path on a real monthly file split into 88 chunks
+ *   dotnet run -c Release -- --source-file "%LOCALAPPDATA%/PerformanceMonitorLite/archive/202605_query_snapshots.parquet" --num-files 88
  *
- *   # Isolate the thread-count effect on the existing accumulator strategy
- *   dotnet run -- --source-file "$LOCALAPPDATA/PerformanceMonitorLite/archive/202604_query_snapshots.parquet" \
- *                 --strategy accumulator --threads 1
+ *   # Sweep the batch budget down to find a value query_snapshots survives
+ *   dotnet run -c Release -- --source-file ".../202605_query_snapshots.parquet" --num-files 88 --max-batch-mb 40
  */
 
 var sourceFile = GetArg(args, "--source-file", "");
@@ -53,7 +58,7 @@ if (string.IsNullOrEmpty(sourceFile) && string.IsNullOrEmpty(mergeFilesArg) && !
 {
     Console.Error.WriteLine("error: --source-file <path> OR --merge-files <a.parquet,...> OR --synthetic required");
     Console.Error.WriteLine("  --source-file:  split the given monthly parquet into chunks, then compact (full repro)");
-    Console.Error.WriteLine("  --merge-files:  merge the given comma-separated files directly (skip split)");
+    Console.Error.WriteLine("  --merge-files:  compact the given comma-separated files directly (skip split)");
     Console.Error.WriteLine("  --synthetic:    generate a query_snapshots-shaped source file (see --synthetic-rows, --synthetic-plan-kb)");
     return 2;
 }
@@ -63,21 +68,12 @@ if (!string.IsNullOrEmpty(sourceFile) && !File.Exists(sourceFile))
     return 2;
 }
 
-var strategy = GetArg(args, "--strategy", "tournament").ToLowerInvariant();
-if (strategy != "accumulator" && strategy != "tournament")
-{
-    Console.Error.WriteLine($"error: --strategy must be 'accumulator' or 'tournament', got '{strategy}'");
-    return 2;
-}
-var dbMode = GetArg(args, "--db-mode", "memory").ToLowerInvariant();
-if (dbMode != "memory" && dbMode != "file")
-{
-    Console.Error.WriteLine($"error: --db-mode must be 'memory' or 'file', got '{dbMode}'");
-    return 2;
-}
-var memoryLimit = GetArg(args, "--memory-limit", "1GB");
-var threads = int.Parse(GetArg(args, "--threads", "1"));
-var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", "8192"));
+var table = GetArg(args, "--table", "query_snapshots");
+var memoryLimit = GetArg(args, "--memory-limit", ParquetCompaction.DefaultMemoryLimit);
+var threads = int.Parse(GetArg(args, "--threads", ParquetCompaction.DefaultThreads.ToString()));
+var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.DefaultRowGroupSize.ToString()));
+var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.MaxBatchInputBytes / (1024 * 1024)).ToString()));
+var maxBatchBytes = maxBatchMb * 1024L * 1024L;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
 var cycles = int.Parse(GetArg(args, "--cycles", "1"));
 var keep = args.Contains("--keep");
@@ -96,6 +92,7 @@ foreach (var mf in mergeFiles)
         return 2;
     }
 }
+
 if (synthetic)
 {
     sourceFile = Path.Combine(tempDir, "synthetic_query_snapshots.parquet").Replace("\\", "/");
@@ -105,7 +102,7 @@ if (synthetic)
 }
 else if (mergeFiles.Count > 0)
 {
-    Console.WriteLine($"Mode:     merge-files (no split, isolate compaction)");
+    Console.WriteLine($"Mode:     merge-files (no split — real files)");
     Console.WriteLine($"Inputs:");
     foreach (var mf in mergeFiles)
         Console.WriteLine($"  {mf} ({new FileInfo(mf).Length / 1024.0 / 1024.0:F1} MB)");
@@ -116,7 +113,6 @@ else
     Console.WriteLine($"Source:   {sourceFile} ({new FileInfo(sourceFile).Length / 1024.0 / 1024.0:F1} MB)");
 }
 Console.WriteLine($"Temp dir: {tempDir}");
-/* Print engine version so we can correlate with standalone DuckDB CLI tests */
 using (var versionCon = new DuckDBConnection("DataSource=:memory:"))
 {
     versionCon.Open();
@@ -124,9 +120,9 @@ using (var versionCon = new DuckDBConnection("DataSource=:memory:"))
     versionCmd.CommandText = "SELECT version()";
     Console.WriteLine($"Engine:   DuckDB {versionCmd.ExecuteScalar()}");
 }
-Console.WriteLine($"Strategy: {strategy}");
-Console.WriteLine($"DB mode:  {dbMode}");
-Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}");
+Console.WriteLine($"Code:     ParquetCompaction (linked from Lite/Services — real production merge)");
+Console.WriteLine($"Table:    {table}");
+Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
 if (mergeFiles.Count == 0)
     Console.WriteLine($"Splitting source into {numFiles} chunks");
 Console.WriteLine();
@@ -148,7 +144,7 @@ try
     if (mergeFiles.Count > 0)
     {
         Console.WriteLine($"[1/3] Skipping split — using {mergeFiles.Count} provided files");
-        sourcePaths = mergeFiles;
+        sourcePaths = mergeFiles.Select(p => p.Replace("\\", "/")).ToList();
     }
     else
     {
@@ -161,171 +157,90 @@ try
     }
     Console.WriteLine();
 
-    Console.WriteLine($"[2/3] Running pair-merge compaction (mirrors ArchiveService.CompactParquetFiles), {cycles} cycle(s)...");
+    /* Mirror ArchiveService.CompactParquetFiles: sort smallest-first, then bucket
+       into size-budgeted batches. This is the exact production sequencing. */
+    var sorted = sourcePaths
+        .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
+        .ToList();
+    var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, maxBatchBytes);
+    Console.WriteLine($"[2/3] BuildSizeBudgetedBatches: {sorted.Count} files -> {batches.Count} batch(es) at {maxBatchMb} MB budget");
+    for (var i = 0; i < batches.Count; i++)
+    {
+        var batchBytes = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
+        Console.WriteLine($"      batch {i + 1}: {batches[i].Count} files, {batchBytes / 1024.0 / 1024.0:F1} MB on disk");
+    }
+    Console.WriteLine();
+
+    Console.WriteLine($"[3/3] Running MergeBatchToFile per batch (real production code), {cycles} cycle(s)...");
     var spillDir = Path.Combine(tempDir, "duckdb_tmp").Replace("\\", "/");
     Directory.CreateDirectory(spillDir);
 
-    var targetPath = Path.Combine(tempDir, "compacted.parquet").Replace("\\", "/");
     var process = Process.GetCurrentProcess();
-    var startBytes = GC.GetTotalMemory(forceFullCollection: true);
+    process.Refresh();
     var startWorkingSet = process.WorkingSet64;
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    GC.Collect();
+    process.Refresh();
+    startWorkingSet = process.WorkingSet64;
     Console.WriteLine($"      baseline working set (after GC): {startWorkingSet / 1024.0 / 1024.0:F0} MB");
 
+    /* Background sampler — polls working set during the (opaque) merge calls so
+       the reported peak reflects mid-merge pressure, not just between-batch gaps. */
+    long peakWorkingSet = startWorkingSet;
+    var samplerStop = false;
+    var sampler = new Thread(() =>
+    {
+        var p = Process.GetCurrentProcess();
+        while (!Volatile.Read(ref samplerStop))
+        {
+            p.Refresh();
+            var ws = p.WorkingSet64;
+            if (ws > peakWorkingSet) peakWorkingSet = ws;
+            Thread.Sleep(100);
+        }
+    }) { IsBackground = true };
+    sampler.Start();
+
     var compactionSw = Stopwatch.StartNew();
-    var peakWorkingSet = startWorkingSet;
-    long compactedFileBytes = 0;
     var perCycleWorkingSet = new List<(long peak, long postGc)>();
     var success = false;
     string? failureMessage = null;
+    var outputPaths = new List<string>();
+    long compactedFileBytes = 0;
 
-    var stepCounter = 0;
-    var intermediates = new List<string>();
-
-    var perStepDbCounter = 0;
-    void MergePair(string aPath, string bPath, string outPath, int stepIndex, int totalSteps)
-    {
-        string dataSource;
-        string? dbFile = null;
-        if (dbMode == "file")
-        {
-            /* Each merge gets its own fresh on-disk database so DuckDB has real
-               paging room. Deleted after the step to avoid disk bloat. */
-            dbFile = Path.Combine(tempDir, $"merge_{++perStepDbCounter}.duckdb").Replace("\\", "/");
-            dataSource = $"DataSource={dbFile}";
-        }
-        else
-        {
-            dataSource = "DataSource=:memory:";
-        }
-
-        try
-        {
-            using var con = new DuckDBConnection(dataSource);
-            con.Open();
-            using (var pragma = con.CreateCommand())
-            {
-                var threadsClause = threads > 0 ? $"SET threads = {threads}; " : "";
-                pragma.CommandText =
-                    $"SET memory_limit = '{memoryLimit}'; " +
-                    $"SET preserve_insertion_order = false; " +
-                    $"SET temp_directory = '{spillDir.Replace("'", "''")}'; " +
-                    threadsClause;
-                pragma.ExecuteNonQuery();
-            }
-
-            var pairList = $"'{aPath.Replace("'", "''")}', '{bPath.Replace("'", "''")}'";
-            using var cmd = con.CreateCommand();
-            cmd.CommandText =
-                $"COPY (SELECT * FROM read_parquet([{pairList}], union_by_name=true)) " +
-                $"TO '{outPath.Replace("'", "''")}' " +
-                $"(FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE {rowGroupSize})";
-            cmd.ExecuteNonQuery();
-        }
-        finally
-        {
-            if (dbFile != null)
-            {
-                try { File.Delete(dbFile); } catch { }
-                try { File.Delete(dbFile + ".wal"); } catch { }
-            }
-        }
-
-        process.Refresh();
-        if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
-
-        var aSize = new FileInfo(aPath).Length / 1024.0 / 1024.0;
-        var bSize = new FileInfo(bPath).Length / 1024.0 / 1024.0;
-        var outSize = new FileInfo(outPath).Length / 1024.0 / 1024.0;
-        Console.WriteLine($"      step {stepIndex}/{totalSteps}: {aSize:F1} + {bSize:F1} -> {outSize:F1} MB | peak WS {peakWorkingSet / 1024.0 / 1024.0:F0} MB");
-    }
-
-    string NewIntermediatePath()
-    {
-        var p = targetPath + $".step{++stepCounter}.tmp";
-        intermediates.Add(p);
-        return p;
-    }
-
-    for (var cycle = 1; cycle <= cycles; cycle++)
+    for (var cycle = 1; cycle <= cycles && (cycle == 1 || success); cycle++)
     {
         if (cycles > 1) Console.WriteLine($"      --- cycle {cycle}/{cycles} ---");
-
-        /* Reset per-cycle state */
-        stepCounter = 0;
-        intermediates.Clear();
-        perStepDbCounter = 0;
-        if (File.Exists(targetPath)) File.Delete(targetPath);
-
         var cycleStartPeak = peakWorkingSet;
+        outputPaths.Clear();
+        success = false;
 
         try
         {
-            if (strategy == "accumulator")
+            for (var i = 0; i < batches.Count; i++)
             {
-                /* Sort smallest-first like current production ArchiveService does */
-                var sorted = sourcePaths
-                    .OrderBy(p => new FileInfo(p).Length)
-                    .ToList();
+                var outName = batches.Count == 1
+                    ? $"{table}.parquet"
+                    : $"{table}_pt{i + 1:D3}.parquet";
+                var outPath = Path.Combine(tempDir, $"c{cycle}_{outName}").Replace("\\", "/");
+                if (File.Exists(outPath)) File.Delete(outPath);
 
-                var currentPath = sorted[0];
-                var totalSteps = sorted.Count - 1;
+                var batchSw = Stopwatch.StartNew();
+                ParquetCompaction.MergeBatchToFile(
+                    table, batches[i], outPath, spillDir,
+                    memoryLimit, threads, rowGroupSize);
+                batchSw.Stop();
 
-                for (var i = 1; i < sorted.Count; i++)
-                {
-                    var isFinal = i == sorted.Count - 1;
-                    var stepOutput = isFinal ? targetPath : NewIntermediatePath();
-
-                    MergePair(currentPath, sorted[i], stepOutput, i, totalSteps);
-
-                    if (i >= 2)
-                    {
-                        var prev = intermediates[^2];
-                        try { File.Delete(prev); } catch { }
-                    }
-
-                    currentPath = stepOutput;
-                }
-            }
-            else /* tournament */
-            {
-                var current = new List<string>(sourcePaths);
-                var totalSteps = current.Count - 1;
-
-                while (current.Count > 1)
-                {
-                    var next = new List<string>();
-                    var pairs = current.Count / 2;
-
-                    for (var i = 0; i < pairs; i++)
-                    {
-                        var aPath = current[i * 2];
-                        var bPath = current[i * 2 + 1];
-                        var isLastMerge = current.Count == 2;
-                        var outPath = isLastMerge ? targetPath : NewIntermediatePath();
-
-                        MergePair(aPath, bPath, outPath, stepCounter, totalSteps);
-                        next.Add(outPath);
-
-                        if (intermediates.Contains(aPath))
-                        {
-                            try { File.Delete(aPath); } catch { }
-                        }
-                        if (intermediates.Contains(bPath))
-                        {
-                            try { File.Delete(bPath); } catch { }
-                        }
-                    }
-
-                    if (current.Count % 2 == 1)
-                    {
-                        next.Add(current[^1]);
-                    }
-
-                    current = next;
-                }
+                process.Refresh();
+                if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
+                var outSize = new FileInfo(outPath).Length / 1024.0 / 1024.0;
+                Console.WriteLine($"      batch {i + 1}/{batches.Count}: {batches[i].Count} files -> {outSize:F1} MB " +
+                                  $"in {batchSw.Elapsed.TotalSeconds:F1}s | peak WS {peakWorkingSet / 1024.0 / 1024.0:F0} MB");
+                outputPaths.Add(outPath);
             }
 
-            compactedFileBytes = new FileInfo(targetPath).Length;
+            compactedFileBytes = outputPaths.Sum(p => new FileInfo(p).Length);
             success = true;
         }
         catch (Exception ex)
@@ -334,9 +249,6 @@ try
             break;
         }
 
-        /* Post-cycle measurement: force GC and sample working set after a brief
-           pause to let native finalizers run. This is what the user cares about —
-           does memory release between archival cycles? */
         var cyclePeak = peakWorkingSet;
         GC.Collect();
         GC.WaitForPendingFinalizers();
@@ -350,11 +262,13 @@ try
     }
     compactionSw.Stop();
 
+    samplerStop = true;
+    sampler.Join(1000);
     process.Refresh();
     if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
 
     Console.WriteLine();
-    Console.WriteLine("[3/3] Result:");
+    Console.WriteLine("Result:");
     Console.WriteLine($"      Status:           {(success ? "SUCCESS" : "FAILURE")}");
     Console.WriteLine($"      Wall time:        {compactionSw.Elapsed.TotalSeconds:F2}s");
     Console.WriteLine($"      Baseline WS:      {startWorkingSet / 1024.0 / 1024.0:F0} MB");
@@ -367,24 +281,21 @@ try
             var (peak, postGc) = perCycleWorkingSet[i];
             Console.WriteLine($"        cycle {i + 1}: peak +{peak / 1024.0 / 1024.0:F0} MB, post-GC {postGc / 1024.0 / 1024.0:F0} MB");
         }
-        var firstPostGc = perCycleWorkingSet[0].postGc;
-        var lastPostGc = perCycleWorkingSet[^1].postGc;
-        var drift = (lastPostGc - firstPostGc) / 1024.0 / 1024.0;
+        var drift = (perCycleWorkingSet[^1].postGc - perCycleWorkingSet[0].postGc) / 1024.0 / 1024.0;
         Console.WriteLine($"      WS drift (last - first post-GC): {drift:+0;-0;0} MB");
     }
     if (success)
     {
-        Console.WriteLine($"      Output size:      {compactedFileBytes / 1024.0 / 1024.0:F1} MB");
+        Console.WriteLine($"      Output:           {outputPaths.Count} part file(s), {compactedFileBytes / 1024.0 / 1024.0:F1} MB total");
 
-        /* Sanity check: row count round-trip — output must match inputs */
-        var srcSqlList = mergeFiles.Count > 0
-            ? string.Join(", ", mergeFiles.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"))
-            : $"'{sourceFile.Replace("'", "''").Replace("\\", "/")}'";
+        /* Row-count round-trip: total output rows must equal total source rows. */
+        var srcSqlList = string.Join(", ", sourcePaths.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
+        var outSqlList = string.Join(", ", outputPaths.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
         using var verifyCon = new DuckDBConnection("DataSource=:memory:");
         verifyCon.Open();
         using var verifyCmd = verifyCon.CreateCommand();
         verifyCmd.CommandText =
-            $"SELECT (SELECT COUNT(*) FROM read_parquet('{targetPath.Replace("'", "''")}')) AS out_rows, " +
+            $"SELECT (SELECT COUNT(*) FROM read_parquet([{outSqlList}], union_by_name=true)) AS out_rows, " +
             $"       (SELECT COUNT(*) FROM read_parquet([{srcSqlList}], union_by_name=true)) AS src_rows";
         using var verifyReader = verifyCmd.ExecuteReader();
         verifyReader.Read();
@@ -397,7 +308,6 @@ try
         Console.WriteLine($"      Failure:          {failureMessage}");
     }
 
-    /* Spill dir size — non-zero means DuckDB spilled */
     var spillBytes = Directory.Exists(spillDir)
         ? Directory.GetFiles(spillDir, "*", SearchOption.AllDirectories).Sum(f => new FileInfo(f).Length)
         : 0;
@@ -421,13 +331,11 @@ finally
 static List<string> SplitSourceFile(string sourceFile, string outDir, int numChunks)
 {
     /* Split a real monthly parquet into N chunks using row-number bucketing.
-       Each chunk is written as ZSTD parquet (matching the production format).
-       Empty chunks are skipped.
-       NOTE: This connection deliberately runs with DuckDB defaults (no memory_limit).
-       The merge connections set their own memory_limit. If you see the merge OOM
-       with "X MiB / 953.6 MiB used" where the high-water mark looks like leftover
-       state from this split, that's a clue DuckDB.NET shares buffer state across
-       :memory: connections in the same process. */
+       Each chunk is written as ZSTD parquet matching the production per-cycle
+       archive format (ArchiveService writes per-cycle files with FORMAT PARQUET,
+       COMPRESSION ZSTD and the DuckDB default row group size). Empty chunks are
+       skipped. This connection runs with DuckDB defaults (no memory_limit) — the
+       merge connections set their own via ParquetCompaction. */
     var sourceSql = sourceFile.Replace("'", "''").Replace("\\", "/");
 
     using var con = new DuckDBConnection("DataSource=:memory:");
@@ -449,7 +357,7 @@ static List<string> SplitSourceFile(string sourceFile, string outDir, int numChu
         cmd.CommandText =
             $"COPY (SELECT * FROM read_parquet('{sourceSql}') " +
             $"  WHERE (collection_id % {numChunks}) = {i}) " +
-            $"TO '{path.Replace("'", "''")}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 122880)";
+            $"TO '{path.Replace("'", "''")}' (FORMAT PARQUET, COMPRESSION ZSTD)";
         cmd.ExecuteNonQuery();
         if (new FileInfo(path).Length > 0) paths.Add(path);
     }
@@ -469,10 +377,12 @@ static void GenerateSyntheticSource(string outputPath, int rows, int planKb)
        ZSTD can't collapse content to a single dictionary entry. We aggregate
        a list of md5() hashes per row — each hash uses (collection_id, op_index)
        as a unique seed, defeating both per-row and cross-row compression.
-       This matches the in-memory pain of real plan XML during merge. */
+
+       NOTE: this generates UNIFORM-width plan XML. Real plan XML is heavy-tailed
+       (mostly small, a few multi-MB plans). Uniform synthetic data does not
+       reproduce the row-group memory spikes a fat tail causes — prefer
+       --merge-files against a reporter's real archive when one is available. */
     var sourceSql = outputPath.Replace("'", "''").Replace("\\", "/");
-    /* Each "op" tag is roughly '<op id="' + 32-char md5 + '"/>' = ~46 chars.
-       Pick op count so the assembled XML hits the target byte size. */
     const int opTagBytes = 46;
     var opsPerPlan = Math.Max(4, (planKb * 1024) / opTagBytes);
 
@@ -480,9 +390,6 @@ static void GenerateSyntheticSource(string outputPath, int rows, int planKb)
     con.Open();
 
     using var cmd = con.CreateCommand();
-    /* list_aggregate builds the plan as the concatenation of {opsPerPlan}
-       unique <op id="<md5>"/> tags. md5() is high-entropy and depends on the
-       row index + op index, so the per-row content is irreducible. */
     cmd.CommandText = $@"
 COPY (
     SELECT

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -40,12 +40,14 @@ using PerformanceMonitorLite.Services;
  *
  * Other options:
  *   --profile-only         Print the source data profile and exit (no merge).
+ *   --sweep                Run a matrix of configs (merge-mode x row-group-size x
+ *                          batch budget x memory limit) against the same files
+ *                          and print which ones survive. Ignores --merge-mode etc.
  *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
  *   --synthetic-rows <int> Synthetic row count. Default: 30000
- *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 25
- *   --synthetic-tail-ops <n>  RelOps in a tail (huge) synthetic plan. Default: 6000
- *   --synthetic-tail-every <n> Every Nth row gets a tail plan. Default: 25
- *   --cycles <int>         Re-run the full compaction N times (memory-release test). Default: 1
+ *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 130
+ *   --synthetic-tail-ops <n>  RelOps in a tail (huge) synthetic plan. Default: 75000
+ *   --synthetic-tail-every <n> Every Nth row gets a tail plan. Default: 500
  *   --keep                 Don't delete the temp dir after the run.
  *
  * Examples:
@@ -55,17 +57,19 @@ using PerformanceMonitorLite.Services;
  *   # Run the real compaction against a reporter's actual failing files
  *   dotnet run -c Release -- --merge-files "C:/archive/a.parquet,C:/archive/b.parquet"
  *
- *   # Compare merge strategies on a real monthly file split into 88 chunks
- *   dotnet run -c Release -- --source-file ".../202605_query_snapshots.parquet" --num-files 88 --merge-mode single
+ *   # Sweep configs against a reporter's real files to find one that survives
+ *   dotnet run -c Release -- --merge-files "C:/archive/a.parquet,C:/archive/b.parquet" --sweep
  */
 
 var sourceFile = GetArg(args, "--source-file", "");
 var mergeFilesArg = GetArg(args, "--merge-files", "");
 var synthetic = args.Contains("--synthetic");
 var syntheticRows = int.Parse(GetArg(args, "--synthetic-rows", "30000"));
-var syntheticBaseOps = int.Parse(GetArg(args, "--synthetic-base-ops", "25"));
-var syntheticTailOps = int.Parse(GetArg(args, "--synthetic-tail-ops", "6000"));
-var syntheticTailEvery = int.Parse(GetArg(args, "--synthetic-tail-every", "25"));
+/* Defaults are tuned to the real issue-#933 query_snapshots profile:
+   query_plan p50 ~47 KB, p99 ~1.1 MB, max ~27 MB, mean ~100 KB. */
+var syntheticBaseOps = int.Parse(GetArg(args, "--synthetic-base-ops", "130"));
+var syntheticTailOps = int.Parse(GetArg(args, "--synthetic-tail-ops", "75000"));
+var syntheticTailEvery = int.Parse(GetArg(args, "--synthetic-tail-every", "500"));
 if (string.IsNullOrEmpty(sourceFile) && string.IsNullOrEmpty(mergeFilesArg) && !synthetic)
 {
     Console.Error.WriteLine("error: --source-file <path> OR --merge-files <a.parquet,...> OR --synthetic required");
@@ -93,9 +97,9 @@ var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.
 var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.MaxBatchInputBytes / (1024 * 1024)).ToString()));
 var maxBatchBytes = maxBatchMb * 1024L * 1024L;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
-var cycles = int.Parse(GetArg(args, "--cycles", "1"));
 var keep = args.Contains("--keep");
 var profileOnly = args.Contains("--profile-only");
+var sweep = args.Contains("--sweep");
 
 var tempDir = Path.Combine(Path.GetTempPath(), $"CompactionRepro_{Guid.NewGuid():N}");
 Directory.CreateDirectory(tempDir);
@@ -142,8 +146,15 @@ using (var versionCon = new DuckDBConnection("DataSource=:memory:"))
 }
 Console.WriteLine($"Code:     ParquetCompaction (linked from Lite/Services — real production merge)");
 Console.WriteLine($"Table:    {table}");
-Console.WriteLine($"Merge:    {mergeMode} ({(mergeMode == "single" ? "one COPY over the whole batch" : "pairwise accumulator — current production")})");
-Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
+if (sweep)
+{
+    Console.WriteLine($"Merge:    sweep (matrix of configs — see [sweep] section below)");
+}
+else
+{
+    Console.WriteLine($"Merge:    {mergeMode} ({(mergeMode == "single" ? "one COPY over the whole batch" : "pairwise accumulator — current production")})");
+    Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
+}
 if (mergeFiles.Count == 0)
     Console.WriteLine($"Splitting source into {numFiles} chunks");
 Console.WriteLine();
@@ -194,151 +205,172 @@ try
         return 0;
     }
 
-    /* Mirror ArchiveService.CompactParquetFiles: sort smallest-first, then bucket
-       into size-budgeted batches. This is the exact production sequencing. */
+    /* Sort smallest-first — mirrors ArchiveService.CompactParquetFiles. */
     var sorted = sourcePaths
         .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
         .ToList();
-    var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, maxBatchBytes);
-    Console.WriteLine($"[2/3] BuildSizeBudgetedBatches: {sorted.Count} files -> {batches.Count} batch(es) at {maxBatchMb} MB budget");
-    for (var i = 0; i < batches.Count; i++)
-    {
-        var batchBytes = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
-        Console.WriteLine($"      batch {i + 1}: {batches[i].Count} files, {batchBytes / 1024.0 / 1024.0:F1} MB on disk");
-    }
-    Console.WriteLine();
 
-    Console.WriteLine($"[3/3] Running {mergeMode} merge per batch (real ParquetCompaction code), {cycles} cycle(s)...");
     var spillDir = Path.Combine(tempDir, "duckdb_tmp").Replace("\\", "/");
     Directory.CreateDirectory(spillDir);
-
     var process = Process.GetCurrentProcess();
-    process.Refresh();
-    var startWorkingSet = process.WorkingSet64;
-    GC.Collect();
-    GC.WaitForPendingFinalizers();
-    GC.Collect();
-    process.Refresh();
-    startWorkingSet = process.WorkingSet64;
-    Console.WriteLine($"      baseline working set (after GC): {startWorkingSet / 1024.0 / 1024.0:F0} MB");
 
-    /* Background sampler — polls working set during the (opaque) merge calls so
-       the reported peak reflects mid-merge pressure, not just between-batch gaps. */
-    long peakWorkingSet = startWorkingSet;
-    var samplerStop = false;
-    var sampler = new Thread(() =>
+    /* Run one full compaction (size-budget batching + per-batch merge) for a
+       given config. Never throws — a merge OOM is caught and returned as
+       Ok=false so a sweep can carry on to the next config. */
+    (bool Ok, double StartMb, double PeakMb, double Sec, int Batches, string? Fail, List<string> Outputs)
+        RunOneConfig(string mMode, int rgs, long batchBytes, string memLimit, int thr, bool verbose)
     {
-        var p = Process.GetCurrentProcess();
-        while (!Volatile.Read(ref samplerStop))
+        var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes);
+        if (verbose)
         {
-            p.Refresh();
-            var ws = p.WorkingSet64;
-            if (ws > peakWorkingSet) peakWorkingSet = ws;
-            Thread.Sleep(100);
+            Console.WriteLine($"      {sorted.Count} files -> {batches.Count} batch(es) at {batchBytes / 1024 / 1024} MB budget");
+            for (var i = 0; i < batches.Count; i++)
+            {
+                var bb = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
+                Console.WriteLine($"        batch {i + 1}: {batches[i].Count} files, {bb / 1024.0 / 1024.0:F1} MB on disk");
+            }
         }
-    }) { IsBackground = true };
-    sampler.Start();
 
-    var compactionSw = Stopwatch.StartNew();
-    var perCycleWorkingSet = new List<(long peak, long postGc)>();
-    var success = false;
-    string? failureMessage = null;
-    var outputPaths = new List<string>();
-    long compactedFileBytes = 0;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        process.Refresh();
+        var startWs = process.WorkingSet64;
 
-    for (var cycle = 1; cycle <= cycles && (cycle == 1 || success); cycle++)
-    {
-        if (cycles > 1) Console.WriteLine($"      --- cycle {cycle}/{cycles} ---");
-        var cycleStartPeak = peakWorkingSet;
-        outputPaths.Clear();
-        success = false;
+        /* Background sampler — polls working set during the (opaque) merge calls
+           so the reported peak reflects mid-merge pressure. */
+        long peakWs = startWs;
+        var stop = false;
+        var sampler = new Thread(() =>
+        {
+            var p = Process.GetCurrentProcess();
+            while (!Volatile.Read(ref stop))
+            {
+                p.Refresh();
+                var ws = p.WorkingSet64;
+                if (ws > peakWs) peakWs = ws;
+                Thread.Sleep(75);
+            }
+        }) { IsBackground = true };
+        sampler.Start();
 
+        var sw = Stopwatch.StartNew();
+        var outputs = new List<string>();
+        var ok = false;
+        string? fail = null;
         try
         {
             for (var i = 0; i < batches.Count; i++)
             {
                 var outName = batches.Count == 1
-                    ? $"{table}.parquet"
-                    : $"{table}_pt{i + 1:D3}.parquet";
-                var outPath = Path.Combine(tempDir, $"c{cycle}_{outName}").Replace("\\", "/");
+                    ? $"out_{table}.parquet"
+                    : $"out_{table}_pt{i + 1:D3}.parquet";
+                var outPath = Path.Combine(tempDir, outName).Replace("\\", "/");
                 if (File.Exists(outPath)) File.Delete(outPath);
 
-                var batchInMb = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length) / 1024.0 / 1024.0;
-                Console.WriteLine($"      batch {i + 1}/{batches.Count}: merging {batches[i].Count} files ({batchInMb:F1} MB on disk)...");
-
-                var batchSw = Stopwatch.StartNew();
-                if (mergeMode == "single")
-                {
-                    ParquetCompaction.MergeBatchSingleCopy(
-                        table, batches[i], outPath, spillDir,
-                        memoryLimit, threads, rowGroupSize);
-                }
+                var bsw = Stopwatch.StartNew();
+                if (mMode == "single")
+                    ParquetCompaction.MergeBatchSingleCopy(table, batches[i], outPath, spillDir, memLimit, thr, rgs);
                 else
-                {
-                    ParquetCompaction.MergeBatchToFile(
-                        table, batches[i], outPath, spillDir,
-                        memoryLimit, threads, rowGroupSize);
-                }
-                batchSw.Stop();
+                    ParquetCompaction.MergeBatchToFile(table, batches[i], outPath, spillDir, memLimit, thr, rgs);
+                bsw.Stop();
 
                 process.Refresh();
-                if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
-                var outSize = new FileInfo(outPath).Length / 1024.0 / 1024.0;
-                Console.WriteLine($"        -> done in {batchSw.Elapsed.TotalSeconds:F1}s, output {outSize:F1} MB | peak WS {peakWorkingSet / 1024.0 / 1024.0:F0} MB");
-                outputPaths.Add(outPath);
+                if (process.WorkingSet64 > peakWs) peakWs = process.WorkingSet64;
+                outputs.Add(outPath);
+                if (verbose)
+                {
+                    var os = new FileInfo(outPath).Length / 1024.0 / 1024.0;
+                    Console.WriteLine($"        batch {i + 1}/{batches.Count}: {batches[i].Count} files -> {os:F1} MB " +
+                                      $"in {bsw.Elapsed.TotalSeconds:F1}s | peak WS {peakWs / 1024.0 / 1024.0:F0} MB");
+                }
             }
-
-            compactedFileBytes = outputPaths.Sum(p => new FileInfo(p).Length);
-            success = true;
+            ok = true;
         }
         catch (Exception ex)
         {
-            failureMessage = ex.Message;
-            break;
+            fail = ex.Message.Replace("\r", " ").Replace("\n", " ").Trim();
+            if (fail.Length > 200) fail = fail[..200] + "...";
+        }
+        sw.Stop();
+        stop = true;
+        sampler.Join(1000);
+        process.Refresh();
+        if (process.WorkingSet64 > peakWs) peakWs = process.WorkingSet64;
+
+        return (ok, startWs / 1024.0 / 1024.0, peakWs / 1024.0 / 1024.0,
+                sw.Elapsed.TotalSeconds, batches.Count, fail, outputs);
+    }
+
+    void CleanOutputs()
+    {
+        foreach (var f in Directory.GetFiles(tempDir, $"out_{table}*"))
+        {
+            try { File.Delete(f); } catch { /* best effort */ }
+        }
+    }
+
+    if (sweep)
+    {
+        /* Matrix of configs run against the same source files. All single-copy
+           (one streaming pass — fast) except the last, so a real-data run stays
+           reasonable. Current production is pairwise rgs=8192 batch=200 mem=4GB,
+           already known to OOM on this data — see the issue thread. */
+        var configs = new (string Label, string Mode, int Rgs, int BatchMb, string Mem)[]
+        {
+            ("single   rgs=8192 batch=200 mem=4GB", "single",   8192, 200, "4GB"),
+            ("single   rgs=2048 batch=100 mem=4GB", "single",   2048, 100, "4GB"),
+            ("single   rgs=512  batch=50  mem=4GB", "single",    512,  50, "4GB"),
+            ("single   rgs=512  batch=25  mem=4GB", "single",    512,  25, "4GB"),
+            ("single   rgs=256  batch=25  mem=2GB", "single",    256,  25, "2GB"),
+            ("pairwise rgs=512  batch=50  mem=4GB", "pairwise",  512,  50, "4GB"),
+        };
+
+        Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sorted.Count} source files.");
+        Console.WriteLine();
+
+        var results = new List<(string Label, bool Ok, double PeakDeltaMb, double Sec, int Batches, string? Fail)>();
+        foreach (var c in configs)
+        {
+            Console.WriteLine($"[sweep] {c.Label} ...");
+            var r = RunOneConfig(c.Mode, c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, verbose: false);
+            CleanOutputs();
+            var peakDelta = r.PeakMb - r.StartMb;
+            results.Add((c.Label, r.Ok, peakDelta, r.Sec, r.Batches, r.Fail));
+            Console.WriteLine($"        {(r.Ok ? "OK  " : "FAIL")}  peak +{peakDelta:F0} MB  {r.Sec:F0}s  {r.Batches} part file(s)");
+            if (!r.Ok) Console.WriteLine($"        {r.Fail}");
+            Console.WriteLine();
         }
 
-        var cyclePeak = peakWorkingSet;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-        Thread.Sleep(500);
-        process.Refresh();
-        var postGc = process.WorkingSet64;
-        perCycleWorkingSet.Add((cyclePeak - cycleStartPeak, postGc));
-        if (cycles > 1)
-            Console.WriteLine($"      cycle {cycle} peak +{(cyclePeak - cycleStartPeak) / 1024.0 / 1024.0:F0} MB | post-GC WS {postGc / 1024.0 / 1024.0:F0} MB");
+        Console.WriteLine("[sweep] SUMMARY");
+        Console.WriteLine($"  {"config",-38} {"status",-6} {"peak",10} {"time",7} {"parts",6}");
+        foreach (var r in results)
+            Console.WriteLine($"  {r.Label,-38} {(r.Ok ? "OK" : "FAIL"),-6} {("+" + r.PeakDeltaMb.ToString("F0") + " MB"),10} {(r.Sec.ToString("F0") + "s"),7} {r.Batches,6}");
+        Console.WriteLine();
+        var firstOk = results.FirstOrDefault(r => r.Ok);
+        Console.WriteLine(firstOk.Label != null
+            ? $"  First config that survives this data: {firstOk.Label}"
+            : "  No config survived — every merge OOM'd. Paste this whole output back.");
+        return results.Any(r => r.Ok) ? 0 : 1;
     }
-    compactionSw.Stop();
 
-    samplerStop = true;
-    sampler.Join(1000);
-    process.Refresh();
-    if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
+    /* Single-config run. */
+    Console.WriteLine($"[3/3] Running {mergeMode} merge (real ParquetCompaction code)...");
+    var single = RunOneConfig(mergeMode, rowGroupSize, maxBatchBytes, memoryLimit, threads, verbose: true);
 
     Console.WriteLine();
     Console.WriteLine("Result:");
-    Console.WriteLine($"      Status:           {(success ? "SUCCESS" : "FAILURE")}");
-    Console.WriteLine($"      Wall time:        {compactionSw.Elapsed.TotalSeconds:F2}s");
-    Console.WriteLine($"      Baseline WS:      {startWorkingSet / 1024.0 / 1024.0:F0} MB");
-    Console.WriteLine($"      Peak WS:          {peakWorkingSet / 1024.0 / 1024.0:F0} MB (+{(peakWorkingSet - startWorkingSet) / 1024.0 / 1024.0:F0} MB)");
-    if (cycles > 1 && perCycleWorkingSet.Count > 0)
+    Console.WriteLine($"      Status:           {(single.Ok ? "SUCCESS" : "FAILURE")}");
+    Console.WriteLine($"      Wall time:        {single.Sec:F2}s");
+    Console.WriteLine($"      Peak WS:          {single.PeakMb:F0} MB (baseline {single.StartMb:F0} MB, +{single.PeakMb - single.StartMb:F0} MB)");
+    if (single.Ok)
     {
-        Console.WriteLine($"      Post-GC WS by cycle:");
-        for (var i = 0; i < perCycleWorkingSet.Count; i++)
-        {
-            var (peak, postGc) = perCycleWorkingSet[i];
-            Console.WriteLine($"        cycle {i + 1}: peak +{peak / 1024.0 / 1024.0:F0} MB, post-GC {postGc / 1024.0 / 1024.0:F0} MB");
-        }
-        var drift = (perCycleWorkingSet[^1].postGc - perCycleWorkingSet[0].postGc) / 1024.0 / 1024.0;
-        Console.WriteLine($"      WS drift (last - first post-GC): {drift:+0;-0;0} MB");
-    }
-    if (success)
-    {
-        Console.WriteLine($"      Output:           {outputPaths.Count} part file(s), {compactedFileBytes / 1024.0 / 1024.0:F1} MB total");
+        var outBytes = single.Outputs.Sum(p => new FileInfo(p).Length);
+        Console.WriteLine($"      Output:           {single.Outputs.Count} part file(s), {outBytes / 1024.0 / 1024.0:F1} MB total");
 
         /* Row-count round-trip: total output rows must equal total source rows. */
         var srcSqlList = string.Join(", ", sourcePaths.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
-        var outSqlList = string.Join(", ", outputPaths.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
+        var outSqlList = string.Join(", ", single.Outputs.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
         using var verifyCon = new DuckDBConnection("DataSource=:memory:");
         verifyCon.Open();
         using var verifyCmd = verifyCon.CreateCommand();
@@ -353,7 +385,7 @@ try
     }
     else
     {
-        Console.WriteLine($"      Failure:          {failureMessage}");
+        Console.WriteLine($"      Failure:          {single.Fail}");
     }
 
     var spillBytes = Directory.Exists(spillDir)
@@ -361,7 +393,7 @@ try
         : 0;
     Console.WriteLine($"      Spill on disk:    {spillBytes / 1024.0 / 1024.0:F1} MB ({(spillBytes > 0 ? "spilled" : "did not spill")})");
 
-    return success ? 0 : 1;
+    return single.Ok ? 0 : 1;
 }
 finally
 {
@@ -510,7 +542,7 @@ static void GenerateSyntheticSource(string outputPath, int rows, int baseOps, in
        bytes. A small ZSTD parquet file that decompresses to gigabytes of XML
        is exactly the #933 failure shape. */
     var sourceSql = outputPath.Replace("'", "''").Replace("\\", "/");
-    var mediumOps = baseOps * 8;
+    var mediumOps = baseOps * 22;
 
     using var con = new DuckDBConnection("DataSource=:memory:");
     con.Open();
@@ -522,7 +554,7 @@ COPY (
         SELECT
             i,
             CASE WHEN (i % {tailEvery}) = 0 THEN {tailOps}
-                 WHEN (i % 5) = 0 THEN {mediumOps}
+                 WHEN (i % 25) = 0 THEN {mediumOps}
                  ELSE {baseOps} END AS ops
         FROM generate_series(1, {rows}) t(i)
     )

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -178,7 +178,14 @@ try
     }
     Console.WriteLine();
 
-    ProfileSource(sourcePaths);
+    try
+    {
+        ProfileSource(sourcePaths);
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"[profile] scan failed (non-fatal): {ex.Message}");
+    }
     Console.WriteLine();
 
     if (profileOnly)
@@ -446,10 +453,10 @@ static void ProfileSource(List<string> paths)
     foreach (var c in varcharCols)
     {
         var e = c.Replace("\"", "\"\"");
-        selects.Add($"max(octet_length(\"{e}\"::BLOB)) AS \"{e}__max\"");
-        selects.Add($"quantile_cont(octet_length(\"{e}\"::BLOB), 0.99) AS \"{e}__p99\"");
-        selects.Add($"quantile_cont(octet_length(\"{e}\"::BLOB), 0.50) AS \"{e}__p50\"");
-        selects.Add($"sum(octet_length(\"{e}\"::BLOB))::BIGINT AS \"{e}__sum\"");
+        selects.Add($"max(octet_length(encode(\"{e}\"))) AS \"{e}__max\"");
+        selects.Add($"quantile_cont(octet_length(encode(\"{e}\")), 0.99) AS \"{e}__p99\"");
+        selects.Add($"quantile_cont(octet_length(encode(\"{e}\")), 0.50) AS \"{e}__p50\"");
+        selects.Add($"sum(octet_length(encode(\"{e}\")))::BIGINT AS \"{e}__sum\"");
     }
 
     using var cmd = con.CreateCommand();
@@ -527,7 +534,7 @@ COPY (
         ((i % 200) + 50)::INTEGER AS session_id,
         ('db_' || ((i % 10) + 1)::VARCHAR) AS database_name,
         '00:00:00' AS elapsed_time_formatted,
-        ('SELECT * FROM dbo.Orders o JOIN dbo.Customers c ON c.CustomerId = o.CustomerId WHERE o.OrderDate > ''2026-01-01'' /* q' || (i % 1000)::VARCHAR || ' */') AS query_text,
+        ('SELECT * FROM dbo.Orders o JOIN dbo.Customers c ON c.CustomerId = o.CustomerId WHERE o.OrderDate > ''2026-01-01'' /* ' || chr(1090) || chr(1077) || chr(1089) || chr(1090) || ' q' || (i % 1000)::VARCHAR || ' */') AS query_text,
         ('<ShowPlanXML xmlns=""http://schemas.microsoft.com/sqlserver/2004/07/showplan""><BatchSequence><Batch><Statements><StmtSimple><QueryPlan>' ||
          list_aggregate(
              list_transform(generate_series(1, ops),

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -29,20 +29,18 @@ using PerformanceMonitorLite.Services;
  * the data shape that decides whether compaction OOMs; synthetic data can't
  * fake it. Use --profile-only to get just the profile and skip the merge.
  *
- * Tuning knobs (defaults = current production values from ParquetCompaction):
+ * Tuning knobs (defaults = ParquetCompaction's non-table-specific defaults):
  *   --memory-limit <str>   DuckDB memory_limit per merge connection. Default: 4GB
  *   --threads <int>        DuckDB threads per merge connection. Default: 2
  *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: 8192
  *   --max-batch-mb <int>   Per-batch on-disk input budget (MB). Default: 200
  *   --table <name>         Table name (drives exclude-column logic). Default: query_snapshots
- *   --merge-mode <m>       pairwise (current production) | single (one COPY over
- *                          the whole batch). Default: pairwise
  *
  * Other options:
  *   --profile-only         Print the source data profile and exit (no merge).
- *   --sweep                Run a matrix of configs (merge-mode x row-group-size x
- *                          batch budget x memory limit) against the same files
- *                          and print which ones survive. Ignores --merge-mode etc.
+ *   --sweep                Run a matrix of configs (row-group-size x batch budget
+ *                          x memory limit) against the same files and print which
+ *                          ones survive. Ignores --row-group-size / --max-batch-mb.
  *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
  *   --synthetic-rows <int> Synthetic row count. Default: 30000
  *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 130
@@ -85,16 +83,10 @@ if (!string.IsNullOrEmpty(sourceFile) && !File.Exists(sourceFile))
 }
 
 var table = GetArg(args, "--table", "query_snapshots");
-var mergeMode = GetArg(args, "--merge-mode", "pairwise").ToLowerInvariant();
-if (mergeMode != "pairwise" && mergeMode != "single")
-{
-    Console.Error.WriteLine($"error: --merge-mode must be 'pairwise' or 'single', got '{mergeMode}'");
-    return 2;
-}
 var memoryLimit = GetArg(args, "--memory-limit", ParquetCompaction.DefaultMemoryLimit);
 var threads = int.Parse(GetArg(args, "--threads", ParquetCompaction.DefaultThreads.ToString()));
 var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.DefaultRowGroupSize.ToString()));
-var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.MaxBatchInputBytes / (1024 * 1024)).ToString()));
+var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.DefaultBatchInputBytes / (1024 * 1024)).ToString()));
 var maxBatchBytes = maxBatchMb * 1024L * 1024L;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
 var keep = args.Contains("--keep");
@@ -148,11 +140,10 @@ Console.WriteLine($"Code:     ParquetCompaction (linked from Lite/Services — r
 Console.WriteLine($"Table:    {table}");
 if (sweep)
 {
-    Console.WriteLine($"Merge:    sweep (matrix of configs — see [sweep] section below)");
+    Console.WriteLine($"Mode:     sweep (matrix of configs — see [sweep] section below)");
 }
 else
 {
-    Console.WriteLine($"Merge:    {mergeMode} ({(mergeMode == "single" ? "one COPY over the whole batch" : "pairwise accumulator — current production")})");
     Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
 }
 if (mergeFiles.Count == 0)
@@ -218,7 +209,7 @@ try
        given config. Never throws — a merge OOM is caught and returned as
        Ok=false so a sweep can carry on to the next config. */
     (bool Ok, double StartMb, double PeakMb, double Sec, int Batches, string? Fail, List<string> Outputs)
-        RunOneConfig(string mMode, int rgs, long batchBytes, string memLimit, int thr, bool verbose)
+        RunOneConfig(int rgs, long batchBytes, string memLimit, int thr, bool verbose)
     {
         var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes);
         if (verbose)
@@ -269,10 +260,7 @@ try
                 if (File.Exists(outPath)) File.Delete(outPath);
 
                 var bsw = Stopwatch.StartNew();
-                if (mMode == "single")
-                    ParquetCompaction.MergeBatchSingleCopy(table, batches[i], outPath, spillDir, memLimit, thr, rgs);
-                else
-                    ParquetCompaction.MergeBatchToFile(table, batches[i], outPath, spillDir, memLimit, thr, rgs);
+                ParquetCompaction.MergeBatchToFile(table, batches[i], outPath, spillDir, memLimit, thr, rgs);
                 bsw.Stop();
 
                 process.Refresh();
@@ -312,18 +300,16 @@ try
 
     if (sweep)
     {
-        /* Matrix of configs run against the same source files. All single-copy
-           (one streaming pass — fast) except the last, so a real-data run stays
-           reasonable. Current production is pairwise rgs=8192 batch=200 mem=4GB,
-           already known to OOM on this data — see the issue thread. */
-        var configs = new (string Label, string Mode, int Rgs, int BatchMb, string Mem)[]
+        /* Matrix of merge configs run against the same source files — varies
+           row-group size, batch budget and memory cap to find which combination
+           keeps the merge within the cap on real data. (#933) */
+        var configs = new (string Label, int Rgs, int BatchMb, string Mem)[]
         {
-            ("single   rgs=8192 batch=200 mem=4GB", "single",   8192, 200, "4GB"),
-            ("single   rgs=2048 batch=100 mem=4GB", "single",   2048, 100, "4GB"),
-            ("single   rgs=512  batch=50  mem=4GB", "single",    512,  50, "4GB"),
-            ("single   rgs=512  batch=25  mem=4GB", "single",    512,  25, "4GB"),
-            ("single   rgs=256  batch=25  mem=2GB", "single",    256,  25, "2GB"),
-            ("pairwise rgs=512  batch=50  mem=4GB", "pairwise",  512,  50, "4GB"),
+            ("rgs=8192 batch=200 mem=4GB", 8192, 200, "4GB"),
+            ("rgs=2048 batch=100 mem=4GB", 2048, 100, "4GB"),
+            ("rgs=512  batch=50  mem=4GB",  512,  50, "4GB"),
+            ("rgs=512  batch=25  mem=4GB",  512,  25, "4GB"),
+            ("rgs=256  batch=25  mem=2GB",  256,  25, "2GB"),
         };
 
         Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sorted.Count} source files.");
@@ -333,7 +319,7 @@ try
         foreach (var c in configs)
         {
             Console.WriteLine($"[sweep] {c.Label} ...");
-            var r = RunOneConfig(c.Mode, c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, verbose: false);
+            var r = RunOneConfig(c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, verbose: false);
             CleanOutputs();
             var peakDelta = r.PeakMb - r.StartMb;
             results.Add((c.Label, r.Ok, peakDelta, r.Sec, r.Batches, r.Fail));
@@ -355,8 +341,8 @@ try
     }
 
     /* Single-config run. */
-    Console.WriteLine($"[3/3] Running {mergeMode} merge (real ParquetCompaction code)...");
-    var single = RunOneConfig(mergeMode, rowGroupSize, maxBatchBytes, memoryLimit, threads, verbose: true);
+    Console.WriteLine($"[3/3] Running merge (real ParquetCompaction code)...");
+    var single = RunOneConfig(rowGroupSize, maxBatchBytes, memoryLimit, threads, verbose: true);
 
     Console.WriteLine();
     Console.WriteLine("Result:");

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -24,36 +24,48 @@ using PerformanceMonitorLite.Services;
  *                          to run against a reporter's actual archive files.
  *   --synthetic            Generate a query_snapshots-shaped source, then split.
  *
+ * Every run first prints a read-only [profile] of the source data — the
+ * uncompressed (in-memory) size distribution of each column. That profile is
+ * the data shape that decides whether compaction OOMs; synthetic data can't
+ * fake it. Use --profile-only to get just the profile and skip the merge.
+ *
  * Tuning knobs (defaults = current production values from ParquetCompaction):
  *   --memory-limit <str>   DuckDB memory_limit per merge connection. Default: 4GB
  *   --threads <int>        DuckDB threads per merge connection. Default: 2
  *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: 8192
  *   --max-batch-mb <int>   Per-batch on-disk input budget (MB). Default: 200
  *   --table <name>         Table name (drives exclude-column logic). Default: query_snapshots
+ *   --merge-mode <m>       pairwise (current production) | single (one COPY over
+ *                          the whole batch). Default: pairwise
  *
  * Other options:
+ *   --profile-only         Print the source data profile and exit (no merge).
  *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
  *   --synthetic-rows <int> Synthetic row count. Default: 30000
- *   --synthetic-plan-kb <n> Synthetic plan XML KB per row. Default: 100
+ *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 25
+ *   --synthetic-tail-ops <n>  RelOps in a tail (huge) synthetic plan. Default: 6000
+ *   --synthetic-tail-every <n> Every Nth row gets a tail plan. Default: 25
  *   --cycles <int>         Re-run the full compaction N times (memory-release test). Default: 1
  *   --keep                 Don't delete the temp dir after the run.
  *
  * Examples:
- *   # Run against a reporter's actual failing files
- *   dotnet run -c Release -- --merge-files "C:/archive/20260501_query_snapshots.parquet,C:/archive/202605_query_snapshots.parquet"
+ *   # Just profile a reporter's real files — fast, read-only, no merge
+ *   dotnet run -c Release -- --merge-files "C:/archive/a.parquet,C:/archive/b.parquet" --profile-only
  *
- *   # Reproduce the production path on a real monthly file split into 88 chunks
- *   dotnet run -c Release -- --source-file "%LOCALAPPDATA%/PerformanceMonitorLite/archive/202605_query_snapshots.parquet" --num-files 88
+ *   # Run the real compaction against a reporter's actual failing files
+ *   dotnet run -c Release -- --merge-files "C:/archive/a.parquet,C:/archive/b.parquet"
  *
- *   # Sweep the batch budget down to find a value query_snapshots survives
- *   dotnet run -c Release -- --source-file ".../202605_query_snapshots.parquet" --num-files 88 --max-batch-mb 40
+ *   # Compare merge strategies on a real monthly file split into 88 chunks
+ *   dotnet run -c Release -- --source-file ".../202605_query_snapshots.parquet" --num-files 88 --merge-mode single
  */
 
 var sourceFile = GetArg(args, "--source-file", "");
 var mergeFilesArg = GetArg(args, "--merge-files", "");
 var synthetic = args.Contains("--synthetic");
 var syntheticRows = int.Parse(GetArg(args, "--synthetic-rows", "30000"));
-var syntheticPlanKb = int.Parse(GetArg(args, "--synthetic-plan-kb", "100"));
+var syntheticBaseOps = int.Parse(GetArg(args, "--synthetic-base-ops", "25"));
+var syntheticTailOps = int.Parse(GetArg(args, "--synthetic-tail-ops", "6000"));
+var syntheticTailEvery = int.Parse(GetArg(args, "--synthetic-tail-every", "25"));
 if (string.IsNullOrEmpty(sourceFile) && string.IsNullOrEmpty(mergeFilesArg) && !synthetic)
 {
     Console.Error.WriteLine("error: --source-file <path> OR --merge-files <a.parquet,...> OR --synthetic required");
@@ -69,6 +81,12 @@ if (!string.IsNullOrEmpty(sourceFile) && !File.Exists(sourceFile))
 }
 
 var table = GetArg(args, "--table", "query_snapshots");
+var mergeMode = GetArg(args, "--merge-mode", "pairwise").ToLowerInvariant();
+if (mergeMode != "pairwise" && mergeMode != "single")
+{
+    Console.Error.WriteLine($"error: --merge-mode must be 'pairwise' or 'single', got '{mergeMode}'");
+    return 2;
+}
 var memoryLimit = GetArg(args, "--memory-limit", ParquetCompaction.DefaultMemoryLimit);
 var threads = int.Parse(GetArg(args, "--threads", ParquetCompaction.DefaultThreads.ToString()));
 var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.DefaultRowGroupSize.ToString()));
@@ -77,6 +95,7 @@ var maxBatchBytes = maxBatchMb * 1024L * 1024L;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
 var cycles = int.Parse(GetArg(args, "--cycles", "1"));
 var keep = args.Contains("--keep");
+var profileOnly = args.Contains("--profile-only");
 
 var tempDir = Path.Combine(Path.GetTempPath(), $"CompactionRepro_{Guid.NewGuid():N}");
 Directory.CreateDirectory(tempDir);
@@ -97,7 +116,8 @@ if (synthetic)
 {
     sourceFile = Path.Combine(tempDir, "synthetic_query_snapshots.parquet").Replace("\\", "/");
     Console.WriteLine($"Mode:     synthetic+split+merge");
-    Console.WriteLine($"Synthetic: {syntheticRows} rows, ~{syntheticPlanKb} KB plan XML per row");
+    Console.WriteLine($"Synthetic: {syntheticRows} rows, {syntheticBaseOps} base ops/plan, " +
+                      $"{syntheticTailOps} ops on every {syntheticTailEvery}th row (heavy tail)");
     Console.WriteLine($"Source:   {sourceFile} (will be generated)");
 }
 else if (mergeFiles.Count > 0)
@@ -122,6 +142,7 @@ using (var versionCon = new DuckDBConnection("DataSource=:memory:"))
 }
 Console.WriteLine($"Code:     ParquetCompaction (linked from Lite/Services — real production merge)");
 Console.WriteLine($"Table:    {table}");
+Console.WriteLine($"Merge:    {mergeMode} ({(mergeMode == "single" ? "one COPY over the whole batch" : "pairwise accumulator — current production")})");
 Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
 if (mergeFiles.Count == 0)
     Console.WriteLine($"Splitting source into {numFiles} chunks");
@@ -131,9 +152,9 @@ try
 {
     if (synthetic)
     {
-        Console.WriteLine($"[0/3] Generating synthetic source ({syntheticRows} rows, ~{syntheticPlanKb} KB plan/row)...");
+        Console.WriteLine($"[0/3] Generating synthetic source ({syntheticRows} rows, heavy-tailed plan XML)...");
         var sw = Stopwatch.StartNew();
-        GenerateSyntheticSource(sourceFile, syntheticRows, syntheticPlanKb);
+        GenerateSyntheticSource(sourceFile, syntheticRows, syntheticBaseOps, syntheticTailOps, syntheticTailEvery);
         sw.Stop();
         var size = new FileInfo(sourceFile).Length / 1024.0 / 1024.0;
         Console.WriteLine($"      Generated {size:F1} MB in {sw.ElapsedMilliseconds} ms");
@@ -157,6 +178,15 @@ try
     }
     Console.WriteLine();
 
+    ProfileSource(sourcePaths);
+    Console.WriteLine();
+
+    if (profileOnly)
+    {
+        Console.WriteLine("[profile-only] --profile-only set; skipping the merge. Done.");
+        return 0;
+    }
+
     /* Mirror ArchiveService.CompactParquetFiles: sort smallest-first, then bucket
        into size-budgeted batches. This is the exact production sequencing. */
     var sorted = sourcePaths
@@ -171,7 +201,7 @@ try
     }
     Console.WriteLine();
 
-    Console.WriteLine($"[3/3] Running MergeBatchToFile per batch (real production code), {cycles} cycle(s)...");
+    Console.WriteLine($"[3/3] Running {mergeMode} merge per batch (real ParquetCompaction code), {cycles} cycle(s)...");
     var spillDir = Path.Combine(tempDir, "duckdb_tmp").Replace("\\", "/");
     Directory.CreateDirectory(spillDir);
 
@@ -226,17 +256,28 @@ try
                 var outPath = Path.Combine(tempDir, $"c{cycle}_{outName}").Replace("\\", "/");
                 if (File.Exists(outPath)) File.Delete(outPath);
 
+                var batchInMb = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length) / 1024.0 / 1024.0;
+                Console.WriteLine($"      batch {i + 1}/{batches.Count}: merging {batches[i].Count} files ({batchInMb:F1} MB on disk)...");
+
                 var batchSw = Stopwatch.StartNew();
-                ParquetCompaction.MergeBatchToFile(
-                    table, batches[i], outPath, spillDir,
-                    memoryLimit, threads, rowGroupSize);
+                if (mergeMode == "single")
+                {
+                    ParquetCompaction.MergeBatchSingleCopy(
+                        table, batches[i], outPath, spillDir,
+                        memoryLimit, threads, rowGroupSize);
+                }
+                else
+                {
+                    ParquetCompaction.MergeBatchToFile(
+                        table, batches[i], outPath, spillDir,
+                        memoryLimit, threads, rowGroupSize);
+                }
                 batchSw.Stop();
 
                 process.Refresh();
                 if (process.WorkingSet64 > peakWorkingSet) peakWorkingSet = process.WorkingSet64;
                 var outSize = new FileInfo(outPath).Length / 1024.0 / 1024.0;
-                Console.WriteLine($"      batch {i + 1}/{batches.Count}: {batches[i].Count} files -> {outSize:F1} MB " +
-                                  $"in {batchSw.Elapsed.TotalSeconds:F1}s | peak WS {peakWorkingSet / 1024.0 / 1024.0:F0} MB");
+                Console.WriteLine($"        -> done in {batchSw.Elapsed.TotalSeconds:F1}s, output {outSize:F1} MB | peak WS {peakWorkingSet / 1024.0 / 1024.0:F0} MB");
                 outputPaths.Add(outPath);
             }
 
@@ -371,20 +412,98 @@ static string GetArg(string[] args, string key, string defaultValue)
     return defaultValue;
 }
 
-static void GenerateSyntheticSource(string outputPath, int rows, int planKb)
+/* Read-only scan of the source files: reports the in-memory (uncompressed) size
+   distribution of every VARCHAR column. This is the data shape that decides
+   whether compaction OOMs — a single monster plan-XML cell forces an unspillable
+   allocation no matter how small the file is on disk. Synthetic data can't fake
+   this, so this profile is the thing we actually need from a real archive. */
+static void ProfileSource(List<string> paths)
 {
-    /* Generate query_snapshots-shaped parquet with high-entropy plan XML so
-       ZSTD can't collapse content to a single dictionary entry. We aggregate
-       a list of md5() hashes per row — each hash uses (collection_id, op_index)
-       as a unique seed, defeating both per-row and cross-row compression.
+    Console.WriteLine("[profile] Source data shape (read-only scan — no merge):");
+    var pathSql = string.Join(", ", paths.Select(p => $"'{p.Replace("'", "''").Replace("\\", "/")}'"));
 
-       NOTE: this generates UNIFORM-width plan XML. Real plan XML is heavy-tailed
-       (mostly small, a few multi-MB plans). Uniform synthetic data does not
-       reproduce the row-group memory spikes a fat tail causes — prefer
-       --merge-files against a reporter's real archive when one is available. */
+    using var con = new DuckDBConnection("DataSource=:memory:");
+    con.Open();
+
+    var varcharCols = new List<string>();
+    using (var d = con.CreateCommand())
+    {
+        d.CommandText = $"DESCRIBE SELECT * FROM read_parquet([{pathSql}], union_by_name=true)";
+        using var dr = d.ExecuteReader();
+        while (dr.Read())
+        {
+            if (dr.GetString(1).Contains("VARCHAR", StringComparison.OrdinalIgnoreCase))
+                varcharCols.Add(dr.GetString(0));
+        }
+    }
+    if (varcharCols.Count == 0)
+    {
+        Console.WriteLine("      (no VARCHAR columns)");
+        return;
+    }
+
+    var selects = new List<string> { "count(*) AS row_count" };
+    foreach (var c in varcharCols)
+    {
+        var e = c.Replace("\"", "\"\"");
+        selects.Add($"max(octet_length(\"{e}\"::BLOB)) AS \"{e}__max\"");
+        selects.Add($"quantile_cont(octet_length(\"{e}\"::BLOB), 0.99) AS \"{e}__p99\"");
+        selects.Add($"quantile_cont(octet_length(\"{e}\"::BLOB), 0.50) AS \"{e}__p50\"");
+        selects.Add($"sum(octet_length(\"{e}\"::BLOB))::BIGINT AS \"{e}__sum\"");
+    }
+
+    using var cmd = con.CreateCommand();
+    cmd.CommandText = $"SELECT {string.Join(", ", selects)} FROM read_parquet([{pathSql}], union_by_name=true)";
+    using var r = cmd.ExecuteReader();
+    r.Read();
+
+    var rowCount = r.GetInt64(0);
+    Console.WriteLine($"      rows: {rowCount:N0}   VARCHAR columns: {varcharCols.Count}");
+    Console.WriteLine($"      {"column",-24} {"p50",10} {"p99",12} {"max",14} {"total",12}");
+
+    double Val(int idx) => r.IsDBNull(idx) ? 0 : Convert.ToDouble(r.GetValue(idx));
+    long grandTotal = 0;
+    for (var i = 0; i < varcharCols.Count; i++)
+    {
+        var b = 1 + i * 4;
+        var max = Val(b);
+        var p99 = Val(b + 1);
+        var p50 = Val(b + 2);
+        var sum = Val(b + 3);
+        grandTotal += (long)sum;
+        Console.WriteLine($"      {varcharCols[i],-24} {Human(p50),10} {Human(p99),12} {Human(max),14} {Human(sum),12}");
+    }
+
+    var onDisk = paths.Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
+    Console.WriteLine($"      total uncompressed VARCHAR: {grandTotal / 1024.0 / 1024.0:F1} MB" +
+                      $"   (on disk: {onDisk / 1024.0 / 1024.0:F1} MB, ~{(onDisk > 0 ? grandTotal / (double)onDisk : 0):F1}x expansion)");
+}
+
+static string Human(double bytes)
+{
+    if (bytes >= 1024.0 * 1024.0) return $"{bytes / 1024.0 / 1024.0:F1} MB";
+    if (bytes >= 1024.0) return $"{bytes / 1024.0:F1} KB";
+    return $"{bytes:F0} B";
+}
+
+static void GenerateSyntheticSource(string outputPath, int rows, int baseOps, int tailOps, int tailEvery)
+{
+    /* Generate query_snapshots-shaped parquet with REALISTIC plan XML:
+
+       - Low entropy. Real SQL plan XML is mostly repeated tag/attribute
+         structure, so it compresses ~20-40:1 on disk and expands hard in
+         memory. (The old generator used md5() hashes — high entropy — which
+         compress poorly and barely expand, so it never reproduced the OOM.)
+       - Heavy-tailed. Most rows get a small plan (baseOps RelOps); every
+         tailEvery-th row gets a huge one (tailOps RelOps); rows divisible by 5
+         get a medium plan. A few multi-MB plans clustered into one parquet row
+         group is what drives the in-memory spike — uniform-width data can't.
+
+       The merge cost we care about is in-memory VARCHAR bytes, not on-disk
+       bytes. A small ZSTD parquet file that decompresses to gigabytes of XML
+       is exactly the #933 failure shape. */
     var sourceSql = outputPath.Replace("'", "''").Replace("\\", "/");
-    const int opTagBytes = 46;
-    var opsPerPlan = Math.Max(4, (planKb * 1024) / opTagBytes);
+    var mediumOps = baseOps * 8;
 
     using var con = new DuckDBConnection("DataSource=:memory:");
     con.Open();
@@ -392,6 +511,14 @@ static void GenerateSyntheticSource(string outputPath, int rows, int planKb)
     using var cmd = con.CreateCommand();
     cmd.CommandText = $@"
 COPY (
+    WITH r AS (
+        SELECT
+            i,
+            CASE WHEN (i % {tailEvery}) = 0 THEN {tailOps}
+                 WHEN (i % 5) = 0 THEN {mediumOps}
+                 ELSE {baseOps} END AS ops
+        FROM generate_series(1, {rows}) t(i)
+    )
     SELECT
         i AS collection_id,
         TIMESTAMP '2026-04-01 00:00:00' + INTERVAL (i) MINUTE AS collection_time,
@@ -400,19 +527,19 @@ COPY (
         ((i % 200) + 50)::INTEGER AS session_id,
         ('db_' || ((i % 10) + 1)::VARCHAR) AS database_name,
         '00:00:00' AS elapsed_time_formatted,
-        ('SELECT * FROM t_' || (i % 1000)::VARCHAR || ' WHERE c = ''' || md5(i::VARCHAR) || '''') AS query_text,
-        ('<plan id=""' || i::VARCHAR || '"">' ||
+        ('SELECT * FROM dbo.Orders o JOIN dbo.Customers c ON c.CustomerId = o.CustomerId WHERE o.OrderDate > ''2026-01-01'' /* q' || (i % 1000)::VARCHAR || ' */') AS query_text,
+        ('<ShowPlanXML xmlns=""http://schemas.microsoft.com/sqlserver/2004/07/showplan""><BatchSequence><Batch><Statements><StmtSimple><QueryPlan>' ||
          list_aggregate(
-             list_transform(generate_series(1, {opsPerPlan}),
-                            j -> '<op id=""' || md5((i::VARCHAR || ':' || j::VARCHAR)) || '""/>'),
+             list_transform(generate_series(1, ops),
+                 j -> '<RelOp NodeId=""' || j::VARCHAR || '"" PhysicalOp=""Clustered Index Scan"" LogicalOp=""Clustered Index Scan"" EstimateRows=""' || (j * 1.5)::VARCHAR || '"" EstimateIO=""0.003"" EstimateCPU=""0.0001"" AvgRowSize=""' || (40 + (j % 80))::VARCHAR || '"" EstimatedTotalSubtreeCost=""' || (j * 0.017)::VARCHAR || '"" Parallel=""0"" EstimateRebinds=""0"" EstimateRewinds=""0""><OutputList><ColumnReference Database=""[mydb]"" Schema=""[dbo]"" Table=""[Orders]"" Column=""[Col' || (j % 30)::VARCHAR || ']""/></OutputList><IndexScan Ordered=""0"" ForcedIndex=""0""><DefinedValues/><Object Database=""[mydb]"" Schema=""[dbo]"" Table=""[Orders]"" Index=""[PK_Orders_' || (i % 50)::VARCHAR || ']""/></IndexScan></RelOp>'),
              'string_agg', '') ||
-         '</plan>') AS query_plan,
-        ('<liveplan id=""' || i::VARCHAR || '"">' ||
+         '</QueryPlan></StmtSimple></Statements></Batch></BatchSequence></ShowPlanXML>') AS query_plan,
+        ('<ShowPlanXML xmlns=""http://schemas.microsoft.com/sqlserver/2004/07/showplan""><BatchSequence><Batch><Statements><StmtSimple><QueryPlan>' ||
          list_aggregate(
-             list_transform(generate_series(1, {opsPerPlan}),
-                            j -> '<op id=""' || md5(('L:' || i::VARCHAR || ':' || j::VARCHAR)) || '""/>'),
+             list_transform(generate_series(1, {baseOps}),
+                 j -> '<RelOp NodeId=""' || j::VARCHAR || '"" PhysicalOp=""Hash Match"" LogicalOp=""Aggregate"" Parallel=""1""><OutputList><ColumnReference Database=""[mydb]"" Schema=""[dbo]"" Table=""[Orders]"" Column=""[Col' || (j % 30)::VARCHAR || ']""/></OutputList></RelOp>'),
              'string_agg', '') ||
-         '</liveplan>') AS live_query_plan,
+         '</QueryPlan></StmtSimple></Statements></Batch></BatchSequence></ShowPlanXML>') AS live_query_plan,
         CASE (i % 5) WHEN 0 THEN 'running' WHEN 1 THEN 'suspended' WHEN 2 THEN 'sleeping' WHEN 3 THEN 'background' ELSE 'rollback' END AS status,
         CASE WHEN i % 7 = 0 THEN ((i % 200) + 1)::INTEGER ELSE NULL END AS blocking_session_id,
         CASE (i % 4) WHEN 0 THEN 'PAGEIOLATCH_SH' WHEN 1 THEN 'CXPACKET' WHEN 2 THEN 'LCK_M_S' ELSE NULL END AS wait_type,
@@ -432,7 +559,7 @@ COPY (
         ('Program_' || (i % 30)::VARCHAR) AS program_name,
         (i % 5)::INTEGER AS open_transaction_count,
         ((i % 100))::DECIMAL(5,2) AS percent_complete
-    FROM generate_series(1, {rows}) t(i)
+    FROM r
 ) TO '{sourceSql}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 122880)";
     cmd.ExecuteNonQuery();
 }


### PR DESCRIPTION
## Summary

Fixes the `query_snapshots` parquet-compaction OOM in #933, and reworks `tools/CompactionRepro` into a tool that actually exercises production code so the fix could be found empirically rather than guessed.

**The fix** (`ParquetCompaction` + `ArchiveService`):
- `MergeBatchToFile` is now a single streaming COPY over the whole batch. The previous incremental pairwise accumulator re-read an ever-larger intermediate file each step — ~5x slower on a real backlog and OOM-prone.
- New `PerTableCompaction` overrides: `query_snapshots` (wide query-plan XML, ~30x in-memory expansion) compacts in 100 MB batches at `ROW_GROUP_SIZE` 2048. Every other table keeps the 200 MB / 8192 defaults.
- A config sweep on the reporter's real 100-file / 15 GB-uncompressed archive validated this config: ~27s, ~1.8 GB headroom under the 4 GB cap, ~6 monthly part files.

**Why the repro rework was needed:** earlier `CompactionRepro` kept hand-copied merge loops that silently drifted from production — every prior #933 fix "passed the repro" and still OOM'd on real installs. It now links the real `ParquetCompaction.cs`, profiles source-data shape, and has a `--sweep` config matrix. That sweep, run on the reporter's actual files, is what pinned the fix.

## Test plan

- [x] `Lite` builds clean
- [x] All 260 `Lite.Tests` pass
- [x] `CompactionRepro` builds and runs (single-config + sweep)
- [ ] Reporter confirms on the next nightly — `Parquet compaction complete` with no `Failed to compact 202605/query_snapshots`

🤖 Generated with [Claude Code](https://claude.com/claude-code)