### PR TITLE
Extend ToolRecommendations registry for missing fact-keys

### DIFF
--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -398,11 +398,12 @@ internal static class ToolRecommendations
         ["CXPACKET"] = [new("get_top_queries_by_cpu", "Find parallel queries", new() { ["parallel_only"] = "true" }), new("audit_config", "Check CTFP and MAXDOP")],
         ["THREADPOOL"] = [new("get_top_queries_by_cpu", "Find resource-consuming queries"), new("get_blocking", "Check if blocking is holding threads")],
         ["PAGEIOLATCH_SH"] = [new("get_file_io_stats", "Check I/O latency"), new("get_memory_stats", "Check buffer pool")],
-        ["PAGEIOLATCH_EX"] = [new("get_file_io_stats", "Check I/O latency"), new("get_memory_stats", "Check buffer pool")],
+        ["PAGEIOLATCH_EX"] = [new("get_file_io_stats", "Check I/O latency"), new("get_memory_stats", "Check buffer pool"), new("get_tempdb_trend", "Check whether tempdb I/O is driving EX-mode waits")],
         ["RESOURCE_SEMAPHORE"] = [new("get_resource_semaphore", "Check memory grants")],
-        ["WRITELOG"] = [new("get_file_io_stats", "Check log file latency")],
+        ["WRITELOG"] = [new("get_file_io_stats", "Check log file latency"), new("get_perfmon_trend", "Check Transactions/sec commit rate driving log flush pressure", new() { ["counter_name"] = "Transactions/sec" })],
         ["LCK"] = [new("get_blocking", "Get blocking details"), new("get_deadlocks", "Check for deadlocks")],
         ["LCK_M_S"] = [new("get_blocking", "Get reader/writer blocking details")],
+        ["SCH_M"] = [new("get_blocking", "Check if DDL is causing blocking"), new("get_running_jobs", "See if maintenance jobs are taking schema-modification locks")],
         ["BLOCKING_EVENTS"] = [new("get_blocking", "Get detailed blocking reports"), new("get_deadlocks", "Check for deadlocks")],
         ["DEADLOCKS"] = [new("get_deadlocks", "Get deadlock events"), new("get_deadlock_detail", "Get full deadlock XML")],
         ["CPU_SQL_PERCENT"] = [new("get_cpu_utilization", "See CPU trend"), new("get_top_queries_by_cpu", "Find CPU queries")],
@@ -413,6 +414,8 @@ internal static class ToolRecommendations
         ["MEMORY_GRANT_PENDING"] = [new("get_resource_semaphore", "Check memory grants")],
         ["QUERY_SPILLS"] = [new("get_top_queries_by_cpu", "Find queries with spills")],
         ["QUERY_HIGH_DOP"] = [new("get_top_queries_by_cpu", "Find high-DOP queries", new() { ["parallel_only"] = "true" })],
+        ["PARAMETER_SENSITIVITY"] = [new("get_top_queries_by_cpu", "Find the sensitive query and see its cached parameters"), new("analyze_query_plan", "Examine the plan for operators driving the runtime variance"), new("get_query_trend", "Confirm the bimodal duration pattern over time"), new("get_resource_semaphore", "Check whether bad-parameter executions blow up memory grants")],
+        ["PLAN_REGRESSION"] = [new("analyze_query_store_plan", "Compare the regressed plan against the prior plan"), new("get_query_trend", "Confirm the regression timing and that the new plan is consistently worse"), new("get_query_store_top", "Pull the full Query Store entry and forced-plan history before forcing")],
         ["PERFMON_PLE"] = [new("get_memory_stats", "Check buffer pool"), new("get_memory_clerks", "See memory allocation")],
         ["DB_CONFIG"] = [new("audit_config", "Check configuration")],
         ["DISK_SPACE"] = [new("get_file_io_stats", "Check per-file sizes")],
@@ -421,7 +424,11 @@ internal static class ToolRecommendations
         ["ANOMALY_CPU"] = [new("get_cpu_utilization", "See CPU trend"), new("get_active_queries", "Find what ran during spike")],
         ["ANOMALY_WAIT"] = [new("get_wait_stats", "See wait breakdown"), new("compare_analysis", "Compare current vs baseline")],
         ["ANOMALY_BLOCKING"] = [new("get_blocking", "Get blocking details"), new("get_deadlocks", "Get deadlock events")],
-        ["ANOMALY_IO"] = [new("get_file_io_stats", "Check I/O latency"), new("get_memory_stats", "Check buffer pool")]
+        ["ANOMALY_IO"] = [new("get_file_io_stats", "Check I/O latency"), new("get_memory_stats", "Check buffer pool")],
+        ["ANOMALY_SESSION_SPIKE"] = [new("get_session_stats", "See which application is driving the session-count spike"), new("get_active_queries", "Find what those sessions were doing at the spike")],
+        ["ANOMALY_QUERY_DURATION"] = [new("get_top_queries_by_cpu", "Find the queries whose runtime moved the average"), new("analyze_query_plan", "Examine the plan for the queries that slowed down"), new("get_query_trend", "Track the regressed query across executions")],
+        ["ANOMALY_MEMORY_PRESSURE"] = [new("get_memory_stats", "See current memory allocation"), new("get_memory_clerks", "Find which clerks are growing"), new("get_memory_pressure_events", "Pull the RING_BUFFER_RESOURCE_MONITOR notifications driving the anomaly"), new("get_resource_semaphore", "Check whether query grants are competing with buffer pool")],
+        ["ANOMALY_BATCH_REQUESTS"] = [new("get_perfmon_trend", "Confirm the batch-rate change across the window", new() { ["counter_name"] = "Batch Requests/sec" }), new("get_top_queries_by_cpu", "Find which queries account for the new batch volume"), new("get_active_queries", "See what's actually running at the elevated rate")]
     };
 
     public static System.Collections.Generic.List<object> GetForStoryPath(string storyPath)

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -625,7 +625,8 @@ internal static class ToolRecommendations
         [
             new("get_file_io_stats", "Check I/O latency per database file"),
             new("get_file_io_trend", "Track I/O latency trend"),
-            new("get_memory_stats", "Check buffer pool and memory pressure")
+            new("get_memory_stats", "Check buffer pool and memory pressure"),
+            new("get_tempdb_trend", "Check whether tempdb I/O is driving the EX-mode waits")
         ],
         ["RESOURCE_SEMAPHORE"] =
         [
@@ -636,7 +637,8 @@ internal static class ToolRecommendations
         ["WRITELOG"] =
         [
             new("get_file_io_stats", "Check transaction log file latency"),
-            new("get_file_io_trend", "Track log I/O latency over time")
+            new("get_file_io_trend", "Track log I/O latency over time"),
+            new("get_perfmon_trend", "Check Transactions/sec to see commit rate driving log flush pressure", new() { ["counter_name"] = "Transactions/sec" })
         ],
         ["LCK"] =
         [
@@ -669,7 +671,8 @@ internal static class ToolRecommendations
         ["SCH_M"] =
         [
             new("get_waiting_tasks", "See what's waiting on schema locks"),
-            new("get_blocked_process_reports", "Check if DDL operations are causing blocking")
+            new("get_blocked_process_reports", "Check if DDL operations are causing blocking"),
+            new("get_running_jobs", "See whether maintenance jobs (index rebuilds, stats updates) are taking schema-modification locks")
         ],
         ["CPU_SQL_PERCENT"] =
         [
@@ -715,6 +718,19 @@ internal static class ToolRecommendations
         [
             new("get_top_queries_by_cpu", "Find high-DOP queries", new() { ["parallel_only"] = "true" }),
             new("audit_config", "Check CTFP and MAXDOP settings")
+        ],
+        ["PARAMETER_SENSITIVITY"] =
+        [
+            new("get_top_queries_by_cpu", "Find the sensitive query in the plan cache and see its current cached parameters"),
+            new("analyze_query_plan", "Examine the plan for the operators driving the runtime variance (seek vs scan, grant size, join type)"),
+            new("get_query_trend", "Confirm the bimodal duration pattern across executions over time"),
+            new("get_memory_grants", "Check whether the bad-parameter executions are also blowing up memory grants")
+        ],
+        ["PLAN_REGRESSION"] =
+        [
+            new("analyze_query_store_plan", "Compare the regressed plan against the prior plan to see what the optimizer changed"),
+            new("get_query_trend", "Confirm the regression timing and that the new plan is consistently worse"),
+            new("get_query_store_top", "Pull the full Query Store entry including plan_id and forced-plan history before considering a force")
         ],
         ["PERFMON_PLE"] =
         [
@@ -766,6 +782,31 @@ internal static class ToolRecommendations
             new("get_file_io_stats", "Check per-file I/O latency"),
             new("get_file_io_trend", "Track I/O latency over time"),
             new("get_memory_stats", "Check if buffer pool is undersized")
+        ],
+        ["ANOMALY_SESSION_SPIKE"] =
+        [
+            new("get_session_stats", "See which application is driving the session-count spike"),
+            new("get_active_queries", "Find what those sessions were doing at the spike"),
+            new("get_waiting_tasks", "Check whether the new sessions are piling up on a shared wait")
+        ],
+        ["ANOMALY_QUERY_DURATION"] =
+        [
+            new("get_query_duration_trend", "Confirm the duration shift across the analysis window"),
+            new("get_top_queries_by_cpu", "Find the queries whose runtime moved the average"),
+            new("analyze_query_plan", "Examine the plan for the queries that slowed down")
+        ],
+        ["ANOMALY_MEMORY_PRESSURE"] =
+        [
+            new("get_memory_stats", "See current memory allocation and target vs total"),
+            new("get_memory_clerks", "Find which clerks are growing"),
+            new("get_memory_pressure_events", "Pull the RING_BUFFER_RESOURCE_MONITOR notifications driving the anomaly"),
+            new("get_memory_grants", "Check whether query grants are competing with buffer pool")
+        ],
+        ["ANOMALY_BATCH_REQUESTS"] =
+        [
+            new("get_perfmon_trend", "Confirm the batch-rate change across the window", new() { ["counter_name"] = "Batch Requests/sec" }),
+            new("get_top_queries_by_cpu", "Find which queries account for the new batch volume"),
+            new("get_active_queries", "See what's actually running at the elevated rate")
         ],
         ["BAD_ACTOR"] =
         [


### PR DESCRIPTION
## Summary

The advice-rewrite in PR #1011 names specific MCP tools in the
Investigation prose for each fact-key. Several fact-keys had no
`ByFactKey` entry at all, so the `next_tools` array returned to MCP
clients was empty for those findings. This PR adds entries for the
gaps and augments a few existing entries with tools the advice prose
was already naming.

Registry-only change — no edits to `FactAdvice.cs`, the `AdviceBlock`
shape, the `GetForFactKey` lookup, or the prefix-fallback handling.

## Added mappings

**Lite** (`Lite/Mcp/McpAnalysisTools.cs`):
- `PAGEIOLATCH_EX`: add `get_tempdb_trend`
- `WRITELOG`: add `get_perfmon_trend` (Transactions/sec)
- `SCH_M`: add `get_running_jobs`
- `PARAMETER_SENSITIVITY`: new entry — `get_top_queries_by_cpu`,
  `analyze_query_plan`, `get_query_trend`, `get_memory_grants`
- `PLAN_REGRESSION`: new entry — `analyze_query_store_plan`,
  `get_query_trend`, `get_query_store_top`
- `ANOMALY_SESSION_SPIKE`: new entry — `get_session_stats`,
  `get_active_queries`, `get_waiting_tasks`
- `ANOMALY_QUERY_DURATION`: new entry — `get_query_duration_trend`,
  `get_top_queries_by_cpu`, `analyze_query_plan`
- `ANOMALY_MEMORY_PRESSURE`: new entry — `get_memory_stats`,
  `get_memory_clerks`, `get_memory_pressure_events`, `get_memory_grants`
- `ANOMALY_BATCH_REQUESTS`: new entry — `get_perfmon_trend`,
  `get_top_queries_by_cpu`, `get_active_queries`

**Dashboard** (`Dashboard/Mcp/McpAnalysisTools.cs`):
- `PAGEIOLATCH_EX`: add `get_tempdb_trend`
- `WRITELOG`: add `get_perfmon_trend` (Transactions/sec)
- `SCH_M`: new entry — `get_blocking`, `get_running_jobs` (was absent
  in Dashboard's registry)
- `PARAMETER_SENSITIVITY`: new entry — uses `get_resource_semaphore`
  where Lite uses `get_memory_grants` (per-app naming)
- `PLAN_REGRESSION`: new entry
- `ANOMALY_SESSION_SPIKE` / `ANOMALY_QUERY_DURATION` /
  `ANOMALY_MEMORY_PRESSURE` / `ANOMALY_BATCH_REQUESTS`: new entries.
  Dashboard substitutes equivalents where a Lite-only tool doesn't
  exist (no `get_waiting_tasks` or `get_query_duration_trend` in
  Dashboard).

## Verified but NOT added

- `get_resource_semaphore` on Lite: tool only exists on Dashboard.
  Lite's `RESOURCE_SEMAPHORE` and grant-related entries already use
  `get_memory_grants`, which is the Lite-side equivalent. No change
  needed.
- `get_resource_semaphore` on Dashboard `RESOURCE_SEMAPHORE`: already
  present in the existing entry. No change needed.

## Lite/Dashboard scoping notes

The two apps maintain separate registries (each `McpAnalysisTools.cs`
has its own `ByFactKey`). The Lite registry uses fuller one-sentence
`Reason` strings; the Dashboard registry uses terser ones. I matched
each app's existing voice rather than unifying them — that's a
separate refactor.

Tool name verification: for every candidate, I grepped
`[McpServerTool(Name = ...)]` in each app's `Mcp/` directory before
adding the mapping. Tools that don't exist in an app were not added
to that app's registry.

## Test plan

- [x] `dotnet build -c Debug` clean on the full solution.
- [x] `dotnet test Lite.Tests/Lite.Tests.csproj` — 292/292 passed.
- [x] `dotnet test Dashboard.Tests/Dashboard.Tests.csproj` — 28/28 passed.
- [x] Spot-checked new entries in both files for indentation, field
      order, and trailing-comma consistency with neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)