### PR TITLE
Wire scheduled analysis + finding notifications (Lite Stage 2)

### DIFF
--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitorLite;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Tests for Stage 2 finding-notification wiring: the FindingMessageFormatter
+/// (message composition + DrillDown mapping) and the AnalysisNotificationService
+/// severity filter + per-finding cooldown.
+/// </summary>
+public class AnalysisNotificationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+
+    public AnalysisNotificationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LiteNotifyTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _duckDb = new DuckDbInitializer(Path.Combine(_tempDir, "test.duckdb"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch { /* Best-effort cleanup */ }
+    }
+
+    private static AnalysisFinding MakeFinding(
+        string hash,
+        double severity = 1.8,
+        string category = "cpu_pressure",
+        int serverId = 1,
+        double? rootValue = 92.5,
+        Dictionary<string, double>? metadata = null,
+        Dictionary<string, object>? drillDown = null)
+    {
+        return new AnalysisFinding
+        {
+            ServerId = serverId,
+            ServerName = "TestServer",
+            Category = category,
+            StoryPath = "CPU_SPIKE → PLAN_REGRESSION",
+            StoryPathHash = hash,
+            Severity = severity,
+            Confidence = 0.67,
+            FactCount = 2,
+            RootFactKey = "CPU_SPIKE",
+            RootFactValue = rootValue,
+            TimeRangeStart = DateTime.UtcNow.AddHours(-4),
+            TimeRangeEnd = DateTime.UtcNow,
+            RootFactMetadata = metadata,
+            DrillDown = drillDown
+        };
+    }
+
+    /* ── FindingMessageFormatter ── */
+
+    [Fact]
+    public void MetricName_AppendsShortHash_SoDistinctFindingsDoNotCollide()
+    {
+        // Two distinct findings sharing one coarse Category must yield distinct metric
+        // names, or EmailAlertService's {serverId}:{metricName} cooldown collapses them.
+        var a = FindingMessageFormatter.MetricName(MakeFinding("aaaaaaaa11111111", category: "cpu_pressure"));
+        var b = FindingMessageFormatter.MetricName(MakeFinding("bbbbbbbb22222222", category: "cpu_pressure"));
+
+        Assert.Equal("Analysis: cpu_pressure [aaaaaaaa]", a);
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void CurrentValue_NullRootValue_EmitsKeyOnly()
+    {
+        var value = FindingMessageFormatter.CurrentValue(MakeFinding("h", rootValue: null));
+
+        Assert.Equal("CPU_SPIKE", value);
+        Assert.DoesNotContain("()", value);
+    }
+
+    [Fact]
+    public void CurrentValue_AnomalyFinding_IncludesFlattenedBaselineContext()
+    {
+        var finding = MakeFinding("h", metadata: new Dictionary<string, double>
+        {
+            ["deviation_sigma"] = 4.1,
+            ["baseline_mean"] = 68.2,
+            ["baseline_hour"] = 14,
+            ["baseline_dow"] = 2
+        });
+
+        var value = FindingMessageFormatter.CurrentValue(finding);
+
+        Assert.Contains("4.1σ", value);
+        Assert.Contains("Tue 14:00", value);
+    }
+
+    [Fact]
+    public void BuildContext_MapsAnonymousListAndObjectDrillDown()
+    {
+        var finding = MakeFinding("h", drillDown: new Dictionary<string, object>
+        {
+            ["top_cpu_queries"] = new List<object>
+            {
+                new { query_hash = "0x1", avg_cpu_ms = 250.0, executions = 1000L },
+                new { query_hash = "0x2", avg_cpu_ms = 90.0, executions = 500L }
+            },
+            ["spike_peak"] = new { peak_time = "2026-05-22T10:00:00Z", cpu_percent = 99 }
+        });
+
+        var context = FindingMessageFormatter.BuildContext(finding);
+
+        Assert.Equal(2, context.Details.Count);
+
+        var queries = context.Details.Single(d => d.Heading == "Top Cpu Queries");
+        Assert.Contains(queries.Fields, f => f.Label.StartsWith("#1") && f.Value == "0x1");
+
+        var peak = context.Details.Single(d => d.Heading == "Spike Peak");
+        Assert.Contains(peak.Fields, f => f.Label == "Cpu Percent" && f.Value == "99");
+    }
+
+    [Fact]
+    public void BuildContext_CapsListAtThreeItems()
+    {
+        var finding = MakeFinding("h", drillDown: new Dictionary<string, object>
+        {
+            ["items"] = new List<object>
+            {
+                new { n = 1 }, new { n = 2 }, new { n = 3 }, new { n = 4 }, new { n = 5 }
+            }
+        });
+
+        var context = FindingMessageFormatter.BuildContext(finding);
+
+        // 3 items kept x 1 property each = 3 fields; #4 and #5 dropped.
+        var item = Assert.Single(context.Details);
+        Assert.Equal(3, item.Fields.Count);
+        Assert.DoesNotContain(item.Fields, f => f.Label.StartsWith("#4"));
+    }
+
+    [Fact]
+    public void BuildContext_NoDrillDown_ReturnsEmptyContext()
+    {
+        var context = FindingMessageFormatter.BuildContext(MakeFinding("h"));
+        Assert.Empty(context.Details);
+    }
+
+    [Fact]
+    public void DetailText_CarriesStoryPathAndChainMetadata()
+    {
+        var text = FindingMessageFormatter.DetailText(MakeFinding("h"));
+
+        Assert.Contains("CPU_SPIKE → PLAN_REGRESSION", text);
+        Assert.Contains("Severity", text);
+        Assert.Contains("Confidence", text);
+    }
+
+    /* ── AnalysisNotificationService: severity filter + cooldown ── */
+    /* TrySendAlertEmailAsync writes one config_alert_log row per call (regardless of
+       whether a channel is configured), so the row count is an observable proxy for
+       "did the service decide to notify". */
+
+    [Fact]
+    public async Task NotifyAsync_SameFinding_NotifiesOnceWithinCooldown()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var notifier = new AnalysisNotificationService(new EmailAlertService(_duckDb));
+        var finding = MakeFinding("samehash00000001", severity: 2.0);
+
+        await notifier.NotifyAsync(new[] { finding });
+        await notifier.NotifyAsync(new[] { finding });
+
+        Assert.Equal(1, await CountAlertLogRowsAsync());
+    }
+
+    [Fact]
+    public async Task NotifyAsync_DistinctFindings_EachNotifies()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var notifier = new AnalysisNotificationService(new EmailAlertService(_duckDb));
+
+        await notifier.NotifyAsync(new[]
+        {
+            MakeFinding("hash000000000001", severity: 2.0),
+            MakeFinding("hash000000000002", severity: 2.0)
+        });
+
+        Assert.Equal(2, await CountAlertLogRowsAsync());
+    }
+
+    [Fact]
+    public async Task NotifyAsync_BelowSeverityThreshold_DoesNotNotify()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+
+        var notifier = new AnalysisNotificationService(new EmailAlertService(_duckDb));
+        await notifier.NotifyAsync(new[] { MakeFinding("lowsev0000000001", severity: 1.0) });
+
+        Assert.Equal(0, await CountAlertLogRowsAsync());
+    }
+
+    private async Task<long> CountAlertLogRowsAsync()
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM config_alert_log";
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+}

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -116,6 +116,13 @@ public partial class App : Application
     public static string MuteRuleDefaultExpiration { get; set; } = "24 hours"; // Default expiration for new mute rules
     public static bool LogAlertDismissals { get; set; } = true; // Log alert dismiss/mute actions to file
 
+    /* Automated analysis notifications (scheduled triage) */
+    public static bool AnalysisNotificationsEnabled { get; set; } = false;  // Master switch — also gates the scheduler
+    public static int AnalysisIntervalMinutes { get; set; } = 30;           // How often scheduled analysis runs
+    public static double AnalysisNotifySeverity { get; set; } = 1.5;        // Minimum finding severity (0.0-2.0) to notify on
+    public static int AnalysisNotifyCooldownMinutes { get; set; } = 360;    // Re-notify gap per finding (keyed by StoryPathHash)
+    public static int AnalysisTimeoutSeconds { get; set; } = 120;           // Per-server analysis timeout
+
     /* Connection settings */
     public static int ConnectionTimeoutSeconds { get; set; } = 5;
 
@@ -538,6 +545,12 @@ public partial class App : Application
             if (root.TryGetProperty("smtp_username", out v)) SmtpUsername = v.GetString() ?? "";
             if (root.TryGetProperty("smtp_from_address", out v)) SmtpFromAddress = v.GetString() ?? "";
             if (root.TryGetProperty("smtp_recipients", out v)) SmtpRecipients = v.GetString() ?? "";
+
+            if (root.TryGetProperty("analysis_notifications_enabled", out v)) AnalysisNotificationsEnabled = v.GetBoolean();
+            if (root.TryGetProperty("analysis_interval_minutes", out v)) AnalysisIntervalMinutes = (int)Math.Clamp(v.GetInt64(), 5, 360);
+            if (root.TryGetProperty("analysis_notify_severity", out v)) AnalysisNotifySeverity = Math.Clamp(v.GetDouble(), 0.0, 2.0);
+            if (root.TryGetProperty("analysis_notify_cooldown_minutes", out v)) AnalysisNotifyCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 30, 10080);
+            if (root.TryGetProperty("analysis_timeout_seconds", out v)) AnalysisTimeoutSeconds = (int)Math.Clamp(v.GetInt64(), 30, 600);
         }
         catch { /* Use defaults */ }
     }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -111,8 +111,13 @@ public partial class MainWindow : Window
             var archiveService = new ArchiveService(_databaseInitializer, App.ArchiveDirectory, new AppLoggerAdapter<ArchiveService>());
             var retentionService = new RetentionService(App.ArchiveDirectory, new AppLoggerAdapter<RetentionService>());
 
+            // Routes high-severity analysis findings to email/Slack/Teams; the background
+            // service runs scheduled analysis and hands findings to it.
+            var analysisNotificationService = new AnalysisNotificationService(_emailAlertService);
+
             _backgroundService = new CollectionBackgroundService(
                 _collectorService, _databaseInitializer, archiveService, retentionService, _serverManager,
+                analysisNotificationService,
                 new AppLoggerAdapter<CollectionBackgroundService>());
 
             // Start background collection

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -837,10 +837,11 @@ internal static class ToolRecommendations
     private static readonly string[] DayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
     /// <summary>
-    /// Formats baseline context from anomaly fact metadata into a human-readable object
-    /// for MCP output. Example: "4.1σ above baseline for Tue 14:00, mean 68.2"
+    /// Formats baseline context from anomaly fact metadata into a structured dictionary
+    /// (deviation, ratio, baseline mean/stddev, time bucket, tier, samples). Used by MCP
+    /// output and by AnalysisNotificationService's finding formatter.
     /// </summary>
-    private static Dictionary<string, object>? FormatBaselineContext(Dictionary<string, double> metadata)
+    internal static Dictionary<string, object>? FormatBaselineContext(Dictionary<string, double> metadata)
     {
         var result = new Dictionary<string, object>();
 

--- a/Lite/Services/AnalysisNotificationService.cs
+++ b/Lite/Services/AnalysisNotificationService.cs
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Mcp;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Routes high-severity analysis findings into the notification channels.
+/// Filters by severity, dedups per finding (so a recurring finding does not
+/// re-notify every analysis cycle), composes a readable message, and hands off
+/// to <see cref="EmailAlertService"/> — which fans out to email + Slack + Teams
+/// and logs to config_alert_log.
+///
+/// Called by the scheduled-analysis loop in CollectionBackgroundService with the
+/// findings returned by each completed AnalysisService.AnalyzeAsync.
+/// </summary>
+public sealed class AnalysisNotificationService
+{
+    private readonly EmailAlertService _emailAlertService;
+
+    /// <summary>
+    /// Per-finding re-notification cooldown, keyed "{serverId}:{StoryPathHash}".
+    /// In-memory only — lost on app restart (each active finding then re-notifies once).
+    /// Never evicts; bounded by servers x distinct story patterns.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+
+    public AnalysisNotificationService(EmailAlertService emailAlertService)
+    {
+        _emailAlertService = emailAlertService;
+    }
+
+    /// <summary>
+    /// Notifies on every finding at or above the configured severity that is not
+    /// inside its re-notification cooldown. Never throws.
+    /// </summary>
+    public async Task NotifyAsync(IReadOnlyList<AnalysisFinding> findings)
+    {
+        if (findings is null || findings.Count == 0)
+            return;
+
+        var threshold = App.AnalysisNotifySeverity;
+        var cooldown = TimeSpan.FromMinutes(App.AnalysisNotifyCooldownMinutes);
+        var now = DateTime.UtcNow;
+
+        foreach (var finding in findings)
+        {
+            if (finding.Severity < threshold)
+                continue;
+
+            var key = $"{finding.ServerId}:{finding.StoryPathHash}";
+            if (_cooldowns.TryGetValue(key, out var last) && now - last < cooldown)
+                continue;
+
+            try
+            {
+                /* TrySendAlertEmailAsync fans out to email + Slack + Teams and logs a
+                   config_alert_log row. It returns no success/failure signal, so the
+                   cooldown is stamped regardless — a finding whose delivery failed is
+                   suppressed for the full cooldown (accepted best-effort behavior). */
+                await _emailAlertService.TrySendAlertEmailAsync(
+                    FindingMessageFormatter.MetricName(finding),
+                    finding.ServerName,
+                    FindingMessageFormatter.CurrentValue(finding),
+                    threshold.ToString("F1"),
+                    finding.ServerId,
+                    FindingMessageFormatter.BuildContext(finding),
+                    numericCurrentValue: finding.Severity,
+                    numericThresholdValue: threshold,
+                    muted: false,
+                    detailText: FindingMessageFormatter.DetailText(finding));
+
+                _cooldowns[key] = now;
+            }
+            catch (Exception ex)
+            {
+                /* TrySendAlertEmailAsync is documented never to throw; this guards a
+                   formatter defect so one bad finding cannot abort the rest. */
+                AppLogger.Error("AnalysisNotify",
+                    $"Failed to notify on finding {finding.StoryPathHash}: {ex.Message}", ex);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Composes the arguments for an analysis-finding notification. The engine never
+/// populates <see cref="AnalysisFinding.StoryText"/>, so the readable message is
+/// built here from the finding's structured fields and drill-down detail.
+/// </summary>
+internal static class FindingMessageFormatter
+{
+    private const int FieldValueLimit = 300;
+
+    /// <summary>
+    /// Alert metric name. The "Analysis: " prefix groups these in the Alerts tab; the
+    /// short hash suffix makes each distinct finding unique, so EmailAlertService's own
+    /// {serverId}:{metricName} cooldown cannot collapse two findings sharing a Category.
+    /// </summary>
+    public static string MetricName(AnalysisFinding finding)
+    {
+        var hash = finding.StoryPathHash ?? string.Empty;
+        var shortHash = hash.Length >= 8 ? hash[..8] : hash;
+        var category = string.IsNullOrEmpty(finding.Category) ? "finding" : finding.Category;
+        return $"Analysis: {category} [{shortHash}]";
+    }
+
+    /// <summary>
+    /// Headline value — the root fact and its value, plus baseline context for anomaly findings.
+    /// </summary>
+    public static string CurrentValue(AnalysisFinding finding)
+    {
+        var root = string.IsNullOrEmpty(finding.RootFactKey) ? finding.Category : finding.RootFactKey;
+        var sb = new StringBuilder(root);
+
+        if (finding.RootFactValue.HasValue)
+            sb.Append($" ({finding.RootFactValue.Value:F1})");
+
+        if (finding.RootFactMetadata is { Count: > 0 })
+        {
+            var baseline = ToolRecommendations.FormatBaselineContext(finding.RootFactMetadata);
+            if (baseline is { Count: > 0 })
+            {
+                var parts = baseline.Select(kv => $"{Humanize(kv.Key)} {kv.Value}");
+                sb.Append(" — ").Append(string.Join(", ", parts));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Plain-text detail block — the causal chain and supporting metadata.
+    /// </summary>
+    public static string DetailText(AnalysisFinding finding)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"  Story: {finding.StoryPath}");
+        sb.AppendLine($"  Severity: {finding.Severity:F2} (notify threshold {App.AnalysisNotifySeverity:F1})");
+        sb.AppendLine($"  Confidence: {finding.Confidence:F2}");
+        sb.AppendLine($"  Facts in chain: {finding.FactCount}");
+
+        if (!string.IsNullOrEmpty(finding.DatabaseName))
+            sb.AppendLine($"  Database: {finding.DatabaseName}");
+
+        if (finding.TimeRangeStart.HasValue && finding.TimeRangeEnd.HasValue)
+            sb.AppendLine($"  Window: {finding.TimeRangeStart.Value:u} - {finding.TimeRangeEnd.Value:u}");
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Maps the finding's ephemeral <see cref="AnalysisFinding.DrillDown"/> detail into an
+    /// <see cref="AlertContext"/>. DrillDown values are anonymous types behind object
+    /// (a bare object, or a List&lt;object&gt; of them), so they are round-tripped through
+    /// System.Text.Json and walked as JsonElement — robust to any shape DrillDownCollector emits.
+    /// </summary>
+    public static AlertContext BuildContext(AnalysisFinding finding)
+    {
+        var context = new AlertContext();
+        if (finding.DrillDown is null || finding.DrillDown.Count == 0)
+            return context;
+
+        foreach (var (key, value) in finding.DrillDown)
+        {
+            if (value is null)
+                continue;
+
+            var item = new AlertDetailItem { Heading = Humanize(key) };
+            try
+            {
+                FlattenInto(item.Fields, JsonSerializer.SerializeToElement(value));
+            }
+            catch
+            {
+                /* Unexpected value shape — skip this drill-down entry, keep the rest. */
+                continue;
+            }
+
+            if (item.Fields.Count > 0)
+                context.Details.Add(item);
+        }
+
+        return context;
+    }
+
+    /// <summary>
+    /// Flattens one drill-down value into label/value field pairs. Arrays are capped at
+    /// the first 3 elements; nested objects/arrays are rendered as compact JSON.
+    /// </summary>
+    private static void FlattenInto(List<(string Label, string Value)> fields, JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var child in element.EnumerateArray())
+                {
+                    if (index >= 3)
+                        break;
+                    index++;
+
+                    if (child.ValueKind == JsonValueKind.Object)
+                    {
+                        foreach (var prop in child.EnumerateObject())
+                            fields.Add(($"#{index} {Humanize(prop.Name)}", ScalarText(prop.Value)));
+                    }
+                    else
+                    {
+                        fields.Add(($"#{index}", ScalarText(child)));
+                    }
+                }
+                break;
+
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                    fields.Add((Humanize(prop.Name), ScalarText(prop.Value)));
+                break;
+
+            default:
+                fields.Add(("value", ScalarText(element)));
+                break;
+        }
+    }
+
+    /// <summary>Renders a single JSON value as truncated display text.</summary>
+    private static string ScalarText(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => Truncate(element.GetString() ?? string.Empty),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => string.Empty,
+            // Nested object/array — show compact raw JSON rather than recursing further.
+            _ => Truncate(element.GetRawText())
+        };
+    }
+
+    /// <summary>Turns a snake_case key into spaced Title Case ("top_blocking_chains" -> "Top Blocking Chains").</summary>
+    private static string Humanize(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+            return key;
+
+        var words = key.Replace('_', ' ').Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return string.Join(' ', words.Select(w => char.ToUpperInvariant(w[0]) + w[1..]));
+    }
+
+    private static string Truncate(string text)
+    {
+        return text.Length <= FieldValueLimit ? text : text[..FieldValueLimit] + "…";
+    }
+}

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -7,11 +7,13 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Analysis;
 using PerformanceMonitorLite.Database;
 
 namespace PerformanceMonitorLite.Services;
@@ -27,12 +29,18 @@ public class CollectionBackgroundService : BackgroundService
     private readonly ServerManager? _serverManager;
     private readonly ArchiveService? _archiveService;
     private readonly RetentionService? _retentionService;
+    private readonly AnalysisNotificationService? _notificationService;
     private readonly ILogger<CollectionBackgroundService>? _logger;
 
     private static readonly TimeSpan CollectionInterval = TimeSpan.FromMinutes(1);
     /* Start at UtcNow so maintenance tasks don't all fire on the very first cycle. */
     private DateTime _lastArchiveTime = DateTime.UtcNow;
     private DateTime _lastRetentionTime = DateTime.UtcNow;
+    private DateTime _lastAnalysisTime = DateTime.UtcNow;
+
+    /* Server IDs whose scheduled analysis is currently running — prevents relaunching
+       analysis for a server whose previous (possibly hung) pass has not finished. */
+    private readonly ConcurrentDictionary<int, byte> _analysisInFlight = new();
 
     /* Archive every hour, retention once per day */
     private static readonly TimeSpan ArchiveInterval = TimeSpan.FromHours(1);
@@ -54,6 +62,7 @@ public class CollectionBackgroundService : BackgroundService
         ArchiveService? archiveService = null,
         RetentionService? retentionService = null,
         ServerManager? serverManager = null,
+        AnalysisNotificationService? notificationService = null,
         ILogger<CollectionBackgroundService>? logger = null)
     {
         _collectorService = collectorService;
@@ -61,6 +70,7 @@ public class CollectionBackgroundService : BackgroundService
         _serverManager = serverManager;
         _archiveService = archiveService;
         _retentionService = retentionService;
+        _notificationService = notificationService;
         _logger = logger;
     }
 
@@ -115,6 +125,9 @@ public class CollectionBackgroundService : BackgroundService
 
                 /* Periodic retention cleanup */
                 RunRetentionIfDue();
+
+                /* Periodic scheduled analysis + high-severity finding notifications */
+                await RunAnalysisIfDueAsync(stoppingToken);
 
                 /* Log process memory at the end of each cycle. Lets bug reporters
                    self-report memory without Task Manager, gives us a continuous
@@ -187,6 +200,91 @@ public class CollectionBackgroundService : BackgroundService
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Retention cleanup failed");
+        }
+    }
+
+    /// <summary>
+    /// Runs the triage engine for each enabled server on a configurable interval and
+    /// routes high-severity findings to the notification channels. Gated by
+    /// App.AnalysisNotificationsEnabled — zero cost when off.
+    /// </summary>
+    private async Task RunAnalysisIfDueAsync(CancellationToken stoppingToken)
+    {
+        /* Feature off, or dependencies not injected in this construction path. */
+        if (!App.AnalysisNotificationsEnabled ||
+            _duckDb == null || _serverManager == null || _notificationService == null)
+        {
+            return;
+        }
+
+        if (DateTime.UtcNow - _lastAnalysisTime < TimeSpan.FromMinutes(App.AnalysisIntervalMinutes))
+        {
+            return;
+        }
+        _lastAnalysisTime = DateTime.UtcNow;
+
+        var timeout = TimeSpan.FromSeconds(App.AnalysisTimeoutSeconds);
+        var planFetcher = new SqlPlanFetcher(_serverManager);
+
+        foreach (var server in _serverManager.GetEnabledServers())
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var serverName = RemoteCollectorService.GetServerNameForStorage(server);
+            var serverId = RemoteCollectorService.GetDeterministicHashCode(serverName);
+
+            /* Skip a server whose previous analysis is still running — a hung
+               connection that outlived its timeout would otherwise pile up tasks. */
+            if (!_analysisInFlight.TryAdd(serverId, 0))
+            {
+                continue;
+            }
+
+            try
+            {
+                /* Fresh AnalysisService per server: IsAnalyzing is a single instance
+                   flag, so a shared instance whose task is abandoned on timeout would
+                   block analysis for every other server. */
+                var analysisService = new AnalysisService(_duckDb, planFetcher);
+                var analyzeTask = analysisService.AnalyzeAsync(serverId, serverName, hoursBack: 4);
+
+                /* Clear the in-flight marker only when the task truly finishes — not
+                   when the timeout below moves us on — so a hung server is not relaunched. */
+                _ = analyzeTask.ContinueWith(
+                    completed => _analysisInFlight.TryRemove(serverId, out _),
+                    TaskScheduler.Default);
+
+                var finished = await Task.WhenAny(analyzeTask, Task.Delay(timeout, stoppingToken));
+
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (finished != analyzeTask)
+                {
+                    _logger?.LogWarning(
+                        "Scheduled analysis for {Server} exceeded {Timeout}s — skipped this cycle",
+                        serverName, App.AnalysisTimeoutSeconds);
+                    continue;
+                }
+
+                await _notificationService.NotifyAsync(await analyzeTask);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Scheduled analysis failed for {Server}", serverName);
+                /* If analyzeTask was never created (e.g. ctor threw), the continuation
+                   never ran — clear the marker defensively. */
+                _analysisInFlight.TryRemove(serverId, out _);
+            }
         }
     }
 

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -273,6 +273,32 @@
                            Margin="20,0,0,0" TextWrapping="Wrap"/>
                 <CheckBox x:Name="LogAlertDismissalsCheckBox" Content="Log alert dismiss and mute actions"
                           Margin="20,8,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+
+                <!-- Automated Analysis Notifications -->
+                <TextBlock Text="Automated Analysis Notifications" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,14,0,4"/>
+                <TextBlock Text="Periodically run the triage engine and send high-severity findings through the channels above."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,0,0,4" TextWrapping="Wrap"/>
+                <CheckBox x:Name="AnalysisNotificationsCheckBox" Content="Enable scheduled analysis notifications"
+                          Margin="20,4,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Run analysis every" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisIntervalBox" Width="45" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Notify on finding severity at or above" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisNotifySeverityBox" Width="45" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="(0.0 - 2.0)" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <TextBlock Text="Requires SMTP or a webhook configured below for delivery; findings are recorded in the Alerts tab either way."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,4,0,0" TextWrapping="Wrap"/>
             </StackPanel>
         </Border>
 

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -605,6 +605,9 @@ public partial class SettingsWindow : Window
             _ => 3
         };
         LogAlertDismissalsCheckBox.IsChecked = App.LogAlertDismissals;
+        AnalysisNotificationsCheckBox.IsChecked = App.AnalysisNotificationsEnabled;
+        AnalysisIntervalBox.Text = App.AnalysisIntervalMinutes.ToString();
+        AnalysisNotifySeverityBox.Text = App.AnalysisNotifySeverity.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture);
         UpdateAlertControlStates();
     }
 
@@ -657,6 +660,16 @@ public partial class SettingsWindow : Window
             validationErrors.Add("Email alert cooldown must be between 1 and 120 minutes.");
         App.MuteRuleDefaultExpiration = (MuteRuleDefaultExpirationCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "24 hours";
         App.LogAlertDismissals = LogAlertDismissalsCheckBox.IsChecked == true;
+        App.AnalysisNotificationsEnabled = AnalysisNotificationsCheckBox.IsChecked == true;
+        if (int.TryParse(AnalysisIntervalBox.Text, out var analysisInterval) && analysisInterval >= 5 && analysisInterval <= 360)
+            App.AnalysisIntervalMinutes = analysisInterval;
+        else
+            validationErrors.Add("Analysis interval must be between 5 and 360 minutes.");
+        if (double.TryParse(AnalysisNotifySeverityBox.Text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var analysisSeverity)
+            && analysisSeverity >= 0.0 && analysisSeverity <= 2.0)
+            App.AnalysisNotifySeverity = analysisSeverity;
+        else
+            validationErrors.Add("Analysis notify severity must be between 0.0 and 2.0.");
 
         var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
         try
@@ -702,6 +715,9 @@ public partial class SettingsWindow : Window
             root["email_cooldown_minutes"] = App.EmailCooldownMinutes;
             root["mute_rule_default_expiration"] = App.MuteRuleDefaultExpiration;
             root["log_alert_dismissals"] = App.LogAlertDismissals;
+            root["analysis_notifications_enabled"] = App.AnalysisNotificationsEnabled;
+            root["analysis_interval_minutes"] = App.AnalysisIntervalMinutes;
+            root["analysis_notify_severity"] = App.AnalysisNotifySeverity;
 
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(settingsPath, root.ToJsonString(options));
@@ -740,6 +756,8 @@ public partial class SettingsWindow : Window
         AlertLongRunningJobMultiplierBox.Text = "3";
         AlertCooldownBox.Text = "5";
         EmailCooldownBox.Text = "15";
+        AnalysisIntervalBox.Text = "30";
+        AnalysisNotifySeverityBox.Text = "1.5";
         AlertExcludedDatabasesBox.Text = "";
         MuteRuleDefaultExpirationCombo.SelectedIndex = 1; // 24 hours
         UpdateAlertPreviewText();


### PR DESCRIPTION
Second Lite-side workstream of the automated-triage stack — the "act" half. High-severity findings from the engine in Stages 1 + 3 now ride the email/webhook channels and the alert-history log on a configurable schedule, alongside the existing threshold-alert engine.

## Notification service

- `Lite/Services/AnalysisNotificationService.cs` (new, public sealed) — severity-gated, `{serverId}:{StoryPathHash}` in-memory cooldown, defensive `try/catch`. Hands findings off to `EmailAlertService.TrySendAlertEmailAsync` (10-param Lite shape with `detailText`) which fans out to email + Slack + Teams + alert log.
- `FindingMessageFormatter` (internal static) — composes the alert subject/value/detail block from the finding's structured fields. Uses `ToolRecommendations.FormatBaselineContext` (now promoted from private to internal static for shared use).

## Scheduler

- `Lite/Services/CollectionBackgroundService.cs` — `RunAnalysisIfDueAsync` runs the analysis engine for each enabled server on a configurable interval. Per-server fresh `AnalysisService` (IsAnalyzing is a single-instance flag), per-server `Task.WhenAny` timeout, `ConcurrentDictionary<int,byte>` in-flight tracking cleared only on real task completion so a permanently-hung connection parks one server without blocking the others.

## Settings + UI

- Five new App.* settings: `AnalysisNotificationsEnabled` (false), `AnalysisIntervalMinutes` (30), `AnalysisNotifySeverity` (1.5), `AnalysisNotifyCooldownMinutes` (360), `AnalysisTimeoutSeconds` (120). All gated through `App.xaml.cs` with bounds clamping at consumption.
- `Lite/Windows/SettingsWindow.xaml` + `.xaml.cs` — new "Automated Analysis Notifications" group.
- Ships disabled by default.

## Merge with dev

This branch was based on Stage 1; current commit merges in the dev tip which now also has Stage 3 (PR #1002) and the Dashboard port. No conflicts — Stage 2's additions are on the service/notification surface, separate from Stage 3's reconstructor/scoring additions.

## Design history

Designed in a plan file and revised across two adversarial review rounds. Round 1 caught the per-server in-flight tracking gap (a single shared `AnalysisService` with `Task.WhenAny` timeout would silently kill analysis for all servers); round 2 caught the lambda-parameter shadowing of `out _` discards.

## Verification

- `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug`: clean (0 warnings, 0 errors).
- `dotnet test Lite.Tests/Lite.Tests.csproj`: **292/292 pass** (282 prior + 10 new `AnalysisNotificationTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)