### PR TITLE
Overview lanes: plot Total CPU alongside SQL CPU (#1004)

### DIFF
--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -57,7 +57,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         }
 
         _crosshairManager = new CorrelatedCrosshairManager();
-        _crosshairManager.AddLane(CpuChart, "CPU", "%");
+        _crosshairManager.AddLane(CpuChart, "SQL CPU", "%");
         _crosshairManager.AddLane(WaitStatsChart, "Wait Stats", "ms/sec");
         _crosshairManager.AddLane(BlockingChart, "Blocking", "events");
         _crosshairManager.AddLane(MemoryChart, "Buffer Pool", "MB");
@@ -126,10 +126,12 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         // minAnomalyValue: absolute floor below which dots/arrows are suppressed even if outside band.
         // Prevents "1% CPU above 0.5% baseline" false alarms on idle servers.
         if (cpuTask.IsCompletedSuccessfully)
-            UpdateLane(CpuChart, "CPU %",
-                cpuTask.Result.OrderBy(d => d.SampleTime)
-                    .Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(),
-                "#4FC3F7", 0, 105, cpuBaseline, minAnomalyValue: 10);
+        {
+            var ordered = cpuTask.Result.OrderBy(d => d.SampleTime).ToList();
+            var sqlSeries = ordered.Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpuUtilization)).ToList();
+            var totalSeries = ordered.Select(d => (d.SampleTime.ToOADate(), (double)d.TotalCpuUtilization)).ToList();
+            UpdateCpuLane(sqlSeries, totalSeries, cpuBaseline);
+        }
         else
             ShowEmpty(CpuChart, "CPU %");
 
@@ -199,7 +201,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
             if (refCpuTask.IsCompletedSuccessfully)
                 AddGhostLine(CpuChart, refCpuTask.Result
-                    .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.SqlServerCpuUtilization)).ToList(), "#4FC3F7");
+                    .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.TotalCpuUtilization)).ToList(), "#FF7043");
 
             if (refWaitTask.IsCompletedSuccessfully)
                 AddGhostLine(WaitStatsChart, refWaitTask.Result
@@ -347,6 +349,102 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         BlockingChart.Plot.Legend.IsVisible = false;
         BlockingChart.Plot.Axes.Margins(bottom: 0);
         BlockingChart.Plot.Axes.SetLimitsY(0, Math.Max(maxCount * 1.3, 2));
+    }
+
+    /* Two-series CPU lane: SQL CPU (blue) + Total non-idle CPU (orange).
+       Total is what the Lite alert evaluates by default (see CpuAlertMode in Lite/App.xaml.cs),
+       so plotting it directly avoids the "alert says 95% but chart shows 60%" confusion (PM #1004).
+       Baseline band + anomaly markers stay on SQL because that's the metric the CPU baseline
+       was computed from. Dashboard does not yet have its own CpuAlertMode (deferred follow-up). */
+    private void UpdateCpuLane(
+        List<(double Time, double Value)> sqlData,
+        List<(double Time, double Value)> totalData,
+        BaselineBucket? baseline = null)
+    {
+        ClearChart(CpuChart);
+        TabHelpers.ApplyThemeToChart(CpuChart);
+
+        if (sqlData.Count == 0 && totalData.Count == 0)
+        {
+            ShowEmpty(CpuChart, "CPU %");
+            return;
+        }
+
+        var sqlTimes = sqlData.Select(d => d.Time).ToArray();
+        var sqlValues = sqlData.Select(d => d.Value).ToArray();
+        var totalTimes = totalData.Select(d => d.Time).ToArray();
+        var totalValues = totalData.Select(d => d.Value).ToArray();
+
+        _crosshairManager?.SetLaneData(CpuChart, sqlTimes, sqlValues);
+        _crosshairManager?.AddLaneSeries(CpuChart, "Total", "%", totalTimes, totalValues);
+
+        // Baseline band — applies to SQL CPU (what the baseline was computed on)
+        if (baseline != null && baseline.SampleCount > 0 && baseline.EffectiveStdDev > 0)
+        {
+            var upper = baseline.Mean + 2 * baseline.EffectiveStdDev;
+            var lower = Math.Max(0, baseline.Mean - 2 * baseline.EffectiveStdDev);
+
+            _crosshairManager?.SetLaneBaseline(CpuChart, lower, upper, 10);
+
+            var band = CpuChart.Plot.Add.HorizontalSpan(lower, upper);
+            band.FillStyle.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(25);
+            band.LineStyle.Width = 0;
+
+            var meanLine = CpuChart.Plot.Add.HorizontalLine(baseline.Mean);
+            meanLine.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(60);
+            meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
+            meanLine.LineWidth = 1;
+
+            var anomalyIndices = new List<int>();
+            for (int i = 0; i < sqlValues.Length; i++)
+            {
+                if ((sqlValues[i] > upper && sqlValues[i] >= 10) || sqlValues[i] < lower)
+                    anomalyIndices.Add(i);
+            }
+
+            if (anomalyIndices.Count > 0)
+            {
+                var anomalyTimes = anomalyIndices.Select(i => sqlTimes[i]).ToArray();
+                var anomalyVals = anomalyIndices.Select(i => sqlValues[i]).ToArray();
+                var anomalyScatter = CpuChart.Plot.Add.Scatter(anomalyTimes, anomalyVals);
+                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.MarkerSize = 6;
+                anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
+                anomalyScatter.LineWidth = 0;
+            }
+        }
+
+        if (totalValues.Length > 0)
+        {
+            var totalScatter = CpuChart.Plot.Add.Scatter(totalTimes, totalValues);
+            totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+            totalScatter.MarkerSize = 0;
+            totalScatter.LineWidth = 1.5f;
+            totalScatter.LegendText = "Total";
+            totalScatter.ConnectStyle = ScottPlot.ConnectStyle.Straight;
+        }
+
+        if (sqlValues.Length > 0)
+        {
+            var sqlScatter = CpuChart.Plot.Add.Scatter(sqlTimes, sqlValues);
+            sqlScatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            sqlScatter.MarkerSize = 0;
+            sqlScatter.LineWidth = 1.5f;
+            sqlScatter.LegendText = "SQL";
+            sqlScatter.ConnectStyle = ScottPlot.ConnectStyle.Straight;
+        }
+
+        CpuChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        if (CpuChart != FileIoChart)
+            CpuChart.Plot.Axes.Bottom.TickLabelStyle.IsVisible = false;
+
+        TabHelpers.ReapplyAxisColors(CpuChart);
+
+        CpuChart.Plot.Title("");
+        CpuChart.Plot.YLabel("");
+        CpuChart.Plot.Legend.IsVisible = false;
+        CpuChart.Plot.Axes.Margins(bottom: 0);
+        CpuChart.Plot.Axes.SetLimitsY(0, 105);
     }
 
     private void UpdateLane(ScottPlot.WPF.WpfPlot chart, string title,

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -57,7 +57,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         }
 
         _crosshairManager = new CorrelatedCrosshairManager();
-        _crosshairManager.AddLane(CpuChart, "CPU", "%");
+        _crosshairManager.AddLane(CpuChart, "SQL CPU", "%");
         _crosshairManager.AddLane(WaitStatsChart, "Wait Stats", "ms/sec");
         _crosshairManager.AddLane(BlockingChart, "Blocking", "events");
         _crosshairManager.AddLane(MemoryChart, "Buffer Pool", "MB");
@@ -111,9 +111,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             // minAnomalyValue: absolute floor below which dots/arrows are suppressed even if outside band.
             // Prevents "1% CPU above 0.5% baseline" false alarms on idle servers.
             if (cpuTask.IsCompletedSuccessfully)
-                UpdateLane(CpuChart, "CPU %",
-                    cpuTask.Result.Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpu)).ToList(),
-                    "#4FC3F7", 0, 105, cpuBaseline, minAnomalyValue: 10);
+            {
+                var sqlSeries = cpuTask.Result.Select(d => (d.SampleTime.ToOADate(), (double)d.SqlServerCpu)).ToList();
+                var totalSeries = cpuTask.Result.Select(d => (d.SampleTime.ToOADate(), (double)d.TotalCpu)).ToList();
+                UpdateCpuLane(sqlSeries, totalSeries, cpuBaseline);
+            }
             else
                 ShowEmpty(CpuChart, "CPU %");
 
@@ -176,7 +178,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
                 if (refCpuTask.IsCompletedSuccessfully && refCpuTask.Result != null)
                     AddGhostLine(CpuChart, refCpuTask.Result
-                        .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.SqlServerCpu)).ToList(), "#4FC3F7");
+                        .Select(d => (d.SampleTime.Add(timeShift).ToOADate(), (double)d.TotalCpu)).ToList(), "#FF7043");
 
                 if (refWaitTask.IsCompletedSuccessfully && refWaitTask.Result != null)
                     AddGhostLine(WaitStatsChart, refWaitTask.Result
@@ -309,6 +311,106 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         BlockingChart.Plot.Axes.SetLimitsY(0, Math.Max(maxCount * 1.3, 2));
 
         BlockingChart.Refresh();
+    }
+
+    /* Two-series CPU lane: SQL CPU (blue) + Total non-idle CPU (orange).
+       Total is what the alert evaluates by default (see CpuAlertMode), so
+       plotting it directly avoids the "alert says 95% but chart shows 60%"
+       confusion (PM #1004). Baseline band + anomaly markers stay on SQL
+       because that's the metric the CPU baseline was computed from. */
+    private void UpdateCpuLane(
+        List<(double Time, double Value)> sqlData,
+        List<(double Time, double Value)> totalData,
+        BaselineBucket? baseline = null)
+    {
+        ClearChart(CpuChart);
+        ApplyTheme(CpuChart);
+
+        if (sqlData.Count == 0 && totalData.Count == 0)
+        {
+            ShowEmpty(CpuChart, "CPU %");
+            return;
+        }
+
+        var sqlTimes = sqlData.Select(d => d.Time).ToArray();
+        var sqlValues = sqlData.Select(d => d.Value).ToArray();
+        var totalTimes = totalData.Select(d => d.Time).ToArray();
+        var totalValues = totalData.Select(d => d.Value).ToArray();
+
+        // Register SQL as the first (lane-default-named) series, Total as a named second series
+        _crosshairManager?.SetLaneData(CpuChart, sqlTimes, sqlValues);
+        _crosshairManager?.AddLaneSeries(CpuChart, "Total", "%", totalTimes, totalValues);
+
+        // Baseline band — applies to SQL CPU (what the baseline was computed on)
+        if (baseline != null && baseline.SampleCount > 0 && baseline.EffectiveStdDev > 0)
+        {
+            var upper = baseline.Mean + 2 * baseline.EffectiveStdDev;
+            var lower = Math.Max(0, baseline.Mean - 2 * baseline.EffectiveStdDev);
+
+            _crosshairManager?.SetLaneBaseline(CpuChart, lower, upper, 10);
+
+            var band = CpuChart.Plot.Add.HorizontalSpan(lower, upper);
+            band.FillStyle.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(25);
+            band.LineStyle.Width = 0;
+
+            var meanLine = CpuChart.Plot.Add.HorizontalLine(baseline.Mean);
+            meanLine.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(60);
+            meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
+            meanLine.LineWidth = 1;
+
+            // Anomaly markers on SQL series only
+            var anomalyIndices = new List<int>();
+            for (int i = 0; i < sqlValues.Length; i++)
+            {
+                if ((sqlValues[i] > upper && sqlValues[i] >= 10) || sqlValues[i] < lower)
+                    anomalyIndices.Add(i);
+            }
+
+            if (anomalyIndices.Count > 0)
+            {
+                var anomalyTimes = anomalyIndices.Select(i => sqlTimes[i]).ToArray();
+                var anomalyVals = anomalyIndices.Select(i => sqlValues[i]).ToArray();
+                var anomalyScatter = CpuChart.Plot.Add.Scatter(anomalyTimes, anomalyVals);
+                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.MarkerSize = 6;
+                anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
+                anomalyScatter.LineWidth = 0;
+            }
+        }
+
+        if (totalValues.Length > 0)
+        {
+            var totalScatter = CpuChart.Plot.Add.Scatter(totalTimes, totalValues);
+            totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+            totalScatter.MarkerSize = 0;
+            totalScatter.LineWidth = 1.5f;
+            totalScatter.LegendText = "Total";
+            totalScatter.ConnectStyle = ScottPlot.ConnectStyle.Straight;
+        }
+
+        if (sqlValues.Length > 0)
+        {
+            var sqlScatter = CpuChart.Plot.Add.Scatter(sqlTimes, sqlValues);
+            sqlScatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            sqlScatter.MarkerSize = 0;
+            sqlScatter.LineWidth = 1.5f;
+            sqlScatter.LegendText = "SQL";
+            sqlScatter.ConnectStyle = ScottPlot.ConnectStyle.Straight;
+        }
+
+        CpuChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        if (CpuChart != FileIoChart)
+            CpuChart.Plot.Axes.Bottom.TickLabelStyle.IsVisible = false;
+
+        ReapplyAxisColors(CpuChart);
+
+        CpuChart.Plot.Title("");
+        CpuChart.Plot.YLabel("");
+        CpuChart.Plot.Legend.IsVisible = false;
+        CpuChart.Plot.Axes.Margins(bottom: 0);
+        CpuChart.Plot.Axes.SetLimitsY(0, 105);
+
+        CpuChart.Refresh();
     }
 
     private void UpdateLane(ScottPlot.WPF.WpfPlot chart, string title,

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1325,7 +1325,7 @@ public partial class MainWindow : Window
                 await _emailAlertService.TrySendAlertEmailAsync(
                     "High CPU",
                     summary.DisplayName,
-                    $"{alertCpuValue:F0}%",
+                    $"{alertCpuValue:F0}% ({cpuMetricLabel})",
                     $"{App.AlertCpuThreshold}%",
                     summary.ServerId,
                     muted: isMuted,


### PR DESCRIPTION
## Summary
- Overview lanes' "CPU %" chart now plots two series: **SQL CPU** (blue) and **Total non-idle CPU** (orange) — so the chart shows what the alert evaluates (Total, by default) without losing the SQL-only line.
- Mirrored to Dashboard's matching `CorrelatedTimelineLanesControl` per the file's SYNC WARNING.
- Baseline band + anomaly markers stay on SQL CPU since that's what the existing baseline metric was computed against. Comparison ghost line follows Total.

## Background
Reported as erikdarlingdata/PerformanceStudio#349 — user got a "High CPU 95%" alert but his Overview chart never showed above ~60%. The alert evaluates `sqlserver_cpu_utilization + other_process_cpu_utilization` (per #902, default `CpuAlertMode = Total`), while the lane plotted SQL only.

PR #902 closed this gap for the Overview *cards* (which already show `"X% (SQL Y%)"`) but didn't update the lane chart. This finishes the Lite half and keeps Dashboard in sync. Dashboard's `CpuAlertMode` port + `ResourceOverviewCpuChart` update remain deferred follow-ups.

## Test plan
- [ ] Lite: Open Overview tab, hover the CPU lane — tooltip shows both `SQL CPU: N %` and `Total: M %`.
- [ ] Lite: On a server with non-zero `other_process_cpu`, confirm the orange line sits above the blue line; on a dedicated SQL box where Other ≈ 0, the lines coincide.
- [ ] Lite: Trigger an alert by setting CPU threshold low; confirm the alerted % matches the orange Total line at that timestamp.
- [ ] Lite: Comparison overlay still works — ghost line follows the Total series.
- [ ] Dashboard: Same checks on the Resource Metrics → Server Trends sub-tab CPU lane.
- [ ] Both: Baseline band and anomaly red dots still appear on the SQL line where applicable.

Closes #1004.
