### PR TITLE
Fix Lite SnoozeBalloon dismiss/snooze buttons being no-ops

### DIFF
--- a/Lite/Controls/SnoozeBalloon.xaml.cs
+++ b/Lite/Controls/SnoozeBalloon.xaml.cs
@@ -20,6 +20,7 @@ public partial class SnoozeBalloon : UserControl
     private readonly MuteRuleService _muteRuleService;
     private readonly string _serverName;
     private readonly string _metricName;
+    private readonly Action _closePopup;
     private bool _closed;
 
     public SnoozeBalloon(
@@ -28,13 +29,15 @@ public partial class SnoozeBalloon : UserControl
         BalloonIcon icon,
         string serverName,
         string metricName,
-        MuteRuleService muteRuleService)
+        MuteRuleService muteRuleService,
+        Action closePopup)
     {
         InitializeComponent();
 
         _muteRuleService = muteRuleService;
         _serverName = serverName;
         _metricName = metricName;
+        _closePopup = closePopup;
 
         TitleText.Text = title;
         MessageText.Text = message;
@@ -98,7 +101,10 @@ public partial class SnoozeBalloon : UserControl
 
     private void CloseBalloon()
     {
-        RaiseEvent(new RoutedEventArgs(TaskbarIcon.BalloonClosingEvent));
+        /* Hardcodet's BalloonClosingEvent is emitted BY the library when it closes; it has no
+           listener that translates a balloon-initiated raise back into a close. To actually
+           tear the popup down we have to call TaskbarIcon.CloseBalloon() directly. */
+        _closePopup();
     }
 
     private static string FormatDuration(TimeSpan d) =>

--- a/Lite/Services/SystemTrayService.cs
+++ b/Lite/Services/SystemTrayService.cs
@@ -176,7 +176,8 @@ public class SystemTrayService : IDisposable
         if (_trayIcon == null)
             return;
 
-        var balloon = new SnoozeBalloon(title, message, icon, serverName, metricName, muteRuleService);
+        var trayIcon = _trayIcon;
+        var balloon = new SnoozeBalloon(title, message, icon, serverName, metricName, muteRuleService, () => trayIcon.CloseBalloon());
         _trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 15000);
     }
 


### PR DESCRIPTION
Closes #992

## Summary
- `SnoozeBalloon.CloseBalloon()` was raising `TaskbarIcon.BalloonClosingEvent` expecting the library to close the popup. Hardcodet only *emits* that event during its own close path; it has no listener that converts a balloon-initiated raise into a close. So user dismiss/snooze clicks did nothing.
- Pass an `Action closePopup` to `SnoozeBalloon` that invokes `TaskbarIcon.CloseBalloon()` directly — the same method used internally for timeout and replacement closes.

## Test plan
- [x] Reproduced on `dev`: HammerDB driving sql2025 triggered Blocking Detected / Deadlocks Detected popups; clicking Dismiss did nothing across 400+ clicks on the same popup.
- [x] Built fix locally; same load, single Dismiss click closes the popup cleanly.
- [ ] Verify Snooze 15m / 1h / 4h buttons also close the popup AND register a mute rule (path is shared with Dismiss via `CloseBalloon()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)