### PR TITLE
Render advice + remediation T-SQL in alert notifications across Lite and Dashboard (triage v1 PR (b))

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Services;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Dashboard's first notification-formatter tests. Mirrors the Lite suite's
+/// FindingMessageFormatter.BuildContext ordering/omission cases plus the
+/// AlertContext serialization round-trip (triage v1 PR (b)). Dashboard threads
+/// the notify threshold as a method parameter, so BuildContext takes (finding, threshold).
+/// </summary>
+public class AnalysisNotificationTests
+{
+    private static AnalysisFinding MakeFinding(
+        string hash,
+        double severity = 1.8,
+        string category = "cpu_pressure",
+        int serverId = 1,
+        double? rootValue = 92.5,
+        Dictionary<string, double>? metadata = null,
+        Dictionary<string, object>? drillDown = null,
+        string rootFactKey = "CPU_SPIKE")
+    {
+        return new AnalysisFinding
+        {
+            ServerId = serverId,
+            ServerName = "TestServer",
+            Category = category,
+            StoryPath = "CPU_SPIKE → PLAN_REGRESSION",
+            StoryPathHash = hash,
+            Severity = severity,
+            Confidence = 0.67,
+            FactCount = 2,
+            RootFactKey = rootFactKey,
+            RootFactValue = rootValue,
+            TimeRangeStart = DateTime.UtcNow.AddHours(-4),
+            TimeRangeEnd = DateTime.UtcNow,
+            RootFactMetadata = metadata,
+            DrillDown = drillDown
+        };
+    }
+
+    private static Dictionary<string, object> RegressedQueriesDrillDown() => new()
+    {
+        ["regressed_queries"] = new List<object>
+        {
+            new
+            {
+                database = "AdventureWorks",
+                query_id = 4242L,
+                best_plan_id = 17L,
+                latest_plan_hash = "0xDEAD",
+                best_plan_hash = "0xBEEF",
+                latest_cpu_per_exec_us = 9000.0,
+                best_cpu_per_exec_us = 1200.0,
+                regression_factor = 7.5
+            }
+        }
+    };
+
+    [Fact]
+    public void BuildContext_RenderingOrder_DiagnosisAdviceTsqlDrillDown()
+    {
+        var finding = MakeFinding("planreg000000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        // [0] Diagnosis, [1] Advice prose, [2] Remediation T-SQL, [3] regressed_queries drill-down.
+        Assert.Equal(4, context.Details.Count);
+        Assert.Equal("Diagnosis", context.Details[0].Heading);
+
+        Assert.NotNull(context.Details[1].Body);
+        Assert.False(context.Details[1].IsCodeBlock);
+        Assert.Contains("Investigation:", context.Details[1].Body);
+        Assert.Contains("Remediation:", context.Details[1].Body);
+
+        Assert.Equal("Remediation T-SQL", context.Details[2].Heading);
+        Assert.True(context.Details[2].IsCodeBlock);
+        Assert.NotNull(context.Details[2].Body);
+        Assert.Contains("sp_query_store_force_plan", context.Details[2].Body);
+
+        Assert.Equal("Regressed Queries", context.Details[3].Heading);
+    }
+
+    [Fact]
+    public void BuildContext_UnknownFactKey_OmitsAdviceAndTsql()
+    {
+        var finding = MakeFinding("unknown000000001", rootFactKey: "ZZZ_TEST");
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        // Diagnosis only — no advice block for an unknown fact key, and no T-SQL.
+        var only = Assert.Single(context.Details);
+        Assert.Equal("Diagnosis", only.Heading);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Remediation T-SQL");
+    }
+
+    [Fact]
+    public void BuildContext_NonPlanRegression_OmitsTsqlOnly()
+    {
+        // CPU_SPIKE has advice but is not PLAN_REGRESSION, so advice renders but no T-SQL.
+        var context = FindingMessageFormatter.BuildContext(MakeFinding("cpuonly000000001"), notifyThreshold: 1.5);
+
+        Assert.Contains(context.Details, d => d.Body is not null && !d.IsCodeBlock);
+        Assert.DoesNotContain(context.Details, d => d.IsCodeBlock);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Remediation T-SQL");
+    }
+
+    [Fact]
+    public void AlertContext_SerializesAndDeserializes_PreservingFieldsBodyAndCodeBlock()
+    {
+        // MINOR-3: round-trip the real BuildContext output for a PLAN_REGRESSION finding (generated
+        // T-SQL with newlines/brackets/semicolons/-- comments + drill-down Fields), not a hand-built
+        // context, through the production AlertContextSerializer / DTO.
+        var finding = MakeFinding("roundtrip0000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        Assert.Equal(context.Details.Count, restored.Details.Count);
+        for (int i = 0; i < context.Details.Count; i++)
+        {
+            var expected = context.Details[i];
+            var actual = restored.Details[i];
+
+            Assert.Equal(expected.Heading, actual.Heading);
+            Assert.Equal(expected.Body, actual.Body);
+            Assert.Equal(expected.IsCodeBlock, actual.IsCodeBlock);
+            Assert.Equal(expected.Fields.Count, actual.Fields.Count);
+            for (int j = 0; j < expected.Fields.Count; j++)
+            {
+                Assert.Equal(expected.Fields[j].Label, actual.Fields[j].Label);
+                Assert.Equal(expected.Fields[j].Value, actual.Fields[j].Value);
+            }
+        }
+
+        // The T-SQL code block in particular must survive intact.
+        var tsql = restored.Details.Single(d => d.IsCodeBlock);
+        Assert.Contains("sp_query_store_force_plan", tsql.Body);
+    }
+}

--- a/Dashboard/AlertDetailWindow.xaml
+++ b/Dashboard/AlertDetailWindow.xaml
@@ -7,6 +7,9 @@
         ResizeMode="NoResize"
         Icon="/EDD.ico"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Window.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -88,7 +91,68 @@
             <StackPanel>
                 <TextBlock Text="Details" FontWeight="SemiBold" FontSize="13"
                            Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>
+
+                <!-- Structured detail items (advice prose, remediation T-SQL, drill-down).
+                     Shown when the persisted ContextJson deserializes. -->
+                <ScrollViewer x:Name="DetailItemsScroll" Visibility="Collapsed"
+                              MaxHeight="380" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="DetailItems">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,10">
+                                    <TextBlock Text="{Binding Heading}" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+
+                                    <!-- Remediation T-SQL: monospace, read-only, with Copy. -->
+                                    <StackPanel Visibility="{Binding IsCodeBlock, Converter={StaticResource BoolToVis}}">
+                                        <Button Content="Copy" HorizontalAlignment="Right"
+                                                Padding="8,2" Margin="0,0,0,4"
+                                                Click="CopyTsqlButton_Click"/>
+                                        <TextBox Text="{Binding Body, Mode=OneWay}" IsReadOnly="True"
+                                                 FontFamily="Consolas" FontSize="12" TextWrapping="NoWrap"
+                                                 MaxHeight="240"
+                                                 VerticalScrollBarVisibility="Auto"
+                                                 HorizontalScrollBarVisibility="Auto"
+                                                 Background="Transparent"
+                                                 Foreground="{DynamicResource ForegroundBrush}"
+                                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
+                                    </StackPanel>
+
+                                    <!-- Advice prose. -->
+                                    <TextBlock Text="{Binding Body}" TextWrapping="Wrap"
+                                               Visibility="{Binding IsProse, Converter={StaticResource BoolToVis}}"
+                                               Foreground="{DynamicResource ForegroundBrush}"/>
+
+                                    <!-- Label/value field rows. -->
+                                    <ItemsControl ItemsSource="{Binding Fields}"
+                                                  Visibility="{Binding HasFields, Converter={StaticResource BoolToVis}}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid Margin="0,1">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="130"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
+                                                               TextWrapping="Wrap"/>
+                                                    <TextBlock Grid.Column="1" Text="{Binding Value}"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
+                                                               FontFamily="Consolas" FontSize="12"
+                                                               TextWrapping="Wrap"/>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <!-- Legacy / no-context fallback: flat persisted detail text. -->
                 <TextBox x:Name="DetailTextBox" IsReadOnly="True" TextWrapping="Wrap"
+                         Visibility="Collapsed"
                          Background="Transparent" BorderThickness="0"
                          Foreground="{DynamicResource ForegroundBrush}" FontFamily="Consolas"
                          FontSize="12" MaxHeight="300"

--- a/Dashboard/AlertDetailWindow.xaml.cs
+++ b/Dashboard/AlertDetailWindow.xaml.cs
@@ -4,8 +4,10 @@
  * Licensed under the MIT License - see LICENSE file for details
  */
 
+using System.Collections.Generic;
 using System.Windows;
 using PerformanceMonitorDashboard.Controls;
+using PerformanceMonitorDashboard.Services;
 
 namespace PerformanceMonitorDashboard
 {
@@ -26,11 +28,77 @@ namespace PerformanceMonitorDashboard
             if (item.Muted)
                 MutedBanner.Visibility = Visibility.Visible;
 
-            if (!string.IsNullOrWhiteSpace(item.DetailText))
+            /* Prefer the structured context (advice / remediation T-SQL / drill-down) persisted as
+               ContextJson; fall back to the flat detail text for older rows that have no context. */
+            if (TryBuildDetailViews(item.ContextJson, out var views))
             {
-                DetailTextBox.Text = item.DetailText;
+                DetailItems.ItemsSource = views;
+                DetailItemsScroll.Visibility = Visibility.Visible;
                 DetailPanel.Visibility = Visibility.Visible;
             }
+            else if (!string.IsNullOrWhiteSpace(item.DetailText))
+            {
+                DetailTextBox.Text = item.DetailText;
+                DetailTextBox.Visibility = Visibility.Visible;
+                DetailPanel.Visibility = Visibility.Visible;
+            }
+        }
+
+        /* WPF cannot data-bind to AlertDetailItem.Fields (a List<(string,string)> ValueTuple — its
+           Item1/Item2 are fields, not properties), so the deserialized context is projected into
+           bindable view-models the DataTemplate can render. */
+        private static bool TryBuildDetailViews(string? contextJson, out List<DetailItemView> views)
+        {
+            views = new List<DetailItemView>();
+            if (!AlertContextSerializer.TryDeserialize(contextJson, out var context))
+                return false;
+
+            foreach (var detail in context.Details)
+            {
+                var view = new DetailItemView
+                {
+                    Heading = detail.Heading,
+                    Body = detail.Body,
+                    IsCodeBlock = detail.IsCodeBlock
+                };
+                foreach (var (label, value) in detail.Fields)
+                    view.Fields.Add(new FieldView { Label = label, Value = value });
+                views.Add(view);
+            }
+
+            return views.Count > 0;
+        }
+
+        private void CopyTsqlButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { DataContext: DetailItemView view } && !string.IsNullOrEmpty(view.Body))
+            {
+                try
+                {
+                    Clipboard.SetText(view.Body);
+                }
+                catch
+                {
+                    /* Clipboard can be locked by another process — swallow contention. */
+                }
+            }
+        }
+
+        public sealed class DetailItemView
+        {
+            public string Heading { get; set; } = "";
+            public string? Body { get; set; }
+            public bool IsCodeBlock { get; set; }
+            public List<FieldView> Fields { get; } = new();
+
+            public bool IsProse => !IsCodeBlock && !string.IsNullOrEmpty(Body);
+            public bool HasFields => Fields.Count > 0;
+        }
+
+        public sealed class FieldView
+        {
+            public string Label { get; set; } = "";
+            public string Value { get; set; } = "";
         }
     }
 }

--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -81,7 +81,8 @@ namespace PerformanceMonitorDashboard.Controls
                 IsWarning = !e.MetricName.Contains("Cleared") && !e.MetricName.Contains("Resolved")
                             && !e.MetricName.Contains("Deadlock") && !e.MetricName.Contains("Poison"),
                 Muted = e.Muted,
-                DetailText = e.DetailText
+                DetailText = e.DetailText,
+                ContextJson = e.ContextJson
             }).ToList();
 
             _lastRefreshed = DateTime.UtcNow;
@@ -568,5 +569,6 @@ namespace PerformanceMonitorDashboard.Controls
         public bool IsWarning { get; set; }
         public bool Muted { get; set; }
         public string? DetailText { get; set; }
+        public string? ContextJson { get; set; }
     }
 }

--- a/Dashboard/Services/AlertContext.cs
+++ b/Dashboard/Services/AlertContext.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace PerformanceMonitorDashboard.Services
 {
@@ -26,5 +27,87 @@ namespace PerformanceMonitorDashboard.Services
     {
         public string Heading { get; set; } = "";
         public List<(string Label, string Value)> Fields { get; set; } = new();
+
+        /// <summary>
+        /// Multi-paragraph prose for this item (advice Investigation / Remediation).
+        /// When non-null, renderers emit this as flowing paragraph text rather than
+        /// label/value rows.
+        /// </summary>
+        public string? Body { get; set; }
+
+        /// <summary>
+        /// Marks this item as a copy-paste code block. Renderers emit a monospace
+        /// &lt;pre&gt; (HTML) / fenced (plain text) / Consolas TextBox with a copy
+        /// button (dialog). Webhooks render only the heading + a "see email or in-app
+        /// dialog for the copy-paste T-SQL" hint when this flag is true.
+        /// </summary>
+        public bool IsCodeBlock { get; set; }
+    }
+
+    /// <summary>
+    /// Serialization DTO for persisting <see cref="AlertContext"/> as JSON.
+    /// <see cref="AlertDetailItem.Fields"/> is a <c>List&lt;(string,string)&gt;</c>
+    /// ValueTuple, which System.Text.Json will not round-trip (tuple elements are
+    /// fields, not properties); these DTOs name every member explicitly so the
+    /// persisted context survives the round-trip into the in-app dialog.
+    /// <see cref="AlertContext.AttachmentXml"/>/<see cref="AlertContext.AttachmentFileName"/>
+    /// are deliberately not persisted (the dialog has no attachment surface).
+    /// </summary>
+    public record AlertContextDto(List<AlertDetailItemDto> Details);
+    public record AlertDetailItemDto(string Heading, List<FieldDto> Fields, string? Body, bool IsCodeBlock);
+    public record FieldDto(string Label, string Value);
+
+    /// <summary>
+    /// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
+    /// persisted alongside the flat detail text. Centralizes the DTO mapping so the persistence
+    /// write (EmailAlertService) and the dialog read (AlertDetailWindow) cannot drift.
+    /// </summary>
+    public static class AlertContextSerializer
+    {
+        public static string Serialize(AlertContext context)
+        {
+            var dto = new AlertContextDto(
+                context.Details.ConvertAll(d => new AlertDetailItemDto(
+                    d.Heading,
+                    d.Fields.ConvertAll(f => new FieldDto(f.Label, f.Value)),
+                    d.Body,
+                    d.IsCodeBlock)));
+            return JsonSerializer.Serialize(dto);
+        }
+
+        public static bool TryDeserialize(string? json, out AlertContext context)
+        {
+            context = new AlertContext();
+            if (string.IsNullOrWhiteSpace(json))
+                return false;
+
+            try
+            {
+                var dto = JsonSerializer.Deserialize<AlertContextDto>(json);
+                if (dto?.Details is null)
+                    return false;
+
+                foreach (var d in dto.Details)
+                {
+                    var item = new AlertDetailItem
+                    {
+                        Heading = d.Heading,
+                        Body = d.Body,
+                        IsCodeBlock = d.IsCodeBlock
+                    };
+                    if (d.Fields is not null)
+                    {
+                        foreach (var f in d.Fields)
+                            item.Fields.Add((f.Label, f.Value));
+                    }
+                    context.Details.Add(item);
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/Dashboard/Services/AnalysisNotificationService.cs
+++ b/Dashboard/Services/AnalysisNotificationService.cs
@@ -171,7 +171,8 @@ namespace PerformanceMonitorDashboard.Services
                             alertSent: false,
                             notificationType: "tray",
                             muted: false,
-                            detailText: FindingMessageFormatter.PlainTextDiagnosis(finding, threshold));
+                            detailText: FindingMessageFormatter.PlainTextDiagnosis(finding, threshold),
+                            contextJson: AlertContextSerializer.Serialize(context));
                     }
 
                     _cooldowns[key] = now;
@@ -282,6 +283,30 @@ namespace PerformanceMonitorDashboard.Services
             if (finding.TimeRangeStart.HasValue && finding.TimeRangeEnd.HasValue)
                 diagnosis.Fields.Add(("Window", $"{finding.TimeRangeStart.Value:u} → {finding.TimeRangeEnd.Value:u}"));
             context.Details.Add(diagnosis);
+
+            /* Advice (Investigation/Remediation prose) + generated remediation T-SQL, when the
+               shared analysis library has a block for this finding's root fact-key. Inserted
+               after Diagnosis and before the drill-down so every surface renders the same order:
+               Diagnosis → Advice → Remediation T-SQL → drill-down. */
+            var advice = FactAdvice.GetForFinding(finding);
+            if (advice is not null)
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = advice.Headline,
+                    Body = $"Investigation: {advice.Investigation}\n\nRemediation: {advice.Remediation}"
+                });
+
+                if (!string.IsNullOrEmpty(advice.RemediationTsql))
+                {
+                    context.Details.Add(new AlertDetailItem
+                    {
+                        Heading = "Remediation T-SQL",
+                        Body = advice.RemediationTsql,
+                        IsCodeBlock = true
+                    });
+                }
+            }
 
             /* Drill-down values are anonymous types behind object (a bare object, or a
                List<object> of them). Round-trip through System.Text.Json and walk as

--- a/Dashboard/Services/EmailAlertService.cs
+++ b/Dashboard/Services/EmailAlertService.cs
@@ -144,7 +144,8 @@ namespace PerformanceMonitorDashboard.Services
                             }
                         }
 
-                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, "email", sendError);
+                        var emailContextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
+                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, sent, "email", sendError, contextJson: emailContextJson);
                     }
                 }
 
@@ -156,7 +157,8 @@ namespace PerformanceMonitorDashboard.Services
                         metricName, serverName, currentValue, thresholdValue, serverId, context);
                     if (webhookSent)
                     {
-                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, true, "webhook");
+                        var webhookContextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
+                        RecordAlert(serverId, serverName, metricName, currentValue, thresholdValue, true, "webhook", contextJson: webhookContextJson);
                     }
                 }
             }
@@ -171,7 +173,8 @@ namespace PerformanceMonitorDashboard.Services
         /// </summary>
         public void RecordAlert(string serverId, string serverName, string metricName,
             string currentValue, string thresholdValue, bool alertSent,
-            string notificationType, string? sendError = null, bool muted = false, string? detailText = null)
+            string notificationType, string? sendError = null, bool muted = false, string? detailText = null,
+            string? contextJson = null)
         {
             var entry = new AlertLogEntry
             {
@@ -185,7 +188,8 @@ namespace PerformanceMonitorDashboard.Services
                 NotificationType = notificationType,
                 SendError = sendError,
                 Muted = muted,
-                DetailText = detailText
+                DetailText = detailText,
+                ContextJson = contextJson
             };
 
             lock (_alertLogLock)
@@ -502,5 +506,6 @@ namespace PerformanceMonitorDashboard.Services
         public bool Hidden { get; set; }
         public bool Muted { get; set; }
         public string? DetailText { get; set; }
+        public string? ContextJson { get; set; }
     }
 }

--- a/Dashboard/Services/EmailTemplateBuilder.cs
+++ b/Dashboard/Services/EmailTemplateBuilder.cs
@@ -210,28 +210,50 @@ namespace PerformanceMonitorDashboard.Services
                 sb.Append($"<span style=\"font-family:{FontStack};font-size:14px;font-weight:600;color:#E0E0E0;\">{WebUtility.HtmlEncode(item.Heading)}</span>");
                 sb.Append("</td></tr>");
 
-                /* Detail item fields */
-                sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
-                sb.Append($"<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\" style=\"background-color:#333333;border-radius:4px;\">");
-
-                for (int i = 0; i < item.Fields.Count; i++)
+                if (item.IsCodeBlock && !string.IsNullOrEmpty(item.Body))
                 {
-                    var (label, value) = item.Fields[i];
-                    bool isLast = i == item.Fields.Count - 1;
-                    bool isQuery = label.Contains("Query") || label.Contains("SQL");
-
-                    if (isQuery && !string.IsNullOrEmpty(value))
-                    {
-                        AppendQueryRow(sb, label, value, isLast);
-                    }
-                    else
-                    {
-                        AppendDataRow(sb, label, value, isLast);
-                    }
+                    /* Copy-paste code block (remediation T-SQL) — monospace, matches AppendQueryRow style. */
+                    sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                    sb.Append("<div style=\"background-color:#333333;border-radius:4px;padding:10px 16px;\">");
+                    sb.Append($"<pre style=\"margin:0;font-family:'Courier New',Consolas,monospace;font-size:12px;color:#E0E0E0;white-space:pre-wrap;word-break:break-all;\">{WebUtility.HtmlEncode(item.Body)}</pre>");
+                    sb.Append("</div>");
+                    sb.Append("</td></tr>");
                 }
+                else if (!string.IsNullOrEmpty(item.Body))
+                {
+                    /* Prose paragraphs (advice Investigation / Remediation), one <p> per blank-line chunk. */
+                    sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                    foreach (var para in item.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        sb.Append($"<p style=\"margin:0 0 8px 0;font-family:{FontStack};font-size:13px;color:#E0E0E0;line-height:1.5;\">{WebUtility.HtmlEncode(para)}</p>");
+                    }
+                    sb.Append("</td></tr>");
+                }
+                else
+                {
+                    /* Detail item fields */
+                    sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                    sb.Append($"<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\" style=\"background-color:#333333;border-radius:4px;\">");
 
-                sb.Append("</table>");
-                sb.Append("</td></tr>");
+                    for (int i = 0; i < item.Fields.Count; i++)
+                    {
+                        var (label, value) = item.Fields[i];
+                        bool isLast = i == item.Fields.Count - 1;
+                        bool isQuery = label.Contains("Query") || label.Contains("SQL");
+
+                        if (isQuery && !string.IsNullOrEmpty(value))
+                        {
+                            AppendQueryRow(sb, label, value, isLast);
+                        }
+                        else
+                        {
+                            AppendDataRow(sb, label, value, isLast);
+                        }
+                    }
+
+                    sb.Append("</table>");
+                    sb.Append("</td></tr>");
+                }
             }
         }
 
@@ -270,9 +292,31 @@ namespace PerformanceMonitorDashboard.Services
                 foreach (var item in context.Details)
                 {
                     sb.Append($"\r\n  {item.Heading}\r\n");
-                    foreach (var (label, value) in item.Fields)
+
+                    if (item.IsCodeBlock && !string.IsNullOrEmpty(item.Body))
                     {
-                        sb.Append($"  {label}: {value}\r\n");
+                        /* Fenced block for the copy-paste remediation T-SQL. */
+                        sb.Append("  ```\r\n");
+                        foreach (var line in item.Body.Replace("\r\n", "\n").Split('\n'))
+                        {
+                            sb.Append($"  {line}\r\n");
+                        }
+                        sb.Append("  ```\r\n");
+                    }
+                    else if (!string.IsNullOrEmpty(item.Body))
+                    {
+                        /* Prose paragraphs (advice), one indented chunk per blank-line break. */
+                        foreach (var para in item.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            sb.Append($"  {para}\r\n");
+                        }
+                    }
+                    else
+                    {
+                        foreach (var (label, value) in item.Fields)
+                        {
+                            sb.Append($"  {label}: {value}\r\n");
+                        }
                     }
                 }
             }

--- a/Dashboard/Services/WebhookAlertService.cs
+++ b/Dashboard/Services/WebhookAlertService.cs
@@ -26,6 +26,11 @@ namespace PerformanceMonitorDashboard.Services
         private const string EditionName = "Performance Monitor Dashboard";
         private const string TeamsWebhookCredentialKey = "TeamsWebhook";
         private const string SlackWebhookCredentialKey = "SlackWebhook";
+
+        /* Webhooks do not deliver the copy-paste T-SQL (too large, wrong channel) — they point
+           at the email / in-app dialog instead. This string must stay byte-identical to the
+           Lite copy (plan §5.4). */
+        private const string TsqlWebhookHint = "See email or in-app Alert Details for the copy-paste T-SQL.";
         private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
         private static readonly CredentialService s_credentialService = new();
 
@@ -266,6 +271,25 @@ namespace PerformanceMonitorDashboard.Services
             {
                 foreach (var detail in context.Details)
                 {
+                    if (detail.IsCodeBlock)
+                    {
+                        /* Remediation T-SQL: point at the email / in-app dialog, never inline it. */
+                        facts.Add(new { name = detail.Heading, value = TsqlWebhookHint });
+                        continue;
+                    }
+
+                    if (!string.IsNullOrEmpty(detail.Body))
+                    {
+                        /* Advice prose: one "Advice" fact for the headline, then a fact per
+                           Investigation/Remediation paragraph (split on the blank line). */
+                        facts.Add(new { name = "Advice", value = detail.Heading });
+                        foreach (var para in detail.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            var (label, text) = SplitProseLabel(para);
+                            facts.Add(new { name = label, value = text });
+                        }
+                    }
+
                     foreach (var (label, value) in detail.Fields)
                     {
                         facts.Add(new { name = label, value });
@@ -402,6 +426,21 @@ namespace PerformanceMonitorDashboard.Services
                 {
                     blocks.Add(new { type = "divider" });
 
+                    if (detail.IsCodeBlock)
+                    {
+                        /* Remediation T-SQL: point at the email / in-app dialog, never inline it. */
+                        blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*{detail.Heading}*\n{TsqlWebhookHint}" } });
+                        continue;
+                    }
+
+                    if (!string.IsNullOrEmpty(detail.Body))
+                    {
+                        /* Advice prose flows as a single mrkdwn section; the synthesized Body is
+                           "Investigation: ...\n\nRemediation: ..." which Slack renders verbatim. */
+                        blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*{detail.Heading}*\n{detail.Body}" } });
+                        continue;
+                    }
+
                     var detailFields = new List<object>();
                     detailFields.Add(new { type = "mrkdwn", text = $"*{detail.Heading}*" });
 
@@ -451,6 +490,24 @@ namespace PerformanceMonitorDashboard.Services
             "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
             _ => ("#2eaef1", "INFO", "\U0001F535")
         };
+
+        /// <summary>
+        /// Splits a synthesized advice paragraph ("Investigation: ..." / "Remediation: ...") into a
+        /// (label, value) pair on the first ": ". Falls back to ("Detail", paragraph) when there is no
+        /// leading label. Depends on advice prose containing no interior blank-line break so each
+        /// Body chunk is a single labelled paragraph (audited safe for the current FactAdvice blocks);
+        /// a future block with a paragraph break degrades to the "Detail" fallback rather than breaking.
+        /// Must stay byte-identical to the Lite copy (plan §5.4).
+        /// </summary>
+        private static (string Label, string Value) SplitProseLabel(string paragraph)
+        {
+            var idx = paragraph.IndexOf(": ", StringComparison.Ordinal);
+            if (idx > 0)
+            {
+                return (paragraph.Substring(0, idx), paragraph.Substring(idx + 2));
+            }
+            return ("Detail", paragraph);
+        }
 
         /// <summary>
         /// Posts a JSON payload to a webhook URL. Returns null on success, error message on failure.

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -45,7 +45,8 @@ public class AnalysisNotificationTests : IDisposable
         int serverId = 1,
         double? rootValue = 92.5,
         Dictionary<string, double>? metadata = null,
-        Dictionary<string, object>? drillDown = null)
+        Dictionary<string, object>? drillDown = null,
+        string rootFactKey = "CPU_SPIKE")
     {
         return new AnalysisFinding
         {
@@ -57,7 +58,7 @@ public class AnalysisNotificationTests : IDisposable
             Severity = severity,
             Confidence = 0.67,
             FactCount = 2,
-            RootFactKey = "CPU_SPIKE",
+            RootFactKey = rootFactKey,
             RootFactValue = rootValue,
             TimeRangeStart = DateTime.UtcNow.AddHours(-4),
             TimeRangeEnd = DateTime.UtcNow,
@@ -121,9 +122,11 @@ public class AnalysisNotificationTests : IDisposable
 
         var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
 
-        // Details[0] is now the Diagnosis card; the two drill-downs follow.
-        Assert.Equal(3, context.Details.Count);
+        // Details[0] = Diagnosis, [1] = Advice (CPU_SPIKE has an advice block), then the two drill-downs.
+        Assert.Equal(4, context.Details.Count);
         Assert.Equal("Diagnosis", context.Details[0].Heading);
+        Assert.NotNull(context.Details[1].Body);
+        Assert.False(context.Details[1].IsCodeBlock);
 
         var queries = context.Details.Single(d => d.Heading == "Top Cpu Queries");
         Assert.Contains(queries.Fields, f => f.Label.StartsWith("#1") && f.Value == "0x1");
@@ -145,8 +148,8 @@ public class AnalysisNotificationTests : IDisposable
 
         var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
 
-        // Diagnosis at [0], drill-down "Items" at [1]. 3 items kept x 1 property each = 3 fields; #4 and #5 dropped.
-        Assert.Equal(2, context.Details.Count);
+        // Diagnosis at [0], Advice at [1], drill-down "Items" at [2]. 3 items kept x 1 property each = 3 fields; #4 and #5 dropped.
+        Assert.Equal(3, context.Details.Count);
         var item = context.Details.Single(d => d.Heading == "Items");
         Assert.Equal(3, item.Fields.Count);
         Assert.DoesNotContain(item.Fields, f => f.Label.StartsWith("#4"));
@@ -156,9 +159,10 @@ public class AnalysisNotificationTests : IDisposable
     public void BuildContext_NoDrillDown_StillEmitsDiagnosis()
     {
         var context = FindingMessageFormatter.BuildContext(MakeFinding("h"), notifyThreshold: 1.5);
-        // After the §7.0 precursor, BuildContext always emits a Diagnosis card even with no DrillDown.
-        var only = Assert.Single(context.Details);
-        Assert.Equal("Diagnosis", only.Heading);
+        // Diagnosis card + the CPU_SPIKE advice block, even with no DrillDown.
+        Assert.Equal(2, context.Details.Count);
+        Assert.Equal("Diagnosis", context.Details[0].Heading);
+        Assert.NotNull(context.Details[1].Body);
     }
 
     [Fact]
@@ -179,6 +183,110 @@ public class AnalysisNotificationTests : IDisposable
         Assert.Contains("CPU_SPIKE → PLAN_REGRESSION", text);
         Assert.Contains("Severity", text);
         Assert.Contains("Confidence", text);
+    }
+
+    /* ── Advice + remediation T-SQL rendering (triage v1 PR (b)) ── */
+
+    private static Dictionary<string, object> RegressedQueriesDrillDown() => new()
+    {
+        ["regressed_queries"] = new List<object>
+        {
+            new
+            {
+                database = "AdventureWorks",
+                query_id = 4242L,
+                best_plan_id = 17L,
+                latest_plan_hash = "0xDEAD",
+                best_plan_hash = "0xBEEF",
+                latest_cpu_per_exec_us = 9000.0,
+                best_cpu_per_exec_us = 1200.0,
+                regression_factor = 7.5
+            }
+        }
+    };
+
+    [Fact]
+    public void BuildContext_RenderingOrder_DiagnosisAdviceTsqlDrillDown()
+    {
+        var finding = MakeFinding("planreg000000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        // [0] Diagnosis, [1] Advice prose, [2] Remediation T-SQL, [3] regressed_queries drill-down.
+        Assert.Equal(4, context.Details.Count);
+        Assert.Equal("Diagnosis", context.Details[0].Heading);
+
+        Assert.NotNull(context.Details[1].Body);
+        Assert.False(context.Details[1].IsCodeBlock);
+        Assert.Contains("Investigation:", context.Details[1].Body);
+        Assert.Contains("Remediation:", context.Details[1].Body);
+
+        Assert.Equal("Remediation T-SQL", context.Details[2].Heading);
+        Assert.True(context.Details[2].IsCodeBlock);
+        Assert.NotNull(context.Details[2].Body);
+        Assert.Contains("sp_query_store_force_plan", context.Details[2].Body);
+
+        Assert.Equal("Regressed Queries", context.Details[3].Heading);
+    }
+
+    [Fact]
+    public void BuildContext_UnknownFactKey_OmitsAdviceAndTsql()
+    {
+        var finding = MakeFinding("unknown000000001", rootFactKey: "ZZZ_TEST");
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        // Diagnosis only — no advice block for an unknown fact key, and no T-SQL.
+        var only = Assert.Single(context.Details);
+        Assert.Equal("Diagnosis", only.Heading);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Remediation T-SQL");
+    }
+
+    [Fact]
+    public void BuildContext_NonPlanRegression_OmitsTsqlOnly()
+    {
+        // CPU_SPIKE has advice but is not PLAN_REGRESSION, so advice renders but no T-SQL.
+        var context = FindingMessageFormatter.BuildContext(MakeFinding("cpuonly000000001"), notifyThreshold: 1.5);
+
+        Assert.Contains(context.Details, d => d.Body is not null && !d.IsCodeBlock);
+        Assert.DoesNotContain(context.Details, d => d.IsCodeBlock);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Remediation T-SQL");
+    }
+
+    [Fact]
+    public void AlertContext_SerializesAndDeserializes_PreservingFieldsBodyAndCodeBlock()
+    {
+        // MINOR-3: round-trip the real BuildContext output for a PLAN_REGRESSION finding (generated
+        // T-SQL with newlines/brackets/semicolons/-- comments + drill-down Fields), not a hand-built
+        // context, through the production AlertContextSerializer / DTO.
+        var finding = MakeFinding("roundtrip0000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        Assert.Equal(context.Details.Count, restored.Details.Count);
+        for (int i = 0; i < context.Details.Count; i++)
+        {
+            var expected = context.Details[i];
+            var actual = restored.Details[i];
+
+            Assert.Equal(expected.Heading, actual.Heading);
+            Assert.Equal(expected.Body, actual.Body);
+            Assert.Equal(expected.IsCodeBlock, actual.IsCodeBlock);
+            Assert.Equal(expected.Fields.Count, actual.Fields.Count);
+            for (int j = 0; j < expected.Fields.Count; j++)
+            {
+                Assert.Equal(expected.Fields[j].Label, actual.Fields[j].Label);
+                Assert.Equal(expected.Fields[j].Value, actual.Fields[j].Value);
+            }
+        }
+
+        // The T-SQL code block in particular must survive intact.
+        var tsql = restored.Details.Single(d => d.IsCodeBlock);
+        Assert.Contains("sp_query_store_force_plan", tsql.Body);
     }
 
     /* ── AnalysisNotificationService: severity filter + cooldown ── */

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 25;
+    internal const int CurrentSchemaVersion = 26;
 
     private readonly string _archivePath;
 
@@ -702,6 +702,19 @@ public class DuckDbInitializer
             /* v25: Added memory_pressure_events table for RING_BUFFER_RESOURCE_MONITOR notifications.
                     New table only — created by GetAllTableStatements(). */
             _logger?.LogInformation("Running migration to v25: adding memory_pressure_events table");
+        }
+
+        if (fromVersion < 26)
+        {
+            _logger?.LogInformation("Running migration to v26: adding context_json column to alert log");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE config_alert_log ADD COLUMN IF NOT EXISTS context_json VARCHAR");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v26 encountered an error (non-fatal): {Error}", ex.Message);
+            }
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -697,7 +697,8 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
     send_error VARCHAR,
     dismissed BOOLEAN NOT NULL DEFAULT false,
     muted BOOLEAN NOT NULL DEFAULT false,
-    detail_text VARCHAR
+    detail_text VARCHAR,
+    context_json VARCHAR
 )";
 
     public const string CreateMuteRulesTable = @"

--- a/Lite/Services/AlertContext.cs
+++ b/Lite/Services/AlertContext.cs
@@ -7,6 +7,7 @@
  */
 
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -28,4 +29,86 @@ public class AlertDetailItem
 {
     public string Heading { get; set; } = "";
     public List<(string Label, string Value)> Fields { get; set; } = new();
+
+    /// <summary>
+    /// Multi-paragraph prose for this item (advice Investigation / Remediation).
+    /// When non-null, renderers emit this as flowing paragraph text rather than
+    /// label/value rows.
+    /// </summary>
+    public string? Body { get; set; }
+
+    /// <summary>
+    /// Marks this item as a copy-paste code block. Renderers emit a monospace
+    /// &lt;pre&gt; (HTML) / fenced (plain text) / Consolas TextBox with a copy
+    /// button (dialog). Webhooks render only the heading + a "see email or in-app
+    /// dialog for the copy-paste T-SQL" hint when this flag is true.
+    /// </summary>
+    public bool IsCodeBlock { get; set; }
+}
+
+/// <summary>
+/// Serialization DTO for persisting <see cref="AlertContext"/> as JSON.
+/// <see cref="AlertDetailItem.Fields"/> is a <c>List&lt;(string,string)&gt;</c>
+/// ValueTuple, which System.Text.Json will not round-trip (tuple elements are
+/// fields, not properties); these DTOs name every member explicitly so the
+/// persisted context survives the round-trip into the in-app dialog.
+/// <see cref="AlertContext.AttachmentXml"/>/<see cref="AlertContext.AttachmentFileName"/>
+/// are deliberately not persisted (the dialog has no attachment surface).
+/// </summary>
+public record AlertContextDto(List<AlertDetailItemDto> Details);
+public record AlertDetailItemDto(string Heading, List<FieldDto> Fields, string? Body, bool IsCodeBlock);
+public record FieldDto(string Label, string Value);
+
+/// <summary>
+/// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
+/// persisted alongside the flat detail_text. Centralizes the DTO mapping so the persistence
+/// write (EmailAlertService) and the dialog read (AlertDetailWindow) cannot drift.
+/// </summary>
+public static class AlertContextSerializer
+{
+    public static string Serialize(AlertContext context)
+    {
+        var dto = new AlertContextDto(
+            context.Details.ConvertAll(d => new AlertDetailItemDto(
+                d.Heading,
+                d.Fields.ConvertAll(f => new FieldDto(f.Label, f.Value)),
+                d.Body,
+                d.IsCodeBlock)));
+        return JsonSerializer.Serialize(dto);
+    }
+
+    public static bool TryDeserialize(string? json, out AlertContext context)
+    {
+        context = new AlertContext();
+        if (string.IsNullOrWhiteSpace(json))
+            return false;
+
+        try
+        {
+            var dto = JsonSerializer.Deserialize<AlertContextDto>(json);
+            if (dto?.Details is null)
+                return false;
+
+            foreach (var d in dto.Details)
+            {
+                var item = new AlertDetailItem
+                {
+                    Heading = d.Heading,
+                    Body = d.Body,
+                    IsCodeBlock = d.IsCodeBlock
+                };
+                if (d.Fields is not null)
+                {
+                    foreach (var f in d.Fields)
+                        item.Fields.Add((f.Label, f.Value));
+                }
+                context.Details.Add(item);
+            }
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/Lite/Services/AnalysisNotificationService.cs
+++ b/Lite/Services/AnalysisNotificationService.cs
@@ -218,6 +218,30 @@ internal static class FindingMessageFormatter
             diagnosis.Fields.Add(("Window", $"{finding.TimeRangeStart.Value:u} → {finding.TimeRangeEnd.Value:u}"));
         context.Details.Add(diagnosis);
 
+        /* Advice (Investigation/Remediation prose) + generated remediation T-SQL, when the
+           shared analysis library has a block for this finding's root fact-key. Inserted
+           after Diagnosis and before the drill-down so every surface renders the same order:
+           Diagnosis → Advice → Remediation T-SQL → drill-down. */
+        var advice = FactAdvice.GetForFinding(finding);
+        if (advice is not null)
+        {
+            context.Details.Add(new AlertDetailItem
+            {
+                Heading = advice.Headline,
+                Body = $"Investigation: {advice.Investigation}\n\nRemediation: {advice.Remediation}"
+            });
+
+            if (!string.IsNullOrEmpty(advice.RemediationTsql))
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = "Remediation T-SQL",
+                    Body = advice.RemediationTsql,
+                    IsCodeBlock = true
+                });
+            }
+        }
+
         /* Drill-down values are anonymous types behind object (a bare object, or a
            List<object> of them). Round-trip through System.Text.Json and walk as
            JsonElement — robust to any shape DrillDownCollector emits. */

--- a/Lite/Services/EmailAlertService.cs
+++ b/Lite/Services/EmailAlertService.cs
@@ -145,8 +145,12 @@ public class EmailAlertService
                 ?? (double.TryParse(currentValue.TrimEnd('%'), out var cv) ? cv : 0);
             var logThreshold = numericThresholdValue
                 ?? (double.TryParse(thresholdValue.TrimEnd('%'), out var tv) ? tv : 0);
+            /* Persist the structured context as JSON alongside the flat detail_text so the
+               in-app dialog can render the same advice / T-SQL / drill-down shape that
+               email and webhooks already show (and survive purge of the source findings). */
+            string? contextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
             await LogAlertAsync(serverId, serverName, metricName,
-                logCurrent, logThreshold, sent, notificationType, sendError, muted, detailText);
+                logCurrent, logThreshold, sent, notificationType, sendError, muted, detailText, contextJson);
         }
         catch (Exception ex)
         {
@@ -334,7 +338,7 @@ AND   send_error IS NULL";
     /// Reuses the injected DuckDbInitializer instead of creating a new one each time.
     /// </summary>
     private async Task LogAlertAsync(int serverId, string serverName, string metricName,
-        double currentValue, double thresholdValue, bool alertSent, string notificationType, string? sendError, bool muted = false, string? detailText = null)
+        double currentValue, double thresholdValue, bool alertSent, string notificationType, string? sendError, bool muted = false, string? detailText = null, string? contextJson = null)
     {
         try
         {
@@ -353,8 +357,8 @@ AND   send_error IS NULL";
 
             using var command = connection.CreateCommand();
             command.CommandText = @"
-INSERT INTO config_alert_log (alert_time, server_id, server_name, metric_name, current_value, threshold_value, alert_sent, notification_type, send_error, muted, detail_text)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
+INSERT INTO config_alert_log (alert_time, server_id, server_name, metric_name, current_value, threshold_value, alert_sent, notification_type, send_error, muted, detail_text, context_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
 
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = DateTime.UtcNow });
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = serverId });
@@ -367,6 +371,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = sendError ?? (object)DBNull.Value });
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = muted });
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = detailText ?? (object)DBNull.Value });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = contextJson ?? (object)DBNull.Value });
 
             await command.ExecuteNonQueryAsync();
 

--- a/Lite/Services/EmailTemplateBuilder.cs
+++ b/Lite/Services/EmailTemplateBuilder.cs
@@ -205,7 +205,7 @@ internal static class EmailTemplateBuilder
         /* Separator + heading */
         sb.Append("<tr><td style=\"padding:0 24px;\"><table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\"><tr><td style=\"height:1px;background-color:#404040;font-size:0;line-height:0;\">&nbsp;</td></tr></table></td></tr>");
         sb.Append("<tr><td style=\"padding:12px 24px 4px 24px;\">");
-        sb.Append($"<span style=\"font-family:{FontStack};font-size:13px;font-weight:600;color:#E4E6EB;letter-spacing:0.5px;\">RECENT EVENTS</span>");
+        sb.Append($"<span style=\"font-family:{FontStack};font-size:13px;font-weight:600;color:#E4E6EB;letter-spacing:0.5px;\">DETAILS</span>");
         sb.Append("</td></tr>");
 
         foreach (var item in context.Details)
@@ -215,28 +215,50 @@ internal static class EmailTemplateBuilder
             sb.Append($"<span style=\"font-family:{FontStack};font-size:14px;font-weight:600;color:#E0E0E0;\">{WebUtility.HtmlEncode(item.Heading)}</span>");
             sb.Append("</td></tr>");
 
-            /* Detail item fields */
-            sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
-            sb.Append($"<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\" style=\"background-color:#333333;border-radius:4px;\">");
-
-            for (int i = 0; i < item.Fields.Count; i++)
+            if (item.IsCodeBlock && !string.IsNullOrEmpty(item.Body))
             {
-                var (label, value) = item.Fields[i];
-                bool isLast = i == item.Fields.Count - 1;
-                bool isQuery = label.Contains("Query") || label.Contains("SQL");
-
-                if (isQuery && !string.IsNullOrEmpty(value))
-                {
-                    AppendQueryRow(sb, label, value, isLast);
-                }
-                else
-                {
-                    AppendDataRow(sb, label, value, isLast);
-                }
+                /* Copy-paste code block (remediation T-SQL) — monospace, matches AppendQueryRow style. */
+                sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                sb.Append("<div style=\"background-color:#333333;border-radius:4px;padding:10px 16px;\">");
+                sb.Append($"<pre style=\"margin:0;font-family:'Courier New',Consolas,monospace;font-size:12px;color:#E0E0E0;white-space:pre-wrap;word-break:break-all;\">{WebUtility.HtmlEncode(item.Body)}</pre>");
+                sb.Append("</div>");
+                sb.Append("</td></tr>");
             }
+            else if (!string.IsNullOrEmpty(item.Body))
+            {
+                /* Prose paragraphs (advice Investigation / Remediation), one <p> per blank-line chunk. */
+                sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                foreach (var para in item.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                {
+                    sb.Append($"<p style=\"margin:0 0 8px 0;font-family:{FontStack};font-size:13px;color:#E0E0E0;line-height:1.5;\">{WebUtility.HtmlEncode(para)}</p>");
+                }
+                sb.Append("</td></tr>");
+            }
+            else
+            {
+                /* Detail item fields */
+                sb.Append("<tr><td style=\"padding:2px 24px 8px 24px;\">");
+                sb.Append($"<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" width=\"100%\" style=\"background-color:#333333;border-radius:4px;\">");
 
-            sb.Append("</table>");
-            sb.Append("</td></tr>");
+                for (int i = 0; i < item.Fields.Count; i++)
+                {
+                    var (label, value) = item.Fields[i];
+                    bool isLast = i == item.Fields.Count - 1;
+                    bool isQuery = label.Contains("Query") || label.Contains("SQL");
+
+                    if (isQuery && !string.IsNullOrEmpty(value))
+                    {
+                        AppendQueryRow(sb, label, value, isLast);
+                    }
+                    else
+                    {
+                        AppendDataRow(sb, label, value, isLast);
+                    }
+                }
+
+                sb.Append("</table>");
+                sb.Append("</td></tr>");
+            }
         }
     }
 
@@ -271,13 +293,35 @@ internal static class EmailTemplateBuilder
 
         if (context?.Details?.Count > 0)
         {
-            sb.Append($"\r\n--- Recent Events ---\r\n");
+            sb.Append($"\r\n--- Details ---\r\n");
             foreach (var item in context.Details)
             {
                 sb.Append($"\r\n  {item.Heading}\r\n");
-                foreach (var (label, value) in item.Fields)
+
+                if (item.IsCodeBlock && !string.IsNullOrEmpty(item.Body))
                 {
-                    sb.Append($"  {label}: {value}\r\n");
+                    /* Fenced block for the copy-paste remediation T-SQL. */
+                    sb.Append("  ```\r\n");
+                    foreach (var line in item.Body.Replace("\r\n", "\n").Split('\n'))
+                    {
+                        sb.Append($"  {line}\r\n");
+                    }
+                    sb.Append("  ```\r\n");
+                }
+                else if (!string.IsNullOrEmpty(item.Body))
+                {
+                    /* Prose paragraphs (advice), one indented chunk per blank-line break. */
+                    foreach (var para in item.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        sb.Append($"  {para}\r\n");
+                    }
+                }
+                else
+                {
+                    foreach (var (label, value) in item.Fields)
+                    {
+                        sb.Append($"  {label}: {value}\r\n");
+                    }
                 }
             }
         }

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -41,7 +41,8 @@ SELECT
     send_error,
     muted,
     detail_text,
-    source
+    source,
+    context_json
 FROM v_config_alert_log
 WHERE alert_time >= $1
 AND   server_id = $2
@@ -67,7 +68,8 @@ SELECT
     send_error,
     muted,
     detail_text,
-    source
+    source,
+    context_json
 FROM v_config_alert_log
 WHERE alert_time >= $1
 AND   dismissed = FALSE
@@ -94,7 +96,8 @@ LIMIT $2";
                 SendError = reader.IsDBNull(8) ? null : reader.GetString(8),
                 Muted = !reader.IsDBNull(9) && reader.GetBoolean(9),
                 DetailText = reader.IsDBNull(10) ? null : reader.GetString(10),
-                Source = reader.IsDBNull(11) ? "live" : reader.GetString(11)
+                Source = reader.IsDBNull(11) ? "live" : reader.GetString(11),
+                ContextJson = reader.IsDBNull(12) ? null : reader.GetString(12)
             });
         }
 
@@ -404,6 +407,7 @@ public class AlertHistoryRow
     public bool Muted { get; set; }
     public string? DetailText { get; set; }
     public string Source { get; set; } = "live";
+    public string? ContextJson { get; set; }
 
     public bool IsArchived => string.Equals(Source, "archive", StringComparison.OrdinalIgnoreCase);
 

--- a/Lite/Services/WebhookAlertService.cs
+++ b/Lite/Services/WebhookAlertService.cs
@@ -25,6 +25,11 @@ public class WebhookAlertService
 {
     private const string EditionName = "Performance Monitor Lite";
     private const string SnoozeHint = "To silence this alert: open Performance Monitor Lite → Settings → Manage Mute Rules";
+
+    /* Webhooks do not deliver the copy-paste T-SQL (too large, wrong channel) — they point
+       at the email / in-app dialog instead. This string must stay byte-identical to the
+       Dashboard copy (plan §5.4). */
+    private const string TsqlWebhookHint = "See email or in-app Alert Details for the copy-paste T-SQL.";
     private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
 
     private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
@@ -200,6 +205,25 @@ public class WebhookAlertService
         {
             foreach (var detail in context.Details)
             {
+                if (detail.IsCodeBlock)
+                {
+                    /* Remediation T-SQL: point at the email / in-app dialog, never inline it. */
+                    facts.Add(new { name = detail.Heading, value = TsqlWebhookHint });
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(detail.Body))
+                {
+                    /* Advice prose: one "Advice" fact for the headline, then a fact per
+                       Investigation/Remediation paragraph (split on the blank line). */
+                    facts.Add(new { name = "Advice", value = detail.Heading });
+                    foreach (var para in detail.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        var (label, text) = SplitProseLabel(para);
+                        facts.Add(new { name = label, value = text });
+                    }
+                }
+
                 foreach (var (label, value) in detail.Fields)
                 {
                     facts.Add(new { name = label, value });
@@ -340,6 +364,21 @@ public class WebhookAlertService
             {
                 blocks.Add(new { type = "divider" });
 
+                if (detail.IsCodeBlock)
+                {
+                    /* Remediation T-SQL: point at the email / in-app dialog, never inline it. */
+                    blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*{detail.Heading}*\n{TsqlWebhookHint}" } });
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(detail.Body))
+                {
+                    /* Advice prose flows as a single mrkdwn section; the synthesized Body is
+                       "Investigation: ...\n\nRemediation: ..." which Slack renders verbatim. */
+                    blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*{detail.Heading}*\n{detail.Body}" } });
+                    continue;
+                }
+
                 var detailFields = new List<object>();
                 detailFields.Add(new { type = "mrkdwn", text = $"*{detail.Heading}*" });
 
@@ -395,6 +434,24 @@ public class WebhookAlertService
         "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
         _ => ("#2eaef1", "INFO", "\U0001F535")
     };
+
+    /// <summary>
+    /// Splits a synthesized advice paragraph ("Investigation: ..." / "Remediation: ...") into a
+    /// (label, value) pair on the first ": ". Falls back to ("Detail", paragraph) when there is no
+    /// leading label. Depends on advice prose containing no interior blank-line break so each
+    /// Body chunk is a single labelled paragraph (audited safe for the current FactAdvice blocks);
+    /// a future block with a paragraph break degrades to the "Detail" fallback rather than breaking.
+    /// Must stay byte-identical to the Dashboard copy (plan §5.4).
+    /// </summary>
+    private static (string Label, string Value) SplitProseLabel(string paragraph)
+    {
+        var idx = paragraph.IndexOf(": ", StringComparison.Ordinal);
+        if (idx > 0)
+        {
+            return (paragraph.Substring(0, idx), paragraph.Substring(idx + 2));
+        }
+        return ("Detail", paragraph);
+    }
 
     /// <summary>
     /// Posts a JSON payload to a webhook URL. Returns null on success, error message on failure.

--- a/Lite/Windows/AlertDetailWindow.xaml
+++ b/Lite/Windows/AlertDetailWindow.xaml
@@ -7,6 +7,9 @@
         ResizeMode="NoResize"
         Icon="/EDD.ico"
         Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Window.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -88,7 +91,68 @@
             <StackPanel>
                 <TextBlock Text="Details" FontWeight="SemiBold" FontSize="13"
                            Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>
+
+                <!-- Structured detail items (advice prose, remediation T-SQL, drill-down).
+                     Shown when the persisted context_json deserializes. -->
+                <ScrollViewer x:Name="DetailItemsScroll" Visibility="Collapsed"
+                              MaxHeight="380" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="DetailItems">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,10">
+                                    <TextBlock Text="{Binding Heading}" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+
+                                    <!-- Remediation T-SQL: monospace, read-only, with Copy. -->
+                                    <StackPanel Visibility="{Binding IsCodeBlock, Converter={StaticResource BoolToVis}}">
+                                        <Button Content="Copy" HorizontalAlignment="Right"
+                                                Padding="8,2" Margin="0,0,0,4"
+                                                Click="CopyTsqlButton_Click"/>
+                                        <TextBox Text="{Binding Body, Mode=OneWay}" IsReadOnly="True"
+                                                 FontFamily="Consolas" FontSize="12" TextWrapping="NoWrap"
+                                                 MaxHeight="240"
+                                                 VerticalScrollBarVisibility="Auto"
+                                                 HorizontalScrollBarVisibility="Auto"
+                                                 Background="Transparent"
+                                                 Foreground="{DynamicResource ForegroundBrush}"
+                                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
+                                    </StackPanel>
+
+                                    <!-- Advice prose. -->
+                                    <TextBlock Text="{Binding Body}" TextWrapping="Wrap"
+                                               Visibility="{Binding IsProse, Converter={StaticResource BoolToVis}}"
+                                               Foreground="{DynamicResource ForegroundBrush}"/>
+
+                                    <!-- Label/value field rows. -->
+                                    <ItemsControl ItemsSource="{Binding Fields}"
+                                                  Visibility="{Binding HasFields, Converter={StaticResource BoolToVis}}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid Margin="0,1">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="130"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
+                                                               TextWrapping="Wrap"/>
+                                                    <TextBlock Grid.Column="1" Text="{Binding Value}"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
+                                                               FontFamily="Consolas" FontSize="12"
+                                                               TextWrapping="Wrap"/>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <!-- Legacy / no-context fallback: flat persisted detail_text. -->
                 <TextBox x:Name="DetailTextBox" IsReadOnly="True" TextWrapping="Wrap"
+                         Visibility="Collapsed"
                          Background="Transparent" BorderThickness="0"
                          Foreground="{DynamicResource ForegroundBrush}" FontFamily="Consolas"
                          FontSize="12" MaxHeight="300"

--- a/Lite/Windows/AlertDetailWindow.xaml.cs
+++ b/Lite/Windows/AlertDetailWindow.xaml.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System.Collections.Generic;
 using System.Windows;
 using PerformanceMonitorLite.Services;
 
@@ -28,10 +29,76 @@ public partial class AlertDetailWindow : Window
         if (item.Muted)
             MutedBanner.Visibility = Visibility.Visible;
 
-        if (!string.IsNullOrWhiteSpace(item.DetailText))
+        /* Prefer the structured context (advice / remediation T-SQL / drill-down) persisted as
+           context_json; fall back to the flat detail_text for pre-v26 rows that have no context. */
+        if (TryBuildDetailViews(item.ContextJson, out var views))
         {
-            DetailTextBox.Text = item.DetailText;
+            DetailItems.ItemsSource = views;
+            DetailItemsScroll.Visibility = Visibility.Visible;
             DetailPanel.Visibility = Visibility.Visible;
         }
+        else if (!string.IsNullOrWhiteSpace(item.DetailText))
+        {
+            DetailTextBox.Text = item.DetailText;
+            DetailTextBox.Visibility = Visibility.Visible;
+            DetailPanel.Visibility = Visibility.Visible;
+        }
+    }
+
+    /* WPF cannot data-bind to AlertDetailItem.Fields (a List<(string,string)> ValueTuple — its
+       Item1/Item2 are fields, not properties), so the deserialized context is projected into
+       bindable view-models the DataTemplate can render. */
+    private static bool TryBuildDetailViews(string? contextJson, out List<DetailItemView> views)
+    {
+        views = new List<DetailItemView>();
+        if (!AlertContextSerializer.TryDeserialize(contextJson, out var context))
+            return false;
+
+        foreach (var detail in context.Details)
+        {
+            var view = new DetailItemView
+            {
+                Heading = detail.Heading,
+                Body = detail.Body,
+                IsCodeBlock = detail.IsCodeBlock
+            };
+            foreach (var (label, value) in detail.Fields)
+                view.Fields.Add(new FieldView { Label = label, Value = value });
+            views.Add(view);
+        }
+
+        return views.Count > 0;
+    }
+
+    private void CopyTsqlButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: DetailItemView view } && !string.IsNullOrEmpty(view.Body))
+        {
+            try
+            {
+                Clipboard.SetText(view.Body);
+            }
+            catch
+            {
+                /* Clipboard can be locked by another process — swallow contention. */
+            }
+        }
+    }
+
+    public sealed class DetailItemView
+    {
+        public string Heading { get; set; } = "";
+        public string? Body { get; set; }
+        public bool IsCodeBlock { get; set; }
+        public List<FieldView> Fields { get; } = new();
+
+        public bool IsProse => !IsCodeBlock && !string.IsNullOrEmpty(Body);
+        public bool HasFields => Fields.Count > 0;
+    }
+
+    public sealed class FieldView
+    {
+        public string Label { get; set; } = "";
+        public string Value { get; set; } = "";
     }
 }


### PR DESCRIPTION
## Summary

Surfaces the `FactAdvice` prose (Investigation/Remediation) and `FactRemediation` remediation T-SQL — landed by PR #1011's data layer but rendered nowhere — across **all six notification surfaces of both apps**:

| Surface | Lite | Dashboard |
| --- | --- | --- |
| In-app dialog | `Lite/Windows/AlertDetailWindow.xaml(.cs)` | `Dashboard/AlertDetailWindow.xaml(.cs)` |
| Email (HTML + plain text) | `Lite/Services/EmailTemplateBuilder.cs` | `Dashboard/Services/EmailTemplateBuilder.cs` |
| Webhooks (Teams + Slack) | `Lite/Services/WebhookAlertService.cs` | `Dashboard/Services/WebhookAlertService.cs` |

Render order on every surface: **Diagnosis → Advice → Remediation T-SQL → drill-down**. Webhooks deliver the advice prose plus a byte-identical "See email or in-app Alert Details for the copy-paste T-SQL." hint instead of inlining the T-SQL.

`AlertDetailItem` gains two orthogonal axes — `Body` (prose) and `IsCodeBlock` (monospace/copyable) — in both apps' per-app copies.

### Folded-in fix: drill-down persistence

The in-app dialog previously lost all the rich drill-down detail that email/webhooks get from the live `AlertContext`. This PR persists the structured context as JSON so the dialog renders the same shape:

- **Lite**: new `context_json VARCHAR` column on `config_alert_log` (schema **v26** additive migration, `ADD COLUMN IF NOT EXISTS`). History reads append `context_json` **after** `source` → ordinal **12** (`source` stays at 11; the view `v_config_alert_log` needs no DDL change — `SELECT *` propagates the column and `UNION ALL BY NAME` NULL-fills pre-v26 archive parquet).
- **Dashboard**: nullable `AlertLogEntry.ContextJson` in `alert_history.json` (old records deserialize `null`). Also fixes the pre-existing gap where Dashboard's email/webhook `RecordAlert` calls passed no detail at all.

Attachment XML/filename are deliberately **not** round-tripped through the persisted JSON (the dialog has no attachment surface; the live `AlertContext` still carries them into email).

## Tests

- **Lite.Tests**: 4 existing `BuildContext` tests updated for the new Advice item; 4 new (rendering order, unknown fact-key omission, non-PLAN_REGRESSION T-SQL omission, DTO serialization round-trip). 293 → **297** passing.
- **Dashboard.Tests**: new `AnalysisNotificationTests.cs` — **Dashboard's first notification-formatter tests** (3 ordering/omission + DTO round-trip). 28 → **32** passing.

The round-trip tests serialize the real `BuildContext` output for a PLAN_REGRESSION finding (generated T-SQL with newlines/brackets/semicolons/comments + drill-down fields), not a hand-built context.

## Deviations from the plan (mechanism only, no design changes)

- Added a co-located `AlertContextSerializer` static helper at the bottom of each app's `AlertContext.cs` (with the DTO records) to centralize the `AlertContext`↔DTO map/unmap used by the persistence write, the dialog read, and the round-trip test. Stays within "no new files."
- The dialog `ItemsControl` binds to a projected bindable view-model (`DetailItemView`/`FieldView`, co-located in each code-behind) instead of the plan's literal `DetailItems.ItemsSource = ctx.Details`: WPF cannot data-bind to `AlertDetailItem.Fields` because `List<(string,string)>` exposes `Item1`/`Item2` as fields, not properties. Same `ItemsControl` + `DataTemplate` + `DataTrigger` structure; only the bound type differs.

Plan: `~/.claude/plans/triage-v1-pr-b-plan.md` (two adversarial review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
