### PR TITLE
Make un-awaited async (CS4014) a build error in both apps

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -617,7 +617,7 @@ namespace PerformanceMonitorDashboard.Controls
         {
             try
             {
-                using var _ = Helpers.MethodProfiler.StartTiming("QueryPerformance");
+                using var profiler = Helpers.MethodProfiler.StartTiming("QueryPerformance");
 
                 if (_databaseService == null) return;
 
@@ -682,7 +682,7 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     PopulateQueryStatsGrid(await queryStatsTask);
                 }
-                LoadQueryStatsSlicerAsync().ConfigureAwait(false);
+                _ = LoadQueryStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
                 if (ProcStatsSlicer.HasNarrowedSelection)
                 {
                     var slicerProcData = await _databaseService.GetProcedureStatsAsync(0, ProcStatsSlicer.SelectionStart, ProcStatsSlicer.SelectionEnd, fromSlicer: true);
@@ -692,7 +692,7 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     PopulateProcStatsGrid(await procStatsTask);
                 }
-                LoadProcStatsSlicerAsync().ConfigureAwait(false);
+                _ = LoadProcStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
                 if (QueryStoreSlicer.HasNarrowedSelection)
                 {
                     var slicerQsData = await _databaseService.GetQueryStoreDataAsync(0, QueryStoreSlicer.SelectionStart, QueryStoreSlicer.SelectionEnd, fromSlicer: true);
@@ -702,7 +702,7 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     PopulateQueryStoreGrid(await queryStoreTask);
                 }
-                LoadQueryStoreSlicerAsync().ConfigureAwait(false);
+                _ = LoadQueryStoreSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
 
                 // Populate charts from time-series data
                 LoadDurationChart(QueryPerfTrendsQueryChart, await queryDurationTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate, "Duration (ms/sec)", TabHelpers.ChartColors[0], _queryDurationHover);
@@ -749,7 +749,7 @@ namespace PerformanceMonitorDashboard.Controls
             else
                 data = await _databaseService.GetQueryStatsAsync(_queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate);
             PopulateQueryStatsGrid(data);
-            LoadQueryStatsSlicerAsync().ConfigureAwait(false);
+            _ = LoadQueryStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
         }
 
         private async Task RefreshProcStatsGridAsync()
@@ -761,7 +761,7 @@ namespace PerformanceMonitorDashboard.Controls
             else
                 data = await _databaseService.GetProcedureStatsAsync(_procStatsHoursBack, _procStatsFromDate, _procStatsToDate);
             PopulateProcStatsGrid(data);
-            LoadProcStatsSlicerAsync().ConfigureAwait(false);
+            _ = LoadProcStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
         }
 
         private async Task RefreshQueryStoreGridAsync()
@@ -773,7 +773,7 @@ namespace PerformanceMonitorDashboard.Controls
             else
                 data = await _databaseService.GetQueryStoreDataAsync(_queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate);
             PopulateQueryStoreGrid(data);
-            LoadQueryStoreSlicerAsync().ConfigureAwait(false);
+            _ = LoadQueryStoreSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
         }
 
         private void PopulateQueryStatsGrid(List<QueryStatsItem> data)
@@ -851,7 +851,7 @@ namespace PerformanceMonitorDashboard.Controls
 
         private async Task RefreshActiveQueriesAsync()
         {
-            using var _ = Helpers.MethodProfiler.StartTiming("QueryPerf-ActiveQueries");
+            using var profiler = Helpers.MethodProfiler.StartTiming("QueryPerf-ActiveQueries");
             if (_databaseService == null) return;
             if (_isDrillDownActive) return;
 
@@ -879,7 +879,7 @@ namespace PerformanceMonitorDashboard.Controls
                 SetItemsSourcePreservingSort(ActiveQueriesDataGrid, data);
                 ActiveQueriesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
                 SetStatus($"Loaded {data.Count} query snapshots");
-                LoadActiveQueriesSlicerAsync().ConfigureAwait(false);
+                _ = LoadActiveQueriesSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
             }
             catch (Exception ex)
             {
@@ -1276,7 +1276,7 @@ namespace PerformanceMonitorDashboard.Controls
             var snapshots = await _databaseService.GetQuerySnapshotsAsync(0, from, to);
             SetItemsSourcePreservingSort(ActiveQueriesDataGrid, snapshots);
             ActiveQueriesNoDataMessage.Visibility = snapshots.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
-            LoadActiveQueriesSlicerAsync().ConfigureAwait(false);
+            _ = LoadActiveQueriesSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
         }
     }
 }

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -22,14 +22,17 @@
          CA1849: IsDBNull sync - micro-optimization not needed for desktop app (1000+ hits)
          CA2007: ConfigureAwait - not needed for WPF UI apps (500+ hits)
          CA1508: Dead code - false positives on nullable DateTime parameters
-         CA2201: Generic exception - acceptable for global error handlers
-         CS4014: Unawaited async - intentional fire-and-forget refresh calls -->
+         CA2201: Generic exception - acceptable for global error handlers -->
     <!-- NU1701: CredentialManagement package has no .NET 10 version
          CA1001: App/MainWindow live for process lifetime - disposal handled by exit
          CA1707: MCP tool parameters use snake_case intentionally for LLM APIs
          CA1305: MCP tools use ISO 8601 format which is culture-invariant
          CA1507: False positive - 'top' is an MCP parameter name, not a C# identifier -->
-    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CS4014;NU1701;NU1603;CA1001;CA1707;CA1305;CA1507;CA1848;CA2254</NoWarn>
+    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;NU1701;NU1603;CA1001;CA1707;CA1305;CA1507;CA1848;CA2254</NoWarn>
+    <!-- CS4014 is an error: un-awaited async must be an explicit discard (_ = FooAsync())
+         or awaited. Intentional fire-and-forget = discard. Guards against silently
+         shipping fire-and-forget calls (as the E3b snooze handler did). -->
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -25,10 +25,13 @@
          CA2007: ConfigureAwait - not needed for WPF UI apps
          CA1508: Dead code - false positives on nullable DateTime parameters
          CA2201: Generic exception - acceptable for global error handlers
-         CS4014: Unawaited async - intentional fire-and-forget refresh calls
          NU1701: CredentialManagement package has no .NET 10 version
          CA1001: App/MainWindow live for process lifetime - disposal handled by exit -->
-    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CS4014;NU1701;CA1001;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806;CA2254</NoWarn>
+    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;NU1701;CA1001;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806;CA2254</NoWarn>
+    <!-- CS4014 is an error: un-awaited async must be an explicit discard (_ = FooAsync())
+         or awaited. Intentional fire-and-forget = discard. Guards against silently
+         shipping fire-and-forget calls (as the E3b snooze handler did). -->
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What & why

Behaviour-preserving hardening precursor for **Plan E Stage E3c**. Promotes **CS4014** (un-awaited async call) from a blanket-suppressed warning to a **build-breaking error** in both Lite and Dashboard, so a fire-and-forget can't ship silently — as the E3b 15-minute-snooze handler did (CS4014 was in `<NoWarn>`, so the compiler never flagged it).

This PR does **not** change what any call does. It turns on the guard and makes existing intent explicit.

### Mechanism
- Removed `CS4014` from `<NoWarn>` in `Lite/PerformanceMonitorLite.csproj` and `Dashboard/Dashboard.csproj` (rest of the NoWarn list intact).
- Added `<WarningsAsErrors>CS4014</WarningsAsErrors>` to both (no pre-existing `WarningsAsErrors` to merge into).
- `PerformanceMonitor.Notifications` (shared lib) was already CS4014-guarded — left untouched.

## Sites (compiler-enumerated, not grep)

After un-suppressing, the compiler emitted **8 unique CS4014 sites** — all in `Dashboard/Controls/QueryPerformanceContent.xaml.cs`. **Lite had zero.**

All 8 are the **identical detached slicer-refresh shape**: `LoadXxxSlicerAsync().ConfigureAwait(false);` fired after a grid is already populated. Each `LoadXxxSlicerAsync` (in the `.Slicers.cs` partial) returns `Task` used only for its side effect (populating a slicer timeline control), wraps its body in `try { ... } catch { }` that swallows all exceptions by design, and has nothing downstream depending on its completion. This is the **opposite** of the E3b bug shape (no completion/ordering/exception dependency).

| # | Line | Call | Classification |
|---|------|------|----------------|
| 1 | 685  | `LoadQueryStatsSlicerAsync`   | intentional → discard |
| 2 | 695  | `LoadProcStatsSlicerAsync`    | intentional → discard |
| 3 | 705  | `LoadQueryStoreSlicerAsync`   | intentional → discard |
| 4 | 752  | `LoadQueryStatsSlicerAsync`   | intentional → discard |
| 5 | 764  | `LoadProcStatsSlicerAsync`    | intentional → discard |
| 6 | 776  | `LoadQueryStoreSlicerAsync`   | intentional → discard |
| 7 | 882  | `LoadActiveQueriesSlicerAsync`| intentional → discard |
| 8 | 1279 | `LoadActiveQueriesSlicerAsync`| intentional → discard |

**Discards: 8. Suspected bugs: 0. Pragmas: 0.**

Each was converted to `_ = LoadXxxSlicerAsync();` with a one-line comment. The dropped `.ConfigureAwait(false)` was a verified no-op on a non-awaited task (ConfigureAwait only affects an `await` continuation; with nothing awaiting, the Task runs identically) — so the discard is behaviour-identical.

### Incidental: 2 profiler-local renames (CS1656)
Four methods already use `using var _ = Helpers.MethodProfiler.StartTiming(...)`. In the two methods that also got a new `_ =` discard (lines 620 & 854), `_` collided with that using-variable (CS1656 "cannot assign to `_`"). Renamed those two to `using var profiler` — the variable is disposal-only and never read, so behaviour-identical. The other two `using var _` profiler scopes (1080, 1104) had no discard added and were left as-is.

## Guard is live (sanity check)
Temporarily added a bare un-awaited async call in each app and confirmed the build **FAILS** with CS4014-as-error, then removed it:
- Dashboard: `error CS4014` at the scratch line ✅
- Lite: `error CS4014` at the scratch line ✅

## Verification
- `dotnet build Lite` — 0 warnings, 0 errors ✅
- `dotnet build Dashboard` — 0 warnings, 0 errors ✅
- `dotnet test Lite.Tests` — **307 passed**, 0 failed ✅
- `dotnet test Dashboard.Tests` — **38 passed**, 0 failed ✅ (counts unchanged — no runtime behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
