### PR TITLE
Normalize Dashboard/Lite time labels to 24-hour (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dashboard time labels are now consistently 24-hour** ([#1012]) — the time-range header at the top of each tab (e.g. *"Original: May 28, 11:30 PM – May 29, 1:30 AM (PST)"*) and the Query Performance heatmap x-axis tick labels used `h:mm tt`, while every other timestamp in the app (footer "Last refresh", DataGrid columns, slicer, tooltips, logs) already used 24-hour `HH:mm`/`HH:mm:ss`. The AM/PM marker was also being truncated in the column shown by the reporter. Normalized the four outliers to `HH:mm` to match the rest of the app. The Lite heatmap had the same `h:mm tt` straggler — fixed alongside
 - **Lite UI no longer freezes during archival** ([#979]) — archival held DuckDB's exclusive write lock across the entire export-to-Parquet step, blocking every UI query (tab switches showed the spinning wheel, worse with more monitored servers). Export-to-Parquet only reads the database, so it now runs under a shared read lock concurrently with the UI; only the brief `DELETE` takes the exclusive write lock
 - **Lite FinOps no longer recommends an edition downgrade on an Availability Group secondary** ([#980]) — the licensing recommendations suggested "downgrade to Standard to save $X/mo" for any Enterprise instance, with no AG awareness. On a secondary replica that advice is misleading — every replica in an AG must run the same edition. FinOps now detects the AG replica role and, on a secondary, shows an informational note instead of the downgrade/savings estimate
 - **Lite alert emails no longer re-fire after an app restart** ([#981]) — the per-metric email cooldown lived only in memory, so restarting Lite cleared it and an alert sent minutes earlier could be sent again immediately. The cooldown is now seeded from `config_alert_log` (the most recent successful send for that server/metric) the first time each alert is evaluated, so it survives restarts
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#979]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/979
 [#980]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/980
 [#981]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/981
+[#1012]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1012
 
 ## [2.11.0] - 2026-05-19
 

--- a/Dashboard/Controls/QueryPerformanceContent.Heatmap.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.Heatmap.cs
@@ -78,7 +78,7 @@ namespace PerformanceMonitorDashboard.Controls
             for (int i = 0; i < numCols; i += xStep)
             {
                 var t = result.TimeBuckets[i];
-                xTicks.AddMajor(i, t.ToString("M/d\nh:mm tt"));
+                xTicks.AddMajor(i, t.ToString("M/d\nHH:mm"));
             }
             QueryHeatmapChart.Plot.Axes.Bottom.TickGenerator = xTicks;
 

--- a/Dashboard/ServerTab.TimeRange.cs
+++ b/Dashboard/ServerTab.TimeRange.cs
@@ -291,20 +291,20 @@ namespace PerformanceMonitorDashboard
             var displayFrom = Helpers.ServerTimeHelper.ConvertForDisplay(from, Helpers.ServerTimeHelper.CurrentDisplayMode);
             var displayTo = Helpers.ServerTimeHelper.ConvertForDisplay(to, Helpers.ServerTimeHelper.CurrentDisplayMode);
 
-            // Same day: "Feb 7, 2:15 PM – 3:15 PM (PST)"
+            // Same day: "Feb 7, 14:15 – 15:15 (PST)"
             if (displayFrom.Date == displayTo.Date)
             {
-                return $"{prefix}: {displayFrom:MMM d, h:mm tt} – {displayTo:h:mm tt} ({tz})";
+                return $"{prefix}: {displayFrom:MMM d, HH:mm} – {displayTo:HH:mm} ({tz})";
             }
 
-            // Same year, different days: "Feb 6, 3:15 PM – Feb 7, 3:15 PM (PST)"
+            // Same year, different days: "Feb 6, 15:15 – Feb 7, 15:15 (PST)"
             if (displayFrom.Year == displayTo.Year)
             {
-                return $"{prefix}: {displayFrom:MMM d, h:mm tt} – {displayTo:MMM d, h:mm tt} ({tz})";
+                return $"{prefix}: {displayFrom:MMM d, HH:mm} – {displayTo:MMM d, HH:mm} ({tz})";
             }
 
-            // Different years: "Dec 31, 2025, 11:00 PM – Jan 1, 2026, 11:00 PM (PST)"
-            return $"{prefix}: {displayFrom:MMM d, yyyy, h:mm tt} – {displayTo:MMM d, yyyy, h:mm tt} ({tz})";
+            // Different years: "Dec 31, 2025, 23:00 – Jan 1, 2026, 23:00 (PST)"
+            return $"{prefix}: {displayFrom:MMM d, yyyy, HH:mm} – {displayTo:MMM d, yyyy, HH:mm} ({tz})";
         }
 
         private void StoreOriginalRangeIfNeeded()

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -1093,7 +1093,7 @@ public partial class ServerTab : UserControl
         for (int i = 0; i < numCols; i += xStep)
         {
             var t = result.TimeBuckets[i].AddMinutes(UtcOffsetMinutes);
-            xTicks.AddMajor(i, t.ToString("M/d\nh:mm tt"));
+            xTicks.AddMajor(i, t.ToString("M/d\nHH:mm"));
         }
         QueryHeatmapChart.Plot.Axes.Bottom.TickGenerator = xTicks;
         QueryHeatmapChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = QueryHeatmapChart.Plot.Axes.Left.TickLabelStyle.ForeColor;


### PR DESCRIPTION
## Summary

Closes #1012.

The time-range header at the top of every Dashboard tab and the Query Performance heatmap x-axis used 12-hour `h:mm tt`, while everything else in the app (footers, DataGrid columns, slicer, tooltips, logs) already used 24-hour `HH:mm`. The AM/PM marker was also getting truncated in the column the reporter showed, leaving timestamps ambiguous. Lite's heatmap had the same straggler.

## Changes

- `Dashboard/ServerTab.TimeRange.cs` — 3 format strings (`h:mm tt` → `HH:mm`) for the same-day / same-year / cross-year branches of the time-range header
- `Dashboard/Controls/QueryPerformanceContent.Heatmap.cs` — heatmap x-axis tick label (`M/d\nh:mm tt` → `M/d\nHH:mm`)
- `Lite/Controls/ServerTab.Charts.cs` — same heatmap fix on the Lite side
- `CHANGELOG.md` — Unreleased/Fixed entry

## Test plan

- [x] `dotnet build` succeeds with no warnings or errors
- [ ] Open Dashboard, confirm time-range header at top of a tab reads e.g. `Original: May 28, 23:30 – 01:30 (PST)` instead of `11:30 PM – 1:30 AM`
- [ ] Open Query Performance heatmap, confirm x-axis tick labels are `HH:mm` without `AM`/`PM`
- [ ] Repeat the heatmap check on Lite