### PR TITLE
Fix Lite UI freeze during archival (#979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Lite UI no longer freezes during archival** ([#979]) — archival held DuckDB's exclusive write lock across the entire export-to-Parquet step, blocking every UI query (tab switches showed the spinning wheel, worse with more monitored servers). Export-to-Parquet only reads the database, so it now runs under a shared read lock concurrently with the UI; only the brief `DELETE` takes the exclusive write lock
 - **Data Retention job no longer fails with `xp_delete_file` error 22049** ([#972]) — the trace-file cleanup added in v2.11.0 passed a wildcard path to `xp_delete_file`, raising an uncatchable `Msg 22049` that failed the entire `PerformanceMonitor - Data Retention` Agent job on every run once any `Monitor_LongQueries_*.trc` files existed. `xp_delete_file` also cannot delete `.trc` files at all — it only accepts SQL Server backup files and Maintenance Plan report files — so that cleanup step has been removed from `config.data_retention`
 
 ### Changed
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`tools/Remove-OrphanedTraceFiles.ps1`** ([#972]) — one-time cleanup script for `Monitor_LongQueries_*.trc` files left on disk by versions through 2.11.0. Run it on the SQL Server host; it skips files belonging to a running trace and files that are in use
 
 [#972]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/972
+[#979]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/979
 
 ## [2.11.0] - 2026-05-19
 

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -121,45 +121,65 @@ public class ArchiveService
 
         _logger?.LogInformation("Archiving data older than {CutoffDate} to Parquet (prefix: {Timestamp})", cutoffDate, timestamp);
 
-        /* Write lock covers export + DELETE. The DELETEs modify table data, and the
-           next CHECKPOINT will reorganize the file — readers must not be mid-query
-           when that happens or they get "Reached the end of the file" errors. */
-        using (_duckDb.AcquireWriteLock())
-        {
-            using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+        /* Archive each table independently. Export-to-Parquet (COPY ... TO)
+           only READS the database, so it runs under a read lock — concurrently
+           with the UI. Only the DELETE modifies the file, so just the DELETE
+           takes the exclusive write lock, and only briefly. This keeps the UI
+           responsive during archival instead of freezing it for the whole
+           export (issue #979).
 
-            foreach (var (table, timeColumn) in ArchivableTables)
+           Exporting and deleting in separate lock scopes is safe here: the
+           DELETE only removes rows older than cutoffDate, and collectors only
+           ever insert rows timestamped "now", so nothing archivable can be
+           written into the gap between the export and the DELETE. */
+        foreach (var (table, timeColumn) in ArchivableTables)
+        {
+            try
             {
-                try
+                /* Uniquely-named parquet file — no merging needed. Each archival
+                   cycle produces a new file with a timestamp prefix; archive
+                   views use glob (*_table.parquet) to pick up all files. */
+                var parquetPath = Path.Combine(_archivePath, $"{timestamp}_{table}.parquet")
+                    .Replace("\\", "/");
+
+                long rowCount;
+
+                /* Export under a read lock — runs alongside UI queries. */
+                using (_duckDb.AcquireReadLock())
                 {
-                    /* Check if there are rows to archive */
-                    var rowCount = await GetRowCountBeforeCutoff(connection, table, timeColumn, cutoffDate);
+                    using var readConnection = _duckDb.CreateConnection();
+                    await readConnection.OpenAsync();
+
+                    rowCount = await GetRowCountBeforeCutoff(readConnection, table, timeColumn, cutoffDate);
                     if (rowCount == 0)
                     {
                         continue;
                     }
 
-                    /* Export to a uniquely-named parquet file — no merging needed.
-                       Each archival cycle produces a new file with a timestamp prefix.
-                       Archive views use glob (*_table.parquet) to pick up all files. */
-                    var parquetPath = Path.Combine(_archivePath, $"{timestamp}_{table}.parquet")
-                        .Replace("\\", "/");
+                    await ExportToParquet(readConnection, table, timeColumn, cutoffDate, parquetPath);
+                }
 
-                    await ExportToParquet(connection, table, timeColumn, cutoffDate, parquetPath);
+                /* Delete the archived rows under the write lock. The DELETE
+                   modifies table data and the next CHECKPOINT reorganizes the
+                   file — readers must not be mid-query when that happens or
+                   they get "Reached the end of the file" errors — but the
+                   DELETE itself is fast, so the UI stall is brief. */
+                using (_duckDb.AcquireWriteLock())
+                {
+                    using var writeConnection = _duckDb.CreateConnection();
+                    await writeConnection.OpenAsync();
 
-                    /* Delete archived rows from hot table */
-                    using var deleteCmd = connection.CreateCommand();
+                    using var deleteCmd = writeConnection.CreateCommand();
                     deleteCmd.CommandText = $"DELETE FROM {table} WHERE {timeColumn} < $1";
                     deleteCmd.Parameters.Add(new DuckDBParameter { Value = cutoffDate });
                     await deleteCmd.ExecuteNonQueryAsync();
+                }
 
-                    _logger?.LogInformation("Archived {Count} rows from {Table} to {Path}", rowCount, table, parquetPath);
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogError(ex, "Failed to archive table {Table}", table);
-                }
+                _logger?.LogInformation("Archived {Count} rows from {Table} to {Path}", rowCount, table, parquetPath);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to archive table {Table}", table);
             }
         }
 


### PR DESCRIPTION
## Problem

Split out from #976. While Lite is connected to servers, tab navigation intermittently shows the spinning wheel or a 2–3 s delay, correlating with archival and worsening with more monitored servers.

`ArchiveService.ArchiveOldDataAsync` held DuckDB's exclusive write lock (`DuckDbInitializer.s_dbLock`) across the **entire** export-to-Parquet + `DELETE` loop. Export-to-Parquet (`COPY … TO`) only *reads* the database, but under the write lock it blocked every UI read for its full duration — and UI queries take a read lock with no timeout, so a tab switch froze until archival finished.

## Change

In `ArchiveOldDataAsync`, per table:

- **Export-to-Parquet runs under a shared read lock** — concurrent with the UI.
- **Only the `DELETE` takes the exclusive write lock**, briefly.

Splitting the lock scopes is safe here: the `DELETE` only removes rows older than the cutoff, and collectors only ever insert "now"-stamped rows, so nothing archivable can land in the gap between the export and the delete.

`ArchiveAllAndResetAsync` (the size-triggered "export everything → reset database" path) is **left unchanged** — there the write lock also prevents collectors writing rows between the export snapshot and the reset, and it's the rare emergency path rather than the routine one.

## Test plan

- `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — clean, 0 warnings.
- Logic review: export is read-only (`COPY … SELECT … TO`), so a read lock is sufficient; only the `DELETE` mutates the file and keeps the exclusive lock.
- Not yet smoke-tested against a live populated DuckDB with archival triggered — worth a manual pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
