### PR TITLE
B3 PR-A: approval-gated Apply Fix — privileged execution core (no UI)

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -146,4 +146,61 @@ public class AnalysisNotificationTests
         var tsql = restored.Details.Single(d => d.IsCodeBlock);
         Assert.Contains("sp_query_store_force_plan", tsql.Body);
     }
+
+    [Fact]
+    public void BuildContext_PlanRegression_AttachesStructuredRemediationToCodeBlock()
+    {
+        var finding = MakeFinding("remstruct0000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var tsql = context.Details.Single(d => d.IsCodeBlock);
+        Assert.NotNull(tsql.Remediation);
+        Assert.Equal("PLAN_REGRESSION", tsql.Remediation!.FactKey);
+        Assert.Equal("force", tsql.Remediation.Action);
+        var target = Assert.Single(tsql.Remediation.Targets);
+        Assert.Equal("AdventureWorks", target.Database);
+        Assert.Equal(4242, target.QueryId);
+        Assert.Equal(17, target.PlanId);
+    }
+
+    [Fact]
+    public void AlertContext_RemediationAction_SurvivesRoundTrip()
+    {
+        var finding = MakeFinding("remround00000001", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        var rem = restored.Details.Single(d => d.IsCodeBlock).Remediation;
+        Assert.NotNull(rem);
+        Assert.Equal("PLAN_REGRESSION", rem!.FactKey);
+        Assert.Equal("force", rem.Action);
+        var t = Assert.Single(rem.Targets);
+        Assert.Equal("AdventureWorks", t.Database);
+        Assert.Equal(4242, t.QueryId);
+        Assert.Equal(17, t.PlanId);
+        Assert.Equal("0xBEEF", t.BestPlanHash);
+        Assert.Equal(7.5, t.RegressionFactor);
+    }
+
+    [Fact]
+    public void AlertContext_LegacyJsonWithoutRemediation_DeserializesToNull()
+    {
+        // A persisted context written before the Remediation field existed: a code
+        // block with no "Remediation" property. It must deserialize cleanly with
+        // Remediation == null (no Apply button, no crash) — backward compatibility.
+        const string legacyJson =
+            "{\"Details\":[{\"Heading\":\"Remediation T-SQL\",\"Fields\":[]," +
+            "\"Body\":\"EXEC sys.sp_query_store_force_plan @query_id = 1, @plan_id = 2;\",\"IsCodeBlock\":true}]}";
+
+        Assert.True(AlertContextSerializer.TryDeserialize(legacyJson, out var restored));
+        var item = Assert.Single(restored.Details);
+        Assert.True(item.IsCodeBlock);
+        Assert.Null(item.Remediation);
+        Assert.Contains("sp_query_store_force_plan", item.Body);
+    }
 }

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -376,12 +376,25 @@ public class RemediationTests
                 continue;
 
             var text = File.ReadAllText(file);
-            if (text.Contains("ForcePlanAsync") || text.Contains("UnforcePlanAsync"))
+            // Reachability is not only via the executor's own method names: a future
+            // surface (PR-B UI) would reach the privileged force/unforce through the
+            // handler/registry/executor TYPES (e.g. registry.TryGet(...).ApplyAsync()),
+            // never typing "ForcePlanAsync". Guard the whole machinery, not just the
+            // leaf method names, so PR-A's "not UI-reachable" invariant is actually
+            // protected when PR-B adds callers (LOW-1 from the security review).
+            string[] markers =
+            {
+                "ForcePlanAsync", "UnforcePlanAsync",
+                "RemediationHandlerRegistry", "DatabaseServiceRemediationExecutor",
+                "ForcePlanHandler", "IRemediationExecutor", "IRemediationHandler",
+            };
+            if (markers.Any(text.Contains))
                 offenders.Add(rel);
         }
 
         Assert.True(offenders.Count == 0,
-            "No MCP/menu/command surface may reach ForcePlanAsync/UnforcePlanAsync in PR-A. Offending files: " +
+            "No MCP/menu/command surface may reach the remediation-execution machinery " +
+            "(force/unforce, handler, registry, or executor) in PR-A. Offending files: " +
             string.Join(", ", offenders));
     }
 

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Services.Remediation;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// PR-A coverage for the privileged "Apply Fix" core (no UI): the structured
+/// extractor + render-stability, the self-gating handler against a faked executor
+/// (fail-closed permission, audit-table hard block, freshness/skip dispositions,
+/// per-target independence, gate re-derivation, applied-but-unlogged), un-apply
+/// restriction, the registry, and the "no caller reaches the executor" guard.
+/// The single-connection (R2-MOD-1) guarantee is an executor-level/real-server
+/// concern (SPID equality) and cannot be proven against a faked executor.
+/// </summary>
+public class RemediationTests
+{
+    private static AnalysisFinding PlanRegressionFinding(List<object>? rows = null) => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "plan_regression",
+        StoryPath = "PLAN_REGRESSION",
+        StoryPathHash = "planreg000000001",
+        RootFactKey = "PLAN_REGRESSION",
+        DrillDown = new Dictionary<string, object>
+        {
+            ["regressed_queries"] = rows ?? new List<object>
+            {
+                new
+                {
+                    database = "AdventureWorks",
+                    query_id = 4242L,
+                    best_plan_id = 17L,
+                    latest_plan_hash = "0xDEAD",
+                    best_plan_hash = "0xBEEF",
+                    latest_cpu_per_exec_us = 9000.0,
+                    best_cpu_per_exec_us = 1200.0,
+                    regression_factor = 7.5
+                }
+            }
+        }
+    };
+
+    private static RemediationAction ForceAction(params ForcePlanTarget[] targets) =>
+        new("PLAN_REGRESSION", "force", targets.ToList());
+
+    private static ForcePlanTarget Target(string db = "AdventureWorks", long q = 4242, long p = 17) =>
+        new(db, q, p);
+
+    private static readonly RemediationIdentity Identity =
+        new("TESTDOMAIN\\tester", "Analysis: plan_regression [abcd1234]");
+
+    [Fact]
+    public void Extract_SkipsRowsFailingGuards()
+    {
+        var finding = PlanRegressionFinding(new List<object>
+        {
+            new { database = "", query_id = 1L, best_plan_id = 1L },
+            new { database = "Db", query_id = 0L, best_plan_id = 1L },
+            new { database = "Db", query_id = 1L, best_plan_id = 0L },
+            new { database = "Good", query_id = 5L, best_plan_id = 9L }
+        });
+
+        var targets = FactRemediation.ExtractPlanRegressionTargets(finding);
+
+        var only = Assert.Single(targets);
+        Assert.Equal("Good", only.Database);
+        Assert.Equal(5, only.QueryId);
+        Assert.Equal(9, only.PlanId);
+    }
+
+    [Fact]
+    public void Extract_CapsAtFiveTargets()
+    {
+        var rows = Enumerable.Range(1, 8)
+            .Select(i => (object)new { database = $"Db{i}", query_id = (long)i, best_plan_id = (long)(i + 100) })
+            .ToList();
+
+        var targets = FactRemediation.ExtractPlanRegressionTargets(PlanRegressionFinding(rows));
+
+        Assert.Equal(5, targets.Count);
+        Assert.Equal("Db1", targets[0].Database);
+        Assert.Equal("Db5", targets[4].Database);
+    }
+
+    [Fact]
+    public void BuildAction_PlanRegression_ProducesForceActionWithTargets()
+    {
+        var action = FactRemediation.BuildAction(PlanRegressionFinding());
+
+        Assert.NotNull(action);
+        Assert.Equal("PLAN_REGRESSION", action!.FactKey);
+        Assert.Equal("force", action.Action);
+        var t = Assert.Single(action.Targets);
+        Assert.Equal("AdventureWorks", t.Database);
+        Assert.Equal(4242, t.QueryId);
+        Assert.Equal(17, t.PlanId);
+        Assert.Equal(7.5, t.RegressionFactor);
+    }
+
+    [Fact]
+    public void BuildAction_ParameterSensitivity_ReturnsNull()
+    {
+        var finding = PlanRegressionFinding();
+        finding.RootFactKey = "PARAMETER_SENSITIVITY";
+        Assert.Null(FactRemediation.BuildAction(finding));
+    }
+
+    [Fact]
+    public void BuildAction_UnknownKeyOrNoTargets_ReturnsNull()
+    {
+        var unknown = PlanRegressionFinding();
+        unknown.RootFactKey = "ZZZ_TEST";
+        Assert.Null(FactRemediation.BuildAction(unknown));
+
+        Assert.Null(FactRemediation.BuildAction(PlanRegressionFinding(new List<object>())));
+    }
+
+    [Fact]
+    public void GenerateForFinding_RenderStability_ByteForByte()
+    {
+        const string expected =
+            "-- Database: AdventureWorks\n" +
+            "-- query_id = 4242, forcing plan_id = 17\n" +
+            "--   latest plan hash: 0xDEAD (cpu/exec 9000 us)\n" +
+            "--   best plan hash:   0xBEEF   (cpu/exec 1200 us)\n" +
+            "--   regression factor: 7.5x\n" +
+            "USE [AdventureWorks];\n" +
+            "EXEC sys.sp_query_store_force_plan @query_id = 4242, @plan_id = 17;\n" +
+            "\n" +
+            "-- To back out:\n" +
+            "-- EXEC sys.sp_query_store_unforce_plan @query_id = 4242, @plan_id = 17;";
+
+        var actual = FactRemediation.GenerateForFinding(PlanRegressionFinding());
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Registry_ResolvesForcePlanHandler_AndMissesUnknown()
+    {
+        var registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler() });
+
+        Assert.IsType<ForcePlanHandler>(registry.TryGet("PLAN_REGRESSION"));
+        Assert.Null(registry.TryGet("PARAMETER_SENSITIVITY"));
+        Assert.Null(registry.TryGet(null));
+    }
+
+    [Fact]
+    public async Task Apply_Success_ForcesAndWritesSuccessAudit()
+    {
+        var exec = new FakeExecutor();
+        var result = await new ForcePlanHandler().ApplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, outcome.Status);
+        Assert.True(outcome.AuditWritten);
+        Assert.False(outcome.AppliedButUnlogged);
+        Assert.Equal(1, exec.ForceCalls);
+
+        var row = Assert.Single(exec.AuditRecords);
+        Assert.Equal("force", row.Action);
+        Assert.Equal("success", row.Result);
+        Assert.Equal("TESTDOMAIN\\tester", row.OperatorIdentity);
+        Assert.Contains("sp_query_store_force_plan", row.GeneratedSql);
+    }
+
+    [Fact]
+    public async Task Apply_HasAlterZero_FailsClosed_NoElevation_AuditSkipped()
+    {
+        var exec = new FakeExecutor
+        {
+            ForceFunc = (db, q, p) => new ForcePlanOutcome
+            {
+                Database = db, QueryId = q, PlanId = p,
+                Status = RemediationStatus.PermissionDenied, Forced = false, Message = "lacks ALTER"
+            }
+        };
+
+        var result = await new ForcePlanHandler().ApplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.PermissionDenied, outcome.Status);
+        Assert.False(outcome.AppliedButUnlogged);
+        Assert.Equal("skipped", Assert.Single(exec.AuditRecords).Result);
+        Assert.Equal(1, exec.ForceCalls);
+    }
+
+    [Fact]
+    public async Task Apply_AuditTableAbsent_HardBlocks_NoMutation_NoAuditNoUnloggedWarning()
+    {
+        var exec = new FakeExecutor { AuditTableExists = false };
+
+        var result = await new ForcePlanHandler().ApplyAsync(
+            ForceAction(Target(), Target("Other", 9, 9)), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.All(result.Outcomes, o =>
+        {
+            Assert.Equal(RemediationStatus.Blocked, o.Status);
+            Assert.False(o.AuditWritten);
+            Assert.False(o.AppliedButUnlogged);
+            Assert.Contains("2.12.0", o.Message);
+        });
+        Assert.Equal(0, exec.ForceCalls);
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task Apply_Skipped_IsNotForced_AndAuditedSkipped()
+    {
+        var exec = new FakeExecutor
+        {
+            ForceFunc = (db, q, p) => new ForcePlanOutcome
+            {
+                Database = db, QueryId = q, PlanId = p, Status = RemediationStatus.Skipped, Forced = false, Message = "already forced"
+            }
+        };
+
+        var result = await new ForcePlanHandler().ApplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Skipped, outcome.Status);
+        Assert.False(outcome.AppliedButUnlogged);
+        Assert.Equal("skipped", Assert.Single(exec.AuditRecords).Result);
+    }
+
+    [Fact]
+    public async Task Apply_GateChangesAfterPreflight_AbortsTarget()
+    {
+        var exec = new FakeExecutor
+        {
+            PreflightFunc = (db, q, p) => new TargetPreflight
+            {
+                Database = db, QueryId = q, PlanId = p,
+                CurrentDatabase = db, HasAlter = true, QueryStoreState = "READ_WRITE",
+                PlanPresent = true, IsForcedPlan = false, ForceFailureCount = 0
+            },
+            ForceFunc = (db, q, p) => new ForcePlanOutcome
+            {
+                Database = db, QueryId = q, PlanId = p, Status = RemediationStatus.Skipped, Forced = false, Message = "plan vanished"
+            }
+        };
+
+        var handler = new ForcePlanHandler();
+        var pre = await handler.PreflightAsync(ForceAction(Target()), exec, CancellationToken.None);
+        Assert.Equal(RemediationDisposition.Ok, pre.Targets.Single().Disposition);
+
+        var result = await handler.ApplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+        Assert.NotEqual(RemediationStatus.Success, result.Outcomes.Single().Status);
+    }
+
+    [Fact]
+    public async Task Apply_OneTargetThrows_OthersStillRun()
+    {
+        var exec = new FakeExecutor
+        {
+            ForceFunc = (db, q, p) =>
+            {
+                if (q == 1) throw new InvalidOperationException("boom");
+                return new ForcePlanOutcome { Database = db, QueryId = q, PlanId = p, Status = RemediationStatus.Success, Forced = true };
+            }
+        };
+
+        var result = await new ForcePlanHandler().ApplyAsync(
+            ForceAction(Target("A", 1, 1), Target("B", 2, 2)), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.Equal(RemediationStatus.Error, result.Outcomes[0].Status);
+        Assert.Equal(RemediationStatus.Success, result.Outcomes[1].Status);
+    }
+
+    [Fact]
+    public async Task Apply_ForceSucceedsButAuditWriteFails_FlagsAppliedButUnlogged()
+    {
+        var exec = new FakeExecutor { AuditWriteResult = false };
+
+        var result = await new ForcePlanHandler().ApplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, outcome.Status);
+        Assert.False(outcome.AuditWritten);
+        Assert.True(outcome.AppliedButUnlogged);
+    }
+
+    [Theory]
+    [InlineData("Other", true, "READ_WRITE", true, false, 0, RemediationDisposition.BlockWrongDatabase)]
+    [InlineData("AdventureWorks", false, "READ_WRITE", true, false, 0, RemediationDisposition.BlockNoAlter)]
+    [InlineData("AdventureWorks", true, "READ_ONLY", true, false, 0, RemediationDisposition.BlockQueryStoreOff)]
+    [InlineData("AdventureWorks", true, "READ_WRITE", false, false, 0, RemediationDisposition.BlockStale)]
+    [InlineData("AdventureWorks", true, "READ_WRITE", true, true, 0, RemediationDisposition.AlreadyForced)]
+    [InlineData("AdventureWorks", true, "READ_WRITE", true, false, 3, RemediationDisposition.WarnFailing)]
+    [InlineData("AdventureWorks", true, "READ_WRITE", true, false, 0, RemediationDisposition.Ok)]
+    public async Task Preflight_ClassifiesDisposition(
+        string currentDb, bool hasAlter, string qsState, bool planPresent, bool isForced, long failCount, RemediationDisposition expected)
+    {
+        var exec = new FakeExecutor
+        {
+            PreflightFunc = (db, q, p) => new TargetPreflight
+            {
+                Database = db, QueryId = q, PlanId = p,
+                CurrentDatabase = currentDb, HasAlter = hasAlter, QueryStoreState = qsState,
+                PlanPresent = planPresent, IsForcedPlan = isForced, ForceFailureCount = failCount
+            }
+        };
+
+        var pre = await new ForcePlanHandler().PreflightAsync(ForceAction(Target()), exec, CancellationToken.None);
+        Assert.Equal(expected, pre.Targets.Single().Disposition);
+    }
+
+    [Fact]
+    public async Task Preflight_AuditTableAbsent_OverridesPerTargetDisposition()
+    {
+        var exec = new FakeExecutor
+        {
+            AuditTableExists = false,
+            PreflightFunc = (db, q, p) => new TargetPreflight
+            {
+                Database = db, QueryId = q, PlanId = p,
+                CurrentDatabase = db, HasAlter = true, QueryStoreState = "READ_WRITE", PlanPresent = true
+            }
+        };
+
+        var pre = await new ForcePlanHandler().PreflightAsync(ForceAction(Target()), exec, CancellationToken.None);
+        Assert.False(pre.AuditTableExists);
+        Assert.Equal(RemediationDisposition.BlockAuditTableAbsent, pre.Targets.Single().Disposition);
+    }
+
+    [Fact]
+    public async Task Unapply_NoPriorForce_Skips_NoUnforce()
+    {
+        var exec = new FakeExecutor { PriorForce = false };
+
+        var result = await new ForcePlanHandler().UnapplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(RemediationStatus.Skipped, result.Outcomes.Single().Status);
+        Assert.Equal(0, exec.UnforceCalls);
+    }
+
+    [Fact]
+    public async Task Unapply_WithPriorForce_Unforces_AuditsUnforce()
+    {
+        var exec = new FakeExecutor { PriorForce = true };
+
+        var result = await new ForcePlanHandler().UnapplyAsync(ForceAction(Target()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(RemediationStatus.Success, result.Outcomes.Single().Status);
+        Assert.Equal(1, exec.UnforceCalls);
+        Assert.Equal("unforce", Assert.Single(exec.AuditRecords).Action);
+    }
+
+    [Fact]
+    public void NoCaller_ForceUnforce_OnlyReferencedInRemediationCore()
+    {
+        var dashboardDir = FindDashboardSourceDir();
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(dashboardDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(dashboardDir, file).Replace('\\', '/');
+            if (rel.StartsWith("bin/") || rel.StartsWith("obj/"))
+                continue;
+
+            var allowed =
+                rel.StartsWith("Services/Remediation/") ||
+                rel == "Services/DatabaseService.Remediation.cs";
+            if (allowed)
+                continue;
+
+            var text = File.ReadAllText(file);
+            if (text.Contains("ForcePlanAsync") || text.Contains("UnforcePlanAsync"))
+                offenders.Add(rel);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "No MCP/menu/command surface may reach ForcePlanAsync/UnforcePlanAsync in PR-A. Offending files: " +
+            string.Join(", ", offenders));
+    }
+
+    private static string FindDashboardSourceDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Dashboard", "Services", "Remediation", "ForcePlanHandler.cs");
+            if (File.Exists(candidate))
+                return Path.Combine(dir.FullName, "Dashboard");
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the Dashboard source directory from " + AppContext.BaseDirectory);
+    }
+
+    private sealed class FakeExecutor : IRemediationExecutor
+    {
+        public bool AuditTableExists = true;
+        public bool PriorForce = true;
+        public bool AuditWriteResult = true;
+        public Func<string, long, long, TargetPreflight>? PreflightFunc;
+        public Func<string, long, long, ForcePlanOutcome>? ForceFunc;
+        public Func<string, long, long, ForcePlanOutcome>? UnforceFunc;
+
+        public int ForceCalls;
+        public int UnforceCalls;
+        public readonly List<RemediationAuditRecord> AuditRecords = new();
+
+        public Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(PreflightFunc?.Invoke(database, queryId, planId) ?? new TargetPreflight
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                CurrentDatabase = database, HasAlter = true, QueryStoreState = "READ_WRITE", PlanPresent = true
+            });
+
+        public Task<bool> AuditTableExistsAsync(CancellationToken ct) => Task.FromResult(AuditTableExists);
+
+        public Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(PriorForce);
+
+        public Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+        {
+            ForceCalls++;
+            return Task.FromResult(ForceFunc?.Invoke(database, queryId, planId) ?? new ForcePlanOutcome
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "sa", GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+        {
+            UnforceCalls++;
+            return Task.FromResult(UnforceFunc?.Invoke(database, queryId, planId) ?? new ForcePlanOutcome
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "sa", GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
+        {
+            AuditRecords.Add(record);
+            return Task.FromResult(AuditWriteResult);
+        }
+    }
+}

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -71,7 +71,15 @@ SET NUMERIC_ROUNDABORT OFF;";
             await connection.OpenAsync(ct).ConfigureAwait(false);
             await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
 
-            var gate = await ReadGateAsync(connection, queryId, planId, ct).ConfigureAwait(false);
+            // Identity + permission first, using only always-accessible intrinsics
+            // (DB_NAME/SUSER_SNAME/HAS_PERMS_BY_NAME). The Query Store catalog read is
+            // attempted only when ALTER is held and the DB matches — a least-privilege
+            // login lacks VIEW DATABASE STATE and would error reading those views, and
+            // for the display path the disposition is already decided by DB/ALTER.
+            var gate = await ReadGateIdentityAsync(connection, ct).ConfigureAwait(false);
+            if (gate.HasAlter && string.Equals(gate.CurrentDatabase, database, StringComparison.Ordinal))
+                await ReadQueryStoreStateAsync(connection, queryId, planId, gate, ct).ConfigureAwait(false);
+
             return new TargetPreflight
             {
                 Database = database,
@@ -112,7 +120,8 @@ SET NUMERIC_ROUNDABORT OFF;";
             await connection.OpenAsync(ct).ConfigureAwait(false);
             await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
 
-            var gate = await ReadGateAsync(connection, queryId, planId, ct).ConfigureAwait(false);
+            // Gate part 1 — identity + permission, intrinsics only (always accessible).
+            var gate = await ReadGateIdentityAsync(connection, ct).ConfigureAwait(false);
 
             // (1) Correct-database assert (A5). Open with InitialCatalog normally
             // fails closed before here; this makes the wrong-DB boundary explicit.
@@ -123,12 +132,19 @@ SET NUMERIC_ROUNDABORT OFF;";
             }
 
             // (2) ALTER permission — fail closed with grant guidance, no elevation.
+            // Checked BEFORE any Query Store catalog read: a login lacking ALTER also
+            // typically lacks VIEW DATABASE STATE, so reading the QS views would throw
+            // before we could report this clean, actionable result.
             if (!gate.HasAlter)
             {
                 return Outcome(database, queryId, planId, RemediationStatus.PermissionDenied, forced: false, gate,
                     $"The monitoring login '{gate.ExecutingLogin}' lacks ALTER on '{database}'. " +
                     $"Map it into '{database}' (CREATE USER ... FOR LOGIN) and GRANT ALTER, or connect with a login that has it.");
             }
+
+            // Gate part 2 — Query Store state, on the SAME open connection (R2-MOD-1),
+            // only now that ALTER is confirmed.
+            await ReadQueryStoreStateAsync(connection, queryId, planId, gate, ct).ConfigureAwait(false);
 
             // (3) Freshness — plan present, Query Store forceable, current force state.
             if (!gate.PlanPresent)
@@ -211,10 +227,11 @@ SET NUMERIC_ROUNDABORT OFF;";
         };
 
         /// <summary>
-        /// One round-trip read of the per-target gate state on the supplied open
-        /// connection. The IDs are typed BigInt parameters; nothing is concatenated.
+        /// Gate part 1: identity + permission, using only always-accessible intrinsics
+        /// (DB_NAME / SUSER_SNAME / HAS_PERMS_BY_NAME / @@SPID). Safe for a
+        /// least-privilege login that cannot read the Query Store catalog views.
         /// </summary>
-        private static async Task<GateReading> ReadGateAsync(SqlConnection connection, long queryId, long planId, CancellationToken ct)
+        private static async Task<GateReading> ReadGateIdentityAsync(SqlConnection connection, CancellationToken ct)
         {
             using var command = connection.CreateCommand();
             command.CommandTimeout = RemediationCommandTimeoutSeconds;
@@ -223,13 +240,7 @@ SELECT
     current_db = DB_NAME(),
     executing_login = SUSER_SNAME(),
     has_alter = HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER'),
-    qs_state = (SELECT TOP (1) dqso.actual_state_desc FROM sys.database_query_store_options AS dqso),
-    plan_present = CASE WHEN EXISTS (SELECT 1 FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id) THEN 1 ELSE 0 END,
-    is_forced = ISNULL((SELECT TOP (1) CONVERT(int, qsp.is_forced_plan) FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0),
-    force_failure_count = ISNULL((SELECT TOP (1) qsp.force_failure_count FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0),
     spid = @@SPID;";
-            command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = queryId });
-            command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = planId });
 
             using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
             if (!await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -240,24 +251,53 @@ SELECT
                 CurrentDatabase = reader.IsDBNull(0) ? null : reader.GetString(0),
                 ExecutingLogin = reader.IsDBNull(1) ? null : reader.GetString(1),
                 HasAlter = !reader.IsDBNull(2) && reader.GetInt32(2) == 1,
-                QueryStoreState = reader.IsDBNull(3) ? null : reader.GetString(3),
-                PlanPresent = !reader.IsDBNull(4) && reader.GetInt32(4) == 1,
-                IsForcedPlan = !reader.IsDBNull(5) && reader.GetInt32(5) == 1,
-                ForceFailureCount = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
-                Spid = reader.IsDBNull(7) ? (int?)null : Convert.ToInt32(reader.GetInt16(7))
+                Spid = reader.IsDBNull(3) ? (int?)null : Convert.ToInt32(reader.GetInt16(3))
             };
+        }
+
+        /// <summary>
+        /// Gate part 2: Query Store freshness/state for the target, on the SAME open
+        /// connection. Reads sys.database_query_store_options / sys.query_store_plan
+        /// (requires VIEW DATABASE STATE), so it must only run after the ALTER check
+        /// has passed. Mutates <paramref name="gate"/> in place. The IDs are typed
+        /// BigInt parameters; nothing is concatenated.
+        /// </summary>
+        private static async Task ReadQueryStoreStateAsync(SqlConnection connection, long queryId, long planId, GateReading gate, CancellationToken ct)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandTimeout = RemediationCommandTimeoutSeconds;
+            command.CommandText = @"
+SELECT
+    qs_state = (SELECT TOP (1) dqso.actual_state_desc FROM sys.database_query_store_options AS dqso),
+    plan_present = CASE WHEN EXISTS (SELECT 1 FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id) THEN 1 ELSE 0 END,
+    is_forced = ISNULL((SELECT TOP (1) CONVERT(int, qsp.is_forced_plan) FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0),
+    force_failure_count = ISNULL((SELECT TOP (1) qsp.force_failure_count FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0);";
+            command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = queryId });
+            command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = planId });
+
+            using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                return;
+
+            gate.QueryStoreState = reader.IsDBNull(0) ? null : reader.GetString(0);
+            gate.PlanPresent = !reader.IsDBNull(1) && reader.GetInt32(1) == 1;
+            gate.IsForcedPlan = !reader.IsDBNull(2) && reader.GetInt32(2) == 1;
+            gate.ForceFailureCount = reader.IsDBNull(3) ? 0 : reader.GetInt64(3);
         }
 
         private sealed class GateReading
         {
+            // Part 1 (identity) — init-set at construction.
             public string? CurrentDatabase { get; init; }
             public string? ExecutingLogin { get; init; }
             public bool HasAlter { get; init; }
-            public string? QueryStoreState { get; init; }
-            public bool PlanPresent { get; init; }
-            public bool IsForcedPlan { get; init; }
-            public long ForceFailureCount { get; init; }
             public int? Spid { get; init; }
+
+            // Part 2 (Query Store state) — populated only after the ALTER check passes.
+            public string? QueryStoreState { get; set; }
+            public bool PlanPresent { get; set; }
+            public bool IsForcedPlan { get; set; }
+            public long ForceFailureCount { get; set; }
         }
     }
 }

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitorDashboard.Services.Remediation;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    /// <summary>
+    /// Narrow, purpose-built remediation execution methods. There is no general
+    /// SQL-exec API here: the IDs are always typed BigInt parameters and the
+    /// target database is applied ONLY as the connection's InitialCatalog, built
+    /// solely through <see cref="SqlConnectionStringBuilder"/> (never concatenated).
+    ///
+    /// <para>
+    /// These methods run under the EXISTING per-server monitoring connection
+    /// (<see cref="DatabaseService.ConnectionString"/>), retargeted to the user
+    /// database by catalog only. There is no elevated path: <c>UserID</c>/
+    /// <c>Password</c> are never set from any prompt and no credential is captured.
+    /// They are <c>internal</c> and reachable only through
+    /// <see cref="Remediation.DatabaseServiceRemediationExecutor"/>; nothing in the
+    /// MCP or menu/command surface calls them (verified by a no-caller test).
+    /// </para>
+    /// </summary>
+    public partial class DatabaseService
+    {
+        private const int RemediationCommandTimeoutSeconds = 30;
+
+        /*
+        sp_query_store_force_plan requires the standard ANSI SET options (it touches
+        Query Store internals that error 1934 without them). Microsoft.Data.SqlClient
+        opens connections with ARITHABORT OFF by default, so we set the full block
+        explicitly right after opening, matching install/_template.sql. SET options are
+        session-scoped, so they persist for the gate read AND the EXEC on the same
+        connection — no re-open, R2-MOD-1 intact.
+        */
+        private const string RemediationSetOptions = @"
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;";
+
+        private static async Task ApplySessionOptionsAsync(SqlConnection connection, CancellationToken ct)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandTimeout = RemediationCommandTimeoutSeconds;
+            command.CommandText = RemediationSetOptions;
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Read-only display probe (advisory only). Opens its own retargeted
+        /// connection; it is NOT the authoritative gate.
+        /// </summary>
+        internal async Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+        {
+            var builder = new SqlConnectionStringBuilder(_connectionString) { InitialCatalog = database };
+            using var connection = new SqlConnection(builder.ConnectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            var gate = await ReadGateAsync(connection, queryId, planId, ct).ConfigureAwait(false);
+            return new TargetPreflight
+            {
+                Database = database,
+                QueryId = queryId,
+                PlanId = planId,
+                ExecutingLogin = gate.ExecutingLogin,
+                CurrentDatabase = gate.CurrentDatabase,
+                HasAlter = gate.HasAlter,
+                QueryStoreState = gate.QueryStoreState,
+                PlanPresent = gate.PlanPresent,
+                IsForcedPlan = gate.IsForcedPlan,
+                ForceFailureCount = gate.ForceFailureCount
+            };
+        }
+
+        /// <summary>
+        /// Self-gating force. R2-MOD-1: the gate (DB_NAME assert + ALTER check +
+        /// freshness) and the <c>sp_query_store_force_plan</c> EXEC run on ONE open
+        /// retargeted connection with no re-open between them. <see cref="ForcePlanOutcome.GateSpid"/>
+        /// and <see cref="ForcePlanOutcome.ExecSpid"/> are emitted so a caller can
+        /// prove the gate and the mutation shared the same SPID.
+        /// </summary>
+        internal Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => ForceOrUnforceAsync(database, queryId, planId, isUnforce: false, ct);
+
+        /// <summary>Self-gating inverse of <see cref="ForcePlanAsync"/>.</summary>
+        internal Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => ForceOrUnforceAsync(database, queryId, planId, isUnforce: true, ct);
+
+        private async Task<ForcePlanOutcome> ForceOrUnforceAsync(string database, long queryId, long planId, bool isUnforce, CancellationToken ct)
+        {
+            var builder = new SqlConnectionStringBuilder(_connectionString) { InitialCatalog = database };
+
+            // ONE connection for the whole gate + mutation. No re-open between the
+            // gate read and the EXEC — this is what makes the gate unbypassable and
+            // closes the preflight→apply TOCTOU (R2-MOD-1).
+            using var connection = new SqlConnection(builder.ConnectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            var gate = await ReadGateAsync(connection, queryId, planId, ct).ConfigureAwait(false);
+
+            // (1) Correct-database assert (A5). Open with InitialCatalog normally
+            // fails closed before here; this makes the wrong-DB boundary explicit.
+            if (!string.Equals(gate.CurrentDatabase, database, StringComparison.Ordinal))
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.Blocked, forced: false, gate,
+                    $"Connected database '{gate.CurrentDatabase}' does not match target '{database}'; no change made.");
+            }
+
+            // (2) ALTER permission — fail closed with grant guidance, no elevation.
+            if (!gate.HasAlter)
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.PermissionDenied, forced: false, gate,
+                    $"The monitoring login '{gate.ExecutingLogin}' lacks ALTER on '{database}'. " +
+                    $"Map it into '{database}' (CREATE USER ... FOR LOGIN) and GRANT ALTER, or connect with a login that has it.");
+            }
+
+            // (3) Freshness — plan present, Query Store forceable, current force state.
+            if (!gate.PlanPresent)
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.Skipped, forced: false, gate,
+                    "The plan/query is no longer present in Query Store — the suggestion may be superseded.");
+            }
+            if (!string.Equals(gate.QueryStoreState, "READ_WRITE", StringComparison.OrdinalIgnoreCase))
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.Skipped, forced: false, gate,
+                    $"Query Store is '{gate.QueryStoreState}' (not READ_WRITE) on '{database}' — forcing is not possible.");
+            }
+
+            if (!isUnforce && gate.IsForcedPlan)
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.Skipped, forced: false, gate,
+                    "Already forced to this plan — nothing to do.");
+            }
+            if (isUnforce && !gate.IsForcedPlan)
+            {
+                return Outcome(database, queryId, planId, RemediationStatus.Skipped, forced: false, gate,
+                    "This plan is not currently forced — nothing to unforce.");
+            }
+
+            string? warning = null;
+            if (!isUnforce && gate.ForceFailureCount > 0)
+            {
+                // Warn-and-proceed (the operator has confirmed the apply). Re-forcing
+                // a failing plan may not help; the warning rides the outcome message.
+                warning = $"Note: force_failure_count was {gate.ForceFailureCount}; re-forcing may not help.";
+            }
+
+            // Gate passed — issue the mutation on the SAME open connection.
+            var proc = isUnforce ? "sys.sp_query_store_unforce_plan" : "sys.sp_query_store_force_plan";
+            int? execSpid;
+            try
+            {
+                using var exec = connection.CreateCommand();
+                exec.CommandTimeout = RemediationCommandTimeoutSeconds;
+                exec.CommandText = $"EXEC {proc} @query_id = @query_id, @plan_id = @plan_id; SELECT exec_spid = @@SPID;";
+                exec.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = queryId });
+                exec.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = planId });
+                var raw = await exec.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                execSpid = raw is null || raw is DBNull ? (int?)null : Convert.ToInt32(raw);
+            }
+            catch (SqlException ex)
+            {
+                var status = ex.Number is 297 or 15247 or 229 ? RemediationStatus.PermissionDenied : RemediationStatus.Error;
+                return Outcome(database, queryId, planId, status, forced: false, gate,
+                    $"sp_query_store_{(isUnforce ? "unforce" : "force")}_plan failed (error {ex.Number}): {ex.Message}");
+            }
+
+            var verb = isUnforce ? "Unforced" : "Forced";
+            var message = warning is null ? $"{verb} plan {planId} for query {queryId}." : $"{verb} plan {planId} for query {queryId}. {warning}";
+            return new ForcePlanOutcome
+            {
+                Database = database,
+                QueryId = queryId,
+                PlanId = planId,
+                Status = RemediationStatus.Success,
+                Forced = true,
+                ExecutingLogin = gate.ExecutingLogin,
+                Message = message,
+                GateSpid = gate.Spid,
+                ExecSpid = execSpid
+            };
+        }
+
+        private static ForcePlanOutcome Outcome(string database, long queryId, long planId, RemediationStatus status, bool forced, GateReading gate, string message) => new()
+        {
+            Database = database,
+            QueryId = queryId,
+            PlanId = planId,
+            Status = status,
+            Forced = forced,
+            ExecutingLogin = gate.ExecutingLogin,
+            Message = message,
+            GateSpid = gate.Spid,
+            ExecSpid = null
+        };
+
+        /// <summary>
+        /// One round-trip read of the per-target gate state on the supplied open
+        /// connection. The IDs are typed BigInt parameters; nothing is concatenated.
+        /// </summary>
+        private static async Task<GateReading> ReadGateAsync(SqlConnection connection, long queryId, long planId, CancellationToken ct)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandTimeout = RemediationCommandTimeoutSeconds;
+            command.CommandText = @"
+SELECT
+    current_db = DB_NAME(),
+    executing_login = SUSER_SNAME(),
+    has_alter = HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER'),
+    qs_state = (SELECT TOP (1) dqso.actual_state_desc FROM sys.database_query_store_options AS dqso),
+    plan_present = CASE WHEN EXISTS (SELECT 1 FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id) THEN 1 ELSE 0 END,
+    is_forced = ISNULL((SELECT TOP (1) CONVERT(int, qsp.is_forced_plan) FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0),
+    force_failure_count = ISNULL((SELECT TOP (1) qsp.force_failure_count FROM sys.query_store_plan AS qsp WHERE qsp.query_id = @query_id AND qsp.plan_id = @plan_id), 0),
+    spid = @@SPID;";
+            command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = queryId });
+            command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = planId });
+
+            using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                return new GateReading();
+
+            return new GateReading
+            {
+                CurrentDatabase = reader.IsDBNull(0) ? null : reader.GetString(0),
+                ExecutingLogin = reader.IsDBNull(1) ? null : reader.GetString(1),
+                HasAlter = !reader.IsDBNull(2) && reader.GetInt32(2) == 1,
+                QueryStoreState = reader.IsDBNull(3) ? null : reader.GetString(3),
+                PlanPresent = !reader.IsDBNull(4) && reader.GetInt32(4) == 1,
+                IsForcedPlan = !reader.IsDBNull(5) && reader.GetInt32(5) == 1,
+                ForceFailureCount = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                Spid = reader.IsDBNull(7) ? (int?)null : Convert.ToInt32(reader.GetInt16(7))
+            };
+        }
+
+        private sealed class GateReading
+        {
+            public string? CurrentDatabase { get; init; }
+            public string? ExecutingLogin { get; init; }
+            public bool HasAlter { get; init; }
+            public string? QueryStoreState { get; init; }
+            public bool PlanPresent { get; init; }
+            public bool IsForcedPlan { get; init; }
+            public long ForceFailureCount { get; init; }
+            public int? Spid { get; init; }
+        }
+    }
+}

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -235,11 +235,18 @@ SET NUMERIC_ROUNDABORT OFF;";
         {
             using var command = connection.CreateCommand();
             command.CommandTimeout = RemediationCommandTimeoutSeconds;
+            // HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'ALTER') is the DB-scoped form:
+            // it returns 1 for a principal holding ALTER on the connected database
+            // (incl. sysadmin / db_owner) and 0 otherwise. The (NULL, NULL, 'ALTER')
+            // server-scoped form the plan's O5 specified returns NULL even for
+            // sysadmin — verified against sql2022 — so it would fail closed for every
+            // login. DB_NAME() (not a literal) keeps it correct after the catalog
+            // retarget. This is the permission sp_query_store_force_plan actually needs.
             command.CommandText = @"
 SELECT
     current_db = DB_NAME(),
     executing_login = SUSER_SNAME(),
-    has_alter = HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER'),
+    has_alter = CONVERT(int, ISNULL(HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'ALTER'), 0)),
     spid = @@SPID;";
 
             using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);

--- a/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// The production <see cref="IRemediationExecutor"/>: forces/unforces and
+    /// preflights through the per-server <see cref="DatabaseService"/> (retargeted
+    /// user-DB connection), and audits through a <see cref="RemediationAuditWriter"/>
+    /// over the same per-server monitoring connection. Holds no credential of its
+    /// own — it reuses the existing monitoring connection string.
+    /// </summary>
+    public sealed class DatabaseServiceRemediationExecutor : IRemediationExecutor
+    {
+        private readonly DatabaseService _databaseService;
+        private readonly RemediationAuditWriter _auditWriter;
+
+        public DatabaseServiceRemediationExecutor(DatabaseService databaseService)
+        {
+            _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+            _auditWriter = new RemediationAuditWriter(databaseService.ConnectionString);
+        }
+
+        public Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+            => _databaseService.PreflightForcePlanAsync(database, queryId, planId, ct);
+
+        public Task<bool> AuditTableExistsAsync(CancellationToken ct)
+            => _auditWriter.TableExistsAsync(ct);
+
+        public Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct)
+            => _auditWriter.HasPriorForceAsync(database, queryId, planId, ct);
+
+        public Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => _databaseService.ForcePlanAsync(database, queryId, planId, identity, ct);
+
+        public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => _databaseService.UnforcePlanAsync(database, queryId, planId, identity, ct);
+
+        public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
+            => _auditWriter.WriteAsync(record, ct);
+    }
+}

--- a/Dashboard/Services/Remediation/ForcePlanHandler.cs
+++ b/Dashboard/Services/Remediation/ForcePlanHandler.cs
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Handler for PLAN_REGRESSION findings: forces / unforces a Query Store plan
+    /// via <c>sp_query_store_force_plan</c> / <c>sp_query_store_unforce_plan</c>,
+    /// one target at a time, never an opaque batch.
+    ///
+    /// <para>
+    /// The privileged path is structurally self-gating: <see cref="ApplyAsync"/>
+    /// takes no preflight disposition and does not trust one. Before any mutation
+    /// it (1) hard-blocks every target if the audit table is absent (no mutation),
+    /// then (2) for each target delegates to the executor, which re-derives the
+    /// authoritative gate (correct DB + ALTER + freshness) and the EXEC on one
+    /// connection. One audit row is written per attempt — success, skip, error, or
+    /// abort.
+    /// </para>
+    /// </summary>
+    public sealed class ForcePlanHandler : IRemediationHandler
+    {
+        public string FactKey => "PLAN_REGRESSION";
+
+        // Force-plan is reversible (unforce backs it out), so it is not a
+        // destructive action and does not require the typed-confirm hook.
+        public bool IsDestructive => false;
+
+        public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+
+            var targets = new List<TargetPreflight>();
+            foreach (var t in action.Targets)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                TargetPreflight pf;
+                try
+                {
+                    pf = await exec.PreflightForcePlanAsync(t.Database, t.QueryId, t.PlanId, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    pf = new TargetPreflight
+                    {
+                        Database = t.Database,
+                        QueryId = t.QueryId,
+                        PlanId = t.PlanId,
+                        Disposition = RemediationDisposition.Error,
+                        Message = ex.Message
+                    };
+                    targets.Add(pf);
+                    continue;
+                }
+
+                // Audit-table-absent is a server-wide hard block; it overrides any
+                // per-target disposition because no apply can be audited there.
+                if (!auditTableExists)
+                {
+                    pf.Disposition = RemediationDisposition.BlockAuditTableAbsent;
+                    pf.Message = AuditAbsentMessage;
+                }
+                else
+                {
+                    pf.Disposition = ClassifyPreflight(pf, t.Database);
+                    pf.Message ??= DispositionMessage(pf.Disposition, t.Database);
+                }
+
+                targets.Add(pf);
+            }
+
+            return new PreflightResult { Targets = targets, AuditTableExists = auditTableExists };
+        }
+
+        public Task<ApplyResult> ApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+            => RunAsync(action, exec, identity, isUnapply: false, ct);
+
+        public Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+            => RunAsync(action, exec, identity, isUnapply: true, ct);
+
+        private async Task<ApplyResult> RunAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, bool isUnapply, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+            if (identity is null) throw new ArgumentNullException(nameof(identity));
+
+            var actionVerb = isUnapply ? "unforce" : "force";
+            var outcomes = new List<TargetOutcome>();
+
+            // R2-MOD-2: audit-table-absent is a HARD BLOCK before any mutation.
+            // No sp_query_store_force_plan/unforce is attempted; no audit row is
+            // written (there is nowhere to write it). This makes "applied-but-
+            // unlogged" impossible on an un-upgraded server.
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+            if (!auditTableExists)
+            {
+                foreach (var t in action.Targets)
+                {
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        QueryId = t.QueryId,
+                        PlanId = t.PlanId,
+                        Status = RemediationStatus.Blocked,
+                        Message = AuditAbsentMessage,
+                        AuditWritten = false,
+                        AppliedButUnlogged = false
+                    });
+                }
+                return new ApplyResult { Outcomes = outcomes };
+            }
+
+            foreach (var t in action.Targets)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    // Un-apply is restricted to targets B3 itself forced (and that
+                    // are not already unforced) — never undo something we did not do.
+                    if (isUnapply)
+                    {
+                        var priorForce = await exec.HasPriorForceAsync(t.Database, t.QueryId, t.PlanId, ct).ConfigureAwait(false);
+                        if (!priorForce)
+                        {
+                            var skip = new TargetOutcome
+                            {
+                                Database = t.Database,
+                                QueryId = t.QueryId,
+                                PlanId = t.PlanId,
+                                Status = RemediationStatus.Skipped,
+                                Message = "No prior Apply-Fix force for this target to undo.",
+                                AuditWritten = false,
+                                AppliedButUnlogged = false
+                            };
+                            // Audit the skip so the log reflects the attempt.
+                            var skipWritten = await WriteAudit(exec, identity, t, actionVerb, RemediationStatus.Skipped, skip.Message, executingLogin: null, ct).ConfigureAwait(false);
+                            outcomes.Add(WithAudit(skip, skipWritten, appliedButUnlogged: false));
+                            continue;
+                        }
+                    }
+
+                    var outcome = isUnapply
+                        ? await exec.UnforcePlanAsync(t.Database, t.QueryId, t.PlanId, identity, ct).ConfigureAwait(false)
+                        : await exec.ForcePlanAsync(t.Database, t.QueryId, t.PlanId, identity, ct).ConfigureAwait(false);
+
+                    var written = await WriteAudit(exec, identity, t, actionVerb, outcome.Status, outcome.Message, outcome.ExecutingLogin, ct).ConfigureAwait(false);
+
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        QueryId = t.QueryId,
+                        PlanId = t.PlanId,
+                        Status = outcome.Status,
+                        Message = outcome.Message,
+                        ExecutingLogin = outcome.ExecutingLogin,
+                        AuditWritten = written,
+                        // O3: a real mutation that we failed to log against a present table.
+                        AppliedButUnlogged = outcome.Forced && !written
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Per-target independence: one target's failure never aborts the rest.
+                    var written = await TryWriteAuditSafe(exec, identity, t, actionVerb, RemediationStatus.Error, ex.Message, ct).ConfigureAwait(false);
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        QueryId = t.QueryId,
+                        PlanId = t.PlanId,
+                        Status = RemediationStatus.Error,
+                        Message = ex.Message,
+                        AuditWritten = written,
+                        AppliedButUnlogged = false
+                    });
+                }
+            }
+
+            return new ApplyResult { Outcomes = outcomes };
+        }
+
+        private static async Task<bool> WriteAudit(
+            IRemediationExecutor exec,
+            RemediationIdentity identity,
+            ForcePlanTarget target,
+            string actionVerb,
+            RemediationStatus status,
+            string? message,
+            string? executingLogin,
+            CancellationToken ct)
+        {
+            var record = new RemediationAuditRecord
+            {
+                OperatorIdentity = identity.OperatorIdentity,
+                ExecutingLogin = executingLogin,
+                TargetDatabase = target.Database,
+                FactKey = "PLAN_REGRESSION",
+                QueryId = target.QueryId,
+                PlanId = target.PlanId,
+                Action = actionVerb,
+                GeneratedSql = GeneratedSql(actionVerb, target.QueryId, target.PlanId),
+                Result = AuditResult(status),
+                ErrorMessage = status is RemediationStatus.Error or RemediationStatus.PermissionDenied or RemediationStatus.Blocked ? message : null,
+                SourceAlertRef = identity.SourceAlertRef
+            };
+
+            return await exec.WriteAuditAsync(record, ct).ConfigureAwait(false);
+        }
+
+        private static async Task<bool> TryWriteAuditSafe(
+            IRemediationExecutor exec,
+            RemediationIdentity identity,
+            ForcePlanTarget target,
+            string actionVerb,
+            RemediationStatus status,
+            string? message,
+            CancellationToken ct)
+        {
+            try
+            {
+                return await WriteAudit(exec, identity, target, actionVerb, status, message, executingLogin: null, ct).ConfigureAwait(false);
+            }
+            catch
+            {
+                // The audit write itself threw while handling a target error — do
+                // not let it mask the original per-target error outcome.
+                return false;
+            }
+        }
+
+        private static TargetOutcome WithAudit(TargetOutcome o, bool written, bool appliedButUnlogged) => new()
+        {
+            Database = o.Database,
+            QueryId = o.QueryId,
+            PlanId = o.PlanId,
+            Status = o.Status,
+            Message = o.Message,
+            ExecutingLogin = o.ExecutingLogin,
+            AuditWritten = written,
+            AppliedButUnlogged = appliedButUnlogged
+        };
+
+        private static string GeneratedSql(string actionVerb, long queryId, long planId)
+        {
+            var proc = actionVerb == "unforce" ? "sp_query_store_unforce_plan" : "sp_query_store_force_plan";
+            return $"EXEC sys.{proc} @query_id = {queryId}, @plan_id = {planId};";
+        }
+
+        private static string AuditResult(RemediationStatus status) => status switch
+        {
+            RemediationStatus.Success => "success",
+            RemediationStatus.Skipped => "skipped",
+            RemediationStatus.PermissionDenied => "skipped",
+            RemediationStatus.Blocked => "aborted",
+            RemediationStatus.Error => "error",
+            _ => "error"
+        };
+
+        private static RemediationDisposition ClassifyPreflight(TargetPreflight pf, string expectedDatabase)
+        {
+            if (!string.Equals(pf.CurrentDatabase, expectedDatabase, StringComparison.Ordinal))
+                return RemediationDisposition.BlockWrongDatabase;
+            if (!pf.HasAlter)
+                return RemediationDisposition.BlockNoAlter;
+            if (!string.Equals(pf.QueryStoreState, "READ_WRITE", StringComparison.OrdinalIgnoreCase))
+                return RemediationDisposition.BlockQueryStoreOff;
+            if (!pf.PlanPresent)
+                return RemediationDisposition.BlockStale;
+            if (pf.IsForcedPlan)
+                return RemediationDisposition.AlreadyForced;
+            if (pf.ForceFailureCount > 0)
+                return RemediationDisposition.WarnFailing;
+            return RemediationDisposition.Ok;
+        }
+
+        private static string DispositionMessage(RemediationDisposition d, string database) => d switch
+        {
+            RemediationDisposition.Ok => "Ready to apply.",
+            RemediationDisposition.AlreadyForced => "Already forced to this plan — nothing to do.",
+            RemediationDisposition.WarnFailing => "This plan has a non-zero force_failure_count; re-forcing may not help. Review sys.query_store_plan force_failure_reason.",
+            RemediationDisposition.BlockQueryStoreOff => "Query Store is not READ_WRITE on this database — forcing is not possible.",
+            RemediationDisposition.BlockStale => "The plan/query is no longer present in Query Store — the suggestion may be superseded.",
+            RemediationDisposition.BlockNoAlter => NoAlterMessage(database),
+            RemediationDisposition.BlockWrongDatabase => "Connected database does not match the target — apply will not proceed.",
+            RemediationDisposition.BlockAuditTableAbsent => AuditAbsentMessage,
+            _ => "Unable to determine target state."
+        };
+
+        private static string NoAlterMessage(string database) =>
+            $"The monitoring login lacks ALTER on {database}. Map the monitoring login into {database} " +
+            $"(CREATE USER [login] FOR LOGIN [login];) and GRANT ALTER — the same map-then-grant pattern " +
+            $"the README documents for FinOps Index Analysis (it grants reads; Apply Fix needs ALTER) — or " +
+            $"connect with a login that already has it. No elevation prompt is offered.";
+
+        private const string AuditAbsentMessage =
+            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+    }
+}

--- a/Dashboard/Services/Remediation/IRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/IRemediationExecutor.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// The narrow, purpose-built seam between a remediation handler and the
+    /// privileged server access. There is deliberately NO general
+    /// <c>Execute(sql)</c> method: every member is a single, typed operation.
+    ///
+    /// <para>
+    /// The authoritative gate lives inside <see cref="ForcePlanAsync"/> /
+    /// <see cref="UnforcePlanAsync"/>: each opens ONE retargeted connection, runs
+    /// the correct-database assert, the ALTER permission check, and the freshness
+    /// probe on that same open connection, and only then issues the EXEC — no
+    /// re-open between gate and mutation (R2-MOD-1). A handler cannot hand these
+    /// methods a forged "all-clear"; the gate is re-derived internally every call.
+    /// <see cref="PreflightForcePlanAsync"/> is the DISPLAY driver only.
+    /// </para>
+    /// </summary>
+    public interface IRemediationExecutor
+    {
+        /// <summary>
+        /// Read-only display probe for one target (permission, Query Store state,
+        /// freshness, executing login, connected database). Advisory only — does
+        /// NOT authorise a mutation.
+        /// </summary>
+        Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct);
+
+        /// <summary>
+        /// Whether <c>config.remediation_action_log</c> exists on the MONITORING
+        /// connection (PerformanceMonitor DB). When false, apply is hard-blocked
+        /// before any mutation (R2-MOD-2).
+        /// </summary>
+        Task<bool> AuditTableExistsAsync(CancellationToken ct);
+
+        /// <summary>
+        /// Whether a prior successful <c>force</c> for this target was recorded and
+        /// not since unforced — used to restrict un-apply to actions B3 itself
+        /// applied. Queried on the MONITORING connection.
+        /// </summary>
+        Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct);
+
+        /// <summary>
+        /// Self-gating force. Opens one retargeted connection, runs the gate
+        /// (DB_NAME assert + HAS_PERMS_BY_NAME(ALTER) + freshness) and — only if it
+        /// passes — the <c>sp_query_store_force_plan</c> EXEC, on that same open
+        /// connection.
+        /// </summary>
+        Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>Self-gating inverse of <see cref="ForcePlanAsync"/> (sp_query_store_unforce_plan).</summary>
+        Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>
+        /// Writes one audit row on the MONITORING connection. Returns false if the
+        /// INSERT failed against a present table (the O3 applied-but-unlogged case);
+        /// the absent-table case never reaches here (hard-blocked earlier).
+        /// </summary>
+        Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct);
+    }
+}

--- a/Dashboard/Services/Remediation/IRemediationHandler.cs
+++ b/Dashboard/Services/Remediation/IRemediationHandler.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// A per-fact-type remediation handler. Translates a structured
+    /// <see cref="RemediationAction"/> into read-only preflight and typed,
+    /// per-target apply/unapply operations through an <see cref="IRemediationExecutor"/>.
+    ///
+    /// <para>
+    /// <see cref="ApplyAsync"/> / <see cref="UnapplyAsync"/> take NO preflight
+    /// result — they cannot be handed a forged "all-clear"; the authoritative gate
+    /// is re-derived per target via the executor (which gates on a single
+    /// connection, R2-MOD-1). Preflight is advisory display only.
+    /// </para>
+    /// </summary>
+    public interface IRemediationHandler
+    {
+        /// <summary>Registry key; matches <see cref="RemediationAction.FactKey"/>.</summary>
+        string FactKey { get; }
+
+        /// <summary>
+        /// Whether the action destroys/loses state (gates the typed-confirm UI in
+        /// PR-B). The v1 force-plan is reversible, so this is false.
+        /// </summary>
+        bool IsDestructive { get; }
+
+        /// <summary>Read-only, per-target disposition for the UI. Advisory.</summary>
+        Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct);
+
+        /// <summary>
+        /// Structured, per-target apply. Hard-blocks every target when the audit
+        /// table is absent (no mutation). Otherwise applies one target at a time,
+        /// re-gated by the executor, and writes one audit row per attempt.
+        /// </summary>
+        Task<ApplyResult> ApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>Inverse of <see cref="ApplyAsync"/>, restricted to targets B3 itself applied.</summary>
+        Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct);
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationAuditWriter.cs
+++ b/Dashboard/Services/Remediation/RemediationAuditWriter.cs
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Persists remediation audit rows to <c>config.remediation_action_log</c> on
+    /// the MONITORING connection (the PerformanceMonitor DB), NOT the retargeted
+    /// user-DB connection. Also answers the two monitoring-side gate questions:
+    /// whether the audit table exists at all (A1 / R2-MOD-2) and whether a prior
+    /// B3 force exists for a target (so un-apply only undoes what B3 applied).
+    /// </summary>
+    public sealed class RemediationAuditWriter
+    {
+        private readonly string _monitoringConnectionString;
+
+        public RemediationAuditWriter(string monitoringConnectionString)
+        {
+            _monitoringConnectionString = monitoringConnectionString;
+        }
+
+        /// <summary>
+        /// True when <c>config.remediation_action_log</c> exists. The connection
+        /// uses the monitoring connection string as-is (InitialCatalog =
+        /// PerformanceMonitor), built only from the existing connection string.
+        /// </summary>
+        public async Task<bool> TableExistsAsync(CancellationToken ct)
+        {
+            using var connection = new SqlConnection(_monitoringConnectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT object_id = OBJECT_ID(N'config.remediation_action_log', N'U');";
+            var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+            return result is not null && result is not DBNull;
+        }
+
+        /// <summary>
+        /// True when a successful <c>force</c> for this target has been recorded and
+        /// not since matched by a successful <c>unforce</c>.
+        /// </summary>
+        public async Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct)
+        {
+            using var connection = new SqlConnection(_monitoringConnectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT has_prior_force =
+    CASE
+        WHEN
+        (
+            SELECT COUNT_BIG(*)
+            FROM config.remediation_action_log AS r
+            WHERE r.target_database = @target_database
+            AND   r.query_id = @query_id
+            AND   r.plan_id = @plan_id
+            AND   r.action = 'force'
+            AND   r.result = 'success'
+        )
+        >
+        (
+            SELECT COUNT_BIG(*)
+            FROM config.remediation_action_log AS r
+            WHERE r.target_database = @target_database
+            AND   r.query_id = @query_id
+            AND   r.plan_id = @plan_id
+            AND   r.action = 'unforce'
+            AND   r.result = 'success'
+        )
+        THEN 1
+        ELSE 0
+    END;";
+            command.Parameters.Add(new SqlParameter("@target_database", SqlDbType.NVarChar, 128) { Value = database });
+            command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = queryId });
+            command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = planId });
+
+            var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+            return result is not null && result is not DBNull && Convert.ToInt32(result) == 1;
+        }
+
+        /// <summary>
+        /// Writes one audit row (parameterized). Returns false if the INSERT fails
+        /// against a present table (the O3 applied-but-unlogged case) — it never
+        /// throws, so a logging failure cannot turn a successful mutation into a
+        /// reported error. Fills <see cref="RemediationAuditRecord.TargetServer"/>
+        /// from the connection's DataSource when the caller left it null.
+        /// </summary>
+        public async Task<bool> WriteAsync(RemediationAuditRecord record, CancellationToken ct)
+        {
+            try
+            {
+                using var connection = new SqlConnection(_monitoringConnectionString);
+                await connection.OpenAsync(ct).ConfigureAwait(false);
+
+                var targetServer = record.TargetServer
+                    ?? new SqlConnectionStringBuilder(_monitoringConnectionString).DataSource;
+
+                using var command = connection.CreateCommand();
+                command.CommandText = @"
+INSERT INTO
+    config.remediation_action_log
+(
+    operator_identity,
+    executing_login,
+    used_elevated_cred,
+    target_server,
+    target_database,
+    finding_fact_key,
+    query_id,
+    plan_id,
+    action,
+    generated_sql,
+    result,
+    error_message,
+    source_alert_ref
+)
+VALUES
+(
+    @operator_identity,
+    @executing_login,
+    0,
+    @target_server,
+    @target_database,
+    @finding_fact_key,
+    @query_id,
+    @plan_id,
+    @action,
+    @generated_sql,
+    @result,
+    @error_message,
+    @source_alert_ref
+);";
+                command.Parameters.Add(new SqlParameter("@operator_identity", SqlDbType.NVarChar, 256) { Value = (object?)record.OperatorIdentity ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@executing_login", SqlDbType.NVarChar, 128) { Value = (object?)record.ExecutingLogin ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@target_server", SqlDbType.NVarChar, 256) { Value = (object?)targetServer ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@target_database", SqlDbType.NVarChar, 128) { Value = record.TargetDatabase });
+                command.Parameters.Add(new SqlParameter("@finding_fact_key", SqlDbType.VarChar, 64) { Value = record.FactKey });
+                command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = record.QueryId });
+                command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = record.PlanId });
+                command.Parameters.Add(new SqlParameter("@action", SqlDbType.VarChar, 16) { Value = record.Action });
+                command.Parameters.Add(new SqlParameter("@generated_sql", SqlDbType.NVarChar, -1) { Value = (object?)record.GeneratedSql ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@result", SqlDbType.VarChar, 16) { Value = record.Result });
+                command.Parameters.Add(new SqlParameter("@error_message", SqlDbType.NVarChar, -1) { Value = (object?)record.ErrorMessage ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@source_alert_ref", SqlDbType.NVarChar, 256) { Value = (object?)record.SourceAlertRef ?? DBNull.Value });
+
+                var rows = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                return rows == 1;
+            }
+            catch (SqlException)
+            {
+                // O3: a transient INSERT failure against a present table. Surface as
+                // applied-but-unlogged; never roll back the (reversible) mutation.
+                return false;
+            }
+        }
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationHandlerRegistry.cs
+++ b/Dashboard/Services/Remediation/RemediationHandlerRegistry.cs
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Maps a finding's fact key to its remediation handler. A fact key with no
+    /// registered handler yields no Apply affordance (mirrors
+    /// <c>FactRemediation.BuildAction</c> returning null). v1 registers exactly
+    /// one handler: <see cref="ForcePlanHandler"/> for PLAN_REGRESSION.
+    /// </summary>
+    public sealed class RemediationHandlerRegistry
+    {
+        private readonly Dictionary<string, IRemediationHandler> _byKey;
+
+        public RemediationHandlerRegistry(IEnumerable<IRemediationHandler> handlers)
+        {
+            _byKey = new Dictionary<string, IRemediationHandler>(StringComparer.Ordinal);
+            foreach (var handler in handlers)
+            {
+                if (handler is null || string.IsNullOrEmpty(handler.FactKey))
+                    continue;
+                _byKey[handler.FactKey] = handler;
+            }
+        }
+
+        /// <summary>Returns the handler for the fact key, or null if none is registered.</summary>
+        public IRemediationHandler? TryGet(string? factKey)
+        {
+            if (string.IsNullOrEmpty(factKey))
+                return null;
+            return _byKey.TryGetValue(factKey, out var handler) ? handler : null;
+        }
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationIdentity.cs
+++ b/Dashboard/Services/Remediation/RemediationIdentity.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// The executing context an audit row records — NOT a credential carrier.
+    /// v1 has no in-app elevation: the force-plan runs under the existing
+    /// per-server monitoring connection, so this type holds no secret, no
+    /// password, and no <c>SqlCredential</c>. <see cref="OperatorIdentity"/> is
+    /// the OS / Windows user running the Dashboard (recorded as
+    /// <c>operator_identity</c>); the actual <c>executing_login</c> is re-probed
+    /// server-side via <c>SUSER_SNAME()</c> on the same connection that issues the
+    /// mutation. <see cref="SourceAlertRef"/> is an optional traceback handle
+    /// (the alert's metric name / story hash) for the audit row.
+    ///
+    /// <para>
+    /// Kept as a parameter on the handler/executor surface so the signatures stay
+    /// stable if a Phase-2 elevation path is ever added — but in v1 it carries
+    /// nothing privileged.
+    /// </para>
+    /// </summary>
+    public sealed record RemediationIdentity(string OperatorIdentity, string? SourceAlertRef = null);
+}

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>Outcome status for a single per-target apply/unapply attempt.</summary>
+    public enum RemediationStatus
+    {
+        /// <summary>The mutation ran and succeeded.</summary>
+        Success,
+
+        /// <summary>
+        /// No mutation needed or possible, but not an error: already forced, the
+        /// plan/query is gone (stale), or Query Store is not READ_WRITE. Audited
+        /// as <c>skipped</c>.
+        /// </summary>
+        Skipped,
+
+        /// <summary>
+        /// The gate refused the target before any mutation (e.g. the connected DB
+        /// is not the intended target, or the audit table is absent on the
+        /// monitoring server). Audited as <c>aborted</c>.
+        /// </summary>
+        Blocked,
+
+        /// <summary>
+        /// The monitoring login lacks ALTER on the target database. Fails closed
+        /// with grant guidance; no mutation, no elevation prompt. Audited as
+        /// <c>skipped</c>.
+        /// </summary>
+        PermissionDenied,
+
+        /// <summary>The mutation was attempted and the server raised an error.</summary>
+        Error
+    }
+
+    /// <summary>Advisory pre-execution disposition for the UI (display driver only).</summary>
+    public enum RemediationDisposition
+    {
+        Ok,
+        AlreadyForced,
+        WarnFailing,
+        BlockQueryStoreOff,
+        BlockStale,
+        BlockNoAlter,
+        BlockWrongDatabase,
+        BlockAuditTableAbsent,
+        Error
+    }
+
+    /// <summary>
+    /// Read-only preflight reading for one target (display driver only — never the
+    /// authoritative gate; <c>ApplyAsync</c> re-derives its own gate before any
+    /// mutation).
+    /// </summary>
+    public sealed class TargetPreflight
+    {
+        public string Database { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+        public string? ExecutingLogin { get; init; }
+        public string? CurrentDatabase { get; init; }
+        public bool HasAlter { get; init; }
+        public string? QueryStoreState { get; init; }
+        public bool PlanPresent { get; init; }
+        public bool IsForcedPlan { get; init; }
+        public long ForceFailureCount { get; init; }
+        public RemediationDisposition Disposition { get; set; }
+        public string? Message { get; set; }
+    }
+
+    /// <summary>Aggregate preflight result for an action (one entry per target).</summary>
+    public sealed class PreflightResult
+    {
+        public IReadOnlyList<TargetPreflight> Targets { get; init; } = new List<TargetPreflight>();
+
+        /// <summary>
+        /// Whether <c>config.remediation_action_log</c> exists on the monitoring
+        /// server. When false, every target is hard-blocked at apply time (no
+        /// mutation) — the server is on pre-2.12.0 schema.
+        /// </summary>
+        public bool AuditTableExists { get; init; }
+    }
+
+    /// <summary>
+    /// Outcome of a single executor force/unforce call. The executor runs the
+    /// authoritative gate and the EXEC on ONE open connection; <see cref="GateSpid"/>
+    /// and <see cref="ExecSpid"/> are the server SPID observed at the gate read and
+    /// at the mutation respectively — equal SPIDs prove the gate and the mutation
+    /// rode the same connection (R2-MOD-1).
+    /// </summary>
+    public sealed class ForcePlanOutcome
+    {
+        public string Database { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+        public RemediationStatus Status { get; init; }
+
+        /// <summary>True only when an EXEC actually ran and succeeded.</summary>
+        public bool Forced { get; init; }
+        public string? ExecutingLogin { get; init; }
+        public string? Message { get; init; }
+        public int? GateSpid { get; init; }
+        public int? ExecSpid { get; init; }
+    }
+
+    /// <summary>Per-target outcome of an apply/unapply, including the audit disposition.</summary>
+    public sealed class TargetOutcome
+    {
+        public string Database { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+        public RemediationStatus Status { get; init; }
+        public string? Message { get; init; }
+        public string? ExecutingLogin { get; init; }
+
+        /// <summary>Whether the audit row was written for this attempt.</summary>
+        public bool AuditWritten { get; init; }
+
+        /// <summary>
+        /// The force succeeded but the audit INSERT failed against a present table
+        /// (O3). Surfaced as a visible "applied-but-unlogged" warning; never the
+        /// un-upgraded-server default (that case is hard-blocked before mutation).
+        /// </summary>
+        public bool AppliedButUnlogged { get; init; }
+    }
+
+    /// <summary>Aggregate apply/unapply result (one entry per target).</summary>
+    public sealed class ApplyResult
+    {
+        public IReadOnlyList<TargetOutcome> Outcomes { get; init; } = new List<TargetOutcome>();
+    }
+
+    /// <summary>
+    /// One row to write to <c>config.remediation_action_log</c>. Built by the
+    /// handler for every attempt (success / skip / error / abort) and persisted on
+    /// the monitoring connection by the audit writer, which fills
+    /// <see cref="TargetServer"/> from the connection's DataSource when null.
+    /// </summary>
+    public sealed class RemediationAuditRecord
+    {
+        public string? OperatorIdentity { get; init; }
+        public string? ExecutingLogin { get; init; }
+        public string? TargetServer { get; set; }
+        public string TargetDatabase { get; init; } = "";
+        public string FactKey { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+        public string Action { get; init; } = "";          // "force" | "unforce"
+        public string? GeneratedSql { get; init; }
+        public string Result { get; init; } = "";          // "success" | "skipped" | "error" | "aborted"
+        public string? ErrorMessage { get; init; }
+        public string? SourceAlertRef { get; init; }
+    }
+}

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -42,10 +42,49 @@ public static class FactRemediation
         };
     }
 
-    private static string? GenerateForPlanRegression(AnalysisFinding finding)
+    /// <summary>
+    /// Builds the structured, typed remediation action for the finding, or null
+    /// if no execution shape applies. Mirrors <see cref="GenerateForFinding"/>'s
+    /// switch on <see cref="AnalysisFinding.RootFactKey"/>: PLAN_REGRESSION yields
+    /// a "force" action over the extracted targets (when any are valid); every
+    /// other fact key — including PARAMETER_SENSITIVITY — yields null (no handler,
+    /// no Apply affordance), consistent with the "do not force" advice.
+    /// </summary>
+    public static RemediationAction? BuildAction(AnalysisFinding finding)
     {
-        if (finding.DrillDown is null || !finding.DrillDown.TryGetValue("regressed_queries", out var raw) || raw is null)
+        if (finding is null || string.IsNullOrEmpty(finding.RootFactKey))
             return null;
+
+        switch (finding.RootFactKey)
+        {
+            case "PLAN_REGRESSION":
+                var targets = ExtractPlanRegressionTargets(finding);
+                return targets.Count == 0
+                    ? null
+                    : new RemediationAction("PLAN_REGRESSION", "force", targets);
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the typed force-plan targets from a PLAN_REGRESSION finding's
+    /// drill-down. This is the single parse: the preview renderer
+    /// (<see cref="GenerateForPlanRegression"/>) renders entirely from this list,
+    /// and <see cref="BuildAction"/> persists it. Applies the same guards as the
+    /// renderer always has — database non-empty, query_id &gt; 0, best_plan_id
+    /// &gt; 0 — and the same cap of 5 targets. Reads every value the preview
+    /// renders (including the two cpu/exec numbers) so the renderer needs no
+    /// second drill-down read.
+    /// </summary>
+    public static IReadOnlyList<ForcePlanTarget> ExtractPlanRegressionTargets(AnalysisFinding finding)
+    {
+        var targets = new List<ForcePlanTarget>();
+
+        if (finding?.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("regressed_queries", out var raw) ||
+            raw is null)
+            return targets;
 
         JsonElement element;
         try
@@ -54,18 +93,15 @@ public static class FactRemediation
         }
         catch
         {
-            return null;
+            return targets;
         }
 
         if (element.ValueKind != JsonValueKind.Array)
-            return null;
-
-        var sb = new StringBuilder();
-        var emitted = 0;
+            return targets;
 
         foreach (var row in element.EnumerateArray())
         {
-            if (emitted >= 5) break;
+            if (targets.Count >= 5) break;
             if (row.ValueKind != JsonValueKind.Object) continue;
 
             var database = GetString(row, "database");
@@ -74,33 +110,55 @@ public static class FactRemediation
             if (string.IsNullOrEmpty(database) || queryId <= 0 || bestPlanId <= 0)
                 continue;
 
-            var latestHash = GetString(row, "latest_plan_hash");
-            var bestHash = GetString(row, "best_plan_hash");
-            var latestCpu = GetDouble(row, "latest_cpu_per_exec_us");
-            var bestCpu = GetDouble(row, "best_cpu_per_exec_us");
-            var regressionFactor = GetDouble(row, "regression_factor");
+            targets.Add(new ForcePlanTarget(
+                Database: database,
+                QueryId: queryId,
+                PlanId: bestPlanId,
+                BestPlanHash: GetString(row, "best_plan_hash"),
+                LatestPlanHash: GetString(row, "latest_plan_hash"),
+                LatestCpuPerExecUs: GetDouble(row, "latest_cpu_per_exec_us"),
+                BestCpuPerExecUs: GetDouble(row, "best_cpu_per_exec_us"),
+                RegressionFactor: GetDouble(row, "regression_factor")));
+        }
 
+        return targets;
+    }
+
+    /// <summary>
+    /// Thin renderer over <see cref="ExtractPlanRegressionTargets"/>. The output
+    /// is byte-for-byte the same preview the inline parse produced before the
+    /// extract-once refactor (guarded by the render-stability golden test),
+    /// including the two "(cpu/exec ... us)" comment lines.
+    /// </summary>
+    private static string? GenerateForPlanRegression(AnalysisFinding finding)
+    {
+        var targets = ExtractPlanRegressionTargets(finding);
+        if (targets.Count == 0)
+            return null;
+
+        var sb = new StringBuilder();
+        var emitted = 0;
+
+        foreach (var target in targets)
+        {
             if (emitted > 0)
                 sb.AppendLine();
 
-            sb.AppendLine($"-- Database: {database}");
-            sb.AppendLine($"-- query_id = {queryId}, forcing plan_id = {bestPlanId}");
-            if (!string.IsNullOrEmpty(latestHash))
-                sb.AppendLine($"--   latest plan hash: {latestHash} (cpu/exec {latestCpu:F0} us)");
-            if (!string.IsNullOrEmpty(bestHash))
-                sb.AppendLine($"--   best plan hash:   {bestHash}   (cpu/exec {bestCpu:F0} us)");
-            sb.AppendLine($"--   regression factor: {regressionFactor:F1}x");
-            sb.AppendLine($"USE {QuoteName(database)};");
-            sb.AppendLine($"EXEC sys.sp_query_store_force_plan @query_id = {queryId}, @plan_id = {bestPlanId};");
+            sb.AppendLine($"-- Database: {target.Database}");
+            sb.AppendLine($"-- query_id = {target.QueryId}, forcing plan_id = {target.PlanId}");
+            if (!string.IsNullOrEmpty(target.LatestPlanHash))
+                sb.AppendLine($"--   latest plan hash: {target.LatestPlanHash} (cpu/exec {target.LatestCpuPerExecUs:F0} us)");
+            if (!string.IsNullOrEmpty(target.BestPlanHash))
+                sb.AppendLine($"--   best plan hash:   {target.BestPlanHash}   (cpu/exec {target.BestCpuPerExecUs:F0} us)");
+            sb.AppendLine($"--   regression factor: {target.RegressionFactor:F1}x");
+            sb.AppendLine($"USE {QuoteName(target.Database)};");
+            sb.AppendLine($"EXEC sys.sp_query_store_force_plan @query_id = {target.QueryId}, @plan_id = {target.PlanId};");
             sb.AppendLine();
             sb.AppendLine($"-- To back out:");
-            sb.AppendLine($"-- EXEC sys.sp_query_store_unforce_plan @query_id = {queryId}, @plan_id = {bestPlanId};");
+            sb.AppendLine($"-- EXEC sys.sp_query_store_unforce_plan @query_id = {target.QueryId}, @plan_id = {target.PlanId};");
 
             emitted++;
         }
-
-        if (emitted == 0)
-            return null;
 
         return sb.ToString().TrimEnd();
     }

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Structured, typed remediation payload persisted alongside the rendered
+/// preview SQL so an Apply action executes from typed parameters, never by
+/// parsing the preview text. Built by <see cref="FactRemediation.BuildAction"/>
+/// from the same drill-down extraction that renders the preview, and round-trips
+/// through the alert context (PerformanceMonitor.Notifications) so the in-app
+/// dialog can drive a structured, parameterised execution.
+///
+/// <para>
+/// This is data only — it carries no execution authority. The privileged
+/// execution path (Dashboard) re-derives its own gate (permission, freshness,
+/// correct-database) immediately before each mutation and never trusts these
+/// values as anything but typed inputs.
+/// </para>
+/// </summary>
+public sealed record RemediationAction(
+    string FactKey,                              // e.g. "PLAN_REGRESSION" — handler-registry key
+    string Action,                              // "force" (v1). Un-apply derives "unforce".
+    IReadOnlyList<ForcePlanTarget> Targets);
+
+/// <summary>
+/// One force-plan target. <see cref="Database"/>, <see cref="QueryId"/> and
+/// <see cref="PlanId"/> are the only execution inputs (database is applied solely
+/// as the connection's InitialCatalog; the IDs are passed as typed BigInt
+/// parameters to sys.sp_query_store_force_plan). The remaining members are
+/// carried for the freshness re-check and operator display only — they are NOT
+/// execution inputs.
+/// </summary>
+public sealed record ForcePlanTarget(
+    string Database,                            // user DB name (validated non-empty by the extractor)
+    long QueryId,                              // > 0
+    long PlanId,                               // > 0  (== best_plan_id from the finding)
+    string? BestPlanHash = null,               // display / freshness only
+    string? LatestPlanHash = null,             // display / freshness only
+    double LatestCpuPerExecUs = 0,             // display only (renders the preview comment)
+    double BestCpuPerExecUs = 0,               // display only (renders the preview comment)
+    double RegressionFactor = 0);              // display only (surfaced in the confirm modal)

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitor.Notifications;
 
@@ -44,6 +45,15 @@ public class AlertDetailItem
     /// dialog for the copy-paste T-SQL" hint when this flag is true.
     /// </summary>
     public bool IsCodeBlock { get; set; }
+
+    /// <summary>
+    /// Structured, typed remediation payload that lets the in-app dialog drive a
+    /// parameterised Apply from this code block (PLAN_REGRESSION force-plan in
+    /// v1). Null for every item that is not an applicable remediation T-SQL block
+    /// — and null for legacy persisted contexts written before this field existed,
+    /// which is the no-Apply-button case.
+    /// </summary>
+    public RemediationAction? Remediation { get; set; }
 }
 
 /// <summary>
@@ -56,8 +66,26 @@ public class AlertDetailItem
 /// are deliberately not persisted (the dialog has no attachment surface).
 /// </summary>
 public record AlertContextDto(List<AlertDetailItemDto> Details);
-public record AlertDetailItemDto(string Heading, List<FieldDto> Fields, string? Body, bool IsCodeBlock);
+public record AlertDetailItemDto(string Heading, List<FieldDto> Fields, string? Body, bool IsCodeBlock, RemediationActionDto? Remediation = null);
 public record FieldDto(string Label, string Value);
+
+/// <summary>
+/// JSON mirror of <see cref="RemediationAction"/> / <see cref="ForcePlanTarget"/>
+/// (PerformanceMonitor.Analysis). The trailing optional member on
+/// <see cref="AlertDetailItemDto"/> plus the reference-type nullability here make
+/// the round-trip backward-compatible: legacy contextJson with no Remediation
+/// property deserializes the field to null.
+/// </summary>
+public record RemediationActionDto(string FactKey, string Action, List<ForcePlanTargetDto> Targets);
+public record ForcePlanTargetDto(
+    string Database,
+    long QueryId,
+    long PlanId,
+    string? BestPlanHash,
+    string? LatestPlanHash,
+    double LatestCpuPerExecUs,
+    double BestCpuPerExecUs,
+    double RegressionFactor);
 
 /// <summary>
 /// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
@@ -73,7 +101,8 @@ public static class AlertContextSerializer
                 d.Heading,
                 d.Fields.ConvertAll(f => new FieldDto(f.Label, f.Value)),
                 d.Body,
-                d.IsCodeBlock)));
+                d.IsCodeBlock,
+                ToDto(d.Remediation))));
         return JsonSerializer.Serialize(dto);
     }
 
@@ -95,7 +124,8 @@ public static class AlertContextSerializer
                 {
                     Heading = d.Heading,
                     Body = d.Body,
-                    IsCodeBlock = d.IsCodeBlock
+                    IsCodeBlock = d.IsCodeBlock,
+                    Remediation = FromDto(d.Remediation)
                 };
                 if (d.Fields is not null)
                 {
@@ -110,5 +140,52 @@ public static class AlertContextSerializer
         {
             return false;
         }
+    }
+
+    private static RemediationActionDto? ToDto(RemediationAction? action)
+    {
+        if (action is null)
+            return null;
+
+        var targets = new List<ForcePlanTargetDto>(action.Targets.Count);
+        foreach (var t in action.Targets)
+        {
+            targets.Add(new ForcePlanTargetDto(
+                t.Database,
+                t.QueryId,
+                t.PlanId,
+                t.BestPlanHash,
+                t.LatestPlanHash,
+                t.LatestCpuPerExecUs,
+                t.BestCpuPerExecUs,
+                t.RegressionFactor));
+        }
+
+        return new RemediationActionDto(action.FactKey, action.Action, targets);
+    }
+
+    private static RemediationAction? FromDto(RemediationActionDto? dto)
+    {
+        if (dto is null)
+            return null;
+
+        var targets = new List<ForcePlanTarget>(dto.Targets?.Count ?? 0);
+        if (dto.Targets is not null)
+        {
+            foreach (var t in dto.Targets)
+            {
+                targets.Add(new ForcePlanTarget(
+                    t.Database,
+                    t.QueryId,
+                    t.PlanId,
+                    t.BestPlanHash,
+                    t.LatestPlanHash,
+                    t.LatestCpuPerExecUs,
+                    t.BestCpuPerExecUs,
+                    t.RegressionFactor));
+            }
+        }
+
+        return new RemediationAction(dto.FactKey, dto.Action, targets);
     }
 }

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -263,7 +263,12 @@ internal static class FindingMessageFormatter
                 {
                     Heading = "Remediation T-SQL",
                     Body = advice.RemediationTsql,
-                    IsCodeBlock = true
+                    IsCodeBlock = true,
+                    /* Structured, typed payload for an in-app Apply (PR-B). Rides in the
+                       persisted contextJson; may be null (e.g. PARAMETER_SENSITIVITY has
+                       advice + prose but no force action), in which case no Apply affordance
+                       is offered. Built from the same drill-down the preview rendered. */
+                    Remediation = FactRemediation.BuildAction(finding)
                 });
             }
         }

--- a/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
+++ b/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 2.11.0 to 2.12.0
+Creates config.remediation_action_log — the durable, append-only audit trail for
+the approval-gated "Apply Fix" feature (B3). One row is written per apply/unapply
+attempt (success, skip, error, or abort), so every privileged mutation the
+Dashboard issues against a monitored server (today: sys.sp_query_store_force_plan
+for a plan regression) is recorded with who/what/when/where/result.
+
+Lives in the config schema alongside the other operational logs
+(config.collection_log, config.installation_history). Idempotent: guarded by
+OBJECT_ID so a re-run is a no-op.
+
+B3 is coupled to this 2.12.0 schema: the Dashboard hard-blocks Apply on any
+server where this table does not yet exist (no mutation is attempted), so an
+un-upgraded server can never produce an applied-but-unlogged action.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+IF OBJECT_ID(N'config.remediation_action_log', N'U') IS NULL
+BEGIN
+    CREATE TABLE
+        config.remediation_action_log
+    (
+        action_id bigint IDENTITY(1, 1) NOT NULL
+            CONSTRAINT pk_remediation_action_log
+            PRIMARY KEY CLUSTERED,
+        applied_utc datetime2(7) NOT NULL
+            CONSTRAINT df_remediation_action_log_applied_utc
+            DEFAULT (SYSUTCDATETIME()),
+        operator_identity nvarchar(256) NULL, /* app / OS identity that clicked Apply */
+        executing_login sysname NULL,         /* SUSER_SNAME() actually used on the target */
+        used_elevated_cred bit NOT NULL
+            CONSTRAINT df_remediation_action_log_used_elevated_cred
+            DEFAULT (0),                       /* always 0 in v1 (no in-app elevation); reserved */
+        target_server nvarchar(256) NULL,
+        target_database sysname NOT NULL,
+        finding_fact_key varchar(64) NOT NULL, /* e.g. 'PLAN_REGRESSION' */
+        query_id bigint NOT NULL,
+        plan_id bigint NOT NULL,
+        action varchar(16) NOT NULL,           /* 'force' | 'unforce' */
+        generated_sql nvarchar(max) NULL,      /* the previewed statement, recorded only — never executed */
+        result varchar(16) NOT NULL,           /* 'success' | 'skipped' | 'error' | 'aborted' */
+        error_message nvarchar(max) NULL,
+        source_alert_ref nvarchar(256) NULL    /* metric_name / story hash for traceback */
+    );
+
+    PRINT 'Created config.remediation_action_log';
+END;
+ELSE
+BEGIN
+    PRINT 'config.remediation_action_log already exists — no action taken';
+END;
+GO

--- a/upgrades/2.11.0-to-2.12.0/upgrade.txt
+++ b/upgrades/2.11.0-to-2.12.0/upgrade.txt
@@ -1,1 +1,2 @@
 01_extend_blocked_process_report_columns.sql
+02_create_remediation_action_log.sql


### PR DESCRIPTION
## PR-A — Approval-gated "Apply Fix": privileged execution **core** (no UI)

**PR-A of B3**: the security-critical core that mutates a monitored, likely-production SQL Server via `sp_query_store_force_plan`. **No UI, no MCP exposure, no mutating caller** — PR-B adds the gated Apply button over this already-reviewed core. **Do not merge** until the security-reviewer pass on this code.

Plan (spec): `C:\Users\edarl\.claude\plans\b3-phase1-implementation.md`. Baseline `origin/dev` `b404c76`. Three commits: core, gate-split, real-server fixes.

### The six security invariants and how each is enforced
1. **Structured execution only.** `sp_query_store_force_plan`/`unforce_plan` is issued with typed `@query_id`/`@plan_id` as `SqlDbType.BigInt`; never the rendered SQL text. `database` is applied **only** as `InitialCatalog`, built solely through `SqlConnectionStringBuilder` (never concatenated). No general `Execute(sql)` exists. → `DatabaseService.Remediation.cs`.
2. **Single-connection self-gating (R2-MOD-1).** `ForcePlanAsync`/`UnforcePlanAsync` open **one** retargeted `SqlConnection` and run, on that same open connection with no re-open: identity/permission gate (`DB_NAME()==target` assert (A5) + DB-scoped ALTER check), then the Query Store freshness read, then — only if all pass — the EXEC. The outcome carries the `@@SPID` at the gate read and at the EXEC; the real-server harness asserts they are **equal** (observed `72==72`). `ApplyAsync` takes no preflight disposition and re-derives its own gate — unbypassable.
3. **No elevation.** Runs under the existing per-server monitoring connection. No credential prompt, no `SecureString`/`SqlCredential`, no elevated path. `has_alter=0` **fails closed** with map-then-grant guidance. `used_elevated_cred` always `0`.
4. **Audit-table-absent = HARD BLOCK (R2-MOD-2).** `OBJECT_ID('config.remediation_action_log') IS NULL` (monitoring connection) blocks every target with **no mutation attempted**.
5. **Audited apply + unapply.** One `config.remediation_action_log` row per attempt (success/skip/error/abort), after both apply and unapply, on the monitoring connection.
6. **Never automatic.** PR-A has no caller that triggers a mutation (A4 no-caller test). PR-B adds the gated UI.

### Real-server findings — two bugs the faked-executor unit tests could not reach
Caught by running the actual `DatabaseServiceRemediationExecutor` + `ForcePlanHandler` against sql2022 (the faked `IRemediationExecutor` can't exercise live T-SQL):
- **ALTER-permission form (security-gate correctness).** The plan's O5 specified `HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER')`, but that **server-scoped** form returns **NULL even for sysadmin** (verified on sql2022) — so the gate would fail closed for **every** login and Apply could never run. Fixed to the **DB-scoped** form `HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'ALTER')` (1 for ALTER-holders incl. sysadmin/db_owner, 0 otherwise). `DB_NAME()` keeps it correct after the catalog retarget.
- **Unforce delegation.** `UnforcePlanAsync` delegated with `isUnforce: false` (would re-force on un-apply); corrected to `isUnforce: true`.
- **Gate split** so `has_alter=0` fails closed *before* any Query Store catalog read (a least-privilege login lacks VIEW DATABASE STATE and would otherwise error 297 reading `sys.query_store_plan`). Identity+ALTER use only always-accessible intrinsics; the QS read runs only after ALTER passes — on the **same** open connection (R2-MOD-1 intact).

### Structured-params persistence
`RemediationAction`/`ForcePlanTarget` (`.Analysis`, incl. `LatestCpuPerExecUs`/`BestCpuPerExecUs` for render stability — M1). `FactRemediation` refactored to **extract once** (`ExtractPlanRegressionTargets`) + `BuildAction`; rendered preview byte-for-byte unchanged. Round-trips via an optional member on `AlertDetailItem`/`AlertContextDto`/`AlertContextSerializer` in the existing `contextJson`. **Old contexts without it → null** (no Apply, no crash).

### Upgrade script
`upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql` (+ `upgrade.txt`), `config` schema, idempotent (`OBJECT_ID` guard). 2.12.0 is the in-flight version (tag `v2.11.0`, csprojs 2.11.0) so it appends to the existing folder. No `install/*.sql` edited.

### Tests (unit)
- Golden render-stability (byte-for-byte incl. the two `(cpu/exec … us)` lines).
- Serializer round-trip (Dashboard + Lite); legacy JSON without the field → null.
- Handler gate vs faked executor: `has_alter=0` fail-closed; audit-table-absent block; already-forced/QS-off/stale/wrong-DB dispositions; per-target independence; gate re-derivation; applied-but-unlogged; per-outcome audit; un-apply restricted to prior B3 forces.
- A4 no-caller: `ForcePlanAsync`/`UnforcePlanAsync` referenced **only** in the executor seam.
- Suites green: **Dashboard.Tests 68/0**, **Lite.Tests 310/0**.

### Real-server verification (sql2022, Query Store DB)
- **Installer @2.12.0** (temporary `<Version>`/`<AssemblyVersion>`/`<FileVersion>`/`<InformationalVersion>` bump in both installer csprojs — reverted, not in this PR; server is the bare hostname `SQL2022`): `Existing installation detected: v2.11.0.0` → `Found 1 upgrade(s)` → applied `2.11.0-to-2.12.0` (`02_create_remediation_action_log.sql - Success`), **RC=0 "Installation completed successfully"**. Verified: `config.remediation_action_log` **PRESENT (15 cols)**, history recorded **2.12.0.0 : SUCCESS**. Second run: `No pending upgrades found` (idempotent).
- **Executor/handler harness** (throwaway, passed 1/1; not committed). Audit table ground-truth (queried via sqlcmd):
  - `force/success`, `executing_login=sa`, `operator_identity=HARNESS\tester` — `is_forced_plan=1`.
  - **R2-MOD-1**: gate `@@SPID` == EXEC `@@SPID` (`72 == 72`).
  - `unforce/success`, `executing_login=sa` — `is_forced_plan=0`.
  - Absent-table → `Blocked`, no mutation.
  - Scoped login (`b3_noalter`, VIEW DATABASE STATE but no ALTER) → `has_alter=False`, `PermissionDenied`, fail closed, no mutation. (Preflight surfaced the login name correctly; the no-ALTER message login string had a harness-logging quirk — the audit table and preflight both record the correct login.)

### Not UI-reachable
A4 no-caller test confirms nothing in the running app reaches the executor. `DatabaseService.Remediation.*` methods are `internal`, reachable only via `DatabaseServiceRemediationExecutor`.

### Notes / deviations
- Executor sets standard ANSI options (incl. `ARITHABORT ON`) before the gate/EXEC — `sp_query_store_force_plan` errors 1934 otherwise (`Microsoft.Data.SqlClient` defaults `ARITHABORT OFF`). Same open connection, so R2-MOD-1 holds.
- `RemediationIdentity` carries an optional `SourceAlertRef` (audit traceback) — minor superset of the plan's `{ OperatorIdentity }`.
- Plan O5 was wrong about the `HAS_PERMS_BY_NAME` form (see above); corrected with real-server evidence.
- All six invariants met; none could-not-be-met.

Do NOT merge — awaiting security-reviewer pass; PR-B follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
