### PR TITLE
Harden by-name server resolution in Apply-Fix confirm (B3 LOW-2)

### DIFF
--- a/Dashboard/RemediationConfirmWindow.xaml
+++ b/Dashboard/RemediationConfirmWindow.xaml
@@ -57,8 +57,17 @@
                 <Border.Background>
                     <SolidColorBrush Color="{StaticResource WarningColor}" Opacity="0.15"/>
                 </Border.Background>
-                <TextBlock x:Name="ByNameText" Foreground="{DynamicResource ForegroundBrush}"
-                           FontStyle="Italic" TextWrapping="Wrap"/>
+                <StackPanel>
+                    <TextBlock x:Name="ByNameText" Foreground="{DynamicResource ForegroundBrush}"
+                               FontStyle="Italic" TextWrapping="Wrap"/>
+                    <!-- LOW-2: a by-name-resolved server may be the wrong target if it was
+                         renamed/replaced since the alert. Require explicit acknowledgement
+                         (and no Enter click-through) before Apply is enabled. -->
+                    <CheckBox x:Name="ByNameAckCheck" Visibility="Collapsed" Margin="0,8,0,0"
+                              Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold"
+                              Content="I confirm this is the correct target server."
+                              Checked="ByNameAck_Changed" Unchecked="ByNameAck_Changed"/>
+                </StackPanel>
             </Border>
 
             <Border x:Name="AuditAbsentBanner" Visibility="Collapsed"

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -91,6 +91,35 @@ namespace PerformanceMonitorDashboard
                     ? $"Un-apply on {request.ServerDisplayName}"
                     : $"Apply to {request.ServerDisplayName}";
             }
+
+            // LOW-2 (wrong-server boundary): when the source server was resolved by
+            // NAME (the alert lacked a stable id and a unique name matched), a server
+            // renamed/replaced since the alert could be a *different* target. Remove
+            // the Enter-key click-through, and — only if Apply would otherwise be
+            // enabled — require an explicit acknowledgement checkbox before enabling
+            // it, so a by-name target can never be applied by a reflexive click/Enter.
+            if (resolvedByName)
+            {
+                ConfirmButton.IsDefault = false;
+                if (ConfirmButton.IsEnabled)
+                {
+                    ByNameAckCheck.Visibility = Visibility.Visible;
+                    ByNameAckCheck.IsChecked = false;
+                    ConfirmButton.IsEnabled = false;
+                    ConfirmButton.ToolTip = "Confirm the target server (checkbox above) to enable.";
+                }
+            }
+        }
+
+        // Gates Apply on the explicit by-name acknowledgement (LOW-2). Only reachable
+        // when ByNameAckCheck is visible — i.e. resolved-by-name AND otherwise-applyable;
+        // the audit-absent / not-actionable hard-blocks leave the checkbox collapsed, so
+        // the button stays disabled there regardless.
+        private void ByNameAck_Changed(object sender, RoutedEventArgs e)
+        {
+            ConfirmButton.IsEnabled = ByNameAckCheck.IsChecked == true;
+            if (ConfirmButton.IsEnabled)
+                ConfirmButton.ClearValue(ToolTipProperty);
         }
 
         private void ConfirmButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Closes the LOW-2 residual from the PR-B security review (#1033): a finding whose persisted `ServerId` is the analysis int-id fallback can resolve to a *different* server by unique-name match if that server was renamed/replaced between the alert and the apply.

PR-B mitigated this with a "resolved by name — verify the server" banner + exact target display + reversible un-apply. This change closes the reflexive-click path:

- On `ResolvedByName`, the confirm dialog **removes the Enter-key default** (`ConfirmButton.IsDefault = false`).
- When Apply would otherwise be enabled, it requires an explicit **"I confirm this is the correct target server"** checkbox before enabling Apply.
- Strictly more restrictive: the audit-table-absent and not-actionable hard-blocks are unaffected (checkbox stays collapsed, button stays disabled). The non-by-name path is unchanged (keeps Enter-to-confirm).

Dashboard.Tests 84/0, build clean (0 warnings, CS4014-as-error). UI-window click behavior isn't unit-tested (consistent with the codebase — no WPF window tests); the gating logic is additive friction and a human spot-click of the by-name case is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)