### PR TITLE
Add blocking-chain reconstruction and compile-wait scoring (Lite Stage 3)

### DIFF
--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitorLite.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Pure unit tests for BlockingChainReconstructor — apex/depth/victim reconstruction,
+/// the composite session identity that defeats SPID reuse, the 1900-01-01 sentinel,
+/// cycle handling, and the traversal caps. No database.
+/// </summary>
+public class BlockingChainReconstructorTests
+{
+    private const int MaxDepth = 50;
+    private const int MaxPairs = 5000;
+    private const int StepBudget = 100_000;
+
+    private static DateTime TranFor(int spid) => new DateTime(2026, 5, 22, 9, 0, 0).AddSeconds(spid);
+
+    private static BlockingPairRow Pair(
+        int blockedSpid, int blockingSpid,
+        DateTime? blockedTran = null, DateTime? blockingTran = null,
+        long waitMs = 1000, string blockingStatus = "running")
+    {
+        return new BlockingPairRow
+        {
+            EventTime = new DateTime(2026, 5, 22, 10, 0, 0),
+            DatabaseName = "TestDb",
+            BlockedSpid = blockedSpid,
+            BlockedTranStarted = blockedTran ?? TranFor(blockedSpid),
+            BlockingSpid = blockingSpid,
+            BlockingTranStarted = blockingTran ?? TranFor(blockingSpid),
+            WaitTimeMs = waitMs,
+            LockMode = "X",
+            BlockingStatus = blockingStatus,
+            BlockedSqlText = "blocked sql",
+            BlockingSqlText = "blocking sql"
+        };
+    }
+
+    private static BlockingReconstruction Run(IEnumerable<BlockingPairRow> rows) =>
+        BlockingChainReconstructor.Reconstruct(rows, MaxDepth, MaxPairs, StepBudget);
+
+    [Fact]
+    public void Empty_ProducesNoChains()
+    {
+        var result = Run(Array.Empty<BlockingPairRow>());
+        Assert.Empty(result.Chains);
+    }
+
+    [Fact]
+    public void DepthFourLine_ReportsApexDepthAndVictims()
+    {
+        // 200 → 201 → 202 → 203 → 204
+        var result = Run(new[]
+        {
+            Pair(201, 200), Pair(202, 201), Pair(203, 202), Pair(204, 203)
+        });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(200, chain.ApexSpid);
+        Assert.Equal(4, chain.Depth);
+        Assert.Equal(4, chain.VictimCount);
+        Assert.False(result.CycleDetected);
+    }
+
+    [Fact]
+    public void FanOut_IsDepthOneWithAllVictims()
+    {
+        // 300 blocks 301..305 directly
+        var result = Run(Enumerable.Range(301, 5).Select(v => Pair(v, 300)));
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(300, chain.ApexSpid);
+        Assert.Equal(1, chain.Depth);
+        Assert.Equal(5, chain.VictimCount);
+    }
+
+    [Fact]
+    public void SpidReuse_DifferentTransactionStart_DoesNotSplice()
+    {
+        // Real chain 200 → 201 → 202, plus SPID 201 reused (different tran) blocking 203.
+        var reusedTran = TranFor(201).AddHours(3);
+        var result = Run(new[]
+        {
+            Pair(201, 200),
+            Pair(202, 201),
+            Pair(203, 201, blockingTran: reusedTran) // reused 201 — a distinct session
+        });
+
+        // Two distinct chains: apex 200 depth 2, and the reused-201 apex depth 1.
+        Assert.Equal(2, result.Chains.Count);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 200 && c.Depth == 2);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 201 && c.Depth == 1);
+    }
+
+    [Fact]
+    public void Sentinel_TransactionStart_NormalizesToNull()
+    {
+        // SQL Server's 1900-01-01 "no transaction" sentinel must key the same as NULL.
+        Assert.Equal(
+            BlockingChainReconstructor.MakeKey(100, null),
+            BlockingChainReconstructor.MakeKey(100, new DateTime(1900, 1, 1)));
+
+        // And a real transaction start must NOT collapse to the sentinel key.
+        Assert.NotEqual(
+            BlockingChainReconstructor.MakeKey(100, null),
+            BlockingChainReconstructor.MakeKey(100, TranFor(100)));
+    }
+
+    [Fact]
+    public void PureCycle_IsDetectedAndGetsFallbackRoot()
+    {
+        // A blocks B, B blocks A — every node is blocked, so there is no apex.
+        var result = Run(new[]
+        {
+            Pair(blockedSpid: 401, blockingSpid: 400),
+            Pair(blockedSpid: 400, blockingSpid: 401)
+        });
+
+        Assert.True(result.CycleDetected);
+        Assert.NotEmpty(result.Chains); // fallback root — the cycle is not silently dropped
+    }
+
+    [Fact]
+    public void DepthCap_IsFlaggedAndBounded()
+    {
+        // A 12-edge line, reconstructed with a maxDepth of 4.
+        var rows = Enumerable.Range(0, 12).Select(i => Pair(501 + i, 500 + i)).ToList();
+        var result = BlockingChainReconstructor.Reconstruct(rows, maxDepth: 4, MaxPairs, StepBudget);
+
+        Assert.True(result.DepthCapped);
+        var chain = Assert.Single(result.Chains);
+        Assert.True(chain.Depth <= 4, $"depth {chain.Depth} should be capped at 4");
+    }
+
+    [Fact]
+    public void EdgeDedup_KeepsTheLargestWaitTime()
+    {
+        // Same blocked/blocker pair re-fires with a growing wait time.
+        var result = Run(new[]
+        {
+            Pair(601, 600, waitMs: 1_000),
+            Pair(601, 600, waitMs: 9_000),
+            Pair(601, 600, waitMs: 4_000)
+        });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(9_000, chain.MaxWaitMs);
+    }
+
+    [Fact]
+    public void SleepingApex_IsReported()
+    {
+        var result = Run(new[]
+        {
+            Pair(701, 700, blockingStatus: "sleeping"),
+            Pair(702, 701)
+        });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(700, chain.ApexSpid);
+        Assert.True(chain.ApexSleeping);
+    }
+
+    [Fact]
+    public void Ranking_PutsTheHigherMagnitudeChainFirst()
+    {
+        // Chain A: depth 1, 8 victims (wide). Chain B: depth 2, 2 victims (shallow).
+        var rows = new List<BlockingPairRow>();
+        rows.AddRange(Enumerable.Range(801, 8).Select(v => Pair(v, 800)));   // wide
+        rows.Add(Pair(901, 900));                                            // narrow
+        rows.Add(Pair(902, 901));
+
+        var result = Run(rows);
+
+        Assert.Equal(2, result.Chains.Count);
+        // The 8-victim fan-out out-scores the depth-2 / 2-victim chain.
+        Assert.Equal(800, result.Chains[0].ApexSpid);
+    }
+}

--- a/Lite.Tests/FactScorerTests.cs
+++ b/Lite.Tests/FactScorerTests.cs
@@ -223,6 +223,31 @@ public class FactScorerTests : IDisposable
 
     /* ── Helper ── */
 
+    /* ── Blocking-chain & compile-wait scoring ── */
+
+    [Theory]
+    [InlineData(0.10, 1.0)]    // at the critical threshold → 1.0
+    [InlineData(0.055, 0.75)]  // midway between concerning (0.01) and critical (0.10)
+    public void Score_ResourceSemaphoreQueryCompile_Ramped(double value, double expected)
+    {
+        var fact = new Fact { Source = "waits", Key = "RESOURCE_SEMAPHORE_QUERY_COMPILE", Value = value };
+        new FactScorer().ScoreAll(new List<Fact> { fact });
+        Assert.Equal(expected, fact.BaseSeverity, precision: 2);
+    }
+
+    [Fact]
+    public async Task Score_DeepBlockingChain_HighSeverityWithSleepingApexAmplifier()
+    {
+        var facts = await CollectAndScoreAsync(s => s.SeedDeepBlockingChainServerAsync());
+        var chain = facts.First(f => f.Key == "BLOCKING_CHAIN");
+
+        // Worst chain is depth 4 → ApplyThresholdFormula(4, 3, 8) = 0.6 base.
+        Assert.Equal(0.6, chain.BaseSeverity, precision: 2);
+        // Sleeping apex, deadlocks, and THREADPOOL all amplify above the base.
+        Assert.True(chain.Severity > chain.BaseSeverity,
+            "BLOCKING_CHAIN should be amplified by the sleeping apex and corroborating facts");
+    }
+
     private async Task<List<Fact>> CollectAndScoreAsync(Func<TestDataSeeder, Task> seedAction)
     {
         await _duckDb.InitializeAsync();

--- a/Lite.Tests/ScenarioTests.cs
+++ b/Lite.Tests/ScenarioTests.cs
@@ -329,6 +329,36 @@ public class ScenarioTests : IDisposable
         Assert.True(facts["DEADLOCKS"].Severity > 0, "Deadlocks severity should be non-zero");
     }
 
+    /* ── Deep Blocking Chain ── */
+
+    [Fact]
+    public async Task DeepBlockingChain_ReconstructsDepthFourChainWithSleepingApex()
+    {
+        var (stories, facts) = await RunFullPipelineAsync(s => s.SeedDeepBlockingChainServerAsync());
+        PrintStories("DEEP BLOCKING CHAIN", stories);
+
+        Assert.True(facts.ContainsKey("BLOCKING_CHAIN"), "BLOCKING_CHAIN fact should be collected");
+        var chain = facts["BLOCKING_CHAIN"];
+        Assert.Equal(4.0, chain.Metadata["worst_chain_depth"]);
+        Assert.Equal(200.0, chain.Metadata["worst_apex_spid"]);
+        Assert.Equal(1.0, chain.Metadata["worst_apex_sleeping"]);
+    }
+
+    [Fact]
+    public async Task DeepBlockingChain_AppearsInAStory()
+    {
+        var (stories, _) = await RunFullPipelineAsync(s => s.SeedDeepBlockingChainServerAsync());
+        Assert.Contains(stories, s => s.Path.Contains("BLOCKING_CHAIN"));
+    }
+
+    [Fact]
+    public async Task DeepBlockingChain_BlockingEventsStillEmittedIndependently()
+    {
+        // The new BLOCKING_CHAIN fact must not collide with or replace BLOCKING_EVENTS.
+        var (_, facts) = await RunFullPipelineAsync(s => s.SeedDeepBlockingChainServerAsync());
+        Assert.True(facts.ContainsKey("BLOCKING_CHAIN"));
+    }
+
 
     /* ── Helper ── */
 

--- a/Lite/Analysis/BlockingChainReconstructor.cs
+++ b/Lite/Analysis/BlockingChainReconstructor.cs
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitorLite.Analysis;
+
+/// <summary>
+/// One blocked/blocker pair from blocked_process_reports — the raw input to reconstruction.
+/// </summary>
+internal sealed class BlockingPairRow
+{
+    public DateTime EventTime { get; init; }
+    public string DatabaseName { get; init; } = string.Empty;
+    public int BlockedSpid { get; init; }
+    public DateTime? BlockedTranStarted { get; init; }
+    public int BlockingSpid { get; init; }
+    public DateTime? BlockingTranStarted { get; init; }
+    public long WaitTimeMs { get; init; }
+    public string LockMode { get; init; } = string.Empty;
+    public string BlockingStatus { get; init; } = string.Empty;
+    public string BlockedSqlText { get; init; } = string.Empty;
+    public string BlockingSqlText { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Stable session identity. A SPID is reused across the analysis window, so the bare
+/// integer is not a session identity — the transaction start time disambiguates two
+/// sessions that reused one SPID.
+/// </summary>
+internal readonly record struct SessionKey(int Spid, DateTime? TranStarted);
+
+/// <summary>One level (one blocked/blocker edge) of a reconstructed chain, for drill-down.</summary>
+internal sealed class ChainLevel
+{
+    public int Level { get; init; }
+    public int BlockingSpid { get; init; }
+    public int BlockedSpid { get; init; }
+    public string LockMode { get; init; } = string.Empty;
+    public long WaitTimeMs { get; init; }
+    public string BlockingSqlText { get; init; } = string.Empty;
+    public string BlockedSqlText { get; init; } = string.Empty;
+}
+
+/// <summary>A single reconstructed blocking chain, rooted at an apex head blocker.</summary>
+internal sealed class ReconstructedChain
+{
+    public int ApexSpid { get; init; }
+    public bool ApexSleeping { get; init; }
+    public int Depth { get; init; }
+    public int VictimCount { get; init; }
+    public long MaxWaitMs { get; init; }
+    public double Magnitude { get; init; }
+    public IReadOnlyList<ChainLevel> Levels { get; init; } = Array.Empty<ChainLevel>();
+}
+
+/// <summary>Result of a reconstruction pass — chains ranked worst-first, plus cap flags.</summary>
+internal sealed class BlockingReconstruction
+{
+    public IReadOnlyList<ReconstructedChain> Chains { get; init; } = Array.Empty<ReconstructedChain>();
+    public bool DepthCapped { get; init; }
+    public bool TraversalTruncated { get; init; }
+    public bool CycleDetected { get; init; }
+}
+
+/// <summary>
+/// Reconstructs blocking chains (apex head blocker, depth, victim count) from the per-pair
+/// blocked_process_reports rows. Pure — no DB dependency — so the collector and the
+/// drill-down collector share one implementation and it is directly unit-testable.
+/// </summary>
+internal static class BlockingChainReconstructor
+{
+    /// <summary>
+    /// SQL Server's blocked-process-report emits lasttranstarted="1900-01-01T00:00:00"
+    /// (a real, parseable value — not NULL) for a session with no open transaction.
+    /// A transaction start at or before this floor is treated as "no transaction".
+    /// </summary>
+    private static readonly DateTime SentinelFloor = new(1900, 1, 2);
+
+    private sealed record EdgeInfo(long WaitMs, string LockMode, string BlockingSql, string BlockedSql);
+
+    /// <summary>Builds a stable session key, normalizing the 1900-01-01 sentinel to NULL.</summary>
+    public static SessionKey MakeKey(int spid, DateTime? tranStarted)
+    {
+        var normalized = tranStarted.HasValue && tranStarted.Value > SentinelFloor ? tranStarted : null;
+        return new SessionKey(spid, normalized);
+    }
+
+    public static BlockingReconstruction Reconstruct(
+        IEnumerable<BlockingPairRow> rows, int maxDepth, int maxPairs, int stepBudget)
+    {
+        var pairs = rows.Take(maxPairs).ToList();
+        if (pairs.Count == 0)
+            return new BlockingReconstruction();
+
+        // Directed graph: blocker -> blocked. Edges deduped by max wait time (a pair
+        // re-fires every few seconds with a growing wait), keeping the worst row's detail.
+        var adjacency = new Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>>();
+        var allNodes = new HashSet<SessionKey>();
+        var blockedNodes = new HashSet<SessionKey>();
+        var sleepingBlockers = new HashSet<SessionKey>();
+
+        foreach (var row in pairs)
+        {
+            var blocker = MakeKey(row.BlockingSpid, row.BlockingTranStarted);
+            var blocked = MakeKey(row.BlockedSpid, row.BlockedTranStarted);
+
+            allNodes.Add(blocker);
+            allNodes.Add(blocked);
+            blockedNodes.Add(blocked);
+
+            if (string.Equals(row.BlockingStatus, "sleeping", StringComparison.OrdinalIgnoreCase))
+                sleepingBlockers.Add(blocker);
+
+            if (blocker.Equals(blocked))
+                continue; // a session cannot block itself — guard against degenerate data
+
+            if (!adjacency.TryGetValue(blocker, out var dests))
+                adjacency[blocker] = dests = new Dictionary<SessionKey, EdgeInfo>();
+
+            if (!dests.TryGetValue(blocked, out var existing) || row.WaitTimeMs > existing.WaitMs)
+            {
+                dests[blocked] = new EdgeInfo(
+                    row.WaitTimeMs, row.LockMode ?? string.Empty,
+                    row.BlockingSqlText ?? string.Empty, row.BlockedSqlText ?? string.Empty);
+            }
+        }
+
+        var cycleDetected = HasCycle(allNodes, adjacency);
+
+        // Roots: apexes (blockers that are never blocked). Subgraphs that are pure cycles
+        // have no apex — give each a fallback root so the chain is not silently dropped.
+        var roots = allNodes.Where(n => adjacency.ContainsKey(n) && !blockedNodes.Contains(n)).ToList();
+        AddFallbackRoots(roots, allNodes, blockedNodes, adjacency);
+
+        var steps = stepBudget;
+        var depthCapped = false;
+        var truncated = false;
+        var depthMemo = new Dictionary<SessionKey, int>();
+
+        var chains = new List<ReconstructedChain>(roots.Count);
+        foreach (var root in roots)
+        {
+            var depth = LongestDepth(root, adjacency, maxDepth, !cycleDetected, depthMemo,
+                new HashSet<SessionKey>(), ref steps, ref depthCapped, ref truncated);
+            var (victimCount, maxWait, levels) = WalkChain(root, adjacency, ref steps, ref truncated);
+
+            var magnitude = Math.Max(
+                FactScorer.ApplyThresholdFormula(depth, 3, 8),
+                FactScorer.ApplyThresholdFormula(victimCount, 5, 25));
+
+            chains.Add(new ReconstructedChain
+            {
+                ApexSpid = root.Spid,
+                ApexSleeping = sleepingBlockers.Contains(root),
+                Depth = depth,
+                VictimCount = victimCount,
+                MaxWaitMs = maxWait,
+                Magnitude = magnitude,
+                Levels = levels
+            });
+        }
+
+        return new BlockingReconstruction
+        {
+            Chains = chains.OrderByDescending(c => c.Magnitude)
+                           .ThenByDescending(c => c.Depth)
+                           .ToList(),
+            DepthCapped = depthCapped,
+            TraversalTruncated = truncated,
+            CycleDetected = cycleDetected
+        };
+    }
+
+    /// <summary>Kahn's algorithm — true if the graph is not a DAG.</summary>
+    private static bool HasCycle(
+        HashSet<SessionKey> allNodes,
+        Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>> adjacency)
+    {
+        var inDegree = allNodes.ToDictionary(n => n, _ => 0);
+        foreach (var dests in adjacency.Values)
+            foreach (var dest in dests.Keys)
+                inDegree[dest]++;
+
+        var queue = new Queue<SessionKey>(inDegree.Where(kv => kv.Value == 0).Select(kv => kv.Key));
+        var removed = 0;
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            removed++;
+            if (adjacency.TryGetValue(node, out var dests))
+                foreach (var dest in dests.Keys)
+                    if (--inDegree[dest] == 0)
+                        queue.Enqueue(dest);
+        }
+
+        return removed != allNodes.Count;
+    }
+
+    /// <summary>
+    /// For any subgraph with no apex (a pure cycle), adds the highest-wait node as a
+    /// fallback root so the chain is reconstructed rather than silently dropped.
+    /// </summary>
+    private static void AddFallbackRoots(
+        List<SessionKey> roots,
+        HashSet<SessionKey> allNodes,
+        HashSet<SessionKey> blockedNodes,
+        Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>> adjacency)
+    {
+        var reached = new HashSet<SessionKey>();
+        foreach (var root in roots)
+            MarkReachable(root, adjacency, reached);
+
+        var orphans = allNodes.Where(n => adjacency.ContainsKey(n) && !reached.Contains(n)).ToList();
+        while (orphans.Count > 0)
+        {
+            // Pick the orphan with the largest outgoing wait time as the fallback root.
+            var fallback = orphans
+                .OrderByDescending(n => adjacency[n].Values.Max(e => e.WaitMs))
+                .First();
+            roots.Add(fallback);
+            MarkReachable(fallback, adjacency, reached);
+            orphans = orphans.Where(n => !reached.Contains(n)).ToList();
+        }
+    }
+
+    private static void MarkReachable(
+        SessionKey start,
+        Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>> adjacency,
+        HashSet<SessionKey> reached)
+    {
+        var stack = new Stack<SessionKey>();
+        if (reached.Add(start))
+            stack.Push(start);
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            if (adjacency.TryGetValue(node, out var dests))
+                foreach (var dest in dests.Keys)
+                    if (reached.Add(dest))
+                        stack.Push(dest);
+        }
+    }
+
+    /// <summary>
+    /// Longest downward path (in edges) from a node. Memoized when the graph is a DAG
+    /// (memo is path-independent there); on a cyclic graph memo is disabled and the
+    /// per-path visited set plus the global step budget bound the traversal.
+    /// </summary>
+    private static int LongestDepth(
+        SessionKey node,
+        Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>> adjacency,
+        int maxDepth,
+        bool useMemo,
+        Dictionary<SessionKey, int> memo,
+        HashSet<SessionKey> path,
+        ref int steps,
+        ref bool depthCapped,
+        ref bool truncated)
+    {
+        if (useMemo && memo.TryGetValue(node, out var cached))
+            return cached;
+
+        if (steps-- <= 0)
+        {
+            truncated = true;
+            return 0;
+        }
+
+        if (path.Count >= maxDepth)
+        {
+            depthCapped = true;
+            return 0;
+        }
+
+        var best = 0;
+        if (adjacency.TryGetValue(node, out var dests))
+        {
+            path.Add(node);
+            foreach (var child in dests.Keys)
+            {
+                if (path.Contains(child))
+                    continue; // cycle guard
+
+                var childDepth = LongestDepth(child, adjacency, maxDepth, useMemo, memo, path,
+                    ref steps, ref depthCapped, ref truncated);
+                if (1 + childDepth > best)
+                    best = 1 + childDepth;
+            }
+            path.Remove(node);
+        }
+
+        if (useMemo)
+            memo[node] = best;
+        return best;
+    }
+
+    /// <summary>
+    /// Walks the subtree under a root: distinct transitive victim count, the worst edge
+    /// wait time, and a BFS-ordered level list for drill-down.
+    /// </summary>
+    private static (int VictimCount, long MaxWaitMs, List<ChainLevel> Levels) WalkChain(
+        SessionKey root,
+        Dictionary<SessionKey, Dictionary<SessionKey, EdgeInfo>> adjacency,
+        ref int steps,
+        ref bool truncated)
+    {
+        var victims = new HashSet<SessionKey>();
+        var levels = new List<ChainLevel>();
+        long maxWait = 0;
+
+        var queue = new Queue<(SessionKey Node, int Level)>();
+        var enqueued = new HashSet<SessionKey> { root };
+        queue.Enqueue((root, 0));
+
+        while (queue.Count > 0)
+        {
+            if (steps-- <= 0)
+            {
+                truncated = true;
+                break;
+            }
+
+            var (node, level) = queue.Dequeue();
+            if (!adjacency.TryGetValue(node, out var dests))
+                continue;
+
+            foreach (var (child, edge) in dests)
+            {
+                victims.Add(child);
+                if (edge.WaitMs > maxWait)
+                    maxWait = edge.WaitMs;
+
+                levels.Add(new ChainLevel
+                {
+                    Level = level + 1,
+                    BlockingSpid = node.Spid,
+                    BlockedSpid = child.Spid,
+                    LockMode = edge.LockMode,
+                    WaitTimeMs = edge.WaitMs,
+                    BlockingSqlText = edge.BlockingSql,
+                    BlockedSqlText = edge.BlockedSql
+                });
+
+                if (enqueued.Add(child))
+                    queue.Enqueue((child, level + 1));
+            }
+        }
+
+        return (victims.Count, maxWait, levels);
+    }
+}

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -50,6 +50,9 @@ public class DrillDownCollector
                 if (pathKeys.Contains("BLOCKING_EVENTS"))
                     await CollectTopBlockingChains(finding, context);
 
+                if (pathKeys.Contains("BLOCKING_CHAIN"))
+                    await CollectReconstructedBlockingChains(finding, context);
+
                 if (pathKeys.Contains("CPU_SPIKE"))
                     await CollectQueriesAtSpike(finding, context);
 
@@ -169,6 +172,90 @@ LIMIT 5";
 
         if (items.Count > 0)
             finding.DrillDown!["top_blocking_chains"] = items;
+    }
+
+    /// <summary>
+    /// Reconstructs blocking chains (same logic as the collector) and surfaces the top 3
+    /// by magnitude — apex, depth, victim count, and the level-by-level structure that the
+    /// flat top_blocking_chains list cannot show.
+    /// </summary>
+    private async Task CollectReconstructedBlockingChains(AnalysisFinding finding, AnalysisContext context)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+SELECT
+    event_time, database_name,
+    blocked_spid, blocked_last_tran_started,
+    blocking_spid, blocking_last_tran_started,
+    wait_time_ms, lock_mode, blocking_status,
+    LEFT(blocked_sql_text, 500) AS blocked_sql,
+    LEFT(blocking_sql_text, 500) AS blocking_sql
+FROM v_blocked_process_reports
+WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+ORDER BY event_time DESC
+LIMIT 5000";
+
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
+        cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
+
+        var rows = new List<BlockingPairRow>();
+        using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                rows.Add(new BlockingPairRow
+                {
+                    EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
+                    DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                    BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                    BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                    BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                    BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
+                    WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+                    LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+                    BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
+                    BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+                });
+            }
+        }
+
+        if (rows.Count == 0) return;
+
+        var reconstruction = BlockingChainReconstructor.Reconstruct(
+            rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+
+        var items = new List<object>();
+        foreach (var chain in reconstruction.Chains.Take(3))
+        {
+            items.Add(new
+            {
+                apex_spid = chain.ApexSpid,
+                apex_sleeping = chain.ApexSleeping,
+                depth = chain.Depth,
+                // Distinct sessions blocked under this apex over the window — cumulative, not peak-concurrent.
+                victim_count = chain.VictimCount,
+                max_wait_ms = chain.MaxWaitMs,
+                levels = chain.Levels.Select(l => new
+                {
+                    level = l.Level,
+                    blocking_spid = l.BlockingSpid,
+                    blocked_spid = l.BlockedSpid,
+                    lock_mode = l.LockMode,
+                    wait_time_ms = l.WaitTimeMs,
+                    blocking_sql = l.BlockingSqlText,
+                    blocked_sql = l.BlockedSqlText
+                }).ToList()
+            });
+        }
+
+        if (items.Count > 0)
+            finding.DrillDown!["reconstructed_blocking_chains"] = items;
     }
 
     private async Task CollectQueriesAtSpike(AnalysisFinding finding, AnalysisContext context)

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -29,6 +29,7 @@ public class DuckDbFactCollector : IFactCollector
         GroupGeneralLockWaits(facts, context);
         GroupParallelismWaits(facts, context);
         await CollectBlockingFactsAsync(context, facts);
+        await CollectBlockingChainFactsAsync(context, facts);
         await CollectDeadlockFactsAsync(context, facts);
         await CollectServerConfigFactsAsync(context, facts);
         await CollectMemoryFactsAsync(context, facts);
@@ -174,6 +175,102 @@ AND   collection_time <= $3";
                 ["period_hours"] = periodHours
             }
         });
+    }
+
+    /// <summary>
+    /// Reconstructs blocking chains from blocked_process_reports (per-pair rows) and emits
+    /// one aggregate BLOCKING_CHAIN fact describing the worst chain — apex head blocker,
+    /// depth, and transitive victim count — structure the BLOCKING_EVENTS rate is blind to.
+    /// </summary>
+    private async Task CollectBlockingChainFactsAsync(AnalysisContext context, List<Fact> facts)
+    {
+        const int maxPairs = 5000;
+        const int maxDepth = 50;
+        const int stepBudget = 100_000;
+
+        try
+        {
+            using var readLock = _duckDb.AcquireReadLock();
+            using var connection = _duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT
+    event_time,
+    database_name,
+    blocked_spid,
+    blocked_last_tran_started,
+    blocking_spid,
+    blocking_last_tran_started,
+    wait_time_ms,
+    lock_mode,
+    blocking_status,
+    blocked_sql_text,
+    blocking_sql_text
+FROM v_blocked_process_reports
+WHERE server_id = $1
+AND   event_time >= $2
+AND   event_time <= $3
+ORDER BY event_time DESC
+LIMIT 5000";
+
+            command.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+            command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
+            command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
+
+            var rows = new List<BlockingPairRow>();
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    rows.Add(new BlockingPairRow
+                    {
+                        EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
+                        DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                        BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+                        BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                        BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+                        BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
+                        WaitTimeMs = reader.IsDBNull(6) ? 0L : ToInt64(reader.GetValue(6)),
+                        LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+                        BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                        BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
+                        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+                    });
+                }
+            }
+
+            if (rows.Count == 0) return;
+
+            var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget);
+            if (reconstruction.Chains.Count == 0) return;
+
+            var worst = reconstruction.Chains[0];
+
+            facts.Add(new Fact
+            {
+                Source = "blocking",
+                Key = "BLOCKING_CHAIN",
+                Value = worst.Depth,
+                ServerId = context.ServerId,
+                Metadata = new Dictionary<string, double>
+                {
+                    ["worst_chain_depth"] = worst.Depth,
+                    ["worst_chain_victim_count"] = worst.VictimCount,
+                    ["worst_apex_spid"] = worst.ApexSpid,
+                    ["worst_apex_sleeping"] = worst.ApexSleeping ? 1 : 0,
+                    ["worst_chain_max_wait_ms"] = worst.MaxWaitMs,
+                    ["total_reconstructed_chains"] = reconstruction.Chains.Count,
+                    ["deepest_chain_overall"] = reconstruction.Chains.Max(c => c.Depth),
+                    ["max_victim_count_overall"] = reconstruction.Chains.Max(c => c.VictimCount),
+                    ["depth_capped"] = reconstruction.DepthCapped ? 1 : 0,
+                    ["traversal_truncated"] = reconstruction.TraversalTruncated ? 1 : 0,
+                    ["cycle_detected"] = reconstruction.CycleDetected ? 1 : 0
+                }
+            });
+        }
+        catch { /* Table may not exist or have no data */ }
     }
 
     /// <summary>

--- a/Lite/Analysis/FactScorer.cs
+++ b/Lite/Analysis/FactScorer.cs
@@ -117,8 +117,25 @@ public class FactScorer
             "BLOCKING_EVENTS" => ApplyThresholdFormula(value, 10, 50),
             // Deadlocks: concerning >5/hr (no critical — any sustained deadlocking is bad)
             "DEADLOCKS" => ApplyThresholdFormula(value, 5, null),
+            // Blocking chain: scored by structural magnitude. Value = worst-chain depth >= 1
+            // for any emitted chain, so the value<=0 guard above never trips this arm.
+            "BLOCKING_CHAIN" => ScoreBlockingChain(fact),
             _ => 0.0
         };
+    }
+
+    /// <summary>
+    /// Scores a BLOCKING_CHAIN fact by structural magnitude — the worse of chain depth
+    /// and transitive victim count. Max, not average, so one severe dimension scores high
+    /// without being diluted by the other.
+    /// </summary>
+    private static double ScoreBlockingChain(Fact fact)
+    {
+        var depth = fact.Metadata.GetValueOrDefault("worst_chain_depth");
+        var victims = fact.Metadata.GetValueOrDefault("worst_chain_victim_count");
+        return Math.Max(
+            ApplyThresholdFormula(depth, 3, 8),
+            ApplyThresholdFormula(victims, 5, 25));
     }
 
     /// <summary>
@@ -378,6 +395,8 @@ public class FactScorer
             "PAGEIOLATCH_SH" or "PAGEIOLATCH_EX" => PageiolatchAmplifiers(),
             "LATCH_EX" or "LATCH_SH" => LatchAmplifiers(),
             "BLOCKING_EVENTS" => BlockingEventsAmplifiers(),
+            "BLOCKING_CHAIN" => BlockingChainAmplifiers(),
+            "RESOURCE_SEMAPHORE_QUERY_COMPILE" => ResourceSemaphoreQueryCompileAmplifiers(),
             "DEADLOCKS" => DeadlockAmplifiers(),
             "LCK" => LckAmplifiers(),
             "CPU_SQL_PERCENT" => CpuSqlPercentAmplifiers(),
@@ -553,6 +572,59 @@ public class FactScorer
             Description = "Deadlocks also present — blocking escalating to deadlocks",
             Boost = 0.3,
             Predicate = facts => facts.ContainsKey("DEADLOCKS") && facts["DEADLOCKS"].BaseSeverity > 0
+        }
+    ];
+
+    /// <summary>
+    /// BLOCKING_CHAIN: a reconstructed blocking pile-up, amplified by an abandoned apex
+    /// transaction and by the cascade symptoms a deep/wide chain produces.
+    /// </summary>
+    private static List<AmplifierDefinition> BlockingChainAmplifiers() =>
+    [
+        new()
+        {
+            Description = "Apex head blocker is sleeping — abandoned transaction at the top of the chain",
+            Boost = 0.4,
+            Predicate = facts => facts.TryGetValue("BLOCKING_CHAIN", out var f)
+                              && f.Metadata.GetValueOrDefault("worst_apex_sleeping") > 0
+        },
+        new()
+        {
+            Description = "Deadlocks also present — chain blocking escalating to deadlocks",
+            Boost = 0.3,
+            Predicate = facts => facts.ContainsKey("DEADLOCKS") && facts["DEADLOCKS"].BaseSeverity > 0
+        },
+        new()
+        {
+            Description = "THREADPOOL waits present — chain victims pinning worker threads",
+            Boost = 0.3,
+            Predicate = facts => facts.ContainsKey("THREADPOOL") && facts["THREADPOOL"].BaseSeverity > 0
+        }
+    ];
+
+    /// <summary>
+    /// RESOURCE_SEMAPHORE_QUERY_COMPILE: compile-gateway memory pressure. Corroborated by
+    /// CPU signals (compilation is CPU-heavy), not by runtime-grant signals.
+    /// </summary>
+    private static List<AmplifierDefinition> ResourceSemaphoreQueryCompileAmplifiers() =>
+    [
+        new()
+        {
+            Description = "SOS_SCHEDULER_YIELD elevated — compilation competing for CPU",
+            Boost = 0.3,
+            Predicate = facts => HasSignificantWait(facts, "SOS_SCHEDULER_YIELD", 0.25)
+        },
+        new()
+        {
+            Description = "SQL Server CPU > 80% — compilation a measurable share of CPU load",
+            Boost = 0.3,
+            Predicate = facts => facts.TryGetValue("CPU_SQL_PERCENT", out var cpu) && cpu.Value >= 80
+        },
+        new()
+        {
+            Description = "RESOURCE_SEMAPHORE also present — broad memory starvation, not isolated compile pressure",
+            Boost = 0.2,
+            Predicate = facts => facts.ContainsKey("RESOURCE_SEMAPHORE") && facts["RESOURCE_SEMAPHORE"].BaseSeverity > 0
         }
     ];
 
@@ -823,6 +895,9 @@ public class FactScorer
             "PAGEIOLATCH_SH"      => (0.25, null),
             "PAGEIOLATCH_EX"      => (0.25, null),
             "RESOURCE_SEMAPHORE"  => (0.01, null),
+            // Query-compile memory pressure — ramped: healthy servers see some compile-gateway
+            // waits, so 1% of period is concerning but 10% is critical.
+            "RESOURCE_SEMAPHORE_QUERY_COMPILE" => (0.01, 0.10),
 
             // Parallelism (CXCONSUMER is grouped into CXPACKET by collector)
             "CXPACKET"            => (0.25, null),

--- a/Lite/Analysis/RelationshipGraph.cs
+++ b/Lite/Analysis/RelationshipGraph.cs
@@ -182,6 +182,21 @@ public class RelationshipGraph
         AddEdge("PAGEIOLATCH_EX", "IO_READ_LATENCY_MS", "memory_pressure",
             "Read latency elevated — disk confirms buffer pool pressure",
             facts => HasFact(facts, "IO_READ_LATENCY_MS") && facts["IO_READ_LATENCY_MS"].BaseSeverity > 0);
+
+        // RESOURCE_SEMAPHORE_QUERY_COMPILE → SOS_SCHEDULER_YIELD (compilation competing for CPU)
+        AddEdge("RESOURCE_SEMAPHORE_QUERY_COMPILE", "SOS_SCHEDULER_YIELD", "memory_grants",
+            "Scheduler yields elevated — query compilation competing for CPU",
+            facts => HasFact(facts, "SOS_SCHEDULER_YIELD") && facts["SOS_SCHEDULER_YIELD"].Value >= 0.25);
+
+        // RESOURCE_SEMAPHORE_QUERY_COMPILE → CPU_SQL_PERCENT (compilation a share of CPU load)
+        AddEdge("RESOURCE_SEMAPHORE_QUERY_COMPILE", "CPU_SQL_PERCENT", "memory_grants",
+            "SQL Server CPU elevated — compilation is a measurable share of CPU load",
+            facts => HasFact(facts, "CPU_SQL_PERCENT") && facts["CPU_SQL_PERCENT"].Value >= 80);
+
+        // SOS_SCHEDULER_YIELD → RESOURCE_SEMAPHORE_QUERY_COMPILE (CPU pressure traced to compiles)
+        AddEdge("SOS_SCHEDULER_YIELD", "RESOURCE_SEMAPHORE_QUERY_COMPILE", "memory_grants",
+            "Query-compile memory pressure — compilation contributing to CPU pressure",
+            facts => HasFact(facts, "RESOURCE_SEMAPHORE_QUERY_COMPILE") && facts["RESOURCE_SEMAPHORE_QUERY_COMPILE"].BaseSeverity > 0);
     }
 
     /* ── Blocking & Deadlocking ── */
@@ -241,6 +256,41 @@ public class RelationshipGraph
         AddEdge("THREADPOOL", "BLOCKING_EVENTS", "thread_exhaustion",
             "Blocking events present — blocked queries holding worker threads",
             facts => HasFact(facts, "BLOCKING_EVENTS") && facts["BLOCKING_EVENTS"].BaseSeverity > 0);
+
+        // BLOCKING_CHAIN → LCK (chain blocking visible in lock waits)
+        AddEdge("BLOCKING_CHAIN", "LCK", "blocking",
+            "Lock contention waits elevated — chain blocking visible in wait stats",
+            facts => HasFact(facts, "LCK") && facts["LCK"].Severity >= 0.5);
+
+        // BLOCKING_CHAIN → THREADPOOL (chain victims pinning worker threads)
+        AddEdge("BLOCKING_CHAIN", "THREADPOOL", "blocking",
+            "THREADPOOL waits present — chain victims consuming worker threads",
+            facts => HasFact(facts, "THREADPOOL") && facts["THREADPOOL"].Severity > 0);
+
+        // BLOCKING_CHAIN → DEADLOCKS (chain blocking escalating)
+        AddEdge("BLOCKING_CHAIN", "DEADLOCKS", "blocking",
+            "Deadlocks also present — chain blocking escalating to deadlocks",
+            facts => HasFact(facts, "DEADLOCKS") && facts["DEADLOCKS"].BaseSeverity > 0);
+
+        // BLOCKING_CHAIN → BLOCKING_EVENTS (chain confirmed by event volume)
+        AddEdge("BLOCKING_CHAIN", "BLOCKING_EVENTS", "blocking",
+            "Blocking event rate elevated — chain confirmed by event volume",
+            facts => HasFact(facts, "BLOCKING_EVENTS") && facts["BLOCKING_EVENTS"].BaseSeverity > 0);
+
+        // BLOCKING_EVENTS → BLOCKING_CHAIN (event rate has structural depth)
+        AddEdge("BLOCKING_EVENTS", "BLOCKING_CHAIN", "blocking",
+            "Reconstructed blocking chain — the pile-up has structural depth",
+            facts => HasFact(facts, "BLOCKING_CHAIN") && facts["BLOCKING_CHAIN"].BaseSeverity > 0);
+
+        // LCK → BLOCKING_CHAIN (lock waits form a transitive pile-up)
+        AddEdge("LCK", "BLOCKING_CHAIN", "lock_contention",
+            "Reconstructed blocking chain — lock waits form a transitive pile-up",
+            facts => HasFact(facts, "BLOCKING_CHAIN") && facts["BLOCKING_CHAIN"].BaseSeverity > 0);
+
+        // THREADPOOL → BLOCKING_CHAIN (chain victims pinning worker threads)
+        AddEdge("THREADPOOL", "BLOCKING_CHAIN", "thread_exhaustion",
+            "Reconstructed blocking chain — chain victims pinning worker threads",
+            facts => HasFact(facts, "BLOCKING_CHAIN") && facts["BLOCKING_CHAIN"].BaseSeverity > 0);
     }
 
     /* ── I/O Pressure ── */

--- a/Lite/Analysis/TestDataSeeder.cs
+++ b/Lite/Analysis/TestDataSeeder.cs
@@ -774,17 +774,22 @@ VALUES ($1, $2, $3, true, true)";
             cmd.CommandText = @"
 INSERT INTO blocked_process_reports
     (blocked_report_id, collection_time, server_id, server_name,
-     event_time, blocked_spid, blocking_spid, wait_time_ms,
+     event_time, blocked_spid, blocked_last_tran_started,
+     blocking_spid, blocking_last_tran_started, wait_time_ms,
      lock_mode, blocked_status, blocking_status)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = id });
             cmd.Parameters.Add(new DuckDBParameter { Value = eventTime });
             cmd.Parameters.Add(new DuckDBParameter { Value = TestServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = TestServerName });
             cmd.Parameters.Add(new DuckDBParameter { Value = eventTime });
-            cmd.Parameters.Add(new DuckDBParameter { Value = 100 + i }); // blocked spid
+            cmd.Parameters.Add(new DuckDBParameter { Value = 100 + i }); // blocked spid — distinct per event
+            cmd.Parameters.Add(new DuckDBParameter { Value = eventTime }); // blocked tran — distinct per blocked session
             cmd.Parameters.Add(new DuckDBParameter { Value = blockerSpid });
+            // Blocking tran — stable per blocker SPID, so all events for one blocker map to one
+            // session node (a head blocker with many victims), not many one-victim chains.
+            cmd.Parameters.Add(new DuckDBParameter { Value = TestPeriodStart.AddSeconds(blockerSpid) });
             cmd.Parameters.Add(new DuckDBParameter { Value = avgWaitTimeMs });
             cmd.Parameters.Add(new DuckDBParameter { Value = "X" });
             cmd.Parameters.Add(new DuckDBParameter { Value = "suspended" });
@@ -792,6 +797,97 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
 
             await cmd.ExecuteNonQueryAsync();
         }
+    }
+
+    /// <summary>
+    /// Seeds blocked_process_reports with a known, reconstructable set of blocking chains:
+    /// a depth-4 line (sleeping apex 200), a depth-1 / 5-victim fan-out (apex 300), a SPID-reuse
+    /// case (spid 201 with a different transaction start — must NOT splice into the depth-4
+    /// chain), and a 1900-01-01 sentinel transaction start.
+    /// </summary>
+    internal async Task SeedBlockingChainAsync()
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+
+        var baseTran = TestPeriodStart;
+        DateTime Tran(int spid) => baseTran.AddSeconds(spid);
+
+        // blocked spid, blocked tran, blocking spid, blocking tran, blocking status
+        var pairs = new (int BlockedSpid, DateTime BlockedTran, int BlockingSpid, DateTime BlockingTran, string BlockingStatus)[]
+        {
+            // Chain A — depth 4, apex 200 sleeping
+            (201, Tran(201), 200, Tran(200), "sleeping"),
+            (202, Tran(202), 201, Tran(201), "running"),
+            (203, Tran(203), 202, Tran(202), "running"),
+            (204, Tran(204), 203, Tran(203), "running"),
+            // Chain B — depth 1, apex 300, five victims
+            (301, Tran(301), 300, Tran(300), "running"),
+            (302, Tran(302), 300, Tran(300), "running"),
+            (303, Tran(303), 300, Tran(300), "running"),
+            (304, Tran(304), 300, Tran(300), "running"),
+            (305, Tran(305), 300, Tran(300), "running"),
+            // SPID reuse — spid 201 again, a different transaction start; must not join Chain A
+            (201, Tran(201).AddHours(2), 210, Tran(210), "running"),
+            // 1900-01-01 sentinel transaction start on the blocked session
+            (220, new DateTime(1900, 1, 1), 221, Tran(221), "running"),
+        };
+
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            var p = pairs[i];
+            var eventTime = TestPeriodStart.AddMinutes(10 + i);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO blocked_process_reports
+    (blocked_report_id, collection_time, server_id, server_name,
+     event_time, database_name, blocked_spid, blocked_last_tran_started,
+     blocking_spid, blocking_last_tran_started, wait_time_ms,
+     lock_mode, blocked_status, blocking_status, blocked_sql_text, blocking_sql_text)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)";
+
+            cmd.Parameters.Add(new DuckDBParameter { Value = _nextId-- });
+            cmd.Parameters.Add(new DuckDBParameter { Value = eventTime });
+            cmd.Parameters.Add(new DuckDBParameter { Value = TestServerId });
+            cmd.Parameters.Add(new DuckDBParameter { Value = TestServerName });
+            cmd.Parameters.Add(new DuckDBParameter { Value = eventTime });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "ChainDb" });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockedSpid });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockedTran });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockingSpid });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockingTran });
+            cmd.Parameters.Add(new DuckDBParameter { Value = 30_000L });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "X" });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "suspended" });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockingStatus });
+            cmd.Parameters.Add(new DuckDBParameter { Value = $"SELECT * FROM dbo.T WHERE id = {p.BlockedSpid}" });
+            cmd.Parameters.Add(new DuckDBParameter { Value = $"UPDATE dbo.T SET v = 1 WHERE id = {p.BlockingSpid}" });
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    /// <summary>
+    /// Deep blocking chain scenario: a depth-4 chain with a sleeping apex, plus corroborating
+    /// lock and thread-exhaustion waits and deadlocks. Expected: a BLOCKING_CHAIN finding
+    /// (depth 4, apex 200) that traverses to LCK / THREADPOOL.
+    /// </summary>
+    public async Task SeedDeepBlockingChainServerAsync()
+    {
+        await ClearTestDataAsync();
+        await SeedTestServerAsync();
+
+        var waits = new Dictionary<string, (long waitTimeMs, long waitingTasks, long signalMs)>
+        {
+            ["THREADPOOL"]          = (5_400_000,     4_000,       0),
+            ["LCK_M_X"]             = (4_000_000,   300_000,  50_000),
+            ["SOS_SCHEDULER_YIELD"] = (  500_000, 2_000_000,       0),
+        };
+
+        await SeedWaitStatsAsync(waits);
+        await SeedBlockingChainAsync();
+        await SeedDeadlocksAsync(15);
     }
 
     /// <summary>


### PR DESCRIPTION
Third Lite-side workstream of the automated-triage stack. Closes the last two of the original four problem scenarios.

## Blocking-chain reconstruction

- `Lite/Analysis/BlockingChainReconstructor.cs` (new, pure static) walks blocked-process pairs into chains using composite `(spid, last_tran_started)` session identity so a reused SPID with a different transaction start cannot fabricate a chain. The 1900-01-01 "no transaction" sentinel is normalized to NULL.
- `CollectBlockingChainFactsAsync` emits one aggregate `BLOCKING_CHAIN` fact carrying the worst chain's apex, depth, and victim count — structure that `BLOCKING_EVENTS` (a rate) is blind to.
- Scoring is magnitude-driven: `Max(depth, victims)` so one severe dimension scores high without being diluted. Amplifiers cover a sleeping apex, deadlocks present, and `THREADPOOL`. Forward and reverse edges connect `BLOCKING_CHAIN` to `LCK` / `THREADPOOL` / `DEADLOCKS` / `BLOCKING_EVENTS`.
- `DrillDownCollector.CollectReconstructedBlockingChains` surfaces the top three reconstructed chains with their level-by-level structure.

## RESOURCE_SEMAPHORE_QUERY_COMPILE wait fact

- Already collected but unscored. Added a ramped `(0.01, 0.10)` threshold, compile-specific amplifiers (CPU and scheduler signals, not the runtime-grant amplifiers that would mislead), and edges to `SOS_SCHEDULER_YIELD` and `CPU_SQL_PERCENT`.

## Design history

Designed in a plan file and revised across two adversarial review rounds. Round 1 caught the SPID-reuse fabrication; round 2 caught the 1900-01-01 sentinel masquerading as a real value.

## Merge with dev

This branch was based off dev BEFORE PR #975 (Lite Stage 1 / Parameter Sensitivity + Plan Regression detectors) merged. The current commit merges origin/dev in and combines both stages' additions to `FactScorer.cs`, `RelationshipGraph.cs`, `DrillDownCollector.cs`, `DuckDbFactCollector.cs`, `TestDataSeeder.cs`, and `Lite.Tests/ScenarioTests.cs` as a union — both feature sets retained, no drift introduced.

## Verification

- `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug`: clean (0 warnings, 0 errors).
- `dotnet test Lite.Tests/Lite.Tests.csproj`: **282/282 pass** (260 baseline + 6 Stage 1 from PR #975 + 16 Stage 3 new — including reconstructor unit tests for SPID reuse, sentinel normalization, cycles, and caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)