### PR TITLE
Clear cached plan (DBCC FREEPROCCACHE) — privileged core (unregistered) — PR-A

### DIFF
--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -652,6 +652,20 @@ public class RemediationApplyServiceTests
             });
         }
 
+        public int ClearPlanCalls;
+
+        public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+        {
+            ClearPlanCalls++;
+            return Task.FromResult(new ClearPlanOutcome
+            {
+                QueryHash = queryHash, Status = RemediationStatus.Success, Cleared = true, HandlesCleared = 1,
+                ExecutingLogin = "PerfMonLogin", Message = "Cleared 1 cached plan(s).",
+                GeneratedSql = "DBCC FREEPROCCACHE(0xDEADBEEF);", PriorValue = "1 plan(s) cached for this query hash",
+                GateSpid = 55, ExecSpid = 55
+            });
+        }
+
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
         {
             AuditRecords.Add(record);
@@ -678,6 +692,8 @@ public class RemediationApplyServiceTests
             });
         public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
             => Task.FromResult(new DbConfigOutcome { Database = database, Setting = setting, Status = RemediationStatus.Skipped });
+        public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ClearPlanOutcome { QueryHash = queryHash, Status = RemediationStatus.Skipped });
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct) => Task.FromResult(true);
     }
 }

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1087,6 +1087,482 @@ public class RemediationTests
         Assert.Contains("Reader/writer concurrency semantics change", d.RisksOfChanging[2].Text);
     }
 
+    // ════════════════════════════════════════════════════════════════════════════
+    // CLEAR CACHED PLAN (DBCC FREEPROCCACHE) — destructive privileged core (PR-A;
+    // UNREGISTERED). The two catastrophic axes: never-bare/null-handle-guard, and the
+    // ALTER-SERVER-STATE fail-closed gate. Plus the §2a row-level detector exclusion.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>A CPU finding carrying an abnormal_cpu_plans drill-down with one qualifying row.</summary>
+    private static AnalysisFinding CpuFinding(List<object>? rows = null, string rootKey = "CPU_SQL_PERCENT") => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "cpu",
+        StoryPath = rootKey,
+        StoryPathHash = "cpuplan000000001",
+        RootFactKey = rootKey,
+        DrillDown = new Dictionary<string, object>
+        {
+            ["abnormal_cpu_plans"] = rows ?? new List<object>
+            {
+                new
+                {
+                    query_hash = "0xABCDEF0123456789",
+                    database = "AdventureWorks",
+                    current_cpu_per_exec_ms = 45.0,
+                    baseline_cpu_per_exec_ms = 9.0,
+                    anomaly_ratio = 5.0,
+                    execution_count = 1200L,
+                    total_cpu_ms = 54000.0,
+                    latest_plan_handle = "0x06000100ABCD",
+                    query_text = "SELECT * FROM dbo.BigTable WHERE x = @p",
+                    cpu_percent = 62,
+                    plan_regression_cofired = false,
+                    parameter_sensitivity_cofired = false
+                }
+            }
+        }
+    };
+
+    private static RemediationAction ClearAction(string hash = "0xABCDEF0123456789", string db = "AdventureWorks") =>
+        new("CLEAR_PLAN", "clear", Array.Empty<ForcePlanTarget>(),
+            ClearPlanTargets: new[] { new ClearPlanTarget(db, hash, 45.0, 9.0, 5.0, "0x06") },
+            ClearPlanFigures: new ClearPlanFigures(45.0, 9.0, 5.0, 62, false, false));
+
+    // ── BuildClearPlanAction (parallel builder) + BuildAction-unchanged guard ────
+
+    [Fact]
+    public void BuildClearPlanAction_EmitsOnAbnormalCpuPlans()
+    {
+        var action = FactRemediation.BuildClearPlanAction(CpuFinding());
+        Assert.NotNull(action);
+        Assert.Equal("CLEAR_PLAN", action!.FactKey);
+        Assert.Equal("clear", action.Action);
+        Assert.Empty(action.Targets);
+        Assert.Null(action.DbConfigTargets);
+        var t = Assert.Single(action.ClearPlanTargets!);
+        Assert.Equal("0xABCDEF0123456789", t.QueryHash);
+        Assert.Equal("AdventureWorks", t.Database);
+        Assert.Equal(5.0, t.AnomalyRatio);
+        // The figures are carried for the at-apply dialog (no finding in hand).
+        Assert.NotNull(action.ClearPlanFigures);
+        Assert.Equal(45.0, action.ClearPlanFigures!.CurrentCpuPerExecMs);
+        Assert.Equal(62, action.ClearPlanFigures.CpuPercent);
+    }
+
+    [Fact]
+    public void BuildClearPlanAction_CpuSpikeRootKey_AlsoEmits()
+    {
+        var action = FactRemediation.BuildClearPlanAction(CpuFinding(rootKey: "CPU_SPIKE"));
+        Assert.NotNull(action);
+        Assert.Equal("CLEAR_PLAN", action!.FactKey);
+    }
+
+    [Fact]
+    public void BuildClearPlanAction_ReturnsNull_WhenNoDrillDown()
+    {
+        var finding = CpuFinding();
+        finding.DrillDown = new Dictionary<string, object>();   // no abnormal_cpu_plans
+        Assert.Null(FactRemediation.BuildClearPlanAction(finding));
+    }
+
+    [Fact]
+    public void BuildClearPlanAction_ReturnsNull_WhenNotCpuFinding()
+    {
+        var finding = CpuFinding();
+        finding.RootFactKey = "PLAN_REGRESSION";
+        Assert.Null(FactRemediation.BuildClearPlanAction(finding));
+    }
+
+    [Fact]
+    public void BuildClearPlanAction_RejectsRowsWithoutValidQueryHash()
+    {
+        // A row whose query_hash is blank / not a hex handle can never become a target —
+        // it could never resolve a plan handle (defends the never-resolve-garbage edge).
+        var action = FactRemediation.BuildClearPlanAction(CpuFinding(new List<object>
+        {
+            new { query_hash = "", database = "Db", current_cpu_per_exec_ms = 10.0, baseline_cpu_per_exec_ms = 1.0,
+                  anomaly_ratio = 10.0, execution_count = 5L, total_cpu_ms = 5000.0, latest_plan_handle = "",
+                  query_text = "", cpu_percent = 10, plan_regression_cofired = false, parameter_sensitivity_cofired = false },
+            new { query_hash = "notahex", database = "Db", current_cpu_per_exec_ms = 10.0, baseline_cpu_per_exec_ms = 1.0,
+                  anomaly_ratio = 10.0, execution_count = 5L, total_cpu_ms = 5000.0, latest_plan_handle = "",
+                  query_text = "", cpu_percent = 10, plan_regression_cofired = false, parameter_sensitivity_cofired = false }
+        }));
+        Assert.Null(action);
+    }
+
+    [Fact]
+    public void BuildAction_Unchanged_NeverEmitsClearPlan_OnCpuFinding()
+    {
+        // The regression guard (§9): the parallel builder does not leak into BuildAction —
+        // a CPU finding carrying abnormal_cpu_plans yields NO action from BuildAction.
+        Assert.Null(FactRemediation.BuildAction(CpuFinding()));
+    }
+
+    // ── FactRiskDisclosure CLEAR_PLAN arm (two-sided, real figures, both steers) ──
+
+    [Fact]
+    public void RiskDisclosure_ClearPlan_HasAtLeastOneOfEachSide_RealFigures()
+    {
+        var d = FactRiskDisclosure.GetForAction(ClearAction(), CpuFinding());
+        Assert.NotNull(d);
+        Assert.NotEmpty(d!.RisksOfChanging);
+        Assert.NotEmpty(d.RisksOfNotChanging);
+        // Real figures substituted from the carried ClearPlanFigures.
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("5.0x") && r.Text.Contains("45.0 ms") && r.Text.Contains("9.0 ms") && r.Text.Contains("62%"));
+        // The changing side discloses the recompile + not-guaranteed-better + per-handle blast radius.
+        Assert.Contains(d.RisksOfChanging, r => r.Text.Contains("forces a recompile"));
+        Assert.Contains(d.RisksOfChanging, r => r.Text.Contains("NOT guaranteed to produce a better plan"));
+        Assert.Contains(d.RisksOfChanging, r => r.Text.Contains("EVERY currently-cached plan"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_ClearPlan_PlanRegressionCoFired_SteersToForce()
+    {
+        var action = new RemediationAction("CLEAR_PLAN", "clear", Array.Empty<ForcePlanTarget>(),
+            ClearPlanTargets: new[] { new ClearPlanTarget("Db", "0xAA") },
+            ClearPlanFigures: new ClearPlanFigures(40.0, 8.0, 5.0, 50, PlanRegressionCoFired: true, ParameterSensitivityCoFired: false));
+        var d = FactRiskDisclosure.GetForAction(action, null)!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("forcing it") && r.Text.Contains("more durable"));
+        Assert.DoesNotContain(d.RisksOfNotChanging, r => r.Text.Contains("parameter-sensitive"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_ClearPlan_ParameterSensitivityCoFired_SaysWontDurablyHelp()
+    {
+        var action = new RemediationAction("CLEAR_PLAN", "clear", Array.Empty<ForcePlanTarget>(),
+            ClearPlanTargets: new[] { new ClearPlanTarget("Db", "0xAA") },
+            ClearPlanFigures: new ClearPlanFigures(40.0, 8.0, 5.0, 50, PlanRegressionCoFired: false, ParameterSensitivityCoFired: true));
+        var d = FactRiskDisclosure.GetForAction(action, null)!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("parameter-sensitive") && r.Text.Contains("WON'T durably"));
+    }
+
+    [Fact]
+    public void RiskDisclosure_ClearPlan_FiguresSurvivePersistence_NoFinding()
+    {
+        // The RcsiInactionFigures analog: with NO finding (apply-time), the carried
+        // ClearPlanFigures still render the real numbers.
+        var d = FactRiskDisclosure.GetForAction(ClearAction(), null)!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("5.0x") && r.Text.Contains("62%"));
+    }
+
+    // ── ClearPlanHandler invariants ──────────────────────────────────────────────
+
+    [Fact]
+    public void ClearPlan_Handler_IsDestructive_And_ApplyOnly()
+    {
+        var handler = new ClearPlanHandler();
+        Assert.Equal("CLEAR_PLAN", handler.FactKey);
+        Assert.True(handler.IsDestructive);          // the second true in the codebase
+        Assert.False(handler.SupportsUnapply);       // you cannot un-clear a cache
+    }
+
+    [Fact]
+    public async Task ClearPlan_UnapplyAsync_Throws()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            new ClearPlanHandler().UnapplyAsync(ClearAction(), new FakeExecutor(), Identity, CancellationToken.None));
+    }
+
+    [Fact]
+    public void ClearPlan_Handler_IsNotRegistered_InProduction()
+    {
+        // PR-A is dead-code-safe: the PRODUCTION registry must NOT construct ClearPlanHandler.
+        var dir = FindDashboardSourceDir();
+        var serviceSrc = File.ReadAllText(Path.Combine(dir, "Services", "Remediation", "RemediationApplyService.cs"));
+        Assert.DoesNotContain("new ClearPlanHandler()", serviceSrc);
+
+        // And it does not resolve in a registry built like production (no CLEAR_PLAN handler).
+        var productionRegistry = new RemediationHandlerRegistry(
+            new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler() });
+        Assert.Null(productionRegistry.TryGet("CLEAR_PLAN"));
+    }
+
+    [Fact]
+    public void CoreMachineryMarkers_Include_ClearPlanSurface()
+    {
+        Assert.Contains("ClearPlanHandler", CoreMachineryMarkers);
+        Assert.Contains("ClearProcCacheAsync", CoreMachineryMarkers);
+    }
+
+    // ── ClearPlanHandler apply behaviours against the faked executor ─────────────
+
+    [Fact]
+    public async Task ClearPlan_AuditTableAbsent_HardBlocks_NoMutation_NoAudit()
+    {
+        var exec = new FakeExecutor { AuditTableExists = false };
+        var result = await new ClearPlanHandler().ApplyAsync(ClearAction(), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Blocked, o.Status);
+        Assert.False(o.AuditWritten);
+        Assert.Equal(0, exec.ClearPlanCalls);        // no DBCC path even attempted
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task ClearPlan_PermissionDenied_FailsClosed_NoElevation()
+    {
+        // The DOMINANT runtime path: the least-privilege login lacks ALTER SERVER STATE.
+        var exec = new FakeExecutor
+        {
+            ClearPlanFunc = h => new ClearPlanOutcome
+            {
+                QueryHash = h, Status = RemediationStatus.PermissionDenied, Cleared = false, HandlesCleared = 0,
+                ExecutingLogin = "PerfMonLogin",
+                Message = "lacks ALTER SERVER STATE ... GRANT ALTER SERVER STATE TO [PerfMonLogin];",
+                PriorValue = "0 plans (permission denied)"
+            }
+        };
+        var result = await new ClearPlanHandler().ApplyAsync(ClearAction(), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.PermissionDenied, o.Status);
+        Assert.Equal(1, exec.ClearPlanCalls);
+        var rec = Assert.Single(exec.AuditRecords);
+        Assert.Equal("skipped", rec.Result);          // PermissionDenied audits as skipped
+        Assert.True(rec.ConsentAcknowledged);
+        Assert.Equal("CLEAR_PLAN", rec.FactKey);
+        Assert.Equal("clear_cached_plan", rec.Action);
+        Assert.Null(rec.QueryId);
+        Assert.Null(rec.PlanId);
+        Assert.Contains("GRANT ALTER SERVER STATE", rec.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ClearPlan_NoSurvivingHandle_Skips()
+    {
+        var exec = new FakeExecutor
+        {
+            ClearPlanFunc = h => new ClearPlanOutcome
+            {
+                QueryHash = h, Status = RemediationStatus.Skipped, Cleared = false, HandlesCleared = 0,
+                ExecutingLogin = "sa", Message = "No cached plan is currently present", PriorValue = "0 plans (no surviving handle)"
+            }
+        };
+        var result = await new ClearPlanHandler().ApplyAsync(ClearAction(), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(RemediationStatus.Skipped, Assert.Single(result.Outcomes).Status);
+        var rec = Assert.Single(exec.AuditRecords);
+        Assert.Equal("skipped", rec.Result);
+        Assert.True(rec.ConsentAcknowledged);
+    }
+
+    [Fact]
+    public async Task ClearPlan_Success_WritesAudit_ConsentTrue_NullIds_Action()
+    {
+        var exec = new FakeExecutor();   // default success outcome
+        var result = await new ClearPlanHandler().ApplyAsync(ClearAction(), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, o.Status);
+        Assert.True(o.AuditWritten);
+        var rec = Assert.Single(exec.AuditRecords);
+        Assert.Equal("success", rec.Result);
+        Assert.True(rec.ConsentAcknowledged);
+        Assert.Equal("clear_cached_plan", rec.Action);
+        Assert.Null(rec.QueryId);
+        Assert.Null(rec.PlanId);
+        Assert.Contains("DBCC FREEPROCCACHE", rec.GeneratedSql);
+        // The audited action string fits the VarChar(32) @action param (17 chars).
+        Assert.True(rec.Action.Length <= 32);
+    }
+
+    // ── Never-bare / null-handle-guard structural assertions (M-1) ───────────────
+    //
+    // The single-connection SPID equality + the actual DBCC text are executor/real-server
+    // concerns (cannot be exercised against a faked executor). These assert, at the SOURCE
+    // level, that the executor ONLY ever builds the single-`@plan_handle` form, binds the
+    // handle as a typed param, filters plan_handle IS NOT NULL, rejects null/zero-length in
+    // C# before any DBCC string, and never emits the bare/whole-cache form.
+
+    [Fact]
+    public void Executor_NeverEmitsBareFreeProcCache_OnlyTypedSingleHandleForm()
+    {
+        var dir = FindDashboardSourceDir();
+        var src = File.ReadAllText(Path.Combine(dir, "Services", "DatabaseService.Remediation.cs"));
+
+        // The ONLY DBCC text is the single-handle form with a typed @plan_handle param.
+        Assert.Contains("DBCC FREEPROCCACHE(@plan_handle)", src);
+        Assert.Contains("@plan_handle", src);
+        Assert.Contains("SqlDbType.VarBinary, 64", src);
+
+        // The catastrophic bare/whole-cache form must NOT appear anywhere: no
+        // no-argument FREEPROCCACHE statement and no empty-arg form.
+        Assert.DoesNotContain("FREEPROCCACHE;", src);
+        Assert.DoesNotContain("FREEPROCCACHE ;", src);
+        Assert.DoesNotContain("FREEPROCCACHE()", src);   // no empty-arg form
+
+        // The live resolve filters plan_handle IS NOT NULL (the BAD_ACTOR precedent),
+        // and the C# guard rejects null/zero-length BEFORE any DBCC string is built.
+        Assert.Contains("plan_handle IS NOT NULL", src);
+        Assert.Contains("handle.Length == 0", src);
+    }
+
+    [Fact]
+    public void Executor_GateIsNamedAlterServerState_FailClosed()
+    {
+        var dir = FindDashboardSourceDir();
+        var src = File.ReadAllText(Path.Combine(dir, "Services", "DatabaseService.Remediation.cs"));
+
+        // The NAMED server permission, fail-closed via ISNULL(...,0). NOT the generic
+        // (NULL,NULL,'ALTER') token (which returns NULL even for sysadmin).
+        Assert.Contains("HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SERVER STATE')", src);
+        Assert.Contains("ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SERVER STATE'), 0)", src);
+        Assert.DoesNotContain("HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER')", src);
+        // PermissionDenied carries grant guidance.
+        Assert.Contains("GRANT ALTER SERVER STATE", src);
+    }
+
+    [Fact]
+    public void Executor_HexHandleParse_RejectsMalformed_NeverThrows()
+    {
+        // The query_hash → binary(8) bind path: a typed param, never concatenated. A
+        // malformed value parses to null (→ Skip), never a DBCC string.
+        Assert.Null(DatabaseService.TryParseHexHandle(null));
+        Assert.Null(DatabaseService.TryParseHexHandle(""));
+        Assert.Null(DatabaseService.TryParseHexHandle("0x"));
+        Assert.Null(DatabaseService.TryParseHexHandle("0xABC"));     // odd length
+        Assert.Null(DatabaseService.TryParseHexHandle("0xZZ"));      // not hex
+        var ok = DatabaseService.TryParseHexHandle("0xABCDEF0123456789");
+        Assert.NotNull(ok);
+        Assert.Equal(8, ok!.Length);
+        // No "0x" prefix is also accepted (raw hex).
+        Assert.Equal(8, DatabaseService.TryParseHexHandle("ABCDEF0123456789")!.Length);
+    }
+
+    // ── Detector row-level exclusion (§2a / R2-MOD-A / R2-MOD-B) ─────────────────
+    //
+    // The production detector runs this logic as T-SQL against collect.query_stats; the
+    // PlanCacheAnomalyDetector reference encodes the SAME row-level exclusion + per-exec
+    // math so the catastrophic correctness rules are headlessly guarded.
+
+    private static readonly DateTime ServerUp = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime CurrentStart = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private static PlanCacheAnomalyDetector.StatRow Row(
+        string hash, string plan, DateTime t, long workerUs, long execs,
+        DateTime? serverStart = null, string sqlH = "S1", int so = 0, int eo = -1) =>
+        new(hash, sqlH, so, eo, plan, t, serverStart ?? ServerUp, workerUs, execs);
+
+    [Fact]
+    public void Detector_LeakyFirstCollection_YieldsNoTarget()
+    {
+        // R2-MOD-A: a plan_handle whose GLOBAL-first collection is the FIRST in-window row,
+        // carrying delta = full cumulative raw total. The leaky "≥2 in-window" gate would
+        // wrongly pass it; the row-level exclusion drops it. There is no earlier collection
+        // for (sql_handle, offsets, plan_handle) → not a real-delta row → excluded.
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>
+        {
+            // baseline window: a normal plan at low per-exec CPU, WITH a real prior.
+            Row("0xQ1", "P0", CurrentStart.AddHours(-10), 1_000_000, 1000),   // first-collection of P0 (no prior) — excluded
+            Row("0xQ1", "P0", CurrentStart.AddHours(-9),    10_000, 1000),    // real delta: 10us/exec
+            // current window: a NEW plan_handle P1 whose FIRST collected row carries 6h of
+            // accumulated CPU as one delta (the contamination this feature targets).
+            Row("0xQ1", "P1", CurrentStart.AddHours(1), 6_000_000_000, 1000), // first-collection of P1 — excluded
+        };
+
+        var results = PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart);
+        // The only real-delta row is the one baseline row; current window has no real-delta
+        // rows → no current execs → no anomaly. The fake 6h spike never counts.
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Detector_ServerRestartRow_YieldsNoTarget()
+    {
+        // R2-MOD-B: the first post-restart row (server_start_time >= prior collection_time)
+        // carries delta = full cumulative raw total. The row-level predicate requires the
+        // prior collection_time > this row's server_start_time, so a post-restart row is
+        // excluded even though an earlier collection exists.
+        var restart = CurrentStart.AddMinutes(30);   // server restarted mid-window
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>
+        {
+            Row("0xQ2", "P0", CurrentStart.AddHours(-9), 9_000, 1000),                 // first-collection — excluded
+            Row("0xQ2", "P0", CurrentStart.AddHours(-8), 9_000, 1000, ServerUp),       // real delta (prior at -9 > ServerUp)
+            // post-restart row: huge raw total; prior collection (-8) is BEFORE the new
+            // server_start_time (restart), so it is NOT a real-delta row → excluded.
+            Row("0xQ2", "P0", CurrentStart.AddHours(1), 9_000_000_000, 1000, restart),
+        };
+
+        var results = PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Detector_SyntheticMassRestart_ProducesNoTargetsEnMasse()
+    {
+        // A mass restart: MANY plan_handles each with a first-post-restart raw-total row in
+        // the current window. None has a real-delta current row → no targets en masse.
+        var restart = CurrentStart.AddMinutes(15);
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>();
+        for (int i = 0; i < 50; i++)
+        {
+            var hash = "0xQ" + i.ToString("X");
+            var plan = "P" + i;
+            // a real baseline so each query has a baseline per-exec
+            rows.Add(Row(hash, plan, CurrentStart.AddHours(-9), 5_000, 500, ServerUp, sqlH: "S" + i));
+            rows.Add(Row(hash, plan, CurrentStart.AddHours(-8), 5_000, 500, ServerUp, sqlH: "S" + i));
+            // the mass post-restart contaminated row in the current window
+            rows.Add(Row(hash, plan, CurrentStart.AddMinutes(20), 8_000_000_000, 500, restart, sqlH: "S" + i));
+        }
+
+        var results = PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Detector_GenuinePerExecJump_OnRealDeltaRows_EmitsTarget()
+    {
+        // A genuine per-exec jump on REAL-prior-delta rows (an earlier collection exists,
+        // after server_start_time) DOES emit a target. Baseline ~10us/exec; current
+        // ~50us/exec = 5x, material CPU.
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>
+        {
+            Row("0xHOT", "P0", CurrentStart.AddHours(-9), 9_999_999, 1000),                 // first-collection — excluded
+            Row("0xHOT", "P0", CurrentStart.AddHours(-8), 10_000_000, 1000),                // baseline real delta: 10us/exec
+            Row("0xHOT", "P0", CurrentStart.AddHours(-7), 10_000_000, 1000),                // baseline real delta: 10us/exec
+            Row("0xHOT", "P0", CurrentStart.AddHours(1),  50_000_000, 1000),                // current real delta: 50us/exec
+        };
+
+        var results = PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart);
+        var hit = Assert.Single(results);
+        Assert.Equal("0xHOT", hit.QueryHash);
+        Assert.True(hit.AnomalyRatio >= 4.5 && hit.AnomalyRatio <= 5.5, $"ratio was {hit.AnomalyRatio}");
+        Assert.True(hit.CurrentCpuPerExecMs > hit.BaselineCpuPerExecMs);
+    }
+
+    [Fact]
+    public void Detector_StableExpensiveQuery_NoTarget()
+    {
+        // A query that is expensive but STABLE (high but unchanging per-exec) is NOT a
+        // clear-plan candidate — the anomaly gate (ratio < T) excludes it.
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>
+        {
+            Row("0xSTABLE", "P0", CurrentStart.AddHours(-9), 100_000_000, 1000),    // first-collection — excluded
+            Row("0xSTABLE", "P0", CurrentStart.AddHours(-8), 100_000_000, 1000),    // baseline 100us/exec
+            Row("0xSTABLE", "P0", CurrentStart.AddHours(1),  105_000_000, 1000),    // current 105us/exec — ~1.05x
+        };
+
+        Assert.Empty(PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart));
+    }
+
+    [Fact]
+    public void Detector_AnomalousButTrivialCpu_NoTarget()
+    {
+        // Abnormal per-exec ratio but below the materiality floor → no target (clearing
+        // a trivial-CPU query is pointless).
+        var rows = new List<PlanCacheAnomalyDetector.StatRow>
+        {
+            Row("0xTINY", "P0", CurrentStart.AddHours(-9), 100, 10),     // first-collection — excluded
+            Row("0xTINY", "P0", CurrentStart.AddHours(-8), 100, 10),     // baseline 10us/exec
+            Row("0xTINY", "P0", CurrentStart.AddHours(1),  5_000, 10),   // current 500us/exec = 50x but only 5ms total
+        };
+
+        Assert.Empty(PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart));
+    }
+
     // ── Full lock-mode vocabulary classifier (M-1) ───────────────────────────────
 
     [Theory]
@@ -1247,6 +1723,12 @@ public class RemediationTests
         // the gate. It is UNREGISTERED in PR-A (dead-code-safe), but the marker still
         // guards against any UI/MCP/menu file referencing it directly.
         "RcsiHandler",
+        // Clear-cached-plan (DBCC FREEPROCCACHE) destructive core: the new handler + the
+        // DISTINCTIVE executor method name. UNREGISTERED in PR-A (dead-code-safe); the
+        // markers still guard against any UI/MCP/menu file referencing the privileged
+        // surface directly. ClearProcCacheAsync is distinctive enough not to substring-
+        // false-match an unrelated reference.
+        "ClearPlanHandler", "ClearProcCacheAsync",
     };
 
     [Fact]
@@ -1393,6 +1875,22 @@ public class RemediationTests
             {
                 Database = database, Setting = setting, Status = RemediationStatus.Success, Applied = true,
                 ExecutingLogin = "sa", PriorValue = "ON", GeneratedSql = "ALTER DATABASE [x] SET AUTO_SHRINK OFF;",
+                GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        // ── Clear-cached-plan seam (DBCC FREEPROCCACHE) ──────────────────────────
+        public Func<string, ClearPlanOutcome>? ClearPlanFunc;
+        public int ClearPlanCalls;
+
+        public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+        {
+            ClearPlanCalls++;
+            return Task.FromResult(ClearPlanFunc?.Invoke(queryHash) ?? new ClearPlanOutcome
+            {
+                QueryHash = queryHash, Status = RemediationStatus.Success, Cleared = true, HandlesCleared = 1,
+                ExecutingLogin = "sa", Message = "Cleared 1 cached plan(s).",
+                GeneratedSql = "DBCC FREEPROCCACHE(0xDEADBEEF);", PriorValue = "1 plan(s) cached for this query hash",
                 GateSpid = 55, ExecSpid = 55
             });
         }

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -63,7 +63,10 @@ public class SqlServerDrillDownCollector
                     await CollectQueriesAtSpike(finding, context);
 
                 if (pathKeys.Contains("CPU_SQL_PERCENT") || pathKeys.Contains("CPU_SPIKE"))
+                {
                     await CollectTopCpuQueries(finding, context);
+                    await CollectAbnormalCpuPlans(finding, context, pathKeys);
+                }
 
                 if (pathKeys.Contains("QUERY_SPILLS"))
                     await CollectTopSpillingQueries(finding, context);
@@ -337,6 +340,180 @@ ORDER BY CAST(SUM(total_worker_time_delta) AS BIGINT) DESC;";
 
         if (items.Count > 0 && !finding.DrillDown!.ContainsKey("top_cpu_queries"))
             finding.DrillDown!["top_cpu_queries"] = items;
+    }
+
+    /// <summary>
+    /// The plan-cache anomaly detector (§2): one row per offending <c>query_hash</c> whose
+    /// CURRENT per-exec CPU has jumped to an abnormal multiple of its OWN trailing baseline,
+    /// and which is a material CPU contributor in the window. This is the enrichment the
+    /// (PR-B) "Clear cached plan (advanced)" affordance reads. PR-A emits the drill-down but
+    /// does NOT register the handler / emit the affordance — dead-code-safe display only.
+    ///
+    /// <para>
+    /// §2a ROW-LEVEL exclusion (the round-2 correctness fix): the delta framework
+    /// (install/05_delta_framework.sql:218-307) assigns <c>delta = full cumulative raw
+    /// total</c> on TWO arms — first-collection-of-a-plan_handle (the <c>pc.collection_id
+    /// IS NULL</c> arm, :233-235) and the first-post-restart row (the
+    /// <c>server_start_time &gt;= pc.collection_time</c> arm, :235-236). Both inject false
+    /// anomalies on exactly this feature's target population. We exclude BOTH, per row, in
+    /// BOTH the current and baseline windows: a row counts as a REAL prior-delta row only
+    /// when an earlier collection exists for the same (sql_handle, offsets, plan_handle)
+    /// AND that earlier collection_time is &gt; this row's server_start_time (i.e. the
+    /// delta interval started at a real prior collection, not at compile/restart). The
+    /// per-exec math (M-3) and the materiality CPU sum use ONLY these real-delta rows.
+    /// </para>
+    /// </summary>
+    private async Task CollectAbnormalCpuPlans(AnalysisFinding finding, AnalysisContext context, HashSet<string> pathKeys)
+    {
+        // The anomaly threshold (sibling of PLAN_REGRESSION's regression_factor) and the
+        // materiality floor (a query must contribute at least this much CPU in the window
+        // for clearing to be worth offering). Conservative defaults — start ~3x.
+        const double AnomalyThreshold = 3.0;
+        const double MaterialCpuMsFloor = 1000.0;   // 1s of CPU in the window
+
+        // Co-fired-fact awareness (drives the §5 disclosure steer): whether this CPU
+        // finding's story crossed PLAN_REGRESSION / PARAMETER_SENSITIVITY. The analysis
+        // already holds the story path — no extra SQL.
+        var planRegressionCoFired = pathKeys.Contains("PLAN_REGRESSION");
+        var parameterSensitivityCoFired = pathKeys.Contains("PARAMETER_SENSITIVITY");
+
+        using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        using var cmd = connection.CreateCommand();
+        // The baseline window is the @baselineDays preceding the current window (NOT
+        // overlapping it). The current window is [@startTime, @endTime].
+        cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+DECLARE @baselineStart datetime2(7) = DATEADD(DAY, -@baselineDays, @startTime);
+
+/*
+Real-delta rows only (§2a row-level exclusion): a row is a genuine inter-collection
+delta when an EARLIER collection exists for the same (sql_handle, offsets, plan_handle)
+whose collection_time is BOTH < this row's collection_time (it is a prior) AND
+> this row's server_start_time (so the delta interval did not start at compile/restart).
+This drops the first-collection-of-a-plan_handle row and the first-post-restart row in
+one predicate, by row, without using sample_interval_seconds (R2-MIN-A).
+*/
+WITH
+    real_delta AS
+(
+    SELECT
+        qs.query_hash,
+        qs.database_name,
+        qs.collection_time,
+        qs.total_worker_time_delta,
+        qs.execution_count_delta,
+        qs.plan_handle,
+        qs.query_text
+    FROM collect.query_stats AS qs
+    WHERE qs.query_hash IS NOT NULL
+    AND   qs.collection_time >= @baselineStart
+    AND   qs.collection_time <= @endTime
+    AND   EXISTS
+          (
+              SELECT 1
+              FROM collect.query_stats AS prior
+              WHERE prior.sql_handle = qs.sql_handle
+              AND   prior.statement_start_offset = qs.statement_start_offset
+              AND   prior.statement_end_offset = qs.statement_end_offset
+              AND   prior.plan_handle = qs.plan_handle
+              AND   prior.collection_time < qs.collection_time
+              AND   prior.collection_time > qs.server_start_time
+          )
+),
+    windowed AS
+(
+    SELECT
+        rd.query_hash,
+        /* current-window per-exec CPU (ms): SUM(worker)/SUM(execs) on real-delta rows */
+        current_worker_ms =
+            CAST(SUM(CASE WHEN rd.collection_time >= @startTime THEN rd.total_worker_time_delta ELSE 0 END) AS float) / 1000.0,
+        current_execs =
+            SUM(CASE WHEN rd.collection_time >= @startTime THEN rd.execution_count_delta ELSE 0 END),
+        /* baseline-window per-exec CPU (ms): the preceding window, same exclusion */
+        baseline_worker_ms =
+            CAST(SUM(CASE WHEN rd.collection_time < @startTime THEN rd.total_worker_time_delta ELSE 0 END) AS float) / 1000.0,
+        baseline_execs =
+            SUM(CASE WHEN rd.collection_time < @startTime THEN rd.execution_count_delta ELSE 0 END),
+        /* window CPU contribution (ms), §2a exclusion applied (R2-MIN-B) */
+        current_total_cpu_ms =
+            CAST(SUM(CASE WHEN rd.collection_time >= @startTime THEN rd.total_worker_time_delta ELSE 0 END) AS float) / 1000.0
+    FROM real_delta AS rd
+    GROUP BY rd.query_hash
+)
+SELECT TOP 5
+    query_hash = CONVERT(VARCHAR(18), w.query_hash, 1),
+    database_name =
+    (
+        SELECT TOP (1) rd2.database_name
+        FROM real_delta AS rd2
+        WHERE rd2.query_hash = w.query_hash
+        ORDER BY rd2.collection_time DESC
+    ),
+    current_cpu_per_exec_ms = w.current_worker_ms / NULLIF(w.current_execs, 0),
+    baseline_cpu_per_exec_ms = w.baseline_worker_ms / NULLIF(w.baseline_execs, 0),
+    anomaly_ratio =
+        (w.current_worker_ms / NULLIF(w.current_execs, 0)) /
+        NULLIF(w.baseline_worker_ms / NULLIF(w.baseline_execs, 0), 0),
+    execution_count = w.current_execs,
+    total_cpu_ms = w.current_total_cpu_ms,
+    latest_plan_handle =
+    (
+        SELECT TOP (1) CONVERT(VARCHAR(130), rd3.plan_handle, 1)
+        FROM real_delta AS rd3
+        WHERE rd3.query_hash = w.query_hash
+        AND   rd3.plan_handle IS NOT NULL
+        ORDER BY rd3.collection_time DESC
+    ),
+    query_text =
+    (
+        SELECT TOP (1) LEFT(CAST(DECOMPRESS(rd4.query_text) AS NVARCHAR(MAX)), 500)
+        FROM real_delta AS rd4
+        WHERE rd4.query_hash = w.query_hash
+        ORDER BY rd4.collection_time DESC
+    )
+FROM windowed AS w
+WHERE w.current_execs > 0
+AND   w.baseline_execs > 0
+AND   w.baseline_worker_ms > 0
+AND   w.current_total_cpu_ms >= @materialFloor
+/* the anomaly gate: current per-exec >= T x baseline per-exec */
+AND   (w.current_worker_ms / NULLIF(w.current_execs, 0)) >=
+      @threshold * (w.baseline_worker_ms / NULLIF(w.baseline_execs, 0))
+ORDER BY w.current_total_cpu_ms DESC;";
+
+        cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));
+        cmd.Parameters.Add(new SqlParameter("@endTime", context.TimeRangeEnd));
+        cmd.Parameters.Add(new SqlParameter("@baselineDays", 7));
+        cmd.Parameters.Add(new SqlParameter("@threshold", AnomalyThreshold));
+        cmd.Parameters.Add(new SqlParameter("@materialFloor", MaterialCpuMsFloor));
+
+        var items = new List<object>();
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new
+            {
+                query_hash = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                database = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                current_cpu_per_exec_ms = reader.IsDBNull(2) ? 0.0 : Convert.ToDouble(reader.GetValue(2)),
+                baseline_cpu_per_exec_ms = reader.IsDBNull(3) ? 0.0 : Convert.ToDouble(reader.GetValue(3)),
+                anomaly_ratio = reader.IsDBNull(4) ? 0.0 : Convert.ToDouble(reader.GetValue(4)),
+                execution_count = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                total_cpu_ms = reader.IsDBNull(6) ? 0.0 : Convert.ToDouble(reader.GetValue(6)),
+                latest_plan_handle = reader.IsDBNull(7) ? "" : reader.GetString(7),
+                query_text = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                // §2b co-fired flags (drive the §5 disclosure steer); display-only.
+                cpu_percent = 0,
+                plan_regression_cofired = planRegressionCoFired,
+                parameter_sensitivity_cofired = parameterSensitivityCoFired
+            });
+        }
+
+        if (items.Count > 0)
+            finding.DrillDown!["abnormal_cpu_plans"] = items;
     }
 
     private async Task CollectTopSpillingQueries(AnalysisFinding finding, AnalysisContext context)

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -404,6 +405,283 @@ SET NUMERIC_ROUNDABORT OFF;";
             GateSpid = gate.Spid,
             ExecSpid = null
         };
+
+        // ── Clear cached plan (DBCC FREEPROCCACHE behind ALTER SERVER STATE) ────────
+        //
+        // The two catastrophic axes (get these EXACTLY right):
+        //
+        //  1. NEVER the bare/whole-cache form. The only DBCC text this method ever
+        //     builds is the single-handle form `DBCC FREEPROCCACHE(@plan_handle)` with a
+        //     typed varbinary(64) param bound to a NON-NULL, non-zero-length handle. The
+        //     live-resolve selects only `plan_handle IS NOT NULL`; every resolved handle
+        //     is re-checked in C# (null / zero-length → rejected) BEFORE any DBCC string
+        //     is constructed. An empty resolve set is a Skip. There is no code path that
+        //     emits `DBCC FREEPROCCACHE` with no argument.
+        //
+        //  2. Permission gate = the NAMED server permission
+        //     `ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SERVER STATE'), 0) = 1`,
+        //     fail-closed (NULL/error → denied). NOT the generic 'ALTER' server token
+        //     (which returns NULL even for sysadmin — the project_has_perms_by_name_alter
+        //     gotcha). The documented least-privilege login (VIEW SERVER STATE + db_owner)
+        //     LACKS ALTER SERVER STATE, so PermissionDenied is the PRIMARY runtime path —
+        //     returned with a `GRANT ALTER SERVER STATE` guidance string, no elevation,
+        //     no retry. The feature is opt-in.
+        //
+        // Single-connection self-gating (R2-MOD-1): the gate, the live resolve, and every
+        // DBCC run on ONE open connection to the TARGET server (FREEPROCCACHE is
+        // server-scoped — no InitialCatalog retarget). GateSpid == ExecSpid proves it.
+        // No transaction (DBCC is not transactional). Per-handle independence: one
+        // handle's DBCC error never aborts the rest.
+
+        /// <summary>
+        /// The number of query-text snippet characters captured per resolved handle for
+        /// the M-2 disclosure (display only — never an execution input).
+        /// </summary>
+        private const int ClearPlanSnippetLength = 200;
+
+        /// <summary>
+        /// Self-gating clear-cached-plan. See <see cref="IRemediationExecutor.ClearProcCacheAsync"/>.
+        /// The query hash is bound as a typed <c>binary(8)</c> param (the BAD_ACTOR
+        /// precedent, never concatenated); each resolved plan handle is bound as a typed
+        /// <c>varbinary(64)</c> param. The ONLY DBCC text built is the single-handle form.
+        /// </summary>
+        internal async Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+        {
+            // Parse the hex query_hash ("0x...") to the raw binary(8) bytes in C#, so the
+            // value bound to SQL is a typed binary param — never a string concatenated
+            // into the text. A malformed value yields an empty/oversized array → Skip
+            // (it can never resolve a handle, and never produces a DBCC string).
+            var hashBytes = TryParseHexHandle(queryHash);
+            if (hashBytes is null || hashBytes.Length != 8)
+            {
+                return new ClearPlanOutcome
+                {
+                    QueryHash = queryHash,
+                    Status = RemediationStatus.Skipped,
+                    Cleared = false,
+                    HandlesCleared = 0,
+                    Message = "The query hash was not a valid 8-byte hex value; nothing to clear.",
+                    PriorValue = "0 plans (invalid query hash)"
+                };
+            }
+
+            // ONE monitoring connection to the TARGET server. No InitialCatalog retarget:
+            // FREEPROCCACHE is server-scoped. Gate + resolve + DBCC all ride this one open
+            // connection — no re-open between gate and mutation (R2-MOD-1).
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            // ── Gate: NAMED ALTER SERVER STATE, fail-closed ─────────────────────────
+            string? executingLogin;
+            int? gateSpid;
+            bool hasAlterServerState;
+            {
+                using var gate = connection.CreateCommand();
+                gate.CommandTimeout = RemediationCommandTimeoutSeconds;
+                // The NAMED server permission. The generic (NULL,NULL,'ALTER') token
+                // returns NULL even for sysadmin (project_has_perms_by_name_alter_form);
+                // the named 'ALTER SERVER STATE' evaluates 1 for a holder, 0 otherwise.
+                // ISNULL(...,0) makes NULL/indeterminate fail closed.
+                gate.CommandText = @"
+SELECT
+    executing_login = SUSER_SNAME(),
+    has_alter_server_state = CONVERT(int, ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SERVER STATE'), 0)),
+    spid = @@SPID;";
+                using var reader = await gate.ExecuteReaderAsync(ct).ConfigureAwait(false);
+                if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                {
+                    return new ClearPlanOutcome
+                    {
+                        QueryHash = queryHash,
+                        Status = RemediationStatus.Error,
+                        Cleared = false,
+                        Message = "Could not read the permission gate result; no change made."
+                    };
+                }
+                executingLogin = reader.IsDBNull(0) ? null : reader.GetString(0);
+                hasAlterServerState = !reader.IsDBNull(1) && reader.GetInt32(1) == 1;
+                gateSpid = reader.IsDBNull(2) ? (int?)null : Convert.ToInt32(reader.GetInt16(2));
+            }
+
+            if (!hasAlterServerState)
+            {
+                // The DOMINANT runtime outcome on a least-privilege install. Fail closed
+                // with grant guidance — no elevation, no retry, no DBCC.
+                return new ClearPlanOutcome
+                {
+                    QueryHash = queryHash,
+                    Status = RemediationStatus.PermissionDenied,
+                    Cleared = false,
+                    HandlesCleared = 0,
+                    ExecutingLogin = executingLogin,
+                    Message = $"The monitoring login '{executingLogin}' lacks ALTER SERVER STATE on this server, " +
+                              "which clearing a cached plan requires. To opt in, run " +
+                              $"GRANT ALTER SERVER STATE TO [{executingLogin}]; on the target server, or connect with a login that has it. No change was made.",
+                    PriorValue = "0 plans (permission denied)",
+                    GateSpid = gateSpid
+                };
+            }
+
+            // ── Live resolve: current cached plan_handle(s) for this query_hash ─────
+            // Reuse the BAD_ACTOR precedent (plan_handle IS NOT NULL). Capture per handle
+            // the raw varbinary handle + database_name + a short query_text snippet (M-2).
+            var resolved = new List<(byte[] Handle, string? Database, string? Snippet)>();
+            {
+                using var resolve = connection.CreateCommand();
+                resolve.CommandTimeout = RemediationCommandTimeoutSeconds;
+                resolve.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT DISTINCT
+    qs.plan_handle,
+    database_name = qs.database_name,
+    query_text = LEFT(CAST(DECOMPRESS(qs.query_text) AS nvarchar(max)), @snippet_len)
+FROM collect.query_stats AS qs
+WHERE qs.query_hash = @query_hash
+AND   qs.plan_handle IS NOT NULL
+AND   qs.collection_time =
+      (
+          SELECT MAX(qs2.collection_time)
+          FROM collect.query_stats AS qs2
+          WHERE qs2.query_hash = @query_hash
+          AND   qs2.plan_handle = qs.plan_handle
+      );";
+                resolve.Parameters.Add(new SqlParameter("@query_hash", SqlDbType.Binary, 8) { Value = hashBytes });
+                resolve.Parameters.Add(new SqlParameter("@snippet_len", SqlDbType.Int) { Value = ClearPlanSnippetLength });
+
+                using var reader = await resolve.ExecuteReaderAsync(ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
+                {
+                    // M-1 null/zero-length guard: reject in C# BEFORE any DBCC string is
+                    // built. A null or empty handle never becomes a target.
+                    if (reader.IsDBNull(0)) continue;
+                    var handle = (byte[])reader.GetValue(0);
+                    if (handle is null || handle.Length == 0) continue;
+
+                    var db = reader.IsDBNull(1) ? null : reader.GetString(1);
+                    var snippet = reader.IsDBNull(2) ? null : reader.GetString(2);
+                    resolved.Add((handle, db, snippet));
+                }
+            }
+
+            if (resolved.Count == 0)
+            {
+                // Nothing currently cached for this hash (aged out / recompiled). Skip —
+                // the freshness/idempotency analog. No DBCC.
+                return new ClearPlanOutcome
+                {
+                    QueryHash = queryHash,
+                    Status = RemediationStatus.Skipped,
+                    Cleared = false,
+                    HandlesCleared = 0,
+                    ExecutingLogin = executingLogin,
+                    Message = "No cached plan is currently present for this query hash (it may have aged out or recompiled); nothing to clear.",
+                    PriorValue = "0 plans (no surviving handle)",
+                    GateSpid = gateSpid
+                };
+            }
+
+            // ── Execute: one DBCC FREEPROCCACHE(@plan_handle) per surviving handle ──
+            // Per-handle independence: one handle's error never aborts the rest.
+            var handleContexts = new List<ClearPlanHandleContext>(resolved.Count);
+            var sqlLog = new System.Text.StringBuilder();
+            int cleared = 0;
+            int? execSpid = null;
+
+            foreach (var (handle, db, snippet) in resolved)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    using var dbcc = connection.CreateCommand();
+                    dbcc.CommandTimeout = RemediationCommandTimeoutSeconds;
+                    // The ONLY DBCC text ever built: the single-handle form with a typed
+                    // varbinary(64) param. NEVER the bare form. The handle is bound, never
+                    // concatenated.
+                    dbcc.CommandText = "DBCC FREEPROCCACHE(@plan_handle); SELECT exec_spid = @@SPID;";
+                    dbcc.Parameters.Add(new SqlParameter("@plan_handle", SqlDbType.VarBinary, 64) { Value = handle });
+                    var raw = await dbcc.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                    execSpid = raw is null || raw is DBNull ? execSpid : Convert.ToInt32(raw);
+
+                    cleared++;
+                    sqlLog.AppendLine($"DBCC FREEPROCCACHE(0x{Convert.ToHexString(handle)});" +
+                                      (string.IsNullOrEmpty(db) ? "" : $"   -- {db}"));
+                    handleContexts.Add(new ClearPlanHandleContext
+                    {
+                        Database = db,
+                        QueryTextSnippet = snippet,
+                        Cleared = true
+                    });
+                }
+                catch (SqlException ex)
+                {
+                    handleContexts.Add(new ClearPlanHandleContext
+                    {
+                        Database = db,
+                        QueryTextSnippet = snippet,
+                        Cleared = false,
+                        Error = $"DBCC FREEPROCCACHE failed (error {ex.Number}): {ex.Message}"
+                    });
+                }
+            }
+
+            var priorValue = $"{resolved.Count} plan(s) cached for this query hash";
+            if (cleared == 0)
+            {
+                // Every handle errored (e.g. all aged out between resolve and DBCC). Report
+                // an error so it is visible; per-handle errors are carried for detail.
+                return new ClearPlanOutcome
+                {
+                    QueryHash = queryHash,
+                    Status = RemediationStatus.Error,
+                    Cleared = false,
+                    HandlesCleared = 0,
+                    ExecutingLogin = executingLogin,
+                    Message = $"All {resolved.Count} resolved plan handle(s) failed to clear; see per-handle detail.",
+                    Handles = handleContexts,
+                    GeneratedSql = sqlLog.Length == 0 ? null : sqlLog.ToString().TrimEnd(),
+                    PriorValue = priorValue,
+                    GateSpid = gateSpid,
+                    ExecSpid = execSpid
+                };
+            }
+
+            return new ClearPlanOutcome
+            {
+                QueryHash = queryHash,
+                Status = RemediationStatus.Success,
+                Cleared = true,
+                HandlesCleared = cleared,
+                ExecutingLogin = executingLogin,
+                Message = $"Cleared {cleared} cached plan(s) for this query hash; they will recompile on next execution.",
+                Handles = handleContexts,
+                GeneratedSql = sqlLog.ToString().TrimEnd(),
+                PriorValue = priorValue,
+                GateSpid = gateSpid,
+                ExecSpid = execSpid
+            };
+        }
+
+        /// <summary>
+        /// Parses a hex handle string ("0x" + even-length hex) to its raw bytes, or null
+        /// when malformed. Used for the query_hash → binary(8) bind (the value is ALWAYS
+        /// a typed param, never concatenated) and never to build DBCC text.
+        /// </summary>
+        internal static byte[]? TryParseHexHandle(string? hex)
+        {
+            if (string.IsNullOrEmpty(hex)) return null;
+            var s = hex.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? hex.Substring(2) : hex;
+            if (s.Length == 0 || (s.Length % 2) != 0) return null;
+            try
+            {
+                return Convert.FromHexString(s);
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
         /// <summary>
         /// The DB-config gate read: identity + parameterized sys.databases existence +

--- a/Dashboard/Services/Remediation/ClearPlanHandler.cs
+++ b/Dashboard/Services/Remediation/ClearPlanHandler.cs
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Handler for the DESTRUCTIVE clear-cached-plan fix: clears the currently-cached
+    /// execution plan(s) for an abnormally-expensive query via
+    /// <c>DBCC FREEPROCCACHE(@plan_handle)</c> (per resolved handle), forcing a recompile.
+    /// The SECOND <see cref="IsDestructive"/> consumer (after <see cref="RcsiHandler"/>);
+    /// it is gated behind the informed-consent (acknowledge-each-risk) dialog.
+    ///
+    /// <para>
+    /// Routed via the distinct fact key "CLEAR_PLAN" so it is never reachable through any
+    /// always-safe handler. The handler hands the executor only the stable
+    /// <c>query_hash</c>; the executor (<c>exec.ClearProcCacheAsync</c>) re-derives the
+    /// authoritative gate (the NAMED <c>ALTER SERVER STATE</c> permission, fail-closed) +
+    /// the live <c>plan_handle</c> resolve (with the null/zero-length guard, M-1) + the
+    /// per-handle DBCC, all on ONE open connection to the target server. The handler
+    /// cannot hand it a forged all-clear, and there is NO bare/whole-cache DBCC path.
+    /// </para>
+    ///
+    /// <para>
+    /// APPLY-ONLY: <see cref="SupportsUnapply"/> is false — a cleared plan cannot be
+    /// un-cleared (the prior plan is gone). <see cref="UnapplyAsync"/> throws, and
+    /// RemediationApplyService short-circuits any un-apply to a clean UnapplyNotSupported
+    /// report before reaching it. One audit row is written per attempt with
+    /// <c>action='clear_cached_plan'</c>, <c>consent_acknowledged=true</c> (the gate was
+    /// satisfied to reach apply), and query_id/plan_id NULL (this is plan-cache, not
+    /// Query Store). UNREGISTERED in PR-A (dead-code-safe) — PR-B wires it up.
+    /// </para>
+    /// </summary>
+    public sealed class ClearPlanHandler : IRemediationHandler
+    {
+        public string FactKey => "CLEAR_PLAN";
+
+        // DESTRUCTIVE: clearing a cached plan forces a recompile whose new plan is not
+        // guaranteed better, and clears EVERY currently-cached plan for the query hash
+        // (possibly spanning more than the expected query). The second true in the
+        // codebase; it requests the informed-consent gate.
+        public bool IsDestructive => true;
+
+        // Apply-only: you cannot un-clear a cache — the prior plan is gone. prior_value
+        // records what was cleared for the audit trail.
+        public bool SupportsUnapply => false;
+
+        public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+
+            var targets = new List<TargetPreflight>();
+            foreach (var t in ClearTargets(action))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var pf = new TargetPreflight
+                {
+                    Database = t.Database,
+                    Disposition = auditTableExists ? RemediationDisposition.Ok : RemediationDisposition.BlockAuditTableAbsent,
+                    Message = auditTableExists
+                        ? $"Ready to clear the cached plan(s) for query hash {t.QueryHash} on this server (live-resolved at apply; requires ALTER SERVER STATE)."
+                        : AuditAbsentMessage
+                };
+                targets.Add(pf);
+            }
+
+            return new PreflightResult { Targets = targets, AuditTableExists = auditTableExists };
+        }
+
+        public Task<ApplyResult> ApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+            if (identity is null) throw new ArgumentNullException(nameof(identity));
+            return RunApplyAsync(action, exec, identity, ct);
+        }
+
+        // Apply-only. RemediationApplyService short-circuits an un-apply for a
+        // non-supporting handler to a clean report BEFORE any confirm or handler call,
+        // so this is never reached in practice.
+        public Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+            => throw new NotSupportedException("Clearing a cached plan is apply-only; a cleared plan cannot be un-cleared (the prior plan is gone — the cleared-plan summary is recorded for the audit trail).");
+
+        private static async Task<ApplyResult> RunApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            var outcomes = new List<TargetOutcome>();
+            var targets = ClearTargets(action);
+
+            // Audit-table-absent is a HARD BLOCK before any mutation. No DBCC is
+            // attempted; no audit row is written (nowhere to write it).
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+            if (!auditTableExists)
+            {
+                foreach (var t in targets)
+                {
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = RemediationStatus.Blocked,
+                        Message = AuditAbsentMessage,
+                        AuditWritten = false,
+                        AppliedButUnlogged = false
+                    });
+                }
+                return new ApplyResult { Outcomes = outcomes };
+            }
+
+            foreach (var t in targets)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    // The executor re-derives the authoritative gate (ALTER SERVER STATE,
+                    // fail-closed) + live handle resolve (null/zero-length guard) + the
+                    // single-handle DBCC, on one connection — the handler cannot hand it a
+                    // forged all-clear, and there is no bare/whole-cache path.
+                    var outcome = await exec.ClearProcCacheAsync(t.QueryHash, identity, ct).ConfigureAwait(false);
+
+                    var written = await WriteAuditAsync(exec, identity, t, outcome, ct).ConfigureAwait(false);
+
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = outcome.Status,
+                        Message = outcome.Message,
+                        ExecutingLogin = outcome.ExecutingLogin,
+                        AuditWritten = written,
+                        // A real mutation that we failed to log against a present table.
+                        AppliedButUnlogged = outcome.Cleared && !written
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Per-target independence: one target's failure never aborts the rest.
+                    var record = BuildRecord(identity, t, RemediationStatus.Error, ex.Message, priorValue: null, generatedSql: null, executingLogin: null);
+                    var written = await RemediationAuditHelpers.TryWriteAuditSafeAsync(exec, record, ct).ConfigureAwait(false);
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = t.Database,
+                        Status = RemediationStatus.Error,
+                        Message = ex.Message,
+                        AuditWritten = written,
+                        AppliedButUnlogged = false
+                    });
+                }
+            }
+
+            return new ApplyResult { Outcomes = outcomes };
+        }
+
+        private static async Task<bool> WriteAuditAsync(
+            IRemediationExecutor exec,
+            RemediationIdentity identity,
+            ClearPlanTarget target,
+            ClearPlanOutcome outcome,
+            CancellationToken ct)
+        {
+            var record = BuildRecord(
+                identity, target, outcome.Status, outcome.Message,
+                priorValue: outcome.PriorValue, generatedSql: outcome.GeneratedSql, executingLogin: outcome.ExecutingLogin);
+            return await exec.WriteAuditAsync(record, ct).ConfigureAwait(false);
+        }
+
+        private static RemediationAuditRecord BuildRecord(
+            RemediationIdentity identity,
+            ClearPlanTarget target,
+            RemediationStatus status,
+            string? message,
+            string? priorValue,
+            string? generatedSql,
+            string? executingLogin)
+            => new()
+            {
+                OperatorIdentity = identity.OperatorIdentity,
+                ExecutingLogin = executingLogin,
+                TargetDatabase = target.Database,
+                FactKey = "CLEAR_PLAN",
+                QueryId = null,                 // plan-cache, not Query Store — no query_id/plan_id
+                PlanId = null,
+                Action = "clear_cached_plan",   // 17 chars; fits the VarChar(32) @action param
+                PriorValue = priorValue,        // short summary, e.g. "{N} plan(s) cached for this query hash"
+                GeneratedSql = generatedSql,    // the DBCC FREEPROCCACHE statements actually run
+                Result = RemediationAuditHelpers.AuditResult(status),
+                ErrorMessage = RemediationAuditHelpers.IsErrorish(status) ? message : null,
+                // The informed-consent gate was satisfied to reach apply: a destructive
+                // clear that got here passed every risk checkbox.
+                ConsentAcknowledged = true,
+                SourceAlertRef = identity.SourceAlertRef
+            };
+
+        private static IReadOnlyList<ClearPlanTarget> ClearTargets(RemediationAction action) =>
+            action.ClearPlanTargets ?? Array.Empty<ClearPlanTarget>();
+
+        private const string AuditAbsentMessage =
+            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+    }
+}

--- a/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
@@ -52,6 +52,9 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
             => _databaseService.SetDatabaseOptionAsync(database, setting, identity, ct);
 
+        public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+            => _databaseService.ClearProcCacheAsync(queryHash, identity, ct);
+
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
             => _auditWriter.WriteAsync(record, ct);
     }

--- a/Dashboard/Services/Remediation/IRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/IRemediationExecutor.cs
@@ -82,6 +82,22 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct);
 
         /// <summary>
+        /// Self-gating clear-cached-plan (DBCC FREEPROCCACHE). On ONE open monitoring
+        /// connection to the TARGET server (FREEPROCCACHE is server-scoped — no
+        /// InitialCatalog retarget), in order: the NAMED ALTER SERVER STATE permission
+        /// gate (<c>ISNULL(HAS_PERMS_BY_NAME(NULL,NULL,'ALTER SERVER STATE'),0)=1</c>,
+        /// fail-closed — the documented least-privilege login lacks it, so
+        /// PermissionDenied is the PRIMARY path); then a LIVE resolve of the current
+        /// cached <c>plan_handle(s)</c> for the typed <c>query_hash</c> param (selecting
+        /// only <c>plan_handle IS NOT NULL</c>); then — for each non-null, non-zero-length
+        /// handle (rejected in C# BEFORE any DBCC string is built) — one
+        /// <c>DBCC FREEPROCCACHE(@plan_handle)</c> with a typed <c>varbinary(64)</c> param.
+        /// There is NO code path that emits the bare/whole-cache form. An empty resolve
+        /// set is a Skip (nothing to clear). Emits GateSpid/ExecSpid (R2-MOD-1).
+        /// </summary>
+        Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>
         /// Writes one audit row on the MONITORING connection. Returns false if the
         /// INSERT failed against a present table (the O3 applied-but-unlogged case);
         /// the absent-table case never reaches here (hard-blocked earlier).

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -173,6 +173,60 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public int? ExecSpid { get; init; }
     }
 
+    /// <summary>
+    /// One live-resolved cached plan for a query hash: the database it ran in and a short
+    /// query-text snippet (M-2 per-handle blast-radius disclosure). The plan handle itself
+    /// is NEVER surfaced here — it is bound as a typed <c>varbinary(64)</c> parameter
+    /// inside the executor and passed straight to DBCC, never round-tripped as a string.
+    /// </summary>
+    public sealed class ClearPlanHandleContext
+    {
+        public string? Database { get; init; }
+        public string? QueryTextSnippet { get; init; }
+
+        /// <summary>True only when this handle's DBCC FREEPROCCACHE ran without error.</summary>
+        public bool Cleared { get; init; }
+
+        /// <summary>Per-handle error message when <see cref="Cleared"/> is false due to a server error.</summary>
+        public string? Error { get; init; }
+    }
+
+    /// <summary>
+    /// Outcome of a single executor clear-cached-plan call for one query hash. The gate
+    /// (ALTER SERVER STATE permission), the live handle resolve (with the null/zero-length
+    /// guard), and every <c>DBCC FREEPROCCACHE(@plan_handle)</c> run on ONE open monitoring
+    /// connection; <see cref="GateSpid"/>/<see cref="ExecSpid"/> prove they shared it
+    /// (R2-MOD-1, GateSpid == ExecSpid). <see cref="HandlesCleared"/> is the count of
+    /// handles actually cleared; <see cref="Handles"/> carries the per-handle disclosure
+    /// context (M-2). PermissionDenied is the DOMINANT runtime path on a least-privilege
+    /// install (the default login lacks ALTER SERVER STATE — opt-in feature).
+    /// </summary>
+    public sealed class ClearPlanOutcome
+    {
+        public string QueryHash { get; init; } = "";
+        public RemediationStatus Status { get; init; }
+
+        /// <summary>True only when at least one DBCC FREEPROCCACHE actually ran and succeeded.</summary>
+        public bool Cleared { get; init; }
+
+        /// <summary>How many plan handles were cleared (0 on Skip/PermissionDenied/Block).</summary>
+        public int HandlesCleared { get; init; }
+
+        public string? ExecutingLogin { get; init; }
+        public string? Message { get; init; }
+
+        /// <summary>Per-handle context for the disclosure / audit (M-2). Empty on a Skip.</summary>
+        public IReadOnlyList<ClearPlanHandleContext> Handles { get; init; } = new List<ClearPlanHandleContext>();
+
+        /// <summary>The DBCC FREEPROCCACHE statements actually run (display/audit generated_sql).</summary>
+        public string? GeneratedSql { get; init; }
+
+        /// <summary>A short prior-state summary for the audit prior_value ("{N} plans, ~{ratio}x baseline").</summary>
+        public string? PriorValue { get; init; }
+        public int? GateSpid { get; init; }
+        public int? ExecSpid { get; init; }
+    }
+
     /// <summary>Per-target outcome of an apply/unapply, including the audit disposition.</summary>
     public sealed class TargetOutcome
     {

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -177,6 +177,108 @@ public static class FactRemediation
     }
 
     /// <summary>
+    /// Builds the DESTRUCTIVE clear-cached-plan remediation action for a CPU finding
+    /// (CPU_SQL_PERCENT / CPU_SPIKE), or null when it does not apply. PARALLEL to
+    /// <see cref="BuildAction"/>, which stays EXACTLY as-is (it never emits CLEAR_PLAN) —
+    /// this is a SEPARATE entry point, mirroring <see cref="BuildRcsiAction"/>, so the
+    /// CPU finding's normal actions are unchanged and the CLEAR_PLAN action rides a
+    /// SECOND "Clear cached plan (advanced)" detail item (emitted in PR-B).
+    ///
+    /// <para>
+    /// Emits ONLY when the finding carries an <c>abnormal_cpu_plans</c> drill-down (the
+    /// §2 detector enrichment) with at least one qualifying row (the detector has
+    /// already applied the per-exec anomaly threshold + materiality gate + the §2a
+    /// row-level first-collection/restart exclusion server-side; this builder does NOT
+    /// re-derive the math). The action carries FactKey "CLEAR_PLAN" (a distinct
+    /// destructive handler), one <see cref="ClearPlanTarget"/> per qualifying row (the
+    /// stable <c>query_hash</c> is the only execution input — the executor re-resolves
+    /// the live <c>plan_handle(s)</c> at apply), and the <see cref="ClearPlanFigures"/>
+    /// from the FIRST qualifying row so the informed-consent dialog renders the REAL
+    /// numbers at apply time even with no finding in hand.
+    /// </para>
+    /// </summary>
+    public static RemediationAction? BuildClearPlanAction(AnalysisFinding finding)
+    {
+        if (finding is null ||
+            (!string.Equals(finding.RootFactKey, "CPU_SQL_PERCENT", StringComparison.Ordinal) &&
+             !string.Equals(finding.RootFactKey, "CPU_SPIKE", StringComparison.Ordinal)))
+            return null;
+
+        if (finding.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("abnormal_cpu_plans", out var raw) ||
+            raw is null)
+            return null;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return null;
+
+        var targets = new List<ClearPlanTarget>();
+        ClearPlanFigures? figures = null;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (targets.Count >= 5) break;       // defensive cap, sibling of the force-plan cap discipline
+            if (row.ValueKind != JsonValueKind.Object) continue;
+
+            var queryHash = GetString(row, "query_hash");
+            // query_hash is the ONLY execution input. It must be present and look like a
+            // hex handle (0x...); the detector emits it via CONVERT(VARCHAR, .., 1). A
+            // blank/garbage value cannot become a target (it would never resolve a handle).
+            if (string.IsNullOrEmpty(queryHash) ||
+                !queryHash.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
+                queryHash.Length <= 2)
+                continue;
+
+            var database = GetString(row, "database");
+            var current = GetDouble(row, "current_cpu_per_exec_ms");
+            var baseline = GetDouble(row, "baseline_cpu_per_exec_ms");
+            var ratio = GetDouble(row, "anomaly_ratio");
+
+            targets.Add(new ClearPlanTarget(
+                Database: database,
+                QueryHash: queryHash,
+                CurrentCpuPerExecMs: current,
+                BaselineCpuPerExecMs: baseline,
+                AnomalyRatio: ratio,
+                LatestPlanHandle: GetString(row, "latest_plan_handle")));
+
+            // Capture the risk-of-NOT-changing figures from the FIRST qualifying row,
+            // carried on the persisted action so the dialog shows REAL numbers at apply
+            // time (the RcsiInactionFigures precedent). The co-fired flags steer the
+            // honest tool-choice disclosure (§5).
+            figures ??= new ClearPlanFigures(
+                CurrentCpuPerExecMs: current,
+                BaselineCpuPerExecMs: baseline,
+                AnomalyRatio: ratio,
+                CpuPercent: GetInt(row, "cpu_percent"),
+                PlanRegressionCoFired: GetBool(row, "plan_regression_cofired"),
+                ParameterSensitivityCoFired: GetBool(row, "parameter_sensitivity_cofired"));
+        }
+
+        if (targets.Count == 0)
+            return null;
+
+        return new RemediationAction(
+            "CLEAR_PLAN",
+            "clear",
+            Array.Empty<ForcePlanTarget>(),
+            DbConfigTargets: null,
+            RcsiFigures: null,
+            ClearPlanTargets: targets,
+            ClearPlanFigures: figures);
+    }
+
+    /// <summary>
     /// True when the RCSI inaction-risk enrichment fields are present on the row (the
     /// collector emits them only for RCSI-off databases). At least one of the three
     /// structured fields must exist.

--- a/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
+++ b/PerformanceMonitor.Analysis/FactRiskDisclosure.cs
@@ -57,8 +57,72 @@ public static class FactRiskDisclosure
         return action.FactKey switch
         {
             "RCSI" => BuildRcsiDisclosure(action, finding),
+            "CLEAR_PLAN" => BuildClearPlanDisclosure(action, finding),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// The two-sided disclosure for a DESTRUCTIVE clear-cached-plan action (DBCC
+    /// FREEPROCCACHE on the resolved plan handle(s) for a query hash). Mirrors the RCSI
+    /// arm: fixed/reviewed prose for the risk-of-changing side; the risk-of-NOT-changing
+    /// side filled with the REAL per-exec CPU figures carried on the action
+    /// (<see cref="ClearPlanFigures"/>); and the honest tool-choice steer — when
+    /// PLAN_REGRESSION co-fired, forcing is more durable; when PARAMETER_SENSITIVITY
+    /// co-fired, clearing will not durably help. Always returns at least one item on
+    /// EACH side (so the empty-disclosure fail-closed gate is never tripped).
+    /// </summary>
+    private static RiskDisclosure BuildClearPlanDisclosure(RemediationAction action, AnalysisFinding? finding)
+    {
+        var changing = new List<RiskItem>
+        {
+            new("Clearing the cached plan for this query forces a recompile on its next " +
+                "execution (a one-time compile cost)."),
+            new("The recompile is NOT guaranteed to produce a better plan — if the cause is " +
+                "parameter sniffing, SQL Server may cache an equally-bad or different-but-bad " +
+                "plan for whatever parameter value runs next."),
+            new("Apply will live-resolve and clear EVERY currently-cached plan for this query " +
+                "hash. A query hash is not unique to one logical query (hash collisions and " +
+                "pre-parameterization shape-sharing), so confirm the per-handle database/query " +
+                "list in the preview before applying — it may span more than the query you expect."),
+        };
+
+        var f = action.ClearPlanFigures;
+        var notChanging = new List<RiskItem>();
+
+        if (f is { } figures)
+        {
+            notChanging.Add(new(
+                $"This query is currently at ~{figures.AnomalyRatio.ToString("0.0", CultureInfo.InvariantCulture)}x " +
+                $"its normal per-exec CPU ({figures.CurrentCpuPerExecMs.ToString("0.0", CultureInfo.InvariantCulture)} ms " +
+                $"vs baseline {figures.BaselineCpuPerExecMs.ToString("0.0", CultureInfo.InvariantCulture)} ms) and is " +
+                $"responsible for {figures.CpuPercent.ToString(CultureInfo.InvariantCulture)}% of CPU over the window; " +
+                "leaving the bad plan cached keeps it there."));
+
+            if (figures.PlanRegressionCoFired)
+            {
+                notChanging.Add(new(
+                    "A known-better historical plan exists for this query — forcing it (the Plan " +
+                    "Regression remediation) is more durable than clear-and-recompile."));
+            }
+
+            if (figures.ParameterSensitivityCoFired)
+            {
+                notChanging.Add(new(
+                    "This query is parameter-sensitive — clearing the plan likely WON'T durably " +
+                    "help; consider OPTION(RECOMPILE) / OPTIMIZE FOR. Clearing may give brief relief at best."));
+            }
+        }
+        else
+        {
+            // No carried figures (e.g. a legacy/empty action): degrade to the weak-case
+            // baseline rather than overstate — still one item so the gate never trips.
+            notChanging.Add(new(
+                "Per-exec CPU figures were not captured for this query; the case for clearing " +
+                "the cached plan is weak without an anomaly baseline."));
+        }
+
+        return new RiskDisclosure(changing, notChanging);
     }
 
     private static RiskDisclosure BuildRcsiDisclosure(RemediationAction action, AnalysisFinding? finding)

--- a/PerformanceMonitor.Analysis/PlanCacheAnomalyDetector.cs
+++ b/PerformanceMonitor.Analysis/PlanCacheAnomalyDetector.cs
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// The pure, headlessly-testable reference implementation of the §2 plan-cache anomaly
+/// detector's correctness rules. The production detector runs the equivalent logic as a
+/// single T-SQL statement against <c>collect.query_stats</c> (it cannot be unit-tested
+/// against a live server here); this class encodes the SAME row-level exclusion + per-exec
+/// anomaly math so the catastrophic correctness rules (§2a) are guarded by headless tests.
+///
+/// <para>
+/// The two raw-total contamination arms the delta framework (install/05_delta_framework.sql)
+/// injects — first-collection-of-a-plan_handle and the first-post-restart row — are excluded
+/// at the ROW level (R2-MOD-A / R2-MOD-B): a row is a REAL inter-collection delta only when
+/// an EARLIER collection exists for the same (sql_handle, offsets, plan_handle) whose
+/// collection_time is BOTH before this row AND after this row's server_start_time. The
+/// per-exec figures and the materiality CPU sum use ONLY real-delta rows.
+/// </para>
+/// </summary>
+public static class PlanCacheAnomalyDetector
+{
+    /// <summary>Default anomaly threshold (sibling of PLAN_REGRESSION's regression_factor).</summary>
+    public const double DefaultThreshold = 3.0;
+
+    /// <summary>Default materiality floor: a query must contribute at least this much CPU (ms) in the window.</summary>
+    public const double DefaultMaterialCpuMsFloor = 1000.0;
+
+    /// <summary>
+    /// One collected delta row (the fields the detector reads). Mirrors a
+    /// <c>collect.query_stats</c> row AFTER the delta framework has run.
+    /// </summary>
+    public sealed record StatRow(
+        string QueryHash,
+        string SqlHandle,
+        int StatementStartOffset,
+        int StatementEndOffset,
+        string PlanHandle,
+        DateTime CollectionTime,
+        DateTime ServerStartTime,
+        long TotalWorkerTimeDelta,   // microseconds (raw query_stats unit)
+        long ExecutionCountDelta);
+
+    /// <summary>A qualifying anomaly: per-exec CPU has jumped vs the query's own baseline.</summary>
+    public sealed record AnomalyResult(
+        string QueryHash,
+        double CurrentCpuPerExecMs,
+        double BaselineCpuPerExecMs,
+        double AnomalyRatio,
+        long ExecutionCount,
+        double TotalCpuMs);
+
+    /// <summary>
+    /// True when this row is a REAL inter-collection delta (NOT a first-collection or
+    /// first-post-restart raw-total row), i.e. some earlier collection exists for the same
+    /// (sql_handle, offsets, plan_handle) whose collection_time is &lt; this row's AND
+    /// &gt; this row's server_start_time. This single predicate drops BOTH contamination
+    /// arms by row, without using sample_interval_seconds.
+    /// </summary>
+    public static bool IsRealDeltaRow(StatRow row, IReadOnlyList<StatRow> all) =>
+        all.Any(prior =>
+            ReferenceEquals(prior, row) == false &&
+            prior.SqlHandle == row.SqlHandle &&
+            prior.StatementStartOffset == row.StatementStartOffset &&
+            prior.StatementEndOffset == row.StatementEndOffset &&
+            prior.PlanHandle == row.PlanHandle &&
+            prior.CollectionTime < row.CollectionTime &&
+            prior.CollectionTime > row.ServerStartTime);
+
+    /// <summary>
+    /// Evaluates the detector over a set of collected rows and returns one anomaly per
+    /// qualifying query_hash. <paramref name="currentStart"/> splits the window: rows at or
+    /// after it are the current window, earlier real-delta rows are the baseline. Only
+    /// real-delta rows (§2a) feed the per-exec math AND the materiality sum.
+    /// </summary>
+    public static IReadOnlyList<AnomalyResult> Evaluate(
+        IReadOnlyList<StatRow> rows,
+        DateTime currentStart,
+        double threshold = DefaultThreshold,
+        double materialCpuMsFloor = DefaultMaterialCpuMsFloor)
+    {
+        var results = new List<AnomalyResult>();
+        if (rows is null || rows.Count == 0)
+            return results;
+
+        // §2a: keep only genuine inter-collection delta rows.
+        var real = rows.Where(r => IsRealDeltaRow(r, rows)).ToList();
+
+        foreach (var group in real.GroupBy(r => r.QueryHash))
+        {
+            var current = group.Where(r => r.CollectionTime >= currentStart).ToList();
+            var baseline = group.Where(r => r.CollectionTime < currentStart).ToList();
+
+            long curExecs = current.Sum(r => r.ExecutionCountDelta);
+            long baseExecs = baseline.Sum(r => r.ExecutionCountDelta);
+            if (curExecs <= 0 || baseExecs <= 0) continue;
+
+            double curWorkerMs = current.Sum(r => r.TotalWorkerTimeDelta) / 1000.0;
+            double baseWorkerMs = baseline.Sum(r => r.TotalWorkerTimeDelta) / 1000.0;
+            if (baseWorkerMs <= 0) continue;
+
+            double curPerExec = curWorkerMs / curExecs;
+            double basePerExec = baseWorkerMs / baseExecs;
+            if (basePerExec <= 0) continue;
+
+            // materiality: the current-window CPU contribution (real-delta rows only, R2-MIN-B).
+            double totalCpuMs = curWorkerMs;
+            if (totalCpuMs < materialCpuMsFloor) continue;
+
+            double ratio = curPerExec / basePerExec;
+            if (ratio < threshold) continue;
+
+            results.Add(new AnomalyResult(
+                group.Key, curPerExec, basePerExec, ratio, curExecs, totalCpuMs));
+        }
+
+        return results;
+    }
+}

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -26,11 +26,56 @@ namespace PerformanceMonitor.Analysis;
 /// </para>
 /// </summary>
 public sealed record RemediationAction(
-    string FactKey,                              // "PLAN_REGRESSION" | "DB_CONFIG" | "RCSI" — handler-registry key
-    string Action,                              // "force" (plan regression) | "set" (db config). Un-apply derives "unforce".
-    IReadOnlyList<ForcePlanTarget> Targets,      // force-plan targets (empty list for DB_CONFIG)
+    string FactKey,                              // "PLAN_REGRESSION" | "DB_CONFIG" | "RCSI" | "CLEAR_PLAN" — handler-registry key
+    string Action,                              // "force" (plan regression) | "set" (db config) | "clear" (clear cached plan). Un-apply derives "unforce".
+    IReadOnlyList<ForcePlanTarget> Targets,      // force-plan targets (empty list for DB_CONFIG / CLEAR_PLAN)
     IReadOnlyList<DbConfigTarget>? DbConfigTargets = null,  // DB-config targets (null for force-plan)
-    RcsiInactionFigures? RcsiFigures = null);    // B3 Phase 3: RCSI risk-of-not-changing figures carried on the persisted action
+    RcsiInactionFigures? RcsiFigures = null,     // B3 Phase 3: RCSI risk-of-not-changing figures carried on the persisted action
+    IReadOnlyList<ClearPlanTarget>? ClearPlanTargets = null, // clear-cached-plan targets (null for the other fact keys)
+    ClearPlanFigures? ClearPlanFigures = null);  // clear-cached-plan risk-of-not-changing figures carried on the persisted action
+
+/// <summary>
+/// The risk-of-NOT-changing monitoring figures for a destructive CLEAR_PLAN action
+/// (clear cached plan via DBCC FREEPROCCACHE), captured at
+/// <see cref="FactRemediation.BuildClearPlanAction"/> time when the finding (and its
+/// <c>abnormal_cpu_plans</c> drill-down enrichment) IS available, and CARRIED on the
+/// persisted <see cref="RemediationAction"/> so the informed-consent dialog renders the
+/// REAL figures at apply time — when only the persisted action survives (the UI apply
+/// call site has no finding). <see cref="FactRiskDisclosure.GetForAction"/> reads these
+/// in preference to the (often-null at apply time) finding.
+///
+/// <para>
+/// These are DISPLAY/disclosure values only — never an execution input. They mirror the
+/// §2 detector enrichment fields: current vs baseline per-exec CPU (ms), the anomaly
+/// ratio, the query's window CPU share (%), and whether PLAN_REGRESSION /
+/// PARAMETER_SENSITIVITY co-fired (which steer the honest tool-choice disclosure).
+/// </para>
+/// </summary>
+public sealed record ClearPlanFigures(
+    double CurrentCpuPerExecMs,
+    double BaselineCpuPerExecMs,
+    double AnomalyRatio,
+    int CpuPercent,
+    bool PlanRegressionCoFired,
+    bool ParameterSensitivityCoFired);
+
+/// <summary>
+/// One clear-cached-plan target: a (database, query_hash) pair. The
+/// <see cref="QueryHash"/> (the stable cross-collection key, <c>binary(8)</c> rendered
+/// as a hex string like <c>0x...</c>) is the ONLY execution input — the executor
+/// re-resolves the current cached <c>plan_handle(s)</c> for it LIVE at apply time
+/// (the snapshot <see cref="LatestPlanHandle"/> is display only and is NEVER fed to
+/// DBCC). A <c>query_hash</c> is not unique to one logical query, so the live resolve
+/// can return several handles spanning distinct databases — disclosed per-handle (M-2).
+/// The remaining members are carried for the confirm dialog / disclosure only.
+/// </summary>
+public sealed record ClearPlanTarget(
+    string Database,                            // user DB name (display; the gate is server-scoped, not per-DB)
+    string QueryHash,                          // stable key, hex "0x..." (binary(8)); the only execution input
+    double CurrentCpuPerExecMs = 0,            // display only
+    double BaselineCpuPerExecMs = 0,           // display only
+    double AnomalyRatio = 0,                   // display only
+    string? LatestPlanHandle = null);          // display only — the apply path re-resolves live
 
 /// <summary>
 /// The risk-of-NOT-changing monitoring figures for a destructive RCSI action


### PR DESCRIPTION
## What shipped (PR-A — privileged core, dead-code-safe / UNREGISTERED)

The privileged execution core for clearing a bad cached query plan via `DBCC FREEPROCCACHE(@plan_handle)` behind the Phase-3 destructive-consent gate — the **second `IsDestructive` consumer** (after RCSI). `ClearPlanHandler` is **NOT registered** and **no "Clear cached plan (advanced)" affordance is emitted** — the surface is unreachable in production until PR-B. Detector + builder + disclosure + executor + handler + all unit tests are in place.

1. **Detector** (`Dashboard/Analysis/SqlServerDrillDownCollector.cs`) — new `abnormal_cpu_plans` drill-down on the CPU findings (`CPU_SQL_PERCENT`/`CPU_SPIKE`): per-`query_hash` current vs baseline per-exec CPU + `anomaly_ratio` + `latest_plan_handle` (display) over `collect.query_stats` deltas, with the §2a row-level exclusion.
2. **`FactRemediation.BuildClearPlanAction`** (`PerformanceMonitor.Analysis/FactRemediation.cs`) — a PARALLEL builder (mirrors `BuildRcsiAction`); `BuildAction` is untouched. Carries `ClearPlanTarget`s + `ClearPlanFigures`.
3. **`FactRiskDisclosure` CLEAR_PLAN arm** — two-sided, figures from the carried `ClearPlanFigures`, with the honest tool-choice steer (PLAN_REGRESSION co-fired → force; PARAMETER_SENSITIVITY co-fired → won't durably help).
4. **Executor `ClearProcCacheAsync`** (`Dashboard/Services/DatabaseService.Remediation.cs`) — NEW method: single-connection self-gating (permission gate → live handle resolve → per-handle DBCC), GateSpid/ExecSpid.
5. **`ClearPlanHandler`** — `FactKey=CLEAR_PLAN`, `IsDestructive=true`, `SupportsUnapply=false`, `UnapplyAsync` throws; audit-absent hard block; per-target loop; one audit row per attempt. **Unregistered.**
6. **Audit** — `action='clear_cached_plan'` (17 chars, fits `VarChar(32)`), query_id/plan_id NULL, `consent_acknowledged=1`. **No schema change** (verified: `action varchar(32)` + nullable IDs + `consent_acknowledged` already exist).
7. `CoreMachineryMarkers` += `"ClearPlanHandler"`, `"ClearProcCacheAsync"`.

## The two catastrophic-axis invariants (file:line)

1. **NEVER the bare/whole-cache form + null-handle guard.** The only DBCC text built is `DBCC FREEPROCCACHE(@plan_handle)` with a typed `varbinary(64)` param — `Dashboard/Services/DatabaseService.Remediation.cs:602`. The live-resolve selects only `plan_handle IS NOT NULL` (`:542`, the BAD_ACTOR precedent). Null/zero-length handles are rejected in C# **before** any DBCC string is built (`:560`, `if (handle is null || handle.Length == 0) continue;`). Empty resolve set → Skip; malformed `query_hash` → Skip (`TryParseHexHandle`, bound as a typed `binary(8)` param, never concatenated). No code path emits the no-arg form.
2. **Permission gate = NAMED `ALTER SERVER STATE`, fail-closed.** `ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SERVER STATE'), 0)` — `Dashboard/Services/DatabaseService.Remediation.cs:489`. NULL/error → denied; `0` → `PermissionDenied` (`:514`) + `GRANT ALTER SERVER STATE` guidance (`:520`), no elevation, no retry. NOT the generic `'ALTER'` token. This is the **DOMINANT runtime path** on a least-privilege install (the documented login lacks ALTER SERVER STATE — opt-in feature).

Other invariants:
- **Detector row-level exclusion incl. restart** — both raw-total arms (first-collection-per-plan_handle and first-post-restart, `server_start_time >= prior collection_time`) excluded by row in BOTH windows via the real-prior-delta `EXISTS` predicate (`SqlServerDrillDownCollector.cs` `real_delta` CTE; reference impl + headless tests in `PerformanceMonitor.Analysis/PlanCacheAnomalyDetector.cs`).
- **Single-connection self-gating** — gate + resolve + DBCC on one open connection to the target server (FREEPROCCACHE is server-scoped, no retarget); GateSpid==ExecSpid.
- **Dead-code-safe** — `ClearPlanHandler` not registered (`RemediationApplyService.cs:59` unchanged; test `ClearPlan_Handler_IsNotRegistered_InProduction` asserts no `new ClearPlanHandler()` in the service + `TryGet("CLEAR_PLAN")` is null).

## REAL test results

```
Dashboard.Tests:  Failed: 0, Passed: 217, Skipped: 0, Total: 217
Lite.Tests:       Failed: 0, Passed: 349, Skipped: 0, Total: 349
dotnet build Dashboard/Dashboard.csproj -c Debug:  0 Warning(s), 0 Error(s)
```

New §9 coverage: never-bare/null-handle-guard (source-level + `TryParseHexHandle`), ALTER-SERVER-STATE fail-closed (gate source + PermissionDenied apply), detector row-level exclusion (leaky-first-collection → no target; server-restart row + synthetic mass-restart → no targets; genuine per-exec jump → target; stable-expensive / anomalous-but-trivial → no target), parallel builder + `BuildAction`-unchanged guard, FactRiskDisclosure CLEAR_PLAN (both steer branches + figures-survive-persistence), handler invariants, CoreMachineryMarkers, audit (action/NULL ids/consent=1).

## Maintainer real-server checklist (sql2022) — pre-merge gate

> **Lead with the §0 opt-in requirement:** this feature **PermissionDenies by default** — the README least-privilege login (`VIEW SERVER STATE` + `db_owner`) lacks `ALTER SERVER STATE`. It is **opt-in** via `GRANT ALTER SERVER STATE TO [login];`.

1. **PERMISSION DEFAULT FIRST:** on the default least-privilege login (no `ALTER SERVER STATE`), confirm the path returns **PermissionDenied + grant guidance, no DBCC**. THEN `GRANT ALTER SERVER STATE` and confirm the named-form gate flips to 1 (and that sysadmin already evaluates 1).
2. **Only after the grant:** induce a parameter-sniffing regression (hot query at abnormal per-exec CPU); confirm the finding offers it with real ratio figures + the per-handle list; Apply → the cached plan(s) cleared (verify via `dm_exec_query_stats` the handle is gone/recompiled); audit row `clear_cached_plan`/`consent_acknowledged=1`. Re-apply with the plan gone → Skip.
3. **First-collection sanity (B-2):** a plan that merely first-appears in the window (recompiled but not actually regressed per-exec) does NOT raise a false affordance.
4. A stable-expensive query → no affordance (per-exec anomaly gate). A PARAMETER_SENSITIVITY query → affordance + the "won't durably help" disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
