### PR TITLE
Surface advice + remediation SQL in analyze_server MCP output (triage v1 A5)

### DIFF
--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -76,20 +76,31 @@ public sealed class McpAnalysisTools
                     start = findings[0].TimeRangeStart?.ToString("o"),
                     end = findings[0].TimeRangeEnd?.ToString("o")
                 },
-                findings = findings.Select(f => new
+                findings = findings.Select(f =>
                 {
-                    severity = Math.Round(f.Severity, 2),
-                    confidence = Math.Round(f.Confidence, 2),
-                    category = f.Category,
-                    root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
-                    leaf_fact = f.LeafFactKey != null
-                        ? new { key = f.LeafFactKey, value = f.LeafFactValue }
-                        : null,
-                    story_path = f.StoryPath,
-                    story_path_hash = f.StoryPathHash,
-                    fact_count = f.FactCount,
-                    drill_down = f.DrillDown,
-                    next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath)
+                    var advice = FactAdvice.GetForFinding(f);
+                    return new
+                    {
+                        severity = Math.Round(f.Severity, 2),
+                        confidence = Math.Round(f.Confidence, 2),
+                        category = f.Category,
+                        root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
+                        leaf_fact = f.LeafFactKey != null
+                            ? new { key = f.LeafFactKey, value = f.LeafFactValue }
+                            : null,
+                        story_path = f.StoryPath,
+                        story_path_hash = f.StoryPathHash,
+                        fact_count = f.FactCount,
+                        drill_down = f.DrillDown,
+                        next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        advice = advice is null ? null : new
+                        {
+                            headline = advice.Headline,
+                            investigation = advice.Investigation,
+                            remediation = advice.Remediation
+                        },
+                        suggested_remediation_sql = advice?.RemediationTsql
+                    };
                 })
             }, McpHelpers.JsonOptions);
         }

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -64,20 +64,31 @@ public sealed class McpAnalysisTools
                     start = findings[0].TimeRangeStart?.ToString("o"),
                     end = findings[0].TimeRangeEnd?.ToString("o")
                 },
-                findings = findings.Select(f => new
+                findings = findings.Select(f =>
                 {
-                    severity = Math.Round(f.Severity, 2),
-                    confidence = Math.Round(f.Confidence, 2),
-                    category = f.Category,
-                    root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
-                    leaf_fact = f.LeafFactKey != null
-                        ? new { key = f.LeafFactKey, value = f.LeafFactValue }
-                        : null,
-                    story_path = f.StoryPath,
-                    story_path_hash = f.StoryPathHash,
-                    fact_count = f.FactCount,
-                    drill_down = f.DrillDown,
-                    next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath)
+                    var advice = FactAdvice.GetForFinding(f);
+                    return new
+                    {
+                        severity = Math.Round(f.Severity, 2),
+                        confidence = Math.Round(f.Confidence, 2),
+                        category = f.Category,
+                        root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
+                        leaf_fact = f.LeafFactKey != null
+                            ? new { key = f.LeafFactKey, value = f.LeafFactValue }
+                            : null,
+                        story_path = f.StoryPath,
+                        story_path_hash = f.StoryPathHash,
+                        fact_count = f.FactCount,
+                        drill_down = f.DrillDown,
+                        next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        advice = advice is null ? null : new
+                        {
+                            headline = advice.Headline,
+                            investigation = advice.Investigation,
+                            remediation = advice.Remediation
+                        },
+                        suggested_remediation_sql = advice?.RemediationTsql
+                    };
                 })
             }, McpHelpers.JsonOptions);
         }


### PR DESCRIPTION
## What

`analyze_server`'s per-finding JSON now carries two new fields, sourced from `FactAdvice.GetForFinding`:

- **`advice`** — an object with `headline` / `investigation` / `remediation` prose (null when no advice matches the finding's root fact key).
- **`suggested_remediation_sql`** — the copy-paste-ready T-SQL, populated **only** for `PLAN_REGRESSION` findings (the `sp_query_store_force_plan` block), null otherwise.

This brings the AI-client / MCP surface to parity with the in-app dialog, email, and webhook surfaces, which already render this same advice. Completes triage v1's "advise" story across all surfaces.

## How

Both apps (`Lite/Mcp/McpAnalysisTools.cs`, `Dashboard/Mcp/McpAnalysisTools.cs`) — the per-finding `Select` is converted from an expression lambda to a **block lambda** so `GetForFinding` (which does a JSON round-trip to generate the T-SQL) is called **once** per finding, not twice. Every existing field (severity, confidence, category, root_fact, leaf_fact, story_path, story_path_hash, fact_count, drill_down, next_tools) is preserved exactly; only the two new fields are appended.

- **No shared-lib changes** — `FactAdvice` / `FactRemediation` already do the work; this just surfaces it.
- `using PerformanceMonitor.Analysis;` was already present in both files.
- The PLAN_REGRESSION-only asymmetry of `suggested_remediation_sql` matches the existing in-app/email/webhook gating — intentional, not a bug.
- Unknown fact keys → both new fields are `null` (no throw, no empty object).

## Verification

- **Builds:** Lite + Dashboard + both test projects clean (0 warnings, 0 errors).
- **Tests:** `dotnet test` green and unchanged — Lite **310** passed, Dashboard **40** passed (no assertion changed).
- **Shape check:** a temporary probe (removed before commit) ran the real `FactAdvice.GetForFinding` through the exact projection + `McpHelpers.JsonOptions` serialization on three sample findings:
  - `PLAN_REGRESSION` → `advice` populated **and** `suggested_remediation_sql` contains the `EXEC sys.sp_query_store_force_plan @query_id = …, @plan_id = …` block (with the commented `sp_query_store_unforce_plan` back-out line).
  - `CXPACKET` (wait) → `advice` populated, `suggested_remediation_sql` = `null`.
  - unknown key → `advice` = `null`, `suggested_remediation_sql` = `null`.
  - Advice text matched what `FactAdvice.GetForFinding` returns for each key (same call the email/dialog use).

## Follow-up (out of scope here)

`get_analysis_findings` has a *similar* per-finding projection but a different field set (no `drill_down` / `next_tools`) and reads persisted findings. Adding `advice` there would be a trivial, separate follow-up; A5 is scoped to `analyze_server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
