### PR TITLE
Fix #1035: Silence All Alerts now suppresses email too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **"Silence All Alerts" now suppresses email too** ([#1035]) — right-clicking a monitored instance and choosing *Silence All Alerts* hid tray notifications and Alerts-tab badges, but two email paths ignored the silenced state and kept sending: connection up/down emails (*Server Unreachable* / *Server Restored*) and analysis-finding emails (the narrative findings from the analysis engine, which include CPU/memory/blocking stories). Only the threshold-alert path (High CPU, blocking, deadlocks, etc.) honored silencing. Both gaps are closed — a silenced server now produces no tray, email, or alert-history row from any path. The analysis path was the likely source of the reporter's "High CPU" email, since the threshold-based High CPU alert was already suppressed. The shared `AnalysisNotificationService` (used by Lite too) gains an optional per-server silence predicate; Lite has no silencing feature and passes none
 - **Dashboard time labels are now consistently 24-hour** ([#1012]) — the time-range header at the top of each tab (e.g. *"Original: May 28, 11:30 PM – May 29, 1:30 AM (PST)"*) and the Query Performance heatmap x-axis tick labels used `h:mm tt`, while every other timestamp in the app (footer "Last refresh", DataGrid columns, slicer, tooltips, logs) already used 24-hour `HH:mm`/`HH:mm:ss`. The AM/PM marker was also being truncated in the column shown by the reporter. Normalized the four outliers to `HH:mm` to match the rest of the app. The Lite heatmap had the same `h:mm tt` straggler — fixed alongside
 - **Lite UI no longer freezes during archival** ([#979]) — archival held DuckDB's exclusive write lock across the entire export-to-Parquet step, blocking every UI query (tab switches showed the spinning wheel, worse with more monitored servers). Export-to-Parquet only reads the database, so it now runs under a shared read lock concurrently with the UI; only the brief `DELETE` takes the exclusive write lock
 - **Lite FinOps no longer recommends an edition downgrade on an Availability Group secondary** ([#980]) — the licensing recommendations suggested "downgrade to Standard to save $X/mo" for any Enterprise instance, with no AG awareness. On a secondary replica that advice is misleading — every replica in an AG must run the same edition. FinOps now detects the AG replica role and, on a secondary, shows an informational note instead of the downgrade/savings estimate
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#980]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/980
 [#981]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/981
 [#1012]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1012
+[#1035]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1035
 
 ## [2.11.0] - 2026-05-19
 

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -159,7 +159,10 @@ namespace PerformanceMonitorDashboard
                 finding => _serverManager.GetAllServers()
                     .FirstOrDefault(s => string.Equals(s.ServerName, finding.ServerName, StringComparison.OrdinalIgnoreCase))
                     ?.Id ?? finding.ServerId.ToString(),
-                new LoggerAdapter<AnalysisNotificationService>());
+                new LoggerAdapter<AnalysisNotificationService>(),
+                /* Suppress analysis-finding emails for servers the user silenced via
+                   "Silence All Alerts" — matches the threshold-alert guard. */
+                _alertStateService.IsAnySilencingActive);
             _analysisScheduler = new AnalysisScheduler(
                 _serverManager, _credentialService, _preferencesService, _analysisNotificationService);
 
@@ -514,7 +517,13 @@ namespace PerformanceMonitorDashboard
                     // Send notifications on status changes (skip first check)
                     if (_previousConnectionStates.ContainsKey(item.Id))
                     {
-                        if (wasOnline && !isOnline && prefs.NotifyOnConnectionLost)
+                        /* "Silence All Alerts" suppresses connection up/down notifications too —
+                           match the threshold-alert guard so a silenced server produces no tray,
+                           email, or history row. State tracking below still runs unconditionally,
+                           so unsilencing resumes from the correct baseline. */
+                        bool silenced = _alertStateService.IsAnySilencingActive(item.Id);
+
+                        if (!silenced && wasOnline && !isOnline && prefs.NotifyOnConnectionLost)
                         {
                             _notificationService?.ShowServerOfflineNotification(
                                 item.DisplayName,
@@ -530,7 +539,7 @@ namespace PerformanceMonitorDashboard
                                 "Online",
                                 item.Id);
                         }
-                        else if (!wasOnline && isOnline && prefs.NotifyOnConnectionRestored)
+                        else if (!silenced && !wasOnline && isOnline && prefs.NotifyOnConnectionRestored)
                         {
                             _notificationService?.ShowConnectionRestoredNotification(item.DisplayName);
 

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -44,12 +44,12 @@ public class AnalysisNotificationTests : IDisposable
     /// Builds the shared AnalysisNotificationService wired to a real Lite EmailAlertService
     /// (its IFindingAlertSender) over the test DuckDB store, with Lite's serverId resolver.
     /// </summary>
-    private AnalysisNotificationService MakeNotifier()
+    private AnalysisNotificationService MakeNotifier(Func<string, bool>? isServerSilenced = null)
     {
         var webhook = new WebhookAlertService(_settings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>());
         var email = new EmailAlertService(_settings, new DuckDbAlertHistoryStore(_duckDb), webhook, new AppLoggerAdapter<EmailAlertService>());
         return new AnalysisNotificationService(
-            email, _settings, f => f.ServerId.ToString(), new AppLoggerAdapter<AnalysisNotificationService>());
+            email, _settings, f => f.ServerId.ToString(), new AppLoggerAdapter<AnalysisNotificationService>(), isServerSilenced);
     }
 
     private static AnalysisFinding MakeFinding(
@@ -358,6 +358,41 @@ public class AnalysisNotificationTests : IDisposable
         await notifier.NotifyAsync(new[] { MakeFinding("lowsev0000000001", severity: 1.0) });
 
         Assert.Equal(0, await CountAlertLogRowsAsync());
+    }
+
+    [Fact]
+    public async Task NotifyAsync_SilencedServer_DoesNotNotify()
+    {
+        // Issue #1035: a server silenced via "Silence All Alerts" must not produce
+        // analysis-finding emails. The predicate is keyed by resolved serverId ("1").
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var notifier = MakeNotifier(serverId => serverId == "1");
+        await notifier.NotifyAsync(new[] { MakeFinding("silenced00000001", severity: 2.0, serverId: 1) });
+
+        Assert.Equal(0, await CountAlertLogRowsAsync());
+    }
+
+    [Fact]
+    public async Task NotifyAsync_SilencePredicate_OnlySuppressesMatchingServer()
+    {
+        // The predicate is per-server: a finding for an unsilenced server still notifies
+        // even while another server is silenced, and a silenced server consuming no
+        // cooldown means unsilencing resumes immediately on the next cycle.
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var notifier = MakeNotifier(serverId => serverId == "1");
+        await notifier.NotifyAsync(new[]
+        {
+            MakeFinding("aaaa000000000001", severity: 2.0, serverId: 1), // silenced — suppressed
+            MakeFinding("bbbb000000000002", severity: 2.0, serverId: 2)  // not silenced — notifies
+        });
+
+        Assert.Equal(1, await CountAlertLogRowsAsync());
     }
 
     private async Task<long> CountAlertLogRowsAsync()

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -39,6 +39,7 @@ public sealed class AnalysisNotificationService
     private readonly IFindingAlertSender _sender;
     private readonly IAlertSettings _settings;
     private readonly Func<AnalysisFinding, string> _resolveServerId;
+    private readonly Func<string, bool>? _isServerSilenced;
     private readonly ILogger<AnalysisNotificationService> _logger;
 
     /// <summary>
@@ -57,16 +58,24 @@ public sealed class AnalysisNotificationService
     /// Dashboard: the <c>IServerManager</c> GUID lookup with the int-id fallback.
     /// </param>
     /// <param name="logger">Diagnostic logger.</param>
+    /// <param name="isServerSilenced">
+    /// Optional predicate (keyed by resolved <c>serverId</c>) that suppresses notifications
+    /// for a silenced server. Dashboard passes its <c>AlertStateService.IsAnySilencingActive</c>
+    /// so "Silence All Alerts" also stops analysis-finding emails; Lite has no silencing
+    /// feature and leaves this null (never silenced).
+    /// </param>
     public AnalysisNotificationService(
         IFindingAlertSender sender,
         IAlertSettings settings,
         Func<AnalysisFinding, string> serverIdResolver,
-        ILogger<AnalysisNotificationService> logger)
+        ILogger<AnalysisNotificationService> logger,
+        Func<string, bool>? isServerSilenced = null)
     {
         _sender = sender;
         _settings = settings;
         _resolveServerId = serverIdResolver;
         _logger = logger;
+        _isServerSilenced = isServerSilenced;
     }
 
     /// <summary>
@@ -105,6 +114,13 @@ public sealed class AnalysisNotificationService
                behaviour); the resolved serverId below is only the persistence shape. */
             var key = $"{finding.ServerId}:{finding.StoryPathHash}";
             var serverId = _resolveServerId(finding);
+
+            /* Honor per-server silencing (Dashboard "Silence All Alerts"). Checked after
+               resolving serverId but before the cooldown seed/stamp, so a silenced server
+               neither notifies nor consumes its cooldown — unsilencing resumes immediately. */
+            if (_isServerSilenced is not null && _isServerSilenced(serverId))
+                continue;
+
             var metricName = FindingMessageFormatter.MetricName(finding);
 
             /* Seed the in-memory cooldown from the alert log on first lookup per key so an


### PR DESCRIPTION
Fixes #1035.

## Problem

Right-clicking a monitored instance and choosing **Silence All Alerts** hid tray notifications and Alerts-tab badges, but email kept going out. "Silence All Alerts" only records the server in `AlertStateService._silencedServers`, and only **one** of the Dashboard's three email-producing paths consulted that state:

| Path | Respected silencing? |
|------|----------------------|
| Threshold alerts (High CPU, blocking, deadlocks, memory, etc.) — `EvaluateAlertConditionsAsync` | ✅ Yes (existing `IsAnySilencingActive` guard) |
| Connection up/down — `Server Unreachable` / `Server Restored` in `CheckAllConnectionsAsync` | ❌ No guard |
| Analysis findings — `AnalysisNotificationService.NotifyAsync` → `SendFindingAlertAsync` | ❌ No reference to silence state at all |

The reporter's "High CPU" email almost certainly came from the **analysis-finding** path: the threshold-based High CPU alert was already being suppressed, but the analysis engine's CPU/memory/blocking narrative findings fire on their own cadence and bypassed silencing entirely.

## Fix

- **Connection path:** guard the up/down notification block with `IsAnySilencingActive`, so a silenced server produces no tray, email, or history row. The unconditional `_previousConnectionStates` update still runs, so unsilencing resumes from the correct baseline.
- **Analysis path:** add an optional per-server silence predicate to the shared `AnalysisNotificationService`. Dashboard passes `AlertStateService.IsAnySilencingActive`; Lite has no silencing feature and passes none (defaults to never-silenced). The check runs after serverId resolution but **before** the cooldown seed/stamp, so a silenced server consumes no cooldown and unsilencing resumes immediately.

A silenced server now produces no tray, email, or alert-history row from any path.

## Test plan

- [x] `dotnet build Dashboard/Dashboard.csproj` — clean (0 warnings/errors)
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj` — clean (0 warnings/errors)
- [x] Dashboard test suite — 84/84 pass
- [x] Lite test suite — 312/312 pass, including 2 new cases:
  - `NotifyAsync_SilencedServer_DoesNotNotify`
  - `NotifyAsync_SilencePredicate_OnlySuppressesMatchingServer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
