### PR TITLE
Fix Memory Grants always 0 in Memory Utilization chart (#978)

### DIFF
--- a/Dashboard/Services/DatabaseService.ResourceMetrics.cs
+++ b/Dashboard/Services/DatabaseService.ResourceMetrics.cs
@@ -311,10 +311,15 @@ namespace PerformanceMonitorDashboard.Services
                                 ms.total_memory_mb,
                                 granted_memory_mb = ISNULL(
                                     (
-                                        SELECT
+                                        SELECT TOP (1)
                                             SUM(mgs.granted_memory_mb)
                                         FROM collect.memory_grant_stats AS mgs
-                                        WHERE mgs.collection_time = ms.collection_time
+                                        WHERE mgs.collection_time >= DATEADD(MINUTE, -5, ms.collection_time)
+                                        AND   mgs.collection_time <= DATEADD(MINUTE, 5, ms.collection_time)
+                                        GROUP BY
+                                            mgs.collection_time
+                                        ORDER BY
+                                            ABS(DATEDIFF(SECOND, mgs.collection_time, ms.collection_time)) ASC
                                     ), 0)
                             FROM collect.memory_stats AS ms
                             WHERE ms.collection_time >= @from_date
@@ -337,10 +342,15 @@ namespace PerformanceMonitorDashboard.Services
                                 ms.total_memory_mb,
                                 granted_memory_mb = ISNULL(
                                     (
-                                        SELECT
+                                        SELECT TOP (1)
                                             SUM(mgs.granted_memory_mb)
                                         FROM collect.memory_grant_stats AS mgs
-                                        WHERE mgs.collection_time = ms.collection_time
+                                        WHERE mgs.collection_time >= DATEADD(MINUTE, -5, ms.collection_time)
+                                        AND   mgs.collection_time <= DATEADD(MINUTE, 5, ms.collection_time)
+                                        GROUP BY
+                                            mgs.collection_time
+                                        ORDER BY
+                                            ABS(DATEDIFF(SECOND, mgs.collection_time, ms.collection_time)) ASC
                                     ), 0)
                             FROM collect.memory_stats AS ms
                             WHERE ms.collection_time >= DATEADD(HOUR, @hours_back, SYSDATETIME())


### PR DESCRIPTION
## Summary

Fixes #978 — the "Memory Grants" line on Overview → Resource Overview → Memory Utilization is always 0 MB.

`GetMemoryDataAsync` correlated `collect.memory_grant_stats` to `collect.memory_stats` with an **exact `collection_time` equality**. The two tables are filled by separate collectors, each stamping its own `SYSDATETIME()` default, so the timestamps never align — the correlated subquery matched 0 rows and `ISNULL(...,0)` collapsed it to 0 on every sample.

Verified on sql2022's `PerformanceMonitor` DB: **0 rows** where `memory_stats.collection_time` equals any `memory_grant_stats.collection_time`.

## Fix

Replaced the exact-match subquery with a nearest-snapshot lookup — the `TOP (1)` grant snapshot within ±5 minutes, ordered by absolute time distance. Applied to both query branches (`fromDate/toDate` and `hoursBack`).

Dashboard-only embedded-SQL change; no schema or install-script changes. Fixes historical data too.

## Test plan

- [x] Verified the old query matches 0 rows against live data
- [x] Verified the fixed query returns real non-zero values (e.g. 51 MB) during grant activity
- [x] `dotnet build Dashboard/Dashboard.csproj -c Debug` — succeeds, 0 warnings/errors
- [x] Confirmed Lite is unaffected (plots grants as an independent series, no join)

🤖 Generated with [Claude Code](https://claude.com/claude-code)