### PR TITLE
Dashboard IAlertSettings adapter (Plan E Stage E1)

### DIFF
--- a/Dashboard.Tests/DashboardAlertSettingsTests.cs
+++ b/Dashboard.Tests/DashboardAlertSettingsTests.cs
@@ -1,0 +1,136 @@
+using System;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Plan E Stage E1 — verifies the Dashboard <see cref="IAlertSettings"/> adapter mirrors
+/// Plan D's invariance discipline: it reads live from <see cref="IUserPreferencesService"/>
+/// (no caching), it clamps the analysis-notify bounds at the settings boundary (the inline
+/// clamp was removed from AnalysisNotificationService), and the credential-backed getters
+/// route to the service statics without throwing when no credential is present.
+/// </summary>
+public class DashboardAlertSettingsTests
+{
+    /// <summary>Minimal IUserPreferencesService over one mutable UserPreferences instance.</summary>
+    private sealed class FakePreferencesService : IUserPreferencesService
+    {
+        public UserPreferences Preferences { get; } = new();
+
+        public UserPreferences GetPreferences() => Preferences;
+        public void SavePreferences(UserPreferences preferences) { }
+        public void UpdateWaitStatsRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCpuRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateMemoryRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateFileIoRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateExpensiveQueriesRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateBlockingRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCollectionHealthRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+    }
+
+    [Fact]
+    public void ReadsLiveFromPreferences_NoCaching()
+    {
+        var fake = new FakePreferencesService();
+        var settings = new DashboardAlertSettings(fake);
+
+        // Plain string/bool/int pass-throughs reflect the current value on every access.
+        fake.Preferences.SmtpServer = "smtp.example.com";
+        Assert.Equal("smtp.example.com", settings.SmtpServer);
+
+        fake.Preferences.SmtpServer = "smtp.changed.com";
+        Assert.Equal("smtp.changed.com", settings.SmtpServer);
+
+        fake.Preferences.SmtpEnabled = true;
+        Assert.True(settings.SmtpEnabled);
+
+        fake.Preferences.EmailCooldownMinutes = 42;
+        Assert.Equal(42, settings.EmailCooldownMinutes);
+
+        fake.Preferences.TeamsWebhookEnabled = true;
+        Assert.True(settings.TeamsWebhookEnabled);
+
+        fake.Preferences.TeamsProxyAddress = "http://proxy:8080";
+        Assert.Equal("http://proxy:8080", settings.TeamsProxyAddress);
+    }
+
+    [Fact]
+    public void AnalysisNotifySeverity_ClampsToZeroTwoRange()
+    {
+        var fake = new FakePreferencesService();
+        var settings = new DashboardAlertSettings(fake);
+
+        fake.Preferences.AnalysisNotifySeverity = -3.0;
+        Assert.Equal(0.0, settings.AnalysisNotifySeverity);
+
+        fake.Preferences.AnalysisNotifySeverity = 9.9;
+        Assert.Equal(2.0, settings.AnalysisNotifySeverity);
+
+        fake.Preferences.AnalysisNotifySeverity = 1.25;
+        Assert.Equal(1.25, settings.AnalysisNotifySeverity);
+    }
+
+    [Fact]
+    public void AnalysisNotifyCooldownMinutes_ClampsTo30To10080Range()
+    {
+        var fake = new FakePreferencesService();
+        var settings = new DashboardAlertSettings(fake);
+
+        fake.Preferences.AnalysisNotifyCooldownMinutes = 5;
+        Assert.Equal(30, settings.AnalysisNotifyCooldownMinutes);
+
+        fake.Preferences.AnalysisNotifyCooldownMinutes = 99999;
+        Assert.Equal(10080, settings.AnalysisNotifyCooldownMinutes);
+
+        fake.Preferences.AnalysisNotifyCooldownMinutes = 360;
+        Assert.Equal(360, settings.AnalysisNotifyCooldownMinutes);
+    }
+
+    [Fact]
+    public void CredentialBackedGetters_RouteToStatics_WithoutThrowing()
+    {
+        var fake = new FakePreferencesService();
+        var settings = new DashboardAlertSettings(fake);
+
+        // Structural/smoke check: these route to EmailAlertService.GetSmtpPassword() and
+        // WebhookAlertService.Get{Teams,Slack}WebhookUrl(). They must not throw; with no
+        // credential present the password getter returns null and the URL getters "".
+        var ex = Record.Exception(() =>
+        {
+            _ = settings.GetSmtpPassword();
+            _ = settings.TeamsWebhookUrl;
+            _ = settings.SlackWebhookUrl;
+        });
+        Assert.Null(ex);
+        Assert.NotNull(settings.TeamsWebhookUrl);
+        Assert.NotNull(settings.SlackWebhookUrl);
+    }
+
+    [Fact]
+    public void TransientAdapter_ReadsFromGivenPreferences_NotLiveService()
+    {
+        // The test-send adapter (MOD-1) reads the UserPreferences it was handed — the form
+        // values the user just typed — never the saved IUserPreferencesService.
+        var formValues = new UserPreferences
+        {
+            SmtpEnabled = true,
+            SmtpServer = "typed.example.com",
+            SmtpPort = 2525,
+            SmtpFromAddress = "from@example.com",
+            SmtpRecipients = "to@example.com",
+            EmailCooldownMinutes = 7
+        };
+        var settings = new UserPreferencesAlertSettings(formValues);
+
+        Assert.Equal("typed.example.com", settings.SmtpServer);
+        Assert.Equal(2525, settings.SmtpPort);
+        Assert.Equal("from@example.com", settings.SmtpFromAddress);
+        Assert.Equal("to@example.com", settings.SmtpRecipients);
+        Assert.Equal(7, settings.EmailCooldownMinutes);
+        Assert.True(settings.SmtpEnabled);
+    }
+}

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Installer.Core\Installer.Core.csproj" />
     <ProjectReference Include="..\PerformanceMonitor.Analysis\PerformanceMonitor.Analysis.csproj" />
+    <ProjectReference Include="..\PerformanceMonitor.Notifications\PerformanceMonitor.Notifications.csproj" />
     <ProjectReference Include="..\PerformanceMonitor.PlanAnalysis\PerformanceMonitor.PlanAnalysis.csproj" />
   </ItemGroup>
 

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -112,8 +112,10 @@ namespace PerformanceMonitorDashboard
             ServerListView.ItemsSource = _serverListItems;
 
             _credentialService = new CredentialService();
-            _emailAlertService = new EmailAlertService(_preferencesService);
-            _ = new WebhookAlertService(_preferencesService);
+            /* Saved-prefs settings adapter shared by the three alert services (Plan E E1). */
+            var alertSettings = new DashboardAlertSettings(_preferencesService);
+            _emailAlertService = new EmailAlertService(alertSettings, _preferencesService);
+            _ = new WebhookAlertService(alertSettings);
 
             _alertCheckTimer = new DispatcherTimer();
             _alertCheckTimer.Tick += AlertCheckTimer_Tick;
@@ -122,7 +124,7 @@ namespace PerformanceMonitorDashboard
                alert engine (all dependencies exist by this point); started by
                _analysisScheduler.Configure() in MainWindow_Loaded. */
             _analysisNotificationService = new AnalysisNotificationService(
-                _emailAlertService, _preferencesService, _serverManager);
+                _emailAlertService, alertSettings, _serverManager);
             _analysisScheduler = new AnalysisScheduler(
                 _serverManager, _credentialService, _preferencesService, _analysisNotificationService);
 

--- a/Dashboard/Services/AnalysisNotificationService.cs
+++ b/Dashboard/Services/AnalysisNotificationService.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitorDashboard.Analysis;
 using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Mcp;
 
@@ -34,7 +35,7 @@ namespace PerformanceMonitorDashboard.Services
     public sealed class AnalysisNotificationService
     {
         private readonly EmailAlertService _emailAlertService;
-        private readonly IUserPreferencesService _preferencesService;
+        private readonly IAlertSettings _settings;
         private readonly IServerManager _serverManager;
 
         /// <summary>
@@ -48,11 +49,11 @@ namespace PerformanceMonitorDashboard.Services
 
         public AnalysisNotificationService(
             EmailAlertService emailAlertService,
-            IUserPreferencesService preferencesService,
+            IAlertSettings settings,
             IServerManager serverManager)
         {
             _emailAlertService = emailAlertService;
-            _preferencesService = preferencesService;
+            _settings = settings;
             _serverManager = serverManager;
         }
 
@@ -65,10 +66,11 @@ namespace PerformanceMonitorDashboard.Services
             if (findings is null || findings.Count == 0)
                 return;
 
-            var prefs = _preferencesService.GetPreferences();
-            // Bounds enforced at consumption — keeps the prefs surface simple.
-            var threshold = Math.Clamp(prefs.AnalysisNotifySeverity, 0.0, 2.0);
-            var cooldownMinutes = Math.Clamp(prefs.AnalysisNotifyCooldownMinutes, 30, 10080);
+            // Bounds are enforced in the settings adapter (DashboardAlertSettings clamps
+            // AnalysisNotifySeverity to [0, 2] and AnalysisNotifyCooldownMinutes to
+            // [30, 10080]); the service consumes the already-clamped values.
+            var threshold = _settings.AnalysisNotifySeverity;
+            var cooldownMinutes = _settings.AnalysisNotifyCooldownMinutes;
             var cooldown = TimeSpan.FromMinutes(cooldownMinutes);
             var now = DateTime.UtcNow;
 
@@ -85,13 +87,13 @@ namespace PerformanceMonitorDashboard.Services
             // A user who lowers AnalysisNotifyCooldownMinutes below EmailCooldownMinutes
             // can lose alert-history rows during the SMTP cooldown window; accepted.
             var emailWouldLog =
-                prefs.SmtpEnabled
-                && !string.IsNullOrWhiteSpace(prefs.SmtpServer)
-                && !string.IsNullOrWhiteSpace(prefs.SmtpFromAddress)
-                && !string.IsNullOrWhiteSpace(prefs.SmtpRecipients);
+                _settings.SmtpEnabled
+                && !string.IsNullOrWhiteSpace(_settings.SmtpServer)
+                && !string.IsNullOrWhiteSpace(_settings.SmtpFromAddress)
+                && !string.IsNullOrWhiteSpace(_settings.SmtpRecipients);
             var webhooksAttempted =
-                (prefs.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(WebhookAlertService.GetTeamsWebhookUrl()))
-             || (prefs.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(WebhookAlertService.GetSlackWebhookUrl()));
+                (_settings.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.TeamsWebhookUrl))
+             || (_settings.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(_settings.SlackWebhookUrl));
 
             /* Drop entries past 2× cooldown so the dict stays bounded — any entry
                past 1× is already re-fire-eligible, doubling gives clock-skew margin.

--- a/Dashboard/Services/DashboardAlertSettings.cs
+++ b/Dashboard/Services/DashboardAlertSettings.cs
@@ -1,0 +1,69 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    /// <summary>
+    /// Adapts Dashboard's <see cref="IUserPreferencesService"/> + credential statics to
+    /// <see cref="IAlertSettings"/>. Pass-through only — reads live preferences on every
+    /// access (no caching) so a settings save is seen immediately, matching today's direct
+    /// <c>GetPreferences()</c> reads in the alert services. This is the <b>saved-prefs</b>
+    /// adapter used by the live alert path; the test-send path uses a transient
+    /// form-values adapter instead (see <see cref="UserPreferencesAlertSettings"/>).
+    ///
+    /// <para>
+    /// The SMTP password and webhook URLs live in Windows Credential Manager, not in
+    /// <see cref="UserPreferences"/>; the adapter routes those through the existing
+    /// <see cref="EmailAlertService"/> / <see cref="WebhookAlertService"/> credential
+    /// statics (relocated to a Dashboard credential helper in a later stage).
+    /// </para>
+    ///
+    /// <para>
+    /// The analysis-notify bounds (<see cref="AnalysisNotifySeverity"/> to [0, 2],
+    /// <see cref="AnalysisNotifyCooldownMinutes"/> to [30, 10080]) are clamped here — the
+    /// settings boundary — so the consuming services need no inline clamp. Clamp is
+    /// idempotent, so per-access clamping is safe.
+    /// </para>
+    /// </summary>
+    public sealed class DashboardAlertSettings : IAlertSettings
+    {
+        private readonly IUserPreferencesService _preferencesService;
+
+        public DashboardAlertSettings(IUserPreferencesService preferencesService)
+        {
+            _preferencesService = preferencesService;
+        }
+
+        private UserPreferences Prefs => _preferencesService.GetPreferences();
+
+        public bool   SmtpEnabled     => Prefs.SmtpEnabled;
+        public string SmtpServer      => Prefs.SmtpServer;
+        public int    SmtpPort        => Prefs.SmtpPort;
+        public bool   SmtpUseSsl      => Prefs.SmtpUseSsl;
+        public string SmtpUsername    => Prefs.SmtpUsername;
+        public string SmtpFromAddress => Prefs.SmtpFromAddress;
+        public string SmtpRecipients  => Prefs.SmtpRecipients;
+        public string? GetSmtpPassword() => EmailAlertService.GetSmtpPassword();
+
+        public int EmailCooldownMinutes => Prefs.EmailCooldownMinutes;
+
+        public bool   TeamsWebhookEnabled => Prefs.TeamsWebhookEnabled;
+        public string TeamsWebhookUrl     => WebhookAlertService.GetTeamsWebhookUrl();
+        public string TeamsProxyAddress   => Prefs.TeamsProxyAddress;
+
+        public bool   SlackWebhookEnabled => Prefs.SlackWebhookEnabled;
+        public string SlackWebhookUrl     => WebhookAlertService.GetSlackWebhookUrl();
+        public string SlackProxyAddress   => Prefs.SlackProxyAddress;
+
+        public double AnalysisNotifySeverity        => Math.Clamp(Prefs.AnalysisNotifySeverity, 0.0, 2.0);
+        public int    AnalysisNotifyCooldownMinutes => Math.Clamp(Prefs.AnalysisNotifyCooldownMinutes, 30, 10080);
+    }
+}

--- a/Dashboard/Services/EmailAlertService.cs
+++ b/Dashboard/Services/EmailAlertService.cs
@@ -15,7 +15,9 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Models;
 
 namespace PerformanceMonitorDashboard.Services
@@ -31,7 +33,11 @@ namespace PerformanceMonitorDashboard.Services
         private static readonly CredentialService s_credentialService = new();
         private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
 
-        private readonly UserPreferencesService _preferencesService;
+        private readonly IAlertSettings _settings;
+        /* Retained for the LogAlertDismissals toggle in HideAlerts/HideAllAlerts, which is a
+           history-management concern (not an alert setting) and so is not on IAlertSettings.
+           Those methods move to JsonAlertHistoryStore in E3c; this field goes with them. */
+        private readonly IUserPreferencesService _preferencesService;
         private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
 
         /* Alert log — loaded from JSON on startup, saved on exit, new alerts added in-memory */
@@ -49,8 +55,9 @@ namespace PerformanceMonitorDashboard.Services
         /// </summary>
         public static EmailAlertService? Current { get; private set; }
 
-        public EmailAlertService(UserPreferencesService preferencesService)
+        public EmailAlertService(IAlertSettings settings, IUserPreferencesService preferencesService)
         {
+            _settings = settings;
             _preferencesService = preferencesService;
             Current = this;
 
@@ -78,13 +85,11 @@ namespace PerformanceMonitorDashboard.Services
         {
             try
             {
-                var prefs = _preferencesService.GetPreferences();
-
                 /* Attempt email delivery if SMTP is fully configured */
-                if (prefs.SmtpEnabled &&
-                    !string.IsNullOrWhiteSpace(prefs.SmtpServer) &&
-                    !string.IsNullOrWhiteSpace(prefs.SmtpFromAddress) &&
-                    !string.IsNullOrWhiteSpace(prefs.SmtpRecipients))
+                if (_settings.SmtpEnabled &&
+                    !string.IsNullOrWhiteSpace(_settings.SmtpServer) &&
+                    !string.IsNullOrWhiteSpace(_settings.SmtpFromAddress) &&
+                    !string.IsNullOrWhiteSpace(_settings.SmtpRecipients))
                 {
                     var cooldownKey = $"{serverId}:{metricName}";
 
@@ -103,7 +108,7 @@ namespace PerformanceMonitorDashboard.Services
                     }
 
                     var withinCooldown = _cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
-                        DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes);
+                        DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(_settings.EmailCooldownMinutes);
 
                     if (!withinCooldown)
                     {
@@ -111,11 +116,11 @@ namespace PerformanceMonitorDashboard.Services
                         string? sendError = null;
                         var subject = $"[SQL Monitor Alert] {metricName} on {serverName}";
                         var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildAlertEmail(
-                            metricName, serverName, currentValue, thresholdValue, prefs.EmailCooldownMinutes, context);
+                            metricName, serverName, currentValue, thresholdValue, _settings.EmailCooldownMinutes, context);
 
                         try
                         {
-                            await SendEmailAsync(prefs, subject, htmlBody, plainTextBody, context);
+                            await SendEmailAsync(_settings, subject, htmlBody, plainTextBody, context);
                             sent = true;
                             _cooldowns[cooldownKey] = DateTime.UtcNow;
 
@@ -388,23 +393,23 @@ namespace PerformanceMonitorDashboard.Services
         /// Sends a test email to verify SMTP configuration.
         /// Returns null on success, or the error message on failure.
         /// </summary>
-        public async Task<string?> SendTestEmailAsync(UserPreferences prefs)
+        public async Task<string?> SendTestEmailAsync(IAlertSettings settings)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(prefs.SmtpServer))
+                if (string.IsNullOrWhiteSpace(settings.SmtpServer))
                     return "SMTP server is not configured.";
 
-                if (string.IsNullOrWhiteSpace(prefs.SmtpFromAddress))
+                if (string.IsNullOrWhiteSpace(settings.SmtpFromAddress))
                     return "From address is not configured.";
 
-                if (string.IsNullOrWhiteSpace(prefs.SmtpRecipients))
+                if (string.IsNullOrWhiteSpace(settings.SmtpRecipients))
                     return "No recipients configured.";
 
                 var subject = "[SQL Monitor] Test Email";
                 var (htmlBody, plainTextBody) = EmailTemplateBuilder.BuildTestEmail();
 
-                await SendEmailAsync(prefs, subject, htmlBody, plainTextBody);
+                await SendEmailAsync(settings, subject, htmlBody, plainTextBody);
                 return null;
             }
             catch (Exception ex)
@@ -445,24 +450,24 @@ namespace PerformanceMonitorDashboard.Services
             }
         }
 
-        private static async Task SendEmailAsync(UserPreferences prefs, string subject, string htmlBody, string plainTextBody, AlertContext? context = null)
+        private static async Task SendEmailAsync(IAlertSettings settings, string subject, string htmlBody, string plainTextBody, AlertContext? context = null)
         {
-            using var smtpClient = new SmtpClient(prefs.SmtpServer, prefs.SmtpPort)
+            using var smtpClient = new SmtpClient(settings.SmtpServer, settings.SmtpPort)
             {
-                EnableSsl = prefs.SmtpUseSsl,
+                EnableSsl = settings.SmtpUseSsl,
                 DeliveryMethod = SmtpDeliveryMethod.Network,
                 Timeout = 30000
             };
 
-            if (!string.IsNullOrWhiteSpace(prefs.SmtpUsername))
+            if (!string.IsNullOrWhiteSpace(settings.SmtpUsername))
             {
-                var password = GetSmtpPassword();
-                smtpClient.Credentials = new NetworkCredential(prefs.SmtpUsername, password ?? "");
+                var password = settings.GetSmtpPassword();
+                smtpClient.Credentials = new NetworkCredential(settings.SmtpUsername, password ?? "");
             }
 
             using var message = new MailMessage
             {
-                From = new MailAddress(prefs.SmtpFromAddress),
+                From = new MailAddress(settings.SmtpFromAddress),
                 Subject = subject
             };
 
@@ -480,7 +485,7 @@ namespace PerformanceMonitorDashboard.Services
                 message.Attachments.Add(new Attachment(stream, context.AttachmentFileName, "application/xml"));
             }
 
-            foreach (var recipient in prefs.SmtpRecipients.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            foreach (var recipient in settings.SmtpRecipients.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
                 message.To.Add(recipient);
             }

--- a/Dashboard/Services/UserPreferencesAlertSettings.cs
+++ b/Dashboard/Services/UserPreferencesAlertSettings.cs
@@ -1,0 +1,59 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    /// <summary>
+    /// Transient <see cref="IAlertSettings"/> backed by a single <see cref="UserPreferences"/>
+    /// instance rather than the live <see cref="Interfaces.IUserPreferencesService"/>. Used by
+    /// the "test before you save" path (<c>SettingsWindow.TestEmailButton_Click</c>), which builds
+    /// a <see cref="UserPreferences"/> from the live SMTP textboxes the user just typed and sends a
+    /// test email with <i>those</i> values — NOT the saved preferences. Routing the test through
+    /// <see cref="DashboardAlertSettings"/> (which reads saved prefs) would silently test stale
+    /// settings, so this distinct adapter is mandatory.
+    ///
+    /// <para>
+    /// The SMTP password still comes from Credential Manager: the test path saves the typed
+    /// password to the credential store first, then the send reads it back, so
+    /// <see cref="GetSmtpPassword"/> routes to the same credential static as the saved adapter.
+    /// </para>
+    /// </summary>
+    public sealed class UserPreferencesAlertSettings : IAlertSettings
+    {
+        private readonly UserPreferences _prefs;
+
+        public UserPreferencesAlertSettings(UserPreferences prefs)
+        {
+            _prefs = prefs;
+        }
+
+        public bool   SmtpEnabled     => _prefs.SmtpEnabled;
+        public string SmtpServer      => _prefs.SmtpServer;
+        public int    SmtpPort        => _prefs.SmtpPort;
+        public bool   SmtpUseSsl      => _prefs.SmtpUseSsl;
+        public string SmtpUsername    => _prefs.SmtpUsername;
+        public string SmtpFromAddress => _prefs.SmtpFromAddress;
+        public string SmtpRecipients  => _prefs.SmtpRecipients;
+        public string? GetSmtpPassword() => EmailAlertService.GetSmtpPassword();
+
+        public int EmailCooldownMinutes => _prefs.EmailCooldownMinutes;
+
+        public bool   TeamsWebhookEnabled => _prefs.TeamsWebhookEnabled;
+        public string TeamsWebhookUrl     => WebhookAlertService.GetTeamsWebhookUrl();
+        public string TeamsProxyAddress   => _prefs.TeamsProxyAddress;
+
+        public bool   SlackWebhookEnabled => _prefs.SlackWebhookEnabled;
+        public string SlackWebhookUrl     => WebhookAlertService.GetSlackWebhookUrl();
+        public string SlackProxyAddress   => _prefs.SlackProxyAddress;
+
+        public double AnalysisNotifySeverity        => Math.Clamp(_prefs.AnalysisNotifySeverity, 0.0, 2.0);
+        public int    AnalysisNotifyCooldownMinutes => Math.Clamp(_prefs.AnalysisNotifyCooldownMinutes, 30, 10080);
+    }
+}

--- a/Dashboard/Services/WebhookAlertService.cs
+++ b/Dashboard/Services/WebhookAlertService.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 
@@ -34,7 +35,7 @@ namespace PerformanceMonitorDashboard.Services
         private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
         private static readonly CredentialService s_credentialService = new();
 
-        private readonly UserPreferencesService _preferencesService;
+        private readonly IAlertSettings _settings;
         private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
 
         private int _consecutiveTeamsFailures;
@@ -44,9 +45,9 @@ namespace PerformanceMonitorDashboard.Services
 
         public static WebhookAlertService? Current { get; private set; }
 
-        public WebhookAlertService(UserPreferencesService preferencesService)
+        public WebhookAlertService(IAlertSettings settings)
         {
-            _preferencesService = preferencesService;
+            _settings = settings;
             Current = this;
         }
 
@@ -108,27 +109,25 @@ namespace PerformanceMonitorDashboard.Services
         {
             try
             {
-                var prefs = _preferencesService.GetPreferences();
-
                 var cooldownKey = $"webhook:{serverId}:{metricName}";
                 if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
-                    DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(prefs.EmailCooldownMinutes))
+                    DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(_settings.EmailCooldownMinutes))
                 {
                     return false;
                 }
 
                 bool sent = false;
 
-                var teamsUrl = GetTeamsWebhookUrl();
-                if (prefs.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(teamsUrl))
+                var teamsUrl = _settings.TeamsWebhookUrl;
+                if (_settings.TeamsWebhookEnabled && !string.IsNullOrWhiteSpace(teamsUrl))
                 {
-                    sent |= await TrySendTeamsAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
+                    sent |= await TrySendTeamsAlertAsync(metricName, serverName, currentValue, thresholdValue, context);
                 }
 
-                var slackUrl = GetSlackWebhookUrl();
-                if (prefs.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(slackUrl))
+                var slackUrl = _settings.SlackWebhookUrl;
+                if (_settings.SlackWebhookEnabled && !string.IsNullOrWhiteSpace(slackUrl))
                 {
-                    sent |= await TrySendSlackAlertAsync(prefs, metricName, serverName, currentValue, thresholdValue, context);
+                    sent |= await TrySendSlackAlertAsync(metricName, serverName, currentValue, thresholdValue, context);
                 }
 
                 if (sent)
@@ -192,7 +191,6 @@ namespace PerformanceMonitorDashboard.Services
         #region Teams
 
         private async Task<bool> TrySendTeamsAlertAsync(
-            UserPreferences prefs,
             string metricName,
             string serverName,
             string currentValue,
@@ -202,7 +200,7 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var payload = BuildTeamsPayload(metricName, serverName, currentValue, thresholdValue, context: context);
-                var error = await PostWebhookAsync(GetTeamsWebhookUrl(), payload, prefs.TeamsProxyAddress);
+                var error = await PostWebhookAsync(_settings.TeamsWebhookUrl, payload, _settings.TeamsProxyAddress);
 
                 if (error != null)
                 {
@@ -331,7 +329,6 @@ namespace PerformanceMonitorDashboard.Services
         #region Slack
 
         private async Task<bool> TrySendSlackAlertAsync(
-            UserPreferences prefs,
             string metricName,
             string serverName,
             string currentValue,
@@ -341,7 +338,7 @@ namespace PerformanceMonitorDashboard.Services
             try
             {
                 var payload = BuildSlackPayload(metricName, serverName, currentValue, thresholdValue, context: context);
-                var error = await PostWebhookAsync(GetSlackWebhookUrl(), payload, prefs.SlackProxyAddress);
+                var error = await PostWebhookAsync(_settings.SlackWebhookUrl, payload, _settings.SlackProxyAddress);
 
                 if (error != null)
                 {

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -1005,8 +1005,10 @@ namespace PerformanceMonitorDashboard
 
             try
             {
-                var emailService = EmailAlertService.Current ?? new EmailAlertService((UserPreferencesService)_preferencesService);
-                var error = await emailService.SendTestEmailAsync(testPrefs);
+                var emailService = EmailAlertService.Current ?? new EmailAlertService(new DashboardAlertSettings(_preferencesService), _preferencesService);
+                /* Test before save: send with the values the user just typed (transient,
+                   form-values adapter), NOT the saved-prefs DashboardAlertSettings (MOD-1). */
+                var error = await emailService.SendTestEmailAsync(new UserPreferencesAlertSettings(testPrefs));
 
                 if (error == null)
                 {

--- a/Dashboard/packages.lock.json
+++ b/Dashboard/packages.lock.json
@@ -741,6 +741,9 @@
       "performancemonitor.analysis": {
         "type": "Project"
       },
+      "performancemonitor.notifications": {
+        "type": "Project"
+      },
       "performancemonitor.plananalysis": {
         "type": "Project"
       }


### PR DESCRIPTION
## Summary

Stage **E1** of Plan E — the Dashboard-side mirror of Plan D (#1017). Makes Dashboard's three alert/notification services read settings through the shared `IAlertSettings` interface (in `PerformanceMonitor.Notifications`) instead of `IUserPreferencesService`/`CredentialService` directly. **After E1, both Lite and Dashboard satisfy the same `IAlertSettings` contract** — the gate for E2 (storage interfaces) and E3 (extraction).

Pure refactor: **no files move to the lib, no schema/storage change, behaviour-preserving, zero Lite changes.**

## What changed

- **`Dashboard/Dashboard.csproj`** — adds the `PerformanceMonitor.Notifications` `<ProjectReference>` (it didn't reference the lib before).
- **`DashboardAlertSettings`** (new) — saved-prefs `IAlertSettings` adapter over `IUserPreferencesService`. 14 plain settings read live (no caching) from `GetPreferences()`; `GetSmtpPassword()`/`TeamsWebhookUrl`/`SlackWebhookUrl` route to the existing `EmailAlertService`/`WebhookAlertService` credential statics; the `Math.Clamp` for `AnalysisNotifySeverity` ([0,2]) and `AnalysisNotifyCooldownMinutes` ([30,10080]) moves here (the settings boundary).
- **`UserPreferencesAlertSettings`** (new) — transient `IAlertSettings` over a single `UserPreferences` instance, used only by the test-send path (see MOD-1 below).
- **`EmailAlertService` / `WebhookAlertService` / `AnalysisNotificationService`** — ctors now take `IAlertSettings`; SMTP/cooldown/webhook/analysis-notify reads go through `_settings.*`. The inline `Math.Clamp` in `AnalysisNotificationService` is removed (now in the adapter). Credential and URL statics stay in place (the adapter routes to them; relocation is E3c).
- **Construction sites** — `MainWindow.xaml.cs` builds one `DashboardAlertSettings(_preferencesService)` and injects it into all three services; `SettingsWindow.xaml.cs:1008` live-path fallback uses it too.

## MOD-1: test-before-save preserved with a transient adapter

`SettingsWindow.TestEmailButton_Click` builds `testPrefs` from the live SMTP textboxes the user just typed and sends a test email with **those** values, not saved prefs. The test send wraps `testPrefs` in the transient `UserPreferencesAlertSettings` — it does **not** route through `DashboardAlertSettings` (which reads *saved* prefs), so the test still uses what the user typed.

## Behaviour-preserving / scope

- Identical emails, Teams/Slack payloads, SMTP/cooldown behaviour. The credential/URL getters route to the same statics, so values are unchanged.
- **Lite untouched** — zero Lite files changed.
- No storage/schema change (that's E2).

## One deviation (documented in the commit)

`EmailAlertService` keeps an `IUserPreferencesService` ctor parameter **alongside** the new `IAlertSettings` one, solely for the two `LogAlertDismissals` reads in `HideAlerts`/`HideAllAlerts`. Those are a history-management logging toggle (not an alert setting), so they're not on `IAlertSettings`. §5 said "ctor takes `IAlertSettings` instead of `UserPreferencesService`"; a strict literal swap would break those reads. `HideAlerts`/`HideAllAlerts` and this field move to `JsonAlertHistoryStore` in E3c (§4.2). All the *settings* reads move to `IAlertSettings` exactly as specced.

## Verification

- Builds clean: Dashboard, PerformanceMonitor.Notifications, Lite.
- `dotnet test Dashboard.Tests` — **37/37** (32 baseline + 5 new adapter tests: live-read/no-cache, both clamp ranges, credential-getter smoke, transient-adapter form-value read).
- `dotnet test Lite.Tests` — **300/300**, unchanged.

Plan: `~/.claude/plans/plan-e-alert-service-extraction.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)