### PR TITLE
Bootstrap Dashboard.Tests project source (plan 3)

### DIFF
--- a/Dashboard.Tests/BaselineBucketTests.cs
+++ b/Dashboard.Tests/BaselineBucketTests.cs
@@ -1,0 +1,55 @@
+using PerformanceMonitorDashboard.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests for BaselineBucket.EffectiveStdDev: proportional floor and division-by-zero handling.
+/// </summary>
+public class BaselineBucketTests
+{
+    // ── Division by zero: proportional floor ──
+
+    [Fact]
+    public void EffectiveStdDev_ZeroStdDev_UsesProportionalFloor()
+    {
+        // All identical values → stddev = 0, mean = 50
+        var bucket = new BaselineBucket
+        {
+            HourOfDay = 14, DayOfWeek = 3,
+            Mean = 50.0, StdDev = 0.0, SampleCount = 20,
+            Tier = BaselineTier.Full
+        };
+
+        // Should be max(0, 50 * 0.01) = 0.5
+        Assert.Equal(0.5, bucket.EffectiveStdDev);
+    }
+
+    [Fact]
+    public void EffectiveStdDev_ZeroMeanAndZeroStdDev_ReturnsZero()
+    {
+        // Zero activity → skip scoring
+        var bucket = new BaselineBucket
+        {
+            HourOfDay = 14, DayOfWeek = 3,
+            Mean = 0.0, StdDev = 0.0, SampleCount = 20,
+            Tier = BaselineTier.Full
+        };
+
+        Assert.Equal(0.0, bucket.EffectiveStdDev);
+    }
+
+    [Fact]
+    public void EffectiveStdDev_NormalStdDev_ReturnsActual()
+    {
+        var bucket = new BaselineBucket
+        {
+            HourOfDay = 14, DayOfWeek = 3,
+            Mean = 50.0, StdDev = 5.0, SampleCount = 20,
+            Tier = BaselineTier.Full
+        };
+
+        // StdDev (5.0) > Mean * 0.01 (0.5), so return actual
+        Assert.Equal(5.0, bucket.EffectiveStdDev);
+    }
+}

--- a/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/Dashboard.Tests/Dashboard.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CS4014;NU1701;CA1001;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dashboard\Dashboard.csproj" />
+  </ItemGroup>
+</Project>

--- a/Dashboard.Tests/FactScorerTests.cs
+++ b/Dashboard.Tests/FactScorerTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitorDashboard.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests FactScorer Layer 1 (base severity) and Layer 2 (amplifiers).
+/// Validates threshold formulas, amplifier firing, and severity capping.
+/// </summary>
+public class FactScorerTests
+{
+    /* ── Threshold formula unit tests ── */
+
+    [Theory]
+    [InlineData(0.0, 0.25, null, 0.0)]        // Zero → 0.0
+    [InlineData(0.125, 0.25, null, 0.5)]       // Half of concerning → 0.5
+    [InlineData(0.25, 0.25, null, 1.0)]        // At concerning (no critical) → 1.0
+    [InlineData(0.50, 0.25, null, 1.0)]        // Above concerning (no critical) → capped at 1.0
+    [InlineData(0.0, 0.25, 0.75, 0.0)]         // Zero → 0.0
+    [InlineData(0.125, 0.25, 0.75, 0.25)]      // Half of concerning → 0.25
+    [InlineData(0.25, 0.25, 0.75, 0.5)]        // At concerning → 0.5
+    [InlineData(0.50, 0.25, 0.75, 0.75)]       // Midway → 0.75
+    [InlineData(0.75, 0.25, 0.75, 1.0)]        // At critical → 1.0
+    [InlineData(1.00, 0.25, 0.75, 1.0)]        // Above critical → 1.0
+    public void ApplyThresholdFormula_ReturnsExpected(
+        double value, double concerning, double? critical, double expected)
+    {
+        var result = FactScorer.ApplyThresholdFormula(value, concerning, critical);
+        Assert.Equal(expected, result, precision: 4);
+    }
+
+    /* ── Unknown wait types ── */
+
+    [Fact]
+    public void Score_UnknownWaitType_GetsSeverityZero()
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "waits", Key = "UNKNOWN_WAIT_XYZ", Value = 0.50 }
+        };
+
+        var scorer = new FactScorer();
+        scorer.ScoreAll(facts);
+
+        Assert.Equal(0.0, facts[0].BaseSeverity);
+    }
+
+    /* ── Layer 2: Amplifier tests ── */
+
+    [Fact]
+    public void Amplifier_SeverityCappedAt2()
+    {
+        // Synthetic: create a fact set where amplifiers would push past 2.0
+        var facts = new List<Fact>
+        {
+            new() { Source = "waits", Key = "CXPACKET", Value = 0.80 },           // base = 1.0
+            new() { Source = "waits", Key = "SOS_SCHEDULER_YIELD", Value = 0.50 }, // > 25% threshold
+            new() { Source = "waits", Key = "THREADPOOL", Value = 0.05,           // real thread exhaustion
+                Metadata = new() { ["wait_time_ms"] = 7_200_000, ["avg_ms_per_wait"] = 3_600 } },  // 2h total, 3.6s avg
+            new() { Source = "config", Key = "CONFIG_CTFP", Value = 5 },          // bad CTFP
+            new() { Source = "config", Key = "CONFIG_MAXDOP", Value = 0 },        // bad MAXDOP
+        };
+
+        var scorer = new FactScorer();
+        scorer.ScoreAll(facts);
+
+        var cx = facts.First(f => f.Key == "CXPACKET");
+
+        // base 1.0 * (1.0 + 0.3 SOS + 0.4 THREADPOOL + 0.3 CTFP + 0.2 MAXDOP) = 2.2 → capped at 2.0
+        Assert.True(cx.Severity <= 2.0, "Severity should never exceed 2.0");
+        Assert.Equal(2.0, cx.Severity);
+    }
+}

--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using PerformanceMonitorDashboard.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests the InferenceEngine and RelationshipGraph against seeded scenarios.
+/// Validates that stories are built with correct paths and severity ordering.
+/// </summary>
+public class InferenceEngineTests
+{
+    /* ── Unit tests: graph edge evaluation ── */
+
+    [Fact]
+    public void Graph_NoEdgesForUnknownFact()
+    {
+        var graph = new RelationshipGraph();
+        var facts = new Dictionary<string, Fact>();
+
+        var edges = graph.GetActiveEdges("UNKNOWN_THING", facts);
+        Assert.Empty(edges);
+    }
+
+    [Fact]
+    public void Graph_CxPacketEdgeFires_WhenSosIsHigh()
+    {
+        var graph = new RelationshipGraph();
+        var facts = new Dictionary<string, Fact>
+        {
+            ["SOS_SCHEDULER_YIELD"] = new() { Key = "SOS_SCHEDULER_YIELD", Value = 0.50, Severity = 0.67 }
+        };
+
+        var edges = graph.GetActiveEdges("CXPACKET", facts);
+        Assert.Contains(edges, e => e.Destination == "SOS_SCHEDULER_YIELD");
+    }
+
+    [Fact]
+    public void Graph_CxPacketEdgeDoesNotFire_WhenSosIsLow()
+    {
+        var graph = new RelationshipGraph();
+        var facts = new Dictionary<string, Fact>
+        {
+            ["SOS_SCHEDULER_YIELD"] = new() { Key = "SOS_SCHEDULER_YIELD", Value = 0.10, Severity = 0.13 }
+        };
+
+        var edges = graph.GetActiveEdges("CXPACKET", facts);
+        Assert.DoesNotContain(edges, e => e.Destination == "SOS_SCHEDULER_YIELD");
+    }
+}

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -33,6 +33,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Dashboard.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CredentialManagement" Version="1.0.2" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />

--- a/PerformanceMonitor.sln
+++ b/PerformanceMonitor.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer.Tests", "Installe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer.Core", "Installer.Core\Installer.Core.csproj", "{AFA0BA1D-42D6-4E01-9D6C-B7E327E1B7D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dashboard.Tests", "Dashboard.Tests\Dashboard.Tests.csproj", "{769BF5E2-21F2-4D14-8C45-DC46FB9E3D86}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{AFA0BA1D-42D6-4E01-9D6C-B7E327E1B7D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFA0BA1D-42D6-4E01-9D6C-B7E327E1B7D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFA0BA1D-42D6-4E01-9D6C-B7E327E1B7D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{769BF5E2-21F2-4D14-8C45-DC46FB9E3D86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{769BF5E2-21F2-4D14-8C45-DC46FB9E3D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{769BF5E2-21F2-4D14-8C45-DC46FB9E3D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{769BF5E2-21F2-4D14-8C45-DC46FB9E3D86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Populates the previously scaffold-only `Dashboard.Tests/` folder with the pure-algorithm subset of `Lite.Tests` — every test that exercises shared analysis code without a DuckDB or SQL Server dependency. Three ported files, 18 cases, ~1s wall time.

## What changed

- **New `Dashboard.Tests/Dashboard.Tests.csproj`** — mirrors `Lite.Tests/Lite.Tests.csproj` byte-for-byte modulo the project reference (`net10.0-windows`, xunit.v3 3.2.2, `Microsoft.NET.Test.Sdk` 18.5.1, same `NoWarn` set, `UseWPF=true`).
- **New `Dashboard.Tests/FactScorerTests.cs`** — 12 cases: 10 `ApplyThresholdFormula` `[InlineData]` rows, `Score_UnknownWaitType_GetsSeverityZero`, `Amplifier_SeverityCappedAt2`.
- **New `Dashboard.Tests/InferenceEngineTests.cs`** — 3 cases: `Graph_NoEdgesForUnknownFact`, `Graph_CxPacketEdgeFires_WhenSosIsHigh`, `Graph_CxPacketEdgeDoesNotFire_WhenSosIsLow`.
- **New `Dashboard.Tests/BaselineBucketTests.cs`** — 3 cases on `BaselineBucket.EffectiveStdDev` (proportional floor, zero-activity, pass-through). Renamed from Lite's `BaselineProviderTests` because only the value-type cases port; the provider-level DuckDB cases are deferred. `using DuckDB.NET.Data;` stripped.
- **Modified `Dashboard/Dashboard.csproj`** — adds `<InternalsVisibleTo Include="Dashboard.Tests" />`. `FactScorer.ApplyThresholdFormula` is `internal static`, so the Theory port would not compile without this.
- **Modified `PerformanceMonitor.sln`** — adds `Dashboard.Tests` project block + per-config Debug/Release build mappings under a fresh GUID.

Test bodies, `[InlineData]` rows, and assertions are byte-identical to the Lite originals — the shared algorithms are byte-identical between Lite and Dashboard, so the ported tests pass without behavior change.

## Out of scope (intentionally deferred)

- **`BlockingChainReconstructorTests`** — `Dashboard/Analysis/BlockingChainReconstructor.cs` is on `dev`, but Lite's matching test file lives only on the unmerged Lite Stage 3 worktree. The parity port rides in the same PR that brings Lite Stage 3's reconstructor tests to dev, not this bootstrap — keeping Lite and Dashboard symmetrical.
- **All SQL-touching ports** — `SqlServerFactCollector`, `SqlServerFindingStore`, `SqlServerAnomalyDetector`, the database paths of `SqlServerBaselineProvider`, full `AnalysisService`/`Scenario` pipelines. The plan documents these under §10 and recommends TestContainers as the fixture surface; that decision is its own PR.
- **`FinOpsHealthCalculator` / `HighImpactScorer` parity** — Dashboard FinOps has no pure scoring class to mirror Lite's; structurally different surface, gets bespoke tests later.
- **UI / WPF tests** — separate concern; `UseWPF=true` in the test project is for type loading only.

## Test plan

- [x] `dotnet build Dashboard.Tests/Dashboard.Tests.csproj -c Debug` — 0 warnings, 0 errors.
- [x] `dotnet test Dashboard.Tests/Dashboard.Tests.csproj` — **18 passed**, 0 failed, 0 skipped (~1s).
- [x] `dotnet build PerformanceMonitor.sln -c Debug` — full-solution build clean, 0 warnings, 0 errors.
- [x] `dotnet test Lite.Tests/Lite.Tests.csproj` — Lite.Tests still passes (260/260), confirming tests were COPIED + renamed, not moved.
- [x] code-reviewer agent review — clean, no findings.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>