### PR TITLE
Add advice to get_analysis_findings MCP output (triage advise symmetry)

### DIFF
--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -354,13 +354,28 @@ public sealed class McpAnalysisTools
             {
                 server = resolved.Value.ServerName,
                 finding_count = findings.Count,
-                findings = findings.Select(f => new
+                findings = findings.Select(f =>
                 {
-                    severity = Math.Round(f.Severity, 2),
-                    category = f.Category,
-                    story_path = f.StoryPath,
-                    story_path_hash = f.StoryPathHash,
-                    analysis_time = f.AnalysisTime.ToString("o")
+                    // Persisted findings carry no drill-down (it is ephemeral —
+                    // see AnalysisModels.cs), so generate advice prose only.
+                    // suggested_remediation_sql is intentionally omitted: it
+                    // would always be null here. The operator re-runs
+                    // analyze_server when they need the copy-paste T-SQL.
+                    var advice = FactAdvice.GetForFactKey(f.RootFactKey);
+                    return new
+                    {
+                        severity = Math.Round(f.Severity, 2),
+                        category = f.Category,
+                        story_path = f.StoryPath,
+                        story_path_hash = f.StoryPathHash,
+                        analysis_time = f.AnalysisTime.ToString("o"),
+                        advice = advice is null ? null : new
+                        {
+                            headline = advice.Headline,
+                            investigation = advice.Investigation,
+                            remediation = advice.Remediation
+                        }
+                    };
                 })
             }, McpHelpers.JsonOptions);
         }

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -527,25 +527,40 @@ public sealed class McpAnalysisTools
             {
                 server = resolved.Value.ServerName,
                 finding_count = findings.Count,
-                findings = findings.Select(f => new
+                findings = findings.Select(f =>
                 {
-                    finding_id = f.FindingId,
-                    analysis_time = f.AnalysisTime.ToString("o"),
-                    severity = Math.Round(f.Severity, 2),
-                    confidence = Math.Round(f.Confidence, 2),
-                    category = f.Category,
-                    root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
-                    leaf_fact = f.LeafFactKey != null
-                        ? new { key = f.LeafFactKey, value = f.LeafFactValue }
-                        : null,
-                    story_path = f.StoryPath,
-                    story_path_hash = f.StoryPathHash,
-                    fact_count = f.FactCount,
-                    time_range = new
+                    // Persisted findings carry no drill-down (it is ephemeral —
+                    // see AnalysisModels.cs), so generate advice prose only.
+                    // suggested_remediation_sql is intentionally omitted: it
+                    // would always be null here. The operator re-runs
+                    // analyze_server when they need the copy-paste T-SQL.
+                    var advice = FactAdvice.GetForFactKey(f.RootFactKey);
+                    return new
                     {
-                        start = f.TimeRangeStart?.ToString("o"),
-                        end = f.TimeRangeEnd?.ToString("o")
-                    }
+                        finding_id = f.FindingId,
+                        analysis_time = f.AnalysisTime.ToString("o"),
+                        severity = Math.Round(f.Severity, 2),
+                        confidence = Math.Round(f.Confidence, 2),
+                        category = f.Category,
+                        root_fact = new { key = f.RootFactKey, value = f.RootFactValue },
+                        leaf_fact = f.LeafFactKey != null
+                            ? new { key = f.LeafFactKey, value = f.LeafFactValue }
+                            : null,
+                        story_path = f.StoryPath,
+                        story_path_hash = f.StoryPathHash,
+                        fact_count = f.FactCount,
+                        time_range = new
+                        {
+                            start = f.TimeRangeStart?.ToString("o"),
+                            end = f.TimeRangeEnd?.ToString("o")
+                        },
+                        advice = advice is null ? null : new
+                        {
+                            headline = advice.Headline,
+                            investigation = advice.Investigation,
+                            remediation = advice.Remediation
+                        }
+                    };
                 })
             }, McpHelpers.JsonOptions);
         }


### PR DESCRIPTION
## What

`get_analysis_findings` now includes an `advice` object
(`headline` / `investigation` / `remediation`) on each persisted finding,
populated via `FactAdvice.GetForFactKey(f.RootFactKey)`. Both apps
(Lite + Dashboard). No shared-library changes — `FactAdvice` already lives
in `PerformanceMonitor.Analysis` and both MCP files already import it.

This is for symmetry with `analyze_server`, which gained `advice` +
`suggested_remediation_sql` in #1030.

## Why advice-only (no `suggested_remediation_sql`)

`suggested_remediation_sql` is **intentionally omitted** here. The
copy-paste T-SQL is generated by `FactRemediation` from a finding's
**drill-down** (e.g. `best_plan_id`), but drill-down is ephemeral and **not
persisted** (`AnalysisModels.cs` — "Ephemeral — not persisted"). For
persisted findings the field would therefore always be `null`, which would
mislead. The `remediation` prose already covers the guidance; when the
operator needs the runnable T-SQL they re-run `analyze_server`.

That's also why this uses `FactAdvice.GetForFactKey` (prose from the fact
key alone, which persisted findings have) rather than `GetForFinding`
(which tries to generate T-SQL from a non-existent drill-down).

## Verification

- Lite + Dashboard build clean (0 warnings); both test projects green and
  unchanged: Lite 310 passed, Dashboard 40 passed.
- Shape check through the exact projection:
  - `CXPACKET` → `advice` populated (parallelism headline/investigation/
    remediation, identical to `FactAdvice.GetForFactKey` — the same prose
    `analyze_server` and the email/dialog render).
  - unknown key → `advice` is `null`.
  - no `suggested_remediation_sql` field present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
