### PR TITLE
B3 PR-B: approval-gated Apply Fix UI over the privileged core

### DIFF
--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services.Remediation;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// PR-B coverage for the gated Apply Fix orchestrator: the confirm gate (the
+/// privileged handler is unreachable unless confirm() returns true), M3 fail-closed
+/// server resolution, applied-but-unlogged permanent-vs-transient surfacing (LOW-2),
+/// and the AlertDetailWindow view-model gating (CanApply).
+/// </summary>
+public class RemediationApplyServiceTests
+{
+    private static readonly ServerConnection Server =
+        new() { Id = "11111111-1111-1111-1111-111111111111", ServerName = "SQL2022", DisplayName = "Prod SQL2022" };
+
+    private static RemediationAction ForceAction(double regression = 7.5) =>
+        new("PLAN_REGRESSION", "force", new List<ForcePlanTarget> { new("AdventureWorks", 4242, 17, RegressionFactor: regression) });
+
+    private static RemediationApplyService BuildService(
+        FakeExecutor exec,
+        IRemediationHandler? handler = null,
+        Func<ServerConnection, CancellationToken, Task<AuditWriteFailureKind>>? classifier = null)
+    {
+        var handlers = handler is null ? new[] { (IRemediationHandler)new ForcePlanHandler() } : new[] { handler };
+        var registry = new RemediationHandlerRegistry(handlers);
+        return new RemediationApplyService(serverManager: null!, registry, _ => exec, classifier);
+    }
+
+    private static RemediationApplyService BuildServiceNoHandler(FakeExecutor exec) =>
+        new(serverManager: null!, new RemediationHandlerRegistry(Array.Empty<IRemediationHandler>()), _ => exec, null);
+
+    // ── Confirm gate ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Gate_ConfirmFalse_NeverReachesHandler()
+    {
+        var exec = new FakeExecutor();
+        var service = BuildService(exec);
+
+        var report = await service.ApplyAsync(
+            ForceAction(), Server, previewSql: "preview", operatorIdentity: "DOM\\op", sourceAlertRef: "ref",
+            confirm: _ => Task.FromResult(false), CancellationToken.None);
+
+        Assert.Equal(RemediationRunStatus.NotConfirmed, report.Status);
+        Assert.Empty(report.Targets);
+        Assert.Equal(0, exec.ForceCalls);          // the privileged path was never entered
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task Gate_ConfirmTrue_ReachesHandlerExactlyOnce()
+    {
+        var exec = new FakeExecutor();
+        var confirmCalls = 0;
+        var service = BuildService(exec);
+
+        var report = await service.ApplyAsync(
+            ForceAction(), Server, "preview", "DOM\\op", "ref",
+            confirm: req => { confirmCalls++; return Task.FromResult(true); }, CancellationToken.None);
+
+        Assert.Equal(1, confirmCalls);
+        Assert.Equal(RemediationRunStatus.Ran, report.Status);
+        Assert.Equal(1, exec.ForceCalls);
+        Assert.Equal(RemediationStatus.Success, Assert.Single(report.Targets).Status);
+    }
+
+    [Fact]
+    public async Task Gate_ConfirmRequest_CarriesServerRegressionAndCaveat()
+    {
+        var exec = new FakeExecutor();
+        var service = BuildService(exec);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(ForceAction(regression: 9.0), Server, "preview", "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Prod SQL2022", captured!.ServerDisplayName);
+        Assert.Equal("preview", captured.PreviewSql);
+        Assert.Equal(9.0, Assert.Single(captured.Targets).RegressionFactor);
+        Assert.Contains("still the better choice", RemediationConfirmRequest.StillBetterCaveat);
+    }
+
+    [Fact]
+    public async Task Apply_NoHandler_ReturnsNoHandler_NeverConfirms()
+    {
+        var exec = new FakeExecutor();
+        var service = BuildServiceNoHandler(exec);
+        var confirmed = false;
+
+        var report = await service.ApplyAsync(ForceAction(), Server, "preview", "DOM\\op", "ref",
+            confirm: _ => { confirmed = true; return Task.FromResult(true); }, CancellationToken.None);
+
+        Assert.Equal(RemediationRunStatus.NoHandler, report.Status);
+        Assert.False(confirmed);
+        Assert.Equal(0, exec.ForceCalls);
+    }
+
+    [Fact]
+    public async Task Unapply_ConfirmTrue_ReachesUnforce()
+    {
+        var exec = new FakeExecutor { PriorForce = true };
+        var service = BuildService(exec);
+
+        var report = await service.UnapplyAsync(ForceAction(), Server, "DOM\\op", "ref",
+            confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        Assert.Equal(RemediationRunStatus.Ran, report.Status);
+        Assert.True(report.IsUnapply);
+        Assert.Equal(1, exec.UnforceCalls);
+    }
+
+    // ── LOW-2: applied-but-unlogged permanent vs transient ───────────────────────
+
+    [Fact]
+    public async Task Apply_AppliedButUnlogged_PermanentClassification_Surfaced()
+    {
+        var exec = new FakeExecutor { AuditWriteResult = false };   // force succeeds, audit INSERT fails
+        var classifierCalls = 0;
+        var service = BuildService(exec, classifier: (_, _) => { classifierCalls++; return Task.FromResult(AuditWriteFailureKind.Permanent); });
+
+        var report = await service.ApplyAsync(ForceAction(), Server, "preview", "DOM\\op", "ref",
+            confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        var t = Assert.Single(report.Targets);
+        Assert.True(t.AppliedButUnlogged);
+        Assert.Equal(AuditWriteFailureKind.Permanent, t.AuditFailureKind);
+        Assert.Equal(1, classifierCalls);
+    }
+
+    [Fact]
+    public async Task Apply_AppliedButUnlogged_TransientClassification_Surfaced()
+    {
+        var exec = new FakeExecutor { AuditWriteResult = false };
+        var service = BuildService(exec, classifier: (_, _) => Task.FromResult(AuditWriteFailureKind.Transient));
+
+        var report = await service.ApplyAsync(ForceAction(), Server, "preview", "DOM\\op", "ref",
+            confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        var t = Assert.Single(report.Targets);
+        Assert.True(t.AppliedButUnlogged);
+        Assert.Equal(AuditWriteFailureKind.Transient, t.AuditFailureKind);
+    }
+
+    [Fact]
+    public async Task Apply_Success_AuditWritten_DoesNotClassify()
+    {
+        var exec = new FakeExecutor { AuditWriteResult = true };
+        var classifierCalls = 0;
+        var service = BuildService(exec, classifier: (_, _) => { classifierCalls++; return Task.FromResult(AuditWriteFailureKind.Permanent); });
+
+        var report = await service.ApplyAsync(ForceAction(), Server, "preview", "DOM\\op", "ref",
+            confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        var t = Assert.Single(report.Targets);
+        Assert.False(t.AppliedButUnlogged);
+        Assert.Equal(AuditWriteFailureKind.None, t.AuditFailureKind);
+        Assert.Equal(0, classifierCalls);          // classifier only runs for an unlogged target
+    }
+
+    // ── M3 fail-closed server resolution ─────────────────────────────────────────
+
+    private static List<ServerConnection> Servers(params (string id, string name)[] defs) =>
+        defs.Select(d => new ServerConnection { Id = d.id, ServerName = d.name, DisplayName = d.name }).ToList();
+
+    [Fact]
+    public void Resolve_GuidMatch_Resolves()
+    {
+        var servers = Servers(("guid-a", "SQL2022"), ("guid-b", "SQL2019"));
+        var r = RemediationApplyService.ResolveServer("guid-a", "SQL2022", servers);
+
+        Assert.True(r.IsResolved);
+        Assert.False(r.ResolvedByName);
+        Assert.Equal("guid-a", r.Server!.Id);
+    }
+
+    [Fact]
+    public void Resolve_IntIdFallback_GuidMiss_ResolvesByUniqueName()
+    {
+        // The notify-time resolver wrote the finding's int id ("3"); GetServerById misses.
+        var servers = Servers(("guid-a", "SQL2022"), ("guid-b", "SQL2019"));
+        var r = RemediationApplyService.ResolveServer("3", "SQL2022", servers);
+
+        Assert.True(r.IsResolved);
+        Assert.True(r.ResolvedByName);
+        Assert.Equal("guid-a", r.Server!.Id);
+    }
+
+    [Fact]
+    public void Resolve_EmptyServerId_ResolvesByUniqueName()
+    {
+        var servers = Servers(("guid-a", "SQL2022"));
+        var r = RemediationApplyService.ResolveServer("", "SQL2022", servers);
+
+        Assert.True(r.IsResolved);
+        Assert.True(r.ResolvedByName);
+    }
+
+    [Fact]
+    public void Resolve_AmbiguousByName_FailsClosed()
+    {
+        var servers = Servers(("guid-a", "SQL2022"), ("guid-b", "SQL2022"));
+        var r = RemediationApplyService.ResolveServer("3", "SQL2022", servers);
+
+        Assert.False(r.IsResolved);
+        Assert.Null(r.Server);
+        Assert.Contains("unambiguously", r.Reason);
+    }
+
+    [Fact]
+    public void Resolve_Unresolved_FailsClosed()
+    {
+        var servers = Servers(("guid-a", "SQL2022"));
+        var r = RemediationApplyService.ResolveServer("3", "GhostServer", servers);
+
+        Assert.False(r.IsResolved);
+        Assert.Null(r.Server);
+        Assert.False(string.IsNullOrEmpty(r.Reason));
+    }
+
+    [Fact]
+    public void HasHandlerFor_KnownAndUnknown()
+    {
+        var service = BuildService(new FakeExecutor());
+        Assert.True(service.HasHandlerFor("PLAN_REGRESSION"));
+        Assert.False(service.HasHandlerFor("PARAMETER_SENSITIVITY"));
+        Assert.False(service.HasHandlerFor(null));
+    }
+
+    // ── AlertDetailWindow view-model gating (CanApply) ───────────────────────────
+
+    [Fact]
+    public void CanApply_RequiresKnownFix_ResolvedServer_AndNotBusy()
+    {
+        // Known fix + resolved server -> enabled.
+        var enabled = new AlertDetailWindow.DetailItemView { ShowApply = true };
+        enabled.SetServerResolved(true);
+        Assert.True(enabled.CanApply);
+
+        // Resolved-but-unknown-fix (ShowApply false) -> never enabled.
+        var noFix = new AlertDetailWindow.DetailItemView { ShowApply = false };
+        noFix.SetServerResolved(true);
+        Assert.False(noFix.CanApply);
+
+        // Known fix but server unresolved (M3) -> hard-disabled.
+        var unresolved = new AlertDetailWindow.DetailItemView { ShowApply = true };
+        unresolved.SetServerResolved(false);
+        Assert.False(unresolved.CanApply);
+
+        // Mid-run -> disabled.
+        var busy = new AlertDetailWindow.DetailItemView { ShowApply = true };
+        busy.SetServerResolved(true);
+        busy.BeginRun("Applying…");
+        Assert.False(busy.CanApply);
+    }
+
+    // ── Fake executor (PR-B-local) ───────────────────────────────────────────────
+
+    private sealed class FakeExecutor : IRemediationExecutor
+    {
+        public bool AuditTableExists = true;
+        public bool PriorForce = true;
+        public bool AuditWriteResult = true;
+
+        public int ForceCalls;
+        public int UnforceCalls;
+        public readonly List<RemediationAuditRecord> AuditRecords = new();
+
+        public Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(new TargetPreflight
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                CurrentDatabase = database, HasAlter = true, QueryStoreState = "READ_WRITE",
+                PlanPresent = true, ExecutingLogin = "PerfMonLogin"
+            });
+
+        public Task<bool> AuditTableExistsAsync(CancellationToken ct) => Task.FromResult(AuditTableExists);
+        public Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct) => Task.FromResult(PriorForce);
+
+        public Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+        {
+            ForceCalls++;
+            return Task.FromResult(new ForcePlanOutcome
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "PerfMonLogin", GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+        {
+            UnforceCalls++;
+            return Task.FromResult(new ForcePlanOutcome
+            {
+                Database = database, QueryId = queryId, PlanId = planId,
+                Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "PerfMonLogin", GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
+        {
+            AuditRecords.Add(record);
+            return Task.FromResult(AuditWriteResult);
+        }
+    }
+}

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -357,8 +357,32 @@ public class RemediationTests
         Assert.Equal("unforce", Assert.Single(exec.AuditRecords).Action);
     }
 
+    // ── Reachability-with-gate guard (replaces PR-A's no-caller guard) ──────────
+    //
+    // PR-A asserted the privileged machinery had NO non-core caller. PR-B adds a
+    // legitimate caller (the Apply Fix UI), so "no caller" can no longer hold. The
+    // invariant becomes "reachable ONLY through the gate," proven in two parts:
+    //
+    //   A. The core machinery TYPES + force/unforce methods (handler, registry,
+    //      executor, ForcePlanAsync/UnforcePlanAsync) are still referenced ONLY
+    //      inside the remediation core — the UI never touches them directly.
+    //   B. The single gated entry point (RemediationApplyService) is referenced
+    //      outside the core ONLY by the sanctioned Apply Fix UI files. That facade
+    //      runs the operator confirm before any handler.ApplyAsync (proven
+    //      behaviourally by Gate_* in RemediationApplyServiceTests).
+    //
+    // Together: the UI reaches the privileged executor only via RemediationApplyService,
+    // and RemediationApplyService reaches the handler only after confirm() == true.
+
+    private static readonly string[] CoreMachineryMarkers =
+    {
+        "ForcePlanAsync", "UnforcePlanAsync",
+        "RemediationHandlerRegistry", "DatabaseServiceRemediationExecutor",
+        "ForcePlanHandler", "IRemediationExecutor", "IRemediationHandler",
+    };
+
     [Fact]
-    public void NoCaller_ForceUnforce_OnlyReferencedInRemediationCore()
+    public void CoreMachinery_OnlyReferencedInRemediationCore()
     {
         var dashboardDir = FindDashboardSourceDir();
 
@@ -376,25 +400,51 @@ public class RemediationTests
                 continue;
 
             var text = File.ReadAllText(file);
-            // Reachability is not only via the executor's own method names: a future
-            // surface (PR-B UI) would reach the privileged force/unforce through the
-            // handler/registry/executor TYPES (e.g. registry.TryGet(...).ApplyAsync()),
-            // never typing "ForcePlanAsync". Guard the whole machinery, not just the
-            // leaf method names, so PR-A's "not UI-reachable" invariant is actually
-            // protected when PR-B adds callers (LOW-1 from the security review).
-            string[] markers =
-            {
-                "ForcePlanAsync", "UnforcePlanAsync",
-                "RemediationHandlerRegistry", "DatabaseServiceRemediationExecutor",
-                "ForcePlanHandler", "IRemediationExecutor", "IRemediationHandler",
-            };
-            if (markers.Any(text.Contains))
+            if (CoreMachineryMarkers.Any(text.Contains))
                 offenders.Add(rel);
         }
 
         Assert.True(offenders.Count == 0,
-            "No MCP/menu/command surface may reach the remediation-execution machinery " +
-            "(force/unforce, handler, registry, or executor) in PR-A. Offending files: " +
+            "The privileged remediation machinery (force/unforce, handler, registry, executor) " +
+            "must be reached ONLY through RemediationApplyService — no UI/MCP/menu/command file " +
+            "may reference the machinery types directly. Offending files: " + string.Join(", ", offenders));
+    }
+
+    [Fact]
+    public void GatedEntry_ReferencedOnlyBySanctionedUiPath()
+    {
+        var dashboardDir = FindDashboardSourceDir();
+
+        // The ONLY files outside the remediation core allowed to reach the gated
+        // facade. Any other file gaining a reference to RemediationApplyService is a
+        // new, unreviewed path to the privileged executor and must fail the build.
+        var sanctioned = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "MainWindow.xaml.cs",                    // constructs + injects the service
+            "Controls/AlertsHistoryContent.xaml.cs", // threads it into the alert detail dialog
+            "AlertDetailWindow.xaml.cs",             // invokes Apply/Un-apply via the service
+            "RemediationConfirmWindow.xaml.cs",      // the confirm modal (gate UI)
+        };
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(dashboardDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(dashboardDir, file).Replace('\\', '/');
+            if (rel.StartsWith("bin/") || rel.StartsWith("obj/"))
+                continue;
+            if (rel.StartsWith("Services/Remediation/"))
+                continue;
+            if (sanctioned.Contains(rel))
+                continue;
+
+            var text = File.ReadAllText(file);
+            if (text.Contains("RemediationApplyService"))
+                offenders.Add(rel);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Only the sanctioned Apply Fix UI path may reference RemediationApplyService. " +
+            "A new reference is an unreviewed path to the privileged executor. Offending files: " +
             string.Join(", ", offenders));
     }
 

--- a/Dashboard/AlertDetailWindow.xaml
+++ b/Dashboard/AlertDetailWindow.xaml
@@ -116,6 +116,32 @@
                                                  Background="Transparent"
                                                  Foreground="{DynamicResource ForegroundBrush}"
                                                  BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
+
+                                        <!-- Apply Fix: only present when this block carries a structured,
+                                             known-fix-type RemediationAction. Hard-disabled (with a tooltip)
+                                             when the source server cannot be unambiguously resolved (M3). -->
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                                                    Margin="0,6,0,0"
+                                                    Visibility="{Binding ShowApply, Converter={StaticResource BoolToVis}}">
+                                            <Button x:Name="ApplyButton" Content="Apply Fix…"
+                                                    Padding="10,3" Margin="0,0,8,0"
+                                                    IsEnabled="{Binding CanApply}"
+                                                    ToolTip="{Binding ApplyDisabledReason}"
+                                                    Click="ApplyButton_Click"/>
+                                            <Button x:Name="UnapplyButton" Content="Un-apply"
+                                                    Padding="10,3"
+                                                    IsEnabled="{Binding CanApply}"
+                                                    ToolTip="{Binding ApplyDisabledReason}"
+                                                    Click="UnapplyButton_Click"/>
+                                        </StackPanel>
+
+                                        <!-- Per-run result / warnings (success / skipped / blocked /
+                                             permission-denied / applied-but-unlogged). -->
+                                        <TextBlock Text="{Binding ResultText}" TextWrapping="Wrap"
+                                                   Margin="0,6,0,0"
+                                                   FontWeight="{Binding ResultBold}"
+                                                   Foreground="{Binding ResultBrush}"
+                                                   Visibility="{Binding HasResult, Converter={StaticResource BoolToVis}}"/>
                                     </StackPanel>
 
                                     <!-- Advice prose. -->

--- a/Dashboard/AlertDetailWindow.xaml.cs
+++ b/Dashboard/AlertDetailWindow.xaml.cs
@@ -4,19 +4,48 @@
  * Licensed under the MIT License - see LICENSE file for details
  */
 
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
+using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Controls;
-using PerformanceMonitorDashboard.Services;
+using PerformanceMonitorDashboard.Services.Remediation;
 
 namespace PerformanceMonitorDashboard
 {
     public partial class AlertDetailWindow : Window
     {
+        private readonly RemediationApplyService? _applyService;
+        private readonly ServerResolution _resolution;
+        private readonly string _operatorIdentity;
+        private readonly string? _sourceAlertRef;
+
         public AlertDetailWindow(AlertHistoryDisplayItem item)
+            : this(item, applyService: null)
+        {
+        }
+
+        public AlertDetailWindow(AlertHistoryDisplayItem item, RemediationApplyService? applyService)
         {
             InitializeComponent();
+
+            _applyService = applyService;
+            _sourceAlertRef = item.MetricName;
+            _operatorIdentity = ResolveOperatorIdentity();
+
+            // M3 fail-closed server resolution. Resolve once; every remediation block
+            // in this alert is for the same source server. Unresolved/ambiguous ->
+            // Apply is hard-disabled (the resolution carries the tooltip reason).
+            _resolution = _applyService is not null
+                ? _applyService.ResolveServer(item.ServerId, item.ServerName)
+                : new ServerResolution { Reason = "Apply Fix is unavailable in this context." };
 
             TimeText.Text = item.TimeLocal;
             ServerText.Text = item.ServerName;
@@ -48,7 +77,7 @@ namespace PerformanceMonitorDashboard
         /* WPF cannot data-bind to AlertDetailItem.Fields (a List<(string,string)> ValueTuple — its
            Item1/Item2 are fields, not properties), so the deserialized context is projected into
            bindable view-models the DataTemplate can render. */
-        private static bool TryBuildDetailViews(string? contextJson, out List<DetailItemView> views)
+        private bool TryBuildDetailViews(string? contextJson, out List<DetailItemView> views)
         {
             views = new List<DetailItemView>();
             if (!AlertContextSerializer.TryDeserialize(contextJson, out var context))
@@ -60,14 +89,102 @@ namespace PerformanceMonitorDashboard
                 {
                     Heading = detail.Heading,
                     Body = detail.Body,
-                    IsCodeBlock = detail.IsCodeBlock
+                    IsCodeBlock = detail.IsCodeBlock,
+                    Remediation = detail.Remediation
                 };
                 foreach (var (label, value) in detail.Fields)
                     view.Fields.Add(new FieldView { Label = label, Value = value });
+
+                ConfigureApplyAffordance(view);
                 views.Add(view);
             }
 
             return views.Count > 0;
+        }
+
+        /// <summary>
+        /// Decides whether this block shows an Apply affordance and whether it is
+        /// enabled. Shown ONLY for a non-null RemediationAction whose fact key has a
+        /// registered handler. Enabled ONLY when the source server resolved
+        /// unambiguously (M3 fail-closed); otherwise hard-disabled with a tooltip.
+        /// </summary>
+        private void ConfigureApplyAffordance(DetailItemView view)
+        {
+            var known = _applyService is not null
+                && view.Remediation is not null
+                && _applyService.HasHandlerFor(view.Remediation.FactKey);
+
+            view.ShowApply = known;
+            view.SetServerResolved(known && _resolution.IsResolved);
+            view.ApplyDisabledReason = _resolution.IsResolved
+                ? null
+                : _resolution.Reason;
+        }
+
+        private async void ApplyButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { DataContext: DetailItemView view })
+                await RunRemediationAsync(view, isUnapply: false);
+        }
+
+        private async void UnapplyButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement { DataContext: DetailItemView view })
+                await RunRemediationAsync(view, isUnapply: true);
+        }
+
+        private async Task RunRemediationAsync(DetailItemView view, bool isUnapply)
+        {
+            if (_applyService is null || view.Remediation is null || _resolution.Server is null || view.IsBusy)
+                return;
+
+            view.BeginRun(isUnapply ? "Un-applying…" : "Applying…");
+            try
+            {
+                var report = isUnapply
+                    ? await _applyService.UnapplyAsync(
+                        view.Remediation, _resolution.Server, _operatorIdentity, _sourceAlertRef, ConfirmAsync, CancellationToken.None)
+                    : await _applyService.ApplyAsync(
+                        view.Remediation, _resolution.Server, view.Body, _operatorIdentity, _sourceAlertRef, ConfirmAsync, CancellationToken.None);
+
+                view.SetResult(FormatReport(report), SeverityOf(report));
+            }
+            catch (Exception ex)
+            {
+                view.SetResult($"{(isUnapply ? "Un-apply" : "Apply")} failed: {ex.Message}", ResultSeverity.Error);
+            }
+        }
+
+        /// <summary>
+        /// The confirm gate. Invoked by the service from a background continuation,
+        /// so it marshals to the UI thread to show the modal. Returning true is the
+        /// only thing that lets the privileged handler run.
+        /// </summary>
+        private async Task<bool> ConfirmAsync(RemediationConfirmRequest request)
+        {
+            return await Dispatcher.InvokeAsync(() =>
+            {
+                var dialog = new RemediationConfirmWindow(request, _resolution.ResolvedByName, _resolution.Reason)
+                {
+                    Owner = this
+                };
+                return dialog.ShowDialog() == true;
+            });
+        }
+
+        private static string ResolveOperatorIdentity()
+        {
+            try
+            {
+                var name = System.Security.Principal.WindowsIdentity.GetCurrent()?.Name;
+                if (!string.IsNullOrEmpty(name))
+                    return name;
+            }
+            catch
+            {
+                /* WindowsIdentity can throw in constrained contexts — fall back. */
+            }
+            return Environment.UserName;
         }
 
         private void CopyTsqlButton_Click(object sender, RoutedEventArgs e)
@@ -85,7 +202,80 @@ namespace PerformanceMonitorDashboard
             }
         }
 
-        public sealed class DetailItemView
+        // ── Result formatting ──────────────────────────────────────────────────
+
+        private static string FormatReport(RemediationRunReport report)
+        {
+            switch (report.Status)
+            {
+                case RemediationRunStatus.NoHandler:
+                    return "No remediation handler is registered for this finding.";
+                case RemediationRunStatus.NotConfirmed:
+                    return "Cancelled — no change was made.";
+            }
+
+            var verb = report.IsUnapply ? "unforced" : "forced";
+            var sb = new StringBuilder();
+            foreach (var t in report.Targets)
+            {
+                if (sb.Length > 0) sb.Append('\n');
+                sb.Append(FormatTarget(t, verb));
+            }
+            return sb.Length > 0 ? sb.ToString() : "No targets were processed.";
+        }
+
+        private static string FormatTarget(RemediationTargetReport t, string verb)
+        {
+            var where = $"[{t.Database}] query_id {t.QueryId}, plan_id {t.PlanId}";
+
+            // Applied-but-unlogged (O3 + LOW-2): the mutation succeeded; distinguish a
+            // permanent setup/grant failure (loud, "fix this") from a transient one.
+            if (t.AppliedButUnlogged)
+            {
+                return t.AuditFailureKind switch
+                {
+                    AuditWriteFailureKind.Permanent =>
+                        $"⚠ {where}: plan {verb}, but the audit row could NOT be written — the monitoring "
+                        + "login lacks INSERT on config.remediation_action_log. EVERY Apply on this server "
+                        + "will go unlogged until this grant is fixed. The change is in place (reversible via Un-apply).",
+                    _ =>
+                        $"⚠ {where}: plan {verb}, but writing the audit row failed (transient). The change is "
+                        + "in place; re-check config.remediation_action_log."
+                };
+            }
+
+            return t.Status switch
+            {
+                RemediationStatus.Success => $"✓ {where}: plan {verb}.",
+                RemediationStatus.Skipped => $"• {where}: skipped — {t.Message}",
+                RemediationStatus.PermissionDenied => $"⛔ {where}: {t.Message}",
+                RemediationStatus.Blocked => $"⛔ {where}: {t.Message}",
+                RemediationStatus.Error => $"✗ {where}: {t.Message}",
+                _ => $"{where}: {t.Message}"
+            };
+        }
+
+        private static ResultSeverity SeverityOf(RemediationRunReport report)
+        {
+            if (report.Status == RemediationRunStatus.NotConfirmed || report.Status == RemediationRunStatus.NoHandler)
+                return ResultSeverity.Info;
+
+            // A permanent unlogged failure, or any hard error/block/permission-denied,
+            // is loud.
+            if (report.Targets.Any(t =>
+                    (t.AppliedButUnlogged && t.AuditFailureKind == AuditWriteFailureKind.Permanent)
+                    || t.Status is RemediationStatus.Error or RemediationStatus.Blocked or RemediationStatus.PermissionDenied))
+                return ResultSeverity.Error;
+
+            if (report.Targets.Any(t => t.AppliedButUnlogged || t.Status == RemediationStatus.Skipped))
+                return ResultSeverity.Warning;
+
+            return report.AnySuccess ? ResultSeverity.Success : ResultSeverity.Info;
+        }
+
+        public enum ResultSeverity { Info, Success, Warning, Error }
+
+        public sealed class DetailItemView : INotifyPropertyChanged
         {
             public string Heading { get; set; } = "";
             public string? Body { get; set; }
@@ -94,6 +284,88 @@ namespace PerformanceMonitorDashboard
 
             public bool IsProse => !IsCodeBlock && !string.IsNullOrEmpty(Body);
             public bool HasFields => Fields.Count > 0;
+
+            /// <summary>Structured remediation payload (null when this block is not an applicable fix).</summary>
+            public RemediationAction? Remediation { get; set; }
+
+            /// <summary>Whether to render the Apply/Un-apply buttons at all (set before binding).</summary>
+            public bool ShowApply { get; set; }
+
+            /// <summary>Tooltip explaining why Apply is disabled (set before binding).</summary>
+            public string? ApplyDisabledReason { get; set; }
+
+            private bool _serverResolved;
+            public void SetServerResolved(bool resolved)
+            {
+                _serverResolved = resolved;
+                OnChanged(nameof(CanApply));
+            }
+
+            private bool _isBusy;
+            public bool IsBusy
+            {
+                get => _isBusy;
+                private set { _isBusy = value; OnChanged(nameof(IsBusy)); OnChanged(nameof(CanApply)); }
+            }
+
+            /// <summary>Enabled only for a known fix + resolved server + not mid-run.</summary>
+            public bool CanApply => ShowApply && _serverResolved && !_isBusy;
+
+            private string? _resultText;
+            public string? ResultText
+            {
+                get => _resultText;
+                private set { _resultText = value; OnChanged(nameof(ResultText)); OnChanged(nameof(HasResult)); }
+            }
+            public bool HasResult => !string.IsNullOrEmpty(_resultText);
+
+            private Brush _resultBrush = SystemColors.ControlTextBrush;
+            public Brush ResultBrush
+            {
+                get => _resultBrush;
+                private set { _resultBrush = value; OnChanged(nameof(ResultBrush)); }
+            }
+
+            private FontWeight _resultBold = FontWeights.Normal;
+            public FontWeight ResultBold
+            {
+                get => _resultBold;
+                private set { _resultBold = value; OnChanged(nameof(ResultBold)); }
+            }
+
+            public void BeginRun(string message)
+            {
+                IsBusy = true;
+                ResultBrush = BrushFor(ResultSeverity.Info);
+                ResultBold = FontWeights.Normal;
+                ResultText = message;
+            }
+
+            public void SetResult(string message, ResultSeverity severity)
+            {
+                IsBusy = false;
+                ResultBrush = BrushFor(severity);
+                ResultBold = severity is ResultSeverity.Error or ResultSeverity.Warning
+                    ? FontWeights.SemiBold
+                    : FontWeights.Normal;
+                ResultText = message;
+            }
+
+            private static Brush BrushFor(ResultSeverity severity)
+            {
+                var key = severity switch
+                {
+                    ResultSeverity.Success => "SuccessBrush",
+                    ResultSeverity.Warning => "WarningBrush",
+                    ResultSeverity.Error => "ErrorBrush",
+                    _ => "ForegroundBrush"
+                };
+                return Application.Current?.TryFindResource(key) as Brush ?? SystemColors.ControlTextBrush;
+            }
+
+            public event PropertyChangedEventHandler? PropertyChanged;
+            private void OnChanged(string name) =>
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
         public sealed class FieldView

--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -20,6 +20,7 @@ using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitorDashboard.Services.Remediation;
 using PerformanceMonitor.Ui;
 using PerformanceMonitor.Common;
 
@@ -30,6 +31,13 @@ namespace PerformanceMonitorDashboard.Controls
         public event EventHandler? AlertsDismissed;
 
         public MuteRuleService? MuteRuleService { get; set; }
+
+        /// <summary>
+        /// Gated orchestrator for Apply Fix. Injected from MainWindow; when null the
+        /// alert detail dialog shows no Apply affordance. The UI touches only this
+        /// facade — never the remediation handler/registry/executor directly.
+        /// </summary>
+        public RemediationApplyService? RemediationApplyService { get; set; }
 
         private List<AlertHistoryDisplayItem> _allAlerts = new();
         private DateTime? _lastRefreshed;
@@ -73,6 +81,7 @@ namespace PerformanceMonitorDashboard.Controls
             _allAlerts = entries.Select(e => new AlertHistoryDisplayItem
             {
                 AlertTime = e.AlertTime,
+                ServerId = e.ServerId,
                 ServerName = e.ServerName,
                 MetricName = e.MetricName,
                 CurrentValue = e.CurrentValue,
@@ -491,7 +500,7 @@ namespace PerformanceMonitorDashboard.Controls
             if (row.DataContext is not AlertHistoryDisplayItem item) return;
 
             var owner = Window.GetWindow(this);
-            var detailWindow = new AlertDetailWindow(item);
+            var detailWindow = new AlertDetailWindow(item, RemediationApplyService);
             if (owner != null) detailWindow.Owner = owner;
             detailWindow.ShowDialog();
         }
@@ -504,7 +513,7 @@ namespace PerformanceMonitorDashboard.Controls
             var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
             if (dataGrid?.SelectedItem is not AlertHistoryDisplayItem item) return;
 
-            var detailWindow = new AlertDetailWindow(item) { Owner = Window.GetWindow(this) };
+            var detailWindow = new AlertDetailWindow(item, RemediationApplyService) { Owner = Window.GetWindow(this) };
             detailWindow.ShowDialog();
         }
 
@@ -561,6 +570,14 @@ namespace PerformanceMonitorDashboard.Controls
     {
         public DateTime AlertTime { get; set; }
         public string TimeLocal => AlertTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+
+        /// <summary>
+        /// Source server identity carried from <c>AlertLogEntry.ServerId</c>. Usually
+        /// a <c>ServerConnection.Id</c> GUID, but can be the finding's stable int id
+        /// (the notify-time resolver's fallback) — which is why Apply Fix resolution
+        /// is fail-closed (M3).
+        /// </summary>
+        public string ServerId { get; set; } = "";
         public string ServerName { get; set; } = "";
         public string MetricName { get; set; } = "";
         public string CurrentValue { get; set; } = "";

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -71,6 +71,13 @@ namespace PerformanceMonitorDashboard
         private readonly JsonAlertHistoryStore _alertHistoryStore;
         private readonly CredentialService _credentialService;
 
+        /// <summary>
+        /// Gated Apply Fix orchestrator (PR-B). The only non-core holder of the
+        /// remediation machinery; threaded into the Alerts history UI so the alert
+        /// detail dialog can drive a confirmed, audited apply/un-apply.
+        /// </summary>
+        private readonly Services.Remediation.RemediationApplyService _remediationApplyService;
+
         // Scheduled analysis-finding notifications — separate cadence and gating from
         // the threshold-alert engine above. Owns its own DispatcherTimer internally;
         // re-Configured after every settings save. Field name avoids colliding with
@@ -121,6 +128,10 @@ namespace PerformanceMonitorDashboard
             ServerListView.ItemsSource = _serverListItems;
 
             _credentialService = new CredentialService();
+            /* Gated Apply Fix orchestrator (PR-B): registry + executor + audit over the
+               existing per-server monitoring connection. No elevation — reuses the
+               same credentials the rest of the Dashboard already holds. */
+            _remediationApplyService = new Services.Remediation.RemediationApplyService(_serverManager, _credentialService);
             /* Saved-prefs settings adapter shared by the three alert services (Plan E E1). */
             var alertSettings = new DashboardAlertSettings(_preferencesService);
             /* Alert-history store owns the alert_history.json list + management API (Plan E E2).
@@ -801,6 +812,7 @@ namespace PerformanceMonitorDashboard
 
             _alertsHistoryContent = new AlertsHistoryContent();
             _alertsHistoryContent.MuteRuleService = _muteRuleService;
+            _alertsHistoryContent.RemediationApplyService = _remediationApplyService;
             _alertsHistoryContent.AlertsDismissed += (_, _) => UpdateAlertBadge();
 
             var headerPanel = new StackPanel { Orientation = Orientation.Horizontal };

--- a/Dashboard/RemediationConfirmWindow.xaml
+++ b/Dashboard/RemediationConfirmWindow.xaml
@@ -1,0 +1,126 @@
+<Window x:Class="PerformanceMonitorDashboard.RemediationConfirmWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Confirm Apply Fix"
+        Width="560" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="/EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" x:Name="HeaderText" FontSize="16" FontWeight="SemiBold"
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
+
+        <!-- Who / where -->
+        <Grid Grid.Row="1" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Server:" FontWeight="SemiBold"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" x:Name="ServerText"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Executing as:" FontWeight="SemiBold"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="ExecutingText"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3" TextWrapping="Wrap"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Initiated by:" FontWeight="SemiBold"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="OperatorText"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,3" TextWrapping="Wrap"/>
+        </Grid>
+
+        <!-- Banners: resolved-by-name note + audit-table-absent hard block -->
+        <StackPanel Grid.Row="2">
+            <Border x:Name="ByNameBanner" Visibility="Collapsed"
+                    CornerRadius="4" Padding="8" Margin="0,0,0,8">
+                <Border.Background>
+                    <SolidColorBrush Color="{StaticResource WarningColor}" Opacity="0.15"/>
+                </Border.Background>
+                <TextBlock x:Name="ByNameText" Foreground="{DynamicResource ForegroundBrush}"
+                           FontStyle="Italic" TextWrapping="Wrap"/>
+            </Border>
+
+            <Border x:Name="AuditAbsentBanner" Visibility="Collapsed"
+                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                <Border.Background>
+                    <SolidColorBrush Color="{StaticResource ErrorColor}" Opacity="0.20"/>
+                </Border.Background>
+                <TextBlock x:Name="AuditAbsentText" Foreground="{DynamicResource ForegroundBrush}"
+                           FontWeight="SemiBold" TextWrapping="Wrap"/>
+            </Border>
+        </StackPanel>
+
+        <!-- Targets -->
+        <Border Grid.Row="3" Background="{DynamicResource BackgroundBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                CornerRadius="4" Padding="8" Margin="0,0,0,10">
+            <StackPanel>
+                <TextBlock x:Name="TargetsHeader" Text="Targets" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                <ItemsControl x:Name="TargetsList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="0,2">
+                                <TextBlock Foreground="{DynamicResource ForegroundBrush}" TextWrapping="Wrap"
+                                           FontFamily="Consolas" FontSize="12" Text="{Binding HeadLine}"/>
+                                <TextBlock Foreground="{DynamicResource AccentBrush}" TextWrapping="Wrap"
+                                           FontSize="11" Text="{Binding StatusLine}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
+        <!-- M2: still-better caveat -->
+        <Border Grid.Row="4" x:Name="CaveatBanner" CornerRadius="4" Padding="10" Margin="0,0,0,10">
+            <Border.Background>
+                <SolidColorBrush Color="{StaticResource WarningColor}" Opacity="0.22"/>
+            </Border.Background>
+            <StackPanel>
+                <TextBlock x:Name="CaveatHeader" Text="⚠ Verify this is still the right fix"
+                           FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                <TextBlock x:Name="CaveatText" Foreground="{DynamicResource ForegroundBrush}" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- SQL preview -->
+        <StackPanel Grid.Row="5" Margin="0,0,0,12">
+            <TextBlock Text="SQL to execute:" FontWeight="SemiBold"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="SqlPreview" IsReadOnly="True" FontFamily="Consolas" FontSize="12"
+                     TextWrapping="NoWrap" MaxHeight="180"
+                     VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                     Background="Transparent" Foreground="{DynamicResource ForegroundBrush}"
+                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
+        </StackPanel>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="CancelButton" Content="Cancel" Padding="14,5" Margin="0,0,8,0"
+                    Click="CancelButton_Click" IsCancel="True"/>
+            <Button x:Name="ConfirmButton" Padding="14,5" Click="ConfirmButton_Click" IsDefault="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -1,0 +1,144 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using PerformanceMonitorDashboard.Services.Remediation;
+
+namespace PerformanceMonitorDashboard
+{
+    /// <summary>
+    /// The five-W confirm gate for an Apply / Un-apply. Shows the exact SQL, which
+    /// server + database(s), the executing identity (SUSER_SNAME) and the operator,
+    /// the original regression factor, and the M2 "verify the forced plan is still
+    /// better against current data" caveat. The dialog only returns true when the
+    /// operator explicitly clicks the apply button — that return value is the sole
+    /// thing that lets <see cref="RemediationApplyService"/> reach the privileged
+    /// handler.
+    /// </summary>
+    public partial class RemediationConfirmWindow : Window
+    {
+        public RemediationConfirmWindow(RemediationConfirmRequest request, bool resolvedByName, string? resolvedByNameReason)
+        {
+            InitializeComponent();
+
+            var verb = request.IsUnapply ? "Un-apply Fix" : "Apply Fix";
+            Title = $"Confirm {verb}";
+            HeaderText.Text = request.IsUnapply
+                ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
+                : $"Force the historical-better plan on {request.ServerDisplayName}?";
+
+            ServerText.Text = request.ServerDisplayName;
+            ExecutingText.Text = string.IsNullOrEmpty(request.ExecutingLogin)
+                ? "(monitoring login — re-probed at execution time via SUSER_SNAME())"
+                : request.ExecutingLogin;
+            OperatorText.Text = request.OperatorIdentity;
+
+            if (resolvedByName)
+            {
+                ByNameBanner.Visibility = Visibility.Visible;
+                ByNameText.Text = resolvedByNameReason
+                    ?? "The source server was resolved by name (the alert did not carry a stable server id). "
+                       + "Confirm this is the intended server before applying.";
+            }
+
+            TargetsHeader.Text = request.Targets.Count == 1 ? "Target" : $"Targets ({request.Targets.Count})";
+            var rows = new List<TargetRow>();
+            foreach (var t in request.Targets)
+                rows.Add(TargetRow.From(t, request.IsUnapply));
+            TargetsList.ItemsSource = rows;
+
+            // M2 caveat is an apply-time judgment; on un-apply there is no "still
+            // better" decision, so the caveat is hidden.
+            if (request.IsUnapply)
+            {
+                CaveatBanner.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                CaveatText.Text = RemediationConfirmRequest.StillBetterCaveat;
+            }
+
+            SqlPreview.Text = request.PreviewSql;
+
+            // Audit-table-absent hard block: the privileged core would block every
+            // target with no mutation, so disable the confirm button and say why.
+            if (!request.AuditTableExists)
+            {
+                AuditAbsentBanner.Visibility = Visibility.Visible;
+                AuditAbsentText.Text =
+                    "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). "
+                    + "Apply Fix is hard-blocked here — no change will be made. Upgrade this server to "
+                    + "2.12.0 to enable audited Apply Fix.";
+                ConfirmButton.Content = request.IsUnapply ? "Un-apply" : "Apply";
+                ConfirmButton.IsEnabled = false;
+                ConfirmButton.ToolTip = AuditAbsentText.Text;
+            }
+            else if (!request.IsUnapply && !request.AnyActionable)
+            {
+                // Nothing applyable (already forced / stale / QS off / no ALTER / wrong DB).
+                ConfirmButton.Content = $"Apply to {request.ServerDisplayName}";
+                ConfirmButton.IsEnabled = false;
+                ConfirmButton.ToolTip = "No target is in an applyable state — see the per-target notes above.";
+            }
+            else
+            {
+                ConfirmButton.Content = request.IsUnapply
+                    ? $"Un-apply on {request.ServerDisplayName}"
+                    : $"Apply to {request.ServerDisplayName}";
+            }
+        }
+
+        private void ConfirmButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        /// <summary>Bindable projection of one confirm target.</summary>
+        private sealed class TargetRow
+        {
+            public string HeadLine { get; private set; } = "";
+            public string StatusLine { get; private set; } = "";
+
+            public static TargetRow From(RemediationConfirmTarget t, bool isUnapply)
+            {
+                var head = $"[{t.Database}]  query_id {t.QueryId}, plan_id {t.PlanId}";
+                if (!isUnapply && t.RegressionFactor > 0)
+                    head += $"  —  regression {t.RegressionFactor.ToString("0.#", CultureInfo.InvariantCulture)}x";
+
+                var status = DescribeDisposition(t, isUnapply);
+                return new TargetRow { HeadLine = head, StatusLine = status };
+            }
+
+            private static string DescribeDisposition(RemediationConfirmTarget t, bool isUnapply)
+            {
+                if (isUnapply)
+                    return "Will unforce if this plan was forced by Apply Fix; otherwise skipped.";
+
+                return t.Disposition switch
+                {
+                    RemediationDisposition.Ok => "Ready to apply.",
+                    RemediationDisposition.WarnFailing => "⚠ " + (t.DispositionMessage ?? "Has a prior force failure; re-forcing may not help."),
+                    RemediationDisposition.AlreadyForced => "Already forced — will be skipped.",
+                    RemediationDisposition.BlockStale => "Plan/query no longer present — will be skipped.",
+                    RemediationDisposition.BlockQueryStoreOff => "Query Store is not READ_WRITE — cannot force.",
+                    RemediationDisposition.BlockNoAlter => "Monitoring login lacks ALTER — will fail closed (no change).",
+                    RemediationDisposition.BlockWrongDatabase => "Connected DB does not match the target — will not proceed.",
+                    RemediationDisposition.BlockAuditTableAbsent => "Audit table absent (pre-2.12.0) — hard-blocked.",
+                    _ => t.DispositionMessage ?? "Unable to determine target state."
+                };
+            }
+        }
+    }
+}

--- a/Dashboard/Services/Remediation/AuditWritabilityProbe.cs
+++ b/Dashboard/Services/Remediation/AuditWritabilityProbe.cs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Read-only classifier for an applied-but-unlogged audit failure (LOW-2). A
+    /// force that succeeds but whose audit row will not write looks identical
+    /// whether the cause is a one-off (deadlock / timeout) or a permanent setup
+    /// problem (the login simply lacks INSERT on a present
+    /// <c>config.remediation_action_log</c>). The permanent case would silently
+    /// drop EVERY audit row on that server, so it must be surfaced loudly rather
+    /// than buried as a per-target warning.
+    ///
+    /// <para>
+    /// This is a PR-B-owned, purely read-only probe on the MONITORING connection
+    /// (PerformanceMonitor DB) — it issues no mutation and is invoked only AFTER an
+    /// applied-but-unlogged outcome, never on the apply path itself. It does not
+    /// touch the reviewed PR-A execution/audit core.
+    /// </para>
+    /// </summary>
+    public static class AuditWritabilityProbe
+    {
+        /// <summary>
+        /// Classifies why a prior audit INSERT failed against a present table.
+        /// Permanent when the login has no INSERT permission on
+        /// <c>config.remediation_action_log</c>; Transient when it does (so the
+        /// earlier failure was a one-off); Unknown if the probe itself fails.
+        /// </summary>
+        public static async Task<AuditWriteFailureKind> ClassifyAsync(string monitoringConnectionString, CancellationToken ct)
+        {
+            try
+            {
+                using var connection = new SqlConnection(monitoringConnectionString);
+                await connection.OpenAsync(ct).ConfigureAwait(false);
+
+                using var command = connection.CreateCommand();
+                // OBJECT-scoped INSERT permission on the audit table. NULL (table
+                // unexpectedly gone) is treated as not-insertable -> permanent.
+                command.CommandText =
+                    "SELECT can_insert = ISNULL(HAS_PERMS_BY_NAME(N'config.remediation_action_log', N'OBJECT', N'INSERT'), 0);";
+
+                var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                var canInsert = result is not null && result is not System.DBNull && System.Convert.ToInt32(result) == 1;
+                return canInsert ? AuditWriteFailureKind.Transient : AuditWriteFailureKind.Permanent;
+            }
+            catch
+            {
+                // The classification probe is best-effort; a probe failure must not
+                // escalate or mask the (successful, reversible) mutation.
+                return AuditWriteFailureKind.Unknown;
+            }
+        }
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationApplyModels.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyModels.cs
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Top-level outcome of a <see cref="RemediationApplyService"/> run. Distinguishes
+    /// the three terminal states the UI must surface differently: there was no
+    /// handler for the fact key (no Apply affordance should ever have been shown),
+    /// the operator declined the confirm modal (nothing ran — the gate held), or the
+    /// privileged handler actually ran (per-target results follow).
+    /// </summary>
+    public enum RemediationRunStatus
+    {
+        /// <summary>No registered handler for the action's fact key — nothing ran.</summary>
+        NoHandler,
+
+        /// <summary>The operator declined the confirm modal — the gate held; no mutation.</summary>
+        NotConfirmed,
+
+        /// <summary>The handler ran; see <see cref="RemediationRunReport.Targets"/>.</summary>
+        Ran
+    }
+
+    /// <summary>
+    /// Why a post-apply audit INSERT failed (LOW-2). Only meaningful for a target
+    /// whose force succeeded but whose audit row could not be written against a
+    /// present <c>config.remediation_action_log</c>.
+    /// </summary>
+    public enum AuditWriteFailureKind
+    {
+        /// <summary>No audit failure — the row was written.</summary>
+        None,
+
+        /// <summary>
+        /// The login can INSERT, so the failure was a one-off (deadlock / timeout) —
+        /// a soft warning; retrying or Un-apply/Apply again will likely log fine.
+        /// </summary>
+        Transient,
+
+        /// <summary>
+        /// The login lacks INSERT on a present <c>config.remediation_action_log</c>
+        /// — a setup/grant misconfiguration that will silently drop EVERY audit row
+        /// until fixed. Surfaced loudly ("fix this") so a force-succeeds-but-never-
+        /// logged deployment is visible, not buried.
+        /// </summary>
+        Permanent,
+
+        /// <summary>The classification probe itself failed — surface as a soft warning.</summary>
+        Unknown
+    }
+
+    /// <summary>
+    /// The resolved (or deliberately unresolved) source server for an alert. M3 is
+    /// fail-closed: a missing or ambiguous resolution yields <see cref="Server"/>
+    /// null and a <see cref="Reason"/> for the disabled-Apply tooltip — the UI never
+    /// silently picks a server.
+    /// </summary>
+    public sealed class ServerResolution
+    {
+        public ServerConnection? Server { get; init; }
+
+        /// <summary>True only when a single, unambiguous server was resolved.</summary>
+        public bool IsResolved => Server is not null;
+
+        /// <summary>
+        /// True when resolution fell back to a unique <c>ServerName</c> match
+        /// (the persisted ServerId was an int-id fallback / legacy / missing GUID).
+        /// Surfaced as a note in the confirm modal.
+        /// </summary>
+        public bool ResolvedByName { get; init; }
+
+        /// <summary>Why Apply is disabled (tooltip text) when <see cref="IsResolved"/> is false.</summary>
+        public string? Reason { get; init; }
+    }
+
+    /// <summary>One target row shown in the confirm modal (the "what / where").</summary>
+    public sealed class RemediationConfirmTarget
+    {
+        public string Database { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+
+        /// <summary>Original regression_factor from the finding (M2 — surfaced so the operator owns the still-better judgment).</summary>
+        public double RegressionFactor { get; init; }
+
+        /// <summary>Advisory preflight disposition for this target (display only).</summary>
+        public RemediationDisposition Disposition { get; init; }
+        public string? DispositionMessage { get; init; }
+    }
+
+    /// <summary>
+    /// The five-W payload the confirm modal renders. Built by
+    /// <see cref="RemediationApplyService"/> from the read-only preflight + the
+    /// action; handed to the operator's confirm callback. The callback returning
+    /// true is the ONLY thing that lets the privileged handler run.
+    /// </summary>
+    public sealed class RemediationConfirmRequest
+    {
+        public string ServerDisplayName { get; init; } = "";
+        public bool IsUnapply { get; init; }
+
+        /// <summary>Exact SQL preview shown verbatim (the code-block T-SQL for apply; the unforce statements for un-apply).</summary>
+        public string PreviewSql { get; init; } = "";
+
+        /// <summary>OS / Windows user driving the Dashboard (audited as operator_identity).</summary>
+        public string OperatorIdentity { get; init; } = "";
+
+        /// <summary>SUSER_SNAME() under the monitoring connection (from preflight) — the identity the mutation actually runs as.</summary>
+        public string? ExecutingLogin { get; init; }
+
+        public IReadOnlyList<RemediationConfirmTarget> Targets { get; init; } = new List<RemediationConfirmTarget>();
+
+        /// <summary>False when the target server is pre-2.12.0 schema — apply will hard-block.</summary>
+        public bool AuditTableExists { get; init; }
+
+        /// <summary>True when at least one target is in a state where applying can do something.</summary>
+        public bool AnyActionable =>
+            AuditTableExists &&
+            Targets.Any(t => t.Disposition is RemediationDisposition.Ok or RemediationDisposition.WarnFailing);
+
+        /// <summary>
+        /// M2 caveat: freshness proves the plan is present and forceable — NOT that
+        /// the forced plan is still the better choice. That judgment is the
+        /// operator's. Mirrors FactAdvice.cs:393-394; surfaced in the modal so it
+        /// cannot be missed by not reading the preview comment.
+        /// </summary>
+        public const string StillBetterCaveat =
+            "Freshness was verified (plan present, forceable, Query Store READ_WRITE) — " +
+            "but NOT that the forced plan is still the better choice. Schema changes, data " +
+            "growth, or updated statistics may have made the historical plan stale. Verify " +
+            "the forced plan is still better against current data before applying.";
+    }
+
+    /// <summary>Per-target result the UI surfaces after a run.</summary>
+    public sealed class RemediationTargetReport
+    {
+        public string Database { get; init; } = "";
+        public long QueryId { get; init; }
+        public long PlanId { get; init; }
+        public RemediationStatus Status { get; init; }
+        public string? Message { get; init; }
+        public bool AuditWritten { get; init; }
+
+        /// <summary>The mutation succeeded but the audit row could not be written (O3).</summary>
+        public bool AppliedButUnlogged { get; init; }
+
+        /// <summary>Permanent-vs-transient classification for an applied-but-unlogged target (LOW-2).</summary>
+        public AuditWriteFailureKind AuditFailureKind { get; init; }
+    }
+
+    /// <summary>Aggregate run report handed back to the UI.</summary>
+    public sealed class RemediationRunReport
+    {
+        public RemediationRunStatus Status { get; init; }
+        public bool IsUnapply { get; init; }
+        public IReadOnlyList<RemediationTargetReport> Targets { get; init; } = new List<RemediationTargetReport>();
+
+        public bool AnySuccess => Targets.Any(t => t.Status == RemediationStatus.Success);
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// The single, UI-agnostic entry point the Dashboard uses to apply / un-apply a
+    /// remediation. It is the ONLY non-core caller of the privileged remediation
+    /// machinery (registry / handler / executor) — the UI binds to this facade and
+    /// never touches those types directly, which is what keeps "reachable only
+    /// through the gate" both true and statically checkable.
+    ///
+    /// <para>
+    /// The confirm gate lives INSIDE this service: <see cref="RunAsync"/> invokes the
+    /// operator's confirm callback and calls the handler's privileged
+    /// <c>ApplyAsync</c>/<c>UnapplyAsync</c> ONLY when that callback returns true.
+    /// There is no auto-apply, no apply-on-load, and no batch-without-confirm path.
+    /// The read-only preflight that drives the modal is display only; the handler /
+    /// executor re-derive the authoritative gate on the mutating connection (PR-A).
+    /// </para>
+    /// </summary>
+    public sealed class RemediationApplyService
+    {
+        private readonly ServerManager _serverManager;
+        private readonly RemediationHandlerRegistry _registry;
+        private readonly Func<ServerConnection, IRemediationExecutor> _executorFactory;
+        private readonly Func<ServerConnection, CancellationToken, Task<AuditWriteFailureKind>> _auditFailureClassifier;
+
+        /// <summary>
+        /// Production constructor. Builds the v1 registry (force-plan only) and wires
+        /// the executor + audit-failure classifier over the existing per-server
+        /// monitoring connection (no elevation — the connection is reused as-is).
+        /// </summary>
+        public RemediationApplyService(ServerManager serverManager, ICredentialService credentialService)
+        {
+            _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
+            if (credentialService is null) throw new ArgumentNullException(nameof(credentialService));
+
+            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler() });
+            _executorFactory = server =>
+                new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
+            _auditFailureClassifier = (server, ct) =>
+                AuditWritabilityProbe.ClassifyAsync(server.GetConnectionString(credentialService), ct);
+        }
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo Dashboard.Tests): inject a fake registry,
+        /// executor factory, and audit-failure classifier. Routes through the exact
+        /// same gated <see cref="RunAsync"/>, so it cannot bypass the confirm gate.
+        /// </summary>
+        internal RemediationApplyService(
+            ServerManager serverManager,
+            RemediationHandlerRegistry registry,
+            Func<ServerConnection, IRemediationExecutor> executorFactory,
+            Func<ServerConnection, CancellationToken, Task<AuditWriteFailureKind>>? auditFailureClassifier = null)
+        {
+            _serverManager = serverManager;
+            _registry = registry;
+            _executorFactory = executorFactory;
+            _auditFailureClassifier = auditFailureClassifier
+                ?? ((_, _) => Task.FromResult(AuditWriteFailureKind.Unknown));
+        }
+
+        /// <summary>
+        /// Whether a registered handler exists for this fact key (one half of the
+        /// UI's Apply-affordance gate; the other half is unambiguous server
+        /// resolution). Null / unknown fact keys yield no Apply button.
+        /// </summary>
+        public bool HasHandlerFor(string? factKey) => _registry.TryGet(factKey) is not null;
+
+        /// <summary>
+        /// M3 fail-closed server resolution. GUID match first; on a miss (incl. the
+        /// int-id fallback / legacy / empty ServerId) fall back to a UNIQUE
+        /// ServerName match; ambiguous (&gt;1) or unresolved (0) yields no server and
+        /// a reason for the disabled-Apply tooltip. Never silently picks a server.
+        /// </summary>
+        public ServerResolution ResolveServer(string? serverId, string serverName)
+            => ResolveServer(serverId, serverName, _serverManager.GetAllServers());
+
+        /// <summary>Pure resolution logic (unit-testable without a live ServerManager).</summary>
+        public static ServerResolution ResolveServer(string? serverId, string serverName, IReadOnlyList<ServerConnection> allServers)
+        {
+            if (allServers is null)
+                return new ServerResolution { Reason = "No servers are configured." };
+
+            // 1. Exact GUID match (the normal path for alerts produced by the GUID resolver).
+            if (!string.IsNullOrEmpty(serverId))
+            {
+                var byId = allServers.FirstOrDefault(s => string.Equals(s.Id, serverId, StringComparison.Ordinal));
+                if (byId is not null)
+                    return new ServerResolution { Server = byId };
+            }
+
+            // 2/3. GUID miss (incl. the int-id fallback from MainWindow's notify-time
+            // resolver, and legacy/empty ServerId) -> resolve by a UNIQUE ServerName.
+            var byName = allServers
+                .Where(s => string.Equals(s.ServerName, serverName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (byName.Count == 1)
+                return new ServerResolution { Server = byName[0], ResolvedByName = true };
+
+            // 4. Ambiguous or unresolved -> FAIL CLOSED. This is the wrong-server boundary.
+            var reason = byName.Count > 1
+                ? $"Cannot unambiguously resolve the source server for this alert: " +
+                  $"{byName.Count} configured servers are named \"{serverName}\". Apply is disabled."
+                : "Cannot resolve the source server for this alert (it may have been renamed or " +
+                  "removed since the alert fired). Apply is disabled.";
+            return new ServerResolution { Reason = reason };
+        }
+
+        /// <summary>
+        /// Apply a remediation against a resolved server. Runs read-only preflight,
+        /// presents the confirm request, and — ONLY if the operator confirms —
+        /// invokes the privileged handler.
+        /// </summary>
+        public Task<RemediationRunReport> ApplyAsync(
+            RemediationAction action,
+            ServerConnection server,
+            string? previewSql,
+            string operatorIdentity,
+            string? sourceAlertRef,
+            Func<RemediationConfirmRequest, Task<bool>> confirm,
+            CancellationToken ct)
+            => RunAsync(action, server, previewSql, operatorIdentity, sourceAlertRef, confirm, isUnapply: false, ct);
+
+        /// <summary>Un-apply (unforce) a previously applied remediation. Same gated shape as Apply.</summary>
+        public Task<RemediationRunReport> UnapplyAsync(
+            RemediationAction action,
+            ServerConnection server,
+            string operatorIdentity,
+            string? sourceAlertRef,
+            Func<RemediationConfirmRequest, Task<bool>> confirm,
+            CancellationToken ct)
+            => RunAsync(action, server, previewSql: null, operatorIdentity, sourceAlertRef, confirm, isUnapply: true, ct);
+
+        private async Task<RemediationRunReport> RunAsync(
+            RemediationAction action,
+            ServerConnection server,
+            string? previewSql,
+            string operatorIdentity,
+            string? sourceAlertRef,
+            Func<RemediationConfirmRequest, Task<bool>> confirm,
+            bool isUnapply,
+            CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (server is null) throw new ArgumentNullException(nameof(server));
+            if (confirm is null) throw new ArgumentNullException(nameof(confirm));
+
+            var handler = _registry.TryGet(action.FactKey);
+            if (handler is null)
+                return new RemediationRunReport { Status = RemediationRunStatus.NoHandler, IsUnapply = isUnapply };
+
+            var exec = _executorFactory(server);
+
+            // Read-only preflight: DISPLAY DRIVER ONLY. Populates the confirm modal's
+            // per-target dispositions and executing identity. It is NOT the gate —
+            // the handler/executor re-derive the authoritative gate (correct-DB +
+            // ALTER + freshness) on the mutating connection (PR-A, R2-MOD-1).
+            var preflight = await handler.PreflightAsync(action, exec, ct).ConfigureAwait(false);
+
+            var preview = string.IsNullOrEmpty(previewSql)
+                ? RenderPreview(action, isUnapply)
+                : previewSql!;
+
+            var request = BuildConfirmRequest(action, server, preview, operatorIdentity, isUnapply, preflight);
+
+            // ── THE GATE ──────────────────────────────────────────────────────────
+            // The privileged handler.ApplyAsync/UnapplyAsync below is reached ONLY
+            // when the operator's confirm callback returns true. This is the single
+            // sanctioned path to the executor; there is no automatic, on-load, or
+            // batch-without-confirm route.
+            var confirmed = await confirm(request).ConfigureAwait(false);
+            if (!confirmed)
+                return new RemediationRunReport { Status = RemediationRunStatus.NotConfirmed, IsUnapply = isUnapply };
+
+            var identity = new RemediationIdentity(operatorIdentity, sourceAlertRef);
+            var result = isUnapply
+                ? await handler.UnapplyAsync(action, exec, identity, ct).ConfigureAwait(false)
+                : await handler.ApplyAsync(action, exec, identity, ct).ConfigureAwait(false);
+
+            var targets = new List<RemediationTargetReport>(result.Outcomes.Count);
+            foreach (var o in result.Outcomes)
+            {
+                // LOW-2: only an applied-but-unlogged target needs the permanent-vs-
+                // transient classification; everything else is None.
+                var failureKind = AuditWriteFailureKind.None;
+                if (o.AppliedButUnlogged)
+                    failureKind = await _auditFailureClassifier(server, ct).ConfigureAwait(false);
+
+                targets.Add(new RemediationTargetReport
+                {
+                    Database = o.Database,
+                    QueryId = o.QueryId,
+                    PlanId = o.PlanId,
+                    Status = o.Status,
+                    Message = o.Message,
+                    AuditWritten = o.AuditWritten,
+                    AppliedButUnlogged = o.AppliedButUnlogged,
+                    AuditFailureKind = failureKind
+                });
+            }
+
+            return new RemediationRunReport
+            {
+                Status = RemediationRunStatus.Ran,
+                IsUnapply = isUnapply,
+                Targets = targets
+            };
+        }
+
+        private static RemediationConfirmRequest BuildConfirmRequest(
+            RemediationAction action,
+            ServerConnection server,
+            string preview,
+            string operatorIdentity,
+            bool isUnapply,
+            PreflightResult preflight)
+        {
+            // Preflight targets align 1:1 with action targets (the handler builds them
+            // in order). Match by index; tolerate a short preflight list defensively.
+            var confirmTargets = new List<RemediationConfirmTarget>(action.Targets.Count);
+            for (var i = 0; i < action.Targets.Count; i++)
+            {
+                var t = action.Targets[i];
+                var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
+                confirmTargets.Add(new RemediationConfirmTarget
+                {
+                    Database = t.Database,
+                    QueryId = t.QueryId,
+                    PlanId = t.PlanId,
+                    RegressionFactor = t.RegressionFactor,
+                    Disposition = pf?.Disposition ?? RemediationDisposition.Error,
+                    DispositionMessage = pf?.Message
+                });
+            }
+
+            var executingLogin = preflight.Targets
+                .Select(p => p.ExecutingLogin)
+                .FirstOrDefault(l => !string.IsNullOrEmpty(l));
+
+            return new RemediationConfirmRequest
+            {
+                ServerDisplayName = string.IsNullOrEmpty(server.DisplayName) ? server.ServerName : server.DisplayName,
+                IsUnapply = isUnapply,
+                PreviewSql = preview,
+                OperatorIdentity = operatorIdentity,
+                ExecutingLogin = executingLogin,
+                Targets = confirmTargets,
+                AuditTableExists = preflight.AuditTableExists
+            };
+        }
+
+        /// <summary>
+        /// Canonical EXEC preview rendered from the typed targets — exactly the
+        /// statement that will run (matches the audited generated_sql). Used for the
+        /// un-apply modal, and as a fallback when no code-block preview is supplied.
+        /// </summary>
+        private static string RenderPreview(RemediationAction action, bool isUnapply)
+        {
+            var proc = isUnapply ? "sp_query_store_unforce_plan" : "sp_query_store_force_plan";
+            var sb = new StringBuilder();
+            foreach (var t in action.Targets)
+            {
+                sb.Append("-- [").Append(t.Database).Append("]\n");
+                sb.Append("EXEC sys.").Append(proc)
+                  .Append(" @query_id = ").Append(t.QueryId)
+                  .Append(", @plan_id = ").Append(t.PlanId).Append(";\n");
+            }
+            return sb.ToString().TrimEnd('\n');
+        }
+    }
+}


### PR DESCRIPTION
PR-B of B3 "Apply Fix": the **gated Dashboard UI** over the privileged force-plan executor merged in **PR-A (#1032)**. A Dashboard operator reviews a `PLAN_REGRESSION` finding's remediation in the alert detail dialog and clicks **Apply Fix…** behind a confirm modal. This PR is pure presentation + orchestration over the already-reviewed core — **no change to PR-A's mutation/audit/gate logic**.

> Do not merge yet — this is the path that exposes the privileged executor, so it gets a diff review + a dedicated security-reviewer pass on the actual code first (same bar as PR-A).

## Six security properties (and how each is enforced)

**1. The ONLY path to the executor is the gated flow.**
The UI reaches the executor solely through `RemediationApplyService.ApplyAsync` → read-only **preflight (display)** → **confirm modal** → `handler.ApplyAsync` (which re-gates on one connection per PR-A's R2-MOD-1). `ApplyAsync`/`UnapplyAsync` run only from the operator's button click — there is **no auto-apply, no apply-on-load, and no batch-without-per-action-confirm**. The confirm gate lives *inside* `RunAsync`, immediately before the single call site of the privileged handler.

**2. No-caller guard → reachability-with-gate (replaced, not deleted).**
PR-A's `NoCaller_ForceUnforce_OnlyReferencedInRemediationCore` necessarily fails now (PR-B adds a legitimate caller). It is replaced with three assertions that prove *reachable only through the gate*:
- `CoreMachinery_OnlyReferencedInRemediationCore` — the machinery **types** + `ForcePlanAsync`/`UnforcePlanAsync` are still referenced only inside `Services/Remediation/`; the UI never touches them directly.
- `GatedEntry_ReferencedOnlyBySanctionedUiPath` — the single gated facade `RemediationApplyService` is referenced outside the core **only** by the 4 sanctioned UI files (`MainWindow`, `AlertsHistoryContent`, `AlertDetailWindow`, `RemediationConfirmWindow`). A new reference fails the build.
- `Gate_ConfirmFalse_NeverReachesHandler` / `Gate_ConfirmTrue_ReachesHandlerExactlyOnce` — behavioural proof the service cannot reach `handler.ApplyAsync` unless `confirm()` returns `true`.

**3. Fail-closed server resolution (M3).**
`ServerId` is restored onto `AlertHistoryDisplayItem` and mapped from `AlertLogEntry.ServerId`. Resolution: exact **GUID** match → unique **ServerName** match → **ambiguous / unresolved / int-id-fallback ⇒ Apply HARD-DISABLED** with a tooltip. Never silently picks a server. Unit-tested incl. the int-id-fallback case from `MainWindow.xaml.cs:148-150`.

**4. Confirm modal (M2 + the five W's).**
`RemediationConfirmWindow` shows the exact SQL preview, server + per-target database, the executing identity (`SUSER_SNAME()` from preflight) + the operator, the original `regression_factor`, and an explicit caveat: *freshness proves plan-present/forceable — NOT that the forced plan is still better; verify against current data*. This surfaces `FactAdvice.cs:393-394` in the modal rather than relying on the operator reading the preview comment.

**5. Result surfacing incl. LOW-2.**
Per-target outcomes: success / skipped / blocked (audit-table-absent → "upgrade this server to 2.12.0") / permission-denied (fail-closed grant guidance, no elevation prompt) / applied-but-unlogged. **LOW-2:** a *permanent* audit-INSERT failure (login lacks `INSERT` on a present `config.remediation_action_log`) is distinguished from a transient one by a read-only `AuditWritabilityProbe` and surfaced **loudly** (bold/error: "every Apply will go unlogged until fixed") vs a soft transient warning — so a force-succeeds-nothing-ever-logged misconfiguration is visible, not buried.

**6. Never automatic.**
No path applies without the operator's explicit per-action confirm. No elevation/credential prompt — the existing per-server monitoring connection only (PR-A's model). B4 (fully automatic) stays out.

## Files
**New** — `Dashboard/Services/Remediation/RemediationApplyService.cs` (gated facade + M3 resolution), `RemediationApplyModels.cs` (UI DTOs), `AuditWritabilityProbe.cs` (LOW-2 read-only classifier); `Dashboard/RemediationConfirmWindow.xaml(.cs)` (confirm modal).
**Modified** — `AlertDetailWindow.xaml(.cs)` (Apply/Un-apply buttons, results, server resolution), `Controls/AlertsHistoryContent.xaml.cs` (`ServerId` + service threading), `MainWindow.xaml.cs` (construct + inject the service).

The UI references only the gated facade + result DTOs — never the handler/registry/executor types or the force/unforce methods.

## Verification
- **Build:** Dashboard + test projects clean (`CS4014` is WarningsAsErrors; 0 errors). The one build warning is PR-A's pre-existing `FakeExecutor.UnforceFunc`.
- **Tests:** `dotnet test` **84 passed / 0 failed** (baseline 68 → replaced 1 no-caller test with 2 reachability tests + 15 new PR-B tests: gate, M3 resolution, applied-but-unlogged permanent-vs-transient, `CanApply` view-model gating).
- **Real-server (sql2022, 2.12.0 schema present)** via the full production gated path (`RemediationApplyService` → `ForcePlanHandler` → `DatabaseServiceRemediationExecutor` → `DatabaseService.Remediation` → live DB), target `StatsAsymTest` query_id 1 / plan_id 1:
  - **Apply** → `is_forced_plan` 0→1, audit row `force | success | sa | StatsAsymTest`
  - **Un-apply** → 1→0, audit row `unforce | success | sa | StatsAsymTest`
  - **confirm=false** → `NotConfirmed`, 0 targets, plan unchanged (gate held)
  - **absent-table** (monitoring conn → tempdb) → `Blocked` with the 2.12.0 upgrade message, no mutation
  - Server left clean (`is_forced_plan=0`).

  The literal mouse-driven click-through of the WPF dialog remains a manual spot-check for a human; the underlying gated path the dialog invokes is verified end-to-end above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)