### PR TITLE
Dashboard: port CpuAlertMode (Total/SqlOnly) from Lite (#1004)

### DIFF
--- a/Dashboard/Controls/DailySummaryContent.xaml.cs
+++ b/Dashboard/Controls/DailySummaryContent.xaml.cs
@@ -29,6 +29,7 @@ namespace PerformanceMonitorDashboard.Controls
     public partial class DailySummaryContent : UserControl
     {
         private DatabaseService? _databaseService;
+        private UserPreferencesService? _preferencesService;
         private DateTime? _dailySummaryDate = null; // null means today
 
         // Daily Summary filter state
@@ -52,10 +53,10 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>
         /// Initializes the control with required dependencies.
         /// </summary>
-        /// <param name="databaseService">The database service for data retrieval.</param>
-        public void Initialize(DatabaseService databaseService)
+        public void Initialize(DatabaseService databaseService, UserPreferencesService preferencesService)
         {
             _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+            _preferencesService = preferencesService ?? throw new ArgumentNullException(nameof(preferencesService));
         }
 
         /// <summary>
@@ -86,7 +87,8 @@ namespace PerformanceMonitorDashboard.Controls
                     DailySummaryNoDataMessage.Visibility = Visibility.Collapsed;
                 }
 
-                var data = await _databaseService.GetDailySummaryAsync(_dailySummaryDate);
+                var mode = _preferencesService?.GetPreferences().CpuAlertMode ?? CpuAlertMode.Total;
+                var data = await _databaseService.GetDailySummaryAsync(_dailySummaryDate, mode);
 
                 // Store unfiltered data and reset filters when new data is loaded
                 _dailySummaryUnfilteredData = data;

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -1539,14 +1539,19 @@ namespace PerformanceMonitorDashboard
                     "0", prefs.DeadlockThreshold.ToString(), true, "tray");
             }
 
-            /* High CPU alerts */
+            /* High CPU alerts — evaluator picks Total or SQL based on prefs.CpuAlertMode */
+            int? alertCpuValue = prefs.CpuAlertMode == CpuAlertMode.Total
+                ? health.TotalCpuPercent
+                : health.CpuPercent;
+            string cpuMetricLabel = prefs.CpuAlertMode == CpuAlertMode.Total ? "Total CPU" : "SQL CPU";
+
             bool cpuExceeded = prefs.NotifyOnHighCpu
-                && health.TotalCpuPercent.HasValue
-                && health.TotalCpuPercent.Value >= prefs.CpuThresholdPercent;
+                && alertCpuValue.HasValue
+                && alertCpuValue.Value >= prefs.CpuThresholdPercent;
 
             if (cpuExceeded)
             {
-                var totalCpu = health.TotalCpuPercent!.Value;
+                var cpuValue = alertCpuValue!.Value;
                 _activeHighCpuAlert[serverId] = true;
                 if (!_lastHighCpuAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= alertCooldown)
                 {
@@ -1558,7 +1563,7 @@ namespace PerformanceMonitorDashboard
                     {
                         _notificationService?.ShowSnoozableNotification(
                             "High CPU",
-                            $"{serverName}: CPU at {totalCpu}%",
+                            $"{serverName}: {cpuMetricLabel} at {cpuValue}% (threshold: {prefs.CpuThresholdPercent}%)",
                             NotificationType.Warning,
                             serverName,
                             "High CPU",
@@ -1566,16 +1571,16 @@ namespace PerformanceMonitorDashboard
                     }
 
                     _emailAlertService.RecordAlert(serverId, serverName, "High CPU",
-                        $"{totalCpu:F0}%",
+                        $"{cpuValue:F0}% ({cpuMetricLabel})",
                         $"{prefs.CpuThresholdPercent}%", !isMuted, isMuted ? "muted" : "tray", muted: isMuted,
-                        detailText: $"  CPU: {totalCpu:F0}%\n  Threshold: {prefs.CpuThresholdPercent}%");
+                        detailText: $"  {cpuMetricLabel}: {cpuValue:F0}%\n  Threshold: {prefs.CpuThresholdPercent}%");
 
                     if (!isMuted)
                     {
                         await _emailAlertService.TrySendAlertEmailAsync(
                             "High CPU",
                             serverName,
-                            $"{totalCpu:F0}%",
+                            $"{cpuValue:F0}% ({cpuMetricLabel})",
                             $"{prefs.CpuThresholdPercent}%",
                             serverId);
                     }
@@ -1583,9 +1588,9 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activeHighCpuAlert.TryRemove(serverId, out var wasCpu) && wasCpu)
             {
-                var cpuText = health.TotalCpuPercent.HasValue ? $"{health.TotalCpuPercent.Value:F0}%" : "N/A";
+                var cpuText = alertCpuValue.HasValue ? $"{alertCpuValue.Value:F0}%" : "N/A";
                 _notificationService?.ShowNotification("CPU Resolved",
-                    $"{serverName}: CPU back to {cpuText}");
+                    $"{serverName}: {cpuMetricLabel} back to {cpuText}");
                 _emailAlertService.RecordAlert(serverId, serverName, "CPU Resolved",
                     cpuText, $"{prefs.CpuThresholdPercent}%", true, "tray");
             }

--- a/Dashboard/Models/ServerHealthStatus.cs
+++ b/Dashboard/Models/ServerHealthStatus.cs
@@ -190,7 +190,15 @@ namespace PerformanceMonitorDashboard.Models
             }
         }
 
-        public string CpuDisplayText => TotalCpuPercent.HasValue ? $"{TotalCpuPercent}%" : "--";
+        public string CpuDisplayText
+        {
+            get
+            {
+                if (!_cpuPercent.HasValue) return "--";
+                if (!_otherCpuPercent.HasValue) return $"{_cpuPercent}%";
+                return $"{TotalCpuPercent}% (SQL {_cpuPercent}%)";
+            }
+        }
 
         public string CpuDetailText
         {

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -6,9 +6,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace PerformanceMonitorDashboard.Models
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum CpuAlertMode
+    {
+        /// <summary>sql_server_cpu + other_process_cpu — matches OS user+system, "is the box in trouble".</summary>
+        Total,
+        /// <summary>SQL Server scheduler ProcessUtilization only.</summary>
+        SqlOnly
+    }
+
     public class UserPreferences
     {
         // Time display mode: ServerTime, LocalTime, UTC
@@ -81,6 +91,7 @@ namespace PerformanceMonitorDashboard.Models
         public int DeadlockThreshold { get; set; } = 1; // Alert when deadlocks >= X since last check
         public bool NotifyOnHighCpu { get; set; } = true;
         public int CpuThresholdPercent { get; set; } = 90; // Alert when CPU > X%
+        public CpuAlertMode CpuAlertMode { get; set; } = CpuAlertMode.Total; // Total non-idle CPU (default) or SQL scheduler only
         public bool NotifyOnPoisonWaits { get; set; } = true;
         public int PoisonWaitThresholdMs { get; set; } = 500; // Alert when avg ms per wait > X
         public bool NotifyOnLongRunningQueries { get; set; } = true;

--- a/Dashboard/ServerTab.Charts.cs
+++ b/Dashboard/ServerTab.Charts.cs
@@ -469,19 +469,30 @@ namespace PerformanceMonitorDashboard
 
             var dataList = cpuData?.OrderBy(d => d.SampleTime).ToList() ?? new List<CpuDataPoint>();
 
-            // Build time series with boundary points for continuous lines
-            var (xs, ys) = TabHelpers.FillTimeSeriesGaps(
+            // Build time series with boundary points for continuous lines.
+            // Two series: SQL CPU (blue) + Total non-idle CPU (orange) — matches the alert metric (PM#1004).
+            var (xsTotal, ysTotal) = TabHelpers.FillTimeSeriesGaps(
+                dataList.Select(d => d.SampleTime),
+                dataList.Select(d => (double)d.TotalCpu));
+            var (xsSql, ysSql) = TabHelpers.FillTimeSeriesGaps(
                 dataList.Select(d => d.SampleTime),
                 dataList.Select(d => (double)d.SqlServerCpu));
 
-            if (xs.Length > 0)
+            if (xsTotal.Length > 0)
             {
-                var scatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[0];
-                scatter.LegendText = "SQL CPU %";
-                _resourceOverviewCpuHover?.Add(scatter, "SQL CPU %");
+                var totalScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsTotal, ysTotal);
+                totalScatter.LineWidth = 2;
+                totalScatter.MarkerSize = 5;
+                totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+                totalScatter.LegendText = "Total CPU %";
+                _resourceOverviewCpuHover?.Add(totalScatter, "Total CPU %");
+
+                var sqlScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsSql, ysSql);
+                sqlScatter.LineWidth = 2;
+                sqlScatter.MarkerSize = 5;
+                sqlScatter.Color = TabHelpers.ChartColors[0];
+                sqlScatter.LegendText = "SQL CPU %";
+                _resourceOverviewCpuHover?.Add(sqlScatter, "SQL CPU %");
 
                 _legendPanels[ResourceOverviewCpuChart] = ResourceOverviewCpuChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
                 ResourceOverviewCpuChart.Plot.Legend.FontSize = 12;

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -94,7 +94,7 @@ namespace PerformanceMonitorDashboard
             Focusable = true;
 
             // Initialize Overview sub-tab UserControls
-            DailySummaryTab.Initialize(_databaseService);
+            DailySummaryTab.Initialize(_databaseService, _preferencesService);
             CriticalIssuesTab.Initialize(_databaseService);
             CriticalIssuesTab.InvestigateRequested += OnInvestigateCriticalIssue;
             DefaultTraceTab.Initialize(_databaseService);

--- a/Dashboard/Services/DatabaseService.Overview.cs
+++ b/Dashboard/Services/DatabaseService.Overview.cs
@@ -22,19 +22,24 @@ namespace PerformanceMonitorDashboard.Services
         // Overview Tab Data Access
         // ============================================
 
-                public async Task<List<DailySummaryItem>> GetDailySummaryAsync(DateTime? summaryDate = null)
+                public async Task<List<DailySummaryItem>> GetDailySummaryAsync(DateTime? summaryDate = null, CpuAlertMode cpuAlertMode = CpuAlertMode.Total)
                 {
                     var items = new List<DailySummaryItem>();
-        
+
                     await using var tc = await OpenThrottledConnectionAsync();
                     var connection = tc.Connection;
-        
+
+                    // CPU column for the High CPU events count + critical-health check. Matches the alert's metric (PM#1004).
+                    // Note: this only applies on the date-parameterized path. The view at report.daily_summary (hit when
+                    // summaryDate is null) still uses sqlserver_cpu_utilization — see follow-up bug for that.
+                    string cpuColumn = cpuAlertMode == CpuAlertMode.SqlOnly ? "sqlserver_cpu_utilization" : "total_cpu_utilization";
+
                     // If no date provided, use the view directly (today's summary)
                     // Otherwise, replicate the view logic with the specified date
                     string query;
                     if (summaryDate.HasValue)
                     {
-                        query = @"
+                        query = $@"
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
         DECLARE
@@ -106,7 +111,7 @@ namespace PerformanceMonitorDashboard.Services
                 SELECT
                     COUNT_BIG(*)
                 FROM collect.cpu_utilization_stats AS cus
-                WHERE cus.sqlserver_cpu_utilization >= 80
+                WHERE cus.{cpuColumn} >= 80
                 AND   cus.collection_time >= @day_start
                 AND   cus.collection_time < @day_end
             ),
@@ -133,7 +138,7 @@ namespace PerformanceMonitorDashboard.Services
                         SELECT
                             1/0
                         FROM collect.cpu_utilization_stats AS cus
-                        WHERE cus.sqlserver_cpu_utilization >= 90
+                        WHERE cus.{cpuColumn} >= 90
                         AND   cus.collection_time >= @day_start
                         AND   cus.collection_time < @day_end
                     )

--- a/Dashboard/Services/DatabaseService.Overview.cs
+++ b/Dashboard/Services/DatabaseService.Overview.cs
@@ -29,9 +29,9 @@ namespace PerformanceMonitorDashboard.Services
                     await using var tc = await OpenThrottledConnectionAsync();
                     var connection = tc.Connection;
 
-                    // CPU column for the High CPU events count + critical-health check. Matches the alert's metric (PM#1004).
-                    // Note: this only applies on the date-parameterized path. The view at report.daily_summary (hit when
-                    // summaryDate is null) still uses sqlserver_cpu_utilization — see follow-up bug for that.
+                    // CPU column for the High CPU events count + critical-health check (PM#1004).
+                    // The view at report.daily_summary always uses total_cpu_utilization (no per-user prefs available there).
+                    // This date-parameterized path additionally honors the user's CpuAlertMode.
                     string cpuColumn = cpuAlertMode == CpuAlertMode.SqlOnly ? "sqlserver_cpu_utilization" : "total_cpu_utilization";
 
                     // If no date provided, use the view directly (today's summary)

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -193,6 +193,13 @@
                                          VerticalAlignment="Center"
                                          TextAlignment="Center"/>
                                 <TextBlock Text="%" VerticalAlignment="Center"/>
+                                <TextBlock Text="measured as" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                                <ComboBox x:Name="CpuAlertModeBox"
+                                          Width="240"
+                                          VerticalAlignment="Center">
+                                    <ComboBoxItem Content="Total non-idle CPU (SQL + other processes)" Tag="Total"/>
+                                    <ComboBoxItem Content="SQL Server only (scheduler %)" Tag="SqlOnly"/>
+                                </ComboBox>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <CheckBox x:Name="NotifyOnPoisonWaitsCheckBox"

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using System.Windows.Navigation;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard
@@ -170,6 +171,7 @@ namespace PerformanceMonitorDashboard
             DeadlockThresholdTextBox.Text = prefs.DeadlockThreshold.ToString(CultureInfo.InvariantCulture);
             NotifyOnHighCpuCheckBox.IsChecked = prefs.NotifyOnHighCpu;
             CpuThresholdTextBox.Text = prefs.CpuThresholdPercent.ToString(CultureInfo.InvariantCulture);
+            CpuAlertModeBox.SelectedIndex = prefs.CpuAlertMode == CpuAlertMode.SqlOnly ? 1 : 0;
             NotifyOnPoisonWaitsCheckBox.IsChecked = prefs.NotifyOnPoisonWaits;
             PoisonWaitThresholdTextBox.Text = prefs.PoisonWaitThresholdMs.ToString(CultureInfo.InvariantCulture);
             NotifyOnLongRunningQueriesCheckBox.IsChecked = prefs.NotifyOnLongRunningQueries;
@@ -408,6 +410,7 @@ namespace PerformanceMonitorDashboard
             DeadlockThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnDeadlockCheckBox.IsChecked == true;
             NotifyOnHighCpuCheckBox.IsEnabled = notificationsEnabled;
             CpuThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnHighCpuCheckBox.IsChecked == true;
+            CpuAlertModeBox.IsEnabled = notificationsEnabled && NotifyOnHighCpuCheckBox.IsChecked == true;
             NotifyOnPoisonWaitsCheckBox.IsEnabled = notificationsEnabled;
             PoisonWaitThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnPoisonWaitsCheckBox.IsChecked == true;
             NotifyOnLongRunningQueriesCheckBox.IsEnabled = notificationsEnabled;
@@ -648,6 +651,7 @@ namespace PerformanceMonitorDashboard
                 prefs.CpuThresholdPercent = cpuThreshold;
             else if (prefs.NotifyOnHighCpu)
                 validationErrors.Add("CPU threshold must be between 1 and 100");
+            prefs.CpuAlertMode = CpuAlertModeBox.SelectedIndex == 1 ? CpuAlertMode.SqlOnly : CpuAlertMode.Total;
 
             prefs.NotifyOnPoisonWaits = NotifyOnPoisonWaitsCheckBox.IsChecked == true;
             if (int.TryParse(PoisonWaitThresholdTextBox.Text, out int poisonWaitThreshold) && poisonWaitThreshold > 0)

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -350,7 +350,7 @@ SELECT
         SELECT
             COUNT_BIG(*)
         FROM collect.cpu_utilization_stats AS cus
-        WHERE cus.sqlserver_cpu_utilization >= 80
+        WHERE cus.total_cpu_utilization >= 80
         AND   cus.collection_time >= DATEADD(DAY, 0, CONVERT(date, SYSDATETIME()))
     ),
     collectors_failing =
@@ -383,7 +383,7 @@ SELECT
                 SELECT
                     1/0
                 FROM collect.cpu_utilization_stats AS cus
-                WHERE cus.sqlserver_cpu_utilization >= 90
+                WHERE cus.total_cpu_utilization >= 90
                 AND   cus.collection_time >= DATEADD(HOUR, -1, SYSDATETIME())
             )
             THEN N'CPU_CRITICAL'


### PR DESCRIPTION
## Summary
Ports `CpuAlertMode` from Lite (PR #902) into Dashboard so the desktop dashboard's alert evaluator, overview card, chart, and email/tray text all agree on what "CPU" means. Default mode is **Total non-idle CPU**; users can flip to **SQL Server only** in Settings → Alerts.

## What's in here
- **`UserPreferences.cs`** — new `CpuAlertMode` enum + property (default `Total`). `[JsonStringEnumConverter]` keeps `preferences.json` readable.
- **`SettingsWindow`** — "measured as" dropdown next to the CPU threshold (two options: total non-idle, SQL only).
- **`ServerHealthStatus.CpuDisplayText`** — now renders `"Total% (SQL X%)"` when both values are known, matching Lite's overview card format.
- **`MainWindow.CheckPerformanceAlerts` (High CPU branch)** — picks Total or SQL based on prefs; the tray notification text, the `RecordAlert` row, the email's `currentValue`, and the `detailText` all carry the `Total CPU` / `SQL CPU` qualifier (mirrors the Lite email-qualifier fix in PR #1005).
- **`ResourceOverviewCpuChart`** — plots two series (SQL blue + Total orange), matching the Server Trends lanes change in PR #1005.
- **`DatabaseService.GetDailySummaryAsync`** — date-parameterized path takes a `CpuAlertMode` arg and swaps the column in the `high_cpu_events` count + `CPU_CRITICAL` health check. `DailySummaryContent` reads the mode from prefs at refresh time.

## What's deferred (intentional)
The `report.daily_summary` **view** (install/47_create_reporting_views.sql:297) still hardcodes `sqlserver_cpu_utilization`. It's hit when the daily-summary date picker is on "today" (the default landing case) and from MCP. Moving the view to `total_cpu_utilization` requires an upgrade migration, so it's a separate bug. For non-today date selections, the inline query honors the user's mode.

## Test plan
- [ ] Settings → Alerts: confirm the dropdown loads with the saved value and the "Total" / "SQL Only" choice round-trips through `preferences.json`.
- [ ] Trigger a High CPU alert in each mode; confirm:
  - Tray bubble reads `Total CPU at N%` (or `SQL CPU at N%`).
  - Email "Current Value" reads `N% (Total CPU)` / `N% (SQL CPU)`.
  - The metric used to evaluate the threshold matches the dropdown.
- [ ] Overview → Resource Overview: confirm CPU chart shows two lines (blue + orange) with the legend reading `SQL CPU %` / `Total CPU %`.
- [ ] Daily Summary: pick a non-today date — confirm `high_cpu_events` count differs between Total and SqlOnly modes on a server with non-trivial `other_process_cpu`.
- [ ] Overview cards: confirm CPU cell reads `94% (SQL 60%)` when both values are present.

Related to #1004. Companion to PR #1005 (lanes + Lite email qualifier).
