### PR TITLE
Lite: non-interactive Azure auth (service principal + managed identity) — #1038

### DIFF
--- a/Lite.Tests/AzureAuthConnectionStringTests.cs
+++ b/Lite.Tests/AzureAuthConnectionStringTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.IO;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Common;
 using PerformanceMonitorLite.Models;
@@ -291,6 +292,85 @@ public class AzureAuthConnectionStringTests
         finally
         {
             cs.DeleteCredential(server.Id);
+        }
+    }
+
+    // ---- ServerManager.UpdateServer credential lifecycle (Credential Manager) -------------
+    // ServerManager owns its own CredentialService (real Windows Credential Manager, DPAPI),
+    // same seam the tests above use. These drive UpdateServer against a temp config directory
+    // and a unique GUID server id, asserting the orphaned-secret cleanup, then clean up.
+
+    [Fact]
+    public void UpdateServer_ServicePrincipalToEntraMfa_BlankUsername_DeletesOrphanedSecret()
+    {
+        var configDir = Path.Combine(Path.GetTempPath(), "pmlite-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+        var manager = new ServerManager(configDir);
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal
+        };
+        var cs = manager.CredentialService;
+
+        try
+        {
+            // Add as ServicePrincipal: stores client id + client secret in Credential Manager.
+            manager.AddServer(server, "client-id-123", "the-sp-secret");
+            Assert.True(cs.CredentialExists(server.Id), "precondition: SP secret should be stored");
+
+            // Switch to EntraMFA with a BLANK MFA username (the legitimate, reachable case).
+            // No username means the username-storing EntraMFA arm must NOT fire, and the stale
+            // SP secret must be deleted rather than left orphaned (LOW-1).
+            server.AuthenticationType = AuthenticationTypes.EntraMFA;
+            manager.UpdateServer(server, username: string.Empty, password: null);
+
+            Assert.False(cs.CredentialExists(server.Id),
+                "orphaned SP secret must be deleted when switching SP -> EntraMFA with a blank username");
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+            try { Directory.Delete(configDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void UpdateServer_ServicePrincipalToEntraMfa_NonBlankUsername_StoresUsername()
+    {
+        // Regression guard for the fix: a NON-blank EntraMFA username must still hit the earlier
+        // EntraMFA arm and STORE the username (not get deleted by the broadened cleanup arm).
+        var configDir = Path.Combine(Path.GetTempPath(), "pmlite-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+        var manager = new ServerManager(configDir);
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal
+        };
+        var cs = manager.CredentialService;
+
+        try
+        {
+            manager.AddServer(server, "client-id-123", "the-sp-secret");
+
+            server.AuthenticationType = AuthenticationTypes.EntraMFA;
+            manager.UpdateServer(server, username: "user@tenant.com", password: null);
+
+            Assert.True(cs.CredentialExists(server.Id),
+                "non-blank EntraMFA username must be stored, not deleted");
+            var stored = cs.GetCredential(server.Id);
+            Assert.NotNull(stored);
+            Assert.Equal("user@tenant.com", stored!.Value.Username);
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+            try { Directory.Delete(configDir, recursive: true); } catch { /* best effort */ }
         }
     }
 }

--- a/Lite.Tests/AzureAuthConnectionStringTests.cs
+++ b/Lite.Tests/AzureAuthConnectionStringTests.cs
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Connection-string SHAPE tests for the non-interactive Azure auth modes (#1038):
+/// service principal and managed identity. The testable surface is the keywords emitted by
+/// ServerConnection.BuildConnectionString / ApplyAuthentication. Real Azure auth (token
+/// acquisition against a tenant) is a maintainer E2E step and is NOT exercised here.
+/// </summary>
+public class AzureAuthConnectionStringTests
+{
+    private static SqlConnectionStringBuilder Parse(string connStr) => new(connStr);
+
+    // ---- Service Principal ----------------------------------------------------------------
+
+    [Fact]
+    public void ServicePrincipal_SetsActiveDirectoryServicePrincipal_WithClientIdAndSecret()
+    {
+        var server = new ServerConnection
+        {
+            ServerName = "myazure.database.windows.net",
+            DatabaseName = "mydb",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal,
+            EncryptMode = "Mandatory"
+        };
+
+        var conn = Parse(server.BuildConnectionString("client-id-123", "the-secret"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+        Assert.Equal("client-id-123", conn.UserID);
+        Assert.Equal("the-secret", conn.Password);
+        Assert.False(conn.IntegratedSecurity);
+        Assert.Equal(SqlConnectionEncryptOption.Mandatory, conn.Encrypt);
+    }
+
+    [Fact]
+    public void ServicePrincipal_FallsBackToAzureClientId_WhenUsernameNull()
+    {
+        var server = new ServerConnection
+        {
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal,
+            AzureClientId = "model-client-id"
+        };
+
+        var conn = Parse(server.BuildConnectionString(null, "secret"));
+
+        Assert.Equal("model-client-id", conn.UserID);
+        Assert.Equal("secret", conn.Password);
+    }
+
+    [Fact]
+    public void ServicePrincipal_HonorsStrictEncrypt()
+    {
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal,
+            EncryptMode = "Strict"
+        };
+
+        var conn = Parse(server.BuildConnectionString("c", "p"));
+
+        Assert.Equal(SqlConnectionEncryptOption.Strict, conn.Encrypt);
+    }
+
+    // ---- Managed Identity -----------------------------------------------------------------
+
+    [Fact]
+    public void ManagedIdentity_SystemAssigned_NoUserIdNoPassword()
+    {
+        var server = new ServerConnection
+        {
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.ManagedIdentity
+        };
+
+        var conn = Parse(server.BuildConnectionString(null, null));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, conn.Authentication);
+        Assert.True(string.IsNullOrEmpty(conn.UserID));
+        Assert.True(string.IsNullOrEmpty(conn.Password));
+        Assert.False(conn.IntegratedSecurity);
+    }
+
+    [Fact]
+    public void ManagedIdentity_UserAssigned_SetsUserIdToClientId()
+    {
+        var server = new ServerConnection
+        {
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.ManagedIdentity,
+            ManagedIdentityClientId = "uami-client-id"
+        };
+
+        var conn = Parse(server.BuildConnectionString(null, null));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, conn.Authentication);
+        Assert.Equal("uami-client-id", conn.UserID);
+        Assert.True(string.IsNullOrEmpty(conn.Password));
+    }
+
+    // ---- Regression: existing modes unchanged ---------------------------------------------
+
+    [Fact]
+    public void Windows_UsesIntegratedSecurity_NoAuthenticationKeyword()
+    {
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.Windows };
+        var conn = Parse(server.BuildConnectionString(null, null));
+
+        Assert.True(conn.IntegratedSecurity);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, conn.Authentication);
+    }
+
+    [Fact]
+    public void SqlServer_SetsUserIdAndPassword_NoAuthenticationKeyword()
+    {
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.SqlServer };
+        var conn = Parse(server.BuildConnectionString("sa", "pw"));
+
+        Assert.False(conn.IntegratedSecurity);
+        Assert.Equal("sa", conn.UserID);
+        Assert.Equal("pw", conn.Password);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, conn.Authentication);
+    }
+
+    [Fact]
+    public void EntraMfa_SetsActiveDirectoryInteractive()
+    {
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.EntraMFA };
+        var conn = Parse(server.BuildConnectionString("user@tenant.com", null));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryInteractive, conn.Authentication);
+        Assert.Equal("user@tenant.com", conn.UserID);
+    }
+
+    // ---- AuthenticationDisplay switch -----------------------------------------------------
+
+    [Theory]
+    [InlineData(AuthenticationTypes.ServicePrincipal, "Azure — Service Principal")]
+    [InlineData(AuthenticationTypes.ManagedIdentity, "Azure — Managed Identity")]
+    [InlineData(AuthenticationTypes.EntraMFA, "Microsoft Entra MFA")]
+    [InlineData(AuthenticationTypes.SqlServer, "SQL Server")]
+    [InlineData(AuthenticationTypes.Windows, "Windows")]
+    public void AuthenticationDisplay_MapsEachMode(string authType, string expected)
+    {
+        var server = new ServerConnection { AuthenticationType = authType };
+        Assert.Equal(expected, server.AuthenticationDisplay);
+    }
+
+    // ---- Two-build-site PARITY ------------------------------------------------------------
+    // The dialog's Test-Connection builder and ServerConnection's production builder both route
+    // their auth keywords through the shared ServerConnection.ApplyAuthentication helper. This
+    // proves they emit identical Authentication / UserID / Password / IntegratedSecurity for
+    // each auth mode given the same inputs (the dialog's other knobs — ConnectTimeout etc. —
+    // intentionally differ and are out of scope for auth parity).
+
+    private static (SqlAuthenticationMethod Auth, string? User, string? Pwd, bool Integrated) AuthShape(
+        string authType, string? user, string? pwd, string? azureClientId, string? miClientId)
+    {
+        var b = new SqlConnectionStringBuilder();
+        ServerConnection.ApplyAuthentication(b, authType, user, pwd, azureClientId, miClientId);
+        return (b.Authentication, b.UserID, b.Password, b.IntegratedSecurity);
+    }
+
+    [Theory]
+    [InlineData(AuthenticationTypes.Windows)]
+    [InlineData(AuthenticationTypes.SqlServer)]
+    [InlineData(AuthenticationTypes.EntraMFA)]
+    [InlineData(AuthenticationTypes.ServicePrincipal)]
+    [InlineData(AuthenticationTypes.ManagedIdentity)]
+    public void BuildSites_ProduceIdenticalAuthShape_PerMode(string authType)
+    {
+        // Production builder (ServerConnection) call shape: (username, password, AzureClientId, ManagedIdentityClientId).
+        // Dialog builder call shape: (UserID-from-control, secret-from-PasswordBox, null azureClientId, miClientId).
+        // For SP the dialog passes the client id as the username, so both reduce to the same inputs.
+        string? user = authType switch
+        {
+            AuthenticationTypes.SqlServer => "sa",
+            AuthenticationTypes.EntraMFA => "user@tenant.com",
+            AuthenticationTypes.ServicePrincipal => "client-id",
+            _ => null
+        };
+        string? pwd = authType is AuthenticationTypes.SqlServer or AuthenticationTypes.ServicePrincipal ? "secret" : null;
+        string? mi = authType == AuthenticationTypes.ManagedIdentity ? "uami-id" : null;
+
+        var production = AuthShape(authType, user, pwd, azureClientId: "client-id", miClientId: mi);
+        var dialog = AuthShape(authType, user, pwd, azureClientId: null, miClientId: mi);
+
+        Assert.Equal(production, dialog);
+    }
+
+    // ---- GetConnectionString / HasStoredCredentials (Credential Manager) ------------------
+    // These touch the real Windows Credential Manager (DPAPI, per-user). Each test uses a unique
+    // GUID server id and deletes its credential afterward.
+
+    [Fact]
+    public void GetConnectionString_ServicePrincipal_FetchesStoredSecret()
+    {
+        var cs = new CredentialService();
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal
+        };
+        try
+        {
+            Assert.True(cs.SaveCredential(server.Id, "stored-client-id", "stored-secret"));
+
+            var conn = Parse(server.GetConnectionString(cs));
+
+            Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+            Assert.Equal("stored-client-id", conn.UserID);
+            Assert.Equal("stored-secret", conn.Password);
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+        }
+    }
+
+    [Fact]
+    public void GetConnectionString_ManagedIdentity_FetchesNoSecret()
+    {
+        var cs = new CredentialService();
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.ManagedIdentity
+        };
+        try
+        {
+            // Even if a stale credential somehow existed, MI must not pull it into the string.
+            cs.SaveCredential(server.Id, "leftover", "leftover-secret");
+
+            var conn = Parse(server.GetConnectionString(cs));
+
+            Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, conn.Authentication);
+            Assert.True(string.IsNullOrEmpty(conn.Password));
+            Assert.NotEqual("leftover", conn.UserID);
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+        }
+    }
+
+    [Fact]
+    public void HasStoredCredentials_ManagedIdentity_IsTrue_WithoutCredential()
+    {
+        var cs = new CredentialService();
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            AuthenticationType = AuthenticationTypes.ManagedIdentity
+        };
+
+        Assert.True(server.HasStoredCredentials(cs));
+    }
+
+    [Fact]
+    public void HasStoredCredentials_ServicePrincipal_ReflectsCredentialManager()
+    {
+        var cs = new CredentialService();
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            AuthenticationType = AuthenticationTypes.ServicePrincipal
+        };
+        try
+        {
+            Assert.False(server.HasStoredCredentials(cs));
+
+            Assert.True(cs.SaveCredential(server.Id, "client", "secret"));
+            Assert.True(server.HasStoredCredentials(cs));
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+        }
+    }
+}

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -43,10 +43,30 @@ public class ServerConnection : INotifyPropertyChanged
     }
     
     /// <summary>
-    /// Authentication type: Windows, SqlServer, or EntraMFA
+    /// Authentication type: Windows, SqlServer, EntraMFA, ServicePrincipal, or ManagedIdentity
     /// </summary>
     public string AuthenticationType { get; set; } = AuthenticationTypes.Windows;
-    
+
+    /// <summary>
+    /// Service-principal application/client id (used as UserID for ServicePrincipal auth).
+    /// Non-secret; safe to persist in servers.json. The SP secret is NEVER stored here —
+    /// it lives only in Windows Credential Manager (DPAPI) via CredentialService.
+    /// </summary>
+    public string? AzureClientId { get; set; }
+
+    /// <summary>
+    /// Optional Microsoft Entra tenant id. Stored for display/future use only.
+    /// MDS resolves the tenant from the target server's AAD authority during the handshake,
+    /// so this is NOT injected into the connection string (no first-class SP tenant keyword).
+    /// </summary>
+    public string? AzureTenantId { get; set; }
+
+    /// <summary>
+    /// Optional user-assigned managed identity client id. Blank = system-assigned identity.
+    /// Non-secret; safe to persist in servers.json.
+    /// </summary>
+    public string? ManagedIdentityClientId { get; set; }
+
     public string? Description { get; set; }
     public DateTime CreatedDate { get; set; } = DateTime.Now;
     public DateTime LastConnected { get; set; } = DateTime.Now;
@@ -126,6 +146,8 @@ public class ServerConnection : INotifyPropertyChanged
     {
         AuthenticationTypes.EntraMFA => "Microsoft Entra MFA",
         AuthenticationTypes.SqlServer => "SQL Server",
+        AuthenticationTypes.ServicePrincipal => "Azure — Service Principal",
+        AuthenticationTypes.ManagedIdentity => "Azure — Managed Identity",
         _ => "Windows"
     };
 
@@ -196,8 +218,11 @@ public class ServerConnection : INotifyPropertyChanged
         string? username = null;
         string? password = null;
 
-        if (AuthenticationType == AuthenticationTypes.SqlServer)
+        if (AuthenticationType == AuthenticationTypes.SqlServer ||
+            AuthenticationType == AuthenticationTypes.ServicePrincipal)
         {
+            // SqlServer: stored username + password.
+            // ServicePrincipal: stored client id (Username) + client secret (Password).
             var cred = credentialService.GetCredential(Id);
             if (cred.HasValue)
             {
@@ -205,6 +230,7 @@ public class ServerConnection : INotifyPropertyChanged
                 password = cred.Value.Password;
             }
         }
+        // ManagedIdentity fetches no credential (no secret).
 
         return BuildConnectionString(username, password);
     }
@@ -230,7 +256,7 @@ public class ServerConnection : INotifyPropertyChanged
     /// <summary>
     /// Builds the connection string with the given credentials.
     /// </summary>
-    private string BuildConnectionString(string? username, string? password)
+    internal string BuildConnectionString(string? username, string? password)
     {
         var builder = new SqlConnectionStringBuilder
         {
@@ -253,17 +279,41 @@ public class ServerConnection : INotifyPropertyChanged
             _ => SqlConnectionEncryptOption.Optional
         };
 
-        if (AuthenticationType == AuthenticationTypes.Windows)
+        ApplyAuthentication(builder, AuthenticationType, username, password, AzureClientId, ManagedIdentityClientId);
+
+        return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Applies the authentication-mode keywords (IntegratedSecurity / Authentication / UserID /
+    /// Password) to a connection-string builder. Shared by <see cref="BuildConnectionString"/> and
+    /// the Add/Edit dialog's Test-Connection builder so the two build sites never diverge.
+    /// </summary>
+    /// <param name="builder">The builder to mutate.</param>
+    /// <param name="authenticationType">One of the <see cref="AuthenticationTypes"/> constants.</param>
+    /// <param name="username">SQL username, Entra UPN, or SP client id (depending on mode).</param>
+    /// <param name="password">SQL password or SP client secret (depending on mode). Never logged.</param>
+    /// <param name="azureClientId">SP client id fallback when <paramref name="username"/> is null.</param>
+    /// <param name="managedIdentityClientId">User-assigned MI client id; blank = system-assigned.</param>
+    internal static void ApplyAuthentication(
+        SqlConnectionStringBuilder builder,
+        string authenticationType,
+        string? username,
+        string? password,
+        string? azureClientId,
+        string? managedIdentityClientId)
+    {
+        if (authenticationType == AuthenticationTypes.Windows)
         {
             builder.IntegratedSecurity = true;
         }
-        else if (AuthenticationType == AuthenticationTypes.SqlServer)
+        else if (authenticationType == AuthenticationTypes.SqlServer)
         {
             builder.IntegratedSecurity = false;
             builder.UserID = username ?? string.Empty;
             builder.Password = password ?? string.Empty;
         }
-        else if (AuthenticationType == AuthenticationTypes.EntraMFA)
+        else if (authenticationType == AuthenticationTypes.EntraMFA)
         {
             // Microsoft Entra MFA (Azure AD Interactive)
             builder.IntegratedSecurity = false;
@@ -274,8 +324,24 @@ public class ServerConnection : INotifyPropertyChanged
                 builder.UserID = username;
             }
         }
-
-        return builder.ConnectionString;
+        else if (authenticationType == AuthenticationTypes.ServicePrincipal)
+        {
+            // Microsoft Entra service principal (non-interactive): client id + secret.
+            builder.IntegratedSecurity = false;
+            builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryServicePrincipal;
+            builder.UserID = username ?? azureClientId ?? string.Empty;   // client/app id
+            builder.Password = password ?? string.Empty;                  // client secret (from Credential Manager)
+        }
+        else if (authenticationType == AuthenticationTypes.ManagedIdentity)
+        {
+            // Azure managed identity (non-interactive): no secret.
+            builder.IntegratedSecurity = false;
+            builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
+            if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
+            {
+                builder.UserID = managedIdentityClientId;   // user-assigned MI; omit for system-assigned
+            }
+        }
     }
 
     /// <summary>
@@ -283,11 +349,15 @@ public class ServerConnection : INotifyPropertyChanged
     /// </summary>
     public bool HasStoredCredentials(CredentialService credentialService)
     {
-        if (AuthenticationType == AuthenticationTypes.Windows || AuthenticationType == AuthenticationTypes.EntraMFA)
+        // Zero-touch auth modes need no stored secret.
+        if (AuthenticationType == AuthenticationTypes.Windows ||
+            AuthenticationType == AuthenticationTypes.EntraMFA ||
+            AuthenticationType == AuthenticationTypes.ManagedIdentity)
         {
             return true;
         }
 
+        // SqlServer (password) and ServicePrincipal (client secret) require a stored credential.
         return credentialService.CredentialExists(Id);
     }
 }

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -123,6 +123,16 @@ public class ServerManager
                 throw new InvalidOperationException("Failed to save username to Windows Credential Manager");
             }
         }
+        else if (server.AuthenticationType == AuthenticationTypes.ServicePrincipal && !string.IsNullOrEmpty(username) && password != null)
+        {
+            // For service principal, save client id (username) + client secret (password).
+            // The secret lives ONLY in Windows Credential Manager (DPAPI), never in servers.json.
+            if (!_credentialService.SaveCredential(server.Id, username, password))
+            {
+                throw new InvalidOperationException("Failed to save service principal secret to Windows Credential Manager");
+            }
+        }
+        // ManagedIdentity stores nothing (no secret).
 
         // Initialize status as unknown for new server
         _connectionStatuses[server.Id] = new ServerConnectionStatus { ServerId = server.Id };
@@ -165,9 +175,21 @@ public class ServerManager
                 throw new InvalidOperationException("Failed to update username in Windows Credential Manager");
             }
         }
-        else if (server.AuthenticationType == AuthenticationTypes.Windows)
+        else if (server.AuthenticationType == AuthenticationTypes.ServicePrincipal && !string.IsNullOrEmpty(username) && password != null)
         {
-            // For Windows auth, remove any stored credentials
+            // For service principal, update client id (username) + client secret (password).
+            // The secret lives ONLY in Windows Credential Manager (DPAPI), never in servers.json.
+            if (!_credentialService.UpdateCredential(server.Id, username, password))
+            {
+                throw new InvalidOperationException("Failed to update service principal secret in Windows Credential Manager");
+            }
+        }
+        else if (server.AuthenticationType == AuthenticationTypes.Windows ||
+                 server.AuthenticationType == AuthenticationTypes.ManagedIdentity)
+        {
+            // Zero-touch auth (Windows / Managed Identity): remove any stored credential.
+            // This also deletes an orphaned secret left behind when switching away from
+            // SqlServer or ServicePrincipal (e.g. SP -> MI, SP -> Windows).
             _credentialService.DeleteCredential(server.Id);
         }
 

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -185,11 +185,18 @@ public class ServerManager
             }
         }
         else if (server.AuthenticationType == AuthenticationTypes.Windows ||
-                 server.AuthenticationType == AuthenticationTypes.ManagedIdentity)
+                 server.AuthenticationType == AuthenticationTypes.ManagedIdentity ||
+                 server.AuthenticationType == AuthenticationTypes.EntraMFA)
         {
             // Zero-touch auth (Windows / Managed Identity): remove any stored credential.
             // This also deletes an orphaned secret left behind when switching away from
             // SqlServer or ServicePrincipal (e.g. SP -> MI, SP -> Windows).
+            //
+            // EntraMFA reaches this arm ONLY when the MFA username is blank, because the
+            // earlier EntraMFA arm (which requires a non-blank username) runs first and stores
+            // the username. The blank-username case is exactly the orphan case: switching e.g.
+            // SP -> EntraMFA with no username must delete the stale SP client secret rather than
+            // leaving it in Credential Manager indefinitely.
             _credentialService.DeleteCredential(server.Id);
         }
 

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -45,6 +45,12 @@
             <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA" Foreground="{DynamicResource ForegroundBrush}"
                          Checked="AuthMode_Changed"
                          ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
+            <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed" Margin="0,4,0,0"
+                         ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+            <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed" Margin="0,4,0,0"
+                         ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running Lite."/>
         </StackPanel>
 
         <!-- SQL Auth Credentials -->
@@ -60,6 +66,27 @@
             <TextBlock Text="Username (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
             <TextBox x:Name="EntraMfaUsernameBox" Margin="0,0,0,8"
                      ToolTip="Optional: Pre-populate the authentication dialog with this email"/>
+        </StackPanel>
+
+        <!-- Service Principal Credentials -->
+        <StackPanel Grid.Row="7" x:Name="ServicePrincipalPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Client (Application) ID" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureClientIdBox" Margin="0,0,0,8"
+                     ToolTip="The Application (client) ID of the Entra app registration / service principal."/>
+            <TextBlock Text="Client Secret" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="AzureClientSecretBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Tenant ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureTenantIdBox" Margin="0,0,0,4"
+                     ToolTip="Optional. Stored for reference; the tenant is resolved automatically from the target server."/>
+        </StackPanel>
+
+        <!-- Managed Identity Credentials -->
+        <StackPanel Grid.Row="7" x:Name="ManagedIdentityPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="User-Assigned Identity Client ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="ManagedIdentityClientIdBox" Margin="0,0,0,8"
+                     ToolTip="Leave blank to use the system-assigned managed identity. Set to a client id to use a specific user-assigned identity."/>
+            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                       Text="Managed Identity only works when Lite is running on an Azure VM / resource that has a managed identity assigned — not on a typical workstation. Use Service Principal for non-interactive auth from a workstation."/>
         </StackPanel>
 
         <!-- Connection Options -->

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -81,7 +81,7 @@ public partial class AddServerDialog : Window
         else if (existing.AuthenticationType == AuthenticationTypes.SqlServer)
         {
             SqlAuthRadio.IsChecked = true;
-            
+
             // Load credentials if stored
             var credentialService = new CredentialService();
             var cred = credentialService.GetCredential(existing.Id);
@@ -90,6 +90,28 @@ public partial class AddServerDialog : Window
                 UsernameBox.Text = cred.Value.Username;
                 PasswordBox.Password = cred.Value.Password;
             }
+        }
+        else if (existing.AuthenticationType == AuthenticationTypes.ServicePrincipal)
+        {
+            ServicePrincipalAuthRadio.IsChecked = true;
+            AzureClientIdBox.Text = existing.AzureClientId ?? "";
+            AzureTenantIdBox.Text = existing.AzureTenantId ?? "";
+
+            // Pre-fill the client id and secret from Credential Manager (mirrors SQL-password pre-fill).
+            var credentialService = new CredentialService();
+            var cred = credentialService.GetCredential(existing.Id);
+            if (cred.HasValue)
+            {
+                // The stored credential's username is the client id; prefer the model value when present.
+                if (string.IsNullOrEmpty(AzureClientIdBox.Text))
+                    AzureClientIdBox.Text = cred.Value.Username;
+                AzureClientSecretBox.Password = cred.Value.Password;
+            }
+        }
+        else if (existing.AuthenticationType == AuthenticationTypes.ManagedIdentity)
+        {
+            ManagedIdentityAuthRadio.IsChecked = true;
+            ManagedIdentityClientIdBox.Text = existing.ManagedIdentityClientId ?? "";
         }
         else
         {
@@ -101,15 +123,26 @@ public partial class AddServerDialog : Window
 
     private void AuthMode_Changed(object sender, RoutedEventArgs e)
     {
-        if (SqlCredentialsPanel != null && EntraMfaPanel != null)
+        if (SqlCredentialsPanel != null && EntraMfaPanel != null &&
+            ServicePrincipalPanel != null && ManagedIdentityPanel != null)
         {
             // Show credentials panel for SQL Server authentication
             SqlCredentialsPanel.Visibility = SqlAuthRadio.IsChecked == true
                 ? Visibility.Visible
                 : Visibility.Collapsed;
-            
+
             // Show MFA panel for Microsoft Entra MFA
             EntraMfaPanel.Visibility = EntraMfaAuthRadio.IsChecked == true
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+            // Show service principal panel
+            ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+            // Show managed identity panel
+            ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }
@@ -152,24 +185,47 @@ public partial class AddServerDialog : Window
             MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true
         };
 
+        // Determine auth type + per-mode credentials from the live UI controls, then apply via the
+        // SHARED helper so this Test-Connection builder never diverges from ServerConnection's
+        // production builder (the two-bodies trap). See ServerConnection.ApplyAuthentication.
+        string authType;
+        string? userId = null;
+        string? secret = null;
+        string? azureClientId = null;
+        string? managedIdentityClientId = null;
+
         if (WindowsAuthRadio.IsChecked == true)
         {
-            builder.IntegratedSecurity = true;
+            authType = AuthenticationTypes.Windows;
         }
         else if (SqlAuthRadio.IsChecked == true)
         {
-            builder.IntegratedSecurity = false;
-            builder.UserID = UsernameBox.Text.Trim();
-            builder.Password = PasswordBox.Password;
+            authType = AuthenticationTypes.SqlServer;
+            userId = UsernameBox.Text.Trim();
+            secret = PasswordBox.Password;
         }
         else if (EntraMfaAuthRadio.IsChecked == true)
         {
-            builder.IntegratedSecurity = false;
-            builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
-            var mfaUsername = EntraMfaUsernameBox.Text.Trim();
-            if (!string.IsNullOrEmpty(mfaUsername))
-                builder.UserID = mfaUsername;
+            authType = AuthenticationTypes.EntraMFA;
+            userId = EntraMfaUsernameBox.Text.Trim();
         }
+        else if (ServicePrincipalAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ServicePrincipal;
+            userId = AzureClientIdBox.Text.Trim();
+            secret = AzureClientSecretBox.Password;
+        }
+        else if (ManagedIdentityAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ManagedIdentity;
+            managedIdentityClientId = ManagedIdentityClientIdBox.Text.Trim();
+        }
+        else
+        {
+            authType = AuthenticationTypes.SqlServer;
+        }
+
+        ServerConnection.ApplyAuthentication(builder, authType, userId, secret, azureClientId, managedIdentityClientId);
 
         return builder;
     }
@@ -289,6 +345,29 @@ public partial class AddServerDialog : Window
             authenticationType = AuthenticationTypes.EntraMFA;
             username = EntraMfaUsernameBox.Text.Trim();
         }
+        else if (ServicePrincipalAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.ServicePrincipal;
+            // For service principal, the credential is (client id, client secret).
+            username = AzureClientIdBox.Text.Trim();
+            password = AzureClientSecretBox.Password;
+
+            if (string.IsNullOrEmpty(username))
+            {
+                StatusText.Text = "Client (Application) ID is required for service principal authentication.";
+                return;
+            }
+            if (string.IsNullOrEmpty(password))
+            {
+                StatusText.Text = "Client secret is required for service principal authentication.";
+                return;
+            }
+        }
+        else if (ManagedIdentityAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.ManagedIdentity;
+            // No secret to store for managed identity.
+        }
         else // SQL Server Authentication
         {
             authenticationType = AuthenticationTypes.SqlServer;
@@ -345,6 +424,15 @@ public partial class AddServerDialog : Window
                 AddedServer.ServerName = serverName;
                 AddedServer.DisplayName = displayName;
                 AddedServer.AuthenticationType = authenticationType;
+                AddedServer.AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
+                    : null;
+                AddedServer.AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
+                    : null;
+                AddedServer.ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                    ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
+                    : null;
                 AddedServer.IsEnabled = EnabledCheckBox.IsChecked == true;
                 AddedServer.TrustServerCertificate = TrustCertCheckBox.IsChecked == true;
                 AddedServer.EncryptMode = GetSelectedEncryptMode();
@@ -371,6 +459,15 @@ public partial class AddServerDialog : Window
                     ServerName = serverName,
                     DisplayName = displayName,
                     AuthenticationType = authenticationType,
+                    AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                        ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
+                        : null,
+                    AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                        ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
+                        : null,
+                    ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                        ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
+                        : null,
                     IsEnabled = EnabledCheckBox.IsChecked == true,
                     TrustServerCertificate = TrustCertCheckBox.IsChecked == true,
                     EncryptMode = GetSelectedEncryptMode(),

--- a/PerformanceMonitor.Common/Models/AuthenticationTypes.cs
+++ b/PerformanceMonitor.Common/Models/AuthenticationTypes.cs
@@ -27,4 +27,17 @@ public static class AuthenticationTypes
     /// Microsoft Entra MFA (Azure AD) interactive authentication.
     /// </summary>
     public const string EntraMFA = "EntraMFA";
+
+    /// <summary>
+    /// Microsoft Entra service principal (client id + secret) — non-interactive.
+    /// Maps to SqlAuthenticationMethod.ActiveDirectoryServicePrincipal.
+    /// </summary>
+    public const string ServicePrincipal = "ServicePrincipal";
+
+    /// <summary>
+    /// Azure managed identity (system- or user-assigned) — non-interactive.
+    /// Maps to SqlAuthenticationMethod.ActiveDirectoryManagedIdentity.
+    /// Only works when the app runs on an Azure resource with a managed identity.
+    /// </summary>
+    public const string ManagedIdentity = "ManagedIdentity";
 }


### PR DESCRIPTION
## What shipped (Phase A of #1038)

Two non-interactive Azure SQL auth modes for Lite, so a fleet of Azure SQL instances can authenticate with **no per-server interactive prompt**:

- **Service Principal** — `Authentication=ActiveDirectoryServicePrincipal`, client id + client secret.
- **Managed Identity** — `Authentication=ActiveDirectoryManagedIdentity`, system-assigned (no id) or user-assigned (client id).

Both ride the **same AAD provider infrastructure that already powers EntraMFA**, selected via the `Authentication=` keyword. Per-server (credential profiles are deferred Phase B).

### Changes
- `AuthenticationTypes`: `ServicePrincipal` / `ManagedIdentity` constants (additive, backward compatible).
- `ServerConnection`: non-secret model fields `AzureClientId` / `AzureTenantId` (stored-but-unused; MDS resolves tenant from the server authority) / `ManagedIdentityClientId`; SP + MI connection-string arms; `GetConnectionString` fetches the SP secret (MI fetches nothing); `HasStoredCredentials` (MI = true, SP = Credential-Manager check); `AuthenticationDisplay` arms (was a silent `_ => "Windows"`). Auth-keyword logic extracted into a shared `ApplyAuthentication` helper.
- `ServerManager`: save SP secret on Add/Update; explicit orphan-secret delete when switching SP→MI / SP→Windows; `DeleteServer` already clears it.
- `AddServerDialog` (XAML + code-behind): SP + MI radios and panels (shared `Grid.Row=7` visibility toggle); MI panel carries the workstation-vs-Azure note; edit-load pre-fills the SP client id + secret from Credential Manager (mirrors the SQL-password pre-fill); persists the new fields; Test-Connection builder routed through the shared helper.

### Two-build-site handling
The dialog's `BuildConnectionBuilder` (Test Connection) and `ServerConnection.BuildConnectionString` (production) are the two auth-deciding build sites. Rather than maintain two parallel arm-sets, both now call the shared `ServerConnection.ApplyAuthentication`. A parity test asserts they emit identical `Authentication`/`UserID`/`Password`/`IntegratedSecurity` for every auth mode.

### Security
- The SP **secret lives only in Windows Credential Manager (DPAPI)** via the existing per-server-GUID `CredentialService`. It is **never** a serialized model property (not in `servers.json`) and **never logged** (no connection-string-on-error path).
- MI stores nothing.

### Dependency note
**No new NuGet.** SP/MI use the AAD providers in the already-referenced `Microsoft.Data.SqlClient.Extensions.Azure 1.0.0` (transitively MSAL + Azure.Identity). That reference is **load-bearing** — if it is dropped/bumped, SP + MI + EntraMFA break together.

## Build + test (real results)

```
dotnet build Lite/PerformanceMonitorLite.csproj -c Debug
Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test Lite.Tests
Passed! - Failed: 0, Passed: 334, Skipped: 0, Total: 334  (22 new Azure-auth tests)
```

New tests: SP shape (ActiveDirectoryServicePrincipal, UserID=clientId, Password=secret, IntegratedSecurity=false, Encrypt honored); MI system- and user-assigned; `GetConnectionString` SP-secret fetch / MI no-fetch; `HasStoredCredentials` (MI true, SP cred-manager); `AuthenticationDisplay`; two-build-site parity; Windows/SqlServer/EntraMFA regression.

## Maintainer Azure E2E checklist (plan §9 — cannot be unit-tested without a tenant)
- [ ] Real Azure SQL DB + service principal granted access → add SP server in Lite → Test → connects non-interactively; collection runs.
- [ ] (If available) Azure-VM-hosted Lite with a managed identity → MI server connects with no secret.
- [ ] A fleet of several SP servers connects in **parallel** (proves the MFA serialization lock excludes SP/MI) — no serialization, no interactive prompt.
- [ ] Secret rotation via Edit Server reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)