### PR TITLE
Make Lite FinOps AG-aware (#980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Lite UI no longer freezes during archival** ([#979]) — archival held DuckDB's exclusive write lock across the entire export-to-Parquet step, blocking every UI query (tab switches showed the spinning wheel, worse with more monitored servers). Export-to-Parquet only reads the database, so it now runs under a shared read lock concurrently with the UI; only the brief `DELETE` takes the exclusive write lock
+- **Lite FinOps no longer recommends an edition downgrade on an Availability Group secondary** ([#980]) — the licensing recommendations suggested "downgrade to Standard to save $X/mo" for any Enterprise instance, with no AG awareness. On a secondary replica that advice is misleading — every replica in an AG must run the same edition. FinOps now detects the AG replica role and, on a secondary, shows an informational note instead of the downgrade/savings estimate
 - **Data Retention job no longer fails with `xp_delete_file` error 22049** ([#972]) — the trace-file cleanup added in v2.11.0 passed a wildcard path to `xp_delete_file`, raising an uncatchable `Msg 22049` that failed the entire `PerformanceMonitor - Data Retention` Agent job on every run once any `Monitor_LongQueries_*.trc` files existed. `xp_delete_file` also cannot delete `.trc` files at all — it only accepts SQL Server backup files and Maintenance Plan report files — so that cleanup step has been removed from `config.data_retention`
 
 ### Changed
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#972]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/972
 [#979]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/979
+[#980]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/980
 
 ## [2.11.0] - 2026-05-19
 

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -2418,6 +2418,14 @@
                                     </StackPanel>
                                 </DataGridTextColumn.Header>
                             </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding AgReplicaRoleDisplay}" Width="90">
+                                <DataGridTextColumn.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AgReplicaRoleDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                        <TextBlock Text="AG Role" FontWeight="Bold" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </DataGridTextColumn.Header>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Binding="{Binding ClusteredDisplay}" Width="80">
                                 <DataGridTextColumn.Header>
                                     <StackPanel Orientation="Horizontal">

--- a/Lite/Services/LocalDataService.FinOps.Recommendations.cs
+++ b/Lite/Services/LocalDataService.FinOps.Recommendations.cs
@@ -22,6 +22,47 @@ public partial class LocalDataService
     // ============================================
 
     /// <summary>
+    /// Returns the Availability Group role of the connected instance: "Primary",
+    /// "Secondary", or "Standalone". "Standalone" is also returned for non-AG
+    /// instances and any platform where the AG state DMVs are unavailable
+    /// (e.g. Azure SQL Database), so callers can treat it as "not a secondary".
+    /// </summary>
+    private static async Task<string> GetAgReplicaRoleAsync(SqlConnection connection)
+    {
+        /* The DMV is referenced only inside dynamic SQL guarded by an OBJECT_ID
+           check, so the outer batch still compiles on platforms without it. */
+        const string sql = @"
+DECLARE @role nvarchar(20) = N'Standalone';
+IF CONVERT(int, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
+   AND OBJECT_ID(N'sys.dm_hadr_availability_replica_states') IS NOT NULL
+BEGIN
+    DECLARE @detected nvarchar(20);
+    EXEC sys.sp_executesql N'
+        SELECT @r =
+            CASE
+                WHEN MAX(CASE WHEN ars.role = 1 THEN 1 ELSE 0 END) = 1 THEN N''Primary''
+                WHEN MAX(CASE WHEN ars.role = 2 THEN 1 ELSE 0 END) = 1 THEN N''Secondary''
+                ELSE N''Standalone''
+            END
+        FROM sys.dm_hadr_availability_replica_states AS ars
+        WHERE ars.is_local = 1;',
+        N'@r nvarchar(20) OUTPUT', @r = @detected OUTPUT;
+    SET @role = ISNULL(@detected, N'Standalone');
+END;
+SELECT @role;";
+        try
+        {
+            using var command = new SqlCommand(sql, connection) { CommandTimeout = 30 };
+            return await command.ExecuteScalarAsync() as string ?? "Standalone";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"AG replica role detection failed: {ex.Message}");
+            return "Standalone";
+        }
+    }
+
+    /// <summary>
     /// Runs all Phase 1 recommendation checks and returns a consolidated list.
     /// Uses DuckDB for collected data and live SQL queries for server-specific checks.
     /// </summary>
@@ -50,11 +91,34 @@ public partial class LocalDataService
 
             if (edition.Contains("Enterprise", StringComparison.OrdinalIgnoreCase))
             {
+                var agRole = await GetAgReplicaRoleAsync(sqlConn);
+
+                if (agRole == "Secondary")
+                {
+                    /* On an Availability Group secondary, a "downgrade to Standard
+                       to save money" recommendation is misleading: every replica in
+                       an AG must run the same SQL Server edition, so the decision
+                       belongs to the AG as a whole and must be evaluated on the
+                       primary. Emit an informational note instead and skip the
+                       savings estimates (#980). */
+                    recommendations.Add(new RecommendationRow
+                    {
+                        Category = "Licensing",
+                        Severity = "Low",
+                        Confidence = "High",
+                        Finding = "Enterprise Edition — Availability Group secondary replica",
+                        Detail = "This instance is currently a secondary replica in an Availability Group. " +
+                                 "Every replica in an AG must run the same SQL Server edition, so edition and " +
+                                 "licensing decisions apply to the whole group and should be evaluated on the " +
+                                 "primary replica. A secondary used only for failover may also be covered by " +
+                                 "Software Assurance rather than separately licensed."
+                    });
+                }
                 // SQL Server 2019 (major version 15) moved TDE to Standard Edition.
                 // On 2019+, dm_db_persisted_sku_features won't report TDE since it's
                 // no longer Enterprise-restricted — so we skip the TDE-specific check
                 // and give version-appropriate guidance instead.
-                if (majorVersion >= 15)
+                else if (majorVersion >= 15)
                 {
                     // 2019+: Most features that were Enterprise-only moved to Standard
                     // in 2016 SP1, and TDE moved in 2019. Very few Enterprise-only

--- a/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
+++ b/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
@@ -35,7 +35,8 @@ DECLARE
             ELSE N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files'
         END,
     @storage_gb decimal(19,2),
-    @host_os nvarchar(256);
+    @host_os nvarchar(256),
+    @ag_role nvarchar(20) = N'Standalone';
 
 EXEC sys.sp_executesql @storage_sql, N'@gb decimal(19,2) OUTPUT', @gb = @storage_gb OUTPUT;
 
@@ -49,6 +50,24 @@ BEGIN
     DECLARE @on_pos int = CHARINDEX(N' on ', @ver);
     IF @on_pos > 0
         SET @host_os = LTRIM(SUBSTRING(@ver, @on_pos + 4, LEN(@ver)));
+END;
+
+/* Availability Group replica role. The DMV is referenced only inside
+   OBJECT_ID-guarded dynamic SQL, so this batch still compiles on Azure SQL
+   Database and non-AG instances — both leave @ag_role at 'Standalone' (#980). */
+IF CONVERT(int, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
+   AND OBJECT_ID(N'sys.dm_hadr_availability_replica_states') IS NOT NULL
+BEGIN
+    DECLARE @ag_detected nvarchar(20);
+    EXEC sys.sp_executesql N'
+        SELECT @r = CASE
+            WHEN MAX(CASE WHEN ars.role = 1 THEN 1 ELSE 0 END) = 1 THEN N''Primary''
+            WHEN MAX(CASE WHEN ars.role = 2 THEN 1 ELSE 0 END) = 1 THEN N''Secondary''
+            ELSE N''Standalone'' END
+        FROM sys.dm_hadr_availability_replica_states AS ars
+        WHERE ars.is_local = 1;',
+        N'@r nvarchar(20) OUTPUT', @r = @ag_detected OUTPUT;
+    SET @ag_role = ISNULL(@ag_detected, N'Standalone');
 END;
 
 SELECT
@@ -65,7 +84,8 @@ SELECT
     CONVERT(int, SERVERPROPERTY('EngineEdition')),
     CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
     CONVERT(int, SERVERPROPERTY('IsClustered')),
-    @host_os
+    @host_os,
+    @ag_role
 FROM sys.dm_os_sys_info AS si;";
 
         using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };
@@ -93,6 +113,7 @@ FROM sys.dm_os_sys_info AS si;";
                 IsHadrEnabled = reader.IsDBNull(11) ? null : Convert.ToInt32(reader.GetValue(11)) == 1,
                 IsClustered = reader.IsDBNull(12) ? null : Convert.ToInt32(reader.GetValue(12)) == 1,
                 HostOsVersion = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                AgReplicaRole = reader.IsDBNull(14) ? "Standalone" : reader.GetString(14),
                 LastUpdated = DateTime.Now
             };
         }

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -178,6 +178,7 @@ public class ServerPropertyRow
     public DateTime? LastUpdated { get; set; }
     public bool? IsHadrEnabled { get; set; }
     public bool? IsClustered { get; set; }
+    public string AgReplicaRole { get; set; } = "Standalone";
 
     public decimal? AvgCpuPct { get; set; }
     public decimal? StorageTotalGb { get; set; }
@@ -195,6 +196,7 @@ public class ServerPropertyRow
     }
     public string HadrDisplay => IsHadrEnabled.HasValue ? (IsHadrEnabled.Value ? "Yes" : "No") : "";
     public string ClusteredDisplay => IsClustered.HasValue ? (IsClustered.Value ? "Yes" : "No") : "";
+    public string AgReplicaRoleDisplay => string.Equals(AgReplicaRole, "Standalone", StringComparison.OrdinalIgnoreCase) ? "—" : AgReplicaRole;
     public string ProvisioningDisplay => ProvisioningStatus?.Replace("_", " ") ?? "";
 
     // FinOps cost — from server config


### PR DESCRIPTION
## Problem

Split out from #976. Lite's FinOps determined the SQL Server edition with `SERVERPROPERTY('Edition')` and nothing else. On an Availability Group **readable secondary** that returns "Enterprise Edition" just like the primary, so FinOps:

- recommended *"Enterprise → Standard would save ~$X/mo"* on a replica whose edition can't be changed independently — every replica in an AG must run the same edition; and
- gave no indication in the inventory that the instance was a secondary at all.

## Change

- **`GetAgReplicaRoleAsync`** — detects `Primary` / `Secondary` / `Standalone` from `sys.dm_hadr_availability_replica_states`. The DMV is referenced only inside `OBJECT_ID`-guarded dynamic SQL, so the batch stays valid on Azure SQL Database and non-AG instances (both return `Standalone`).
- **`GetRecommendationsAsync`** — on an Enterprise instance that is an AG **secondary**, it now emits a single informational `Licensing` note ("edition/licensing decisions apply to the whole AG, evaluate on the primary; a passive secondary may be SA-covered") *instead of* the downgrade recommendations and savings estimates.
- **`GetServerPropertiesLiveAsync`** — also returns the replica role, surfaced as a new **AG Role** column in the FinOps server inventory grid (`ServerPropertyRow.AgReplicaRole` / `AgReplicaRoleDisplay`).

## Test plan

- `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — full rebuild, 0 warnings, 0 errors.
- The AG-role T-SQL and the full modified `GetServerPropertiesLiveAsync` batch were run against SQL Server 2016, 2019, and 2022 — all return `Standalone` on these non-AG instances with no errors, confirming the `OBJECT_ID` guard and the combined batch are valid across versions.
- The `Secondary` path could not be exercised (no AG in the test environment); the role logic (`MAX(CASE role = 1/2 …)` over `is_local = 1`) is standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
