### PR TITLE
B3 Phase 3 PR-B: RCSI Apply live behind informed-consent gate

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -244,6 +244,153 @@ public class AnalysisNotificationTests
         Assert.Null(rem!.DbConfigTargets);
     }
 
+    // ── B3 Phase 3 (PR-B): second "Enable RCSI (advanced)" detail item + cross-surface ──
+
+    private static AnalysisFinding DbConfigRcsiFinding(
+        bool rcsiOff = true, bool enrichment = true, bool alsoAutoShrink = false,
+        int blocking = 12, int deadlocks = 3, int? rwPct = 80, string hash = "dbconfig00000099")
+    {
+        var row = new Dictionary<string, object?>
+        {
+            ["database"] = "Foo",
+            ["recovery_model"] = "FULL",
+            ["rcsi"] = !rcsiOff,                  // rcsi == true means RCSI is ON
+            ["query_store"] = true,
+            ["issues"] = rcsiOff ? new[] { "RCSI OFF" } : System.Array.Empty<string>(),
+            ["auto_shrink"] = alsoAutoShrink,
+            ["auto_close"] = false,
+            ["page_verify"] = "CHECKSUM",
+        };
+        if (enrichment)
+        {
+            row["rcsi_blocking_events"] = blocking;
+            row["rcsi_deadlocks"] = deadlocks;
+            row["rcsi_reader_writer_pct"] = rwPct;
+        }
+        return MakeFinding(hash, rootFactKey: "DB_CONFIG", category: "config_issues",
+            drillDown: new Dictionary<string, object> { ["config_issues"] = new List<object> { row } });
+    }
+
+    [Fact]
+    public void BuildContext_RcsiOffWithEnrichment_EmitsSecondEnableRcsiItem()
+    {
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(), notifyThreshold: 1.5);
+
+        var rcsiItem = Assert.Single(context.Details, d => d.Heading == "Enable RCSI (advanced)");
+        Assert.True(rcsiItem.IsCodeBlock);
+        Assert.NotNull(rcsiItem.Remediation);
+        Assert.Equal("RCSI", rcsiItem.Remediation!.FactKey);
+        Assert.Contains("SET READ_COMMITTED_SNAPSHOT ON", rcsiItem.Body);
+        // The figures rode the action (captured while the finding was in hand).
+        Assert.NotNull(rcsiItem.Remediation.RcsiFigures);
+        Assert.Equal(12, rcsiItem.Remediation.RcsiFigures!.BlockingEvents);
+
+        // The cross-surface disclosure item is also present (read-only, both email bodies + webhook).
+        var disclosure = Assert.Single(context.Details, d => d.Heading == "RCSI — risks of changing / not changing");
+        Assert.False(disclosure.IsCodeBlock);
+        Assert.Contains("Risks of CHANGING", disclosure.Body);
+        Assert.Contains("Risks of NOT changing", disclosure.Body);
+        Assert.Contains("RCSI eliminates", disclosure.Body);   // 80% reader/writer
+    }
+
+    [Fact]
+    public void BuildContext_RcsiOn_EmitsNoEnableRcsiItem()
+    {
+        // RCSI already ON -> the affordance must NOT appear (M2-1 polarity).
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(rcsiOff: false), notifyThreshold: 1.5);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Enable RCSI (advanced)");
+        Assert.DoesNotContain(context.Details, d => d.Heading == "RCSI — risks of changing / not changing");
+    }
+
+    [Fact]
+    public void BuildContext_RcsiOffNoEnrichment_EmitsNoEnableRcsiItem()
+    {
+        // Legacy alert: RCSI off but no §3.3 enrichment -> no affordance.
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(enrichment: false), notifyThreshold: 1.5);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Enable RCSI (advanced)");
+    }
+
+    [Fact]
+    public void BuildContext_RcsiItem_NotGatedBehindAlwaysSafeRemediationTsql()
+    {
+        // The residual round-2 note: emit the RCSI item on ANY config_issues-bearing
+        // finding, NOT only when the always-safe block emitted a Remediation T-SQL item.
+        // Here ONLY RCSI is wrong (no auto_shrink/auto_close/page_verify issue), so the
+        // always-safe BuildAction yields null and NO "Remediation T-SQL" item is emitted —
+        // yet the RCSI item must still appear.
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(alsoAutoShrink: false), notifyThreshold: 1.5);
+
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Remediation T-SQL");
+        Assert.Contains(context.Details, d => d.Heading == "Enable RCSI (advanced)");
+    }
+
+    [Fact]
+    public void BuildContext_BothItems_WhenAlsoAlwaysSafeIssue()
+    {
+        // RCSI off + an always-safe issue (auto_shrink ON): BOTH the always-safe
+        // "Remediation T-SQL" item AND the separate "Enable RCSI (advanced)" item appear,
+        // each with its own singular Remediation. The always-safe one never carries RCSI.
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(alsoAutoShrink: true), notifyThreshold: 1.5);
+
+        var safe = Assert.Single(context.Details, d => d.Heading == "Remediation T-SQL");
+        Assert.Equal("DB_CONFIG", safe.Remediation!.FactKey);
+        Assert.All(safe.Remediation.DbConfigTargets!, t => Assert.NotEqual(DbConfigSetting.ReadCommittedSnapshotOn, t.Setting));
+
+        var rcsi = Assert.Single(context.Details, d => d.Heading == "Enable RCSI (advanced)");
+        Assert.Equal("RCSI", rcsi.Remediation!.FactKey);
+    }
+
+    [Fact]
+    public void BuildContext_RcsiItem_RemediationActionAndFigures_SurviveRoundTrip()
+    {
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(), notifyThreshold: 1.5);
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        var rcsi = Assert.Single(restored.Details, d => d.Heading == "Enable RCSI (advanced)");
+        Assert.NotNull(rcsi.Remediation);
+        Assert.Equal("RCSI", rcsi.Remediation!.FactKey);
+        var t = Assert.Single(rcsi.Remediation.DbConfigTargets!);
+        Assert.Equal(DbConfigSetting.ReadCommittedSnapshotOn, t.Setting);
+        // The real figures survive the persistence round-trip.
+        Assert.NotNull(rcsi.Remediation.RcsiFigures);
+        Assert.Equal(12, rcsi.Remediation.RcsiFigures!.BlockingEvents);
+        Assert.Equal(3, rcsi.Remediation.RcsiFigures.Deadlocks);
+        Assert.Equal(80, rcsi.Remediation.RcsiFigures.ReaderWriterPct);
+    }
+
+    [Fact]
+    public void CrossSurface_RiskDisclosure_RendersInBothEmailBodiesAndWebhook()
+    {
+        var context = FindingMessageFormatter.BuildContext(DbConfigRcsiFinding(), notifyThreshold: 1.5);
+        var branding = EmailAlertService.Branding;
+
+        // Both email bodies flow from context.Details — the disclosure must render in EACH
+        // (feedback_emailtemplatebuilder_two_bodies: HTML + plain-text are separate bodies).
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "High CPU", "TestServer", "n/a", "n/a", 15, branding, context);
+
+        foreach (var body in new[] { html, plain })
+        {
+            Assert.Contains("RCSI — risks of changing / not changing", body);
+            Assert.Contains("Risks of CHANGING", body);
+            Assert.Contains("Risks of NOT changing", body);
+            Assert.Contains("RCSI eliminates", body);
+        }
+
+        // Webhook payloads (Teams + Slack) also flow from context.Details.
+        var teams = WebhookAlertService.BuildTeamsPayload(
+            "High CPU", "TestServer", "n/a", "n/a", branding, context: context);
+        var slack = WebhookAlertService.BuildSlackPayload(
+            "High CPU", "TestServer", "n/a", "n/a", branding, context: context);
+
+        foreach (var payload in new[] { teams, slack })
+        {
+            Assert.Contains("Risks of NOT changing", payload);
+            Assert.Contains("RCSI eliminates", payload);
+        }
+    }
+
     [Fact]
     public void AlertContext_LegacyJsonWithoutRemediation_DeserializesToNull()
     {

--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -440,14 +440,14 @@ public class RemediationApplyServiceTests
             var allChecked = checkedCount == 5;   // never true in this loop (0..4)
             Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
                 baseActionable: true, requiresConsent: true, allRiskBoxesChecked: allChecked,
-                resolvedByName: false, byNameAck: false),
+                resolvedByName: false, byNameAck: false, riskBoxCount: 5),
                 $"Apply must stay DISABLED with a subset ({checkedCount}/5) of risk boxes checked.");
         }
 
         // All boxes checked -> enabled (no by-name complication).
         Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
-            resolvedByName: false, byNameAck: false));
+            resolvedByName: false, byNameAck: false, riskBoxCount: 5));
     }
 
     [Fact]
@@ -456,11 +456,11 @@ public class RemediationApplyServiceTests
         // Enabled with all checked...
         Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
-            resolvedByName: false, byNameAck: false));
+            resolvedByName: false, byNameAck: false, riskBoxCount: 4));
         // ...then un-checking ANY box (allRiskBoxesChecked flips false) re-disables.
         Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: false,
-            resolvedByName: false, byNameAck: false));
+            resolvedByName: false, byNameAck: false, riskBoxCount: 4));
     }
 
     [Fact]
@@ -469,15 +469,15 @@ public class RemediationApplyServiceTests
         // Risk boxes all checked but by-name NOT acked -> still disabled.
         Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
-            resolvedByName: true, byNameAck: false));
+            resolvedByName: true, byNameAck: false, riskBoxCount: 4));
         // By-name acked but a risk box still unchecked -> still disabled.
         Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: false,
-            resolvedByName: true, byNameAck: true));
+            resolvedByName: true, byNameAck: true, riskBoxCount: 4));
         // BOTH satisfied -> enabled.
         Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
-            resolvedByName: true, byNameAck: true));
+            resolvedByName: true, byNameAck: true, riskBoxCount: 4));
     }
 
     [Fact]
@@ -487,7 +487,28 @@ public class RemediationApplyServiceTests
         // of consent (the consent gate is ADDITIVE to AnyActionable, never a replacement).
         Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: false, requiresConsent: true, allRiskBoxesChecked: true,
-            resolvedByName: false, byNameAck: false));
+            resolvedByName: false, byNameAck: false, riskBoxCount: 4));
+    }
+
+    [Fact]
+    public void Gate_Destructive_ZeroRiskBoxes_FailsClosed()
+    {
+        // FAIL CLOSED (LOW-1): a destructive (requiresConsent) request with NO rendered
+        // risk boxes must keep Apply DISABLED, even though allRiskBoxesChecked is vacuously
+        // true (List.TrueForAll on an empty list) and the base apply-ability holds. A
+        // future destructive handler whose disclosure is empty/null can never enable Apply
+        // with zero acknowledged checkboxes.
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: false, byNameAck: false, riskBoxCount: 0));
+        // Still fails closed even if the (irrelevant) by-name ack is satisfied.
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: true, byNameAck: true, riskBoxCount: 0));
+        // One real risk box, all checked -> enabled (the guard only blocks the empty case).
+        Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: false, byNameAck: false, riskBoxCount: 1));
     }
 
     [Fact]
@@ -498,10 +519,10 @@ public class RemediationApplyServiceTests
         // exactly as before Phase 3 — no regression for force-plan / always-safe.
         Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: false, allRiskBoxesChecked: false,
-            resolvedByName: false, byNameAck: false));
+            resolvedByName: false, byNameAck: false, riskBoxCount: 0));
         Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
             baseActionable: true, requiresConsent: false, allRiskBoxesChecked: false,
-            resolvedByName: true, byNameAck: false));
+            resolvedByName: true, byNameAck: false, riskBoxCount: 0));
     }
 
     // ── Real figures survive persistence to apply time (CRITICAL correctness) ─────

--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services.Remediation;
@@ -419,6 +420,152 @@ public class RemediationApplyServiceTests
             CancellationToken.None, finding: RcsiFinding(rwPct: 8));
 
         Assert.Contains(captured!.Risks!.RisksOfNotChanging, r => r.Text.Contains("RCSI does NOT resolve"));
+    }
+
+    // ── HARD gate-enforcement (B-1, MANDATORY): the acknowledge-each-risk predicate ──
+    //
+    // The dialog IS the trust boundary; the confirm callback returns true ONLY when the
+    // gate is satisfied. The dialog's exact enablement predicate is the pure, testable
+    // RemediationConfirmWindow.ComputeConfirmEnabled. These prove: a destructive request
+    // keeps Apply DISABLED until ALL risk checkboxes are checked; a subset leaves it
+    // disabled; un-checking any one re-disables; and the by-name ack combines (BOTH
+    // required for a destructive by-name target).
+
+    [Fact]
+    public void Gate_Destructive_Disabled_UntilAllRiskBoxesChecked()
+    {
+        // 5 risk boxes (e.g. 3 changing + 2 not-changing). Disabled until ALL are ticked.
+        for (var checkedCount = 0; checkedCount < 5; checkedCount++)
+        {
+            var allChecked = checkedCount == 5;   // never true in this loop (0..4)
+            Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+                baseActionable: true, requiresConsent: true, allRiskBoxesChecked: allChecked,
+                resolvedByName: false, byNameAck: false),
+                $"Apply must stay DISABLED with a subset ({checkedCount}/5) of risk boxes checked.");
+        }
+
+        // All boxes checked -> enabled (no by-name complication).
+        Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: false, byNameAck: false));
+    }
+
+    [Fact]
+    public void Gate_Destructive_UncheckingAnyBox_ReDisables()
+    {
+        // Enabled with all checked...
+        Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: false, byNameAck: false));
+        // ...then un-checking ANY box (allRiskBoxesChecked flips false) re-disables.
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: false,
+            resolvedByName: false, byNameAck: false));
+    }
+
+    [Fact]
+    public void Gate_Destructive_ByName_RequiresBoth_RiskBoxesAndByNameAck()
+    {
+        // Risk boxes all checked but by-name NOT acked -> still disabled.
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: true, byNameAck: false));
+        // By-name acked but a risk box still unchecked -> still disabled.
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: false,
+            resolvedByName: true, byNameAck: true));
+        // BOTH satisfied -> enabled.
+        Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: true, byNameAck: true));
+    }
+
+    [Fact]
+    public void Gate_NotActionable_NeverEnabled_EvenWithAllConsent()
+    {
+        // Audit-absent / nothing-applyable: baseActionable false hard-blocks regardless
+        // of consent (the consent gate is ADDITIVE to AnyActionable, never a replacement).
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: false, requiresConsent: true, allRiskBoxesChecked: true,
+            resolvedByName: false, byNameAck: false));
+    }
+
+    [Fact]
+    public void Gate_NonDestructive_Unaffected_ByConsentArm()
+    {
+        // A non-destructive (requiresConsent false) request ignores the risk-box arm:
+        // base actionable + (by-name ack if resolved-by-name) is the whole predicate,
+        // exactly as before Phase 3 — no regression for force-plan / always-safe.
+        Assert.True(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: false, allRiskBoxesChecked: false,
+            resolvedByName: false, byNameAck: false));
+        Assert.False(RemediationConfirmWindow.ComputeConfirmEnabled(
+            baseActionable: true, requiresConsent: false, allRiskBoxesChecked: false,
+            resolvedByName: true, byNameAck: false));
+    }
+
+    // ── Real figures survive persistence to apply time (CRITICAL correctness) ─────
+    //
+    // The UI apply call site passes NO finding; only the persisted RemediationAction
+    // survives. The RCSI figures must therefore ride the action through the AlertContext
+    // serialize -> deserialize round-trip, so the dialog shows the REAL blocking numbers,
+    // not the weak-case baseline.
+
+    [Fact]
+    public async Task Apply_Destructive_RealFigures_SurvivePersistence_NoFindingAtApplyTime()
+    {
+        // 1. Build the action the way AnalysisNotificationService does (finding in hand).
+        var finding = RcsiFinding(rwPct: 80);
+        var builtAction = FactRemediation.BuildRcsiAction(finding);
+        Assert.NotNull(builtAction);
+        Assert.NotNull(builtAction!.RcsiFigures);
+        Assert.Equal(12, builtAction.RcsiFigures!.BlockingEvents);
+
+        // 2. Round-trip it through the persisted AlertContext (the only thing that
+        //    survives to the UI apply call site).
+        var ctx = new AlertContext();
+        ctx.Details.Add(new AlertDetailItem { Heading = "Enable RCSI (advanced)", IsCodeBlock = true, Remediation = builtAction });
+        Assert.True(AlertContextSerializer.TryDeserialize(AlertContextSerializer.Serialize(ctx), out var round));
+        var persistedAction = round.Details[0].Remediation!;
+        Assert.NotNull(persistedAction.RcsiFigures);
+        Assert.Equal(12, persistedAction.RcsiFigures!.BlockingEvents);
+        Assert.Equal(3, persistedAction.RcsiFigures.Deadlocks);
+        Assert.Equal(80, persistedAction.RcsiFigures.ReaderWriterPct);
+
+        // 3. Apply with the PERSISTED action and NO finding (exactly the UI call site).
+        //    The confirm request's Risks must show the REAL figures, not weak-case.
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new RcsiHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(persistedAction, Server, previewSql: "preview", "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); },
+            CancellationToken.None /* finding defaults to null — the UI apply call site */);
+
+        Assert.NotNull(captured!.Risks);
+        Assert.Contains(captured.Risks!.RisksOfNotChanging,
+            r => r.Text.Contains("12") && r.Text.Contains("blocked-process events") && r.Text.Contains("3 deadlocks"));
+        Assert.Contains(captured.Risks.RisksOfNotChanging, r => r.Text.Contains("80%") && r.Text.Contains("RCSI eliminates"));
+        // NOT the weak-case baseline (proves the real figures reached the dialog).
+        Assert.DoesNotContain(captured.Risks.RisksOfNotChanging, r => r.Text.Contains("Little or no reader/writer blocking"));
+    }
+
+    [Fact]
+    public async Task Apply_Destructive_NoFiguresNoFinding_ShowsWeakCaseBaseline()
+    {
+        // Genuinely no data: an action WITHOUT figures + no finding -> weak-case baseline.
+        var bareAction = RcsiAction();   // built without RcsiFigures
+        Assert.Null(bareAction.RcsiFigures);
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new RcsiHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(bareAction, Server, previewSql: "preview", "DOM\\op", "ref",
+            confirm: req => { captured = req; return Task.FromResult(false); }, CancellationToken.None);
+
+        Assert.Contains(captured!.Risks!.RisksOfNotChanging, r => r.Text.Contains("Little or no reader/writer blocking"));
     }
 
     // ── Fake executor (PR-B-local) ───────────────────────────────────────────────

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -742,19 +742,26 @@ public class RemediationTests
     }
 
     [Fact]
-    public void Rcsi_Handler_IsUnregistered_DeadCodeSafe()
+    public void Rcsi_Handler_IsRegistered_AndReachableThroughGate()
     {
-        // PR-A is dead-code-safe: a registry without RcsiHandler (the production shape:
-        // ForcePlanHandler + DbConfigHandler) does not route "RCSI" to anything, so no
-        // Apply affordance can reach the destructive handler. PR-B adds the registration.
-        var productionRegistry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler() });
-        Assert.Null(productionRegistry.TryGet("RCSI"));
+        // PR-B makes RCSI LIVE: the PRODUCTION wiring registers RcsiHandler so the Apply
+        // affordance can appear and route to the destructive handler — but ONLY through
+        // the gated RemediationApplyService facade (proven by the Gate_* behavioural tests
+        // and the reachability guards CoreMachinery_OnlyReferencedInRemediationCore +
+        // GatedEntry_ReferencedOnlyBySanctionedUiPath).
+        var productionRegistry = new RemediationHandlerRegistry(
+            new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler() });
+        Assert.IsType<RcsiHandler>(productionRegistry.TryGet("RCSI"));
 
-        // And the PRODUCTION wiring must NOT yet construct an RcsiHandler — assert at the
-        // source level that RemediationApplyService.cs does not register it in PR-A.
+        // Assert at the source level that the PRODUCTION wiring now constructs RcsiHandler.
         var dir = FindDashboardSourceDir();
         var serviceSrc = File.ReadAllText(Path.Combine(dir, "Services", "Remediation", "RemediationApplyService.cs"));
-        Assert.DoesNotContain("new RcsiHandler()", serviceSrc);
+        Assert.Contains("new RcsiHandler()", serviceSrc);
+
+        // The always-safe DbConfigHandler still routes ONLY DB_CONFIG — never RCSI — so
+        // the two affordances can never cross at the registry/handler layer.
+        Assert.IsType<DbConfigHandler>(productionRegistry.TryGet("DB_CONFIG"));
+        Assert.NotEqual("RCSI", productionRegistry.TryGet("DB_CONFIG")!.FactKey);
     }
 
     [Fact]

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -99,7 +99,15 @@ public sealed class McpAnalysisTools
                             investigation = advice.Investigation,
                             remediation = advice.Remediation
                         },
-                        suggested_remediation_sql = advice?.RemediationTsql
+                        suggested_remediation_sql = advice?.RemediationTsql,
+                        // B3 Phase 3 (§6): two-sided risk DISCLOSURE for a destructive
+                        // remediation — read-only here (no consent gate off-app; consent
+                        // is enforced only by the in-app acknowledge-each-risk dialog).
+                        destructive_risk_disclosure = advice?.Risks is null ? null : new
+                        {
+                            risks_of_changing = advice.Risks.RisksOfChanging.Select(r => r.Text).ToArray(),
+                            risks_of_not_changing = advice.Risks.RisksOfNotChanging.Select(r => r.Text).ToArray()
+                        }
                     };
                 })
             }, McpHelpers.JsonOptions);

--- a/Dashboard/RemediationConfirmWindow.xaml
+++ b/Dashboard/RemediationConfirmWindow.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header -->
@@ -125,8 +126,52 @@
                      BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
         </StackPanel>
 
+        <!-- B3 Phase 3: informed-consent acknowledge-each-risk gate (destructive only) -->
+        <StackPanel Grid.Row="6" x:Name="ConsentSection" Visibility="Collapsed" Margin="0,0,0,12">
+            <!-- One-line framing banner (FactKey-specific; RCSI arm) -->
+            <Border x:Name="ConsentBanner" CornerRadius="4" Padding="10" Margin="0,0,0,10">
+                <Border.Background>
+                    <SolidColorBrush Color="{StaticResource ErrorColor}" Opacity="0.20"/>
+                </Border.Background>
+                <TextBlock x:Name="ConsentBannerText" Foreground="{DynamicResource ForegroundBrush}"
+                           FontWeight="SemiBold" TextWrapping="Wrap"/>
+            </Border>
+
+            <!-- RISK OF CHANGING -->
+            <TextBlock Text="RISK OF CHANGING" FontWeight="SemiBold" FontSize="13"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <ItemsControl x:Name="ChangingRisksList" Margin="0,0,0,10">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox Margin="0,3" IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                  Checked="RiskBox_Changed" Unchecked="RiskBox_Changed"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <TextBlock Text="{Binding Text}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                        </CheckBox>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <!-- RISK OF NOT CHANGING -->
+            <TextBlock Text="RISK OF NOT CHANGING" FontWeight="SemiBold" FontSize="13"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <ItemsControl x:Name="NotChangingRisksList">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox Margin="0,3" IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                  Checked="RiskBox_Changed" Unchecked="RiskBox_Changed"
+                                  Foreground="{DynamicResource ForegroundBrush}">
+                            <TextBlock Text="{Binding Text}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                        </CheckBox>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
         <!-- Buttons -->
-        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="CancelButton" Content="Cancel" Padding="14,5" Margin="0,0,8,0"
                     Click="CancelButton_Click" IsCancel="True"/>
             <Button x:Name="ConfirmButton" Padding="14,5" Click="ConfirmButton_Click" IsDefault="True"/>

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -22,18 +22,34 @@ namespace PerformanceMonitorDashboard
     /// </summary>
     public partial class RemediationConfirmWindow : Window
     {
+        // ── B3 Phase 3: informed-consent gate state ──────────────────────────────
+        // The dialog IS the trust boundary. For a destructive (RequiresInformedConsent)
+        // request, ConfirmButton is enabled ONLY when every risk checkbox is ticked AND
+        // the base apply-ability holds AND (if resolved-by-name) the by-name ack is ticked.
+        private readonly bool _requiresConsent;
+        private readonly bool _resolvedByName;
+        private bool _baseActionable;                 // audit present + at least one actionable target
+        private readonly List<RiskRow> _changingRisks = new();
+        private readonly List<RiskRow> _notChangingRisks = new();
+
         public RemediationConfirmWindow(RemediationConfirmRequest request, bool resolvedByName, string? resolvedByNameReason)
         {
             InitializeComponent();
 
+            _requiresConsent = request.RequiresInformedConsent;
+            _resolvedByName = resolvedByName;
+
             var verb = request.IsUnapply ? "Un-apply Fix" : "Apply Fix";
             Title = $"Confirm {verb}";
             var isDbConfig = string.Equals(request.FactKey, "DB_CONFIG", System.StringComparison.Ordinal);
-            HeaderText.Text = isDbConfig
-                ? $"Apply the always-safe database setting change(s) on {request.ServerDisplayName}?"
-                : request.IsUnapply
-                    ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
-                    : $"Force the historical-better plan on {request.ServerDisplayName}?";
+            var isRcsi = string.Equals(request.FactKey, "RCSI", System.StringComparison.Ordinal);
+            HeaderText.Text = isRcsi
+                ? $"Enable READ_COMMITTED_SNAPSHOT (RCSI) — a database-wide concurrency change — on {request.ServerDisplayName}?"
+                : isDbConfig
+                    ? $"Apply the always-safe database setting change(s) on {request.ServerDisplayName}?"
+                    : request.IsUnapply
+                        ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
+                        : $"Force the historical-better plan on {request.ServerDisplayName}?";
 
             ServerText.Text = request.ServerDisplayName;
             ExecutingText.Text = string.IsNullOrEmpty(request.ExecutingLogin)
@@ -55,10 +71,15 @@ namespace PerformanceMonitorDashboard
                 rows.Add(TargetRow.From(t, request.IsUnapply));
             TargetsList.ItemsSource = rows;
 
-            // Fact-key-specific caveat. DB_CONFIG: the always-safe note (RCSI excluded).
-            // PLAN_REGRESSION: the M2 still-better caveat (apply-time judgment; hidden
-            // on un-apply where there is no "still better" decision).
-            if (isDbConfig)
+            // Fact-key-specific caveat. RCSI: the always-safe caveat does NOT apply (the
+            // two-sided risk sections below carry the framing). DB_CONFIG: the always-safe
+            // note (RCSI excluded). PLAN_REGRESSION: the M2 still-better caveat (apply-time
+            // judgment; hidden on un-apply where there is no "still better" decision).
+            if (isRcsi)
+            {
+                CaveatBanner.Visibility = Visibility.Collapsed;
+            }
+            else if (isDbConfig)
             {
                 CaveatText.Text =
                     "These three settings are always-safe to change on a live database (online, no blocking). "
@@ -73,10 +94,30 @@ namespace PerformanceMonitorDashboard
                 CaveatText.Text = RemediationConfirmRequest.StillBetterCaveat;
             }
 
+            // B3 Phase 3: render the two-sided acknowledge-each-risk sections for a
+            // destructive request. ALWAYS render both sections (RCSI has >= 1 each).
+            if (_requiresConsent && request.Risks is not null)
+            {
+                ConsentSection.Visibility = Visibility.Visible;
+                ConsentBannerText.Text = isRcsi
+                    ? "RCSI is a database-wide concurrency change. Read both risk lists; every box must be checked to enable Apply."
+                    : "This is a possibly-destructive change. Read both risk lists; every box must be checked to enable Apply.";
+
+                foreach (var r in request.Risks.RisksOfChanging)
+                    _changingRisks.Add(new RiskRow(r.Text));
+                foreach (var r in request.Risks.RisksOfNotChanging)
+                    _notChangingRisks.Add(new RiskRow(r.Text));
+
+                ChangingRisksList.ItemsSource = _changingRisks;
+                NotChangingRisksList.ItemsSource = _notChangingRisks;
+            }
+
             SqlPreview.Text = request.PreviewSql;
 
             // Audit-table-absent hard block: the privileged core would block every
             // target with no mutation, so disable the confirm button and say why.
+            // _baseActionable is the audit-present + actionable predicate the consent /
+            // by-name gates further restrict — never loosen.
             if (!request.AuditTableExists)
             {
                 AuditAbsentBanner.Visibility = Visibility.Visible;
@@ -85,14 +126,14 @@ namespace PerformanceMonitorDashboard
                     + "Apply Fix is hard-blocked here — no change will be made. Upgrade this server to "
                     + "2.12.0 to enable audited Apply Fix.";
                 ConfirmButton.Content = request.IsUnapply ? "Un-apply" : "Apply";
-                ConfirmButton.IsEnabled = false;
+                _baseActionable = false;
                 ConfirmButton.ToolTip = AuditAbsentText.Text;
             }
             else if (!request.IsUnapply && !request.AnyActionable)
             {
                 // Nothing applyable (already forced / stale / QS off / no ALTER / wrong DB).
                 ConfirmButton.Content = $"Apply to {request.ServerDisplayName}";
-                ConfirmButton.IsEnabled = false;
+                _baseActionable = false;
                 ConfirmButton.ToolTip = "No target is in an applyable state — see the per-target notes above.";
             }
             else
@@ -100,37 +141,93 @@ namespace PerformanceMonitorDashboard
                 ConfirmButton.Content = request.IsUnapply
                     ? $"Un-apply on {request.ServerDisplayName}"
                     : $"Apply to {request.ServerDisplayName}";
+                _baseActionable = true;
             }
 
             // LOW-2 (wrong-server boundary): when the source server was resolved by
             // NAME (the alert lacked a stable id and a unique name matched), a server
             // renamed/replaced since the alert could be a *different* target. Remove
             // the Enter-key click-through, and — only if Apply would otherwise be
-            // enabled — require an explicit acknowledgement checkbox before enabling
-            // it, so a by-name target can never be applied by a reflexive click/Enter.
-            if (resolvedByName)
-            {
+            // enabled — require an explicit acknowledgement checkbox before enabling it.
+            // The destructive-consent risk boxes ALSO suppress the default-Enter and add
+            // their own N-checkbox gate; both combine in RecomputeConfirmEnabled.
+            if (resolvedByName || _requiresConsent)
                 ConfirmButton.IsDefault = false;
-                if (ConfirmButton.IsEnabled)
-                {
-                    ByNameAckCheck.Visibility = Visibility.Visible;
-                    ByNameAckCheck.IsChecked = false;
-                    ConfirmButton.IsEnabled = false;
-                    ConfirmButton.ToolTip = "Confirm the target server (checkbox above) to enable.";
-                }
+
+            if (resolvedByName && _baseActionable)
+            {
+                ByNameAckCheck.Visibility = Visibility.Visible;
+                ByNameAckCheck.IsChecked = false;
+            }
+
+            RecomputeConfirmEnabled();
+        }
+
+        /// <summary>
+        /// The single enablement predicate (generalizes the LOW-2 by-name ack to N risk
+        /// boxes). Apply is enabled ONLY when the base apply-ability holds AND, for a
+        /// destructive request, EVERY risk checkbox is ticked, AND, for a by-name-resolved
+        /// server, the by-name ack is ticked. A destructive RCSI on a by-name target
+        /// therefore requires BOTH all risk boxes AND the by-name ack.
+        /// </summary>
+        private void RecomputeConfirmEnabled()
+        {
+            var allRiskBoxesChecked = _changingRisks.TrueForAll(r => r.IsChecked)
+                && _notChangingRisks.TrueForAll(r => r.IsChecked);
+            var byNameAck = ByNameAckCheck.IsChecked == true;
+
+            var enabled = ComputeConfirmEnabled(
+                _baseActionable, _requiresConsent, allRiskBoxesChecked, _resolvedByName, byNameAck);
+            ConfirmButton.IsEnabled = enabled;
+
+            if (enabled)
+            {
+                ConfirmButton.ClearValue(ToolTipProperty);
+            }
+            else if (!_baseActionable)
+            {
+                // Keep the audit-absent / not-actionable tooltip already set above.
+            }
+            else if (_requiresConsent && !allRiskBoxesChecked)
+            {
+                ConfirmButton.ToolTip = "Acknowledge every risk (all checkboxes above) to enable.";
+            }
+            else if (_resolvedByName && !byNameAck)
+            {
+                ConfirmButton.ToolTip = "Confirm the target server (checkbox above) to enable.";
             }
         }
 
-        // Gates Apply on the explicit by-name acknowledgement (LOW-2). Only reachable
-        // when ByNameAckCheck is visible — i.e. resolved-by-name AND otherwise-applyable;
-        // the audit-absent / not-actionable hard-blocks leave the checkbox collapsed, so
-        // the button stays disabled there regardless.
-        private void ByNameAck_Changed(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// PURE enablement predicate — the whole consent gate (B-1). Apply is enabled ONLY
+        /// when the base apply-ability holds AND, for a destructive request, EVERY risk
+        /// checkbox is ticked, AND, for a by-name-resolved server, the by-name ack is
+        /// ticked. A destructive RCSI on a by-name target requires BOTH all risk boxes AND
+        /// the by-name ack. Extracted as internal static so the HARD gate-enforcement test
+        /// (Dashboard.Tests) verifies the exact predicate the dialog uses, without WPF.
+        /// </summary>
+        internal static bool ComputeConfirmEnabled(
+            bool baseActionable,
+            bool requiresConsent,
+            bool allRiskBoxesChecked,
+            bool resolvedByName,
+            bool byNameAck)
         {
-            ConfirmButton.IsEnabled = ByNameAckCheck.IsChecked == true;
-            if (ConfirmButton.IsEnabled)
-                ConfirmButton.ClearValue(ToolTipProperty);
+            if (!baseActionable)
+                return false;
+            if (requiresConsent && !allRiskBoxesChecked)
+                return false;
+            if (resolvedByName && !byNameAck)
+                return false;
+            return true;
         }
+
+        // Re-evaluates the full enablement predicate when any risk checkbox toggles.
+        private void RiskBox_Changed(object sender, RoutedEventArgs e) => RecomputeConfirmEnabled();
+
+        // Gates Apply on the explicit by-name acknowledgement (LOW-2), combined with the
+        // destructive-consent risk boxes via the unified RecomputeConfirmEnabled.
+        private void ByNameAck_Changed(object sender, RoutedEventArgs e) => RecomputeConfirmEnabled();
 
         private void ConfirmButton_Click(object sender, RoutedEventArgs e)
         {
@@ -142,6 +239,19 @@ namespace PerformanceMonitorDashboard
         {
             DialogResult = false;
             Close();
+        }
+
+        /// <summary>
+        /// One acknowledge-each-risk checkbox row (B3 Phase 3). <see cref="IsChecked"/>
+        /// is two-way bound to the CheckBox; the unified RecomputeConfirmEnabled reads it.
+        /// The CheckBox Checked/Unchecked events also fire RiskBox_Changed so the gate
+        /// re-evaluates on every toggle. Text is read-only/wrap-enabled (display only).
+        /// </summary>
+        private sealed class RiskRow
+        {
+            public RiskRow(string text) => Text = text;
+            public string Text { get; }
+            public bool IsChecked { get; set; }
         }
 
         /// <summary>Bindable projection of one confirm target.</summary>

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -174,10 +174,11 @@ namespace PerformanceMonitorDashboard
         {
             var allRiskBoxesChecked = _changingRisks.TrueForAll(r => r.IsChecked)
                 && _notChangingRisks.TrueForAll(r => r.IsChecked);
+            var riskBoxCount = _changingRisks.Count + _notChangingRisks.Count;
             var byNameAck = ByNameAckCheck.IsChecked == true;
 
             var enabled = ComputeConfirmEnabled(
-                _baseActionable, _requiresConsent, allRiskBoxesChecked, _resolvedByName, byNameAck);
+                _baseActionable, _requiresConsent, allRiskBoxesChecked, _resolvedByName, byNameAck, riskBoxCount);
             ConfirmButton.IsEnabled = enabled;
 
             if (enabled)
@@ -211,11 +212,17 @@ namespace PerformanceMonitorDashboard
             bool requiresConsent,
             bool allRiskBoxesChecked,
             bool resolvedByName,
-            bool byNameAck)
+            bool byNameAck,
+            int riskBoxCount)
         {
             if (!baseActionable)
                 return false;
-            if (requiresConsent && !allRiskBoxesChecked)
+            // FAIL CLOSED (LOW-1): a destructive request enables Apply ONLY when there is at
+            // least one rendered risk box AND every box is checked. List.TrueForAll on an
+            // EMPTY list returns true, so without the riskBoxCount > 0 guard a FUTURE
+            // destructive handler whose disclosure is empty/null would enable Apply with zero
+            // acknowledged checkboxes. The count guard removes that implicit coupling.
+            if (requiresConsent && !(riskBoxCount > 0 && allRiskBoxesChecked))
                 return false;
             if (resolvedByName && !byNameAck)
                 return false;

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -52,7 +52,11 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
             if (credentialService is null) throw new ArgumentNullException(nameof(credentialService));
 
-            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler() });
+            // B3 Phase 3 (PR-B): RcsiHandler is now LIVE. It is the only IsDestructive
+            // handler; reaching it requires the informed-consent (acknowledge-each-risk)
+            // confirm dialog returning true. Routed via the distinct "RCSI" fact key so
+            // it can never be reached through the always-safe DbConfigHandler.
+            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler() });
             _executorFactory = server =>
                 new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
             _auditFailureClassifier = (server, ct) =>

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -87,7 +87,15 @@ public sealed class McpAnalysisTools
                             investigation = advice.Investigation,
                             remediation = advice.Remediation
                         },
-                        suggested_remediation_sql = advice?.RemediationTsql
+                        suggested_remediation_sql = advice?.RemediationTsql,
+                        // B3 Phase 3 (§6): two-sided risk DISCLOSURE for a destructive
+                        // remediation, read-only (Lite has no Apply path; its RCSI fields
+                        // are null/0 so the inaction side shows the weak-case baseline).
+                        destructive_risk_disclosure = advice?.Risks is null ? null : new
+                        {
+                            risks_of_changing = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(advice.Risks.RisksOfChanging, r => r.Text)),
+                            risks_of_not_changing = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(advice.Risks.RisksOfNotChanging, r => r.Text))
+                        }
                     };
                 })
             }, McpHelpers.JsonOptions);

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -18,7 +18,8 @@ public sealed record AdviceBlock(
     string Headline,
     string Investigation,
     string Remediation,
-    string? RemediationTsql = null);
+    string? RemediationTsql = null,
+    RiskDisclosure? Risks = null);
 
 /// <summary>
 /// Static lookup mapping fact-keys (the same constants emitted by
@@ -74,7 +75,22 @@ public static class FactAdvice
             return null;
 
         var tsql = FactRemediation.GenerateForFinding(finding);
-        return tsql is null ? advice : advice with { RemediationTsql = tsql };
+        if (tsql is not null)
+            advice = advice with { RemediationTsql = tsql };
+
+        // B3 Phase 3 (§6): when the finding offers a DESTRUCTIVE remediation, append the
+        // two-sided RiskDisclosure so every read-only surface (email / webhook / MCP)
+        // SHOWS the operator the same risks they'd see in-app — they simply cannot click
+        // Apply off-app (no consent gate there; consent is enforced only by the dialog).
+        var destructiveAction = FactRemediation.BuildRcsiAction(finding);
+        if (destructiveAction is not null)
+        {
+            var risks = FactRiskDisclosure.GetForAction(destructiveAction, finding);
+            if (risks is not null)
+                advice = advice with { Risks = risks };
+        }
+
+        return advice;
     }
 
     /// <summary>

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -133,10 +133,47 @@ public static class FactRemediation
                 continue;
 
             var target = new DbConfigTarget(database, DbConfigSetting.ReadCommittedSnapshotOn, "OFF");
-            return new RemediationAction("RCSI", "set", Array.Empty<ForcePlanTarget>(), new[] { target });
+
+            // Capture the risk-of-NOT-changing figures HERE (the finding is available)
+            // and carry them on the persisted action, so the informed-consent dialog can
+            // render the REAL numbers at apply time — when only the persisted action
+            // survives (the UI apply call site passes no finding). FactRiskDisclosure
+            // reads these from the action in preference to the finding.
+            var figures = new RcsiInactionFigures(
+                BlockingEvents: GetInt(row, "rcsi_blocking_events"),
+                Deadlocks: GetInt(row, "rcsi_deadlocks"),
+                ReaderWriterPct: GetNullableInt(row, "rcsi_reader_writer_pct"));
+
+            return new RemediationAction("RCSI", "set", Array.Empty<ForcePlanTarget>(), new[] { target }, figures);
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Renders the display-only RCSI code block for the "Enable RCSI (advanced)" detail
+    /// item (B3 Phase 3, §4.3): the enabling ALTER with a "was OFF" comment, a commented
+    /// back-out statement, and the test-on-a-copy note. Returns null when no RCSI action
+    /// applies (RCSI on / no enrichment). The Dashboard executor builds its OWN validated
+    /// + bracketed statement and never executes this rendered text.
+    /// </summary>
+    public static string? GenerateRcsiPreview(AnalysisFinding finding)
+    {
+        var action = BuildRcsiAction(finding);
+        if (action?.DbConfigTargets is not { Count: > 0 } targets)
+            return null;
+
+        var db = targets[0].Database;
+        var quoted = QuoteName(db);
+        var sb = new StringBuilder();
+        sb.AppendLine($"-- Database: {db}");
+        sb.AppendLine($"ALTER DATABASE {quoted} SET READ_COMMITTED_SNAPSHOT ON;   -- was OFF");
+        sb.AppendLine();
+        sb.AppendLine("-- To back out (itself a destructive change — blocking returns):");
+        sb.AppendLine($"-- ALTER DATABASE {quoted} SET READ_COMMITTED_SNAPSHOT OFF;");
+        sb.AppendLine();
+        sb.Append("-- Test on a copy first if the application relies on default locking behavior or uses NOLOCK hints.");
+        return sb.ToString();
     }
 
     /// <summary>
@@ -433,6 +470,28 @@ public static class FactRemediation
     {
         if (!row.TryGetProperty(property, out var v)) return 0.0;
         return v.ValueKind == JsonValueKind.Number ? v.GetDouble() : 0.0;
+    }
+
+    private static int GetInt(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return 0;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number when v.TryGetInt32(out var i) => i,
+            JsonValueKind.Number => (int)v.GetDouble(),
+            _ => 0
+        };
+    }
+
+    private static int? GetNullableInt(JsonElement row, string property)
+    {
+        if (!row.TryGetProperty(property, out var v)) return null;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number when v.TryGetInt32(out var i) => i,
+            JsonValueKind.Number => (int)v.GetDouble(),
+            _ => null
+        };
     }
 
     private static bool GetBool(JsonElement row, string property)

--- a/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
+++ b/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
@@ -81,7 +81,7 @@ public static class FactRiskDisclosure
                 "tested on a copy first."),
         };
 
-        var figures = ReadInactionFigures(finding, database);
+        var figures = ReadInactionFigures(action, finding, database);
         var notChanging = BuildInactionRisks(db, figures);
 
         return new RiskDisclosure(changing, notChanging);
@@ -139,13 +139,30 @@ public static class FactRiskDisclosure
     }
 
     /// <summary>
-    /// Reads the three enrichment fields for the action's target database from the
-    /// finding's <c>config_issues</c> drill-down. Degrades to the weak-case baseline
-    /// (null/zero) when the finding, drill-down, or fields are absent. Reads the
-    /// analysis window length from the finding when available.
+    /// Resolves the three inaction figures, REAL-figures-first: the figures captured on
+    /// the persisted <see cref="RemediationAction"/> at BuildRcsiAction time take
+    /// precedence (this is what survives to apply time — the UI apply call site has no
+    /// finding). Only when the action carries none do we fall back to the finding's
+    /// <c>config_issues</c> drill-down (the analysis-time path: email/webhook/MCP build
+    /// the disclosure while the finding is still in hand). Degrades to the weak-case
+    /// baseline (null/zero) when neither source has the data.
     /// </summary>
-    private static InactionFigures ReadInactionFigures(AnalysisFinding? finding, string database)
+    private static InactionFigures ReadInactionFigures(RemediationAction action, AnalysisFinding? finding, string database)
     {
+        // Real-figures path: the action carries the figures captured when the finding
+        // WAS available, so the dialog shows the true blocking/deadlock/reader-writer
+        // numbers even though the apply call site passes no finding.
+        if (action.RcsiFigures is { } carried)
+        {
+            return new InactionFigures
+            {
+                HoursBack = HoursBack(finding),
+                BlockingEvents = carried.BlockingEvents,
+                Deadlocks = carried.Deadlocks,
+                ReaderWriterPct = carried.ReaderWriterPct
+            };
+        }
+
         var figures = new InactionFigures { HoursBack = HoursBack(finding) };
 
         if (finding?.DrillDown is null ||

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -26,10 +26,33 @@ namespace PerformanceMonitor.Analysis;
 /// </para>
 /// </summary>
 public sealed record RemediationAction(
-    string FactKey,                              // "PLAN_REGRESSION" | "DB_CONFIG" — handler-registry key
+    string FactKey,                              // "PLAN_REGRESSION" | "DB_CONFIG" | "RCSI" — handler-registry key
     string Action,                              // "force" (plan regression) | "set" (db config). Un-apply derives "unforce".
     IReadOnlyList<ForcePlanTarget> Targets,      // force-plan targets (empty list for DB_CONFIG)
-    IReadOnlyList<DbConfigTarget>? DbConfigTargets = null);  // DB-config targets (null for force-plan)
+    IReadOnlyList<DbConfigTarget>? DbConfigTargets = null,  // DB-config targets (null for force-plan)
+    RcsiInactionFigures? RcsiFigures = null);    // B3 Phase 3: RCSI risk-of-not-changing figures carried on the persisted action
+
+/// <summary>
+/// The risk-of-NOT-changing monitoring figures for a destructive RCSI action
+/// (B3 Phase 3), captured at <see cref="FactRemediation.BuildRcsiAction"/> time when
+/// the finding (and its drill-down enrichment) IS available, and CARRIED on the
+/// persisted <see cref="RemediationAction"/> so the informed-consent dialog renders
+/// the REAL figures at apply time — when only the persisted action survives (the UI
+/// apply call site has no finding). <see cref="FactRiskDisclosure.GetForAction"/>
+/// reads these in preference to the (often-null at apply time) finding, falling back
+/// to the weak-case baseline only when they are genuinely absent.
+///
+/// <para>
+/// These are DISPLAY/disclosure values only — never an execution input. The mirror
+/// the §3.3 drill-down enrichment fields: per-database blocked-process event count,
+/// deadlock count, and reader-vs-writer share (0–100, null when no reader/writer
+/// blocked-process rows were captured).
+/// </para>
+/// </summary>
+public sealed record RcsiInactionFigures(
+    int BlockingEvents,
+    int Deadlocks,
+    int? ReaderWriterPct);
 
 /// <summary>
 /// The fixed, hardcoded set of database settings B3 can apply. This enum — NOT any

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -80,7 +80,21 @@ public record RemediationActionDto(
     string FactKey,
     string Action,
     List<ForcePlanTargetDto> Targets,
-    List<DbConfigTargetDto>? DbConfigTargets = null);
+    List<DbConfigTargetDto>? DbConfigTargets = null,
+    RcsiInactionFiguresDto? RcsiFigures = null);
+
+/// <summary>
+/// JSON mirror of <see cref="RcsiInactionFigures"/> (B3 Phase 3). Carried on the
+/// persisted RCSI action so the informed-consent dialog shows the REAL blocking/
+/// deadlock/reader-writer figures at apply time (the UI apply call site has no
+/// finding). The trailing optional member on <see cref="RemediationActionDto"/>
+/// keeps the round-trip backward-compatible: legacy/non-RCSI contextJson without it
+/// deserializes to null.
+/// </summary>
+public record RcsiInactionFiguresDto(
+    int BlockingEvents,
+    int Deadlocks,
+    int? ReaderWriterPct);
 public record ForcePlanTargetDto(
     string Database,
     long QueryId,
@@ -184,7 +198,11 @@ public static class AlertContextSerializer
                 dbConfigTargets.Add(new DbConfigTargetDto(t.Database, (int)t.Setting, t.CurrentValue));
         }
 
-        return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets);
+        var rcsiFigures = action.RcsiFigures is { } f
+            ? new RcsiInactionFiguresDto(f.BlockingEvents, f.Deadlocks, f.ReaderWriterPct)
+            : null;
+
+        return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets, rcsiFigures);
     }
 
     private static RemediationAction? FromDto(RemediationActionDto? dto)
@@ -223,6 +241,13 @@ public static class AlertContextSerializer
                 dbConfigTargets.Add(new DbConfigTarget(t.Database, (DbConfigSetting)t.Setting, t.CurrentValue));
         }
 
-        return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets);
+        // B3 Phase 3: the RCSI risk figures must survive the round-trip so the dialog
+        // shows the REAL numbers at apply time. Legacy/non-RCSI JSON without the field
+        // deserializes to null -> the disclosure falls back to the finding/weak-case.
+        var rcsiFigures = dto.RcsiFigures is { } f
+            ? new RcsiInactionFigures(f.BlockingEvents, f.Deadlocks, f.ReaderWriterPct)
+            : null;
+
+        return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets, rcsiFigures);
     }
 }

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -289,6 +289,44 @@ internal static class FindingMessageFormatter
             }
         }
 
+        /* B3 Phase 3 (PR-B): the DESTRUCTIVE "Enable RCSI (advanced)" affordance is a
+           SEPARATE detail item from the always-safe DB-config Apply — a distinct view
+           with its own singular Remediation (FactKey "RCSI"), so the two Apply buttons
+           live on two views and can never cross. Emitted on ANY config_issues-bearing
+           finding where RCSI is OFF + the §3.3 enrichment is present (BuildRcsiAction
+           returns non-null); it is NOT gated behind the always-safe block's
+           advice.RemediationTsql condition (a finding can offer RCSI even when no
+           always-safe setting is wrong). The risk-of-not-changing figures are captured
+           HERE (the finding is in hand) onto the action so the in-app dialog renders the
+           REAL numbers at apply time; the in-app consent gate is what makes it live. */
+        var rcsiAction = FactRemediation.BuildRcsiAction(finding);
+        if (rcsiAction is not null)
+        {
+            context.Details.Add(new AlertDetailItem
+            {
+                Heading = "Enable RCSI (advanced)",
+                Body = FactRemediation.GenerateRcsiPreview(finding),
+                IsCodeBlock = true,
+                Remediation = rcsiAction
+            });
+
+            /* Cross-surface disclosure (§6): the two-sided risk renders as READ-ONLY
+               prose on email (both bodies) / webhook (all flow from context.Details) —
+               you cannot consent through an email, so there is NO checkbox gate off-app.
+               The in-app dialog renders the SAME RiskDisclosure as acknowledge-each-risk
+               checkboxes (the only surface that ENFORCES consent). Built from advice.Risks
+               (FactAdvice.GetForFinding), which the MCP findings output also reads. */
+            var risksBody = RenderRiskDisclosureBody(advice?.Risks);
+            if (risksBody is not null)
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = "RCSI — risks of changing / not changing",
+                    Body = risksBody
+                });
+            }
+        }
+
         /* Drill-down values are anonymous types behind object (a bare object, or a
            List<object> of them). Round-trip through System.Text.Json and walk as
            JsonElement — robust to any shape DrillDownCollector emits. */
@@ -316,6 +354,28 @@ internal static class FindingMessageFormatter
         }
 
         return context;
+    }
+
+    /// <summary>
+    /// Renders the two-sided <see cref="RiskDisclosure"/> as read-only prose for the
+    /// cross-surface (email / webhook) disclosure item (B3 Phase 3, §6). Sections are
+    /// separated by blank lines so the email/webhook prose renderer emits one paragraph
+    /// per chunk. Returns null when there is nothing to disclose.
+    /// </summary>
+    private static string? RenderRiskDisclosureBody(RiskDisclosure? risks)
+    {
+        if (risks is null ||
+            (risks.RisksOfChanging.Count == 0 && risks.RisksOfNotChanging.Count == 0))
+            return null;
+
+        var sb = new StringBuilder();
+        sb.Append("Risks of CHANGING:");
+        foreach (var r in risks.RisksOfChanging)
+            sb.Append("\n\n• ").Append(r.Text);
+        sb.Append("\n\nRisks of NOT changing:");
+        foreach (var r in risks.RisksOfNotChanging)
+            sb.Append("\n\n• ").Append(r.Text);
+        return sb.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## What this ships

PR-B is the **reachability + UI + disclosure** half of B3 Phase 3 (§10 of the approved plan). It makes the **destructive RCSI Apply LIVE** — an operator can now enable `READ_COMMITTED_SNAPSHOT` on a production database — strictly behind the informed-consent (acknowledge-each-risk) gate. PR-A (#1040, the privileged core) is already on `dev`.

### 1. Registration (the reachability seam)
`new RcsiHandler()` added to the production handler array at `Dashboard/Services/Remediation/RemediationApplyService.cs:55`. `HasHandlerFor("RCSI")` is now true, so the Apply affordance appears and routes to the destructive handler — but **only through the gated `RemediationApplyService` facade**.

### 2. The gate (file:line — the whole point of this PR)
`RemediationConfirmWindow.ComputeConfirmEnabled` (`Dashboard/RemediationConfirmWindow.xaml.cs`) is the pure, statically-testable enablement predicate the dialog uses:

```
if (!baseActionable)                     return false;   // audit-absent / nothing applyable
if (requiresConsent && !allRiskBoxesChecked) return false;   // every risk box must be ticked
if (resolvedByName && !byNameAck)        return false;   // LOW-2 by-name ack
return true;
```

- Generalizes the Phase-1 LOW-2 single `ByNameAckCheck` to **N risk checkboxes** (one per `RisksOfChanging` / `RisksOfNotChanging` item, both sections always rendered, read-only/wrap-enabled text).
- The consent gate is **additive** to `AnyActionable`, never a replacement. `IsDefault=false` for a destructive request (no Enter click-through).
- A destructive RCSI on a by-name-resolved server requires **BOTH** all risk boxes **AND** the by-name ack.
- RCSI banner arm: "RCSI is a database-wide concurrency change. Read both risk lists; every box must be checked to enable Apply."

**No path bypasses it:** the privileged handler runs only after `confirm(request)` returns true (PR-A's gate at `RemediationApplyService.cs:204`); the dialog is the sole confirm caller (`AlertDetailWindow.ConfirmAsync`). The always-safe DB_CONFIG path can never execute an RCSI target — `ExtractDbConfigTargets` never emits `ReadCommittedSnapshotOn`, the RCSI target is built only by `BuildRcsiAction` with FactKey `"RCSI"` → `RcsiHandler`, and the two are distinct detail items with distinct singular `Remediation`s. `consent_acknowledged=1` is written by `RcsiHandler` on success/skip (PR-A, now live).

### 3. Real-figures-in-dialog fix (CRITICAL correctness)
The UI apply call site passes **no finding** (`AlertDetailWindow.xaml.cs:147`); only the persisted `RemediationAction` survives. Without a fix the dialog would show the weak-case baseline even when real blocking exists.

**Mechanism chosen:** carry the figures ON the persisted action.
- New `RcsiInactionFigures(BlockingEvents, Deadlocks, ReaderWriterPct)` on `RemediationAction`, populated in `FactRemediation.BuildRcsiAction` (when the finding + §3.3 enrichment ARE in hand).
- Round-trips via `RemediationActionDto.RcsiFigures` (mirrors the Phase-2 `DbConfigTargetDto` round-trip; backward-compatible — legacy/non-RCSI JSON deserializes to null).
- `FactRiskDisclosure.GetForAction` reads the action's figures **action-first**, falling back to the finding (analysis-time surfaces) and then the weak-case baseline.
- Proven by `Apply_Destructive_RealFigures_SurvivePersistence_NoFindingAtApplyTime`: build → serialize → deserialize → apply with no finding → the request's `Risks` show the REAL 12 events / 3 deadlocks / 80% (RCSI eliminates), NOT the baseline.

### 4. Second affordance
`AnalysisNotificationService.BuildContext` emits a separate **"Enable RCSI (advanced)"** code-block detail item (`BuildRcsiAction`, FactKey `"RCSI"`) on any `config_issues`-bearing finding with RCSI OFF + enrichment — **NOT gated behind the always-safe `advice.RemediationTsql` condition** (per the round-2 residual note). RCSI-on or no-enrichment yields no second item.

### 5. Cross-surface disclosure (read-only — no consent UI off-app)
`AdviceBlock` gains `Risks`, populated in `FactAdvice.GetForFinding` for a destructive action. Rendered as:
- a prose disclosure detail item → **BOTH email bodies (HTML + plain-text)** and the **webhook (Teams + Slack)**, all via `context.Details`;
- `destructive_risk_disclosure` in the **Dashboard + Lite MCP** findings output.

Cross-surface parity test asserts the disclosure header + "Risks of CHANGING / NOT changing" + "RCSI eliminates" appear in HTML, plain-text, Teams, AND Slack (per `feedback_emailtemplatebuilder_two_bodies`).

## REAL test results

```
dotnet build Dashboard/Dashboard.csproj -c Debug   →  Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test Dashboard.Tests  →  Passed!  Failed: 0, Passed: 189, Skipped: 0, Total: 189
dotnet test Lite.Tests       →  Passed!  Failed: 0, Passed: 312, Skipped: 0, Total: 312
```

New PR-B tests include: the HARD gate-enforcement battery (`Gate_Destructive_Disabled_UntilAllRiskBoxesChecked`, `Gate_Destructive_UncheckingAnyBox_ReDisables`, `Gate_Destructive_ByName_RequiresBoth_RiskBoxesAndByNameAck`, `Gate_NotActionable_NeverEnabled_EvenWithAllConsent`, `Gate_NonDestructive_Unaffected_ByConsentArm`), real-figures-survive-persistence, second-item emission + not-gated-behind-always-safe + both-items, round-trip with figures, and the cross-surface (both email bodies + Teams + Slack) test. PR-A's `Rcsi_Handler_IsUnregistered_DeadCodeSafe` was updated to `Rcsi_Handler_IsRegistered_AndReachableThroughGate`. The `CoreMachinery_*` reachability guards remain green.

## Maintainer real-server pre-merge gate (plan §9, steps 1–5 — folded into your end-to-end)
1. Scratch DB, RCSI OFF + induced reader/writer blocking captured in `collect.*` → finding offers the RCSI affordance; dialog shows real counts + high reader-writer %; all boxes → Apply → `is_read_committed_snapshot_on = 1`, audit row action RCSI, `prior_value='OFF'`, `consent_acknowledged=1`. Re-apply → freshness-skip.
2. Scratch DB, RCSI OFF but predominantly **writer/writer** → disclosure shows low reader-writer % + the "RCSI won't resolve this" line (honest-both-directions).
3. Fail-closed on a db_owner-of-PerformanceMonitor-only login → PermissionDenied, no ALTER.
4. Hold an open transaction in the target DB, attempt apply → the ALTER waits then errors on timeout; per-target Error, no partial state.
5. Audit-absent + DB-not-found behave as Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)