### PR TITLE
Skip ring-buffer records missing SystemHealth values in CPU collector (#989)

### DIFF
--- a/Lite/Services/RemoteCollectorService.Cpu.cs
+++ b/Lite/Services/RemoteCollectorService.Cpu.cs
@@ -58,14 +58,12 @@ FROM sys.dm_os_sys_info AS dosi;
 
 SELECT TOP (60)
     sample_time = DATEADD(SECOND, -((@ms_ticks - t.timestamp) / 1000), SYSDATETIME()),
-    sqlserver_cpu_utilization = t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer'),
+    sqlserver_cpu_utilization = x.process_utilization,
     other_process_cpu_utilization =
         CASE
-            WHEN (100 - t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer')
-                      - t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer')) < 0
+            WHEN (100 - x.system_idle - x.process_utilization) < 0
             THEN 0
-            ELSE 100 - t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer')
-                     - t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer')
+            ELSE 100 - x.system_idle - x.process_utilization
         END
 FROM
 (
@@ -75,6 +73,16 @@ FROM
     FROM sys.dm_os_ring_buffers AS dorb
     WHERE dorb.ring_buffer_type = N'RING_BUFFER_SCHEDULER_MONITOR'
 ) AS t
+CROSS APPLY
+(
+    SELECT
+        process_utilization = t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer'),
+        system_idle = t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer')
+) AS x
+/* Skip ring-buffer records lacking a complete SystemHealth block — their
+   XML values extract as NULL and would store NULL samples (Issue #989). */
+WHERE x.process_utilization IS NOT NULL
+AND   x.system_idle IS NOT NULL
 ORDER BY t.timestamp DESC
 OPTION(RECOMPILE);";
 

--- a/install/18_collect_cpu_utilization_stats.sql
+++ b/install/18_collect_cpu_utilization_stats.sql
@@ -131,16 +131,12 @@ BEGIN
                     @start_time
                 ),
             sqlserver_cpu_utilization =
-                t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer'),
+                x.process_utilization,
             other_process_cpu_utilization =
                 CASE
-                    WHEN (100 -
-                          t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer') -
-                          t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer')) < 0
+                    WHEN (100 - x.system_idle - x.process_utilization) < 0
                     THEN 0
-                    ELSE 100 -
-                         t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer') -
-                         t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer')
+                    ELSE 100 - x.system_idle - x.process_utilization
                 END
         FROM
         (
@@ -151,12 +147,27 @@ BEGIN
             FROM sys.dm_os_ring_buffers AS dorb
             WHERE dorb.ring_buffer_type = N'RING_BUFFER_SCHEDULER_MONITOR'
         ) AS t
+        CROSS APPLY
+        (
+            SELECT
+                process_utilization =
+                    t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]', 'integer'),
+                system_idle =
+                    t.record.value('(Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]', 'integer')
+        ) AS x
         WHERE DATEADD
         (
             SECOND,
             -((@current_ms_ticks - t.timestamp) / 1000),
             @start_time
         ) > ISNULL(@max_sample_time, DATEADD(DAY, -7, @start_time))
+        /*
+        Skip ring-buffer records that lack a complete SystemHealth block —
+        their XML values extract as NULL and would fail the NOT NULL INSERT,
+        breaking collection until the bad records age out (Issue #989).
+        */
+        AND   x.process_utilization IS NOT NULL
+        AND   x.system_idle IS NOT NULL
         ORDER BY
             t.timestamp DESC
         OPTION(RECOMPILE);


### PR DESCRIPTION
## Summary

Fixes #989. Some `RING_BUFFER_SCHEDULER_MONITOR` records lack a complete `SystemHealth` block, so the `ProcessUtilization` / `SystemIdle` XML values extract as `NULL`.

The Dashboard collector inserts into `NOT NULL` columns, so a single malformed record fails the whole `INSERT` atomically. Nothing is ever inserted → `@max_sample_time` stays `NULL` → every run rescans the full 7-day window and re-hits the same bad records → **the collector never recovers**.

## Changes

- **`install/18_collect_cpu_utilization_stats.sql`** — extract `ProcessUtilization`/`SystemIdle` once via `CROSS APPLY`, then filter out records where either is `NULL`. Valid rows now insert, `@max_sample_time` advances, recovery is immediate (not a 7-day wait).
- **`Lite/Services/RemoteCollectorService.Cpu.cs`** — same `CROSS APPLY` + NULL filter. Lite's DuckDB columns are nullable so it never hard-failed, but it stored `NULL` samples that skew the CPU chart.

Dropped malformed records rather than `ISNULL(..., 0)` (the reporter's suggestion): a fabricated `0` reads as a real "0% CPU" sample and misleads the charts; a record with no `SystemHealth` block is not a CPU reading at all.

## Test plan

- [x] Deployed fixed proc to SQL2022 — `EXEC collect.cpu_utilization_stats_collector @debug=1` runs clean.
- [x] Ring-buffer audit on SQL2022: 256 records, 0 NULL — filter drops nothing valid on a healthy server.
- [x] Synthetic test: a record with an empty `<SystemHealth/>` is filtered out while a valid `42/50` record passes.
- [x] Lite builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)