### PR TITLE
Lite: shared credential profiles — #1038 Phase B

### DIFF
--- a/Lite.Tests/AzureAuthConnectionStringTests.cs
+++ b/Lite.Tests/AzureAuthConnectionStringTests.cs
@@ -209,10 +209,15 @@ public class AzureAuthConnectionStringTests
     // These touch the real Windows Credential Manager (DPAPI, per-user). Each test uses a unique
     // GUID server id and deletes its credential afterward.
 
+    // Profile-less resolver: regression-identical to the removed GetConnectionString(CredentialService)
+    // instance overload. A null IProfileLookup means every server resolves to its own inline auth.
+    private static CredentialResolver ProfileLessResolver(CredentialService cs) => new(cs, profileLookup: null);
+
     [Fact]
     public void GetConnectionString_ServicePrincipal_FetchesStoredSecret()
     {
         var cs = new CredentialService();
+        var resolver = ProfileLessResolver(cs);
         var server = new ServerConnection
         {
             ServerName = "s",
@@ -222,7 +227,7 @@ public class AzureAuthConnectionStringTests
         {
             Assert.True(cs.SaveCredential(server.Id, "stored-client-id", "stored-secret"));
 
-            var conn = Parse(server.GetConnectionString(cs));
+            var conn = Parse(resolver.GetConnectionString(server));
 
             Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
             Assert.Equal("stored-client-id", conn.UserID);
@@ -238,6 +243,7 @@ public class AzureAuthConnectionStringTests
     public void GetConnectionString_ManagedIdentity_FetchesNoSecret()
     {
         var cs = new CredentialService();
+        var resolver = ProfileLessResolver(cs);
         var server = new ServerConnection
         {
             ServerName = "s",
@@ -248,7 +254,7 @@ public class AzureAuthConnectionStringTests
             // Even if a stale credential somehow existed, MI must not pull it into the string.
             cs.SaveCredential(server.Id, "leftover", "leftover-secret");
 
-            var conn = Parse(server.GetConnectionString(cs));
+            var conn = Parse(resolver.GetConnectionString(server));
 
             Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, conn.Authentication);
             Assert.True(string.IsNullOrEmpty(conn.Password));
@@ -264,19 +270,21 @@ public class AzureAuthConnectionStringTests
     public void HasStoredCredentials_ManagedIdentity_IsTrue_WithoutCredential()
     {
         var cs = new CredentialService();
+        var resolver = ProfileLessResolver(cs);
         var server = new ServerConnection
         {
             Id = Guid.NewGuid().ToString(),
             AuthenticationType = AuthenticationTypes.ManagedIdentity
         };
 
-        Assert.True(server.HasStoredCredentials(cs));
+        Assert.True(resolver.HasStoredCredentials(server));
     }
 
     [Fact]
     public void HasStoredCredentials_ServicePrincipal_ReflectsCredentialManager()
     {
         var cs = new CredentialService();
+        var resolver = ProfileLessResolver(cs);
         var server = new ServerConnection
         {
             Id = Guid.NewGuid().ToString(),
@@ -284,10 +292,10 @@ public class AzureAuthConnectionStringTests
         };
         try
         {
-            Assert.False(server.HasStoredCredentials(cs));
+            Assert.False(resolver.HasStoredCredentials(server));
 
             Assert.True(cs.SaveCredential(server.Id, "client", "secret"));
-            Assert.True(server.HasStoredCredentials(cs));
+            Assert.True(resolver.HasStoredCredentials(server));
         }
         finally
         {

--- a/Lite.Tests/CredentialProfileTests.cs
+++ b/Lite.Tests/CredentialProfileTests.cs
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Tests for shared credential profiles (#1038 Phase B): ProfileManager CRUD/persistence, the
+/// fail-closed atomic-tuple resolution (profile creds NOT the server's stale fields), the HARD
+/// dangling-profile test, profile-aware HasStoredCredentials, secret keying, referential integrity,
+/// switch-cleanup, and import round-trip + secret-absent tolerance.
+///
+/// ProfileManager/ServerManager tests touch the real Windows Credential Manager (DPAPI, per-user)
+/// and a temp config dir; each test cleans up. Pure resolution tests use an in-memory IProfileLookup
+/// stub so they don't depend on Credential Manager for the profile non-secret fields.
+/// </summary>
+public class CredentialProfileTests
+{
+    private static SqlConnectionStringBuilder Parse(string connStr) => new(connStr);
+
+    /// <summary>In-memory profile lookup for resolution tests (no Credential Manager dependency for fields).</summary>
+    private sealed class StubProfileLookup : IProfileLookup
+    {
+        private readonly Dictionary<string, CredentialProfile> _byId = new();
+        public void Add(CredentialProfile p) => _byId[p.Id] = p;
+        public CredentialProfile? GetProfile(string id) => _byId.TryGetValue(id, out var p) ? p : null;
+    }
+
+    private static string NewTempConfigDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "pmlite-proftest-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    // ---- Resolution: profile creds, NOT the server's stale fields (B-3) -----------------------
+
+    [Fact]
+    public void Resolution_ProfileServicePrincipal_UsesProfileClientId_NotServerStaleAzureClientId()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup();
+        var profileId = Guid.NewGuid().ToString();
+        lookup.Add(new CredentialProfile
+        {
+            Id = profileId,
+            Name = "fleet-sp",
+            AuthType = AuthenticationTypes.ServicePrincipal,
+            AzureClientId = "profile-client-id"
+        });
+
+        // The server carries a STALE inline AzureClientId that must NOT leak into the resolved string.
+        var server = new ServerConnection
+        {
+            ServerName = "myazure.database.windows.net",
+            AuthenticationType = AuthenticationTypes.SqlServer, // overridden by the profile
+            AzureClientId = "STALE-server-client-id",
+            CredentialProfileId = profileId
+        };
+
+        try
+        {
+            // Profile secret lives under profile_{id}.
+            Assert.True(cs.SaveCredential(ProfileManager.ProfileCredentialId(profileId), "profile-client-id", "profile-secret"));
+
+            var conn = Parse(ServerConnection.ResolveConnectionString(server, cs, lookup));
+
+            Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+            Assert.Equal("profile-client-id", conn.UserID);       // from the profile, not the server
+            Assert.Equal("profile-secret", conn.Password);
+            Assert.NotEqual("STALE-server-client-id", conn.UserID); // server's stale field never used
+        }
+        finally
+        {
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profileId));
+        }
+    }
+
+    [Fact]
+    public void Resolution_ProfileLessServer_IsRegressionIdentical()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup();
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.SqlServer
+            // no CredentialProfileId
+        };
+        try
+        {
+            Assert.True(cs.SaveCredential(server.Id, "sa", "pw"));
+
+            var conn = Parse(ServerConnection.ResolveConnectionString(server, cs, lookup));
+
+            Assert.False(conn.IntegratedSecurity);
+            Assert.Equal("sa", conn.UserID);
+            Assert.Equal("pw", conn.Password);
+            Assert.Equal(SqlAuthenticationMethod.NotSpecified, conn.Authentication);
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+        }
+    }
+
+    // ---- HARD: dangling profile must THROW and never self-fall-back (B-2) ----------------------
+
+    [Fact]
+    public void Resolution_DanglingProfile_Throws_AndNeverFallsBackToServerSelfAuth()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup(); // intentionally EMPTY — the referenced profile is missing
+        var missingId = Guid.NewGuid().ToString();
+
+        // The server has its OWN inline SQL auth that must NEVER be used as a silent fallback.
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.SqlServer,
+            AzureClientId = "server-self-client",
+            CredentialProfileId = missingId
+        };
+        try
+        {
+            // Even with a per-server secret present, the dangling profile must fail closed.
+            cs.SaveCredential(server.Id, "server-self-user", "server-self-pw");
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => ServerConnection.ResolveConnectionString(server, cs, lookup));
+
+            Assert.Contains("credential profile", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(missingId, ex.Message);
+
+            // No connection string was produced; assert the inline auth was never converted into one.
+            // (If a wrong-identity fallback existed it would have built a string with these values.)
+            Assert.DoesNotContain("server-self-user", ex.Message);
+            Assert.DoesNotContain("server-self-pw", ex.Message);
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+        }
+    }
+
+    // ---- HasStoredCredentials profile-aware (N-1) ----------------------------------------------
+
+    [Fact]
+    public void HasStoredCredentials_ProfileBacked_ReflectsProfileSecret_NotServerKey()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup();
+        var profileId = Guid.NewGuid().ToString();
+        lookup.Add(new CredentialProfile { Id = profileId, Name = "p", AuthType = AuthenticationTypes.ServicePrincipal });
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            AuthenticationType = AuthenticationTypes.SqlServer,
+            CredentialProfileId = profileId
+        };
+        try
+        {
+            // A secret under the SERVER key must not satisfy a profile-backed check.
+            cs.SaveCredential(server.Id, "server-user", "server-pw");
+            Assert.False(ServerConnection.HasStoredCredentials(server, cs, lookup));
+
+            // Storing under the PROFILE key satisfies it.
+            cs.SaveCredential(ProfileManager.ProfileCredentialId(profileId), "client", "secret");
+            Assert.True(ServerConnection.HasStoredCredentials(server, cs, lookup));
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profileId));
+        }
+    }
+
+    [Fact]
+    public void HasStoredCredentials_ManagedIdentityProfile_IsTrue_WithoutSecret()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup();
+        var profileId = Guid.NewGuid().ToString();
+        lookup.Add(new CredentialProfile { Id = profileId, Name = "mi", AuthType = AuthenticationTypes.ManagedIdentity });
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            AuthenticationType = AuthenticationTypes.Windows,
+            CredentialProfileId = profileId
+        };
+
+        Assert.True(ServerConnection.HasStoredCredentials(server, cs, lookup));
+    }
+
+    [Fact]
+    public void HasStoredCredentials_DanglingProfile_IsFalse()
+    {
+        var cs = new CredentialService();
+        var lookup = new StubProfileLookup(); // empty
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            AuthenticationType = AuthenticationTypes.ManagedIdentity, // would be true if not profile-backed
+            CredentialProfileId = Guid.NewGuid().ToString()
+        };
+
+        Assert.False(ServerConnection.HasStoredCredentials(server, cs, lookup));
+    }
+
+    // ---- ProfileManager CRUD + persistence + secret keying -------------------------------------
+
+    [Fact]
+    public void ProfileManager_Add_Get_Persists_AndStoresSecretUnderProfileKey()
+    {
+        var configDir = NewTempConfigDir();
+        var sm = new ServerManager(configDir);
+        var pm = new ProfileManager(sm);
+        var cs = pm.CredentialService;
+
+        var profile = new CredentialProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "sql-fleet",
+            AuthType = AuthenticationTypes.SqlServer,
+            Username = "sa"
+        };
+        try
+        {
+            pm.AddProfile(profile, "sa", "the-password");
+
+            // Secret stored under profile_{id}, NOT a bare server GUID key.
+            Assert.True(cs.CredentialExists(ProfileManager.ProfileCredentialId(profile.Id)));
+            Assert.False(cs.CredentialExists(profile.Id)); // bare id key must be empty
+
+            // profiles.json on disk, no secret in it.
+            var json = File.ReadAllText(Path.Combine(configDir, "profiles.json"));
+            Assert.Contains("sql-fleet", json);
+            Assert.DoesNotContain("the-password", json);
+
+            // Round-trip: a fresh manager loads it.
+            var pm2 = new ProfileManager(new ServerManager(configDir));
+            var loaded = pm2.GetProfile(profile.Id);
+            Assert.NotNull(loaded);
+            Assert.Equal("sql-fleet", loaded!.Name);
+            Assert.Equal(AuthenticationTypes.SqlServer, loaded.AuthType);
+        }
+        finally
+        {
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profile.Id));
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ProfileManager_ManagedIdentity_StoresNoSecret()
+    {
+        var configDir = NewTempConfigDir();
+        var pm = new ProfileManager(new ServerManager(configDir));
+        var cs = pm.CredentialService;
+
+        var profile = new CredentialProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "mi",
+            AuthType = AuthenticationTypes.ManagedIdentity
+        };
+        try
+        {
+            pm.AddProfile(profile, username: null, secret: null);
+            Assert.False(cs.CredentialExists(ProfileManager.ProfileCredentialId(profile.Id)));
+            Assert.True(pm.HasStoredSecret(profile)); // MI needs none
+        }
+        finally
+        {
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ProfileManager_Delete_RemovesProfileAndSecret()
+    {
+        var configDir = NewTempConfigDir();
+        var pm = new ProfileManager(new ServerManager(configDir));
+        var cs = pm.CredentialService;
+
+        var profile = new CredentialProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "to-delete",
+            AuthType = AuthenticationTypes.ServicePrincipal,
+            AzureClientId = "cid"
+        };
+        try
+        {
+            pm.AddProfile(profile, "cid", "sec");
+            Assert.True(cs.CredentialExists(ProfileManager.ProfileCredentialId(profile.Id)));
+
+            pm.DeleteProfile(profile.Id);
+
+            Assert.Null(pm.GetProfile(profile.Id));
+            Assert.False(cs.CredentialExists(ProfileManager.ProfileCredentialId(profile.Id)));
+        }
+        finally
+        {
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profile.Id));
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+
+    // ---- Referential integrity: delete blocked while referenced (§6) ---------------------------
+
+    [Fact]
+    public void ProfileManager_Delete_BlockedWhileServerReferences_AllowedAfterReassign()
+    {
+        var configDir = NewTempConfigDir();
+        var sm = new ServerManager(configDir);
+        var pm = new ProfileManager(sm);
+        var cs = pm.CredentialService;
+
+        var profile = new CredentialProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "shared",
+            AuthType = AuthenticationTypes.SqlServer,
+            Username = "sa"
+        };
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            ServerName = "s",
+            CredentialProfileId = profile.Id
+        };
+        try
+        {
+            pm.AddProfile(profile, "sa", "pw");
+            sm.AddServer(server);
+
+            // Blocked while referenced.
+            var ex = Assert.Throws<InvalidOperationException>(() => pm.DeleteProfile(profile.Id));
+            Assert.Contains("used by", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(pm.GetProfile(profile.Id));
+
+            // Reassign (clear the reference) then delete succeeds.
+            server.CredentialProfileId = null;
+            sm.UpdateServer(server);
+            pm.DeleteProfile(profile.Id);
+            Assert.Null(pm.GetProfile(profile.Id));
+        }
+        finally
+        {
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profile.Id));
+            cs.DeleteCredential(server.Id);
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+
+    // ---- Switch-cleanup: assigning a profile deletes the orphaned per-server secret (M-3) ------
+    // Mirrors the dialog's M-3 scrub: store no per-server secret + explicitly delete the server key.
+
+    [Fact]
+    public void SwitchToProfile_DeletesOrphanedPerServerSecret()
+    {
+        var configDir = NewTempConfigDir();
+        var sm = new ServerManager(configDir);
+        var cs = sm.CredentialService;
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.SqlServer
+        };
+        try
+        {
+            // Server starts with an inline SQL secret.
+            sm.AddServer(server, "sa", "inline-pw");
+            Assert.True(cs.CredentialExists(server.Id));
+
+            // Switch onto a profile: the dialog's M-3 path nulls per-server identity, persists with no
+            // secret, and explicitly deletes the per-server key.
+            server.CredentialProfileId = Guid.NewGuid().ToString();
+            server.AzureClientId = null;
+            server.AzureTenantId = null;
+            server.ManagedIdentityClientId = null;
+            sm.UpdateServer(server, null, null);
+            cs.DeleteCredential(server.Id);
+
+            Assert.False(cs.CredentialExists(server.Id), "orphaned per-server secret must be deleted");
+        }
+        finally
+        {
+            cs.DeleteCredential(server.Id);
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+
+    // ---- Import round-trip + secret-absent tolerance (§7) --------------------------------------
+
+    [Fact]
+    public void Import_RoundTrips_AndBuildTolerates_SecretAbsentImportedProfile()
+    {
+        var srcDir = NewTempConfigDir();
+        var dstDir = NewTempConfigDir();
+        var cs = new CredentialService();
+
+        // Build a source profiles.json via a source ProfileManager (no secret stored for it; imports
+        // never carry secrets).
+        var srcPm = new ProfileManager(new ServerManager(srcDir));
+        var profile = new CredentialProfile
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "imported-sp",
+            AuthType = AuthenticationTypes.ServicePrincipal,
+            AzureClientId = "imp-client"
+        };
+        // Add to source WITHOUT a secret to simulate "secret not importable".
+        srcPm.AddProfile(profile, username: null, secret: null);
+        var srcProfilesPath = Path.Combine(srcDir, "profiles.json");
+
+        var dstSm = new ServerManager(dstDir);
+        var dstPm = new ProfileManager(dstSm);
+        dstSm.ProfileLookup = dstPm;
+
+        try
+        {
+            var (imported, _) = dstPm.ImportProfilesFromFile(srcProfilesPath);
+            Assert.Equal(1, imported);
+
+            var loaded = dstPm.GetProfile(profile.Id);
+            Assert.NotNull(loaded);
+            Assert.Equal("imported-sp", loaded!.Name);
+
+            // A server pointed at the imported (secret-absent) profile resolves WITHOUT a wrong identity:
+            // the SP build simply has an empty Password (no secret in Credential Manager), never the
+            // server's own creds. It does NOT throw (the profile exists; only its secret is missing).
+            var server = new ServerConnection
+            {
+                Id = Guid.NewGuid().ToString(),
+                ServerName = "s",
+                AuthenticationType = AuthenticationTypes.SqlServer,
+                CredentialProfileId = profile.Id
+            };
+            var conn = Parse(ServerConnection.ResolveConnectionString(server, cs, dstPm));
+            Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+            Assert.Equal("imp-client", conn.UserID); // profile's non-secret client id
+            Assert.True(string.IsNullOrEmpty(conn.Password)); // secret absent → empty, never wrong identity
+        }
+        finally
+        {
+            cs.DeleteCredential(ProfileManager.ProfileCredentialId(profile.Id));
+            try { Directory.Delete(srcDir, recursive: true); } catch { }
+            try { Directory.Delete(dstDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ProfileManager_NameUniqueness_EnforcedPerProcess()
+    {
+        var configDir = NewTempConfigDir();
+        var pm = new ProfileManager(new ServerManager(configDir));
+        var cs = pm.CredentialService;
+
+        var a = new CredentialProfile { Id = Guid.NewGuid().ToString(), Name = "dup", AuthType = AuthenticationTypes.ManagedIdentity };
+        var b = new CredentialProfile { Id = Guid.NewGuid().ToString(), Name = "dup", AuthType = AuthenticationTypes.ManagedIdentity };
+        try
+        {
+            pm.AddProfile(a);
+            Assert.Throws<InvalidOperationException>(() => pm.AddProfile(b));
+        }
+        finally
+        {
+            try { Directory.Delete(configDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -31,7 +31,7 @@ public class SqlPlanFetcher : IPlanFetcher
 
         try
         {
-            var connectionString = server.GetConnectionString(_serverManager.CredentialService);
+            var connectionString = _serverManager.CredentialResolver.GetConnectionString(server);
             var builder = new SqlConnectionStringBuilder(connectionString)
             {
                 ConnectTimeout = 10,

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -28,7 +28,7 @@ public partial class FinOpsTab : UserControl
 {
     private LocalDataService? _dataService;
     private ServerManager? _serverManager;
-    private CredentialService? _credentialService;
+    private CredentialResolver? _credentialResolver;
     private List<ServerPropertyRow>? _serverInventoryCache;
     private DateTime _serverInventoryCacheTime;
 
@@ -64,7 +64,7 @@ public partial class FinOpsTab : UserControl
     {
         _dataService = dataService;
         _serverManager = serverManager;
-        _credentialService = serverManager.CredentialService;
+        _credentialResolver = serverManager.CredentialResolver;
 
         PopulateServerSelector();
         RefreshData();
@@ -158,15 +158,15 @@ public partial class FinOpsTab : UserControl
 
     private async System.Threading.Tasks.Task LoadRecommendationsAsync(int serverId)
     {
-        if (_dataService == null || _credentialService == null) return;
+        if (_dataService == null || _credentialResolver == null) return;
 
         try
         {
             var selectedServer = ServerSelector.SelectedItem as Models.ServerConnection;
-            var connectionString = selectedServer?.GetConnectionString(_credentialService);
+            var connectionString = selectedServer == null ? null : _credentialResolver.GetConnectionString(selectedServer);
             if (string.IsNullOrEmpty(connectionString)) return;
 
-            var utilityConnectionString = selectedServer!.GetUtilityConnectionString(_credentialService);
+            var utilityConnectionString = _credentialResolver.GetUtilityConnectionString(selectedServer!);
             var data = await _dataService.GetRecommendationsAsync(serverId, connectionString, utilityConnectionString, _currentServerMonthlyCost);
             RecommendationsDataGrid.ItemsSource = data;
             RecommendationsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
@@ -438,7 +438,7 @@ public partial class FinOpsTab : UserControl
     private async System.Threading.Tasks.Task LoadServerInventoryAsync(bool forceRefresh = false)
     {
         using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-ServerInventory");
-        if (_dataService == null || _serverManager == null || _credentialService == null) return;
+        if (_dataService == null || _serverManager == null || _credentialResolver == null) return;
 
         // Use cache if available and less than 5 minutes old
         if (!forceRefresh && _serverInventoryCache != null
@@ -458,7 +458,7 @@ public partial class FinOpsTab : UserControl
             {
                 try
                 {
-                    var connStr = server.GetConnectionString(_credentialService);
+                    var connStr = _credentialResolver.GetConnectionString(server);
 
                     // Step 1: Query live server properties
                     var item = await LocalDataService.GetServerPropertiesLiveAsync(connStr);
@@ -796,14 +796,14 @@ public partial class FinOpsTab : UserControl
     private async void RunIndexAnalysis_Click(object sender, RoutedEventArgs e)
     {
         using var _profiler = Helpers.MethodProfiler.StartTiming("FinOps-IndexAnalysis");
-        if (_serverManager == null || _credentialService == null) return;
+        if (_serverManager == null || _credentialResolver == null) return;
 
         var server = ServerSelector.SelectedItem as ServerConnection;
         if (server == null) return;
 
         try
         {
-            var utilityConnectionString = server.GetUtilityConnectionString(_credentialService);
+            var utilityConnectionString = _credentialResolver.GetUtilityConnectionString(server);
 
             var exists = await LocalDataService.CheckSpIndexCleanupExistsAsync(utilityConnectionString);
             if (!exists)

--- a/Lite/Controls/ServerTab.CopyExport.cs
+++ b/Lite/Controls/ServerTab.CopyExport.cs
@@ -163,7 +163,7 @@ public partial class ServerTab : UserControl
                 {
                     try
                     {
-                        var connStr = _server.GetConnectionString(_credentialService);
+                        var connStr = _credentialResolver.GetConnectionString(_server);
                         planXml = await LocalDataService.FetchQueryPlanOnDemandAsync(connStr, stats.QueryHash);
                     }
                     catch { /* Plan fetch failed — continue without plan */ }
@@ -179,7 +179,7 @@ public partial class ServerTab : UserControl
                 {
                     try
                     {
-                        var connStr = _server.GetConnectionString(_credentialService);
+                        var connStr = _credentialResolver.GetConnectionString(_server);
                         planXml = await LocalDataService.FetchQueryStorePlanAsync(connStr, qs.DatabaseName, qs.PlanId);
                     }
                     catch { /* Plan fetch failed — continue without plan */ }

--- a/Lite/Controls/ServerTab.Plans.cs
+++ b/Lite/Controls/ServerTab.Plans.cs
@@ -49,7 +49,7 @@ public partial class ServerTab : UserControl
             // Fall back to live server
             if (string.IsNullOrEmpty(plan))
             {
-                var connStr = _server.GetConnectionString(_credentialService);
+                var connStr = _credentialResolver.GetConnectionString(_server);
                 plan = await LocalDataService.FetchQueryPlanOnDemandAsync(connStr, row.QueryHash);
                 source = "live server";
             }
@@ -104,7 +104,7 @@ public partial class ServerTab : UserControl
             // Fall back to live server
             if (string.IsNullOrEmpty(plan))
             {
-                var connStr = _server.GetConnectionString(_credentialService);
+                var connStr = _credentialResolver.GetConnectionString(_server);
                 plan = await LocalDataService.FetchProcedurePlanOnDemandAsync(connStr, row.DatabaseName, row.SchemaName, row.ObjectName);
                 source = "live server";
             }
@@ -280,7 +280,7 @@ public partial class ServerTab : UserControl
                 queryText = proc.FullName;
                 try
                 {
-                    var connStr = _server.GetConnectionString(_credentialService);
+                    var connStr = _credentialResolver.GetConnectionString(_server);
                     planXml = await LocalDataService.FetchProcedurePlanOnDemandAsync(
                         connStr, proc.DatabaseName, proc.SchemaName, proc.ObjectName);
                 }
@@ -293,7 +293,7 @@ public partial class ServerTab : UserControl
                 {
                     try
                     {
-                        var connStr = _server.GetConnectionString(_credentialService);
+                        var connStr = _credentialResolver.GetConnectionString(_server);
                         planXml = await LocalDataService.FetchQueryStorePlanAsync(connStr, qs.DatabaseName, qs.PlanId);
                     }
                     catch { }
@@ -355,7 +355,7 @@ public partial class ServerTab : UserControl
                 {
                     try
                     {
-                        var connStr = _server.GetConnectionString(_credentialService);
+                        var connStr = _credentialResolver.GetConnectionString(_server);
                         planXml = await LocalDataService.FetchQueryStorePlanAsync(connStr, qs.DatabaseName, qs.PlanId);
                     }
                     catch { }
@@ -388,7 +388,7 @@ public partial class ServerTab : UserControl
 
         try
         {
-            var connectionString = _server.GetConnectionString(_credentialService);
+            var connectionString = _credentialResolver.GetConnectionString(_server);
 
             var actualPlanXml = await ActualPlanExecutor.ExecuteForActualPlanAsync(
                 connectionString,
@@ -442,7 +442,7 @@ public partial class ServerTab : UserControl
         // Fall back to live server
         try
         {
-            var connStr = _server.GetConnectionString(_credentialService);
+            var connStr = _credentialResolver.GetConnectionString(_server);
             return await LocalDataService.FetchQueryPlanOnDemandAsync(connStr, queryHash);
         }
         catch { return null; }
@@ -486,7 +486,7 @@ public partial class ServerTab : UserControl
         string? planXml = null;
         try
         {
-            var connStr = _server.GetConnectionString(_credentialService);
+            var connStr = _credentialResolver.GetConnectionString(_server);
             foreach (var f in frames)
             {
                 planXml = await LocalDataService.FetchPlanBySqlHandleAsync(
@@ -575,7 +575,7 @@ public partial class ServerTab : UserControl
         string? planXml = null;
         try
         {
-            var connStr = _server.GetConnectionString(_credentialService);
+            var connStr = _credentialResolver.GetConnectionString(_server);
             foreach (var f in frames)
             {
                 planXml = await LocalDataService.FetchPlanBySqlHandleAsync(

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -40,7 +40,7 @@ public partial class ServerTab : UserControl
     private readonly int _serverId;
     public int ServerId => _serverId;
     public ServerConnection Server => _server;
-    private readonly CredentialService _credentialService;
+    private readonly CredentialResolver _credentialResolver;
     private readonly DispatcherTimer _refreshTimer;
     private bool _isRefreshing;
     private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.IPanel?> _legendPanels = new();
@@ -112,14 +112,14 @@ public partial class ServerTab : UserControl
     public event Action<int>? ApplyTimeRangeRequested; /* selectedIndex */
     public event Func<Task>? ManualRefreshRequested;
 
-    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialService credentialService, int utcOffsetMinutes = 0, bool hasMsdbAccess = true, bool isAzureSqlDatabase = false)
+    public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialResolver credentialResolver, int utcOffsetMinutes = 0, bool hasMsdbAccess = true, bool isAzureSqlDatabase = false)
     {
         InitializeComponent();
 
         _server = server;
         _dataService = new LocalDataService(duckDb);
         _serverId = RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(server));
-        _credentialService = credentialService;
+        _credentialResolver = credentialResolver;
         UtcOffsetMinutes = utcOffsetMinutes;
         _hasMsdbAccess = hasMsdbAccess;
         _isAzureSqlDatabase = isAzureSqlDatabase;
@@ -963,7 +963,7 @@ public partial class ServerTab : UserControl
         if (QueryStatsGrid.SelectedItem is not QueryStatsRow item) return;
         if (string.IsNullOrEmpty(item.DatabaseName) || string.IsNullOrEmpty(item.QueryHash)) return;
 
-        var connStr = _server.GetConnectionString(_credentialService);
+        var connStr = _credentialResolver.GetConnectionString(_server);
         var window = new Windows.QueryStatsHistoryWindow(_dataService, _serverId, item.DatabaseName, item.QueryHash, GetHoursBack(), connStr);
         window.Owner = Window.GetWindow(this);
         window.ShowDialog();
@@ -974,7 +974,7 @@ public partial class ServerTab : UserControl
         if (ProcedureStatsGrid.SelectedItem is not ProcedureStatsRow item) return;
         if (string.IsNullOrEmpty(item.DatabaseName) || string.IsNullOrEmpty(item.ObjectName)) return;
 
-        var connStr = _server.GetConnectionString(_credentialService);
+        var connStr = _credentialResolver.GetConnectionString(_server);
         var window = new Windows.ProcedureHistoryWindow(_dataService, _serverId, item.DatabaseName, item.SchemaName, item.ObjectName, GetHoursBack(), connStr);
         window.Owner = Window.GetWindow(this);
         window.ShowDialog();
@@ -985,7 +985,7 @@ public partial class ServerTab : UserControl
         if (QueryStoreGrid.SelectedItem is not QueryStoreRow item) return;
         if (string.IsNullOrEmpty(item.DatabaseName) || item.QueryId == 0) return;
 
-        var connStr = _server.GetConnectionString(_credentialService);
+        var connStr = _credentialResolver.GetConnectionString(_server);
         var window = new Windows.QueryStoreHistoryWindow(_dataService, _serverId, item.DatabaseName, item.QueryId, item.PlanId, item.QueryText, GetHoursBack(), connStr);
         window.Owner = Window.GetWindow(this);
         window.ShowDialog();
@@ -1436,7 +1436,7 @@ public partial class ServerTab : UserControl
 
         try
         {
-            var connectionString = _server.GetConnectionString(_credentialService);
+            var connectionString = _credentialResolver.GetConnectionString(_server);
             var builder = new SqlConnectionStringBuilder(connectionString)
             {
                 ConnectTimeout = 15

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -32,6 +32,7 @@ public partial class MainWindow : Window
 {
     private readonly DuckDbInitializer _databaseInitializer;
     private readonly ServerManager _serverManager;
+    private readonly ProfileManager _profileManager;
     private readonly ScheduleManager _scheduleManager;
     private RemoteCollectorService? _collectorService;
     private CollectionBackgroundService? _backgroundService;
@@ -84,6 +85,12 @@ public partial class MainWindow : Window
             new DuckDbMuteRuleStore(_databaseInitializer),
             new AppLoggerAdapter<MuteRuleService>());
         _serverManager = new ServerManager(App.SharedConfigDirectory, logger: new AppLoggerAdapter<ServerManager>());
+        // Two-phase wiring (§3.1): build the ProfileManager (one-way ServerManager injection for the
+        // referential-integrity query), then late-inject it back as the ServerManager's IProfileLookup
+        // so CheckConnectionAsync resolves profile-backed servers through the same fail-closed logic.
+        // Coupling stays acyclic: ServerManager → IProfileLookup ← ProfileManager, ProfileManager → ServerManager.
+        _profileManager = new ProfileManager(_serverManager, new AppLoggerAdapter<ProfileManager>());
+        _serverManager.ProfileLookup = _profileManager;
         _scheduleManager = new ScheduleManager(App.ConfigDirectory);
 
         // Status bar update timer
@@ -543,7 +550,7 @@ public partial class MainWindow : Window
         }
 
         var utcOffset = status.UtcOffsetMinutes ?? 0;
-        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialService, utcOffset, status.HasMsdbAccess, status.SqlEngineEdition == 5);
+        var serverTab = new ServerTab(server, _databaseInitializer, _serverManager.CredentialResolver, utcOffset, status.HasMsdbAccess, status.SqlEngineEdition == 5);
         var tabHeader = CreateTabHeader(server);
         var tabItem = new TabItem
         {
@@ -852,7 +859,7 @@ public partial class MainWindow : Window
 
     private void AddServerButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverManager) { Owner = this };
+        var dialog = new AddServerDialog(_serverManager, _profileManager) { Owner = this };
         if (dialog.ShowDialog() == true && dialog.AddedServer != null)
         {
             RefreshServerList();
@@ -862,7 +869,7 @@ public partial class MainWindow : Window
 
     private void ManageServersButton_Click(object sender, RoutedEventArgs e)
     {
-        var window = new ManageServersWindow(_serverManager) { Owner = this };
+        var window = new ManageServersWindow(_serverManager, _profileManager) { Owner = this };
         window.ShowDialog();
 
         if (window.ServersChanged)
@@ -974,6 +981,24 @@ public partial class MainWindow : Window
             // Import server connections (upsert by server name)
             var (imported, skipped) = _serverManager.ImportServersFromFile(serversJsonPath);
 
+            // Import credential profiles from the SHARED config dir (M-1: NOT the per-user copy loop
+            // below — profiles.json, like servers.json, lives in App.SharedConfigDirectory, so it must
+            // be imported via ProfileManager which is backed by that dir). Source path is built from
+            // the SAME oldConfigDir variable serversJsonPath uses (M1-R2).
+            int profilesImported = 0;
+            var profilesJsonPath = System.IO.Path.Combine(oldConfigDir, "profiles.json");
+            if (System.IO.File.Exists(profilesJsonPath))
+            {
+                try
+                {
+                    (profilesImported, _) = _profileManager.ImportProfilesFromFile(profilesJsonPath);
+                }
+                catch (Exception pex)
+                {
+                    AppLogger.Warn("Import", $"Failed to import profiles.json: {pex.Message}");
+                }
+            }
+
             // Copy config files that don't already exist in the current install
             var settingsFiles = new[] { "settings.json", "collection_schedule.json", "ignored_wait_types.json" };
             int settingsCopied = 0;
@@ -1002,10 +1027,14 @@ public partial class MainWindow : Window
             var message = $"Imported {imported} server connection(s).";
             if (skipped > 0)
                 message += $"\nSkipped {skipped} duplicate(s) (already configured).";
+            if (profilesImported > 0)
+                message += $"\nImported {profilesImported} credential profile(s).";
             if (settingsCopied > 0)
                 message += $"\nCopied {settingsCopied} settings file(s).";
             if (imported > 0)
                 message += "\n\nCredentials from the previous install are preserved.\nIf any connections fail to authenticate, re-enter the password in Manage Servers.";
+            if (profilesImported > 0)
+                message += "\n\nCredential profile secrets are NOT importable (they live only in Windows Credential Manager, per user).\nEdit each imported profile once in Manage Servers → Credential Profiles to re-enter its secret.";
             if (settingsCopied > 0)
                 message += "\n\nRestart the application to apply imported settings.";
 
@@ -1159,7 +1188,7 @@ public partial class MainWindow : Window
         var server = GetServerFromContextMenu(sender);
         if (server == null) return;
 
-        var dialog = new AddServerDialog(_serverManager, server) { Owner = this };
+        var dialog = new AddServerDialog(_serverManager, _profileManager, server) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             RefreshServerList();

--- a/Lite/Mcp/McpPlanTools.cs
+++ b/Lite/Mcp/McpPlanTools.cs
@@ -95,7 +95,7 @@ public sealed class McpPlanTools
             if (server == null)
                 return $"Could not find connection details for server '{resolved.Value.ServerName}'.";
 
-            var connectionString = server.GetConnectionString(serverManager.CredentialService);
+            var connectionString = serverManager.CredentialResolver.GetConnectionString(server);
             var xml = await LocalDataService.FetchQueryStorePlanAsync(connectionString, database_name, plan_id);
 
             if (string.IsNullOrEmpty(xml))

--- a/Lite/Models/CredentialProfile.cs
+++ b/Lite/Models/CredentialProfile.cs
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json.Serialization;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorLite.Models;
+
+/// <summary>
+/// A named, reusable credential that many <see cref="ServerConnection"/> entries can reference
+/// via <see cref="ServerConnection.CredentialProfileId"/>. One identity (a shared SQL login or a
+/// single Azure service principal / managed identity) can then cover a whole fleet of servers
+/// without per-server secret entry.
+///
+/// SECURITY: this type holds NO secret. The SQL password / SP client secret lives ONLY in Windows
+/// Credential Manager (DPAPI) under the key <c>PerformanceMonitorLite_profile_{Id}</c>, mirroring
+/// the secret-free discipline of <see cref="ServerConnection"/>. profiles.json never stores a secret.
+/// </summary>
+public class CredentialProfile
+{
+    /// <summary>
+    /// Stable unique identifier (Guid string). The REAL key — display name uniqueness is a
+    /// per-process UX nicety only (the shared profiles.json is multi-user-writable).
+    /// </summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Human-friendly display name shown in the profile picker.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Authentication type. Only the three profile-eligible modes are valid:
+    /// <see cref="AuthenticationTypes.SqlServer"/>, <see cref="AuthenticationTypes.ServicePrincipal"/>,
+    /// or <see cref="AuthenticationTypes.ManagedIdentity"/>. Windows (no credential) and EntraMFA
+    /// (interactive, per-user) are NOT profile-eligible — a shared profile is meaningless for them.
+    /// </summary>
+    public string AuthType { get; set; } = AuthenticationTypes.SqlServer;
+
+    /// <summary>
+    /// SQL login username for <see cref="AuthenticationTypes.SqlServer"/> profiles. Non-secret.
+    /// (The matching password is stored only in Credential Manager.)
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Service-principal application/client id for <see cref="AuthenticationTypes.ServicePrincipal"/>
+    /// profiles (used as UserID). Non-secret. (The client secret is stored only in Credential Manager.)
+    /// </summary>
+    public string? AzureClientId { get; set; }
+
+    /// <summary>
+    /// Optional Microsoft Entra tenant id. Stored for display/future use only; not injected into the
+    /// connection string (MDS resolves the tenant from the target server's AAD authority).
+    /// </summary>
+    public string? AzureTenantId { get; set; }
+
+    /// <summary>
+    /// Optional user-assigned managed identity client id for
+    /// <see cref="AuthenticationTypes.ManagedIdentity"/> profiles. Blank = system-assigned. Non-secret.
+    /// </summary>
+    public string? ManagedIdentityClientId { get; set; }
+
+    /// <summary>
+    /// Display-only label for the profile's auth type.
+    /// </summary>
+    [JsonIgnore]
+    public string AuthTypeDisplay => AuthType switch
+    {
+        AuthenticationTypes.SqlServer => "SQL Server",
+        AuthenticationTypes.ServicePrincipal => "Azure — Service Principal",
+        AuthenticationTypes.ManagedIdentity => "Azure — Managed Identity",
+        _ => AuthType
+    };
+
+    /// <summary>
+    /// Display text for the profile picker: name plus a short id suffix to disambiguate duplicate
+    /// display names (N-2 — the shared file can hold same-named profiles; the Id is the real key).
+    /// </summary>
+    [JsonIgnore]
+    public string PickerDisplay =>
+        string.IsNullOrEmpty(Id) || Id.Length < 8
+            ? $"{Name} ({AuthTypeDisplay})"
+            : $"{Name} ({AuthTypeDisplay}) — {Id[..8]}";
+}

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -67,6 +67,14 @@ public class ServerConnection : INotifyPropertyChanged
     /// </summary>
     public string? ManagedIdentityClientId { get; set; }
 
+    /// <summary>
+    /// Optional id of a <see cref="CredentialProfile"/> this server uses instead of inline per-server
+    /// credentials. When set, the profile supplies the auth type + credentials (the server keeps its own
+    /// connection facts: ServerName, DatabaseName, Encrypt, intent, etc.). null = today's per-server
+    /// behavior, unchanged and backward-compatible (old servers.json simply omits this field → null).
+    /// </summary>
+    public string? CredentialProfileId { get; set; }
+
     public string? Description { get; set; }
     public DateTime CreatedDate { get; set; } = DateTime.Now;
     public DateTime LastConnected { get; set; } = DateTime.Now;
@@ -210,53 +218,131 @@ public class ServerConnection : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
-    /// Builds and returns a connection string for this server.
-    /// Credentials are retrieved from Windows Credential Manager if SQL auth is used.
+    /// The immutable, atomic resolution tuple fed to <see cref="ApplyAuthentication"/>. It is sourced
+    /// ENTIRELY from one place — either entirely from a credential profile or entirely from this
+    /// server's own inline fields — never mixed field-by-field. This atomic shape is what structurally
+    /// prevents a wrong-identity build (e.g. a profile secret combined with the server's stale
+    /// AzureClientId). See <see cref="ResolveAuth"/>.
     /// </summary>
-    public string GetConnectionString(CredentialService credentialService)
-    {
-        string? username = null;
-        string? password = null;
+    private readonly record struct ResolvedAuth(
+        string AuthType,
+        string? Username,
+        string? Password,
+        string? AzureClientId,
+        string? ManagedIdentityClientId);
 
-        if (AuthenticationType == AuthenticationTypes.SqlServer ||
-            AuthenticationType == AuthenticationTypes.ServicePrincipal)
+    /// <summary>
+    /// Resolves the single auth tuple for this server, fail-closed (§2, B-2/B-3).
+    /// <list type="bullet">
+    /// <item>No profile (<see cref="CredentialProfileId"/> == null) → tuple sourced entirely from this
+    /// server's own inline fields (today's behavior, regression-identical).</item>
+    /// <item>Profile in effect, profile FOUND → tuple sourced entirely from the profile (its AuthType,
+    /// its non-secret fields, secret from <c>profile_{id}</c>). NEVER reads any <c>this.*</c> auth field.</item>
+    /// <item>Profile in effect, profile MISSING → THROWS "credential profile '{id}' not found". A closed
+    /// branch with NO fall-through to the server-self path — a dangling profile must never silently
+    /// connect under the server's own stale inline auth.</item>
+    /// </list>
+    /// </summary>
+    private ResolvedAuth ResolveAuth(CredentialService credentialService, IProfileLookup? profileLookup)
+    {
+        // No profile referenced → entirely server-self (regression-identical).
+        if (string.IsNullOrEmpty(CredentialProfileId))
         {
-            // SqlServer: stored username + password.
-            // ServicePrincipal: stored client id (Username) + client secret (Password).
-            var cred = credentialService.GetCredential(Id);
+            string? username = null;
+            string? password = null;
+
+            if (AuthenticationType == AuthenticationTypes.SqlServer ||
+                AuthenticationType == AuthenticationTypes.ServicePrincipal)
+            {
+                var cred = credentialService.GetCredential(Id);
+                if (cred.HasValue)
+                {
+                    username = cred.Value.Username;
+                    password = cred.Value.Password;
+                }
+            }
+            // ManagedIdentity fetches no credential (no secret).
+
+            return new ResolvedAuth(AuthenticationType, username, password, AzureClientId, ManagedIdentityClientId);
+        }
+
+        // Profile referenced — CLOSED, fail-closed branch (B-2). No fall-through to server-self.
+        var profile = profileLookup?.GetProfile(CredentialProfileId);
+        if (profile == null)
+        {
+            throw new InvalidOperationException(
+                $"credential profile '{CredentialProfileId}' not found");
+        }
+
+        // Tuple sourced ENTIRELY from the profile (B-3). We never read this.AzureClientId /
+        // this.ManagedIdentityClientId here — only the profile's own fields.
+        string? profileUser = null;
+        string? profileSecret = null;
+        if (profile.AuthType == AuthenticationTypes.SqlServer ||
+            profile.AuthType == AuthenticationTypes.ServicePrincipal)
+        {
+            var cred = credentialService.GetCredential(ProfileManager.ProfileCredentialId(profile.Id));
             if (cred.HasValue)
             {
-                username = cred.Value.Username;
-                password = cred.Value.Password;
+                profileUser = cred.Value.Username;
+                profileSecret = cred.Value.Password;
             }
         }
-        // ManagedIdentity fetches no credential (no secret).
+        // ManagedIdentity profile carries no secret.
 
-        return BuildConnectionString(username, password);
+        return new ResolvedAuth(
+            profile.AuthType,
+            profileUser,
+            profileSecret,
+            profile.AzureClientId,
+            profile.ManagedIdentityClientId);
     }
 
     /// <summary>
-    /// Returns a connection string targeting UtilityDatabase if set, otherwise falls back to GetConnectionString().
-    /// Used for locating community stored procedures (sp_IndexCleanup) that may be installed in a non-default database.
+    /// Builds the connection string for this server, resolving credentials from a profile (when
+    /// <see cref="CredentialProfileId"/> is set) or from this server's own inline fields otherwise.
+    /// This is the single resolution entry point; the removed instance overloads used to expose a
+    /// <see cref="CredentialService"/>-only path that could silently bypass a profile.
     /// </summary>
-    public string GetUtilityConnectionString(CredentialService credentialService)
+    public static string ResolveConnectionString(
+        ServerConnection server,
+        CredentialService credentialService,
+        IProfileLookup? profileLookup)
     {
-        var baseConnStr = GetConnectionString(credentialService);
+        var auth = server.ResolveAuth(credentialService, profileLookup);
+        return server.BuildConnectionString(auth);
+    }
 
-        if (string.IsNullOrWhiteSpace(UtilityDatabase))
+    /// <summary>
+    /// Like <see cref="ResolveConnectionString"/> but targets <see cref="UtilityDatabase"/> when set.
+    /// Used for locating community stored procedures (sp_IndexCleanup) installed in a non-default database.
+    /// </summary>
+    public static string ResolveUtilityConnectionString(
+        ServerConnection server,
+        CredentialService credentialService,
+        IProfileLookup? profileLookup)
+    {
+        var baseConnStr = ResolveConnectionString(server, credentialService, profileLookup);
+
+        if (string.IsNullOrWhiteSpace(server.UtilityDatabase))
             return baseConnStr;
 
         var builder = new SqlConnectionStringBuilder(baseConnStr)
         {
-            InitialCatalog = UtilityDatabase
+            InitialCatalog = server.UtilityDatabase
         };
         return builder.ConnectionString;
     }
 
     /// <summary>
     /// Builds the connection string with the given credentials.
+    /// Used by tests for the server-self shape; production paths go through
+    /// <see cref="ResolveConnectionString"/>, which supplies the resolved tuple.
     /// </summary>
     internal string BuildConnectionString(string? username, string? password)
+        => BuildConnectionString(new ResolvedAuth(AuthenticationType, username, password, AzureClientId, ManagedIdentityClientId));
+
+    private string BuildConnectionString(ResolvedAuth auth)
     {
         var builder = new SqlConnectionStringBuilder
         {
@@ -279,7 +365,9 @@ public class ServerConnection : INotifyPropertyChanged
             _ => SqlConnectionEncryptOption.Optional
         };
 
-        ApplyAuthentication(builder, AuthenticationType, username, password, AzureClientId, ManagedIdentityClientId);
+        // The tuple is atomic: every auth field comes from the SAME source (profile or server).
+        ApplyAuthentication(builder, auth.AuthType, auth.Username, auth.Password,
+            auth.AzureClientId, auth.ManagedIdentityClientId);
 
         return builder.ConnectionString;
     }
@@ -345,19 +433,39 @@ public class ServerConnection : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Checks if credentials are stored in Windows Credential Manager for this server.
+    /// Checks if credentials are available for this server (profile-aware, N-1).
+    /// When a profile is referenced, reflects the profile's stored-secret state (SP/SQL → the
+    /// <c>profile_{id}</c> key; MI → true); a dangling profile reference reports false. Otherwise
+    /// reflects the per-server <c>this.Id</c> key, matching the legacy behavior.
     /// </summary>
-    public bool HasStoredCredentials(CredentialService credentialService)
+    public static bool HasStoredCredentials(
+        ServerConnection server,
+        CredentialService credentialService,
+        IProfileLookup? profileLookup)
     {
+        if (!string.IsNullOrEmpty(server.CredentialProfileId))
+        {
+            var profile = profileLookup?.GetProfile(server.CredentialProfileId);
+            if (profile == null)
+            {
+                // Dangling profile — no resolvable credential.
+                return false;
+            }
+            // MI needs no secret; SQL/SP need the profile secret present.
+            if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+                return true;
+            return credentialService.CredentialExists(ProfileManager.ProfileCredentialId(profile.Id));
+        }
+
         // Zero-touch auth modes need no stored secret.
-        if (AuthenticationType == AuthenticationTypes.Windows ||
-            AuthenticationType == AuthenticationTypes.EntraMFA ||
-            AuthenticationType == AuthenticationTypes.ManagedIdentity)
+        if (server.AuthenticationType == AuthenticationTypes.Windows ||
+            server.AuthenticationType == AuthenticationTypes.EntraMFA ||
+            server.AuthenticationType == AuthenticationTypes.ManagedIdentity)
         {
             return true;
         }
 
         // SqlServer (password) and ServicePrincipal (client secret) require a stored credential.
-        return credentialService.CredentialExists(Id);
+        return credentialService.CredentialExists(server.Id);
     }
 }

--- a/Lite/Services/CredentialResolver.cs
+++ b/Lite/Services/CredentialResolver.cs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// The single profile-or-self credential-resolution indirection point for connection-string
+/// consumers. Owns a <see cref="CredentialService"/> and an optional <see cref="IProfileLookup"/>
+/// and wraps the static fail-closed atomic-tuple resolution on <see cref="ServerConnection"/> so the
+/// ~24 call sites move from <c>server.GetConnectionString(credentialService)</c> (the removed instance
+/// overload) to <c>resolver.GetConnectionString(server)</c>.
+///
+/// Coupling is acyclic: the resolver depends only on <see cref="CredentialService"/> +
+/// <see cref="IProfileLookup"/>; it never references <see cref="ProfileManager"/> concretely.
+/// A null <see cref="IProfileLookup"/> means "no profiles" — every server resolves to its own inline
+/// auth, i.e. today's behavior.
+/// </summary>
+public sealed class CredentialResolver
+{
+    private readonly CredentialService _credentialService;
+    private readonly IProfileLookup? _profileLookup;
+
+    public CredentialResolver(CredentialService credentialService, IProfileLookup? profileLookup)
+    {
+        _credentialService = credentialService;
+        _profileLookup = profileLookup;
+    }
+
+    /// <summary>
+    /// The underlying credential service (for the rare consumer that still needs raw access).
+    /// </summary>
+    public CredentialService CredentialService => _credentialService;
+
+    /// <summary>
+    /// Resolves a connection string for the server (profile-or-self, fail-closed). Throws
+    /// "credential profile '{id}' not found" if the server references a missing profile.
+    /// </summary>
+    public string GetConnectionString(ServerConnection server)
+        => ServerConnection.ResolveConnectionString(server, _credentialService, _profileLookup);
+
+    /// <summary>
+    /// Resolves a connection string targeting the server's UtilityDatabase when set.
+    /// </summary>
+    public string GetUtilityConnectionString(ServerConnection server)
+        => ServerConnection.ResolveUtilityConnectionString(server, _credentialService, _profileLookup);
+
+    /// <summary>
+    /// Profile-aware stored-credential check (N-1).
+    /// </summary>
+    public bool HasStoredCredentials(ServerConnection server)
+        => ServerConnection.HasStoredCredentials(server, _credentialService, _profileLookup);
+}

--- a/Lite/Services/IProfileLookup.cs
+++ b/Lite/Services/IProfileLookup.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Read-only seam for looking up a <see cref="CredentialProfile"/> by id, implemented by
+/// <see cref="ProfileManager"/>. Exists to keep credential resolution acyclic: <see cref="ServerManager"/>
+/// holds this abstraction (late-injected, default null = today's no-profile behavior) so its own
+/// <c>CheckConnectionAsync</c> can resolve through the SAME fail-closed atomic-tuple logic as the
+/// external consumers, WITHOUT taking a hard dependency on <see cref="ProfileManager"/> (which itself
+/// depends on <see cref="ServerManager"/> for the referential-integrity query). Coupling stays one-way:
+/// <c>ServerManager → IProfileLookup ← ProfileManager</c>, and separately <c>ProfileManager → ServerManager</c>.
+/// </summary>
+public interface IProfileLookup
+{
+    /// <summary>
+    /// Returns the profile with the given id, or null if no such profile exists.
+    /// A null return on a non-null id drives the fail-closed resolution branch (throw "not found").
+    /// </summary>
+    CredentialProfile? GetProfile(string id);
+}

--- a/Lite/Services/ProfileManager.cs
+++ b/Lite/Services/ProfileManager.cs
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Manages named, reusable credential profiles persisted to <c>profiles.json</c> in the SHARED config
+/// directory (alongside <c>servers.json</c>), mirroring <see cref="ServerManager"/>'s persistence
+/// discipline (System.Text.Json WriteIndented, <c>.bak</c> backup/restore-on-corruption, a lock, CRUD).
+///
+/// SECURITY: profile secrets live ONLY in Windows Credential Manager under the key
+/// <c>PerformanceMonitorLite_profile_{id}</c> via <see cref="CredentialService"/>; profiles.json holds
+/// no secret. ManagedIdentity profiles store no secret at all.
+///
+/// Implements <see cref="IProfileLookup"/> so <see cref="ServerManager"/> can resolve profile-backed
+/// servers through the same fail-closed logic without depending on this concrete class (§3.1).
+/// Holds a ONE-WAY reference to <see cref="ServerManager"/> for the referential-integrity (in-use)
+/// query only (§6); <see cref="ServerManager"/> never depends on <see cref="ProfileManager"/>.
+/// </summary>
+public class ProfileManager : IProfileLookup
+{
+    /// <summary>
+    /// Credential Manager key prefix for profile secrets. Combined with the bare profile id this yields
+    /// <c>profile_{id}</c>; since servers pass a bare GUID and profiles a <c>profile_</c>-prefixed id,
+    /// the namespaces cannot collide (nor with the SMTP/webhook literals).
+    /// </summary>
+    public const string ProfileKeyPrefix = "profile_";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+    private readonly string _configFilePath;
+    private readonly CredentialService _credentialService;
+    private readonly ServerManager _serverManager;
+    private readonly ILogger<ProfileManager>? _logger;
+    private List<CredentialProfile> _profiles;
+    private readonly object _profilesLock = new();
+
+    /// <summary>
+    /// Builds the Credential Manager key for a profile's secret (<c>profile_{id}</c>).
+    /// </summary>
+    public static string ProfileCredentialId(string profileId) => $"{ProfileKeyPrefix}{profileId}";
+
+    public ProfileManager(ServerManager serverManager, ILogger<ProfileManager>? logger = null)
+    {
+        _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
+        // Profiles live in the SAME directory as servers.json (the shared config dir).
+        var configDirectory = Path.GetDirectoryName(serverManager.ConfigFilePath) ?? App.SharedConfigDirectory;
+        _configFilePath = Path.Combine(configDirectory, "profiles.json");
+        _credentialService = serverManager.CredentialService;
+        _logger = logger;
+        _profiles = new List<CredentialProfile>();
+
+        LoadProfiles();
+    }
+
+    /// <summary>
+    /// Gets the credential service used to store/retrieve profile secrets.
+    /// </summary>
+    public CredentialService CredentialService => _credentialService;
+
+    /// <summary>
+    /// Gets all profiles sorted by display name.
+    /// </summary>
+    public List<CredentialProfile> GetAll()
+    {
+        lock (_profilesLock)
+        {
+            return _profiles.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Gets a profile by its id, or null if not found.
+    /// </summary>
+    public CredentialProfile? GetProfile(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+        lock (_profilesLock)
+        {
+            return _profiles.FirstOrDefault(p => p.Id == id);
+        }
+    }
+
+    /// <summary>
+    /// Adds a new profile. For SqlServer/ServicePrincipal the secret is stored in Credential Manager
+    /// under <c>profile_{id}</c>; ManagedIdentity stores no secret.
+    /// </summary>
+    /// <param name="profile">The profile to add (auth type + non-secret fields).</param>
+    /// <param name="username">SQL username or SP client id (the Credential Manager username).</param>
+    /// <param name="secret">SQL password or SP client secret. Ignored for ManagedIdentity.</param>
+    public void AddProfile(CredentialProfile profile, string? username = null, string? secret = null)
+    {
+        if (profile == null) throw new ArgumentNullException(nameof(profile));
+
+        lock (_profilesLock)
+        {
+            if (_profiles.Any(p => p.Id == profile.Id))
+            {
+                throw new InvalidOperationException($"Profile with ID {profile.Id} already exists");
+            }
+            // Per-process name-uniqueness (UX nicety; the Id is the real key, N-2).
+            if (_profiles.Any(p => string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException($"A profile named '{profile.Name}' already exists");
+            }
+
+            _profiles.Add(profile);
+            SaveProfiles();
+        }
+
+        StoreSecretIfNeeded(profile, username, secret);
+
+        _logger?.LogInformation("Added credential profile '{Name}' ({AuthType})", profile.Name, profile.AuthType);
+    }
+
+    /// <summary>
+    /// Updates an existing profile (and re-stores its secret). Editing a profile's secret intentionally
+    /// affects ALL servers that reference it (the blast radius the editor warns about).
+    /// </summary>
+    public void UpdateProfile(CredentialProfile profile, string? username = null, string? secret = null)
+    {
+        if (profile == null) throw new ArgumentNullException(nameof(profile));
+
+        lock (_profilesLock)
+        {
+            var existing = _profiles.FirstOrDefault(p => p.Id == profile.Id);
+            if (existing == null)
+            {
+                throw new InvalidOperationException($"Profile with ID {profile.Id} not found");
+            }
+            // Per-process name-uniqueness (excluding self).
+            if (_profiles.Any(p => p.Id != profile.Id &&
+                                   string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException($"A profile named '{profile.Name}' already exists");
+            }
+
+            var index = _profiles.IndexOf(existing);
+            _profiles[index] = profile;
+            SaveProfiles();
+        }
+
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+        {
+            // MI never has a secret; clear any stale one (e.g. profile retyped from SP -> MI).
+            _credentialService.DeleteCredential(ProfileCredentialId(profile.Id));
+        }
+        else if (!string.IsNullOrEmpty(username) && secret != null)
+        {
+            // Only re-store when a fresh secret was supplied (edit-load uses pre-fill-on-edit;
+            // a blank PasswordBox means "leave the stored secret unchanged").
+            if (!_credentialService.UpdateCredential(ProfileCredentialId(profile.Id), username, secret))
+            {
+                throw new InvalidOperationException("Failed to update profile secret in Windows Credential Manager");
+            }
+        }
+
+        _logger?.LogInformation("Updated credential profile '{Name}' ({AuthType})", profile.Name, profile.AuthType);
+    }
+
+    /// <summary>
+    /// Deletes a profile and its stored secret. Blocked (throws) while ANY server references it —
+    /// referential integrity is a delete-constraint, not a cascade (§6). Best-effort: it reads this
+    /// process's in-memory server list, so cross-user/in-process races may slip through; the §2
+    /// fail-closed resolution guard is the actual safety net.
+    /// </summary>
+    public void DeleteProfile(string id)
+    {
+        if (string.IsNullOrEmpty(id)) throw new ArgumentException("Profile id cannot be null or empty", nameof(id));
+
+        int inUse = CountServersUsingProfile(id);
+        if (inUse > 0)
+        {
+            throw new InvalidOperationException(
+                $"This profile is used by {inUse} server(s). Reassign or remove them first.");
+        }
+
+        CredentialProfile? profile;
+        lock (_profilesLock)
+        {
+            profile = _profiles.FirstOrDefault(p => p.Id == id);
+            if (profile != null)
+            {
+                _profiles.Remove(profile);
+                SaveProfiles();
+            }
+        }
+
+        if (profile != null)
+        {
+            _credentialService.DeleteCredential(ProfileCredentialId(id));
+            _logger?.LogInformation("Deleted credential profile '{Name}'", profile.Name);
+        }
+    }
+
+    /// <summary>
+    /// Counts the servers (in this process's in-memory list) that reference the given profile id.
+    /// The one-way <see cref="ServerManager"/> dependency exists for exactly this query (§6).
+    /// </summary>
+    public int CountServersUsingProfile(string profileId)
+    {
+        if (string.IsNullOrEmpty(profileId)) return 0;
+        return _serverManager.GetAllServers().Count(s => s.CredentialProfileId == profileId);
+    }
+
+    /// <summary>
+    /// Checks whether a profile's secret is present in Credential Manager. SqlServer/ServicePrincipal
+    /// require one; ManagedIdentity needs none (returns true).
+    /// </summary>
+    public bool HasStoredSecret(CredentialProfile profile)
+    {
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+            return true;
+        return _credentialService.CredentialExists(ProfileCredentialId(profile.Id));
+    }
+
+    private void StoreSecretIfNeeded(CredentialProfile profile, string? username, string? secret)
+    {
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+            return; // no secret
+
+        if (!string.IsNullOrEmpty(username) && secret != null)
+        {
+            if (!_credentialService.SaveCredential(ProfileCredentialId(profile.Id), username, secret))
+            {
+                throw new InvalidOperationException("Failed to save profile secret to Windows Credential Manager");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Imports credential profiles from an external profiles.json file (mirrors
+    /// <see cref="ServerManager.ImportServersFromFile"/>). Upserts by Id; existing ids are skipped.
+    /// Secrets are NOT importable (Credential Manager is per-user/machine) — an imported profile needs
+    /// its secret entered once via the profile editor. Returns (imported, skipped).
+    /// </summary>
+    public (int Imported, int Skipped) ImportProfilesFromFile(string profilesJsonPath)
+    {
+        if (!File.Exists(profilesJsonPath))
+            throw new FileNotFoundException("profiles.json not found", profilesJsonPath);
+
+        var json = File.ReadAllText(profilesJsonPath);
+        var config = JsonSerializer.Deserialize<ProfilesConfig>(json);
+        var importedProfiles = config?.Profiles ?? new List<CredentialProfile>();
+
+        int imported = 0;
+        int skipped = 0;
+
+        lock (_profilesLock)
+        {
+            foreach (var profile in importedProfiles)
+            {
+                // Skip if the same id already exists (keep our local secret association intact).
+                if (_profiles.Any(p => p.Id == profile.Id))
+                {
+                    skipped++;
+                    continue;
+                }
+                // Skip if a same-named profile already exists (per-process name uniqueness).
+                if (_profiles.Any(p => string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                _profiles.Add(profile);
+                imported++;
+            }
+
+            if (imported > 0)
+                SaveProfiles();
+        }
+
+        _logger?.LogInformation("Imported {Imported} credential profiles, skipped {Skipped}", imported, skipped);
+        return (imported, skipped);
+    }
+
+    private void LoadProfiles()
+    {
+        if (!File.Exists(_configFilePath))
+        {
+            _profiles = new List<CredentialProfile>();
+            SaveProfiles();
+            return;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(_configFilePath);
+            var config = JsonSerializer.Deserialize<ProfilesConfig>(json);
+            _profiles = config?.Profiles ?? new List<CredentialProfile>();
+
+            /* Create backup of valid config */
+            try { File.Copy(_configFilePath, _configFilePath + ".bak", overwrite: true); }
+            catch { /* best effort */ }
+
+            _logger?.LogInformation("Loaded {Count} credential profiles", _profiles.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to load profiles.json, attempting backup restore");
+
+            var bakPath = _configFilePath + ".bak";
+            if (File.Exists(bakPath))
+            {
+                try
+                {
+                    string bakJson = File.ReadAllText(bakPath);
+                    var bakConfig = JsonSerializer.Deserialize<ProfilesConfig>(bakJson);
+                    _profiles = bakConfig?.Profiles ?? new List<CredentialProfile>();
+                    _logger?.LogInformation("Restored {Count} credential profiles from backup", _profiles.Count);
+                    return;
+                }
+                catch { /* backup also corrupt, fall through to empty list */ }
+            }
+
+            _profiles = new List<CredentialProfile>();
+            SaveProfiles();
+        }
+    }
+
+    private void SaveProfiles()
+    {
+        lock (_profilesLock)
+        {
+            try
+            {
+                var config = new ProfilesConfig { Profiles = _profiles };
+                string json = JsonSerializer.Serialize(config, s_jsonOptions);
+                File.WriteAllText(_configFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to save profiles.json");
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// JSON wrapper for the profiles list (mirrors ServerManager's private ServersConfig).
+    /// </summary>
+    private class ProfilesConfig
+    {
+        public List<CredentialProfile> Profiles { get; set; } = new();
+    }
+}

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -615,7 +615,7 @@ WHERE server_id = $3";
     protected async Task<List<string>> GetAzureDatabaseListAsync(ServerConnection server, CancellationToken cancellationToken)
     {
         var serverId = GetServerId(server);
-        var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+        var baseConnStr = _serverManager.CredentialResolver.GetConnectionString(server);
         var targetDb = new SqlConnectionStringBuilder(baseConnStr).InitialCatalog;
 
         bool knownInaccessible;
@@ -751,7 +751,7 @@ WHERE server_id = $3";
     /// </summary>
     protected async Task<SqlConnection> OpenAzureDatabaseConnectionAsync(ServerConnection server, string databaseName, CancellationToken cancellationToken)
     {
-        var baseConnStr = server.GetConnectionString(_serverManager.CredentialService);
+        var baseConnStr = _serverManager.CredentialResolver.GetConnectionString(server);
         var connStr = new SqlConnectionStringBuilder(baseConnStr)
         {
             ConnectTimeout = ConnectionTimeoutSeconds,
@@ -794,7 +794,7 @@ WHERE server_id = $3";
             await s_connectionThrottle.WaitAsync(cancellationToken);
             try
             {
-                var connectionString = server.GetConnectionString(_serverManager.CredentialService);
+                var connectionString = _serverManager.CredentialResolver.GetConnectionString(server);
 
             var builder = new SqlConnectionStringBuilder(connectionString)
             {

--- a/Lite/Services/ServerManager.cs
+++ b/Lite/Services/ServerManager.cs
@@ -53,6 +53,29 @@ public class ServerManager
     public CredentialService CredentialService => _credentialService;
 
     /// <summary>
+    /// Full path to this manager's servers.json. Used by <see cref="ProfileManager"/> to colocate
+    /// profiles.json in the same (shared) config directory.
+    /// </summary>
+    public string ConfigFilePath => _configFilePath;
+
+    /// <summary>
+    /// Late-injected profile lookup (§3.1, B1-R2). Default null = today's no-profile behavior: every
+    /// server resolves to its own inline auth. When wired (after <see cref="ProfileManager"/> exists),
+    /// <see cref="CheckConnectionAsync"/> resolves profile-backed servers through the SAME fail-closed
+    /// atomic-tuple logic as the external consumers, rather than flipping them "Offline" under the
+    /// wrong identity. <see cref="ServerManager"/> holds only this abstraction — never ProfileManager —
+    /// so coupling stays acyclic.
+    /// </summary>
+    public IProfileLookup? ProfileLookup { get; set; }
+
+    /// <summary>
+    /// A resolver bound to this manager's credential service + current profile lookup. Hand this to
+    /// connection-string consumers (ServerTab, FinOpsTab, the collector, the MCP path, etc.) so they
+    /// all resolve through the same profile-or-self/fail-closed path.
+    /// </summary>
+    public CredentialResolver CredentialResolver => new(_credentialService, ProfileLookup);
+
+    /// <summary>
     /// Gets all servers sorted by favorite status and last connected time.
     /// </summary>
     public List<ServerConnection> GetAllServers()
@@ -349,7 +372,10 @@ public class ServerManager
 
         try
         {
-            var connectionString = server.GetConnectionString(_credentialService);
+            // Resolve through the same fail-closed atomic-tuple logic as the external consumers
+            // (§3.1). A profile-backed server with a dangling/missing profile throws here rather than
+            // silently connecting under the server's own stale inline auth.
+            var connectionString = ServerConnection.ResolveConnectionString(server, _credentialService, ProfileLookup);
 
             // Modify connection string to use short timeout for connectivity check
             var builder = new SqlConnectionStringBuilder(connectionString)

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -38,19 +38,40 @@
         <!-- Authentication -->
         <TextBlock Grid.Row="5" Text="Authentication" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
         <StackPanel Grid.Row="6" Margin="0,0,0,12">
-            <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication" Foreground="{DynamicResource ForegroundBrush}"
-                         IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
-            <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"
-                         Checked="AuthMode_Changed" Margin="0,0,0,4"/>
-            <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA" Foreground="{DynamicResource ForegroundBrush}"
-                         Checked="AuthMode_Changed"
-                         ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
-            <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
-                         Checked="AuthMode_Changed" Margin="0,4,0,0"
-                         ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
-            <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
-                         Checked="AuthMode_Changed" Margin="0,4,0,0"
-                         ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running Lite."/>
+            <!-- Credential source: inline (per-server) vs a shared credential profile -->
+            <RadioButton x:Name="ConfigureOnServerRadio" Content="Configure credentials on this server"
+                         Foreground="{DynamicResource ForegroundBrush}" IsChecked="True"
+                         Checked="CredentialSource_Changed" Margin="0,0,0,4"/>
+            <RadioButton x:Name="UseProfileRadio" Content="Use a credential profile"
+                         Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="CredentialSource_Changed" Margin="0,0,0,4"
+                         ToolTip="Use a named, shared credential (set up under Manage Servers → Credential Profiles). The profile fully overrides this server's auth type and credentials."/>
+
+            <!-- Profile picker (shown when 'Use a credential profile' is selected) -->
+            <StackPanel x:Name="ProfilePickerPanel" Visibility="Collapsed" Margin="0,4,0,0">
+                <TextBlock Text="Credential Profile" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                <ComboBox x:Name="ProfileComboBox" DisplayMemberPath="PickerDisplay"/>
+                <TextBlock x:Name="NoProfilesNote" TextWrapping="Wrap" FontSize="11" Visibility="Collapsed"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0"
+                           Text="No credential profiles exist yet. Create one under Manage Servers → Credential Profiles."/>
+            </StackPanel>
+
+            <!-- Inline per-server auth radios (hidden when a profile is chosen) -->
+            <StackPanel x:Name="InlineAuthRadios" Margin="0,4,0,0">
+                <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                             IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+                <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+                <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed"
+                             ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
+                <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,4,0,0"
+                             ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+                <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,4,0,0"
+                             ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running Lite."/>
+            </StackPanel>
         </StackPanel>
 
         <!-- SQL Auth Credentials -->

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Linq;
 using System.Windows;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorLite.Helpers;
@@ -19,6 +20,7 @@ namespace PerformanceMonitorLite.Windows;
 public partial class AddServerDialog : Window
 {
     private readonly ServerManager _serverManager;
+    private readonly ProfileManager _profileManager;
     private static bool _isDialogOpen = false;
 
     /// <summary>
@@ -31,18 +33,37 @@ public partial class AddServerDialog : Window
     /// </summary>
     public ServerConnection? AddedServer { get; private set; }
 
-    public AddServerDialog(ServerManager serverManager)
+    public AddServerDialog(ServerManager serverManager, ProfileManager profileManager)
     {
         InitializeComponent();
         _serverManager = serverManager;
+        _profileManager = profileManager;
         _isDialogOpen = true;
         Closed += (s, e) => _isDialogOpen = false;
+
+        PopulateProfilePicker();
+    }
+
+    /// <summary>
+    /// Populates the profile dropdown from the current profile list. Disables the "use profile"
+    /// option when no profiles exist.
+    /// </summary>
+    private void PopulateProfilePicker()
+    {
+        var profiles = _profileManager.GetAll();
+        ProfileComboBox.ItemsSource = profiles;
+        if (profiles.Count == 0)
+        {
+            UseProfileRadio.IsEnabled = false;
+            NoProfilesNote.Visibility = Visibility.Visible;
+        }
     }
 
     /// <summary>
     /// Constructor for editing an existing server.
     /// </summary>
-    public AddServerDialog(ServerManager serverManager, ServerConnection existing) : this(serverManager)
+    public AddServerDialog(ServerManager serverManager, ProfileManager profileManager, ServerConnection existing)
+        : this(serverManager, profileManager)
     {
         Title = "Edit SQL Server";
         ServerNameBox.Text = existing.ServerName;
@@ -64,6 +85,20 @@ public partial class AddServerDialog : Window
         ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
         MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
         MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        // Profile-backed server (M-3 edit-load): preselect "use profile" + the dropdown, and do NOT
+        // call GetCredential(existing.Id) — there is intentionally no per-server secret to load.
+        if (!string.IsNullOrEmpty(existing.CredentialProfileId))
+        {
+            UseProfileRadio.IsChecked = true;
+            var match = _profileManager.GetProfile(existing.CredentialProfileId);
+            if (match != null)
+                ProfileComboBox.SelectedItem = ProfileComboBox.Items
+                    .Cast<CredentialProfile>().FirstOrDefault(p => p.Id == match.Id);
+            // CredentialSource_Changed (fired by IsChecked) hides the inline auth panels.
+            AddedServer = existing;
+            return;
+        }
 
         // Set authentication mode
         if (existing.AuthenticationType == AuthenticationTypes.EntraMFA)
@@ -119,6 +154,36 @@ public partial class AddServerDialog : Window
         }
 
         AddedServer = existing;
+    }
+
+    /// <summary>
+    /// Toggles between the inline per-server auth UI and the credential-profile picker. When a profile
+    /// is chosen the inline auth radios + all per-mode credential panels are hidden (O-2 — the profile
+    /// fully overrides the server's auth type + creds, so the inline panels are removed, not just ignored).
+    /// </summary>
+    private void CredentialSource_Changed(object sender, RoutedEventArgs e)
+    {
+        // Guard against early Checked events during InitializeComponent.
+        if (ProfilePickerPanel == null || InlineAuthRadios == null) return;
+
+        bool useProfile = UseProfileRadio.IsChecked == true;
+
+        ProfilePickerPanel.Visibility = useProfile ? Visibility.Visible : Visibility.Collapsed;
+        InlineAuthRadios.Visibility = useProfile ? Visibility.Collapsed : Visibility.Visible;
+
+        if (useProfile)
+        {
+            // Hide every per-mode inline credential panel.
+            if (SqlCredentialsPanel != null) SqlCredentialsPanel.Visibility = Visibility.Collapsed;
+            if (EntraMfaPanel != null) EntraMfaPanel.Visibility = Visibility.Collapsed;
+            if (ServicePrincipalPanel != null) ServicePrincipalPanel.Visibility = Visibility.Collapsed;
+            if (ManagedIdentityPanel != null) ManagedIdentityPanel.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            // Re-show the panel for the currently selected inline auth mode.
+            AuthMode_Changed(sender, e);
+        }
     }
 
     private void AuthMode_Changed(object sender, RoutedEventArgs e)
@@ -184,6 +249,28 @@ public partial class AddServerDialog : Window
                 : ApplicationIntent.ReadWrite,
             MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true
         };
+
+        // Credential-profile mode: apply the profile's auth via the SAME shared helper, sourcing every
+        // field from the profile (its auth type + non-secret fields + secret from Credential Manager).
+        // Mirrors the atomic-tuple production resolution; never reads the inline controls.
+        if (UseProfileRadio.IsChecked == true && ProfileComboBox.SelectedItem is CredentialProfile profile)
+        {
+            string? profUser = null;
+            string? profSecret = null;
+            if (profile.AuthType is AuthenticationTypes.SqlServer or AuthenticationTypes.ServicePrincipal)
+            {
+                var cred = _profileManager.CredentialService.GetCredential(
+                    ProfileManager.ProfileCredentialId(profile.Id));
+                if (cred.HasValue)
+                {
+                    profUser = cred.Value.Username;
+                    profSecret = cred.Value.Password;
+                }
+            }
+            ServerConnection.ApplyAuthentication(builder, profile.AuthType, profUser, profSecret,
+                profile.AzureClientId, profile.ManagedIdentityClientId);
+            return builder;
+        }
 
         // Determine auth type + per-mode credentials from the live UI controls, then apply via the
         // SHARED helper so this Test-Connection builder never diverges from ServerConnection's
@@ -331,12 +418,30 @@ public partial class AddServerDialog : Window
         if (string.IsNullOrEmpty(displayName))
             displayName = serverName;
 
+        // Credential source: a shared profile, or inline per-server auth.
+        bool useProfile = UseProfileRadio.IsChecked == true;
+        CredentialProfile? selectedProfile = null;
+
         // Determine authentication type
         string authenticationType;
         string? username = null;
         string? password = null;
 
-        if (WindowsAuthRadio.IsChecked == true)
+        if (useProfile)
+        {
+            selectedProfile = ProfileComboBox.SelectedItem as CredentialProfile;
+            if (selectedProfile == null)
+            {
+                StatusText.Text = "Select a credential profile, or choose \"Configure credentials on this server\".";
+                return;
+            }
+            // The profile fully overrides the server's auth; mirror its auth type onto the server's
+            // own AuthenticationType (display + zero-touch UpdateServer arm behavior). The actual
+            // resolution always comes from the profile via CredentialProfileId. No per-server secret
+            // is stored (username/password stay null).
+            authenticationType = selectedProfile.AuthType;
+        }
+        else if (WindowsAuthRadio.IsChecked == true)
         {
             authenticationType = AuthenticationTypes.Windows;
         }
@@ -445,7 +550,23 @@ public partial class AddServerDialog : Window
                 if (decimal.TryParse(MonthlyCostBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     AddedServer.MonthlyCostUsd = editCost;
 
-                _serverManager.UpdateServer(AddedServer, username, password);
+                AddedServer.CredentialProfileId = useProfile ? selectedProfile!.Id : null;
+
+                if (useProfile)
+                {
+                    // M-3: assigning a profile unconditionally scrubs the per-server identity REGARDLESS
+                    // of AuthenticationType — delete the per-server secret and null the per-server Azure/MI
+                    // fields, so a later "switch back to inline" can't silently resurrect a stale secret.
+                    AddedServer.AzureClientId = null;
+                    AddedServer.AzureTenantId = null;
+                    AddedServer.ManagedIdentityClientId = null;
+                    _serverManager.UpdateServer(AddedServer, null, null);
+                    _serverManager.CredentialService.DeleteCredential(AddedServer.Id);
+                }
+                else
+                {
+                    _serverManager.UpdateServer(AddedServer, username, password);
+                }
             }
             else
             {
@@ -477,10 +598,19 @@ public partial class AddServerDialog : Window
                     UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim(),
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
                     MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
-                    MonthlyCostUsd = monthlyCost
+                    MonthlyCostUsd = monthlyCost,
+                    CredentialProfileId = useProfile ? selectedProfile!.Id : null
                 };
 
-                _serverManager.AddServer(AddedServer, username, password);
+                if (useProfile)
+                {
+                    // Profile-backed: store no per-server secret; the profile supplies credentials.
+                    _serverManager.AddServer(AddedServer, null, null);
+                }
+                else
+                {
+                    _serverManager.AddServer(AddedServer, username, password);
+                }
             }
 
             DialogResult = true;

--- a/Lite/Windows/EditCredentialProfileDialog.xaml
+++ b/Lite/Windows/EditCredentialProfileDialog.xaml
@@ -1,0 +1,77 @@
+<Window x:Class="PerformanceMonitorLite.Windows.EditCredentialProfileDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Credential Profile"
+        SizeToContent="Height" Width="440"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="/EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Credential Profile" FontSize="18" FontWeight="Bold" Margin="0,0,0,12"
+                   Foreground="{DynamicResource ForegroundBrush}"/>
+
+        <TextBlock Grid.Row="1" Text="Profile Name" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <TextBox Grid.Row="2" x:Name="NameBox" Margin="0,0,0,12"/>
+
+        <TextBlock Grid.Row="3" Text="Authentication" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <StackPanel Grid.Row="4" Margin="0,0,0,12">
+            <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                         IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+            <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed" Margin="0,0,0,4"
+                         ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+            <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed"
+                         ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running Lite."/>
+        </StackPanel>
+
+        <!-- SQL Auth -->
+        <StackPanel Grid.Row="5" x:Name="SqlCredentialsPanel" Margin="0,0,0,12">
+            <TextBlock Text="Username" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="UsernameBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Password" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="PasswordBox"/>
+        </StackPanel>
+
+        <!-- Service Principal -->
+        <StackPanel Grid.Row="5" x:Name="ServicePrincipalPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Client (Application) ID" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureClientIdBox" Margin="0,0,0,8"
+                     ToolTip="The Application (client) ID of the Entra app registration / service principal."/>
+            <TextBlock Text="Client Secret" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="AzureClientSecretBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Tenant ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureTenantIdBox" Margin="0,0,0,4"
+                     ToolTip="Optional. Stored for reference; the tenant is resolved automatically from the target server."/>
+        </StackPanel>
+
+        <!-- Managed Identity -->
+        <StackPanel Grid.Row="5" x:Name="ManagedIdentityPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="User-Assigned Identity Client ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="ManagedIdentityClientIdBox" Margin="0,0,0,8"
+                     ToolTip="Leave blank to use the system-assigned managed identity. Set to a client id to use a specific user-assigned identity."/>
+            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                       Text="Managed Identity only works when Lite is running on an Azure VM / resource that has a managed identity assigned — not on a typical workstation. Use Service Principal for non-interactive auth from a workstation."/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="6" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
+                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="SaveButton" Content="Save" Width="80" Height="30" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Width="80" Height="30" Click="CancelButton_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Lite/Windows/EditCredentialProfileDialog.xaml.cs
+++ b/Lite/Windows/EditCredentialProfileDialog.xaml.cs
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Windows;
+
+/// <summary>
+/// Add/Edit editor for a single <see cref="CredentialProfile"/>. Offers only the three profile-eligible
+/// auth types (SqlServer / ServicePrincipal / ManagedIdentity). Secrets are entered into a PasswordBox
+/// and stored only in Windows Credential Manager via <see cref="ProfileManager"/> — never in profiles.json.
+/// </summary>
+public partial class EditCredentialProfileDialog : Window
+{
+    private readonly ProfileManager _profileManager;
+    private readonly CredentialProfile? _existing;
+
+    /// <summary>
+    /// The saved/updated profile, or null if cancelled.
+    /// </summary>
+    public CredentialProfile? SavedProfile { get; private set; }
+
+    public EditCredentialProfileDialog(ProfileManager profileManager, CredentialProfile? existing = null)
+    {
+        InitializeComponent();
+        _profileManager = profileManager;
+        _existing = existing;
+
+        if (existing != null)
+        {
+            Title = "Edit Credential Profile";
+            NameBox.Text = existing.Name;
+
+            switch (existing.AuthType)
+            {
+                case AuthenticationTypes.ServicePrincipal:
+                    ServicePrincipalAuthRadio.IsChecked = true;
+                    AzureClientIdBox.Text = existing.AzureClientId ?? "";
+                    AzureTenantIdBox.Text = existing.AzureTenantId ?? "";
+                    break;
+                case AuthenticationTypes.ManagedIdentity:
+                    ManagedIdentityAuthRadio.IsChecked = true;
+                    ManagedIdentityClientIdBox.Text = existing.ManagedIdentityClientId ?? "";
+                    break;
+                default:
+                    SqlAuthRadio.IsChecked = true;
+                    UsernameBox.Text = existing.Username ?? "";
+                    break;
+            }
+
+            // Pre-fill the secret + username from Credential Manager (pre-fill-on-edit pattern).
+            if (existing.AuthType is AuthenticationTypes.SqlServer or AuthenticationTypes.ServicePrincipal)
+            {
+                var cred = _profileManager.CredentialService.GetCredential(
+                    ProfileManager.ProfileCredentialId(existing.Id));
+                if (cred.HasValue)
+                {
+                    if (existing.AuthType == AuthenticationTypes.SqlServer)
+                    {
+                        if (string.IsNullOrEmpty(UsernameBox.Text)) UsernameBox.Text = cred.Value.Username;
+                        PasswordBox.Password = cred.Value.Password;
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(AzureClientIdBox.Text)) AzureClientIdBox.Text = cred.Value.Username;
+                        AzureClientSecretBox.Password = cred.Value.Password;
+                    }
+                }
+            }
+
+            int inUse = _profileManager.CountServersUsingProfile(existing.Id);
+            if (inUse > 0)
+                StatusText.Text = $"{inUse} server(s) use this profile — editing its secret affects all of them.";
+        }
+    }
+
+    private void AuthMode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (SqlCredentialsPanel == null || ServicePrincipalPanel == null || ManagedIdentityPanel == null)
+            return;
+
+        SqlCredentialsPanel.Visibility = SqlAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        var name = NameBox.Text.Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            StatusText.Text = "Profile name is required.";
+            return;
+        }
+
+        string authType;
+        string? username = null;
+        string? secret = null;
+        string? azureClientId = null;
+        string? azureTenantId = null;
+        string? miClientId = null;
+
+        if (ServicePrincipalAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ServicePrincipal;
+            azureClientId = string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim();
+            azureTenantId = string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim();
+            username = azureClientId;
+            secret = AzureClientSecretBox.Password;
+
+            if (string.IsNullOrEmpty(azureClientId))
+            {
+                StatusText.Text = "Client (Application) ID is required for service principal profiles.";
+                return;
+            }
+            // On add (or when no stored secret yet), require the secret. On edit, a blank secret means
+            // "leave the stored secret unchanged".
+            if (_existing == null && string.IsNullOrEmpty(secret))
+            {
+                StatusText.Text = "Client secret is required for service principal profiles.";
+                return;
+            }
+        }
+        else if (ManagedIdentityAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ManagedIdentity;
+            miClientId = string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim();
+        }
+        else
+        {
+            authType = AuthenticationTypes.SqlServer;
+            username = UsernameBox.Text.Trim();
+            secret = PasswordBox.Password;
+
+            if (string.IsNullOrEmpty(username))
+            {
+                StatusText.Text = "Username is required for SQL Server profiles.";
+                return;
+            }
+            if (_existing == null && string.IsNullOrEmpty(secret))
+            {
+                StatusText.Text = "Password is required for SQL Server profiles.";
+                return;
+            }
+        }
+
+        try
+        {
+            if (_existing == null)
+            {
+                var profile = new CredentialProfile
+                {
+                    Name = name,
+                    AuthType = authType,
+                    Username = username,
+                    AzureClientId = azureClientId,
+                    AzureTenantId = azureTenantId,
+                    ManagedIdentityClientId = miClientId
+                };
+                _profileManager.AddProfile(profile, username, secret);
+                SavedProfile = profile;
+            }
+            else
+            {
+                _existing.Name = name;
+                _existing.AuthType = authType;
+                _existing.Username = username;
+                _existing.AzureClientId = azureClientId;
+                _existing.AzureTenantId = azureTenantId;
+                _existing.ManagedIdentityClientId = miClientId;
+
+                // A blank secret on edit leaves the stored secret unchanged (pass null username so
+                // UpdateProfile skips the re-store); a non-blank one updates it.
+                if (string.IsNullOrEmpty(secret))
+                    _profileManager.UpdateProfile(_existing);
+                else
+                    _profileManager.UpdateProfile(_existing, username, secret);
+
+                SavedProfile = _existing;
+            }
+
+            DialogResult = true;
+            Close();
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/Lite/Windows/ExcludedDatabasesDialog.xaml.cs
+++ b/Lite/Windows/ExcludedDatabasesDialog.xaml.cs
@@ -94,7 +94,7 @@ public partial class ExcludedDatabasesDialog : Window
 
     private async Task<List<string>> GetUserDatabasesAsync()
     {
-        var connectionString = _server.GetConnectionString(_serverManager.CredentialService);
+        var connectionString = _serverManager.CredentialResolver.GetConnectionString(_server);
         var builder = new SqlConnectionStringBuilder(connectionString)
         {
             InitialCatalog = "master",

--- a/Lite/Windows/ManageCredentialProfilesDialog.xaml
+++ b/Lite/Windows/ManageCredentialProfilesDialog.xaml
@@ -1,0 +1,54 @@
+<Window x:Class="PerformanceMonitorLite.Windows.ManageCredentialProfilesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Credential Profiles"
+        Height="420" Width="640"
+        WindowStartupLocation="CenterOwner"
+        Icon="/EDD.ico"
+        ResizeMode="CanResizeWithGrip"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Credential Profiles" FontWeight="Bold" FontSize="16"
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" TextWrapping="Wrap" FontSize="11"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,12"
+                   Text="A credential profile is a named, reusable identity (a shared SQL login, an Azure service principal, or a managed identity) that many servers can reference. Secrets are stored only in Windows Credential Manager, never in config files. A profile can't be deleted while a server still uses it."/>
+
+        <DataGrid Grid.Row="2" x:Name="ProfilesGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserAddRows="False" HeadersVisibility="Column" SelectionMode="Single"
+                  MouseDoubleClick="ProfilesGrid_MouseDoubleClick">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Auth Type" Binding="{Binding AuthTypeDisplay}" Width="200"/>
+                <DataGridTextColumn Header="Username / Client ID" Width="200">
+                    <DataGridTextColumn.Binding>
+                        <PriorityBinding>
+                            <Binding Path="Username"/>
+                            <Binding Path="AzureClientId"/>
+                            <Binding Path="ManagedIdentityClientId"/>
+                        </PriorityBinding>
+                    </DataGridTextColumn.Binding>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Grid.Row="3" x:Name="StatusText" FontSize="10" FontStyle="Italic"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,8,0,0"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Add…" Width="80" Height="28" Margin="0,0,8,0" Click="AddButton_Click" Style="{StaticResource AccentButton}"/>
+            <Button Content="Edit…" Width="80" Height="28" Margin="0,0,8,0" Click="EditButton_Click"/>
+            <Button Content="Delete" Width="80" Height="28" Margin="0,0,8,0" Click="DeleteButton_Click"/>
+            <Button Content="Close" Width="80" Height="28" Click="CloseButton_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Lite/Windows/ManageCredentialProfilesDialog.xaml.cs
+++ b/Lite/Windows/ManageCredentialProfilesDialog.xaml.cs
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows;
+using System.Windows.Input;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Windows;
+
+/// <summary>
+/// Manages the list of <see cref="CredentialProfile"/> records (Add/Edit/Delete). Launched from
+/// ManageServersWindow (O-3). Delete is a constraint, not a cascade: a profile referenced by a server
+/// can't be deleted until the server is reassigned (the §2 fail-closed resolution is the safety net
+/// behind this best-effort check).
+/// </summary>
+public partial class ManageCredentialProfilesDialog : Window
+{
+    private readonly ProfileManager _profileManager;
+
+    /// <summary>
+    /// True if any profile was added/edited/deleted, so the caller can refresh.
+    /// </summary>
+    public bool ProfilesChanged { get; private set; }
+
+    public ManageCredentialProfilesDialog(ProfileManager profileManager)
+    {
+        InitializeComponent();
+        _profileManager = profileManager;
+        RefreshGrid();
+    }
+
+    private void RefreshGrid()
+    {
+        ProfilesGrid.ItemsSource = null;
+        var profiles = _profileManager.GetAll();
+        ProfilesGrid.ItemsSource = profiles;
+        StatusText.Text = $"{profiles.Count} profile(s).";
+    }
+
+    private void AddButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new EditCredentialProfileDialog(_profileManager) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void EditButton_Click(object sender, RoutedEventArgs e) => EditSelected();
+
+    private void ProfilesGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e) => EditSelected();
+
+    private void EditSelected()
+    {
+        if (ProfilesGrid.SelectedItem is not CredentialProfile selected)
+            return;
+
+        var dialog = new EditCredentialProfileDialog(_profileManager, selected) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void DeleteButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ProfilesGrid.SelectedItem is not CredentialProfile selected)
+            return;
+
+        var confirm = MessageBox.Show(
+            $"Delete credential profile '{selected.Name}'?\n\nThis removes the profile and its stored secret.",
+            "Delete Credential Profile",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+
+        if (confirm != MessageBoxResult.Yes)
+            return;
+
+        try
+        {
+            _profileManager.DeleteProfile(selected.Id);
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+        catch (System.Exception ex)
+        {
+            // Referential-integrity block (or any failure) surfaces here.
+            MessageBox.Show(ex.Message, "Cannot Delete Profile", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Lite/Windows/ManageServersWindow.xaml
+++ b/Lite/Windows/ManageServersWindow.xaml
@@ -73,6 +73,8 @@
             <Button Content="Add Server" Click="AddButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
             <Button Content="Edit" Click="EditButton_Click" Margin="0,0,8,0"/>
             <Button Content="Excluded Databases" Click="ExcludedDatabases_Click" Margin="0,0,8,0"/>
+            <Button Content="Credential Profiles…" Click="CredentialProfiles_Click" Margin="0,0,8,0"
+                    ToolTip="Manage named, reusable credentials that many servers can share."/>
             <Button Content="Delete" Click="DeleteButton_Click" Margin="0,0,8,0"/>
             <Button Content="Close" Click="CloseButton_Click"/>
         </StackPanel>

--- a/Lite/Windows/ManageServersWindow.xaml.cs
+++ b/Lite/Windows/ManageServersWindow.xaml.cs
@@ -17,16 +17,18 @@ namespace PerformanceMonitorLite.Windows;
 public partial class ManageServersWindow : Window
 {
     private readonly ServerManager _serverManager;
+    private readonly ProfileManager _profileManager;
 
     /// <summary>
     /// Set to true if servers were modified so the caller knows to refresh.
     /// </summary>
     public bool ServersChanged { get; private set; }
 
-    public ManageServersWindow(ServerManager serverManager)
+    public ManageServersWindow(ServerManager serverManager, ProfileManager profileManager)
     {
         InitializeComponent();
         _serverManager = serverManager;
+        _profileManager = profileManager;
         RefreshGrid();
     }
 
@@ -58,7 +60,7 @@ public partial class ManageServersWindow : Window
 
     private void AddButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverManager) { Owner = this };
+        var dialog = new AddServerDialog(_serverManager, _profileManager) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
@@ -83,10 +85,21 @@ public partial class ManageServersWindow : Window
             return;
         }
 
-        var dialog = new AddServerDialog(_serverManager, selected) { Owner = this };
+        var dialog = new AddServerDialog(_serverManager, _profileManager, selected) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void CredentialProfiles_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ManageCredentialProfilesDialog(_profileManager) { Owner = this };
+        dialog.ShowDialog();
+        if (dialog.ProfilesChanged)
+        {
+            // Server rows may display which profile they use; refresh to reflect reassignments.
             RefreshGrid();
         }
     }


### PR DESCRIPTION
## What shipped

Phase B of #1038: a **named credential profile** (a shared SQL login, an Azure service principal, or a managed identity) that many server entries reference, so one identity covers a whole fleet without per-server secret entry. Composing Phase A's SP auth + a shared profile is the #1036 ask ("one identity across all my Azure SQL instances"). **Lite only, no new NuGet, additive + backward compatible** (profiles are opt-in; `CredentialProfileId == null` = today's per-server behavior).

**New:**
- `CredentialProfile` model (`Lite/Models/CredentialProfile.cs`) — Id, Name, AuthType (SqlServer/ServicePrincipal/ManagedIdentity only), non-secret fields. **No secret property.**
- `ProfileManager` (`Lite/Services/ProfileManager.cs`) — shared-dir `profiles.json` mirroring `ServerManager` (WriteIndented, `.bak` restore-on-corruption, lock, CRUD), secret via `profile_{id}`, `ImportProfilesFromFile`, referential-integrity (in-use) query, implements `IProfileLookup`.
- `IProfileLookup` (`Lite/Services/IProfileLookup.cs`), `CredentialResolver` (`Lite/Services/CredentialResolver.cs`).
- `ManageCredentialProfilesDialog` + `EditCredentialProfileDialog` (CRUD UI), launched from a "Credential Profiles…" button in `ManageServersWindow`.

**Modified:** `ServerConnection` (resolution refactor + removed overloads + profile-aware `HasStoredCredentials`); the call-site sweep; `ServerManager` (`IProfileLookup` seam); `MainWindow` (two-phase wiring + import); `AddServerDialog` (profile picker + M-3 scrub + profile-aware edit-load); the migrated tests.

## Fail-closed, atomic-tuple resolution

Resolution produces ONE immutable tuple `(authType, username, password, azureClientId, miClientId)` sourced **entirely** from the profile OR entirely from the server — never field-by-field mixed (so a profile secret can never combine with the server's stale `AzureClientId` to build the wrong SP identity). When `CredentialProfileId != null`:
- profile **found** → tuple entirely from the profile (its AuthType, its non-secret fields, secret from `GetCredential("profile_{id}")`);
- profile **missing** → **throws** `"credential profile '{id}' not found"` in a closed branch with NO fall-through to the server's own `AuthenticationType`/`GetCredential(Id)`/`this.AzureClientId`/`this.ManagedIdentityClientId`. A dangling profile never silently connects under server-self auth.

This is the real safety net behind the best-effort delete-constraint (the shared `%ProgramData%` dir is multi-user-writable, so referential integrity is advisory).

## The acyclicity seam (IProfileLookup)

`ServerManager.CheckConnectionAsync` builds its string inside `ServerManager` and can't depend on the resolver/`ProfileManager` (that recreates a cycle). Instead `ServerManager` holds a late-injected `IProfileLookup` (default null = today's behavior) and resolves through the SAME fail-closed static. Two-phase wiring in `MainWindow.xaml.cs`: build `ServerManager` → `new ProfileManager(serverManager)` → `serverManager.ProfileLookup = profileManager`. Coupling stays one-way: `ServerManager → IProfileLookup ← ProfileManager`, and separately `ProfileManager → ServerManager` (for the in-use query).

## Compiler-enforced sweep

The `ServerConnection.GetConnectionString(CredentialService)` / `GetUtilityConnectionString(CredentialService)` instance overloads were **removed**, so every connection-string call site failed to compile until routed through `CredentialResolver`. All sites across `SqlPlanFetcher`, `McpPlanTools`, `FinOpsTab`, `ExcludedDatabasesDialog`, `ServerTab.*` (15), `RemoteCollectorService`, plus `ServerManager.CheckConnectionAsync` now resolve through the same profile-or-self/fail-closed path. The downstream `new SqlConnectionStringBuilder(connStr){…}` re-parsers were left alone (they only override catalog/timeout, not auth). The MCP/SqlPlanFetcher paths route via `serverManager.CredentialResolver` (the singleton whose `ProfileLookup` is wired), so they pick up profiles without a static-signature change.

## Security note

Profile secrets live **only** in Windows Credential Manager under `profile_{id}`; `CredentialProfile` has no secret property and `profiles.json` never stores one (verified by a test asserting the password is absent from the on-disk JSON). The `profile_` namespace can't collide with bare-GUID server keys or the SMTP/webhook literals. Assigning a profile to a server unconditionally scrubs the per-server identity (`DeleteCredential(server.Id)` + null Azure/MI fields) regardless of auth type (M-3), so a later "switch back to inline" can't resurrect a stale secret.

## Build + test (real results)

`dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — **Build succeeded, 0 Warning(s), 0 Error(s)**.

`dotnet test Lite.Tests` — **Passed! Failed: 0, Passed: 349, Skipped: 0, Total: 349**. Includes the migrated existing tests (off the removed overload, onto the resolver, keeping the SP-secret / MI-no-secret assertions) and 13 new profile tests, notably:
- `Resolution_DanglingProfile_Throws_AndNeverFallsBackToServerSelfAuth` (the HARD fail-closed test)
- `Resolution_ProfileServicePrincipal_UsesProfileClientId_NotServerStaleAzureClientId` (B-3)
- `Resolution_ProfileLessServer_IsRegressionIdentical`
- `HasStoredCredentials_ProfileBacked_ReflectsProfileSecret_NotServerKey` / `_DanglingProfile_IsFalse`
- `ProfileManager_Add_Get_Persists_AndStoresSecretUnderProfileKey` (asserts secret absent from JSON)
- `ProfileManager_Delete_BlockedWhileServerReferences_AllowedAfterReassign`
- `SwitchToProfile_DeletesOrphanedPerServerSecret`
- `Import_RoundTrips_AndBuildTolerates_SecretAbsentImportedProfile`

## Maintainer E2E (real Azure — gate, not run in CI)

- [ ] Create one SP profile, attach it to several Azure SQL servers, confirm all connect non-interactively under the single identity (the #1036 fleet scenario end-to-end).
- [ ] SQL-login profile across several on-prem servers.
- [ ] Delete-constraint blocks while a profile is in use; allowed after reassignment.
- [ ] Import a `profiles.json` from a previous install; confirm secrets must be re-entered once via the profile editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)