### PR TITLE
Sync drift between Dashboard/Analysis and Lite/Analysis (parity sweep)

### DIFF
--- a/Dashboard/Analysis/AnalysisModels.cs
+++ b/Dashboard/Analysis/AnalysisModels.cs
@@ -82,7 +82,7 @@ public class AnalysisStory
 
 /// <summary>
 /// A persisted finding from a previous analysis run.
-/// Maps to the analysis_findings DuckDB table.
+/// Maps to the analysis_findings table.
 /// </summary>
 public class AnalysisFinding
 {
@@ -106,7 +106,7 @@ public class AnalysisFinding
     public int FactCount { get; set; }
 
     /// <summary>
-    /// Drill-down data collected after graph traversal. Ephemeral — not persisted to DuckDB.
+    /// Drill-down data collected after graph traversal. Ephemeral — not persisted.
     /// Contains supporting detail keyed by category (e.g., "top_deadlocks", "queries_at_spike").
     /// </summary>
     public Dictionary<string, object>? DrillDown { get; set; }
@@ -114,12 +114,13 @@ public class AnalysisFinding
     /// <summary>
     /// Metadata from the root fact carried in from <see cref="AnalysisStory.RootFactMetadata"/>.
     /// Ephemeral — used by the notification layer for diagnosis context; not persisted.
+    /// In practice this is anomaly-detector baseline context: mean, stddev, tier, hour, dow.
     /// </summary>
     public Dictionary<string, double>? RootFactMetadata { get; set; }
 }
 
 /// <summary>
-/// A muted finding pattern. Maps to the analysis_muted DuckDB table.
+/// A muted finding pattern. Maps to the analysis_muted table.
 /// </summary>
 public class AnalysisMuted
 {
@@ -133,7 +134,7 @@ public class AnalysisMuted
 }
 
 /// <summary>
-/// A user-configured exclusion filter. Maps to the analysis_exclusions DuckDB table.
+/// A user-configured exclusion filter. Maps to the analysis_exclusions table.
 /// </summary>
 public class AnalysisExclusion
 {
@@ -148,7 +149,7 @@ public class AnalysisExclusion
 }
 
 /// <summary>
-/// A severity threshold value. Maps to the analysis_thresholds DuckDB table.
+/// A severity threshold value. Maps to the analysis_thresholds table.
 /// </summary>
 public class AnalysisThreshold
 {

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -8,7 +8,7 @@ using PerformanceMonitorDashboard.Helpers;
 namespace PerformanceMonitorDashboard.Analysis;
 
 /// <summary>
-/// Orchestrates the full analysis pipeline: collect -> score -> traverse -> persist.
+/// Orchestrates the full analysis pipeline: collect → score → traverse → persist.
 /// Can be run on-demand or on a timer. Each run analyzes a single server's data
 /// for a given time window and persists the findings.
 /// Port of Lite's AnalysisService — uses SQL Server instead of DuckDB.
@@ -27,7 +27,7 @@ public class AnalysisService
 
     /// <summary>
     /// Minimum hours of collected data required before analysis will run.
-    /// Short collection windows distort fraction-of-period calculations --
+    /// Short collection windows distort fraction-of-period calculations —
     /// 5 seconds of THREADPOOL looks alarming in a 16-minute window.
     /// </summary>
     internal double MinimumDataHours { get; set; } = 72;
@@ -98,7 +98,7 @@ public class AnalysisService
 
         try
         {
-            // 0. Check minimum data span -- total history, not the analysis window.
+            // 0. Check minimum data span — total history, not the analysis window.
             // A server with 100h of total history can be analyzed over a 4h window.
             var dataSpanHours = await GetTotalDataSpanHoursAsync();
             if (dataSpanHours < MinimumDataHours)
@@ -281,7 +281,7 @@ public class AnalysisService
 
     /// <summary>
     /// Returns the total span of collected data (no time range filter).
-    /// This answers "has this server been monitored long enough?" -- separate from
+    /// This answers "has this server been monitored long enough?" — separate from
     /// the analysis window. A server with 100 hours of total history can safely
     /// be analyzed over a 4-hour window without dilution.
     /// Dashboard monitors one server per database, so no server_id filtering.

--- a/Dashboard/Analysis/FactScorer.cs
+++ b/Dashboard/Analysis/FactScorer.cs
@@ -336,6 +336,7 @@ public class FactScorer
             || fact.Key.StartsWith("ANOMALY_BATCH_REQUESTS", StringComparison.OrdinalIgnoreCase)
             || fact.Key.StartsWith("ANOMALY_SESSION_SPIKE" , StringComparison.OrdinalIgnoreCase)
             || fact.Key.StartsWith("ANOMALY_QUERY_DURATION", StringComparison.OrdinalIgnoreCase)
+            || fact.Key.StartsWith("ANOMALY_MEMORY_PRESSURE", StringComparison.OrdinalIgnoreCase)
             )
         {
             // Deviation-based scoring: 2σ = 0.5, 4σ = 1.0

--- a/Lite/Analysis/AnalysisModels.cs
+++ b/Lite/Analysis/AnalysisModels.cs
@@ -72,12 +72,17 @@ public class AnalysisStory
     public double? LeafFactValue { get; set; }
     public int FactCount { get; set; }
     public bool IsAbsolution { get; set; }
+
+    /// <summary>
+    /// Metadata from the root fact (raw metric values used to assemble the story).
+    /// Ephemeral — copied onto the finding for the notification layer, not persisted.
+    /// </summary>
     public Dictionary<string, double>? RootFactMetadata { get; set; }
 }
 
 /// <summary>
 /// A persisted finding from a previous analysis run.
-/// Maps to the analysis_findings DuckDB table.
+/// Maps to the analysis_findings table.
 /// </summary>
 public class AnalysisFinding
 {
@@ -101,20 +106,21 @@ public class AnalysisFinding
     public int FactCount { get; set; }
 
     /// <summary>
-    /// Drill-down data collected after graph traversal. Ephemeral — not persisted to DuckDB.
+    /// Drill-down data collected after graph traversal. Ephemeral — not persisted.
     /// Contains supporting detail keyed by category (e.g., "top_deadlocks", "queries_at_spike").
     /// </summary>
     public Dictionary<string, object>? DrillDown { get; set; }
 
     /// <summary>
-    /// Root fact metadata from anomaly detection. Ephemeral — not persisted to DuckDB.
-    /// Contains baseline context (mean, stddev, tier, hour, dow) for anomaly findings.
+    /// Metadata from the root fact carried in from <see cref="AnalysisStory.RootFactMetadata"/>.
+    /// Ephemeral — used by the notification layer for diagnosis context; not persisted.
+    /// In practice this is anomaly-detector baseline context: mean, stddev, tier, hour, dow.
     /// </summary>
     public Dictionary<string, double>? RootFactMetadata { get; set; }
 }
 
 /// <summary>
-/// A muted finding pattern. Maps to the analysis_muted DuckDB table.
+/// A muted finding pattern. Maps to the analysis_muted table.
 /// </summary>
 public class AnalysisMuted
 {
@@ -128,7 +134,7 @@ public class AnalysisMuted
 }
 
 /// <summary>
-/// A user-configured exclusion filter. Maps to the analysis_exclusions DuckDB table.
+/// A user-configured exclusion filter. Maps to the analysis_exclusions table.
 /// </summary>
 public class AnalysisExclusion
 {
@@ -143,7 +149,7 @@ public class AnalysisExclusion
 }
 
 /// <summary>
-/// A severity threshold value. Maps to the analysis_thresholds DuckDB table.
+/// A severity threshold value. Maps to the analysis_thresholds table.
 /// </summary>
 public class AnalysisThreshold
 {

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -28,9 +28,8 @@ public class AnalysisService
     /// Minimum hours of collected data required before analysis will run.
     /// Short collection windows distort fraction-of-period calculations —
     /// 5 seconds of THREADPOOL looks alarming in a 16-minute window.
-    /// Production: 72. Dev/testing: 0.5 (raise before release).
     /// </summary>
-    internal double MinimumDataHours { get; set; } = 24; // TODO: restore to 72 before release
+    internal double MinimumDataHours { get; set; } = 72;
 
     /// <summary>
     /// Raised after each analysis run completes, providing the findings for UI display.
@@ -148,7 +147,7 @@ public class AnalysisService
 
             LastAnalysisTime = DateTime.UtcNow;
 
-            // 5. Notify listeners
+            // 6. Notify listeners
             AnalysisCompleted?.Invoke(this, new AnalysisCompletedEventArgs
             {
                 ServerId = context.ServerId,


### PR DESCRIPTION
## Summary

Parity sweep across `Dashboard/Analysis/` and `Lite/Analysis/` per `dashboard-analysis-parity-sweep.md`. Six drift items, all touching pure (non-DB-bound) algorithm files. Total diff: 26 insertions, 19 deletions across 5 files.

- **D-1** (`Dashboard/Analysis/FactScorer.cs`): Add missing `ANOMALY_MEMORY_PRESSURE` arm to `ScoreAnomalyFact`. Defensive — no `SqlServerAnomalyDetector` emits the key today, but Lite already had the arm and a future port of `DetectMemoryAnomalies` shouldn't silently produce unscored facts.
- **D-2** (`Lite/Analysis/AnalysisService.cs`): Restore `MinimumDataHours` from `24` (dev-only) to `72`; drop the release-blocker TODO. Short collection windows distort fraction-of-period calculations.
- **D-3** (`Lite/Analysis/AnalysisService.cs`): Renumber duplicate `// 5. Notify listeners` to `// 6.`.
- **D-4** (both `AnalysisModels.cs`): Drop "DuckDB" qualifier from five doc strings on both sides — shared model classes, factually wrong on Dashboard. Applied identically so the pair stays in sync.
- **D-5a** (`Lite/Analysis/AnalysisModels.cs`): Add Dashboard's `AnalysisStory.RootFactMetadata` doc block to Lite (Lite had a bare property).
- **D-5b** (both `AnalysisModels.cs`): Synthesize `AnalysisFinding.RootFactMetadata` doc — Dashboard's framing (`<see cref>` link, "not persisted" wording) + Lite's concrete key list (`mean, stddev, tier, hour, dow`). Identical on both sides.
- **D-6** (`Dashboard/Analysis/AnalysisService.cs`): Replace ASCII `->`/`--` with unicode `→`/`—` (4 lines, 6 substitutions) to match Dashboard's own unicode style elsewhere.

**Out of scope** for this sweep:
- D-7 PARAMETER_SENSITIVITY / PLAN_REGRESSION fact pipelines back-port to Lite (feature-deferred, follow-up issue).
- D-8 Memory anomaly back-port to Dashboard (feature-deferred, follow-up issue).
- D-9 Chart-unit baseline metrics on Dashboard (closed; UI-only, no analysis-engine consumer).
- D-10 (FindingStore `ReadFinding` helper), D-11 (BLOCKING_SPIKE multi-line formatting), D-12 (BlockingChainReconstructor `<remarks>` mirror) — deferred per implementation brief; can land in a follow-up.

## Test plan

- [x] `dotnet build Dashboard/Dashboard.csproj -c Debug` — 0 warnings, 0 errors
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — 0 warnings, 0 errors
- [x] `dotnet test Lite.Tests/Lite.Tests.csproj` — 260 passed, 0 failed
- [x] `code-reviewer` agent — clean, no findings
- [x] `planalyzer-sync-checker` — in sync (not touched by this sweep)
- [x] `blocking-reconstructor-sync-checker` — sweep made no changes (Lite copy of file doesn't yet exist on `dev`; tracked separately)
- [ ] Hand-pass on Dashboard against a live server: open analysis pane, confirm findings render and category set is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)