### PR TITLE
B3 Phase 2: always-safe DB-config Apply Fix (ALTER DATABASE SET)

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -188,6 +188,63 @@ public class AnalysisNotificationTests
     }
 
     [Fact]
+    public void AlertContext_DbConfigAction_DbConfigTargetsSurviveRoundTrip()
+    {
+        // m-A: a DB_CONFIG action must come back with its DbConfigTargets intact after
+        // a full serialize -> deserialize. A 3-arg FromDto ctor call would silently
+        // drop them (action survives but un-applyable); this pins they survive.
+        var action = new RemediationAction("DB_CONFIG", "set",
+            Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget>
+            {
+                new("Foo", DbConfigSetting.AutoShrinkOff, "ON"),
+                new("Foo", DbConfigSetting.PageVerifyChecksum, "TORN_PAGE_DETECTION")
+            });
+
+        var context = new AlertContext();
+        context.Details.Add(new AlertDetailItem
+        {
+            Heading = "Remediation T-SQL",
+            IsCodeBlock = true,
+            Body = "ALTER DATABASE [Foo] SET AUTO_SHRINK OFF;",
+            Remediation = action
+        });
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        var rem = restored.Details.Single(d => d.IsCodeBlock).Remediation;
+        Assert.NotNull(rem);
+        Assert.Equal("DB_CONFIG", rem!.FactKey);
+        Assert.Equal("set", rem.Action);
+        Assert.Empty(rem.Targets);                       // force-plan list empty
+        Assert.NotNull(rem.DbConfigTargets);
+        Assert.Equal(2, rem.DbConfigTargets!.Count);
+        Assert.Equal("Foo", rem.DbConfigTargets[0].Database);
+        Assert.Equal(DbConfigSetting.AutoShrinkOff, rem.DbConfigTargets[0].Setting);
+        Assert.Equal("ON", rem.DbConfigTargets[0].CurrentValue);
+        Assert.Equal(DbConfigSetting.PageVerifyChecksum, rem.DbConfigTargets[1].Setting);
+        Assert.Equal("TORN_PAGE_DETECTION", rem.DbConfigTargets[1].CurrentValue);
+    }
+
+    [Fact]
+    public void AlertContext_ForcePlanAction_DbConfigTargetsNull_AfterRoundTrip()
+    {
+        // A force-plan action has no DbConfigTargets; it must round-trip to null
+        // (not an empty list that would imply a DB_CONFIG action).
+        var finding = MakeFinding("remround00000002", rootFactKey: "PLAN_REGRESSION",
+            drillDown: RegressedQueriesDrillDown());
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        var rem = restored.Details.Single(d => d.IsCodeBlock).Remediation;
+        Assert.NotNull(rem);
+        Assert.Null(rem!.DbConfigTargets);
+    }
+
+    [Fact]
     public void AlertContext_LegacyJsonWithoutRemediation_DeserializesToNull()
     {
         // A persisted context written before the Remediation field existed: a code

--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -119,6 +119,79 @@ public class RemediationApplyServiceTests
         Assert.Equal(1, exec.UnforceCalls);
     }
 
+    // ── Apply-only enforcement (m-1 / m-C): un-apply for SupportsUnapply==false ──
+
+    [Fact]
+    public async Task Unapply_HandlerDoesNotSupport_ShortCircuits_NeverConfirms_NeverReachesHandler()
+    {
+        var exec = new FakeExecutor();
+        var handler = new DbConfigHandler();        // SupportsUnapply == false
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { handler }), _ => exec, null);
+
+        var confirmed = false;
+        var dbConfigAction = new RemediationAction("DB_CONFIG", "set",
+            Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget> { new("Foo", DbConfigSetting.AutoShrinkOff, "ON") });
+
+        // Even if a future mis-wired caller invokes UnapplyAsync, it must fail SAFE
+        // (clean report, no NotSupportedException) and never confirm or mutate.
+        var report = await service.UnapplyAsync(dbConfigAction, Server, "DOM\\op", "ref",
+            confirm: _ => { confirmed = true; return Task.FromResult(true); }, CancellationToken.None);
+
+        Assert.Equal(RemediationRunStatus.UnapplyNotSupported, report.Status);
+        Assert.True(report.IsUnapply);
+        Assert.False(confirmed);                    // the gate was never even shown
+        Assert.Equal(0, exec.SetDbCalls);
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task Apply_DbConfig_ConfirmRequest_RendersDbConfigRows_NoQueryId()
+    {
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new DbConfigHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        var action = new RemediationAction("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget> { new("Foo", DbConfigSetting.AutoShrinkOff, "ON") });
+
+        await service.ApplyAsync(action, Server, previewSql: null, "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("DB_CONFIG", captured!.FactKey);
+        var row = Assert.Single(captured.Targets);
+        Assert.Contains("AUTO_SHRINK OFF", row.StatusTitle);
+        Assert.True(captured.AnyActionable);        // a DB_CONFIG Ok is actionable
+        // The fallback preview renders the ALTER statement, not sp_query_store_*.
+        Assert.Contains("ALTER DATABASE [Foo] SET AUTO_SHRINK OFF;", captured.PreviewSql);
+        Assert.DoesNotContain("sp_query_store", captured.PreviewSql);
+    }
+
+    [Fact]
+    public async Task Apply_DbConfig_AllAlreadyDesired_NotActionable()
+    {
+        // Preflight all-AlreadyInDesiredState => AnyActionable false => Apply disabled.
+        var exec = new FakeExecutor();   // PreflightDbConfigAsync returns Ok by default;
+        // override via a handler driven by a preflight that's already-desired:
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new DbConfigHandler() }),
+            _ => new AlreadyDesiredExecutor(), null);
+        RemediationConfirmRequest? captured = null;
+
+        var action = new RemediationAction("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget> { new("Foo", DbConfigSetting.AutoShrinkOff, "OFF") });
+
+        await service.ApplyAsync(action, Server, previewSql: null, "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.False(captured!.AnyActionable);
+        Assert.Equal(RemediationDisposition.AlreadyInDesiredState, Assert.Single(captured.Targets).Disposition);
+    }
+
     // ── LOW-2: applied-but-unlogged permanent vs transient ───────────────────────
 
     [Fact]
@@ -306,10 +379,52 @@ public class RemediationApplyServiceTests
             });
         }
 
+        public int SetDbCalls;
+
+        public Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+            => Task.FromResult(new DbConfigPreflight
+            {
+                Database = database, Setting = setting, DatabaseExists = true, HasAlter = true,
+                AlreadyInDesiredState = false, ExecutingLogin = "PerfMonLogin", CurrentValue = "ON"
+            });
+
+        public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+        {
+            SetDbCalls++;
+            return Task.FromResult(new DbConfigOutcome
+            {
+                Database = database, Setting = setting, Status = RemediationStatus.Success, Applied = true,
+                ExecutingLogin = "PerfMonLogin", PriorValue = "ON", GeneratedSql = "ALTER DATABASE [x] SET AUTO_SHRINK OFF;",
+                GateSpid = 55, ExecSpid = 55
+            });
+        }
+
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
         {
             AuditRecords.Add(record);
             return Task.FromResult(AuditWriteResult);
         }
+    }
+
+    /// <summary>Executor whose DB-config preflight always reports already-in-desired-state.</summary>
+    private sealed class AlreadyDesiredExecutor : IRemediationExecutor
+    {
+        public Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(new TargetPreflight { Database = database });
+        public Task<bool> AuditTableExistsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct) => Task.FromResult(false);
+        public Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ForcePlanOutcome { Database = database });
+        public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ForcePlanOutcome { Database = database });
+        public Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+            => Task.FromResult(new DbConfigPreflight
+            {
+                Database = database, Setting = setting, DatabaseExists = true, HasAlter = true,
+                AlreadyInDesiredState = true, ExecutingLogin = "PerfMonLogin", CurrentValue = "OFF"
+            });
+        public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new DbConfigOutcome { Database = database, Setting = setting, Status = RemediationStatus.Skipped });
+        public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct) => Task.FromResult(true);
     }
 }

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Services.Remediation;
 using Xunit;
 
@@ -357,6 +358,457 @@ public class RemediationTests
         Assert.Equal("unforce", Assert.Single(exec.AuditRecords).Action);
     }
 
+    // ════════════════════════════════════════════════════════════════════════════
+    // B3 Phase 2 — always-safe DB-config fixes (DB_CONFIG)
+    // ════════════════════════════════════════════════════════════════════════════
+
+    private static AnalysisFinding DbConfigFinding(List<object>? rows = null) => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "config_issues",
+        StoryPath = "DB_CONFIG",
+        StoryPathHash = "dbconfig00000001",
+        RootFactKey = "DB_CONFIG",
+        DrillDown = new Dictionary<string, object>
+        {
+            ["config_issues"] = rows ?? new List<object>
+            {
+                new { database = "Foo", recovery_model = "FULL", rcsi = true, query_store = true,
+                      issues = new[] { "auto_shrink ON", "auto_close ON" },
+                      auto_shrink = true, auto_close = true, page_verify = "CHECKSUM" }
+            }
+        }
+    };
+
+    private static RemediationAction DbConfigAction(params DbConfigTarget[] targets) =>
+        new("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(), targets.ToList());
+
+    // ── Extractor: only the three safe settings, NEVER RCSI ──────────────────────
+
+    [Fact]
+    public void ExtractDbConfig_EmitsOnlySafeSettings_NeverRcsi()
+    {
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Db1", rcsi = false, query_store = false,
+                  auto_shrink = true, auto_close = true, page_verify = "NONE",
+                  issues = new[] { "auto_shrink ON", "auto_close ON", "RCSI OFF", "page_verify=NONE" } }
+        });
+
+        var targets = FactRemediation.ExtractDbConfigTargets(finding);
+
+        // 3 safe targets (shrink, close, page_verify) — RCSI is NEVER emitted.
+        Assert.Equal(3, targets.Count);
+        Assert.Contains(targets, t => t.Setting == DbConfigSetting.AutoShrinkOff && t.CurrentValue == "ON");
+        Assert.Contains(targets, t => t.Setting == DbConfigSetting.AutoCloseOff && t.CurrentValue == "ON");
+        Assert.Contains(targets, t => t.Setting == DbConfigSetting.PageVerifyChecksum && t.CurrentValue == "NONE");
+        // No enum value for RCSI exists, but assert defensively none slipped through as page_verify.
+        Assert.All(targets, t => Assert.True(Enum.IsDefined(typeof(DbConfigSetting), t.Setting)));
+    }
+
+    [Fact]
+    public void ExtractDbConfig_PageVerifyChecksum_IsNotEmitted()
+    {
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Db1", rcsi = true, query_store = true,
+                  auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+                  issues = new string[0] }
+        });
+
+        Assert.Empty(FactRemediation.ExtractDbConfigTargets(finding));
+    }
+
+    [Fact]
+    public void ExtractDbConfig_EmptyDatabase_IsSkipped()
+    {
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "", rcsi = true, query_store = true, auto_shrink = true, auto_close = false, page_verify = "CHECKSUM", issues = new string[0] }
+        });
+
+        Assert.Empty(FactRemediation.ExtractDbConfigTargets(finding));
+    }
+
+    [Fact]
+    public void ExtractDbConfig_MultipleDatabases_MultipleTargets()
+    {
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "A", rcsi = true, query_store = true, auto_shrink = true,  auto_close = false, page_verify = "CHECKSUM", issues = new string[0] },
+            new { database = "B", rcsi = true, query_store = true, auto_shrink = false, auto_close = false, page_verify = "TORN_PAGE_DETECTION", issues = new string[0] }
+        });
+
+        var targets = FactRemediation.ExtractDbConfigTargets(finding);
+        Assert.Equal(2, targets.Count);
+        Assert.Equal("A", targets[0].Database);
+        Assert.Equal(DbConfigSetting.AutoShrinkOff, targets[0].Setting);
+        Assert.Equal("B", targets[1].Database);
+        Assert.Equal(DbConfigSetting.PageVerifyChecksum, targets[1].Setting);
+        Assert.Equal("TORN_PAGE_DETECTION", targets[1].CurrentValue);
+    }
+
+    [Fact]
+    public void BuildAction_DbConfig_OnlyRcsi_ReturnsNull()
+    {
+        // A DB whose only issue is RCSI OFF yields no safe target → no action → no Apply button.
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Db1", rcsi = false, query_store = true,
+                  auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+                  issues = new[] { "RCSI OFF" } }
+        });
+
+        Assert.Null(FactRemediation.BuildAction(finding));
+    }
+
+    [Fact]
+    public void BuildAction_DbConfig_ProducesSetActionWithTargets()
+    {
+        var action = FactRemediation.BuildAction(DbConfigFinding());
+
+        Assert.NotNull(action);
+        Assert.Equal("DB_CONFIG", action!.FactKey);
+        Assert.Equal("set", action.Action);
+        Assert.Empty(action.Targets);                       // force-plan list is empty for DB_CONFIG
+        Assert.NotNull(action.DbConfigTargets);
+        Assert.Equal(2, action.DbConfigTargets!.Count);     // shrink + close
+    }
+
+    // ── Render-stability golden (incl. "was X" + RCSI-excluded note) ─────────────
+
+    [Fact]
+    public void GenerateForFinding_DbConfig_RenderStability_ByteForByte()
+    {
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Foo", rcsi = false, query_store = true,
+                  auto_shrink = true, auto_close = true, page_verify = "NONE",
+                  issues = new[] { "auto_shrink ON", "auto_close ON", "RCSI OFF", "page_verify=NONE" } }
+        });
+
+        const string expected =
+            "-- Database: Foo\n" +
+            "ALTER DATABASE [Foo] SET AUTO_SHRINK OFF;   -- was ON\n" +
+            "ALTER DATABASE [Foo] SET AUTO_CLOSE OFF;   -- was ON\n" +
+            "ALTER DATABASE [Foo] SET PAGE_VERIFY CHECKSUM;   -- was NONE\n" +
+            "-- NOTE: [Foo] also has RCSI OFF — intentionally NOT auto-fixed (test on a copy first).";
+
+        var actual = FactRemediation.GenerateForFinding(finding);
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.Replace("\r\n", "\n"));
+    }
+
+    // ── Handler: audit-absent hard block, fail-closed, freshness-skip, db-not-found, success ──
+
+    [Fact]
+    public async Task DbConfig_AuditTableAbsent_HardBlocks_NoMutation_NoAudit()
+    {
+        var exec = new FakeExecutor { AuditTableExists = false };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON"),
+                           new DbConfigTarget("Bar", DbConfigSetting.AutoCloseOff, "ON")),
+            exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.All(result.Outcomes, o =>
+        {
+            Assert.Equal(RemediationStatus.Blocked, o.Status);
+            Assert.False(o.AuditWritten);
+            Assert.Contains("2.12.0", o.Message);
+        });
+        Assert.Equal(0, exec.SetDbCalls);
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task DbConfig_PermissionDenied_FailsClosed_AuditSkipped()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.PermissionDenied, Applied = false,
+                Message = "lacks ALTER", PriorValue = "ON"
+            }
+        };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.PermissionDenied, o.Status);
+        Assert.False(o.AppliedButUnlogged);
+        Assert.Equal("skipped", Assert.Single(exec.AuditRecords).Result);
+        Assert.Equal(1, exec.SetDbCalls);
+    }
+
+    [Fact]
+    public async Task DbConfig_AlreadyDesired_Skips_NoMutationFlag_AuditSkipped()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.Skipped, Applied = false,
+                Message = "already desired", PriorValue = "OFF"
+            }
+        };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "OFF")), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Skipped, o.Status);
+        Assert.False(o.AppliedButUnlogged);
+        Assert.Equal("skipped", Assert.Single(exec.AuditRecords).Result);
+    }
+
+    [Fact]
+    public async Task DbConfig_DatabaseNotFound_Blocks_AuditAborted()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.Blocked, Applied = false,
+                Message = "not found", PriorValue = null
+            }
+        };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Gone", DbConfigSetting.AutoShrinkOff, "ON")), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Blocked, o.Status);
+        Assert.Equal("aborted", Assert.Single(exec.AuditRecords).Result);
+    }
+
+    [Fact]
+    public async Task DbConfig_Success_AppliesAndAudits_NullIds_PriorValue_PreciseAction()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.Success, Applied = true,
+                ExecutingLogin = "sa", PriorValue = "ON",
+                GeneratedSql = "ALTER DATABASE [Foo] SET AUTO_SHRINK OFF;", GateSpid = 7, ExecSpid = 7
+            }
+        };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, o.Status);
+        Assert.True(o.AuditWritten);
+        Assert.False(o.AppliedButUnlogged);
+
+        var row = Assert.Single(exec.AuditRecords);
+        Assert.Equal("DB_CONFIG", row.FactKey);
+        Assert.Equal("set_auto_shrink_off", row.Action);     // precise taxonomy (24/19/18 chars)
+        Assert.Equal("success", row.Result);
+        Assert.Null(row.QueryId);                            // B-1: DB_CONFIG rows have no IDs
+        Assert.Null(row.PlanId);
+        Assert.Equal("ON", row.PriorValue);
+        Assert.Contains("ALTER DATABASE", row.GeneratedSql);
+    }
+
+    [Fact]
+    public async Task DbConfig_AppliesButAuditFails_FlagsAppliedButUnlogged()
+    {
+        var exec = new FakeExecutor { AuditWriteResult = false };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, o.Status);
+        Assert.False(o.AuditWritten);
+        Assert.True(o.AppliedButUnlogged);
+    }
+
+    [Fact]
+    public async Task DbConfig_OneTargetThrows_OthersStillRun()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) =>
+            {
+                if (db == "A") throw new InvalidOperationException("boom");
+                return new DbConfigOutcome { Database = db, Setting = s, Status = RemediationStatus.Success, Applied = true, PriorValue = "ON" };
+            }
+        };
+
+        var result = await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("A", DbConfigSetting.AutoShrinkOff, "ON"),
+                           new DbConfigTarget("B", DbConfigSetting.AutoCloseOff, "ON")),
+            exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.Equal(RemediationStatus.Error, result.Outcomes[0].Status);
+        Assert.Equal(RemediationStatus.Success, result.Outcomes[1].Status);
+    }
+
+    [Fact]
+    public async Task DbConfig_PreciseTaxonomy_AllThreeSettings()
+    {
+        var exec = new FakeExecutor();
+        await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(
+                new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON"),
+                new DbConfigTarget("Foo", DbConfigSetting.AutoCloseOff, "ON"),
+                new DbConfigTarget("Foo", DbConfigSetting.PageVerifyChecksum, "NONE")),
+            exec, Identity, CancellationToken.None);
+
+        var actions = exec.AuditRecords.Select(r => r.Action).ToList();
+        Assert.Contains("set_auto_shrink_off", actions);
+        Assert.Contains("set_auto_close_off", actions);
+        Assert.Contains("set_page_verify_checksum", actions);     // 24 chars — needs varchar(32) + param(32)
+    }
+
+    // ── Preflight dispositions ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(false, true, false, RemediationDisposition.BlockDatabaseNotFound)]
+    [InlineData(true, false, false, RemediationDisposition.BlockNoAlter)]
+    [InlineData(true, true, true, RemediationDisposition.AlreadyInDesiredState)]
+    [InlineData(true, true, false, RemediationDisposition.Ok)]
+    public async Task DbConfig_Preflight_ClassifiesDisposition(bool exists, bool hasAlter, bool alreadyDesired, RemediationDisposition expected)
+    {
+        var exec = new FakeExecutor
+        {
+            DbPreflightFunc = (db, s) => new DbConfigPreflight
+            {
+                Database = db, Setting = s, DatabaseExists = exists, HasAlter = hasAlter,
+                AlreadyInDesiredState = alreadyDesired, CurrentValue = "ON"
+            }
+        };
+
+        var pre = await new DbConfigHandler().PreflightAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, CancellationToken.None);
+        Assert.Equal(expected, pre.Targets.Single().Disposition);
+    }
+
+    [Fact]
+    public async Task DbConfig_Preflight_AuditTableAbsent_OverridesDisposition()
+    {
+        var exec = new FakeExecutor { AuditTableExists = false };
+
+        var pre = await new DbConfigHandler().PreflightAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, CancellationToken.None);
+
+        Assert.False(pre.AuditTableExists);
+        Assert.Equal(RemediationDisposition.BlockAuditTableAbsent, pre.Targets.Single().Disposition);
+    }
+
+    // ── Apply-only enforcement (m-1) + SupportsUnapply ───────────────────────────
+
+    [Fact]
+    public void DbConfig_SupportsUnapply_IsFalse_NotDestructive()
+    {
+        var handler = new DbConfigHandler();
+        Assert.False(handler.SupportsUnapply);
+        Assert.False(handler.IsDestructive);
+    }
+
+    [Fact]
+    public async Task DbConfig_UnapplyAsync_Throws()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            new DbConfigHandler().UnapplyAsync(
+                DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), new FakeExecutor(), Identity, CancellationToken.None));
+    }
+
+    [Fact]
+    public void CoreMachineryMarkers_CoverNewPrivilegedSurface()
+    {
+        // M-2: the reachability guard must list the new handler + executor methods,
+        // or a future UI/MCP file referencing them would silently pass the guard.
+        Assert.Contains("DbConfigHandler", CoreMachineryMarkers);
+        Assert.Contains("SetDatabaseOptionAsync", CoreMachineryMarkers);
+        Assert.Contains("PreflightDbConfigAsync", CoreMachineryMarkers);
+    }
+
+    [Fact]
+    public void Registry_ResolvesDbConfigHandler()
+    {
+        var registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler() });
+        Assert.IsType<DbConfigHandler>(registry.TryGet("DB_CONFIG"));
+        Assert.IsType<ForcePlanHandler>(registry.TryGet("PLAN_REGRESSION"));
+    }
+
+    // ── §1 identifier safety: no-injection / QUOTENAME / same-string (M-1) ───────
+    //
+    // These run against the EXECUTOR's OWN statement builder (DatabaseService.
+    // BuildAlterStatement), NOT the display renderer (m-B). The builder is the exact
+    // composition SetDatabaseOptionAsync uses for the executed statement.
+
+    [Theory]
+    [InlineData(DbConfigSetting.AutoShrinkOff, "SET AUTO_SHRINK OFF")]
+    [InlineData(DbConfigSetting.AutoCloseOff, "SET AUTO_CLOSE OFF")]
+    [InlineData(DbConfigSetting.PageVerifyChecksum, "SET PAGE_VERIFY CHECKSUM")]
+    public void Build_SetClause_IsHardcodedLiteral_RegardlessOfName(DbConfigSetting setting, string expectedClause)
+    {
+        // The SET clause is byte-identical regardless of the (pathological) db name.
+        foreach (var name in new[] { "Db", "Db]; DROP TABLE x--", "[weird]", "Ünîçödé" })
+        {
+            var stmt = DatabaseService.BuildAlterStatement(name, setting);
+            Assert.Contains(expectedClause + ";", stmt);
+            Assert.EndsWith(expectedClause + ";", stmt);
+        }
+    }
+
+    [Theory]
+    [InlineData("normal")]
+    [InlineData("has]bracket")]
+    [InlineData("has]]double")]
+    [InlineData("ev;il-- GO DROP")]
+    [InlineData("'; ALTER DATABASE master SET")]
+    [InlineData("Ünîçödé​")]   // unicode + zero-width
+    public void Build_BracketsIdentifierInert_NoInjection(string name)
+    {
+        var stmt = DatabaseService.BuildAlterStatement(name, DbConfigSetting.AutoShrinkOff);
+
+        // The identifier is bracketed with ]-doubling; the whole thing is one ALTER
+        // with exactly one bracketed token and the hardcoded clause.
+        var expectedToken = "[" + name.Replace("]", "]]") + "]";
+        Assert.Equal($"ALTER DATABASE {expectedToken} SET AUTO_SHRINK OFF;", stmt);
+
+        // No un-doubled close-bracket can prematurely end the identifier: the only
+        // ']' runs in the statement are the doubled ones we produced plus the final.
+        // Reconstruct: stripping the known prefix/suffix yields exactly the token.
+        Assert.StartsWith("ALTER DATABASE [", stmt);
+    }
+
+    [Fact]
+    public void Build_SameString_ValidatedNameIsBracketedExactly()
+    {
+        // M-1: the bracketed token is byte-identical to the validated name passed in
+        // — an implementer cannot validate one variable and bracket a trimmed/cased one.
+        const string validated = "  Padded Name  ";          // deliberate surrounding whitespace
+        var stmt = DatabaseService.BuildAlterStatement(validated, DbConfigSetting.AutoCloseOff);
+        Assert.Equal("ALTER DATABASE [  Padded Name  ] SET AUTO_CLOSE OFF;", stmt);
+
+        // A name differing only by trailing whitespace produces a DIFFERENT statement,
+        // proving the builder brackets exactly what it was given (no normalization).
+        var stmt2 = DatabaseService.BuildAlterStatement(validated.TrimEnd(), DbConfigSetting.AutoCloseOff);
+        Assert.NotEqual(stmt, stmt2);
+    }
+
+    [Fact]
+    public void Build_DisplayRenderer_NotExecuted_ExecutorHasOwnBuilder()
+    {
+        // m-B: the executor's builder is byte-identical to the display QUOTENAME but
+        // is its OWN routine in the Dashboard assembly (not the private Analysis one).
+        // Spot-check parity on a ]-containing name.
+        var stmt = DatabaseService.BuildAlterStatement("a]b", DbConfigSetting.PageVerifyChecksum);
+        Assert.Equal("ALTER DATABASE [a]]b] SET PAGE_VERIFY CHECKSUM;", stmt);
+    }
+
     // ── Reachability-with-gate guard (replaces PR-A's no-caller guard) ──────────
     //
     // PR-A asserted the privileged machinery had NO non-core caller. PR-B adds a
@@ -379,6 +831,9 @@ public class RemediationTests
         "ForcePlanAsync", "UnforcePlanAsync",
         "RemediationHandlerRegistry", "DatabaseServiceRemediationExecutor",
         "ForcePlanHandler", "IRemediationExecutor", "IRemediationHandler",
+        // B3 Phase 2 privileged surface (M-2): the new handler + executor methods
+        // must be reachable ONLY through the gate, exactly like the force-plan ones.
+        "DbConfigHandler", "SetDatabaseOptionAsync", "PreflightDbConfigAsync",
     };
 
     [Fact]
@@ -503,6 +958,29 @@ public class RemediationTests
             {
                 Database = database, QueryId = queryId, PlanId = planId,
                 Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "sa", GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        // ── DB-config seams (Phase 2) ────────────────────────────────────────────
+        public Func<string, DbConfigSetting, DbConfigPreflight>? DbPreflightFunc;
+        public Func<string, DbConfigSetting, DbConfigOutcome>? SetDbFunc;
+        public int SetDbCalls;
+
+        public Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+            => Task.FromResult(DbPreflightFunc?.Invoke(database, setting) ?? new DbConfigPreflight
+            {
+                Database = database, Setting = setting, DatabaseExists = true, HasAlter = true,
+                AlreadyInDesiredState = false, ExecutingLogin = "sa", CurrentValue = "ON"
+            });
+
+        public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+        {
+            SetDbCalls++;
+            return Task.FromResult(SetDbFunc?.Invoke(database, setting) ?? new DbConfigOutcome
+            {
+                Database = database, Setting = setting, Status = RemediationStatus.Success, Applied = true,
+                ExecutingLogin = "sa", PriorValue = "ON", GeneratedSql = "ALTER DATABASE [x] SET AUTO_SHRINK OFF;",
+                GateSpid = 55, ExecSpid = 55
             });
         }
 

--- a/Dashboard/AlertDetailWindow.xaml.cs
+++ b/Dashboard/AlertDetailWindow.xaml.cs
@@ -212,6 +212,8 @@ namespace PerformanceMonitorDashboard
                     return "No remediation handler is registered for this finding.";
                 case RemediationRunStatus.NotConfirmed:
                     return "Cancelled — no change was made.";
+                case RemediationRunStatus.UnapplyNotSupported:
+                    return "This fix type cannot be un-applied — no change was made.";
             }
 
             var verb = report.IsUnapply ? "unforced" : "forced";
@@ -226,27 +228,37 @@ namespace PerformanceMonitorDashboard
 
         private static string FormatTarget(RemediationTargetReport t, string verb)
         {
-            var where = $"[{t.Database}] query_id {t.QueryId}, plan_id {t.PlanId}";
+            // Force-plan rows carry query_id/plan_id; DB_CONFIG rows do not (both 0).
+            var isForcePlan = t.QueryId != 0 || t.PlanId != 0;
+            var where = isForcePlan
+                ? $"[{t.Database}] query_id {t.QueryId}, plan_id {t.PlanId}"
+                : $"[{t.Database}]";
+            // For DB_CONFIG the handler's per-target message already names the setting
+            // and outcome; "plan forced" wording is force-plan-specific.
+            var successText = isForcePlan ? $"plan {verb}" : (t.Message ?? "applied");
 
             // Applied-but-unlogged (O3 + LOW-2): the mutation succeeded; distinguish a
             // permanent setup/grant failure (loud, "fix this") from a transient one.
             if (t.AppliedButUnlogged)
             {
+                var reversal = isForcePlan
+                    ? "The change is in place (reversible via Un-apply)."
+                    : "The change is in place (the prior value was recorded for manual reversal).";
                 return t.AuditFailureKind switch
                 {
                     AuditWriteFailureKind.Permanent =>
-                        $"⚠ {where}: plan {verb}, but the audit row could NOT be written — the monitoring "
+                        $"⚠ {where}: {successText}, but the audit row could NOT be written — the monitoring "
                         + "login lacks INSERT on config.remediation_action_log. EVERY Apply on this server "
-                        + "will go unlogged until this grant is fixed. The change is in place (reversible via Un-apply).",
+                        + "will go unlogged until this grant is fixed. " + reversal,
                     _ =>
-                        $"⚠ {where}: plan {verb}, but writing the audit row failed (transient). The change is "
+                        $"⚠ {where}: {successText}, but writing the audit row failed (transient). The change is "
                         + "in place; re-check config.remediation_action_log."
                 };
             }
 
             return t.Status switch
             {
-                RemediationStatus.Success => $"✓ {where}: plan {verb}.",
+                RemediationStatus.Success => $"✓ {where}: {successText}.",
                 RemediationStatus.Skipped => $"• {where}: skipped — {t.Message}",
                 RemediationStatus.PermissionDenied => $"⛔ {where}: {t.Message}",
                 RemediationStatus.Blocked => $"⛔ {where}: {t.Message}",
@@ -257,7 +269,9 @@ namespace PerformanceMonitorDashboard
 
         private static ResultSeverity SeverityOf(RemediationRunReport report)
         {
-            if (report.Status == RemediationRunStatus.NotConfirmed || report.Status == RemediationRunStatus.NoHandler)
+            if (report.Status is RemediationRunStatus.NotConfirmed
+                or RemediationRunStatus.NoHandler
+                or RemediationRunStatus.UnapplyNotSupported)
                 return ResultSeverity.Info;
 
             // A permanent unlogged failure, or any hard error/block/permission-denied,

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -529,7 +529,13 @@ ORDER BY database_name;";
                 recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
                 rcsi = rcsi == "1",
                 query_store = queryStore == "1",
-                issues
+                issues,
+                // §4.1: structured, wording-independent fields the shared extractor
+                // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
+                // and types to the Lite collector (bool / bool / string).
+                auto_shrink = autoShrink == "1",
+                auto_close = autoClose == "1",
+                page_verify = pageVerify
             });
         }
 

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -28,9 +28,12 @@ namespace PerformanceMonitorDashboard
 
             var verb = request.IsUnapply ? "Un-apply Fix" : "Apply Fix";
             Title = $"Confirm {verb}";
-            HeaderText.Text = request.IsUnapply
-                ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
-                : $"Force the historical-better plan on {request.ServerDisplayName}?";
+            var isDbConfig = string.Equals(request.FactKey, "DB_CONFIG", System.StringComparison.Ordinal);
+            HeaderText.Text = isDbConfig
+                ? $"Apply the always-safe database setting change(s) on {request.ServerDisplayName}?"
+                : request.IsUnapply
+                    ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
+                    : $"Force the historical-better plan on {request.ServerDisplayName}?";
 
             ServerText.Text = request.ServerDisplayName;
             ExecutingText.Text = string.IsNullOrEmpty(request.ExecutingLogin)
@@ -52,9 +55,16 @@ namespace PerformanceMonitorDashboard
                 rows.Add(TargetRow.From(t, request.IsUnapply));
             TargetsList.ItemsSource = rows;
 
-            // M2 caveat is an apply-time judgment; on un-apply there is no "still
-            // better" decision, so the caveat is hidden.
-            if (request.IsUnapply)
+            // Fact-key-specific caveat. DB_CONFIG: the always-safe note (RCSI excluded).
+            // PLAN_REGRESSION: the M2 still-better caveat (apply-time judgment; hidden
+            // on un-apply where there is no "still better" decision).
+            if (isDbConfig)
+            {
+                CaveatText.Text =
+                    "These three settings are always-safe to change on a live database (online, no blocking). "
+                    + "RCSI (READ_COMMITTED_SNAPSHOT) is intentionally excluded — test it on a copy first.";
+            }
+            else if (request.IsUnapply)
             {
                 CaveatBanner.Visibility = Visibility.Collapsed;
             }
@@ -142,9 +152,19 @@ namespace PerformanceMonitorDashboard
 
             public static TargetRow From(RemediationConfirmTarget t, bool isUnapply)
             {
-                var head = $"[{t.Database}]  query_id {t.QueryId}, plan_id {t.PlanId}";
-                if (!isUnapply && t.RegressionFactor > 0)
-                    head += $"  —  regression {t.RegressionFactor.ToString("0.#", CultureInfo.InvariantCulture)}x";
+                // DB_CONFIG rows carry a fact-key-neutral StatusTitle (no query_id/plan_id);
+                // force-plan rows render the query_id/plan_id head + the M2 regression Nx.
+                string head;
+                if (!string.IsNullOrEmpty(t.StatusTitle))
+                {
+                    head = t.StatusTitle!;
+                }
+                else
+                {
+                    head = $"[{t.Database}]  query_id {t.QueryId}, plan_id {t.PlanId}";
+                    if (!isUnapply && t.RegressionFactor > 0)
+                        head += $"  —  regression {t.RegressionFactor.ToString("0.#", CultureInfo.InvariantCulture)}x";
+                }
 
                 var status = DescribeDisposition(t, isUnapply);
                 return new TargetRow { HeadLine = head, StatusLine = status };
@@ -165,6 +185,8 @@ namespace PerformanceMonitorDashboard
                     RemediationDisposition.BlockNoAlter => "Monitoring login lacks ALTER — will fail closed (no change).",
                     RemediationDisposition.BlockWrongDatabase => "Connected DB does not match the target — will not proceed.",
                     RemediationDisposition.BlockAuditTableAbsent => "Audit table absent (pre-2.12.0) — hard-blocked.",
+                    RemediationDisposition.AlreadyInDesiredState => "Already in the desired state — will be skipped.",
+                    RemediationDisposition.BlockDatabaseNotFound => "Database not found on the server — will not proceed.",
                     _ => t.DispositionMessage ?? "Unable to determine target state."
                 };
             }

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -11,6 +11,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Analysis;
 using PerformanceMonitorDashboard.Services.Remediation;
 
 namespace PerformanceMonitorDashboard.Services
@@ -225,6 +226,262 @@ SET NUMERIC_ROUNDABORT OFF;";
             GateSpid = gate.Spid,
             ExecSpid = null
         };
+
+        // ── B3 Phase 2: always-safe DB-config fixes (ALTER DATABASE SET …) ──────────
+        //
+        // The one genuinely new sharp edge vs force-plan: the database is a syntactic
+        // IDENTIFIER in the statement and CANNOT be a parameter. The no-injection
+        // mechanism is three mandatory layers, all on ONE monitoring connection (no
+        // InitialCatalog retarget — we stay on PerformanceMonitor, where even the
+        // README's least-privilege login is db_owner and the by-name permission probe
+        // is fail-closed):
+        //   1. validate the candidate name against sys.databases, PARAMETERIZED
+        //      (@db NVARCHAR(128), no concatenation);
+        //   2. bracket the EXACT validated string with an inline QUOTENAME-equivalent
+        //      (']'→']]') — the same-string invariant (M-1): the string validated in
+        //      layer 1 is byte-identical to the string bracketed here;
+        //   3. the SET clause is a HARDCODED compile-time literal chosen by a switch
+        //      over DbConfigSetting — never data/operator-supplied.
+        // The display renderer's rendered text is NEVER executed; this executor builds
+        // its own statement. FactRemediation.QuoteName is private in another assembly,
+        // so we implement our own byte-identical doubling routine here (m-B).
+
+        /// <summary>
+        /// Inline QUOTENAME-equivalent (byte-identical to FactRemediation.QuoteName,
+        /// which is private in PerformanceMonitor.Analysis — m-B). Wraps an identifier
+        /// in brackets and doubles any embedded close-bracket so even a pathological
+        /// database name is inert. This is the ONLY non-constant token placed in the
+        /// ALTER statement, and only AFTER the name was validated against sys.databases.
+        /// </summary>
+        internal static string QuoteIdentifier(string identifier) =>
+            "[" + identifier.Replace("]", "]]") + "]";
+
+        /// <summary>
+        /// The hardcoded SET-clause literal for each setting. NOTHING here comes from
+        /// data or operator input — the enum is the entire selection surface (§1 layer 3).
+        /// </summary>
+        internal static string SetClauseFor(DbConfigSetting setting) => setting switch
+        {
+            DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
+            DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
+            DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
+        };
+
+        /// <summary>
+        /// Builds the exact ALTER DATABASE statement: the ONLY non-constant token is
+        /// the bracketed, ALREADY-VALIDATED identifier; the SET clause is a hardcoded
+        /// enum-selected literal (§1). Exposed internal so the §11 no-injection /
+        /// same-string tests run against the executor's OWN builder (not the display
+        /// renderer). Callers MUST pass the exact string that the sys.databases
+        /// existence check validated (M-1 same-string invariant).
+        /// </summary>
+        internal static string BuildAlterStatement(string validatedName, DbConfigSetting setting) =>
+            $"ALTER DATABASE {QuoteIdentifier(validatedName)} {SetClauseFor(setting)};";
+
+        /// <summary>
+        /// Read-only display probe (advisory only). Runs on the monitoring connection
+        /// (no retarget); reads existence + ALTER permission + the live setting value.
+        /// </summary>
+        internal async Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+        {
+            // Monitoring connection — InitialCatalog left as PerformanceMonitor.
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            var gate = await ReadDbConfigGateAsync(connection, database, setting, ct).ConfigureAwait(false);
+
+            return new DbConfigPreflight
+            {
+                Database = database,
+                Setting = setting,
+                DatabaseExists = gate.DatabaseExists,
+                HasAlter = gate.HasAlter,
+                AlreadyInDesiredState = gate.AlreadyInDesiredState,
+                ExecutingLogin = gate.ExecutingLogin,
+                CurrentValue = gate.CurrentValue
+            };
+        }
+
+        /// <summary>
+        /// Self-gating always-safe DB-config ALTER (R2-MOD-1). The gate (parameterized
+        /// existence + ALTER permission + live freshness) and the ALTER run on ONE
+        /// open monitoring connection with no re-open between them. The validated @db
+        /// string is the SAME string that gets bracketed and placed in the statement
+        /// (M-1 same-string invariant).
+        /// </summary>
+        internal async Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+        {
+            // ONE monitoring connection for gate + mutation. No InitialCatalog
+            // retarget (least-priv login is db_owner on PerformanceMonitor, not a user
+            // in the target DB), no re-open — this is what closes the gate→ALTER TOCTOU.
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            // Layer 1 (existence, PARAMETERIZED) + permission + live freshness, in one
+            // gate read on this open connection. `database` is bound as @db NVARCHAR(128).
+            var gate = await ReadDbConfigGateAsync(connection, database, setting, ct).ConfigureAwait(false);
+
+            // (1) Existence — absent => block, no ALTER.
+            if (!gate.DatabaseExists)
+            {
+                return DbOutcome(database, setting, RemediationStatus.Blocked, applied: false, gate,
+                    $"Database '{database}' was not found on the server (renamed or dropped since the finding); no change made.");
+            }
+
+            // (2) Permission — fail closed, no elevation, no retry.
+            if (!gate.HasAlter)
+            {
+                return DbOutcome(database, setting, RemediationStatus.PermissionDenied, applied: false, gate,
+                    $"The monitoring login '{gate.ExecutingLogin}' lacks ALTER on '{database}'. " +
+                    $"Map it into '{database}' (CREATE USER ... FOR LOGIN) and GRANT ALTER, or connect with a login that has it.");
+            }
+
+            // (3) Freshness / idempotency — already in desired state => skip, no ALTER.
+            if (gate.AlreadyInDesiredState)
+            {
+                return DbOutcome(database, setting, RemediationStatus.Skipped, applied: false, gate,
+                    $"'{database}' is already in the desired state for {SetClauseFor(setting)}; nothing to do.");
+            }
+
+            // Gate passed. Build the statement: the ONLY non-constant token is the
+            // bracketed, ALREADY-VALIDATED identifier (M-1 same-string: gate.ValidatedName
+            // is the exact @db value sys.databases confirmed). The SET clause is a
+            // hardcoded literal. No parameter is possible for a DDL identifier; QUOTENAME
+            // doubling + prior existence validation is the control.
+            var statement = BuildAlterStatement(gate.ValidatedName!, setting);
+
+            int? execSpid;
+            try
+            {
+                using var exec = connection.CreateCommand();
+                exec.CommandTimeout = RemediationCommandTimeoutSeconds;
+                // ALTER DATABASE SET is not permitted inside an explicit transaction;
+                // it runs in autocommit. It is an online metadata change (no blocking,
+                // no forced disconnects) — which is what makes these three always-safe.
+                exec.CommandText = statement + " SELECT exec_spid = @@SPID;";
+                var raw = await exec.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                execSpid = raw is null || raw is DBNull ? (int?)null : Convert.ToInt32(raw);
+            }
+            catch (SqlException ex)
+            {
+                var status = ex.Number is 297 or 15247 or 229 ? RemediationStatus.PermissionDenied : RemediationStatus.Error;
+                return DbOutcome(database, setting, status, applied: false, gate,
+                    $"ALTER DATABASE {SetClauseFor(setting)} failed (error {ex.Number}): {ex.Message}", statement);
+            }
+
+            return new DbConfigOutcome
+            {
+                Database = database,
+                Setting = setting,
+                Status = RemediationStatus.Success,
+                Applied = true,
+                ExecutingLogin = gate.ExecutingLogin,
+                Message = $"Applied {SetClauseFor(setting)} on '{database}' (was {gate.CurrentValue}).",
+                PriorValue = gate.CurrentValue,
+                GeneratedSql = statement,
+                GateSpid = gate.Spid,
+                ExecSpid = execSpid
+            };
+        }
+
+        private static DbConfigOutcome DbOutcome(string database, DbConfigSetting setting, RemediationStatus status, bool applied, DbConfigGateReading gate, string message, string? generatedSql = null) => new()
+        {
+            Database = database,
+            Setting = setting,
+            Status = status,
+            Applied = applied,
+            ExecutingLogin = gate.ExecutingLogin,
+            Message = message,
+            PriorValue = gate.CurrentValue,
+            GeneratedSql = generatedSql,
+            GateSpid = gate.Spid,
+            ExecSpid = null
+        };
+
+        /// <summary>
+        /// The DB-config gate read: identity + parameterized sys.databases existence +
+        /// ALTER permission + the live current setting value, in one round-trip on the
+        /// open monitoring connection. The setting column is selected by the enum (a
+        /// constant column expression — not data). Captures <see cref="DbConfigGateReading.ValidatedName"/>
+        /// = the exact @db value (the same-string source for QUOTENAME, M-1).
+        /// </summary>
+        private static async Task<DbConfigGateReading> ReadDbConfigGateAsync(SqlConnection connection, string database, DbConfigSetting setting, CancellationToken ct)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandTimeout = RemediationCommandTimeoutSeconds;
+
+            // The current-value column expression is chosen by the enum (constant SQL,
+            // never data). is_auto_shrink_on / is_auto_close_on / page_verify_option_desc
+            // are all server-visible from the monitoring connection (VIEW ANY DATABASE →
+            // public). desired-state is computed server-side so the skip decision uses
+            // the LIVE read, never the extractor's possibly-stale CurrentValue (m-2).
+            string currentValueExpr;
+            string desiredExpr;
+            switch (setting)
+            {
+                case DbConfigSetting.AutoShrinkOff:
+                    currentValueExpr = "CASE WHEN d.is_auto_shrink_on = 1 THEN N'ON' ELSE N'OFF' END";
+                    desiredExpr = "CASE WHEN d.is_auto_shrink_on = 0 THEN 1 ELSE 0 END";
+                    break;
+                case DbConfigSetting.AutoCloseOff:
+                    currentValueExpr = "CASE WHEN d.is_auto_close_on = 1 THEN N'ON' ELSE N'OFF' END";
+                    desiredExpr = "CASE WHEN d.is_auto_close_on = 0 THEN 1 ELSE 0 END";
+                    break;
+                case DbConfigSetting.PageVerifyChecksum:
+                    currentValueExpr = "d.page_verify_option_desc";
+                    desiredExpr = "CASE WHEN d.page_verify_option_desc = N'CHECKSUM' THEN 1 ELSE 0 END";
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting");
+            }
+
+            command.CommandText = $@"
+DECLARE @exists bit =
+    CASE WHEN EXISTS (SELECT 1 FROM sys.databases AS d WHERE d.name = @db) THEN 1 ELSE 0 END;
+
+SELECT
+    db_exists = @exists,
+    executing_login = SUSER_SNAME(),
+    has_alter = CONVERT(int, ISNULL(HAS_PERMS_BY_NAME(@db, 'DATABASE', 'ALTER'), 0)),
+    current_value = (SELECT {currentValueExpr} FROM sys.databases AS d WHERE d.name = @db),
+    already_desired = ISNULL((SELECT {desiredExpr} FROM sys.databases AS d WHERE d.name = @db), 0),
+    spid = @@SPID;";
+            command.Parameters.Add(new SqlParameter("@db", SqlDbType.NVarChar, 128) { Value = database });
+
+            using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                return new DbConfigGateReading();
+
+            var dbExists = !reader.IsDBNull(0) && reader.GetBoolean(0);
+            return new DbConfigGateReading
+            {
+                DatabaseExists = dbExists,
+                // Same-string invariant (M-1): only treat the candidate as validated
+                // when the existence check passed; the bracketed token is THIS exact
+                // string, byte-identical to the validated @db parameter value.
+                ValidatedName = dbExists ? database : null,
+                ExecutingLogin = reader.IsDBNull(1) ? null : reader.GetString(1),
+                HasAlter = !reader.IsDBNull(2) && reader.GetInt32(2) == 1,
+                CurrentValue = reader.IsDBNull(3) ? null : reader.GetString(3),
+                AlreadyInDesiredState = !reader.IsDBNull(4) && reader.GetInt32(4) == 1,
+                Spid = reader.IsDBNull(5) ? (int?)null : Convert.ToInt32(reader.GetInt16(5))
+            };
+        }
+
+        private sealed class DbConfigGateReading
+        {
+            public bool DatabaseExists { get; init; }
+            /// <summary>The validated @db value (== existence-checked string) — the M-1 same-string source for QUOTENAME.</summary>
+            public string? ValidatedName { get; init; }
+            public string? ExecutingLogin { get; init; }
+            public bool HasAlter { get; init; }
+            public string? CurrentValue { get; init; }
+            public bool AlreadyInDesiredState { get; init; }
+            public int? Spid { get; init; }
+        }
 
         /// <summary>
         /// Gate part 1: identity + permission, using only always-accessible intrinsics

--- a/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitorDashboard.Services.Remediation
 {
@@ -44,6 +45,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
         public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
             => _databaseService.UnforcePlanAsync(database, queryId, planId, identity, ct);
+
+        public Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+            => _databaseService.PreflightDbConfigAsync(database, setting, ct);
+
+        public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+            => _databaseService.SetDatabaseOptionAsync(database, setting, identity, ct);
 
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
             => _auditWriter.WriteAsync(record, ct);

--- a/Dashboard/Services/Remediation/DbConfigHandler.cs
+++ b/Dashboard/Services/Remediation/DbConfigHandler.cs
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Handler for DB_CONFIG findings: applies the three ALWAYS-SAFE database
+    /// settings — AUTO_SHRINK OFF, AUTO_CLOSE OFF, PAGE_VERIFY CHECKSUM — one
+    /// (database, setting) target at a time via <c>ALTER DATABASE … SET …</c>.
+    /// RCSI is intentionally NOT in scope (destructive). This is APPLY-ONLY: there
+    /// is no sensible reverse for these settings (<see cref="SupportsUnapply"/> is
+    /// false; <see cref="UnapplyAsync"/> throws), and the prior value is recorded in
+    /// the audit row for any manual reversal.
+    ///
+    /// <para>
+    /// Structurally self-gating, exactly like <see cref="ForcePlanHandler"/>:
+    /// <see cref="ApplyAsync"/> takes no preflight disposition and trusts none. It
+    /// hard-blocks every target when the audit table is absent (no mutation), then
+    /// delegates each target to <c>exec.SetDatabaseOptionAsync</c>, which re-derives
+    /// the authoritative gate (parameterized sys.databases existence + ALTER
+    /// permission + live freshness) and the ALTER on ONE connection. One audit row
+    /// is written per attempt.
+    /// </para>
+    /// </summary>
+    public sealed class DbConfigHandler : IRemediationHandler
+    {
+        public string FactKey => "DB_CONFIG";
+
+        // The three settings are always-safe online metadata changes — not destructive.
+        public bool IsDestructive => false;
+
+        // Apply-only: these settings have no sensible reverse (you would never
+        // re-enable AUTO_SHRINK/AUTO_CLOSE nor downgrade PAGE_VERIFY below CHECKSUM).
+        public bool SupportsUnapply => false;
+
+        public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+
+            var targets = new List<TargetPreflight>();
+            foreach (var t in DbTargets(action))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                TargetPreflight pf;
+                try
+                {
+                    var probe = await exec.PreflightDbConfigAsync(t.Database, t.Setting, ct).ConfigureAwait(false);
+                    pf = ToTargetPreflight(t, probe);
+                }
+                catch (Exception ex)
+                {
+                    pf = new TargetPreflight
+                    {
+                        Database = t.Database,
+                        Disposition = RemediationDisposition.Error,
+                        Message = ex.Message
+                    };
+                    targets.Add(pf);
+                    continue;
+                }
+
+                // Audit-table-absent is a server-wide hard block; it overrides any
+                // per-target disposition (no apply can be audited there).
+                if (!auditTableExists)
+                {
+                    pf.Disposition = RemediationDisposition.BlockAuditTableAbsent;
+                    pf.Message = AuditAbsentMessage;
+                }
+
+                targets.Add(pf);
+            }
+
+            return new PreflightResult { Targets = targets, AuditTableExists = auditTableExists };
+        }
+
+        public Task<ApplyResult> ApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+            if (identity is null) throw new ArgumentNullException(nameof(identity));
+            return RunApplyAsync(action, exec, identity, ct);
+        }
+
+        // Apply-only. Defensive: the UI gates Un-apply on SupportsUnapply==false, and
+        // RemediationApplyService short-circuits an un-apply for a non-supporting
+        // handler to a clean report (m-C), so this is never reached in practice.
+        public Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+            => throw new NotSupportedException("DB-config fixes are apply-only; there is no un-apply for AUTO_SHRINK/AUTO_CLOSE/PAGE_VERIFY.");
+
+        private static async Task<ApplyResult> RunApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            var outcomes = new List<TargetOutcome>();
+            var dbTargets = DbTargets(action);
+
+            // R2-MOD-2: audit-table-absent is a HARD BLOCK before any mutation. No
+            // ALTER is attempted; no audit row is written (nowhere to write it).
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+            if (!auditTableExists)
+            {
+                foreach (var t in dbTargets)
+                {
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = RemediationStatus.Blocked,
+                        Message = AuditAbsentMessage,
+                        AuditWritten = false,
+                        AppliedButUnlogged = false
+                    });
+                }
+                return new ApplyResult { Outcomes = outcomes };
+            }
+
+            foreach (var t in dbTargets)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    // The executor re-derives the authoritative gate and runs the ALTER
+                    // on one connection — the handler cannot hand it a forged all-clear.
+                    var outcome = await exec.SetDatabaseOptionAsync(t.Database, t.Setting, identity, ct).ConfigureAwait(false);
+
+                    var written = await WriteAuditAsync(exec, identity, t, outcome.Status, outcome.Message, outcome.PriorValue, outcome.GeneratedSql, outcome.ExecutingLogin, ct).ConfigureAwait(false);
+
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = outcome.Status,
+                        Message = outcome.Message,
+                        ExecutingLogin = outcome.ExecutingLogin,
+                        AuditWritten = written,
+                        // O3: a real mutation that we failed to log against a present table.
+                        AppliedButUnlogged = outcome.Applied && !written
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Per-target independence: one target's failure never aborts the rest.
+                    var record = BuildRecord(identity, t, RemediationStatus.Error, ex.Message, priorValue: t.CurrentValue, generatedSql: null, executingLogin: null);
+                    var written = await RemediationAuditHelpers.TryWriteAuditSafeAsync(exec, record, ct).ConfigureAwait(false);
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = RemediationStatus.Error,
+                        Message = ex.Message,
+                        AuditWritten = written,
+                        AppliedButUnlogged = false
+                    });
+                }
+            }
+
+            return new ApplyResult { Outcomes = outcomes };
+        }
+
+        private static async Task<bool> WriteAuditAsync(
+            IRemediationExecutor exec,
+            RemediationIdentity identity,
+            DbConfigTarget target,
+            RemediationStatus status,
+            string? message,
+            string? priorValue,
+            string? generatedSql,
+            string? executingLogin,
+            CancellationToken ct)
+        {
+            var record = BuildRecord(identity, target, status, message, priorValue, generatedSql, executingLogin);
+            return await exec.WriteAuditAsync(record, ct).ConfigureAwait(false);
+        }
+
+        private static RemediationAuditRecord BuildRecord(
+            RemediationIdentity identity,
+            DbConfigTarget target,
+            RemediationStatus status,
+            string? message,
+            string? priorValue,
+            string? generatedSql,
+            string? executingLogin)
+            => new()
+            {
+                OperatorIdentity = identity.OperatorIdentity,
+                ExecutingLogin = executingLogin,
+                TargetDatabase = target.Database,
+                FactKey = "DB_CONFIG",
+                QueryId = null,                 // DB_CONFIG rows have no query_id/plan_id (B-1)
+                PlanId = null,
+                Action = AuditAction(target.Setting),
+                PriorValue = priorValue ?? target.CurrentValue,
+                GeneratedSql = generatedSql,
+                Result = RemediationAuditHelpers.AuditResult(status),
+                ErrorMessage = RemediationAuditHelpers.IsErrorish(status) ? message : null,
+                SourceAlertRef = identity.SourceAlertRef
+            };
+
+        /// <summary>The precise audit <c>action</c> taxonomy value per setting (fits varchar(32)).</summary>
+        private static string AuditAction(DbConfigSetting setting) => setting switch
+        {
+            DbConfigSetting.AutoShrinkOff => "set_auto_shrink_off",
+            DbConfigSetting.AutoCloseOff => "set_auto_close_off",
+            DbConfigSetting.PageVerifyChecksum => "set_page_verify_checksum",
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
+        };
+
+        private static TargetPreflight ToTargetPreflight(DbConfigTarget t, DbConfigPreflight probe)
+        {
+            var pf = new TargetPreflight
+            {
+                Database = t.Database,
+                HasAlter = probe.HasAlter,
+                CurrentDatabase = t.Database,
+                ExecutingLogin = probe.ExecutingLogin
+            };
+            pf.Disposition = Classify(probe);
+            pf.Message = DispositionMessage(pf.Disposition, t, probe);
+            return pf;
+        }
+
+        private static RemediationDisposition Classify(DbConfigPreflight probe)
+        {
+            if (!probe.DatabaseExists) return RemediationDisposition.BlockDatabaseNotFound;
+            if (!probe.HasAlter) return RemediationDisposition.BlockNoAlter;
+            if (probe.AlreadyInDesiredState) return RemediationDisposition.AlreadyInDesiredState;
+            return RemediationDisposition.Ok;
+        }
+
+        private static string DispositionMessage(RemediationDisposition d, DbConfigTarget t, DbConfigPreflight probe) => d switch
+        {
+            RemediationDisposition.Ok => $"Ready to apply {SettingTitle(t.Setting)} on [{t.Database}] (currently {probe.CurrentValue}).",
+            RemediationDisposition.AlreadyInDesiredState => "Already in the desired state — will be skipped.",
+            RemediationDisposition.BlockDatabaseNotFound => "Database not found on the server — will not proceed.",
+            RemediationDisposition.BlockNoAlter => $"The monitoring login lacks ALTER on {t.Database} — will fail closed (no change).",
+            RemediationDisposition.BlockAuditTableAbsent => AuditAbsentMessage,
+            _ => "Unable to determine target state."
+        };
+
+        /// <summary>Short human title for a setting (display only).</summary>
+        public static string SettingTitle(DbConfigSetting setting) => setting switch
+        {
+            DbConfigSetting.AutoShrinkOff => "AUTO_SHRINK OFF",
+            DbConfigSetting.AutoCloseOff => "AUTO_CLOSE OFF",
+            DbConfigSetting.PageVerifyChecksum => "PAGE_VERIFY CHECKSUM",
+            _ => setting.ToString()
+        };
+
+        private static IReadOnlyList<DbConfigTarget> DbTargets(RemediationAction action) =>
+            action.DbConfigTargets ?? Array.Empty<DbConfigTarget>();
+
+        private const string AuditAbsentMessage =
+            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+    }
+}

--- a/Dashboard/Services/Remediation/ForcePlanHandler.cs
+++ b/Dashboard/Services/Remediation/ForcePlanHandler.cs
@@ -37,6 +37,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         // destructive action and does not require the typed-confirm hook.
         public bool IsDestructive => false;
 
+        // Force-plan has a real inverse (unforce), so it supports un-apply.
+        public bool SupportsUnapply => true;
+
         public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
         {
             if (action is null) throw new ArgumentNullException(nameof(action));

--- a/Dashboard/Services/Remediation/IRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/IRemediationExecutor.cs
@@ -8,6 +8,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitorDashboard.Services.Remediation
 {
@@ -59,6 +60,26 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
         /// <summary>Self-gating inverse of <see cref="ForcePlanAsync"/> (sp_query_store_unforce_plan).</summary>
         Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>
+        /// Read-only display probe for one DB-config target (existence, ALTER
+        /// permission, live current value / desired-state). Advisory only — does NOT
+        /// authorise a mutation. Runs on the monitoring connection (no retarget).
+        /// </summary>
+        Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct);
+
+        /// <summary>
+        /// Self-gating always-safe DB-config ALTER. R2-MOD-1: the gate (parameterized
+        /// sys.databases existence + HAS_PERMS_BY_NAME(@db,'DATABASE','ALTER') +
+        /// live freshness read) and the <c>ALTER DATABASE [db] SET &lt;literal&gt;</c>
+        /// run on ONE open MONITORING connection (no InitialCatalog retarget, no
+        /// re-open between gate and mutation). The database identifier is validated
+        /// against sys.databases (parameterized), then the SAME validated string is
+        /// bracketed by an inline QUOTENAME-equivalent and placed as the ONLY
+        /// non-constant token; the SET clause is a hardcoded compile-time literal
+        /// chosen by <paramref name="setting"/>. Emits GateSpid/ExecSpid.
+        /// </summary>
+        Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct);
 
         /// <summary>
         /// Writes one audit row on the MONITORING connection. Returns false if the

--- a/Dashboard/Services/Remediation/IRemediationHandler.cs
+++ b/Dashboard/Services/Remediation/IRemediationHandler.cs
@@ -35,6 +35,15 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// </summary>
         bool IsDestructive { get; }
 
+        /// <summary>
+        /// Whether this fix type can be un-applied. Force-plan can (unforce); the
+        /// always-safe DB-config fixes have no sensible reverse, so DbConfigHandler
+        /// returns false. The UI gates the Un-apply button on this, and
+        /// RemediationApplyService fails safe (clean report, no exception) if an
+        /// un-apply is requested for a handler where this is false.
+        /// </summary>
+        bool SupportsUnapply { get; }
+
         /// <summary>Read-only, per-target disposition for the UI. Advisory.</summary>
         Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct);
 

--- a/Dashboard/Services/Remediation/RemediationApplyModels.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyModels.cs
@@ -27,6 +27,14 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// <summary>The operator declined the confirm modal — the gate held; no mutation.</summary>
         NotConfirmed,
 
+        /// <summary>
+        /// An un-apply was requested for a handler that does not support it
+        /// (SupportsUnapply == false). Fails SAFE: nothing ran, no exception (m-C).
+        /// The UI gates the Un-apply button on SupportsUnapply, so this is a
+        /// defensive backstop for a future mis-wired caller.
+        /// </summary>
+        UnapplyNotSupported,
+
         /// <summary>The handler ran; see <see cref="RemediationRunReport.Targets"/>.</summary>
         Ran
     }
@@ -93,6 +101,13 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// <summary>Original regression_factor from the finding (M2 — surfaced so the operator owns the still-better judgment).</summary>
         public double RegressionFactor { get; init; }
 
+        /// <summary>
+        /// Fact-key-neutral display title for a non-force-plan row (DB_CONFIG renders
+        /// this instead of query_id/plan_id), e.g. "[Foo] SET AUTO_SHRINK OFF — was ON".
+        /// Null for force-plan rows (they render the query_id/plan_id head).
+        /// </summary>
+        public string? StatusTitle { get; init; }
+
         /// <summary>Advisory preflight disposition for this target (display only).</summary>
         public RemediationDisposition Disposition { get; init; }
         public string? DispositionMessage { get; init; }
@@ -109,6 +124,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public string ServerDisplayName { get; init; } = "";
         public bool IsUnapply { get; init; }
 
+        /// <summary>The action's fact key ("PLAN_REGRESSION" | "DB_CONFIG"), so the modal can show a fact-key-specific header/banner.</summary>
+        public string FactKey { get; init; } = "";
+
         /// <summary>Exact SQL preview shown verbatim (the code-block T-SQL for apply; the unforce statements for un-apply).</summary>
         public string PreviewSql { get; init; } = "";
 
@@ -123,7 +141,14 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// <summary>False when the target server is pre-2.12.0 schema — apply will hard-block.</summary>
         public bool AuditTableExists { get; init; }
 
-        /// <summary>True when at least one target is in a state where applying can do something.</summary>
+        /// <summary>
+        /// True when at least one target is in a state where applying can do something.
+        /// Ok / WarnFailing are actionable (force-plan AND a DB_CONFIG Ok). The new
+        /// DB_CONFIG dispositions (AlreadyInDesiredState, BlockDatabaseNotFound) are
+        /// deliberately NOT actionable — an all-already-desired DB_CONFIG request
+        /// disables Apply, exactly like an all-AlreadyForced force-plan request. This
+        /// set is unchanged for force-plan (no loosening).
+        /// </summary>
         public bool AnyActionable =>
             AuditTableExists &&
             Targets.Any(t => t.Disposition is RemediationDisposition.Ok or RemediationDisposition.WarnFailing);

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -52,7 +52,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
             if (credentialService is null) throw new ArgumentNullException(nameof(credentialService));
 
-            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler() });
+            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler() });
             _executorFactory = server =>
                 new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
             _auditFailureClassifier = (server, ct) =>
@@ -168,6 +168,14 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             if (handler is null)
                 return new RemediationRunReport { Status = RemediationRunStatus.NoHandler, IsUnapply = isUnapply };
 
+            // m-C fail-safe: an un-apply for a handler that doesn't support it (e.g.
+            // a future mis-wired DB_CONFIG un-apply) short-circuits to a clean report
+            // BEFORE any confirm or handler call — never bubbles NotSupportedException.
+            // The privileged action is a no-op either way; this removes the only path
+            // that turns the guard violation into a crash.
+            if (isUnapply && !handler.SupportsUnapply)
+                return new RemediationRunReport { Status = RemediationRunStatus.UnapplyNotSupported, IsUnapply = true };
+
             var exec = _executorFactory(server);
 
             // Read-only preflight: DISPLAY DRIVER ONLY. Populates the confirm modal's
@@ -234,22 +242,44 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             bool isUnapply,
             PreflightResult preflight)
         {
-            // Preflight targets align 1:1 with action targets (the handler builds them
+            // Preflight targets align 1:1 with action targets (each handler builds them
             // in order). Match by index; tolerate a short preflight list defensively.
-            var confirmTargets = new List<RemediationConfirmTarget>(action.Targets.Count);
-            for (var i = 0; i < action.Targets.Count; i++)
+            // Branch on which target list is populated: DB_CONFIG carries
+            // DbConfigTargets (action.Targets is empty for it), force-plan carries Targets.
+            List<RemediationConfirmTarget> confirmTargets;
+            if (action.DbConfigTargets is { Count: > 0 } dbTargets)
             {
-                var t = action.Targets[i];
-                var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
-                confirmTargets.Add(new RemediationConfirmTarget
+                confirmTargets = new List<RemediationConfirmTarget>(dbTargets.Count);
+                for (var i = 0; i < dbTargets.Count; i++)
                 {
-                    Database = t.Database,
-                    QueryId = t.QueryId,
-                    PlanId = t.PlanId,
-                    RegressionFactor = t.RegressionFactor,
-                    Disposition = pf?.Disposition ?? RemediationDisposition.Error,
-                    DispositionMessage = pf?.Message
-                });
+                    var t = dbTargets[i];
+                    var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
+                    confirmTargets.Add(new RemediationConfirmTarget
+                    {
+                        Database = t.Database,
+                        StatusTitle = $"[{t.Database}] {DbConfigHandler.SettingTitle(t.Setting)} — was {t.CurrentValue}",
+                        Disposition = pf?.Disposition ?? RemediationDisposition.Error,
+                        DispositionMessage = pf?.Message
+                    });
+                }
+            }
+            else
+            {
+                confirmTargets = new List<RemediationConfirmTarget>(action.Targets.Count);
+                for (var i = 0; i < action.Targets.Count; i++)
+                {
+                    var t = action.Targets[i];
+                    var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
+                    confirmTargets.Add(new RemediationConfirmTarget
+                    {
+                        Database = t.Database,
+                        QueryId = t.QueryId,
+                        PlanId = t.PlanId,
+                        RegressionFactor = t.RegressionFactor,
+                        Disposition = pf?.Disposition ?? RemediationDisposition.Error,
+                        DispositionMessage = pf?.Message
+                    });
+                }
             }
 
             var executingLogin = preflight.Targets
@@ -260,6 +290,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             {
                 ServerDisplayName = string.IsNullOrEmpty(server.DisplayName) ? server.ServerName : server.DisplayName,
                 IsUnapply = isUnapply,
+                FactKey = action.FactKey,
                 PreviewSql = preview,
                 OperatorIdentity = operatorIdentity,
                 ExecutingLogin = executingLogin,
@@ -275,6 +306,22 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// </summary>
         private static string RenderPreview(RemediationAction action, bool isUnapply)
         {
+            // DB_CONFIG: render the ALTER DATABASE statements (apply-only — there is no
+            // un-apply branch). Display only; the executor builds its own validated +
+            // bracketed statement and never executes this text. Reaches here only as a
+            // fallback when no code-block preview was supplied.
+            if (action.DbConfigTargets is { Count: > 0 } dbTargets)
+            {
+                var sb2 = new StringBuilder();
+                foreach (var t in dbTargets)
+                {
+                    sb2.Append("ALTER DATABASE ").Append(QuoteIdentifier(t.Database))
+                       .Append(' ').Append(SetClauseFor(t.Setting))
+                       .Append(";   -- was ").Append(t.CurrentValue).Append('\n');
+                }
+                return sb2.ToString().TrimEnd('\n');
+            }
+
             var proc = isUnapply ? "sp_query_store_unforce_plan" : "sp_query_store_force_plan";
             var sb = new StringBuilder();
             foreach (var t in action.Targets)
@@ -286,5 +333,18 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             }
             return sb.ToString().TrimEnd('\n');
         }
+
+        // Display-only bracketing for the fallback preview (mirrors the executor's
+        // QUOTENAME doubling). The executed statement is built by the executor, not here.
+        private static string QuoteIdentifier(string identifier) =>
+            "[" + identifier.Replace("]", "]]") + "]";
+
+        private static string SetClauseFor(DbConfigSetting setting) => setting switch
+        {
+            DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
+            DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
+            DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            _ => "SET /* unknown */"
+        };
     }
 }

--- a/Dashboard/Services/Remediation/RemediationAuditHelpers.cs
+++ b/Dashboard/Services/Remediation/RemediationAuditHelpers.cs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Small shared helpers for the per-fact-type handlers (§5.1) so the audit-result
+    /// taxonomy mapping and the never-throw audit-write wrapper are written once, not
+    /// copy-pasted between ForcePlanHandler and DbConfigHandler (the two-bodies trap).
+    /// The security-reviewed GATE logic lives in the executor, NOT here — these helpers
+    /// only classify a status and shield a per-target error path from a logging throw.
+    /// </summary>
+    internal static class RemediationAuditHelpers
+    {
+        /// <summary>Maps a per-target status onto the audit <c>result</c> taxonomy.</summary>
+        public static string AuditResult(RemediationStatus status) => status switch
+        {
+            RemediationStatus.Success => "success",
+            RemediationStatus.Skipped => "skipped",
+            RemediationStatus.PermissionDenied => "skipped",
+            RemediationStatus.Blocked => "aborted",
+            RemediationStatus.Error => "error",
+            _ => "error"
+        };
+
+        /// <summary>
+        /// True when the status's message should be persisted to the audit
+        /// <c>error_message</c> column (the failure/blocked statuses).
+        /// </summary>
+        public static bool IsErrorish(RemediationStatus status) =>
+            status is RemediationStatus.Error or RemediationStatus.PermissionDenied or RemediationStatus.Blocked;
+
+        /// <summary>
+        /// Writes the audit record, swallowing any throw so a logging failure while
+        /// handling a per-target error never masks the original outcome. Returns false
+        /// on any failure (caller surfaces applied-but-unlogged where relevant).
+        /// </summary>
+        public static async Task<bool> TryWriteAuditSafeAsync(IRemediationExecutor exec, RemediationAuditRecord record, CancellationToken ct)
+        {
+            try
+            {
+                return await exec.WriteAuditAsync(record, ct).ConfigureAwait(false);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationAuditWriter.cs
+++ b/Dashboard/Services/Remediation/RemediationAuditWriter.cs
@@ -121,6 +121,7 @@ INSERT INTO
     query_id,
     plan_id,
     action,
+    prior_value,
     generated_sql,
     result,
     error_message,
@@ -137,6 +138,7 @@ VALUES
     @query_id,
     @plan_id,
     @action,
+    @prior_value,
     @generated_sql,
     @result,
     @error_message,
@@ -147,9 +149,15 @@ VALUES
                 command.Parameters.Add(new SqlParameter("@target_server", SqlDbType.NVarChar, 256) { Value = (object?)targetServer ?? DBNull.Value });
                 command.Parameters.Add(new SqlParameter("@target_database", SqlDbType.NVarChar, 128) { Value = record.TargetDatabase });
                 command.Parameters.Add(new SqlParameter("@finding_fact_key", SqlDbType.VarChar, 64) { Value = record.FactKey });
-                command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = record.QueryId });
-                command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = record.PlanId });
-                command.Parameters.Add(new SqlParameter("@action", SqlDbType.VarChar, 16) { Value = record.Action });
+                // B-1: DB_CONFIG rows have no query_id/plan_id — write DBNull, not 0.
+                command.Parameters.Add(new SqlParameter("@query_id", SqlDbType.BigInt) { Value = (object?)record.QueryId ?? DBNull.Value });
+                command.Parameters.Add(new SqlParameter("@plan_id", SqlDbType.BigInt) { Value = (object?)record.PlanId ?? DBNull.Value });
+                // B-3: widen to VarChar(32) — the DB_CONFIG taxonomy (e.g.
+                // 'set_page_verify_checksum' = 24 chars) silently truncates at 16
+                // here, BEFORE the widened column is reached. Column width alone is
+                // insufficient; this client parameter is the first truncation point.
+                command.Parameters.Add(new SqlParameter("@action", SqlDbType.VarChar, 32) { Value = record.Action });
+                command.Parameters.Add(new SqlParameter("@prior_value", SqlDbType.NVarChar, 128) { Value = (object?)record.PriorValue ?? DBNull.Value });
                 command.Parameters.Add(new SqlParameter("@generated_sql", SqlDbType.NVarChar, -1) { Value = (object?)record.GeneratedSql ?? DBNull.Value });
                 command.Parameters.Add(new SqlParameter("@result", SqlDbType.VarChar, 16) { Value = record.Result });
                 command.Parameters.Add(new SqlParameter("@error_message", SqlDbType.NVarChar, -1) { Value = (object?)record.ErrorMessage ?? DBNull.Value });

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -7,6 +7,7 @@
  */
 
 using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitorDashboard.Services.Remediation
 {
@@ -52,6 +53,13 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         BlockNoAlter,
         BlockWrongDatabase,
         BlockAuditTableAbsent,
+
+        /// <summary>DB_CONFIG: the setting is already in the desired state — idempotent skip (no ALTER).</summary>
+        AlreadyInDesiredState,
+
+        /// <summary>DB_CONFIG: the target database was not found on the server (renamed/dropped) — blocked, no ALTER.</summary>
+        BlockDatabaseNotFound,
+
         Error
     }
 
@@ -111,6 +119,60 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public int? ExecSpid { get; init; }
     }
 
+    /// <summary>
+    /// Read-only display probe for one DB-config target (advisory only — never the
+    /// authoritative gate; <see cref="IRemediationExecutor.SetDatabaseOptionAsync"/>
+    /// re-derives its own gate on the mutating connection before any ALTER).
+    /// </summary>
+    public sealed class DbConfigPreflight
+    {
+        public string Database { get; init; } = "";
+        public DbConfigSetting Setting { get; init; }
+
+        /// <summary>True when the database exists on the server (parameterized sys.databases check).</summary>
+        public bool DatabaseExists { get; init; }
+
+        /// <summary>HAS_PERMS_BY_NAME(@db,'DATABASE','ALTER') wrapped ISNULL(...,0).</summary>
+        public bool HasAlter { get; init; }
+
+        /// <summary>True when the live sys.databases read shows the setting already in the desired state.</summary>
+        public bool AlreadyInDesiredState { get; init; }
+
+        public string? ExecutingLogin { get; init; }
+
+        /// <summary>The current value read live (display/audit prior value).</summary>
+        public string? CurrentValue { get; init; }
+
+        public RemediationDisposition Disposition { get; set; }
+        public string? Message { get; set; }
+    }
+
+    /// <summary>
+    /// Outcome of a single DB-config <c>ALTER DATABASE SET</c> attempt. The gate
+    /// (existence + permission + freshness) and the ALTER run on ONE open monitoring
+    /// connection; <see cref="GateSpid"/>/<see cref="ExecSpid"/> prove they shared it
+    /// (R2-MOD-1). <see cref="GeneratedSql"/> is the exact statement executed.
+    /// </summary>
+    public sealed class DbConfigOutcome
+    {
+        public string Database { get; init; } = "";
+        public DbConfigSetting Setting { get; init; }
+        public RemediationStatus Status { get; init; }
+
+        /// <summary>True only when an ALTER actually ran and succeeded.</summary>
+        public bool Applied { get; init; }
+        public string? ExecutingLogin { get; init; }
+        public string? Message { get; init; }
+
+        /// <summary>The prior setting value, captured at the gate read (audit prior_value).</summary>
+        public string? PriorValue { get; init; }
+
+        /// <summary>The exact ALTER DATABASE statement executed (audited generated_sql).</summary>
+        public string? GeneratedSql { get; init; }
+        public int? GateSpid { get; init; }
+        public int? ExecSpid { get; init; }
+    }
+
     /// <summary>Per-target outcome of an apply/unapply, including the audit disposition.</summary>
     public sealed class TargetOutcome
     {
@@ -151,9 +213,10 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public string? TargetServer { get; set; }
         public string TargetDatabase { get; init; } = "";
         public string FactKey { get; init; } = "";
-        public long QueryId { get; init; }
-        public long PlanId { get; init; }
-        public string Action { get; init; } = "";          // "force" | "unforce"
+        public long? QueryId { get; init; }                 // force-plan only; null for DB_CONFIG
+        public long? PlanId { get; init; }                  // force-plan only; null for DB_CONFIG
+        public string Action { get; init; } = "";          // "force" | "unforce" | "set_*"
+        public string? PriorValue { get; init; }            // DB_CONFIG prior value ("ON" | "NONE" | ...); null for force-plan
         public string? GeneratedSql { get; init; }
         public string Result { get; init; } = "";          // "success" | "skipped" | "error" | "aborted"
         public string? ErrorMessage { get; init; }

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -791,7 +791,13 @@ ORDER BY database_name";
                 recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
                 rcsi = !reader.IsDBNull(4) && reader.GetBoolean(4),
                 query_store = !reader.IsDBNull(6) && reader.GetBoolean(6),
-                issues
+                issues,
+                // §4.1: structured, wording-independent fields the shared extractor
+                // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
+                // and types to the Dashboard collector (bool / bool / string).
+                auto_shrink = !reader.IsDBNull(2) && reader.GetBoolean(2),
+                auto_close = !reader.IsDBNull(3) && reader.GetBoolean(3),
+                page_verify = pageVerify
             });
         }
 

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -38,6 +38,7 @@ public static class FactRemediation
         return finding.RootFactKey switch
         {
             "PLAN_REGRESSION" => GenerateForPlanRegression(finding),
+            "DB_CONFIG" => GenerateForDbConfig(finding),
             _ => null
         };
     }
@@ -62,6 +63,11 @@ public static class FactRemediation
                 return targets.Count == 0
                     ? null
                     : new RemediationAction("PLAN_REGRESSION", "force", targets);
+            case "DB_CONFIG":
+                var dbConfigTargets = ExtractDbConfigTargets(finding);
+                return dbConfigTargets.Count == 0
+                    ? null
+                    : new RemediationAction("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(), dbConfigTargets);
             default:
                 return null;
         }
@@ -164,6 +170,160 @@ public static class FactRemediation
     }
 
     /// <summary>
+    /// Extracts the always-safe DB-config targets from a DB_CONFIG finding's
+    /// drill-down <c>config_issues</c> array. For each row with a non-empty
+    /// <c>database</c>, emits one target per safe setting currently in the wrong
+    /// state, reading the STRUCTURED typed fields (<c>auto_shrink</c> bool,
+    /// <c>auto_close</c> bool, <c>page_verify</c> string) — never parsing the human
+    /// <c>issues</c> strings (which are display wording defined in two collectors
+    /// and would drift). RCSI is NEVER emitted (destructive — excluded);
+    /// recovery_model / query_store are out of scope. This is the single parse:
+    /// <see cref="GenerateForDbConfig"/> renders entirely from this list and
+    /// <see cref="BuildAction"/> persists it. A defensive cap of 50 targets mirrors
+    /// the force-plan cap discipline.
+    /// </summary>
+    public static IReadOnlyList<DbConfigTarget> ExtractDbConfigTargets(AnalysisFinding finding)
+    {
+        var targets = new List<DbConfigTarget>();
+
+        if (finding?.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("config_issues", out var raw) ||
+            raw is null)
+            return targets;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return targets;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return targets;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (targets.Count >= 50) break;
+            if (row.ValueKind != JsonValueKind.Object) continue;
+
+            var database = GetString(row, "database");
+            if (string.IsNullOrEmpty(database))
+                continue;
+
+            // Each setting is an independent (db, setting) target. RCSI is never
+            // emitted — it is intentionally absent from DbConfigSetting.
+            if (GetBool(row, "auto_shrink"))
+            {
+                if (targets.Count >= 50) break;
+                targets.Add(new DbConfigTarget(database, DbConfigSetting.AutoShrinkOff, "ON"));
+            }
+            if (GetBool(row, "auto_close"))
+            {
+                if (targets.Count >= 50) break;
+                targets.Add(new DbConfigTarget(database, DbConfigSetting.AutoCloseOff, "ON"));
+            }
+            var pageVerify = GetString(row, "page_verify");
+            if (!string.IsNullOrEmpty(pageVerify) &&
+                !string.Equals(pageVerify, "CHECKSUM", StringComparison.OrdinalIgnoreCase))
+            {
+                if (targets.Count >= 50) break;
+                targets.Add(new DbConfigTarget(database, DbConfigSetting.PageVerifyChecksum, pageVerify));
+            }
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Thin renderer over <see cref="ExtractDbConfigTargets"/>. Emits the exact
+    /// <c>ALTER DATABASE [db] SET ...;</c> statements that will run (matching the
+    /// executor and the audited generated_sql), grouped by database, with a "was X"
+    /// comment per statement and an explicit note when a database ALSO has RCSI OFF
+    /// (intentionally NOT auto-fixed). The bracketed identifier uses the same
+    /// QUOTENAME doubling as the force-plan renderer; the displayed text is NEVER
+    /// executed (the executor builds its own statement from the validated identifier
+    /// + the enum literal).
+    /// </summary>
+    private static string? GenerateForDbConfig(AnalysisFinding finding)
+    {
+        var targets = ExtractDbConfigTargets(finding);
+        if (targets.Count == 0)
+            return null;
+
+        // Which databases also carry RCSI OFF (so we can append the note). Read the
+        // structured rcsi flag from the same drill-down; never parse issues strings.
+        var rcsiOffDatabases = new HashSet<string>(StringComparer.Ordinal);
+        if (finding?.DrillDown is not null &&
+            finding.DrillDown.TryGetValue("config_issues", out var raw) && raw is not null)
+        {
+            try
+            {
+                var element = JsonSerializer.SerializeToElement(raw);
+                if (element.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var row in element.EnumerateArray())
+                    {
+                        if (row.ValueKind != JsonValueKind.Object) continue;
+                        var db = GetString(row, "database");
+                        // rcsi == false means RCSI is OFF (the wrong-state we exclude).
+                        if (!string.IsNullOrEmpty(db) && row.TryGetProperty("rcsi", out var r)
+                            && r.ValueKind == JsonValueKind.False)
+                            rcsiOffDatabases.Add(db);
+                    }
+                }
+            }
+            catch { /* note is best-effort */ }
+        }
+
+        var sb = new StringBuilder();
+        string? currentDb = null;
+
+        foreach (var target in targets)
+        {
+            if (!string.Equals(currentDb, target.Database, StringComparison.Ordinal))
+            {
+                if (currentDb is not null)
+                {
+                    // Close out the previous database group with its RCSI note (if any).
+                    if (rcsiOffDatabases.Contains(currentDb))
+                        sb.AppendLine($"-- NOTE: {QuoteName(currentDb)} also has RCSI OFF — intentionally NOT auto-fixed (test on a copy first).");
+                    sb.AppendLine();
+                }
+                currentDb = target.Database;
+                sb.AppendLine($"-- Database: {target.Database}");
+            }
+
+            sb.AppendLine($"{StatementFor(target.Setting, target.Database)}   -- was {target.CurrentValue}");
+        }
+
+        if (currentDb is not null && rcsiOffDatabases.Contains(currentDb))
+            sb.AppendLine($"-- NOTE: {QuoteName(currentDb)} also has RCSI OFF — intentionally NOT auto-fixed (test on a copy first).");
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// The full <c>ALTER DATABASE [db] SET ...;</c> statement text for display
+    /// rendering, built from the QUOTENAME'd identifier + a hardcoded SET-clause
+    /// literal selected by the enum. The Dashboard executor builds its OWN
+    /// byte-identical statement and never executes this rendered string.
+    /// </summary>
+    private static string StatementFor(DbConfigSetting setting, string database)
+    {
+        var setClause = setting switch
+        {
+            DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
+            DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
+            DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
+        };
+        return $"ALTER DATABASE {QuoteName(database)} {setClause};";
+    }
+
+    /// <summary>
     /// QUOTENAME-equivalent: wrap an identifier in square brackets and double
     /// any embedded close-bracket. The database name comes from
     /// sys.databases (via the drill-down collector), so it is already a valid
@@ -196,5 +356,21 @@ public static class FactRemediation
     {
         if (!row.TryGetProperty(property, out var v)) return 0.0;
         return v.ValueKind == JsonValueKind.Number ? v.GetDouble() : 0.0;
+    }
+
+    private static bool GetBool(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return false;
+        return v.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            // Defensive: a collector that emitted a "1"/"0" string or a number still
+            // reads correctly, but both collectors emit a JSON bool (§4.1 parity).
+            JsonValueKind.String => string.Equals(v.GetString(), "1", StringComparison.Ordinal)
+                                     || string.Equals(v.GetString(), "true", StringComparison.OrdinalIgnoreCase),
+            JsonValueKind.Number => v.TryGetInt64(out var n) && n != 0,
+            _ => false
+        };
     }
 }

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -26,9 +26,42 @@ namespace PerformanceMonitor.Analysis;
 /// </para>
 /// </summary>
 public sealed record RemediationAction(
-    string FactKey,                              // e.g. "PLAN_REGRESSION" — handler-registry key
-    string Action,                              // "force" (v1). Un-apply derives "unforce".
-    IReadOnlyList<ForcePlanTarget> Targets);
+    string FactKey,                              // "PLAN_REGRESSION" | "DB_CONFIG" — handler-registry key
+    string Action,                              // "force" (plan regression) | "set" (db config). Un-apply derives "unforce".
+    IReadOnlyList<ForcePlanTarget> Targets,      // force-plan targets (empty list for DB_CONFIG)
+    IReadOnlyList<DbConfigTarget>? DbConfigTargets = null);  // DB-config targets (null for force-plan)
+
+/// <summary>
+/// The fixed, hardcoded set of always-safe database settings B3 Phase 2 can apply.
+/// This enum — NOT any data/operator-supplied string — selects the SET clause
+/// literal in the executor (see DatabaseService.Remediation DB-config arm). RCSI
+/// (READ_COMMITTED_SNAPSHOT) is deliberately absent: it is destructive and excluded.
+/// </summary>
+public enum DbConfigSetting
+{
+    /// <summary>ALTER DATABASE [db] SET AUTO_SHRINK OFF;</summary>
+    AutoShrinkOff,
+
+    /// <summary>ALTER DATABASE [db] SET AUTO_CLOSE OFF;</summary>
+    AutoCloseOff,
+
+    /// <summary>ALTER DATABASE [db] SET PAGE_VERIFY CHECKSUM;</summary>
+    PageVerifyChecksum
+}
+
+/// <summary>
+/// One always-safe database-config target: a (database, setting) pair. Each maps
+/// 1:1 onto an independent ALTER DATABASE statement, an audit row, and a confirm
+/// row. <see cref="Database"/> is validated non-empty by the extractor and
+/// re-validated against sys.databases at apply time; <see cref="Setting"/> is the
+/// hardcoded-literal selector (NOT free text). <see cref="CurrentValue"/> is a
+/// possibly-stale display/audit prior-value snapshot ONLY — it is never an
+/// execution input (the live apply-time sys.databases read drives the skip).
+/// </summary>
+public sealed record DbConfigTarget(
+    string Database,
+    DbConfigSetting Setting,
+    string? CurrentValue = null);
 
 /// <summary>
 /// One force-plan target. <see cref="Database"/>, <see cref="QueryId"/> and

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -76,7 +76,11 @@ public record FieldDto(string Label, string Value);
 /// the round-trip backward-compatible: legacy contextJson with no Remediation
 /// property deserializes the field to null.
 /// </summary>
-public record RemediationActionDto(string FactKey, string Action, List<ForcePlanTargetDto> Targets);
+public record RemediationActionDto(
+    string FactKey,
+    string Action,
+    List<ForcePlanTargetDto> Targets,
+    List<DbConfigTargetDto>? DbConfigTargets = null);
 public record ForcePlanTargetDto(
     string Database,
     long QueryId,
@@ -86,6 +90,17 @@ public record ForcePlanTargetDto(
     double LatestCpuPerExecUs,
     double BestCpuPerExecUs,
     double RegressionFactor);
+
+/// <summary>
+/// JSON mirror of <see cref="DbConfigTarget"/>. <see cref="Setting"/> is persisted
+/// as the enum's int value. The trailing optional <c>DbConfigTargets</c> member on
+/// <see cref="RemediationActionDto"/> keeps the round-trip backward-compatible:
+/// legacy contextJson without it deserializes to null.
+/// </summary>
+public record DbConfigTargetDto(
+    string Database,
+    int Setting,
+    string? CurrentValue);
 
 /// <summary>
 /// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
@@ -161,7 +176,15 @@ public static class AlertContextSerializer
                 t.RegressionFactor));
         }
 
-        return new RemediationActionDto(action.FactKey, action.Action, targets);
+        List<DbConfigTargetDto>? dbConfigTargets = null;
+        if (action.DbConfigTargets is not null)
+        {
+            dbConfigTargets = new List<DbConfigTargetDto>(action.DbConfigTargets.Count);
+            foreach (var t in action.DbConfigTargets)
+                dbConfigTargets.Add(new DbConfigTargetDto(t.Database, (int)t.Setting, t.CurrentValue));
+        }
+
+        return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets);
     }
 
     private static RemediationAction? FromDto(RemediationActionDto? dto)
@@ -186,6 +209,20 @@ public static class AlertContextSerializer
             }
         }
 
-        return new RemediationAction(dto.FactKey, dto.Action, targets);
+        // m-A: deserialize the DB-config targets and PASS them to the ctor. The
+        // RemediationAction ctor's trailing DbConfigTargets defaults to null, so a
+        // 3-arg call here would silently drop a DB_CONFIG action's targets on the
+        // round-trip (un-applyable from any persisted context). Legacy JSON without
+        // the field deserializes dto.DbConfigTargets to null -> dbConfigTargets null
+        // -> backward-compatible.
+        List<DbConfigTarget>? dbConfigTargets = null;
+        if (dto.DbConfigTargets is not null)
+        {
+            dbConfigTargets = new List<DbConfigTarget>(dto.DbConfigTargets.Count);
+            foreach (var t in dto.DbConfigTargets)
+                dbConfigTargets.Add(new DbConfigTarget(t.Database, (DbConfigSetting)t.Setting, t.CurrentValue));
+        }
+
+        return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets);
     }
 }

--- a/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
+++ b/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
@@ -6,8 +6,10 @@ Upgrade from 2.11.0 to 2.12.0
 Creates config.remediation_action_log — the durable, append-only audit trail for
 the approval-gated "Apply Fix" feature (B3). One row is written per apply/unapply
 attempt (success, skip, error, or abort), so every privileged mutation the
-Dashboard issues against a monitored server (today: sys.sp_query_store_force_plan
-for a plan regression) is recorded with who/what/when/where/result.
+Dashboard issues against a monitored server (sys.sp_query_store_force_plan for a
+plan regression, or ALTER DATABASE SET for an always-safe DB-config fix) is
+recorded with who/what/when/where/result. Force-plan rows carry query_id/plan_id;
+DB_CONFIG rows leave those NULL and record the prior setting in prior_value.
 
 Lives in the config schema alongside the other operational logs
 (config.collection_log, config.installation_history). Idempotent: guarded by
@@ -50,10 +52,11 @@ BEGIN
             DEFAULT (0),                       /* always 0 in v1 (no in-app elevation); reserved */
         target_server nvarchar(256) NULL,
         target_database sysname NOT NULL,
-        finding_fact_key varchar(64) NOT NULL, /* e.g. 'PLAN_REGRESSION' */
-        query_id bigint NOT NULL,
-        plan_id bigint NOT NULL,
-        action varchar(16) NOT NULL,           /* 'force' | 'unforce' */
+        finding_fact_key varchar(64) NOT NULL, /* e.g. 'PLAN_REGRESSION' | 'DB_CONFIG' */
+        query_id bigint NULL,                  /* force-plan only; NULL for DB_CONFIG rows */
+        plan_id bigint NULL,                   /* force-plan only; NULL for DB_CONFIG rows */
+        action varchar(32) NOT NULL,           /* 'force' | 'unforce' | 'set_auto_shrink_off' | 'set_auto_close_off' | 'set_page_verify_checksum' */
+        prior_value nvarchar(128) NULL,        /* DB_CONFIG prior value for manual reversal ('ON' | 'NONE' | 'TORN_PAGE_DETECTION'); NULL for force-plan */
         generated_sql nvarchar(max) NULL,      /* the previewed statement, recorded only — never executed */
         result varchar(16) NOT NULL,           /* 'success' | 'skipped' | 'error' | 'aborted' */
         error_message nvarchar(max) NULL,


### PR DESCRIPTION
## What shipped

The second privileged **Apply Fix** type — the three **always-safe** database settings, applied via gated `ALTER DATABASE <db> SET …`:

- `AUTO_SHRINK OFF`
- `AUTO_CLOSE OFF`
- `PAGE_VERIFY CHECKSUM`

**RCSI is excluded** (destructive — never emitted by the extractor); `recovery_model`/`query_store` are out of scope. **Apply-only** (no un-apply for DB-config — these have no sensible reverse; the prior value is recorded for manual reversal). Reuses the Phase-1 remediation framework verbatim and adds one handler + the model/extractor/executor/schema/UI deltas. Single PR per plan §10.

Implements the approved plan `b3-phase2-dbconfig.md` (cleared two adversarial security review rounds).

## Security invariants enforced (file:line)

1. **Identifier safety (§1):** the executed `ALTER DATABASE` statement's ONLY non-constant token is the DB identifier — (a) validated by a **parameterized** `sys.databases` existence check (`@db` `NVARCHAR(128)`, no concat) at `Dashboard/Services/DatabaseService.Remediation.cs:441-452`; (b) bracketed by an inline `]`→`]]` routine `QuoteIdentifier` at `:325` (its OWN routine — `FactRemediation.QuoteName` is private in `PerformanceMonitor.Analysis`, m-B); (c) the SET clause is a hardcoded literal chosen by `switch` over `DbConfigSetting` in `SetClauseFor` at `:333`. **Same-string invariant (M-1):** `ValidatedName` is set to the exact `@db` value only on existence (`:465`) and is the exact string passed to `BuildAlterStatement` (`:357`, executed at `:344`).
2. **Single-connection self-gating (§2 / R2-MOD-1):** existence + permission (`HAS_PERMS_BY_NAME(@db,'DATABASE','ALTER')` wrapped `ISNULL(...,0)`, `:448`) + live freshness read + the ALTER all on ONE monitoring connection — no `InitialCatalog` retarget, no re-open, no elevation (`SetDatabaseOptionAsync`, `:300-388`). `GateSpid`/`ExecSpid` emitted (`:385-386`).
3. **Audit integrity (§7):** `02_` create script **amended in place** (2.12.0 unreleased — no tag, csprojs `2.11.0`): `query_id`/`plan_id` → NULL, `action varchar(16)→(32)`, `prior_value nvarchar(128)` added (`upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql:56-59`). Writer passes `DBNull` for null IDs (`RemediationAuditWriter.cs:151-152`) and widens `@action` to `VarChar,32` + adds `@prior_value` (`:155-157`). `RemediationAuditRecord.QueryId/PlanId → long?` + `PriorValue` (`RemediationResults.cs:154-157`).
4. **Reachability guard (M-2):** `"DbConfigHandler"`, `"SetDatabaseOptionAsync"`, `"PreflightDbConfigAsync"` added to `CoreMachineryMarkers` (`Dashboard.Tests/RemediationTests.cs:380-383`); `CoreMachinery_OnlyReferencedInRemediationCore` now covers the new surface.
5. **Deserialize threading (m-A):** `FromDto` deserializes `DbConfigTargets` and passes them to the 4-arg ctor (`PerformanceMonitor.Notifications/AlertContext.cs:189-203`).
6. **Un-apply fail-safe (m-C):** `RunAsync` short-circuits to a clean `UnapplyNotSupported` report when `isUnapply && !handler.SupportsUnapply` (`RemediationApplyService.cs:171-178`) — never bubbles `NotSupportedException`.

Both drill-down collectors enriched with structured `auto_shrink`/`auto_close`/`page_verify` fields (identical JSON names+types) so the shared extractor reads typed fields, never the human `issues` strings (`SqlServerDrillDownCollector.cs`, `Lite/Analysis/DrillDownCollector.cs`).

## Headless test results (real)

- `dotnet build Dashboard/Dashboard.csproj -c Debug` — **clean (0 warnings, 0 errors)**
- `Dashboard.Tests` — **124 passed, 0 failed, 0 skipped**
- `Lite.Tests` — **310 passed, 0 failed, 0 skipped**
- Analysis + Notifications libs build clean.

New tests cover: no-injection/QUOTENAME against the executor's own builder, same-string invariant (trailing-whitespace), extractor (never RCSI / multi-setting / empty-db / RCSI-only→null), render-stability golden, audit-absent hard-block, fail-closed-on-no-ALTER, freshness-skip, DB-not-found, success (null IDs + prior_value + precise taxonomy), applied-but-unlogged, per-target independence, SupportsUnapply, apply-only enforcement, confirm-path threading, AnyActionable, serialization round-trip (DbConfigTargets survive — m-A), `CoreMachineryMarkers` coverage.

> Note: the single-connection SPID-equality and the writer/column no-truncation are executor/real-server concerns (SPID equality cannot be proven against a faked executor) — see the maintainer checklist below.

## Maintainer's real-server pre-merge gate (plan §11, steps 1-6)

I did NOT run sql2022 — these fold into your end-to-end pass (same as Phase 1):

1. Scratch DB `AUTO_SHRINK ON` → apply → `is_auto_shrink_on=0`, audit row `action='set_auto_shrink_off', result='success', prior_value='ON'`, `generated_sql` matches executed statement. Re-apply → freshness-skip (`skipped`, no second ALTER).
2. Multi-setting (AUTO_SHRINK ON + AUTO_CLOSE ON) → two ALTERs, two success rows, both flags 0.
3. PAGE_VERIFY `NONE` → `CHECKSUM`, `prior_value='NONE'`; separate run from `TORN_PAGE_DETECTION` confirms distinct prior.
4. Fail-closed on a db_owner-on-PerformanceMonitor-only login → `PermissionDenied`, no ALTER, grant guidance.
5. Drop scratch DB between finding and apply → `Blocked`, no ALTER.
6. Audit-absent server → hard block, no mutation.
   - Verify the **amended `02_`** via an Installer built at 2.12.0: table created with `query_id`/`plan_id` NULLABLE, `action varchar(32)`, `prior_value nvarchar(128)`; a `set_page_verify_checksum` row stores untruncated; re-run is a no-op. **O1 boundary:** if `v2.12.0` tags before this lands, switch to a `03_` ALTER in `2.12.0-to-2.13.0/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)