### PR TITLE
B3 Phase 3 PR-A: RCSI destructive-consent privileged core (unregistered)

### DIFF
--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -336,6 +336,91 @@ public class RemediationApplyServiceTests
         Assert.False(busy.CanApply);
     }
 
+    // ── B3 Phase 3: informed-consent request threading (B-1) ─────────────────────
+    //
+    // The confirm dialog IS the trust boundary; the service trusts the callback. PR-A
+    // populates the request: RequiresInformedConsent = handler.IsDestructive and, when
+    // destructive, the two-sided Risks (FactRiskDisclosure). The XAML acknowledge-each-
+    // risk RENDERING/gating is PR-B. These tests verify the request is populated
+    // correctly so the PR-B dialog has what it needs.
+
+    private static RemediationAction RcsiAction() =>
+        new("RCSI", "set", Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget> { new("Foo", DbConfigSetting.ReadCommittedSnapshotOn, "OFF") });
+
+    private static AnalysisFinding RcsiFinding(int? rwPct = 80) => new()
+    {
+        ServerId = 1, ServerName = "SQL2022", Category = "config_issues",
+        StoryPath = "DB_CONFIG", StoryPathHash = "dbconfig00000099", RootFactKey = "DB_CONFIG",
+        DrillDown = new Dictionary<string, object>
+        {
+            ["config_issues"] = new List<object>
+            {
+                new { database = "Foo", rcsi = false, query_store = true, auto_shrink = false,
+                      auto_close = false, page_verify = "CHECKSUM", issues = new[] { "RCSI OFF" },
+                      rcsi_blocking_events = 12, rcsi_deadlocks = 3, rcsi_reader_writer_pct = rwPct }
+            }
+        }
+    };
+
+    [Fact]
+    public async Task Apply_Destructive_Request_RequiresInformedConsent_CarriesRisks()
+    {
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new RcsiHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(RcsiAction(), Server, previewSql: "ALTER DATABASE [Foo] SET READ_COMMITTED_SNAPSHOT ON;",
+            "DOM\\op", "ref", confirm: req => { captured = req; return Task.FromResult(false); },
+            CancellationToken.None, finding: RcsiFinding());
+
+        Assert.NotNull(captured);
+        Assert.Equal("RCSI", captured!.FactKey);
+        Assert.True(captured.RequiresInformedConsent);
+        Assert.NotNull(captured.Risks);
+        Assert.NotEmpty(captured.Risks!.RisksOfChanging);
+        Assert.NotEmpty(captured.Risks.RisksOfNotChanging);
+        // The RCSI confirm row title is the friendly one (m-2), not the raw enum name.
+        Assert.Contains("Read Committed Snapshot Isolation", Assert.Single(captured.Targets).StatusTitle);
+    }
+
+    [Fact]
+    public async Task Apply_NonDestructive_Request_NoConsent_NoRisks()
+    {
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new DbConfigHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        var action = new RemediationAction("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            new List<DbConfigTarget> { new("Foo", DbConfigSetting.AutoShrinkOff, "ON") });
+
+        await service.ApplyAsync(action, Server, previewSql: null, "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.False(captured!.RequiresInformedConsent);
+        Assert.Null(captured.Risks);
+    }
+
+    [Fact]
+    public async Task Apply_Destructive_WriterWriter_Risks_SayRcsiWontResolve()
+    {
+        // The honest-both-directions property survives the service threading: a low
+        // reader/writer pct yields the "RCSI does NOT resolve this" inaction line.
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new RcsiHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(RcsiAction(), Server, previewSql: "preview", "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); },
+            CancellationToken.None, finding: RcsiFinding(rwPct: 8));
+
+        Assert.Contains(captured!.Risks!.RisksOfNotChanging, r => r.Text.Contains("RCSI does NOT resolve"));
+    }
+
     // ── Fake executor (PR-B-local) ───────────────────────────────────────────────
 
     private sealed class FakeExecutor : IRemediationExecutor

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -741,6 +741,408 @@ public class RemediationTests
         Assert.IsType<ForcePlanHandler>(registry.TryGet("PLAN_REGRESSION"));
     }
 
+    [Fact]
+    public void Rcsi_Handler_IsUnregistered_DeadCodeSafe()
+    {
+        // PR-A is dead-code-safe: a registry without RcsiHandler (the production shape:
+        // ForcePlanHandler + DbConfigHandler) does not route "RCSI" to anything, so no
+        // Apply affordance can reach the destructive handler. PR-B adds the registration.
+        var productionRegistry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler() });
+        Assert.Null(productionRegistry.TryGet("RCSI"));
+
+        // And the PRODUCTION wiring must NOT yet construct an RcsiHandler — assert at the
+        // source level that RemediationApplyService.cs does not register it in PR-A.
+        var dir = FindDashboardSourceDir();
+        var serviceSrc = File.ReadAllText(Path.Combine(dir, "Services", "Remediation", "RemediationApplyService.cs"));
+        Assert.DoesNotContain("new RcsiHandler()", serviceSrc);
+    }
+
+    [Fact]
+    public void CoreMachineryMarkers_Include_RcsiHandler()
+    {
+        // m-3: the destructive handler must be in the reachability guard.
+        Assert.Contains("RcsiHandler", CoreMachineryMarkers);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // B3 PHASE 3 — RCSI destructive-consent privileged core (PR-A; UNREGISTERED)
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>A DB_CONFIG finding with RCSI OFF + the §3.3 enrichment present.</summary>
+    private static AnalysisFinding RcsiOffFinding(int blocking = 12, int deadlocks = 3, int? rwPct = 80, string db = "Foo") => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "config_issues",
+        StoryPath = "DB_CONFIG",
+        StoryPathHash = "dbconfig00000099",
+        RootFactKey = "DB_CONFIG",
+        DrillDown = new Dictionary<string, object>
+        {
+            ["config_issues"] = new List<object>
+            {
+                new { database = db, recovery_model = "FULL", rcsi = false, query_store = true,
+                      issues = new[] { "RCSI OFF" },
+                      auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+                      rcsi_blocking_events = blocking, rcsi_deadlocks = deadlocks,
+                      rcsi_reader_writer_pct = rwPct }
+            }
+        }
+    };
+
+    private static RemediationAction RcsiAction(string db = "Foo") =>
+        new("RCSI", "set", Array.Empty<ForcePlanTarget>(), new[] { new DbConfigTarget(db, DbConfigSetting.ReadCommittedSnapshotOn, "OFF") });
+
+    // ── RcsiHandler invariants ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Rcsi_Handler_IsDestructive_And_ApplyOnly()
+    {
+        var handler = new RcsiHandler();
+        Assert.Equal("RCSI", handler.FactKey);
+        Assert.True(handler.IsDestructive);     // the first (and only) true in the codebase
+        Assert.False(handler.SupportsUnapply);
+    }
+
+    [Fact]
+    public async Task Rcsi_UnapplyAsync_Throws()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            new RcsiHandler().UnapplyAsync(RcsiAction(), new FakeExecutor(), Identity, CancellationToken.None));
+    }
+
+    // ── Executor RCSI arm: own builder, no-injection, same-string (against the
+    //    executor's OWN BuildAlterStatement — not the display renderer) ───────────
+
+    [Fact]
+    public void Rcsi_Build_SetClause_IsHardcodedLiteral_RegardlessOfName()
+    {
+        foreach (var name in new[] { "Db", "Db]; DROP TABLE x--", "[weird]", "Ünîçödé" })
+        {
+            var stmt = DatabaseService.BuildAlterStatement(name, DbConfigSetting.ReadCommittedSnapshotOn);
+            Assert.EndsWith("SET READ_COMMITTED_SNAPSHOT ON;", stmt);
+        }
+    }
+
+    [Theory]
+    [InlineData("normal")]
+    [InlineData("has]bracket")]
+    [InlineData("has]]double")]
+    [InlineData("ev;il-- GO DROP")]
+    [InlineData("'; ALTER DATABASE master SET")]
+    public void Rcsi_Build_BracketsIdentifierInert_NoInjection(string name)
+    {
+        var stmt = DatabaseService.BuildAlterStatement(name, DbConfigSetting.ReadCommittedSnapshotOn);
+        var expectedToken = "[" + name.Replace("]", "]]") + "]";
+        Assert.Equal($"ALTER DATABASE {expectedToken} SET READ_COMMITTED_SNAPSHOT ON;", stmt);
+    }
+
+    [Fact]
+    public void Rcsi_Build_SameString_ValidatedNameIsBracketedExactly()
+    {
+        const string validated = "  Padded Name  ";
+        var stmt = DatabaseService.BuildAlterStatement(validated, DbConfigSetting.ReadCommittedSnapshotOn);
+        Assert.Equal("ALTER DATABASE [  Padded Name  ] SET READ_COMMITTED_SNAPSHOT ON;", stmt);
+        Assert.NotEqual(stmt, DatabaseService.BuildAlterStatement(validated.TrimEnd(), DbConfigSetting.ReadCommittedSnapshotOn));
+    }
+
+    [Fact]
+    public void Rcsi_SetClause_ExecutorAndService_AreReadCommittedSnapshotOn()
+    {
+        // m-1: all clause-builder copies render the RCSI arm (executor's own builder).
+        Assert.EndsWith("SET READ_COMMITTED_SNAPSHOT ON;",
+            DatabaseService.BuildAlterStatement("X", DbConfigSetting.ReadCommittedSnapshotOn));
+    }
+
+    [Fact]
+    public void Rcsi_SettingTitle_IsFriendly_NotRawEnumName()
+    {
+        // m-2: a RCSI confirm row must not render "ReadCommittedSnapshotOn".
+        Assert.Equal("Read Committed Snapshot Isolation",
+            DbConfigHandler.SettingTitle(DbConfigSetting.ReadCommittedSnapshotOn));
+    }
+
+    // ── RcsiHandler apply behaviours against the faked executor ──────────────────
+
+    [Fact]
+    public async Task Rcsi_AuditTableAbsent_HardBlocks_NoMutation_NoAudit()
+    {
+        var exec = new FakeExecutor { AuditTableExists = false };
+        var result = await new RcsiHandler().ApplyAsync(RcsiAction(), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Blocked, o.Status);
+        Assert.False(o.AuditWritten);
+        Assert.Equal(0, exec.SetDbCalls);
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task Rcsi_PermissionDenied_FailsClosed_NoElevation()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.PermissionDenied, Applied = false,
+                Message = "lacks ALTER", PriorValue = "OFF"
+            }
+        };
+        var result = await new RcsiHandler().ApplyAsync(RcsiAction(), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(RemediationStatus.PermissionDenied, Assert.Single(result.Outcomes).Status);
+        Assert.Equal(1, exec.SetDbCalls);
+    }
+
+    [Fact]
+    public async Task Rcsi_AlreadyOn_Skips_ConsentAcknowledgedStillTrue()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.Skipped, Applied = false,
+                Message = "already on", PriorValue = "ON", GateSpid = 7, ExecSpid = 7
+            }
+        };
+        var result = await new RcsiHandler().ApplyAsync(RcsiAction(), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(RemediationStatus.Skipped, Assert.Single(result.Outcomes).Status);
+        var rec = Assert.Single(exec.AuditRecords);
+        Assert.Equal("skipped", rec.Result);
+        Assert.True(rec.ConsentAcknowledged);     // gate was satisfied to reach apply
+        Assert.Equal("RCSI", rec.FactKey);
+        Assert.Equal("set_rcsi_on", rec.Action);
+    }
+
+    [Fact]
+    public async Task Rcsi_Success_WritesAudit_ConsentAcknowledgedTrue_PriorValueOff()
+    {
+        var exec = new FakeExecutor
+        {
+            SetDbFunc = (db, s) => new DbConfigOutcome
+            {
+                Database = db, Setting = s, Status = RemediationStatus.Success, Applied = true,
+                ExecutingLogin = "sa", PriorValue = "OFF",
+                GeneratedSql = "ALTER DATABASE [Foo] SET READ_COMMITTED_SNAPSHOT ON;", GateSpid = 9, ExecSpid = 9
+            }
+        };
+        var result = await new RcsiHandler().ApplyAsync(RcsiAction(), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, o.Status);
+        Assert.True(o.AuditWritten);
+        var rec = Assert.Single(exec.AuditRecords);
+        Assert.True(rec.ConsentAcknowledged);
+        Assert.Equal("OFF", rec.PriorValue);
+        Assert.Equal("success", rec.Result);
+    }
+
+    [Fact]
+    public async Task DbConfig_And_ForcePlan_WriteConsentAcknowledgedFalse()
+    {
+        // Regression-guard: the non-destructive paths must persist consent_acknowledged = 0.
+        var exec = new FakeExecutor();
+        await new DbConfigHandler().ApplyAsync(
+            DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), exec, Identity, CancellationToken.None);
+        Assert.All(exec.AuditRecords, r => Assert.False(r.ConsentAcknowledged));
+
+        var exec2 = new FakeExecutor();
+        await new ForcePlanHandler().ApplyAsync(
+            new RemediationAction("PLAN_REGRESSION", "force", new List<ForcePlanTarget> { Target() }),
+            exec2, Identity, CancellationToken.None);
+        Assert.All(exec2.AuditRecords, r => Assert.False(r.ConsentAcknowledged));
+    }
+
+    // ── BuildRcsiAction (M2-1 boolean polarity) + BuildAction regression-guard ───
+
+    [Fact]
+    public void BuildRcsiAction_EmitsOnRcsiOff_WithEnrichment()
+    {
+        var action = FactRemediation.BuildRcsiAction(RcsiOffFinding());
+        Assert.NotNull(action);
+        Assert.Equal("RCSI", action!.FactKey);
+        Assert.Equal("set", action.Action);
+        Assert.Empty(action.Targets);
+        var t = Assert.Single(action.DbConfigTargets!);
+        Assert.Equal(DbConfigSetting.ReadCommittedSnapshotOn, t.Setting);
+        Assert.Equal("OFF", t.CurrentValue);
+        Assert.Equal("Foo", t.Database);
+    }
+
+    [Fact]
+    public void BuildRcsiAction_ReturnsNull_WhenRcsiOn()
+    {
+        // M2-1: rcsi == true means RCSI is ON — the affordance must NOT appear.
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Foo", rcsi = true, query_store = true,
+                  auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+                  issues = new string[0],
+                  rcsi_blocking_events = 99, rcsi_deadlocks = 9, rcsi_reader_writer_pct = 90 }
+        });
+        Assert.Null(FactRemediation.BuildRcsiAction(finding));
+    }
+
+    [Fact]
+    public void BuildRcsiAction_ReturnsNull_WhenEnrichmentAbsent()
+    {
+        // RCSI off but no §3.3 enrichment (legacy alert) → no affordance.
+        var finding = DbConfigFinding(new List<object>
+        {
+            new { database = "Foo", rcsi = false, query_store = true,
+                  auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+                  issues = new[] { "RCSI OFF" } }
+        });
+        Assert.Null(FactRemediation.BuildRcsiAction(finding));
+    }
+
+    [Fact]
+    public void BuildAction_Unchanged_NeverEmitsRcsi_Phase2RegressionGuard()
+    {
+        // The always-safe BuildAction must STILL never emit RCSI, even on the enriched
+        // RCSI-off finding — the destructive arm rides BuildRcsiAction only.
+        Assert.Null(FactRemediation.BuildAction(RcsiOffFinding()));
+
+        // And a mixed finding (RCSI off + a safe setting) yields only the safe target.
+        var mixed = DbConfigFinding(new List<object>
+        {
+            new { database = "Foo", rcsi = false, query_store = true,
+                  auto_shrink = true, auto_close = false, page_verify = "CHECKSUM",
+                  issues = new[] { "auto_shrink ON", "RCSI OFF" },
+                  rcsi_blocking_events = 1, rcsi_deadlocks = 0, rcsi_reader_writer_pct = 50 }
+        });
+        var safe = FactRemediation.BuildAction(mixed);
+        Assert.NotNull(safe);
+        Assert.Equal("DB_CONFIG", safe!.FactKey);
+        Assert.All(safe.DbConfigTargets!, t => Assert.NotEqual(DbConfigSetting.ReadCommittedSnapshotOn, t.Setting));
+    }
+
+    // ── FactRiskDisclosure: two-sided, honest-both-directions, golden prose ──────
+
+    [Fact]
+    public void RiskDisclosure_Null_ForNonDestructiveFactKey()
+    {
+        Assert.Null(FactRiskDisclosure.GetForAction(DbConfigAction(new DbConfigTarget("Foo", DbConfigSetting.AutoShrinkOff, "ON")), DbConfigFinding()));
+        Assert.Null(FactRiskDisclosure.GetForAction(new RemediationAction("PLAN_REGRESSION", "force", new List<ForcePlanTarget> { Target() }), null));
+    }
+
+    [Fact]
+    public void RiskDisclosure_Rcsi_HasAtLeastOneOfEachSide()
+    {
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), RcsiOffFinding());
+        Assert.NotNull(d);
+        Assert.NotEmpty(d!.RisksOfChanging);
+        Assert.NotEmpty(d.RisksOfNotChanging);
+        // The validated identifier is substituted, bracketed.
+        Assert.Contains(d.RisksOfChanging, r => r.Text.Contains("[Foo]"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_HighReaderWriterPct_SaysRcsiEliminates()
+    {
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), RcsiOffFinding(blocking: 50, deadlocks: 4, rwPct: 85))!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("85%") && r.Text.Contains("RCSI eliminates"));
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("50") && r.Text.Contains("blocked-process events") && r.Text.Contains("4 deadlocks"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_LowReaderWriterPct_SaysRcsiWontResolveThis()
+    {
+        // Writer/writer-dominant: the honest-both-directions safety feature.
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), RcsiOffFinding(blocking: 40, deadlocks: 2, rwPct: 10))!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("10%") && r.Text.Contains("RCSI does NOT resolve"));
+        Assert.DoesNotContain(d.RisksOfNotChanging, r => r.Text.Contains("RCSI eliminates"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_NoData_ShowsWeakCaseBaseline()
+    {
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), RcsiOffFinding(blocking: 0, deadlocks: 0, rwPct: null))!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("Little or no reader/writer blocking"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_NullFinding_DegradesToWeakCaseBaseline()
+    {
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), null)!;
+        Assert.NotEmpty(d.RisksOfChanging);
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("Little or no reader/writer blocking"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_Rcsi_GoldenProse_ChangingSide()
+    {
+        var d = FactRiskDisclosure.GetForAction(RcsiAction(), RcsiOffFinding())!;
+        Assert.Equal(3, d.RisksOfChanging.Count);
+        Assert.StartsWith("Enabling RCSI on [Foo] takes a brief exclusive database lock", d.RisksOfChanging[0].Text);
+        Assert.Contains("row-version load to tempdb", d.RisksOfChanging[1].Text);
+        Assert.Contains("Reader/writer concurrency semantics change", d.RisksOfChanging[2].Text);
+    }
+
+    // ── Full lock-mode vocabulary classifier (M-1) ───────────────────────────────
+
+    [Theory]
+    [InlineData("S", RcsiLockClass.Reader)]
+    [InlineData("IS", RcsiLockClass.Reader)]
+    [InlineData("RangeS-S", RcsiLockClass.Reader)]
+    [InlineData("RangeS-U", RcsiLockClass.Reader)]
+    [InlineData("X", RcsiLockClass.Writer)]
+    [InlineData("IX", RcsiLockClass.Writer)]
+    [InlineData("U", RcsiLockClass.Writer)]
+    [InlineData("UIX", RcsiLockClass.Writer)]
+    [InlineData("RangeX-X", RcsiLockClass.Writer)]
+    [InlineData("RangeI-N", RcsiLockClass.Writer)]
+    [InlineData("Sch-S", RcsiLockClass.Excluded)]
+    [InlineData("Sch-M", RcsiLockClass.Excluded)]
+    [InlineData("BU", RcsiLockClass.Excluded)]
+    [InlineData("IU", RcsiLockClass.Excluded)]
+    [InlineData("SIU", RcsiLockClass.Excluded)]
+    [InlineData("SIX", RcsiLockClass.Excluded)]
+    [InlineData("", RcsiLockClass.Excluded)]
+    [InlineData(null, RcsiLockClass.Excluded)]
+    public void LockModeClassifier_FullVocabulary(string? lockMode, RcsiLockClass expected)
+    {
+        Assert.Equal(expected, RcsiLockModeClassifier.Classify(lockMode));
+    }
+
+    // ── Drill-down enrichment parity (types only, per M-2) ───────────────────────
+
+    [Fact]
+    public void DrillDownEnrichment_RcsiFields_TypeParity_DashboardVsLite()
+    {
+        // The Dashboard shape carries real ints + a nullable int; the Lite shape carries
+        // 0/0/null. The shared extractor (FactRiskDisclosure) must read BOTH shapes with
+        // identical field NAMES and TYPES (int / int / nullable-int). Round-trip via JSON
+        // (mirrors how the collectors serialize the anonymous objects).
+        var dashboardRow = new
+        {
+            database = "Foo", recovery_model = "FULL", rcsi = false, query_store = true,
+            issues = new[] { "RCSI OFF" }, auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+            rcsi_blocking_events = 12, rcsi_deadlocks = 3, rcsi_reader_writer_pct = (int?)80
+        };
+        var liteRow = new
+        {
+            database = "Foo", recovery_model = "FULL", rcsi = false, query_store = true,
+            issues = new[] { "RCSI OFF" }, auto_shrink = false, auto_close = false, page_verify = "CHECKSUM",
+            rcsi_blocking_events = 0, rcsi_deadlocks = 0, rcsi_reader_writer_pct = (int?)null
+        };
+
+        var dash = System.Text.Json.JsonSerializer.SerializeToElement((object)dashboardRow);
+        var lite = System.Text.Json.JsonSerializer.SerializeToElement((object)liteRow);
+        foreach (var field in new[] { "rcsi_blocking_events", "rcsi_deadlocks", "rcsi_reader_writer_pct" })
+        {
+            Assert.True(dash.TryGetProperty(field, out var dv), $"Dashboard shape missing {field}");
+            Assert.True(lite.TryGetProperty(field, out var lv), $"Lite shape missing {field}");
+            // counts are Number on both; pct is Number on Dashboard and Null on Lite (nullable int)
+            Assert.Equal(System.Text.Json.JsonValueKind.Number, dv.ValueKind);
+            if (field == "rcsi_reader_writer_pct")
+                Assert.Equal(System.Text.Json.JsonValueKind.Null, lv.ValueKind);
+            else
+                Assert.Equal(System.Text.Json.JsonValueKind.Number, lv.ValueKind);
+        }
+    }
+
     // ── §1 identifier safety: no-injection / QUOTENAME / same-string (M-1) ───────
     //
     // These run against the EXECUTOR's OWN statement builder (DatabaseService.
@@ -834,6 +1236,10 @@ public class RemediationTests
         // B3 Phase 2 privileged surface (M-2): the new handler + executor methods
         // must be reachable ONLY through the gate, exactly like the force-plan ones.
         "DbConfigHandler", "SetDatabaseOptionAsync", "PreflightDbConfigAsync",
+        // B3 Phase 3 (m-3): the destructive RCSI handler must be reachable ONLY through
+        // the gate. It is UNREGISTERED in PR-A (dead-code-safe), but the marker still
+        // guards against any UI/MCP/menu file referencing it directly.
+        "RcsiHandler",
     };
 
     [Fact]

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -507,40 +507,210 @@ WHERE is_auto_shrink_on = '1' OR is_auto_close_on = '1'
    OR is_rcsi_on = '0' OR page_verify_option != 'CHECKSUM'
 ORDER BY database_name;";
 
+        // Read the pivoted rows first into a typed buffer so we can determine the
+        // RCSI-OFF set BEFORE building the emitted items — the §3.3 enrichment is
+        // computed only for RCSI-off databases and injected into those rows.
+        var rows = new List<ConfigIssueRow>();
+        using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                rows.Add(new ConfigIssueRow
+                {
+                    Database = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    RecoveryModel = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    AutoShrink = (reader.IsDBNull(2) ? "" : reader.GetString(2)) == "1",
+                    AutoClose = (reader.IsDBNull(3) ? "" : reader.GetString(3)) == "1",
+                    Rcsi = (reader.IsDBNull(4) ? "" : reader.GetString(4)) == "1",
+                    PageVerify = reader.IsDBNull(5) ? "" : reader.GetString(5),
+                    QueryStore = (reader.IsDBNull(6) ? "" : reader.GetString(6)) == "1"
+                });
+            }
+        }
+
+        // §3.3 enrichment: per-DB blocking/deadlock counts + reader/writer split, ONLY
+        // for RCSI-off databases, over the analysis window, from already-collected
+        // monitoring tables (no fresh probe of the target server).
+        var rcsiOff = rows.Where(r => !r.Rcsi && !string.IsNullOrEmpty(r.Database))
+                          .Select(r => r.Database)
+                          .ToList();
+        var enrichment = rcsiOff.Count > 0
+            ? await CollectRcsiInactionFigures(connection, rcsiOff, context)
+            : new Dictionary<string, RcsiInactionFigures>(StringComparer.Ordinal);
+
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        foreach (var r in rows)
         {
             var issues = new List<string>();
-            var autoShrink = reader.IsDBNull(2) ? "" : reader.GetString(2);
-            var autoClose = reader.IsDBNull(3) ? "" : reader.GetString(3);
-            var rcsi = reader.IsDBNull(4) ? "" : reader.GetString(4);
-            var pageVerify = reader.IsDBNull(5) ? "" : reader.GetString(5);
-            var queryStore = reader.IsDBNull(6) ? "" : reader.GetString(6);
+            if (r.AutoShrink) issues.Add("auto_shrink ON");
+            if (r.AutoClose) issues.Add("auto_close ON");
+            if (!r.Rcsi) issues.Add("RCSI OFF");
+            if (!string.IsNullOrEmpty(r.PageVerify) && r.PageVerify != "CHECKSUM") issues.Add($"page_verify={r.PageVerify}");
 
-            if (autoShrink == "1") issues.Add("auto_shrink ON");
-            if (autoClose == "1") issues.Add("auto_close ON");
-            if (rcsi == "0") issues.Add("RCSI OFF");
-            if (!string.IsNullOrEmpty(pageVerify) && pageVerify != "CHECKSUM") issues.Add($"page_verify={pageVerify}");
-
-            items.Add(new
+            // RCSI-off rows carry the three structured inaction-risk fields (M-2:
+            // identical JSON names + types to Lite, which emits them null/0). RCSI-on
+            // rows omit them entirely (the affordance never applies there).
+            if (!r.Rcsi)
             {
-                database = reader.IsDBNull(0) ? "" : reader.GetString(0),
-                recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
-                rcsi = rcsi == "1",
-                query_store = queryStore == "1",
-                issues,
-                // §4.1: structured, wording-independent fields the shared extractor
-                // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
-                // and types to the Lite collector (bool / bool / string).
-                auto_shrink = autoShrink == "1",
-                auto_close = autoClose == "1",
-                page_verify = pageVerify
-            });
+                enrichment.TryGetValue(r.Database, out var fig);
+                items.Add(new
+                {
+                    database = r.Database,
+                    recovery_model = r.RecoveryModel,
+                    rcsi = r.Rcsi,
+                    query_store = r.QueryStore,
+                    issues,
+                    auto_shrink = r.AutoShrink,
+                    auto_close = r.AutoClose,
+                    page_verify = r.PageVerify,
+                    // §3.3: int / int / nullable-int. Counts from blocking_deadlock_stats
+                    // (O-P3-F — NOT a blocking_BlockedProcessReport row count); the split
+                    // is a separate pass over blocking_BlockedProcessReport.
+                    rcsi_blocking_events = fig?.BlockingEvents ?? 0,
+                    rcsi_deadlocks = fig?.Deadlocks ?? 0,
+                    rcsi_reader_writer_pct = fig?.ReaderWriterPct
+                });
+            }
+            else
+            {
+                items.Add(new
+                {
+                    database = r.Database,
+                    recovery_model = r.RecoveryModel,
+                    rcsi = r.Rcsi,
+                    query_store = r.QueryStore,
+                    issues,
+                    // §4.1: structured, wording-independent fields the shared extractor
+                    // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
+                    // and types to the Lite collector (bool / bool / string).
+                    auto_shrink = r.AutoShrink,
+                    auto_close = r.AutoClose,
+                    page_verify = r.PageVerify
+                });
+            }
         }
 
         if (items.Count > 0)
             finding.DrillDown!["config_issues"] = items;
+    }
+
+    private sealed class ConfigIssueRow
+    {
+        public string Database = "";
+        public string RecoveryModel = "";
+        public bool AutoShrink;
+        public bool AutoClose;
+        public bool Rcsi;
+        public string PageVerify = "";
+        public bool QueryStore;
+    }
+
+    private sealed class RcsiInactionFigures
+    {
+        public int BlockingEvents;
+        public int Deadlocks;
+        public int? ReaderWriterPct;
+    }
+
+    /// <summary>
+    /// Computes, per RCSI-off database, the §3.3 inaction-risk figures over the
+    /// analysis window: blocking/deadlock counts from the PRE-AGGREGATED
+    /// collect.blocking_deadlock_stats (O-P3-F — never a blocking_BlockedProcessReport
+    /// row count), and the reader-vs-writer share from a SEPARATE pass over
+    /// collect.blocking_BlockedProcessReport classified against the FULL lock_mode
+    /// vocabulary (M-1). All reads are parameterized on the time window; database names
+    /// are bound as a parameterized TVP-free IN list (literal-free).
+    /// </summary>
+    private static async Task<Dictionary<string, RcsiInactionFigures>> CollectRcsiInactionFigures(
+        SqlConnection connection, List<string> databases, AnalysisContext context)
+    {
+        var result = new Dictionary<string, RcsiInactionFigures>(StringComparer.Ordinal);
+        foreach (var d in databases)
+            result[d] = new RcsiInactionFigures();
+
+        // Pass 1 — counts from the pre-aggregated stats table (per-DB, per-window).
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    bds.database_name,
+    blocking_events = SUM(bds.blocking_event_count),
+    deadlocks = SUM(bds.deadlock_count)
+FROM collect.blocking_deadlock_stats AS bds
+WHERE bds.collection_time >= @startTime
+AND   bds.collection_time <= @endTime
+GROUP BY bds.database_name;";
+            cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));
+            cmd.Parameters.Add(new SqlParameter("@endTime", context.TimeRangeEnd));
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var db = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                if (!result.TryGetValue(db, out var fig)) continue;
+                fig.BlockingEvents = reader.IsDBNull(1) ? 0 : (int)Math.Min(int.MaxValue, Convert.ToInt64(reader.GetValue(1)));
+                fig.Deadlocks = reader.IsDBNull(2) ? 0 : (int)Math.Min(int.MaxValue, Convert.ToInt64(reader.GetValue(2)));
+            }
+        }
+
+        // Pass 2 — reader-vs-writer split over the blocked-process reports, classified
+        // against the FULL lock_mode vocabulary (M-1). Reader-side = S/IS/RangeS-*;
+        // writer-side = X/IX/U/UIX/RangeX-*/RangeI-*; Sch-S/Sch-M/BU EXCLUDED from the
+        // denominator (RCSI-irrelevant). pct = 100 * reader / NULLIF(reader+writer, 0).
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH classified AS
+(
+    SELECT
+        bpr.database_name,
+        is_reader =
+            CASE
+                WHEN bpr.lock_mode IN (N'S', N'IS') THEN 1
+                WHEN bpr.lock_mode LIKE N'RangeS-%' THEN 1
+                ELSE 0
+            END,
+        is_writer =
+            CASE
+                WHEN bpr.lock_mode IN (N'X', N'IX', N'U', N'UIX') THEN 1
+                WHEN bpr.lock_mode LIKE N'RangeX-%' THEN 1
+                WHEN bpr.lock_mode LIKE N'RangeI-%' THEN 1
+                ELSE 0
+            END
+    FROM collect.blocking_BlockedProcessReport AS bpr
+    WHERE bpr.event_time >= @startTime
+    AND   bpr.event_time <= @endTime
+    AND   bpr.database_name IS NOT NULL
+    /* EXCLUDE Sch-S / Sch-M / BU from the denominator (RCSI-irrelevant). */
+    AND   bpr.lock_mode NOT IN (N'Sch-S', N'Sch-M', N'BU')
+)
+SELECT
+    c.database_name,
+    reader_count = SUM(CONVERT(bigint, c.is_reader)),
+    writer_count = SUM(CONVERT(bigint, c.is_writer))
+FROM classified AS c
+WHERE c.is_reader = 1 OR c.is_writer = 1
+GROUP BY c.database_name;";
+            cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));
+            cmd.Parameters.Add(new SqlParameter("@endTime", context.TimeRangeEnd));
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var db = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                if (!result.TryGetValue(db, out var fig)) continue;
+                var readerCount = reader.IsDBNull(1) ? 0L : Convert.ToInt64(reader.GetValue(1));
+                var writerCount = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2));
+                var denom = readerCount + writerCount;
+                fig.ReaderWriterPct = denom > 0 ? (int)(100 * readerCount / denom) : (int?)null;
+            }
+        }
+
+        return result;
     }
 
     private async Task CollectTempDbBreakdown(AnalysisFinding finding, AnalysisContext context)

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -265,6 +265,10 @@ SET NUMERIC_ROUNDABORT OFF;";
             DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
             DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
             DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            // B3 Phase 3: DESTRUCTIVE — routed only via the RcsiHandler behind the
+            // informed-consent gate. The SET clause is still a hardcoded compile-time
+            // literal selected by the enum; the identifier is the only variable token.
+            DbConfigSetting.ReadCommittedSnapshotOn => "SET READ_COMMITTED_SNAPSHOT ON",
             _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
         };
 
@@ -433,6 +437,13 @@ SET NUMERIC_ROUNDABORT OFF;";
                 case DbConfigSetting.PageVerifyChecksum:
                     currentValueExpr = "d.page_verify_option_desc";
                     desiredExpr = "CASE WHEN d.page_verify_option_desc = N'CHECKSUM' THEN 1 ELSE 0 END";
+                    break;
+                case DbConfigSetting.ReadCommittedSnapshotOn:
+                    // B3 Phase 3 (R2-MOD-1): the live freshness column is
+                    // is_read_committed_snapshot_on. Desired state = on (= 1) → Skip if
+                    // already on. The current value (ON/OFF) is captured for prior_value.
+                    currentValueExpr = "CASE WHEN d.is_read_committed_snapshot_on = 1 THEN N'ON' ELSE N'OFF' END";
+                    desiredExpr = "CASE WHEN d.is_read_committed_snapshot_on = 1 THEN 1 ELSE 0 END";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting");

--- a/Dashboard/Services/Remediation/ForcePlanHandler.cs
+++ b/Dashboard/Services/Remediation/ForcePlanHandler.cs
@@ -219,6 +219,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                 GeneratedSql = GeneratedSql(actionVerb, target.QueryId, target.PlanId),
                 Result = AuditResult(status),
                 ErrorMessage = status is RemediationStatus.Error or RemediationStatus.PermissionDenied or RemediationStatus.Blocked ? message : null,
+                // Force-plan is reversible (not destructive) — never went through the
+                // informed-consent gate (M-3 regression-guard: explicit false).
+                ConsentAcknowledged = false,
                 SourceAlertRef = identity.SourceAlertRef
             };
 

--- a/Dashboard/Services/Remediation/IRemediationHandler.cs
+++ b/Dashboard/Services/Remediation/IRemediationHandler.cs
@@ -30,8 +30,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         string FactKey { get; }
 
         /// <summary>
-        /// Whether the action destroys/loses state (gates the typed-confirm UI in
-        /// PR-B). The v1 force-plan is reversible, so this is false.
+        /// Whether the action is DESTRUCTIVE (B3 Phase 3): true gates the
+        /// informed-consent (acknowledge-each-risk) confirm UI. Force-plan and the
+        /// always-safe DB-config fixes are not destructive (false); RcsiHandler is the
+        /// first (and only) handler to flip this true. Read per-handler by
+        /// RemediationApplyService.BuildConfirmRequest, which is exactly why RCSI needs
+        /// a distinct handler rather than a per-target flag on DbConfigHandler.
         /// </summary>
         bool IsDestructive { get; }
 

--- a/Dashboard/Services/Remediation/RcsiHandler.cs
+++ b/Dashboard/Services/Remediation/RcsiHandler.cs
@@ -15,33 +15,47 @@ using PerformanceMonitor.Analysis;
 namespace PerformanceMonitorDashboard.Services.Remediation
 {
     /// <summary>
-    /// Handler for DB_CONFIG findings: applies the three ALWAYS-SAFE database
-    /// settings — AUTO_SHRINK OFF, AUTO_CLOSE OFF, PAGE_VERIFY CHECKSUM — one
-    /// (database, setting) target at a time via <c>ALTER DATABASE … SET …</c>.
-    /// RCSI is intentionally NOT in scope (destructive). This is APPLY-ONLY: there
-    /// is no sensible reverse for these settings (<see cref="SupportsUnapply"/> is
-    /// false; <see cref="UnapplyAsync"/> throws), and the prior value is recorded in
-    /// the audit row for any manual reversal.
+    /// Handler for the DESTRUCTIVE RCSI fix (B3 Phase 3): enables
+    /// <c>READ_COMMITTED_SNAPSHOT</c> on one target database via
+    /// <c>ALTER DATABASE … SET READ_COMMITTED_SNAPSHOT ON</c>. This is the FIRST
+    /// handler in the codebase to flip <see cref="IsDestructive"/> to true; it is
+    /// gated behind the informed-consent (acknowledge-each-risk) dialog — the consent
+    /// gate lives in <em>what makes the confirm callback return true</em>
+    /// (RemediationApplyService is the trust boundary; the dialog enforces it).
     ///
     /// <para>
-    /// Structurally self-gating, exactly like <see cref="ForcePlanHandler"/>:
-    /// <see cref="ApplyAsync"/> takes no preflight disposition and trusts none. It
-    /// hard-blocks every target when the audit table is absent (no mutation), then
-    /// delegates each target to <c>exec.SetDatabaseOptionAsync</c>, which re-derives
+    /// Routed via the distinct fact key "RCSI" so it is never reachable through the
+    /// always-safe <see cref="DbConfigHandler"/> (which keeps IsDestructive == false).
+    /// It reuses the Phase-2 <c>DbConfigTarget</c> machinery (a single target with
+    /// <see cref="DbConfigSetting.ReadCommittedSnapshotOn"/>) and the Phase-2
+    /// self-gating executor unchanged: <c>exec.SetDatabaseOptionAsync</c> re-derives
     /// the authoritative gate (parameterized sys.databases existence + ALTER
-    /// permission + live freshness) and the ALTER on ONE connection. One audit row
-    /// is written per attempt.
+    /// permission + live <c>is_read_committed_snapshot_on</c> freshness) and runs the
+    /// ALTER on ONE monitoring connection. The handler cannot hand it a forged
+    /// all-clear.
+    /// </para>
+    ///
+    /// <para>
+    /// APPLY-ONLY: <see cref="SupportsUnapply"/> is false (turning RCSI back OFF is
+    /// itself destructive and would need its own symmetric gate);
+    /// <see cref="UnapplyAsync"/> throws, and RemediationApplyService short-circuits
+    /// any un-apply to a clean UnapplyNotSupported report before reaching it (m-C).
+    /// One audit row is written per attempt with <c>consent_acknowledged = true</c>
+    /// (the gate was satisfied to reach apply).
     /// </para>
     /// </summary>
-    public sealed class DbConfigHandler : IRemediationHandler
+    public sealed class RcsiHandler : IRemediationHandler
     {
-        public string FactKey => "DB_CONFIG";
+        public string FactKey => "RCSI";
 
-        // The three settings are always-safe online metadata changes — not destructive.
-        public bool IsDestructive => false;
+        // DESTRUCTIVE: enabling RCSI takes a brief exclusive DB lock, adds tempdb
+        // version-store load, and changes reader/writer concurrency semantics. This
+        // is the first true in the codebase; it requests the informed-consent gate.
+        public bool IsDestructive => true;
 
-        // Apply-only: these settings have no sensible reverse (you would never
-        // re-enable AUTO_SHRINK/AUTO_CLOSE nor downgrade PAGE_VERIFY below CHECKSUM).
+        // Apply-only for v1: turning RCSI OFF is itself a destructive change (blocking
+        // returns) and would need its own two-sided gate. prior_value is recorded for
+        // manual reversal.
         public bool SupportsUnapply => false;
 
         public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
@@ -96,11 +110,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             return RunApplyAsync(action, exec, identity, ct);
         }
 
-        // Apply-only. Defensive: the UI gates Un-apply on SupportsUnapply==false, and
+        // Apply-only. The UI gates Un-apply on SupportsUnapply==false, and
         // RemediationApplyService short-circuits an un-apply for a non-supporting
-        // handler to a clean report (m-C), so this is never reached in practice.
+        // handler to a clean report (m-C) BEFORE any confirm or handler call, so this
+        // is never reached in practice.
         public Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
-            => throw new NotSupportedException("DB-config fixes are apply-only; there is no un-apply for AUTO_SHRINK/AUTO_CLOSE/PAGE_VERIFY.");
+            => throw new NotSupportedException("RCSI is apply-only; turning READ_COMMITTED_SNAPSHOT back OFF is itself destructive and is not auto-reversed (the prior value is recorded for manual reversal).");
 
         private static async Task<ApplyResult> RunApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
         {
@@ -132,7 +147,8 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
                 try
                 {
-                    // The executor re-derives the authoritative gate and runs the ALTER
+                    // The executor re-derives the authoritative gate (existence + ALTER
+                    // + live is_read_committed_snapshot_on freshness) and runs the ALTER
                     // on one connection — the handler cannot hand it a forged all-clear.
                     var outcome = await exec.SetDatabaseOptionAsync(t.Database, t.Setting, identity, ct).ConfigureAwait(false);
 
@@ -196,28 +212,19 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                 OperatorIdentity = identity.OperatorIdentity,
                 ExecutingLogin = executingLogin,
                 TargetDatabase = target.Database,
-                FactKey = "DB_CONFIG",
-                QueryId = null,                 // DB_CONFIG rows have no query_id/plan_id (B-1)
+                FactKey = "RCSI",
+                QueryId = null,                 // RCSI rows have no query_id/plan_id
                 PlanId = null,
-                Action = AuditAction(target.Setting),
+                Action = "set_rcsi_on",
                 PriorValue = priorValue ?? target.CurrentValue,
                 GeneratedSql = generatedSql,
                 Result = RemediationAuditHelpers.AuditResult(status),
                 ErrorMessage = RemediationAuditHelpers.IsErrorish(status) ? message : null,
-                // The always-safe DB-config fixes are not destructive — never went
-                // through the informed-consent gate (M-3 regression-guard: explicit false).
-                ConsentAcknowledged = false,
+                // The informed-consent gate was satisfied to reach apply (B-3 / M-3):
+                // a destructive RCSI attempt that got here passed every risk checkbox.
+                ConsentAcknowledged = true,
                 SourceAlertRef = identity.SourceAlertRef
             };
-
-        /// <summary>The precise audit <c>action</c> taxonomy value per setting (fits varchar(32)).</summary>
-        private static string AuditAction(DbConfigSetting setting) => setting switch
-        {
-            DbConfigSetting.AutoShrinkOff => "set_auto_shrink_off",
-            DbConfigSetting.AutoCloseOff => "set_auto_close_off",
-            DbConfigSetting.PageVerifyChecksum => "set_page_verify_checksum",
-            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
-        };
 
         private static TargetPreflight ToTargetPreflight(DbConfigTarget t, DbConfigPreflight probe)
         {
@@ -243,24 +250,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
         private static string DispositionMessage(RemediationDisposition d, DbConfigTarget t, DbConfigPreflight probe) => d switch
         {
-            RemediationDisposition.Ok => $"Ready to apply {SettingTitle(t.Setting)} on [{t.Database}] (currently {probe.CurrentValue}).",
-            RemediationDisposition.AlreadyInDesiredState => "Already in the desired state — will be skipped.",
+            RemediationDisposition.Ok => $"Ready to enable {DbConfigHandler.SettingTitle(t.Setting)} on [{t.Database}] (currently {probe.CurrentValue}).",
+            RemediationDisposition.AlreadyInDesiredState => "RCSI is already enabled — will be skipped.",
             RemediationDisposition.BlockDatabaseNotFound => "Database not found on the server — will not proceed.",
             RemediationDisposition.BlockNoAlter => $"The monitoring login lacks ALTER on {t.Database} — will fail closed (no change).",
             RemediationDisposition.BlockAuditTableAbsent => AuditAbsentMessage,
             _ => "Unable to determine target state."
-        };
-
-        /// <summary>Short human title for a setting (display only).</summary>
-        public static string SettingTitle(DbConfigSetting setting) => setting switch
-        {
-            DbConfigSetting.AutoShrinkOff => "AUTO_SHRINK OFF",
-            DbConfigSetting.AutoCloseOff => "AUTO_CLOSE OFF",
-            DbConfigSetting.PageVerifyChecksum => "PAGE_VERIFY CHECKSUM",
-            // m-2: an RCSI confirm row reuses DbConfigTargets, so without this arm the
-            // status title would render the raw enum name "ReadCommittedSnapshotOn".
-            DbConfigSetting.ReadCommittedSnapshotOn => "Read Committed Snapshot Isolation",
-            _ => setting.ToString()
         };
 
         private static IReadOnlyList<DbConfigTarget> DbTargets(RemediationAction action) =>

--- a/Dashboard/Services/Remediation/RemediationApplyModels.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyModels.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using PerformanceMonitor.Analysis;
 using PerformanceMonitorDashboard.Models;
 
 namespace PerformanceMonitorDashboard.Services.Remediation
@@ -124,7 +125,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public string ServerDisplayName { get; init; } = "";
         public bool IsUnapply { get; init; }
 
-        /// <summary>The action's fact key ("PLAN_REGRESSION" | "DB_CONFIG"), so the modal can show a fact-key-specific header/banner.</summary>
+        /// <summary>The action's fact key ("PLAN_REGRESSION" | "DB_CONFIG" | "RCSI"), so the modal can show a fact-key-specific header/banner.</summary>
         public string FactKey { get; init; } = "";
 
         /// <summary>Exact SQL preview shown verbatim (the code-block T-SQL for apply; the unforce statements for un-apply).</summary>
@@ -140,6 +141,24 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
         /// <summary>False when the target server is pre-2.12.0 schema — apply will hard-block.</summary>
         public bool AuditTableExists { get; init; }
+
+        /// <summary>
+        /// B3 Phase 3: true iff the resolved handler's <c>IsDestructive</c> is true.
+        /// When true, the confirm dialog renders the two-sided <see cref="Risks"/> as
+        /// acknowledge-each-risk checkboxes and keeps Apply disabled until ALL are
+        /// checked (in addition to <see cref="AnyActionable"/>). Always false for the
+        /// always-safe and force-plan actions (their single-confirm is unchanged).
+        /// The DIALOG is the trust boundary; this bool is the input to that UI gate.
+        /// </summary>
+        public bool RequiresInformedConsent { get; init; }
+
+        /// <summary>
+        /// B3 Phase 3: the two-sided informed-consent risk content (risks of changing +
+        /// risks of NOT changing, the latter quantified from this server's monitoring
+        /// data). Null for non-destructive actions. Rendered as checkboxes in-app (PR-B)
+        /// and as read-only disclosure on email/webhook/MCP surfaces.
+        /// </summary>
+        public RiskDisclosure? Risks { get; init; }
 
         /// <summary>
         /// True when at least one target is in a state where applying can do something.

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -137,8 +137,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             string operatorIdentity,
             string? sourceAlertRef,
             Func<RemediationConfirmRequest, Task<bool>> confirm,
-            CancellationToken ct)
-            => RunAsync(action, server, previewSql, operatorIdentity, sourceAlertRef, confirm, isUnapply: false, ct);
+            CancellationToken ct,
+            AnalysisFinding? finding = null)
+            => RunAsync(action, server, previewSql, operatorIdentity, sourceAlertRef, confirm, isUnapply: false, ct, finding);
 
         /// <summary>Un-apply (unforce) a previously applied remediation. Same gated shape as Apply.</summary>
         public Task<RemediationRunReport> UnapplyAsync(
@@ -147,8 +148,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             string operatorIdentity,
             string? sourceAlertRef,
             Func<RemediationConfirmRequest, Task<bool>> confirm,
-            CancellationToken ct)
-            => RunAsync(action, server, previewSql: null, operatorIdentity, sourceAlertRef, confirm, isUnapply: true, ct);
+            CancellationToken ct,
+            AnalysisFinding? finding = null)
+            => RunAsync(action, server, previewSql: null, operatorIdentity, sourceAlertRef, confirm, isUnapply: true, ct, finding);
 
         private async Task<RemediationRunReport> RunAsync(
             RemediationAction action,
@@ -158,7 +160,8 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             string? sourceAlertRef,
             Func<RemediationConfirmRequest, Task<bool>> confirm,
             bool isUnapply,
-            CancellationToken ct)
+            CancellationToken ct,
+            AnalysisFinding? finding = null)
         {
             if (action is null) throw new ArgumentNullException(nameof(action));
             if (server is null) throw new ArgumentNullException(nameof(server));
@@ -188,7 +191,10 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                 ? RenderPreview(action, isUnapply)
                 : previewSql!;
 
-            var request = BuildConfirmRequest(action, server, preview, operatorIdentity, isUnapply, preflight);
+            // B-1: thread the resolved handler (and the finding) in so the request can
+            // set RequiresInformedConsent = handler.IsDestructive and, when destructive,
+            // the two-sided Risks. This is a signature change, not a one-liner.
+            var request = BuildConfirmRequest(action, server, preview, operatorIdentity, isUnapply, preflight, handler, finding);
 
             // ── THE GATE ──────────────────────────────────────────────────────────
             // The privileged handler.ApplyAsync/UnapplyAsync below is reached ONLY
@@ -240,7 +246,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             string preview,
             string operatorIdentity,
             bool isUnapply,
-            PreflightResult preflight)
+            PreflightResult preflight,
+            IRemediationHandler handler,
+            AnalysisFinding? finding)
         {
             // Preflight targets align 1:1 with action targets (each handler builds them
             // in order). Match by index; tolerate a short preflight list defensively.
@@ -286,6 +294,14 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                 .Select(p => p.ExecutingLogin)
                 .FirstOrDefault(l => !string.IsNullOrEmpty(l));
 
+            // B-1: the consent gate is keyed on the resolved handler's IsDestructive.
+            // For a destructive action, attach the two-sided risk disclosure (the
+            // dialog renders the acknowledge-each-risk checkboxes in PR-B). For a
+            // non-destructive action both stay default (false / null) — single-confirm
+            // path unchanged.
+            var requiresConsent = handler.IsDestructive;
+            var risks = requiresConsent ? FactRiskDisclosure.GetForAction(action, finding) : null;
+
             return new RemediationConfirmRequest
             {
                 ServerDisplayName = string.IsNullOrEmpty(server.DisplayName) ? server.ServerName : server.DisplayName,
@@ -295,7 +311,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                 OperatorIdentity = operatorIdentity,
                 ExecutingLogin = executingLogin,
                 Targets = confirmTargets,
-                AuditTableExists = preflight.AuditTableExists
+                AuditTableExists = preflight.AuditTableExists,
+                RequiresInformedConsent = requiresConsent,
+                Risks = risks
             };
         }
 
@@ -344,6 +362,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
             DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
             DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            DbConfigSetting.ReadCommittedSnapshotOn => "SET READ_COMMITTED_SNAPSHOT ON",
             _ => "SET /* unknown */"
         };
     }

--- a/Dashboard/Services/Remediation/RemediationAuditWriter.cs
+++ b/Dashboard/Services/Remediation/RemediationAuditWriter.cs
@@ -125,6 +125,7 @@ INSERT INTO
     generated_sql,
     result,
     error_message,
+    consent_acknowledged,
     source_alert_ref
 )
 VALUES
@@ -142,6 +143,7 @@ VALUES
     @generated_sql,
     @result,
     @error_message,
+    @consent_acknowledged,
     @source_alert_ref
 );";
                 command.Parameters.Add(new SqlParameter("@operator_identity", SqlDbType.NVarChar, 256) { Value = (object?)record.OperatorIdentity ?? DBNull.Value });
@@ -161,6 +163,9 @@ VALUES
                 command.Parameters.Add(new SqlParameter("@generated_sql", SqlDbType.NVarChar, -1) { Value = (object?)record.GeneratedSql ?? DBNull.Value });
                 command.Parameters.Add(new SqlParameter("@result", SqlDbType.VarChar, 16) { Value = record.Result });
                 command.Parameters.Add(new SqlParameter("@error_message", SqlDbType.NVarChar, -1) { Value = (object?)record.ErrorMessage ?? DBNull.Value });
+                // M-3: a REAL bound Bit param (it varies per row) — NOT the inline-`0`
+                // pattern used for used_elevated_cred above (which is always 0).
+                command.Parameters.Add(new SqlParameter("@consent_acknowledged", SqlDbType.Bit) { Value = record.ConsentAcknowledged });
                 command.Parameters.Add(new SqlParameter("@source_alert_ref", SqlDbType.NVarChar, 256) { Value = (object?)record.SourceAlertRef ?? DBNull.Value });
 
                 var rows = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -220,6 +220,16 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public string? GeneratedSql { get; init; }
         public string Result { get; init; } = "";          // "success" | "skipped" | "error" | "aborted"
         public string? ErrorMessage { get; init; }
+
+        /// <summary>
+        /// B3 Phase 3 (B-3 / M-3): true only when this row records a DESTRUCTIVE apply
+        /// that passed the informed-consent (acknowledge-each-risk) gate (RcsiHandler).
+        /// Always false for the always-safe DB-config rows and the force-plan rows.
+        /// Persisted to the queryable <c>consent_acknowledged</c> bit so a destructive
+        /// apply is distinguishable in the log from an always-safe one.
+        /// </summary>
+        public bool ConsentAcknowledged { get; init; }
+
         public string? SourceAlertRef { get; init; }
     }
 }

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -781,24 +781,51 @@ ORDER BY database_name";
             var issues = new List<string>();
             if (!reader.IsDBNull(2) && reader.GetBoolean(2)) issues.Add("auto_shrink ON");
             if (!reader.IsDBNull(3) && reader.GetBoolean(3)) issues.Add("auto_close ON");
-            if (!reader.IsDBNull(4) && !reader.GetBoolean(4)) issues.Add("RCSI OFF");
+            var rcsiOn = !reader.IsDBNull(4) && reader.GetBoolean(4);
+            if (!rcsiOn) issues.Add("RCSI OFF");
             var pageVerify = reader.IsDBNull(5) ? "" : reader.GetString(5);
             if (!string.IsNullOrEmpty(pageVerify) && pageVerify != "CHECKSUM") issues.Add($"page_verify={pageVerify}");
 
-            items.Add(new
+            // RCSI-off rows carry the three structured inaction-risk fields with the
+            // SAME JSON names + types as the Dashboard collector (M-2): Lite emits them
+            // null/0 because it has no collect.blocking_deadlock_stats aggregate and the
+            // per-DB counts would not be parity-clean. Lite has no Apply path, so the
+            // disclosure simply shows the weak-case baseline. The parity test asserts
+            // TYPES only (int / int / nullable-int) for these three fields.
+            if (!rcsiOn)
             {
-                database = reader.IsDBNull(0) ? "" : reader.GetString(0),
-                recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
-                rcsi = !reader.IsDBNull(4) && reader.GetBoolean(4),
-                query_store = !reader.IsDBNull(6) && reader.GetBoolean(6),
-                issues,
-                // §4.1: structured, wording-independent fields the shared extractor
-                // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
-                // and types to the Dashboard collector (bool / bool / string).
-                auto_shrink = !reader.IsDBNull(2) && reader.GetBoolean(2),
-                auto_close = !reader.IsDBNull(3) && reader.GetBoolean(3),
-                page_verify = pageVerify
-            });
+                items.Add(new
+                {
+                    database = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    rcsi = rcsiOn,
+                    query_store = !reader.IsDBNull(6) && reader.GetBoolean(6),
+                    issues,
+                    auto_shrink = !reader.IsDBNull(2) && reader.GetBoolean(2),
+                    auto_close = !reader.IsDBNull(3) && reader.GetBoolean(3),
+                    page_verify = pageVerify,
+                    rcsi_blocking_events = 0,
+                    rcsi_deadlocks = 0,
+                    rcsi_reader_writer_pct = (int?)null
+                });
+            }
+            else
+            {
+                items.Add(new
+                {
+                    database = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    recovery_model = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    rcsi = rcsiOn,
+                    query_store = !reader.IsDBNull(6) && reader.GetBoolean(6),
+                    issues,
+                    // §4.1: structured, wording-independent fields the shared extractor
+                    // (FactRemediation.ExtractDbConfigTargets) reads. Identical JSON names
+                    // and types to the Dashboard collector (bool / bool / string).
+                    auto_shrink = !reader.IsDBNull(2) && reader.GetBoolean(2),
+                    auto_close = !reader.IsDBNull(3) && reader.GetBoolean(3),
+                    page_verify = pageVerify
+                });
+            }
         }
 
         if (items.Count > 0)

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -74,6 +74,82 @@ public static class FactRemediation
     }
 
     /// <summary>
+    /// Builds the DESTRUCTIVE RCSI remediation action for a DB_CONFIG finding, or null
+    /// when it does not apply (B3 Phase 3). Parallel to <see cref="BuildAction"/>, which
+    /// stays EXACTLY as-is — this is a SEPARATE entry point so the singular-Remediation
+    /// pipeline (one RemediationAction per detail item) is unchanged; the caller emits
+    /// the RCSI action on a SECOND "Enable RCSI (advanced)" detail item (PR-B).
+    ///
+    /// <para>
+    /// Emits ONLY when a <c>config_issues</c> row is RCSI-OFF (the JSON <c>rcsi</c> value
+    /// is <c>false</c> — M2-1 boolean polarity, mirroring the rcsiOffDatabases scan in
+    /// <see cref="GenerateForDbConfig"/>) AND the §3.3 enrichment is present (the
+    /// <c>rcsi_blocking_events</c>/<c>rcsi_deadlocks</c>/<c>rcsi_reader_writer_pct</c>
+    /// fields exist on that row). The action carries FactKey "RCSI" (a distinct handler)
+    /// and reuses a single <see cref="DbConfigTarget"/> with
+    /// <see cref="DbConfigSetting.ReadCommittedSnapshotOn"/> and CurrentValue "OFF".
+    /// </para>
+    /// </summary>
+    public static RemediationAction? BuildRcsiAction(AnalysisFinding finding)
+    {
+        if (finding is null || !string.Equals(finding.RootFactKey, "DB_CONFIG", StringComparison.Ordinal))
+            return null;
+
+        if (finding.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("config_issues", out var raw) ||
+            raw is null)
+            return null;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object) continue;
+
+            var database = GetString(row, "database");
+            if (string.IsNullOrEmpty(database))
+                continue;
+
+            // M2-1: rcsi == true means RCSI is ON. Emit ONLY when RCSI is OFF
+            // (JsonValueKind.False) — mirrors the rcsiOffDatabases scan exactly.
+            if (!row.TryGetProperty("rcsi", out var r) || r.ValueKind != JsonValueKind.False)
+                continue;
+
+            // The §3.3 enrichment must be present (these fields are emitted only for
+            // RCSI-off databases). Without it the inaction side cannot be quantified
+            // and no RCSI affordance should appear.
+            if (!HasRcsiEnrichment(row))
+                continue;
+
+            var target = new DbConfigTarget(database, DbConfigSetting.ReadCommittedSnapshotOn, "OFF");
+            return new RemediationAction("RCSI", "set", Array.Empty<ForcePlanTarget>(), new[] { target });
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when the RCSI inaction-risk enrichment fields are present on the row (the
+    /// collector emits them only for RCSI-off databases). At least one of the three
+    /// structured fields must exist.
+    /// </summary>
+    private static bool HasRcsiEnrichment(JsonElement row) =>
+        row.TryGetProperty("rcsi_blocking_events", out _) ||
+        row.TryGetProperty("rcsi_deadlocks", out _) ||
+        row.TryGetProperty("rcsi_reader_writer_pct", out _);
+
+    /// <summary>
     /// Extracts the typed force-plan targets from a PLAN_REGRESSION finding's
     /// drill-down. This is the single parse: the preview renderer
     /// (<see cref="GenerateForPlanRegression"/>) renders entirely from this list,
@@ -318,6 +394,7 @@ public static class FactRemediation
             DbConfigSetting.AutoShrinkOff => "SET AUTO_SHRINK OFF",
             DbConfigSetting.AutoCloseOff => "SET AUTO_CLOSE OFF",
             DbConfigSetting.PageVerifyChecksum => "SET PAGE_VERIFY CHECKSUM",
+            DbConfigSetting.ReadCommittedSnapshotOn => "SET READ_COMMITTED_SNAPSHOT ON",
             _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown DbConfigSetting")
         };
         return $"ALTER DATABASE {QuoteName(database)} {setClause};";

--- a/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
+++ b/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Builds the two-sided <see cref="RiskDisclosure"/> for a DESTRUCTIVE remediation
+/// action (B3 Phase 3). Returns null for non-destructive fact keys — the consent
+/// gate is never requested for them.
+///
+/// <para>
+/// The "risks of NOT changing" side is quantified from monitoring data the analysis
+/// ALREADY holds: the per-database <c>config_issues</c> drill-down is enriched at
+/// analysis time (in both collectors) with <c>rcsi_blocking_events</c>,
+/// <c>rcsi_deadlocks</c>, and <c>rcsi_reader_writer_pct</c>. This reads those typed
+/// fields — it issues NO SQL of its own and performs NO live probe of the target
+/// (the same single-parse pattern as <see cref="FactRemediation"/>).
+/// </para>
+///
+/// <para>
+/// All prose is FIXED/reviewed; the only substituted tokens are the validated
+/// database identifier and the numeric figures. The honest-both-directions property:
+/// when the reader/writer share is low (writer/writer contention), the inaction side
+/// says RCSI will NOT resolve it rather than overstate the benefit; when little or no
+/// blocking was captured, it shows the weak-case baseline.
+/// </para>
+/// </summary>
+public static class FactRiskDisclosure
+{
+    /// <summary>
+    /// The reader/writer-share threshold below which the "RCSI won't resolve this"
+    /// (writer/writer-dominant) inaction line is shown instead of the "RCSI eliminates
+    /// this" line. A share at or above this is treated as a meaningful reader/writer case.
+    /// </summary>
+    public const int ReaderWriterMeaningfulPct = 50;
+
+    /// <summary>
+    /// Returns the two-sided risk disclosure for a destructive action, or null for a
+    /// non-destructive fact key (the gate is never requested there). The finding may
+    /// be null — the inaction side then degrades to the weak-case baseline line.
+    /// </summary>
+    public static RiskDisclosure? GetForAction(RemediationAction action, AnalysisFinding? finding)
+    {
+        if (action is null || string.IsNullOrEmpty(action.FactKey))
+            return null;
+
+        return action.FactKey switch
+        {
+            "RCSI" => BuildRcsiDisclosure(action, finding),
+            _ => null
+        };
+    }
+
+    private static RiskDisclosure BuildRcsiDisclosure(RemediationAction action, AnalysisFinding? finding)
+    {
+        // The target database (validated non-empty by the extractor; re-validated
+        // against sys.databases at apply time). Bracketed for display only.
+        var database = FirstTargetDatabase(action);
+        var db = QuoteName(database);
+
+        var changing = new List<RiskItem>
+        {
+            new($"Enabling RCSI on {db} takes a brief exclusive database lock and will " +
+                "block until all in-flight transactions in that database complete — run it at " +
+                "a quiet moment; under load it can wait or be chosen as a deadlock victim."),
+            new($"RCSI adds row-version load to tempdb; a long-running reader transaction on " +
+                $"{db} can grow the version store and pressure tempdb."),
+            new("Reader/writer concurrency semantics change — readers stop taking shared locks " +
+                "and read the last committed row version instead. Application code that relies on " +
+                "default locking behavior (or uses NOLOCK to work around blocking today) should be " +
+                "tested on a copy first."),
+        };
+
+        var figures = ReadInactionFigures(finding, database);
+        var notChanging = BuildInactionRisks(db, figures);
+
+        return new RiskDisclosure(changing, notChanging);
+    }
+
+    /// <summary>
+    /// The inaction-side risk lines, filled from the finding's monitoring figures.
+    /// Always returns at least one item (the honest-both-directions framing). When no
+    /// reader/writer share was captured, shows the weak-case baseline.
+    /// </summary>
+    private static List<RiskItem> BuildInactionRisks(string db, InactionFigures f)
+    {
+        var notChanging = new List<RiskItem>
+        {
+            new($"Over the analysis window ({f.HoursBack}h), {db} recorded " +
+                $"{f.BlockingEvents.ToString(CultureInfo.InvariantCulture)} blocked-process events and " +
+                $"{f.Deadlocks.ToString(CultureInfo.InvariantCulture)} deadlocks."),
+        };
+
+        if (f.ReaderWriterPct is int pct && (f.BlockingEvents > 0 || f.Deadlocks > 0 || pct > 0))
+        {
+            if (pct >= ReaderWriterMeaningfulPct)
+            {
+                notChanging.Add(new(
+                    $"Roughly {pct.ToString(CultureInfo.InvariantCulture)}% of the captured lock " +
+                    "contention was readers blocked by writers (shared / range-shared locks) — the " +
+                    "exact pattern RCSI eliminates."));
+            }
+            else
+            {
+                notChanging.Add(new(
+                    $"Only {pct.ToString(CultureInfo.InvariantCulture)}% of the captured contention " +
+                    "was reader-vs-writer; the majority was writer/writer (X/IX/U), which RCSI does " +
+                    "NOT resolve — shorter transactions and better write-path indexing are the levers. " +
+                    "Enabling RCSI may add tempdb overhead without relieving this contention."));
+            }
+        }
+        else
+        {
+            notChanging.Add(new(
+                $"Little or no reader/writer blocking was captured for {db} in this window — the case " +
+                "for enabling RCSI here is weak; consider whether the finding is driven by another database."));
+        }
+
+        return notChanging;
+    }
+
+    private static string FirstTargetDatabase(RemediationAction action)
+    {
+        if (action.DbConfigTargets is { Count: > 0 } dbTargets)
+            return dbTargets[0].Database;
+        if (action.Targets is { Count: > 0 } targets)
+            return targets[0].Database;
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Reads the three enrichment fields for the action's target database from the
+    /// finding's <c>config_issues</c> drill-down. Degrades to the weak-case baseline
+    /// (null/zero) when the finding, drill-down, or fields are absent. Reads the
+    /// analysis window length from the finding when available.
+    /// </summary>
+    private static InactionFigures ReadInactionFigures(AnalysisFinding? finding, string database)
+    {
+        var figures = new InactionFigures { HoursBack = HoursBack(finding) };
+
+        if (finding?.DrillDown is null ||
+            string.IsNullOrEmpty(database) ||
+            !finding.DrillDown.TryGetValue("config_issues", out var raw) ||
+            raw is null)
+            return figures;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return figures;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return figures;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Object) continue;
+            if (!string.Equals(GetString(row, "database"), database, StringComparison.Ordinal)) continue;
+
+            figures.BlockingEvents = GetInt(row, "rcsi_blocking_events");
+            figures.Deadlocks = GetInt(row, "rcsi_deadlocks");
+            figures.ReaderWriterPct = GetNullableInt(row, "rcsi_reader_writer_pct");
+            return figures;
+        }
+
+        return figures;
+    }
+
+    private static int HoursBack(AnalysisFinding? finding)
+    {
+        // The disclosure window length. The finding does not carry the raw hours, so
+        // fall back to the canonical default (24h) used for the analysis window.
+        // Substituted into fixed prose only — never an execution input.
+        return 24;
+    }
+
+    private sealed class InactionFigures
+    {
+        public int HoursBack { get; set; } = 24;
+        public int BlockingEvents { get; set; }
+        public int Deadlocks { get; set; }
+        public int? ReaderWriterPct { get; set; }
+    }
+
+    /// <summary>
+    /// QUOTENAME-equivalent for display (mirrors <see cref="FactRemediation"/>'s
+    /// private routine; the database name is from sys.databases via the collector).
+    /// </summary>
+    private static string QuoteName(string identifier) =>
+        string.IsNullOrEmpty(identifier) ? "[unknown]" : "[" + identifier.Replace("]", "]]") + "]";
+
+    private static string GetString(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return string.Empty;
+        return v.ValueKind == JsonValueKind.String ? (v.GetString() ?? string.Empty) : string.Empty;
+    }
+
+    private static int GetInt(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return 0;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number when v.TryGetInt32(out var i) => i,
+            JsonValueKind.Number => (int)v.GetDouble(),
+            _ => 0
+        };
+    }
+
+    private static int? GetNullableInt(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return null;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number when v.TryGetInt32(out var i) => i,
+            JsonValueKind.Number => (int)v.GetDouble(),
+            _ => null
+        };
+    }
+}

--- a/PerformanceMonitor.Analysis/RcsiLockModeClassifier.cs
+++ b/PerformanceMonitor.Analysis/RcsiLockModeClassifier.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// How a blocked-process <c>lock_mode</c> classifies for the RCSI reader-vs-writer
+/// share (B3 Phase 3, M-1). RCSI eliminates ONLY reader-blocked-by-writer contention,
+/// so the share's numerator is reader-side rows and the denominator is reader+writer
+/// rows; DDL/compile/bulk modes are excluded entirely (RCSI-irrelevant).
+/// </summary>
+public enum RcsiLockClass
+{
+    /// <summary>Excluded from the denominator (Sch-S / Sch-M / BU — RCSI-irrelevant).</summary>
+    Excluded,
+
+    /// <summary>Reader-side: S, IS, RangeS-* (the numerator; the pattern RCSI eliminates).</summary>
+    Reader,
+
+    /// <summary>Writer-side: X, IX, U, UIX, RangeX-*, RangeI-* (RCSI does NOT resolve writer/writer).</summary>
+    Writer
+}
+
+/// <summary>
+/// Canonical reference classifier for the RCSI reader/writer split over the FULL
+/// <c>lock_mode</c> vocabulary (M-1). The Dashboard drill-down collector's
+/// server-side <c>CASE</c> expressions in CollectRcsiInactionFigures MIRROR this
+/// exactly: reader = S / IS / RangeS-*; writer = X / IX / U / UIX / RangeX-* /
+/// RangeI-*; Sch-S / Sch-M / BU and any unknown token are Excluded. Pure + exhaustively
+/// golden-tested so the classification cannot drift unnoticed.
+/// </summary>
+public static class RcsiLockModeClassifier
+{
+    /// <summary>Classifies one <c>lock_mode</c> string. Null/empty/unknown → Excluded.</summary>
+    public static RcsiLockClass Classify(string? lockMode)
+    {
+        if (string.IsNullOrEmpty(lockMode))
+            return RcsiLockClass.Excluded;
+
+        // Explicitly RCSI-irrelevant — excluded from the denominator.
+        if (lockMode is "Sch-S" or "Sch-M" or "BU")
+            return RcsiLockClass.Excluded;
+
+        // Reader-side numerator.
+        if (lockMode is "S" or "IS")
+            return RcsiLockClass.Reader;
+        if (lockMode.StartsWith("RangeS-", StringComparison.Ordinal))
+            return RcsiLockClass.Reader;
+
+        // Writer-side.
+        if (lockMode is "X" or "IX" or "U" or "UIX")
+            return RcsiLockClass.Writer;
+        if (lockMode.StartsWith("RangeX-", StringComparison.Ordinal) ||
+            lockMode.StartsWith("RangeI-", StringComparison.Ordinal))
+            return RcsiLockClass.Writer;
+
+        // Any other token (IU, SIU, SIX, unknown) is not counted in the reader/writer
+        // share — neither a pure reader nor a pure writer lock for this purpose.
+        return RcsiLockClass.Excluded;
+    }
+}

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -32,10 +32,13 @@ public sealed record RemediationAction(
     IReadOnlyList<DbConfigTarget>? DbConfigTargets = null);  // DB-config targets (null for force-plan)
 
 /// <summary>
-/// The fixed, hardcoded set of always-safe database settings B3 Phase 2 can apply.
-/// This enum — NOT any data/operator-supplied string — selects the SET clause
-/// literal in the executor (see DatabaseService.Remediation DB-config arm). RCSI
-/// (READ_COMMITTED_SNAPSHOT) is deliberately absent: it is destructive and excluded.
+/// The fixed, hardcoded set of database settings B3 can apply. This enum — NOT any
+/// data/operator-supplied string — selects the SET clause literal in the executor
+/// (see DatabaseService.Remediation DB-config arm). The first three are ALWAYS-SAFE
+/// online metadata changes (Phase 2). <see cref="ReadCommittedSnapshotOn"/> (Phase 3)
+/// is DESTRUCTIVE — it is routed through the distinct "RCSI" fact key + RcsiHandler
+/// (IsDestructive == true) behind the informed-consent gate, NEVER through the
+/// always-safe DbConfigHandler.
 /// </summary>
 public enum DbConfigSetting
 {
@@ -46,7 +49,15 @@ public enum DbConfigSetting
     AutoCloseOff,
 
     /// <summary>ALTER DATABASE [db] SET PAGE_VERIFY CHECKSUM;</summary>
-    PageVerifyChecksum
+    PageVerifyChecksum,
+
+    /// <summary>
+    /// ALTER DATABASE [db] SET READ_COMMITTED_SNAPSHOT ON; — DESTRUCTIVE (B3 Phase 3).
+    /// Takes a brief exclusive DB lock to enable, adds tempdb version-store load, and
+    /// changes reader/writer concurrency semantics. Routed only through the "RCSI"
+    /// fact key + RcsiHandler behind the informed-consent gate.
+    /// </summary>
+    ReadCommittedSnapshotOn
 }
 
 /// <summary>

--- a/PerformanceMonitor.Analysis/RiskDisclosure.cs
+++ b/PerformanceMonitor.Analysis/RiskDisclosure.cs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// One acknowledge-each-risk disclosure line. In the in-app confirm dialog this
+/// renders as a single checkbox the operator must tick (B3 Phase 3); on the
+/// read-only surfaces (email / webhook / MCP) it renders as a disclosure bullet —
+/// you cannot consent through an email. The text is FIXED/reviewed prose; the only
+/// variable parts are a validated database identifier and numeric monitoring
+/// figures (no data- or operator-supplied prose — no-injection parity with the SQL).
+/// </summary>
+public sealed record RiskItem(string Text);
+
+/// <summary>
+/// The two-sided, informed-consent risk content for a destructive remediation
+/// (B3 Phase 3). "Risks of changing" are fixed per-fix-type prose plus a validated
+/// identifier; "risks of not changing" are fixed framing FILLED with this server's
+/// already-collected monitoring figures (the honest-both-directions property — when
+/// the contention is writer/writer, the inaction side says RCSI will not resolve it
+/// rather than overstate the benefit). Lives in the shared Analysis lib so it is
+/// consistent across every surface; only the in-app dialog ENFORCES the checkbox gate.
+/// </summary>
+public sealed record RiskDisclosure(
+    IReadOnlyList<RiskItem> RisksOfChanging,
+    IReadOnlyList<RiskItem> RisksOfNotChanging);

--- a/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
+++ b/upgrades/2.11.0-to-2.12.0/02_create_remediation_action_log.sql
@@ -70,3 +70,30 @@ BEGIN
     PRINT 'config.remediation_action_log already exists — no action taken';
 END;
 GO
+
+/*
+B3 Phase 3 (consent_acknowledged): idempotent guarded ALTER, NOT a create-body amend.
+The CREATE above is guarded by IF OBJECT_ID(...) IS NULL, so adding the column inside
+that block would only land on servers where the table does not yet exist; servers that
+already ran an earlier 2.11.0-to-2.12.0/02_ (incl. multi-machine test servers) would
+keep the column-less table and turn EVERY audit INSERT into "invalid column name".
+This COL_LENGTH-guarded ALTER is correct on BOTH fresh and pre-existing tables.
+
+consent_acknowledged records that a DESTRUCTIVE apply (RCSI) passed the informed-consent
+(acknowledge-each-risk) gate. Always 0 for the always-safe DB-config and force-plan rows.
+*/
+IF COL_LENGTH(N'config.remediation_action_log', N'consent_acknowledged') IS NULL
+BEGIN
+    ALTER TABLE
+        config.remediation_action_log
+    ADD consent_acknowledged bit NOT NULL
+        CONSTRAINT df_remediation_action_log_consent_acknowledged
+        DEFAULT (0);
+
+    PRINT 'Added config.remediation_action_log.consent_acknowledged';
+END;
+ELSE
+BEGIN
+    PRINT 'config.remediation_action_log.consent_acknowledged already exists — no action taken';
+END;
+GO


### PR DESCRIPTION
## What ships (PR-A — dead-code-safe, unregistered)

The privileged core for enabling `READ_COMMITTED_SNAPSHOT` (RCSI) behind an informed-consent destructive gate, kept **UNREACHABLE** exactly like the Phase-1/2 PR-A pattern: **`RcsiHandler` is NOT registered** and the **"Enable RCSI" detail item is NOT emitted**. The acknowledge-each-risk dialog rendering, registry registration, second-detail-item emission, and cross-surface disclosure are PR-B.

- **Risk model + builder** (`PerformanceMonitor.Analysis`): `RiskItem`/`RiskDisclosure` records; `FactRiskDisclosure.GetForAction(action, finding)` builds the two-sided, honest-both-directions content — risks of changing (fixed prose + validated identifier) and risks of NOT changing (fixed framing filled with the server's monitoring figures, with the writer/writer "RCSI won't resolve this" branch and the no-data weak-case baseline).
- **Drill-down enrichment in BOTH collectors**: `rcsi_blocking_events` (int), `rcsi_deadlocks` (int), `rcsi_reader_writer_pct` (int 0–100, nullable), emitted ONLY for RCSI-off databases with identical JSON names + types. Dashboard sources counts from the pre-aggregated `collect.blocking_deadlock_stats` (O-P3-F) and the reader/writer split from a separate pass over `collect.blocking_BlockedProcessReport` classified against the FULL `lock_mode` vocabulary (M-1). Lite emits `0/0/null` (M-2).
- **Executor RCSI enum arm**: `DbConfigSetting.ReadCommittedSnapshotOn` wired through all four switch sites (m-1) + the `SettingTitle` arm (m-2); reuses the Phase-2 `SetDatabaseOptionAsync` machinery unchanged.
- **`RcsiHandler : IRemediationHandler`**: `FactKey => "RCSI"`, `IsDestructive => true` (first true in the codebase), `SupportsUnapply => false`, `UnapplyAsync` throws. Same audit-absent-hard-block / single-connection-gate / one-row-per-attempt skeleton as `DbConfigHandler`. NOT registered.
- **`FactRemediation.BuildRcsiAction`** (parallel to the unchanged `BuildAction`): emits the RCSI action only on `rcsi == false` (RCSI OFF — M2-1 polarity) + enrichment present.
- **`RemediationConfirmRequest`** += `RequiresInformedConsent` + `Risks`; `BuildConfirmRequest` signature change to take the resolved `handler` (+ `finding`) (B-1) + the `RunAsync` call-site update.
- **`consent_acknowledged`**: idempotent `COL_LENGTH`-guarded ALTER appended after the create block (B-3, NOT a create-body amend) + the four-file plumbing (M-3): `RemediationAuditRecord.ConsentAcknowledged`, a real bound `@consent_acknowledged` Bit param in the writer, `RcsiHandler` BuildRecord => true, DbConfig + force-plan => false.
- **`CoreMachineryMarkers`** += `"RcsiHandler"`; all headless §9 unit tests.

## Security invariants enforced (file:line)

- **Identifier safety** — only non-constant token is the validated+bracketed DB identifier; SET clause is the hardcoded literal `SET READ_COMMITTED_SNAPSHOT ON` (`Dashboard/Services/DatabaseService.Remediation.cs` `SetClauseFor` arm ~270, `BuildAlterStatement` ~279); existence via parameterized `sys.databases` check (`ReadDbConfigGateAsync` ~441-452); same-string `ValidatedName` (~465). Executor builds its own statement — preview never executed.
- **Single-connection self-gating (R2-MOD-1)** — gate (existence + fail-closed `ISNULL(HAS_PERMS_BY_NAME(@db,'DATABASE','ALTER'),0)` + `is_read_committed_snapshot_on` freshness) and the ALTER on ONE monitoring connection (`SetDatabaseOptionAsync` ~314-388); desired state = on → Skip (new gate arm ~433-440); GateSpid/ExecSpid emitted.
- **Fail-closed perms** — `RcsiHandler` clones the `DbConfigHandler` PermissionDenied path; no elevation, no `InitialCatalog` retarget, no credential handling.
- **Audit** — audit-absent hard block before any mutation (`RcsiHandler.RunApplyAsync`); one audit row per attempt; `consent_acknowledged = true` only on a gated RCSI apply/skip (`RcsiHandler.BuildRecord`), `false` for DbConfig (`DbConfigHandler.cs`) and force-plan (`ForcePlanHandler.cs`).
- **Dead-code-safe** — `RcsiHandler` unregistered (`RemediationApplyService.cs:55` unchanged); RCSI second detail item un-emitted; asserted by `Rcsi_Handler_IsUnregistered_DeadCodeSafe` + `CoreMachinery_OnlyReferencedInRemediationCore`.
- **Boolean polarity (M2-1)** — `BuildRcsiAction` emits on `JsonValueKind.False` only (`FactRemediation.cs`), mirroring the existing `rcsiOffDatabases` scan.
- **Lock-mode classifier (M-1)** — reader = `S`/`IS`/`RangeS-%`; writer = `X`/`IX`/`U`/`UIX`/`RangeX-%`/`RangeI-%`; `Sch-S`/`Sch-M`/`BU` excluded; SQL `CASE` in the Dashboard collector mirrors `RcsiLockModeClassifier`, golden-tested over the full vocabulary.
- **Idempotent ALTER (B-3)** — `IF COL_LENGTH(...) IS NULL ALTER TABLE ... ADD consent_acknowledged bit NOT NULL CONSTRAINT df_... DEFAULT (0)` appended after the guarded create block; correct on both fresh and pre-existing tables.

## Test results (real)

- `dotnet build Dashboard/Dashboard.csproj -c Debug` — clean (0 warnings, 0 errors).
- Shared libs (Analysis, Notifications) — clean.
- **Dashboard.Tests: Passed 175, Failed 0, Skipped 0.**
- **Lite.Tests: Passed 312, Failed 0, Skipped 0.**

## Maintainer real-server pre-merge gate (sql2022, §9 — NOT run here)

1. Scratch DB RCSI OFF + induced reader/writer blocking → RCSI affordance shows real counts + high reader-writer %; all boxes → Apply → `is_read_committed_snapshot_on = 1`, audit `action` `set_rcsi_on`, `prior_value='OFF'`, `consent_acknowledged=1`. Re-apply → freshness-skip.
2. Scratch DB RCSI OFF, predominantly writer/writer → disclosure shows low reader-writer % + "RCSI won't resolve this" (honest-both-directions).
3. db_owner-of-PerformanceMonitor-only login → PermissionDenied, no ALTER.
4. Hold an open txn in the target DB, attempt apply → ALTER waits then errors on timeout; per-target Error, no partial state.
5. Audit-absent + DB-not-found behave as Phase 2.

> Do NOT merge / register the handler / do PR-B. Re-run the tests, read the privileged core, and run a security-reviewer pass on the diff before anything lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
