### PR TITLE
Port memory-anomaly detection to Dashboard (analysis parity D-8/D-9)

### DIFF
--- a/Dashboard/Analysis/SqlServerAnomalyDetector.cs
+++ b/Dashboard/Analysis/SqlServerAnomalyDetector.cs
@@ -13,7 +13,7 @@ namespace PerformanceMonitorDashboard.Analysis;
 ///
 /// Two detection patterns:
 /// - Z-score: (observed - mean) / stddev — used for continuous metrics
-///   (CPU, batch requests, I/O latency, session counts, query duration)
+///   (CPU, batch requests, I/O latency, session counts, query duration, memory)
 /// - Ratio: currentRate / baselineRate — used for rate/event metrics
 ///   (wait stats, blocking, deadlocks)
 ///
@@ -21,7 +21,6 @@ namespace PerformanceMonitorDashboard.Analysis;
 ///
 /// Port of Lite's AnomalyDetector — uses SQL Server collect.* tables instead of DuckDB views.
 /// No server_id filtering — Dashboard monitors one server per database.
-/// No memory metric — Dashboard doesn't collect memory stats.
 /// </summary>
 public class SqlServerAnomalyDetector
 {
@@ -101,6 +100,7 @@ public class SqlServerAnomalyDetector
         await DetectBatchRequestAnomalies(context, anomalies);
         await DetectSessionAnomalies(context, anomalies);
         await DetectQueryDurationAnomalies(context, anomalies);
+        await DetectMemoryAnomalies(context, anomalies);
 
         return anomalies;
     }
@@ -704,6 +704,79 @@ FROM per_collection;";
         catch (Exception ex)
         {
             Logger.Error($"[SqlServerAnomalyDetector] Query duration anomaly detection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Detects memory utilization anomalies using z-score against time-bucketed baseline.
+    /// Measures total_memory_mb / committed_target_memory_mb as memory pressure %
+    /// (the SQL Server analog of Lite's total_server_memory_mb / target_server_memory_mb).
+    /// </summary>
+    private async Task DetectMemoryAnomalies(AnalysisContext context, List<Fact> anomalies)
+    {
+        try
+        {
+            var baseline = await _baselineProvider.GetBaselineAsync(
+                SqlServerMetricNames.Memory, context.TimeRangeStart);
+
+            if (baseline.SampleCount == 0) return;
+            var effectiveStdDev = baseline.EffectiveStdDev;
+            if (effectiveStdDev <= 0) return;
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    AVG(CAST(total_memory_mb AS FLOAT) / NULLIF(committed_target_memory_mb, 0) * 100) AS avg_pressure,
+    MAX(CAST(total_memory_mb AS FLOAT) / NULLIF(committed_target_memory_mb, 0) * 100) AS peak_pressure,
+    COUNT(*) AS sample_count
+FROM collect.memory_stats
+WHERE collection_time >= @windowStart AND collection_time <= @windowEnd
+AND   committed_target_memory_mb > 0;";
+
+            cmd.Parameters.Add(new SqlParameter("@windowStart", context.TimeRangeStart));
+            cmd.Parameters.Add(new SqlParameter("@windowEnd", context.TimeRangeEnd));
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (!await reader.ReadAsync()) return;
+
+            var avgPressure = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
+            var peakPressure = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
+            var windowSamples = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2));
+
+            if (windowSamples == 0) return;
+
+            var deviation = (peakPressure - baseline.Mean) / effectiveStdDev;
+            if (deviation < GetDeviationThreshold(SqlServerMetricNames.Memory)) return;
+
+            var metadata = new Dictionary<string, double>
+            {
+                ["peak_memory_pressure_pct"] = peakPressure,
+                ["avg_memory_pressure_pct"] = avgPressure,
+                ["baseline_mean"] = baseline.Mean,
+                ["baseline_stddev"] = effectiveStdDev,
+                ["deviation_sigma"] = deviation,
+                ["baseline_samples"] = baseline.SampleCount,
+                ["window_samples"] = windowSamples
+            };
+            AddBaselineContext(metadata, baseline);
+
+            anomalies.Add(new Fact
+            {
+                Source = "anomaly",
+                Key = "ANOMALY_MEMORY_PRESSURE",
+                Value = peakPressure,
+                ServerId = context.ServerId,
+                Metadata = metadata
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[SqlServerAnomalyDetector] Memory anomaly detection failed: {ex.Message}");
         }
     }
 }

--- a/Dashboard/Analysis/SqlServerBaselineProvider.cs
+++ b/Dashboard/Analysis/SqlServerBaselineProvider.cs
@@ -388,6 +388,25 @@ FROM per_interval
 GROUP BY DATEPART(HOUR, minute_bucket),
          (DATEPART(WEEKDAY, minute_bucket) + @@DATEFIRST - 1) % 7;",
 
+            // Point-in-time metric (memory pressure %) — no restart exclusion needed.
+            // Pressure = total memory SQL Server has acquired (sum of clerks) / target memory it can use.
+            // collect.memory_stats columns differ from Lite's perfmon-based view:
+            //   Lite total_server_memory_mb  -> Dashboard total_memory_mb (SUM of clerk pages_kb)
+            //   Lite target_server_memory_mb -> Dashboard committed_target_memory_mb (committed_target_kb)
+            SqlServerMetricNames.Memory => @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT DATEPART(HOUR, collection_time) AS hour_of_day,
+       (DATEPART(WEEKDAY, collection_time) + @@DATEFIRST - 1) % 7 AS day_of_week,
+       AVG(CAST(total_memory_mb AS FLOAT) / NULLIF(committed_target_memory_mb, 0) * 100) AS mean_val,
+       STDEV(CAST(total_memory_mb AS FLOAT) / NULLIF(committed_target_memory_mb, 0) * 100) AS stddev_val,
+       COUNT(*) AS sample_count
+FROM collect.memory_stats
+WHERE collection_time >= @windowStart AND collection_time < @windowEnd
+AND   committed_target_memory_mb > 0
+GROUP BY DATEPART(HOUR, collection_time),
+         (DATEPART(WEEKDAY, collection_time) + @@DATEFIRST - 1) % 7;",
+
             _ => null
         };
     }
@@ -523,4 +542,5 @@ public static class SqlServerMetricNames
     public const string IoLatency = "io_latency";
     public const string Blocking = "blocking";
     public const string Deadlock = "deadlock";
+    public const string Memory = "memory";
 }


### PR DESCRIPTION
## Parity gap closed

Brings Dashboard's analysis engine to **parity with Lite on memory-anomaly detection** — the one advice-affecting gap between the two apps (parity-sweep items **D-8** + the memory half of **D-9**, see `dashboard-analysis-parity-sweep.md`).

Before this PR, Lite emitted `ANOMALY_MEMORY_PRESSURE` findings (and the shared advice explained them) but Dashboard never did, because Dashboard's adapter lacked both the memory baseline arm and the detector. The shared `FactScorer` + `FactAdvice` already handled `ANOMALY_MEMORY_PRESSURE`, so this is **Dashboard-adapter-only**.

## Changes (two files, +95/-2)

**`SqlServerBaselineProvider.cs`**
- Added `SqlServerMetricNames.Memory = "memory"` (matches Lite's `MetricNames.Memory` exactly so the detector's `GetBaselineAsync(..., Memory, ...)` key lines up).
- Added the `Memory` baseline arm — copies the structure of the point-in-time `Cpu` sibling arm (hour-of-day × day-of-week bucketing), swapping in the memory-pressure ratio.

**`SqlServerAnomalyDetector.cs`**
- Ported `DetectMemoryAnomalies` mirroring Lite, with the same metadata keys (`peak_memory_pressure_pct`, `avg_memory_pressure_pct`, `baseline_mean`, `baseline_stddev`, `deviation_sigma`, `baseline_samples`, `window_samples`) + `AddBaselineContext`.
- Registered it in `DetectAnomaliesAsync` in the same position Lite uses (after query-duration).
- Updated the stale class doc comments ("No memory metric…" removed).

## SQL adaptation (the risk)

`collect.memory_stats` column names differ from Lite's perfmon-based DuckDB view, so the pressure ratio was adapted:

| Lite (DuckDB)              | Dashboard (`collect.memory_stats`)          |
|----------------------------|---------------------------------------------|
| `total_server_memory_mb`   | `total_memory_mb` (SUM of clerk `pages_kb`) |
| `target_server_memory_mb`  | `committed_target_memory_mb` (`committed_target_kb`) |

Both represent the same semantic (SQL's acquired memory ÷ target memory). `STDDEV_SAMP` → `STDEV` to match the sibling Dashboard arms; guarded by `committed_target_memory_mb > 0` (mirrors Lite's `target > 0`).

## Shared libs unchanged

`PerformanceMonitor.Analysis` (FactScorer/FactAdvice) untouched — both already key off `ANOMALY_MEMORY_PRESSURE`. Lite untouched.

## Verification

- **Builds clean**: Dashboard + PerformanceMonitor.Analysis (0 warnings, 0 errors). Lite still builds.
- **Tests green**: Dashboard.Tests 40/40, Lite.Tests 310/310.
- **Detect\* surface parity (8 == 8)**: Dashboard's `Detect*` methods now match Lite's exactly (`BatchRequest, Blocking, Cpu, Io, Memory, QueryDuration, Session, Wait`).
- **Real-server check (sql2022, 16,205 memory_stats rows over 30 days)**: both production queries parse and run under READ UNCOMMITTED. Driving the detector end-to-end against a real pressure spike window (2026-05-07 08:00) produced an `ANOMALY_MEMORY_PRESSURE` fire with sane metadata: peak 89.3%, avg 84.1%, baseline mean 80.7%, deviation 10.7σ (high σ from the documented `EffectiveStdDev = mean×0.01` floor on a tight baseline — identical to Lite), 22 baseline + 129 window samples.
- **Pipeline flow confirmed**: `AnalysisService` adds anomalies to facts → `FactScorer.ScoreAll` scores `ANOMALY_MEMORY_PRESSURE` (deviation-based, capped 1.0) → stories/findings → `FactAdvice` surfaces the `ANOMALY_MEMORY_PRESSURE` advice block. Dashboard now gets the same memory-anomaly advice as Lite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)