### PR TITLE
Use %I64d for bigint args in collector RAISERROR debug output (#987)

### DIFF
--- a/install/05_delta_framework.sql
+++ b/install/05_delta_framework.sql
@@ -1189,7 +1189,7 @@ BEGIN
         
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Updated %d rows with delta calculations for %s', 0, 1, @rows_updated, @table_name) WITH NOWAIT;
+            RAISERROR(N'Updated %I64d rows with delta calculations for %s', 0, 1, @rows_updated, @table_name) WITH NOWAIT;
         END;
 
         /*

--- a/install/07_collect_wait_stats.sql
+++ b/install/07_collect_wait_stats.sql
@@ -175,7 +175,7 @@ BEGIN
         
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d wait stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d wait stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
         
         COMMIT TRANSACTION;

--- a/install/08_collect_query_stats.sql
+++ b/install/08_collect_query_stats.sql
@@ -674,7 +674,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d query stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d query stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -974,7 +974,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d Query Store rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d Query Store rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
     END TRY
     BEGIN CATCH

--- a/install/10_collect_procedure_stats.sql
+++ b/install/10_collect_procedure_stats.sql
@@ -822,7 +822,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d procedure/trigger/function stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d procedure/trigger/function stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/11_collect_query_snapshots.sql
+++ b/install/11_collect_query_snapshots.sql
@@ -378,7 +378,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d query snapshots', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d query snapshots', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
     END TRY

--- a/install/14_collect_memory_stats.sql
+++ b/install/14_collect_memory_stats.sql
@@ -290,7 +290,7 @@ BEGIN
         
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d memory stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d memory stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
         
         COMMIT TRANSACTION;

--- a/install/15_collect_memory_grant_stats.sql
+++ b/install/15_collect_memory_grant_stats.sql
@@ -170,7 +170,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d memory grant stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d memory grant stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/16_collect_memory_clerks_stats.sql
+++ b/install/16_collect_memory_clerks_stats.sql
@@ -182,7 +182,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d memory clerk stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d memory clerk stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/17_collect_cpu_scheduler_stats.sql
+++ b/install/17_collect_cpu_scheduler_stats.sql
@@ -418,7 +418,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d CPU scheduler stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d CPU scheduler stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/18_collect_cpu_utilization_stats.sql
+++ b/install/18_collect_cpu_utilization_stats.sql
@@ -184,7 +184,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d CPU utilization stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d CPU utilization stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/19_collect_perfmon_stats.sql
+++ b/install/19_collect_perfmon_stats.sql
@@ -256,7 +256,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d perfmon stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d perfmon stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/20_collect_file_io_stats.sql
+++ b/install/20_collect_file_io_stats.sql
@@ -213,7 +213,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d file I/O stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d file I/O stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/22_collect_blocked_processes.sql
+++ b/install/22_collect_blocked_processes.sql
@@ -312,7 +312,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d blocked process events', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d blocked process events', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/26_blocking_deadlock_analyzer.sql
+++ b/install/26_blocking_deadlock_analyzer.sql
@@ -151,7 +151,7 @@ BEGIN
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'Aggregated %d database(s) with blocking events', 0, 1, @rows_collected) WITH NOWAIT;
+                RAISERROR(N'Aggregated %I64d database(s) with blocking events', 0, 1, @rows_collected) WITH NOWAIT;
             END;
         END
         ELSE
@@ -425,7 +425,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Logged %d critical issue(s) for blocking/deadlock events', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Logged %I64d critical issue(s) for blocking/deadlock events', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         /*

--- a/install/27_collect_ring_buffer_events.sql
+++ b/install/27_collect_ring_buffer_events.sql
@@ -174,7 +174,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d memory pressure events', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d memory pressure events', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/28_collect_system_health_wrapper.sql
+++ b/install/28_collect_system_health_wrapper.sql
@@ -241,7 +241,7 @@ BEGIN
         
         IF @debug = 1
         BEGIN
-            RAISERROR(N'sp_HealthParser completed - %d total rows collected across all tables', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'sp_HealthParser completed - %I64d total rows collected across all tables', 0, 1, @rows_collected) WITH NOWAIT;
         END;
         
     END TRY

--- a/install/29_collect_default_trace.sql
+++ b/install/29_collect_default_trace.sql
@@ -438,7 +438,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d default trace events', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d default trace events', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         /*

--- a/install/30_collect_trace_management.sql
+++ b/install/30_collect_trace_management.sql
@@ -469,7 +469,7 @@ BEGIN
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'Started trace ID: %d with filters - Duration >= %d microseconds OR CPU >= %d ms', 0, 1,
+                RAISERROR(N'Started trace ID: %d with filters - Duration >= %I64d microseconds OR CPU >= %d ms', 0, 1,
                          @trace_id, @duration_threshold_ms, @cpu_threshold_ms) WITH NOWAIT;
             END;
         END;

--- a/install/31_collect_trace_analysis.sql
+++ b/install/31_collect_trace_analysis.sql
@@ -297,7 +297,7 @@ BEGIN
                 IF @debug = 1
                 BEGIN
                     DECLARE @events_from_file bigint = ROWCOUNT_BIG();
-                    RAISERROR(N'Retrieved %d events from this trace file', 0, 1, @events_from_file) WITH NOWAIT;
+                    RAISERROR(N'Retrieved %I64d events from this trace file', 0, 1, @events_from_file) WITH NOWAIT;
                 END;
 
             END TRY
@@ -319,7 +319,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Found %d traces, collected %d total events', 0, 1, @trace_count, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Found %d traces, collected %I64d total events', 0, 1, @trace_count, @rows_collected) WITH NOWAIT;
         END;
 
         IF @trace_count = 0
@@ -413,7 +413,7 @@ BEGIN
 
             IF @debug = 1
             BEGIN
-                RAISERROR(N'Inserted %d new trace analysis records', 0, 1, @rows_collected) WITH NOWAIT;
+                RAISERROR(N'Inserted %I64d new trace analysis records', 0, 1, @rows_collected) WITH NOWAIT;
             END;
         END;
         ELSE

--- a/install/32_collect_latch_stats.sql
+++ b/install/32_collect_latch_stats.sql
@@ -154,7 +154,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d latch stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d latch stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/33_collect_spinlock_stats.sql
+++ b/install/33_collect_spinlock_stats.sql
@@ -159,7 +159,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d spinlock stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d spinlock stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/34_collect_tempdb_stats.sql
+++ b/install/34_collect_tempdb_stats.sql
@@ -288,7 +288,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d tempdb stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d tempdb stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/35_collect_plan_cache_stats.sql
+++ b/install/35_collect_plan_cache_stats.sql
@@ -255,7 +255,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d plan cache stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d plan cache stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/36_collect_session_stats.sql
+++ b/install/36_collect_session_stats.sql
@@ -279,7 +279,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d session stats rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d session stats rows', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         COMMIT TRANSACTION;

--- a/install/37_collect_waiting_tasks.sql
+++ b/install/37_collect_waiting_tasks.sql
@@ -201,7 +201,7 @@ BEGIN
         BEGIN
             IF @rows_collected > 0
             BEGIN
-                RAISERROR(N'Collected %d waiting tasks', 0, 1, @rows_collected) WITH NOWAIT;
+                RAISERROR(N'Collected %I64d waiting tasks', 0, 1, @rows_collected) WITH NOWAIT;
 
                 /*
                 Show top wait types from this collection

--- a/install/43_data_retention.sql
+++ b/install/43_data_retention.sql
@@ -596,7 +596,7 @@ WHERE ' + QUOTENAME(@time_column_name) + N' < @retention_date_param;';
         BEGIN
             DECLARE @duration_ms integer = DATEDIFF(MILLISECOND, @start_time, SYSDATETIME());
             RAISERROR(N'', 0, 1) WITH NOWAIT;
-            RAISERROR(N'Data retention completed: %d total rows deleted from %d tables in %d ms', 0, 1,
+            RAISERROR(N'Data retention completed: %I64d total rows deleted from %d tables in %d ms', 0, 1,
                 @total_deleted,
                 @table_count,
                 @duration_ms

--- a/install/50_configuration_issues_analyzer.sql
+++ b/install/50_configuration_issues_analyzer.sql
@@ -128,7 +128,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Logged %d Query Store disabled issues', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Logged %I64d Query Store disabled issues', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
         /*
@@ -994,7 +994,7 @@ BEGIN
 
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Configuration issues analysis complete: %d total issues logged', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Configuration issues analysis complete: %I64d total issues logged', 0, 1, @rows_collected) WITH NOWAIT;
         END;
 
     END TRY

--- a/install/51_collect_running_jobs.sql
+++ b/install/51_collect_running_jobs.sql
@@ -274,7 +274,7 @@ BEGIN
         BEGIN
             IF @rows_collected > 0
             BEGIN
-                RAISERROR(N'Collected %d running jobs', 0, 1, @rows_collected) WITH NOWAIT;
+                RAISERROR(N'Collected %I64d running jobs', 0, 1, @rows_collected) WITH NOWAIT;
 
                 SELECT TOP (10)
                     rj.job_name,

--- a/install/52_collect_database_size_stats.sql
+++ b/install/52_collect_database_size_stats.sql
@@ -325,7 +325,7 @@ BEGIN
         */
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d database size rows', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d database size rows', 0, 1, @rows_collected) WITH NOWAIT;
 
             SELECT TOP (20)
                 dss.database_name,

--- a/install/53_collect_server_properties.sql
+++ b/install/53_collect_server_properties.sql
@@ -329,7 +329,7 @@ BEGIN
         */
         IF @debug = 1
         BEGIN
-            RAISERROR(N'Collected %d server properties row(s)', 0, 1, @rows_collected) WITH NOWAIT;
+            RAISERROR(N'Collected %I64d server properties row(s)', 0, 1, @rows_collected) WITH NOWAIT;
 
             SELECT TOP (1)
                 sp.server_name,


### PR DESCRIPTION
## Summary

Fixes #987. `RAISERROR`'s `%d` substitution accepts only `int` — passing a `bigint` silently produces no message. Collector `@rows_collected` is declared `bigint` and set from `ROWCOUNT_BIG()`, so every collector's `@debug=1` row-count line (`N'Collected %d ... rows'`) rendered nothing — the user saw only "Commands completed successfully".

This is a diagnostic-output bug only. The Agent jobs never pass `@debug=1`, so actual data collection was never affected — the messages were just invisible when a collector was run by hand.

## Changes

- 35 `%d` → `%I64d` substitutions across 31 install files, for every `RAISERROR` argument whose variable is `bigint` (`@rows_collected`, `@rows_updated`, `@rows_parsed`, `@events_from_file`, `@total_deleted`, `@duration_threshold_ms`).
- Multi-argument calls fixed positionally — `%d` kept for genuine `int` arguments (`@table_count`, `@trace_id`, `@property_count`, CPU-scheduler warning counters, etc.).
- `%I64d` was already used correctly in a few places (`23`, `25`, `43`); this brings the rest in line.

## Test plan

- [x] Full installer run against SQL2022 — 54 files, 0 failures, 45 collectors ran (all 31 changed files compile).
- [x] `EXEC collect.cpu_utilization_stats_collector @debug=1` → `Collected 1 CPU utilization stats rows` (reporter's expected output).
- [x] `EXEC collect.wait_stats_collector @debug=1` → `Collected 84 wait stats rows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)