### PR TITLE
Bring Dashboard alert toasts to parity with Lite

### DIFF
--- a/Dashboard/Controls/SnoozeBalloon.xaml
+++ b/Dashboard/Controls/SnoozeBalloon.xaml
@@ -1,0 +1,60 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.SnoozeBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="360"
+             FontFamily="Segoe UI">
+    <Border Background="{DynamicResource BackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            TextElement.FontFamily="Segoe UI">
+        <StackPanel Margin="14,12,14,12">
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock x:Name="SeverityIcon"
+                           Text="!"
+                           FontSize="16"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="TitleText"
+                           Text="Alert"
+                           FontWeight="SemiBold"
+                           FontSize="13"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+
+            <TextBlock x:Name="MessageText"
+                       Text=""
+                       TextWrapping="Wrap"
+                       FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       Margin="0,0,0,10"/>
+
+            <DockPanel>
+                <Button x:Name="DismissButton"
+                        Content="Dismiss"
+                        DockPanel.Dock="Right"
+                        Padding="10,4"
+                        Click="DismissButton_Click"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                    <Button x:Name="Snooze15Button"
+                            Content="Snooze 15m"
+                            Padding="8,4"
+                            Margin="0,0,4,0"
+                            Click="Snooze15Button_Click"/>
+                    <Button x:Name="Snooze1hButton"
+                            Content="Snooze 1h"
+                            Padding="8,4"
+                            Margin="0,0,4,0"
+                            Click="Snooze1hButton_Click"/>
+                    <Button x:Name="Snooze4hButton"
+                            Content="Snooze 4h"
+                            Padding="8,4"
+                            Click="Snooze4hButton_Click"/>
+                </StackPanel>
+            </DockPanel>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Dashboard/Controls/SnoozeBalloon.xaml.cs
+++ b/Dashboard/Controls/SnoozeBalloon.xaml.cs
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Hardcodet.Wpf.TaskbarNotification;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    public partial class SnoozeBalloon : UserControl
+    {
+        private readonly MuteRuleService _muteRuleService;
+        private readonly string _serverName;
+        private readonly string _metricName;
+        private readonly Action _closePopup;
+        private bool _closed;
+
+        public SnoozeBalloon(
+            string title,
+            string message,
+            BalloonIcon icon,
+            string serverName,
+            string metricName,
+            MuteRuleService muteRuleService,
+            Action closePopup)
+        {
+            InitializeComponent();
+
+            _muteRuleService = muteRuleService;
+            _serverName = serverName;
+            _metricName = metricName;
+            _closePopup = closePopup;
+
+            TitleText.Text = title;
+            MessageText.Text = message;
+            ApplySeverity(icon);
+        }
+
+        private void ApplySeverity(BalloonIcon icon)
+        {
+            switch (icon)
+            {
+                case BalloonIcon.Error:
+                    SeverityIcon.Text = "⚠";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+                    break;
+                case BalloonIcon.Warning:
+                    SeverityIcon.Text = "⚠";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
+                    break;
+                default:
+                    SeverityIcon.Text = "ℹ";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6));
+                    break;
+            }
+        }
+
+        private void Snooze15Button_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromMinutes(15));
+        private void Snooze1hButton_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromHours(1));
+        private void Snooze4hButton_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromHours(4));
+
+        private void Snooze(TimeSpan duration)
+        {
+            if (_closed) return;
+            _closed = true;
+
+            var rule = new MuteRule
+            {
+                ServerName = _serverName,
+                MetricName = _metricName,
+                ExpiresAtUtc = DateTime.UtcNow + duration,
+                Reason = $"Snoozed from popup ({FormatDuration(duration)})"
+            };
+
+            try
+            {
+                _muteRuleService.AddRule(rule);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"[SnoozeBalloon] Failed to add snooze rule: {ex.Message}");
+            }
+
+            CloseBalloon();
+        }
+
+        private void DismissButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_closed) return;
+            _closed = true;
+            CloseBalloon();
+        }
+
+        private void CloseBalloon()
+        {
+            /* Hardcodet's BalloonClosingEvent is emitted BY the library when it closes; it has no
+               listener that translates a balloon-initiated raise back into a close. To actually
+               tear the popup down we have to call TaskbarIcon.CloseBalloon() directly. */
+            _closePopup();
+        }
+
+        private static string FormatDuration(TimeSpan d) =>
+            d.TotalHours >= 1 ? $"{(int)d.TotalHours}h" : $"{(int)d.TotalMinutes}m";
+    }
+}

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -1418,10 +1418,13 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowBlockingNotification(
+                        _notificationService?.ShowSnoozableNotification(
+                            "Blocking Detected",
+                            $"{serverName}: {(int)health.TotalBlocked} blocked session(s), longest {(int)health.LongestBlockedSeconds}s",
+                            NotificationType.Warning,
                             serverName,
-                            (int)health.TotalBlocked,
-                            (int)health.LongestBlockedSeconds);
+                            "Blocking Detected",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "Blocking Detected",
@@ -1480,9 +1483,14 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowDeadlockNotification(
+                        var deadlockPlural = effectiveDeadlockDelta == 1 ? "" : "s";
+                        _notificationService?.ShowSnoozableNotification(
+                            "Deadlock Detected",
+                            $"{serverName}: {(int)effectiveDeadlockDelta} deadlock{deadlockPlural} detected",
+                            NotificationType.Error,
                             serverName,
-                            (int)effectiveDeadlockDelta);
+                            "Deadlocks Detected",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "Deadlocks Detected",
@@ -1526,9 +1534,13 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowHighCpuNotification(
+                        _notificationService?.ShowSnoozableNotification(
+                            "High CPU",
+                            $"{serverName}: CPU at {totalCpu}%",
+                            NotificationType.Warning,
                             serverName,
-                            totalCpu);
+                            "High CPU",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "High CPU",
@@ -1581,7 +1593,13 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowPoisonWaitNotification(serverName, worst.WaitType, worst.AvgMsPerWait);
+                        _notificationService?.ShowSnoozableNotification(
+                            "Poison Wait",
+                            $"{serverName}: {worst.WaitType} avg {worst.AvgMsPerWait:F0}ms/wait",
+                            NotificationType.Error,
+                            serverName,
+                            "Poison Wait",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "Poison Wait",
@@ -1643,8 +1661,14 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowLongRunningQueryNotification(
-                            serverName, worst.SessionId, elapsedMinutes, preview);
+                        var lrqPreview = string.IsNullOrEmpty(preview) ? "" : $" — {preview}";
+                        _notificationService?.ShowSnoozableNotification(
+                            "Long-Running Query",
+                            $"{serverName}: Session #{worst.SessionId} running {elapsedMinutes}m{lrqPreview}",
+                            NotificationType.Warning,
+                            serverName,
+                            "Long-Running Query",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Query",
@@ -1690,7 +1714,13 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowTempDbSpaceNotification(serverName, tempDb.UsedPercent);
+                        _notificationService?.ShowSnoozableNotification(
+                            "TempDB Space",
+                            $"{serverName}: TempDB {tempDb.UsedPercent:F0}% used",
+                            NotificationType.Warning,
+                            serverName,
+                            "TempDB Space",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "TempDB Space",
@@ -1740,8 +1770,13 @@ namespace PerformanceMonitorDashboard
 
                     if (!isMuted)
                     {
-                        _notificationService?.ShowLongRunningJobNotification(
-                            serverName, worst.JobName, currentMinutes, worst.PercentOfAverage ?? 0);
+                        _notificationService?.ShowSnoozableNotification(
+                            "Long-Running Job",
+                            $"{serverName}: {worst.JobName} at {(worst.PercentOfAverage ?? 0):F0}% of avg ({currentMinutes}m)",
+                            NotificationType.Warning,
+                            serverName,
+                            "Long-Running Job",
+                            _muteRuleService);
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Job",

--- a/Dashboard/Services/NotificationService.cs
+++ b/Dashboard/Services/NotificationService.cs
@@ -142,6 +142,45 @@ namespace PerformanceMonitorDashboard.Services
             }
         }
 
+        /// <summary>
+        /// Shows a custom interactive popup with Snooze 15m / 1h / 4h and Dismiss buttons.
+        /// Snooze buttons create a temporary mute rule scoped to <paramref name="serverName"/> + <paramref name="metricName"/>.
+        /// </summary>
+        public void ShowSnoozableNotification(
+            string title,
+            string message,
+            NotificationType type,
+            string serverName,
+            string metricName,
+            MuteRuleService muteRuleService)
+        {
+            if (_trayIcon == null) return;
+
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotificationsEnabled) return;
+
+            var icon = type switch
+            {
+                NotificationType.Error => BalloonIcon.Error,
+                NotificationType.Warning => BalloonIcon.Warning,
+                NotificationType.Success => BalloonIcon.Info,
+                _ => BalloonIcon.Info
+            };
+
+            void Show()
+            {
+                var trayIcon = _trayIcon;
+                if (trayIcon == null) return;
+                var balloon = new Controls.SnoozeBalloon(title, message, icon, serverName, metricName, muteRuleService, () => trayIcon.CloseBalloon());
+                trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 15000);
+            }
+
+            if (_mainWindow.Dispatcher.CheckAccess())
+                Show();
+            else
+                _mainWindow.Dispatcher.Invoke(Show);
+        }
+
         public void ShowServerOnlineNotification(string serverName)
         {
             ShowNotification(
@@ -168,85 +207,6 @@ namespace PerformanceMonitorDashboard.Services
                 "Connection Restored",
                 $"{serverName} connection restored",
                 NotificationType.Success);
-        }
-
-        public void ShowBlockingNotification(string serverName, int blockedSessions, int durationSeconds)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnBlocking) return;
-
-            ShowNotification(
-                "Blocking Detected",
-                $"{serverName}: {blockedSessions} blocked session(s), longest {durationSeconds}s",
-                NotificationType.Warning);
-        }
-
-        public void ShowDeadlockNotification(string serverName, int deadlockCount)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnDeadlock) return;
-
-            var plural = deadlockCount == 1 ? "" : "s";
-            ShowNotification(
-                "Deadlock Detected",
-                $"{serverName}: {deadlockCount} deadlock{plural} detected",
-                NotificationType.Error);
-        }
-
-        public void ShowHighCpuNotification(string serverName, int cpuPercent)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnHighCpu) return;
-
-            ShowNotification(
-                "High CPU",
-                $"{serverName}: CPU at {cpuPercent}%",
-                NotificationType.Warning);
-        }
-
-        public void ShowPoisonWaitNotification(string serverName, string waitType, double avgMs)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnPoisonWaits) return;
-
-            ShowNotification(
-                "Poison Wait",
-                $"{serverName}: {waitType} avg {avgMs:F0}ms/wait",
-                NotificationType.Error);
-        }
-
-        public void ShowLongRunningQueryNotification(string serverName, int sessionId, long elapsedMinutes, string queryPreview)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnLongRunningQueries) return;
-
-            var preview = string.IsNullOrEmpty(queryPreview) ? "" : $" — {queryPreview}";
-            ShowNotification(
-                "Long-Running Query",
-                $"{serverName}: Session #{sessionId} running {elapsedMinutes}m{preview}",
-                NotificationType.Warning);
-        }
-
-        public void ShowTempDbSpaceNotification(string serverName, double usedPercent)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnTempDbSpace) return;
-
-            ShowNotification(
-                "TempDB Space",
-                $"{serverName}: TempDB {usedPercent:F0}% used",
-                NotificationType.Warning);
-        }
-
-        public void ShowLongRunningJobNotification(string serverName, string jobName, long currentMinutes, decimal percentOfAvg)
-        {
-            var prefs = _preferencesService.GetPreferences();
-            if (!prefs.NotifyOnLongRunningJobs) return;
-
-            ShowNotification(
-                "Long-Running Job",
-                $"{serverName}: {jobName} at {percentOfAvg:F0}% of avg ({currentMinutes}m)",
-                NotificationType.Warning);
         }
 
         private void ShowMainWindow()


### PR DESCRIPTION
Closes #994

## Summary
- Replaces Dashboard's native `ShowBalloonTip` toasts with the dark-themed, snoozable custom popup ported from Lite.
- Adds **Snooze 15m / 1h / 4h** + **Dismiss** to the 7 actionable alerts. Snooze creates a temporary `MuteRule` via the existing `MuteRuleService` — the rule shows up in *Settings → Manage Mute Rules* alongside any user-created rules.
- Carries the close-callback fix from #993 so the new popup actually dies on Dismiss (no infinite-click bug like Lite had).
- Removes 7 dead-after-port typed wrapper methods on `NotificationService`; per-metric `prefs.NotifyOnXxx` guards already live at the alert sites.
- Connection-state notifications (Server Online / Offline / Restored / Connection Restored) deliberately stay as native `ShowBalloonTip` — those route to Windows Action Center, which is the right home for transient connectivity events.

## Test plan
- [x] Build clean
- [x] Verified live with HammerDB on sql2025: snoozable popup fires for Blocking / Deadlock / Poison Wait
- [ ] Verify Snooze 15m creates a rule visible in `ManageMuteRulesWindow`, suppresses further alerts for that server+metric for 15 min, leaves other metrics on the same server firing
- [ ] Verify Server Restored / Server Offline still use the native Windows toast (Action Center entry)
- [ ] Verify theme switching: snoozable popup picks up Light / Dark / CoolBreeze brushes (XAML uses `DynamicResource`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)