### PR TITLE
Clear cached plan — reachability + UI (live) — PR-B

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -391,6 +391,142 @@ public class AnalysisNotificationTests
         }
     }
 
+    // ── Clear-cached-plan (PR-B): "Clear cached plan (advanced)" item + cross-surface ──
+
+    private static AnalysisFinding CpuFindingWithAbnormalPlans(
+        bool withRow = true, string rootFactKey = "CPU_SQL_PERCENT",
+        int cpuPercent = 62, bool planRegressionCoFired = false, bool parameterSensitivityCoFired = false)
+    {
+        var rows = new List<object>();
+        if (withRow)
+        {
+            rows.Add(new
+            {
+                query_hash = "0xABCDEF0123456789",
+                database = "AdventureWorks",
+                current_cpu_per_exec_ms = 45.0,
+                baseline_cpu_per_exec_ms = 9.0,
+                anomaly_ratio = 5.0,
+                execution_count = 1200L,
+                total_cpu_ms = 54000.0,
+                latest_plan_handle = "0x06000100ABCD",
+                query_text = "SELECT * FROM dbo.BigTable WHERE x = @p",
+                cpu_percent = cpuPercent,
+                plan_regression_cofired = planRegressionCoFired,
+                parameter_sensitivity_cofired = parameterSensitivityCoFired
+            });
+        }
+        return MakeFinding("cpuplan000000001", rootFactKey: rootFactKey, category: "cpu",
+            drillDown: new Dictionary<string, object> { ["abnormal_cpu_plans"] = rows });
+    }
+
+    [Fact]
+    public void BuildContext_CpuWithAbnormalPlans_EmitsClearCachedPlanItem()
+    {
+        var context = FindingMessageFormatter.BuildContext(CpuFindingWithAbnormalPlans(), notifyThreshold: 1.5);
+
+        var item = Assert.Single(context.Details, d => d.Heading == "Clear cached plan (advanced)");
+        Assert.True(item.IsCodeBlock);
+        Assert.NotNull(item.Remediation);
+        Assert.Equal("CLEAR_PLAN", item.Remediation!.FactKey);
+        var t = Assert.Single(item.Remediation.ClearPlanTargets!);
+        Assert.Equal("0xABCDEF0123456789", t.QueryHash);
+        // The figures rode the action (captured while the finding was in hand) incl. the REAL cpu%.
+        Assert.NotNull(item.Remediation.ClearPlanFigures);
+        Assert.Equal(62, item.Remediation.ClearPlanFigures!.CpuPercent);
+
+        // The cross-surface disclosure item is also present (read-only, both email bodies + webhook).
+        var disclosure = Assert.Single(context.Details, d => d.Heading == "Clear cached plan — risks of changing / not changing");
+        Assert.False(disclosure.IsCodeBlock);
+        Assert.Contains("Risks of CHANGING", disclosure.Body);
+        Assert.Contains("Risks of NOT changing", disclosure.Body);
+        Assert.Contains("62%", disclosure.Body);          // the REAL cpu% (LOW-1 fix), not 0%
+        Assert.Contains("forces a recompile", disclosure.Body);
+    }
+
+    [Fact]
+    public void BuildContext_CpuSpikeRootKey_AlsoEmitsClearCachedPlanItem()
+    {
+        var context = FindingMessageFormatter.BuildContext(
+            CpuFindingWithAbnormalPlans(rootFactKey: "CPU_SPIKE"), notifyThreshold: 1.5);
+        Assert.Contains(context.Details, d => d.Heading == "Clear cached plan (advanced)");
+    }
+
+    [Fact]
+    public void BuildContext_CpuNoQualifyingRow_EmitsNoClearCachedPlanItem()
+    {
+        // No qualifying abnormal_cpu_plans row -> no affordance, no disclosure.
+        var context = FindingMessageFormatter.BuildContext(
+            CpuFindingWithAbnormalPlans(withRow: false), notifyThreshold: 1.5);
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Clear cached plan (advanced)");
+        Assert.DoesNotContain(context.Details, d => d.Heading == "Clear cached plan — risks of changing / not changing");
+    }
+
+    [Fact]
+    public void BuildContext_ClearPlanItem_ActionAndFigures_SurviveRoundTrip()
+    {
+        var context = FindingMessageFormatter.BuildContext(CpuFindingWithAbnormalPlans(), notifyThreshold: 1.5);
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        var item = Assert.Single(restored.Details, d => d.Heading == "Clear cached plan (advanced)");
+        Assert.NotNull(item.Remediation);
+        Assert.Equal("CLEAR_PLAN", item.Remediation!.FactKey);
+        var t = Assert.Single(item.Remediation.ClearPlanTargets!);
+        Assert.Equal("0xABCDEF0123456789", t.QueryHash);
+        // The real figures (incl. the cpu% fix) survive the persistence round-trip.
+        Assert.NotNull(item.Remediation.ClearPlanFigures);
+        Assert.Equal(62, item.Remediation.ClearPlanFigures!.CpuPercent);
+        Assert.Equal(5.0, item.Remediation.ClearPlanFigures.AnomalyRatio);
+    }
+
+    [Fact]
+    public void CrossSurface_ClearPlan_RiskDisclosure_RendersInBothEmailBodiesAndWebhook()
+    {
+        var context = FindingMessageFormatter.BuildContext(CpuFindingWithAbnormalPlans(), notifyThreshold: 1.5);
+        var branding = EmailAlertService.Branding;
+
+        // Both email bodies flow from context.Details — the disclosure must render in EACH
+        // (feedback_emailtemplatebuilder_two_bodies: HTML + plain-text are separate bodies).
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail(
+            "High CPU", "TestServer", "n/a", "n/a", 15, branding, context);
+
+        foreach (var body in new[] { html, plain })
+        {
+            Assert.Contains("Clear cached plan — risks of changing / not changing", body);
+            Assert.Contains("Risks of CHANGING", body);
+            Assert.Contains("Risks of NOT changing", body);
+            Assert.Contains("62%", body);             // the REAL cpu% in both bodies
+        }
+
+        // Webhook payloads (Teams + Slack) also flow from context.Details.
+        var teams = WebhookAlertService.BuildTeamsPayload(
+            "High CPU", "TestServer", "n/a", "n/a", branding, context: context);
+        var slack = WebhookAlertService.BuildSlackPayload(
+            "High CPU", "TestServer", "n/a", "n/a", branding, context: context);
+
+        foreach (var payload in new[] { teams, slack })
+        {
+            Assert.Contains("Risks of NOT changing", payload);
+            Assert.Contains("forces a recompile", payload);
+        }
+    }
+
+    [Fact]
+    public void CrossSurface_ClearPlan_McpDisclosure_FromGetForFinding()
+    {
+        // The MCP analyze_server output reads advice.Risks from FactAdvice.GetForFinding —
+        // the SAME seam email/webhook use. A CPU finding with abnormal_cpu_plans must carry
+        // the two-sided CLEAR_PLAN disclosure there too.
+        var advice = FactAdvice.GetForFinding(CpuFindingWithAbnormalPlans());
+        Assert.NotNull(advice);
+        Assert.NotNull(advice!.Risks);
+        Assert.NotEmpty(advice.Risks!.RisksOfChanging);
+        Assert.NotEmpty(advice.Risks.RisksOfNotChanging);
+        Assert.Contains(advice.Risks.RisksOfChanging, r => r.Text.Contains("forces a recompile"));
+        Assert.Contains(advice.Risks.RisksOfNotChanging, r => r.Text.Contains("62%"));
+    }
+
     [Fact]
     public void AlertContext_LegacyJsonWithoutRemediation_DeserializesToNull()
     {

--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -422,6 +422,78 @@ public class RemediationApplyServiceTests
         Assert.Contains(captured!.Risks!.RisksOfNotChanging, r => r.Text.Contains("RCSI does NOT resolve"));
     }
 
+    // ── Clear-cached-plan: destructive request threading + reachability (PR-B) ──────
+
+    private static RemediationAction ClearPlanAction() =>
+        new("CLEAR_PLAN", "clear", Array.Empty<ForcePlanTarget>(),
+            ClearPlanTargets: new[] { new ClearPlanTarget("AdventureWorks", "0xABCDEF0123456789", 45.0, 9.0, 5.0, "0x06") },
+            ClearPlanFigures: new ClearPlanFigures(45.0, 9.0, 5.0, 62, false, false));
+
+    [Fact]
+    public async Task Apply_ClearPlan_RequiresInformedConsent_CarriesRisks_AndPerQueryTarget()
+    {
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new ClearPlanHandler() }), _ => exec, null);
+        RemediationConfirmRequest? captured = null;
+
+        await service.ApplyAsync(ClearPlanAction(), Server, previewSql: "DBCC FREEPROCCACHE(<resolved>);",
+            "DOM\\op", "ref", confirm: req => { captured = req; return Task.FromResult(false); },
+            CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("CLEAR_PLAN", captured!.FactKey);
+        Assert.True(captured.RequiresInformedConsent);
+        Assert.NotNull(captured.Risks);
+        Assert.NotEmpty(captured.Risks!.RisksOfChanging);
+        Assert.NotEmpty(captured.Risks.RisksOfNotChanging);
+        // The confirm preview carries the per-query target (the per-HANDLE list is resolved
+        // live at apply); it shows the query hash + the anomaly figures.
+        var target = Assert.Single(captured.Targets);
+        Assert.Contains("0xABCDEF0123456789", target.StatusTitle);
+        Assert.Contains("5.0x", target.StatusTitle);
+        // Gate refused (confirm == false): the privileged DBCC path was never entered.
+        Assert.Equal(0, exec.ClearPlanCalls);
+    }
+
+    [Fact]
+    public async Task Apply_ClearPlan_ConfirmTrue_ReachesClearProcCache_NotForceOrSetDb()
+    {
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new ClearPlanHandler() }), _ => exec, null);
+
+        var report = await service.ApplyAsync(ClearPlanAction(), Server, previewSql: "preview",
+            "DOM\\op", "ref", confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        Assert.Equal(RemediationRunStatus.Ran, report.Status);
+        Assert.Equal(1, exec.ClearPlanCalls);   // routed to the DBCC executor method
+        Assert.Equal(0, exec.ForceCalls);       // NOT the force-plan path
+        Assert.Equal(0, exec.SetDbCalls);       // NOT the always-safe DB-config path
+    }
+
+    [Fact]
+    public async Task Apply_AlwaysSafe_DbConfig_CannotExecute_ClearPlanTarget()
+    {
+        // Cross-routing guard: an action that (illegitimately) carries CLEAR_PLAN targets but
+        // is keyed to the always-safe DB_CONFIG handler must NOT reach the DBCC executor.
+        // DbConfigHandler iterates ONLY DbConfigTargets — a CLEAR_PLAN payload is inert to it,
+        // and the registry would never hand a CLEAR_PLAN fact key to DbConfigHandler anyway.
+        var exec = new FakeExecutor();
+        var service = new RemediationApplyService(serverManager: null!,
+            new RemediationHandlerRegistry(new IRemediationHandler[] { new DbConfigHandler() }), _ => exec, null);
+
+        var crossAction = new RemediationAction("DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            DbConfigTargets: null,
+            RcsiFigures: null,
+            ClearPlanTargets: new[] { new ClearPlanTarget("AdventureWorks", "0xABCDEF0123456789") });
+
+        await service.ApplyAsync(crossAction, Server, previewSql: "preview", "DOM\\op", "ref",
+            confirm: _ => Task.FromResult(true), CancellationToken.None);
+
+        Assert.Equal(0, exec.ClearPlanCalls);   // the DBCC path is unreachable via DB_CONFIG
+    }
+
     // ── HARD gate-enforcement (B-1, MANDATORY): the acknowledge-each-risk predicate ──
     //
     // The dialog IS the trust boundary; the confirm callback returns true ONLY when the

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1266,17 +1266,31 @@ public class RemediationTests
     }
 
     [Fact]
-    public void ClearPlan_Handler_IsNotRegistered_InProduction()
+    public void ClearPlan_Handler_IsRegistered_AndReachableThroughGate()
     {
-        // PR-A is dead-code-safe: the PRODUCTION registry must NOT construct ClearPlanHandler.
+        // PR-B makes CLEAR_PLAN LIVE: the PRODUCTION wiring registers ClearPlanHandler so the
+        // "Clear cached plan (advanced)" affordance can appear and route to the destructive
+        // handler — but ONLY through the gated RemediationApplyService facade (proven by the
+        // Gate_* behavioural tests + the reachability guards CoreMachinery_OnlyReferencedInRemediationCore
+        // and GatedEntry_ReferencedOnlyBySanctionedUiPath).
+        var productionRegistry = new RemediationHandlerRegistry(
+            new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler(), new ClearPlanHandler() });
+        Assert.IsType<ClearPlanHandler>(productionRegistry.TryGet("CLEAR_PLAN"));
+
+        // Assert at the source level that the PRODUCTION wiring now constructs ClearPlanHandler.
         var dir = FindDashboardSourceDir();
         var serviceSrc = File.ReadAllText(Path.Combine(dir, "Services", "Remediation", "RemediationApplyService.cs"));
-        Assert.DoesNotContain("new ClearPlanHandler()", serviceSrc);
+        Assert.Contains("new ClearPlanHandler()", serviceSrc);
 
-        // And it does not resolve in a registry built like production (no CLEAR_PLAN handler).
-        var productionRegistry = new RemediationHandlerRegistry(
-            new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler() });
-        Assert.Null(productionRegistry.TryGet("CLEAR_PLAN"));
+        // The destructive CLEAR_PLAN handler can NEVER be reached through the always-safe
+        // force-plan / DB-config handlers, nor cross with the other destructive (RCSI) one:
+        // every fact key resolves to its OWN distinct handler type.
+        Assert.IsType<ForcePlanHandler>(productionRegistry.TryGet("PLAN_REGRESSION"));
+        Assert.IsType<DbConfigHandler>(productionRegistry.TryGet("DB_CONFIG"));
+        Assert.IsType<RcsiHandler>(productionRegistry.TryGet("RCSI"));
+        Assert.NotEqual("CLEAR_PLAN", productionRegistry.TryGet("DB_CONFIG")!.FactKey);
+        Assert.NotEqual("CLEAR_PLAN", productionRegistry.TryGet("PLAN_REGRESSION")!.FactKey);
+        Assert.NotEqual("CLEAR_PLAN", productionRegistry.TryGet("RCSI")!.FactKey);
     }
 
     [Fact]
@@ -1561,6 +1575,50 @@ public class RemediationTests
         };
 
         Assert.Empty(PlanCacheAnomalyDetector.Evaluate(rows, CurrentStart));
+    }
+
+    // ── cpu_percent fix (PR-A security review LOW-1) ─────────────────────────────
+    //
+    // The live detector ran in T-SQL against collect.query_stats; the cpu_percent SHARE is
+    // computed in that SQL (numerator/denominator over the SAME §2a real-delta rows). These
+    // source-level assertions guard that PR-B replaced the hardcoded 0 with the real share.
+
+    [Fact]
+    public void Detector_CpuPercent_IsRealWindowShare_NotHardcodedZero()
+    {
+        var dir = FindDashboardSourceDir();
+        var src = File.ReadAllText(Path.Combine(dir, "Analysis", "SqlServerDrillDownCollector.cs"));
+
+        // The CollectAbnormalCpuPlans detector must NO LONGER hardcode cpu_percent = 0.
+        Assert.DoesNotContain("cpu_percent = 0,", src);
+
+        // It computes the real share: a window_total CTE (same §2a real-delta exclusion) as
+        // the denominator, and cpu_percent = the per-query current_total_cpu_ms / that total.
+        Assert.Contains("window_total", src);
+        Assert.Contains("cpu_percent =", src);
+        Assert.Contains("w.current_total_cpu_ms / NULLIF(wt.total_cpu_ms, 0)", src);
+        Assert.Contains("CROSS JOIN window_total AS wt", src);
+    }
+
+    [Fact]
+    public void ClearPlanFigures_CarryRealCpuPercent_Through_BuildClearPlanAction()
+    {
+        // The carried path (NOT the live finding): a finding whose abnormal_cpu_plans row
+        // has a real cpu_percent flows that number onto ClearPlanFigures, and the disclosure
+        // renders it — so the dialog/disclosure show the real % at apply time.
+        var action = FactRemediation.BuildClearPlanAction(CpuFinding(new List<object>
+        {
+            new { query_hash = "0xABCDEF0123456789", database = "Db", current_cpu_per_exec_ms = 45.0,
+                  baseline_cpu_per_exec_ms = 9.0, anomaly_ratio = 5.0, execution_count = 1200L,
+                  total_cpu_ms = 54000.0, latest_plan_handle = "0x06", query_text = "q",
+                  cpu_percent = 73, plan_regression_cofired = false, parameter_sensitivity_cofired = false }
+        }));
+        Assert.NotNull(action);
+        Assert.Equal(73, action!.ClearPlanFigures!.CpuPercent);
+        Assert.NotEqual(0, action.ClearPlanFigures.CpuPercent);
+
+        var d = FactRiskDisclosure.GetForAction(action, null)!;
+        Assert.Contains(d.RisksOfNotChanging, r => r.Text.Contains("73%"));
     }
 
     // ── Full lock-mode vocabulary classifier (M-1) ───────────────────────────────

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -442,6 +442,20 @@ WITH
             CAST(SUM(CASE WHEN rd.collection_time >= @startTime THEN rd.total_worker_time_delta ELSE 0 END) AS float) / 1000.0
     FROM real_delta AS rd
     GROUP BY rd.query_hash
+),
+    /*
+    LOW-1 fix: the window's TOTAL query CPU (ms) over the SAME §2a real-delta rows in the
+    current window, so each query's cpu_percent is its real share of query CPU over the
+    window (NOT the hardcoded 0 that understated risk in PR-A). Using the same exclusion
+    keeps the numerator and denominator consistent (a query can't show a share computed on
+    contaminated raw-total CPU it won't actually clear, R2-MIN-B).
+    */
+    window_total AS
+(
+    SELECT
+        total_cpu_ms =
+            CAST(SUM(CASE WHEN rd.collection_time >= @startTime THEN rd.total_worker_time_delta ELSE 0 END) AS float) / 1000.0
+    FROM real_delta AS rd
 )
 SELECT TOP 5
     query_hash = CONVERT(VARCHAR(18), w.query_hash, 1),
@@ -459,6 +473,10 @@ SELECT TOP 5
         NULLIF(w.baseline_worker_ms / NULLIF(w.baseline_execs, 0), 0),
     execution_count = w.current_execs,
     total_cpu_ms = w.current_total_cpu_ms,
+    /* LOW-1: real share of the window's total query CPU (rounded int %), 0 when the window
+       total is non-positive (degenerate). Display-only — carried into the disclosure. */
+    cpu_percent =
+        CONVERT(int, ROUND(100.0 * w.current_total_cpu_ms / NULLIF(wt.total_cpu_ms, 0), 0)),
     latest_plan_handle =
     (
         SELECT TOP (1) CONVERT(VARCHAR(130), rd3.plan_handle, 1)
@@ -475,6 +493,7 @@ SELECT TOP 5
         ORDER BY rd4.collection_time DESC
     )
 FROM windowed AS w
+CROSS JOIN window_total AS wt
 WHERE w.current_execs > 0
 AND   w.baseline_execs > 0
 AND   w.baseline_worker_ms > 0
@@ -503,10 +522,12 @@ ORDER BY w.current_total_cpu_ms DESC;";
                 anomaly_ratio = reader.IsDBNull(4) ? 0.0 : Convert.ToDouble(reader.GetValue(4)),
                 execution_count = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
                 total_cpu_ms = reader.IsDBNull(6) ? 0.0 : Convert.ToDouble(reader.GetValue(6)),
-                latest_plan_handle = reader.IsDBNull(7) ? "" : reader.GetString(7),
-                query_text = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                // LOW-1 fix: the REAL window CPU share (was hardcoded 0 in PR-A, which made
+                // the disclosure render "responsible for 0% of CPU" and understate the risk).
+                cpu_percent = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
+                latest_plan_handle = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                query_text = reader.IsDBNull(9) ? "" : reader.GetString(9),
                 // §2b co-fired flags (drive the §5 disclosure steer); display-only.
-                cpu_percent = 0,
                 plan_regression_cofired = planRegressionCoFired,
                 parameter_sensitivity_cofired = parameterSensitivityCoFired
             });

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -43,13 +43,16 @@ namespace PerformanceMonitorDashboard
             Title = $"Confirm {verb}";
             var isDbConfig = string.Equals(request.FactKey, "DB_CONFIG", System.StringComparison.Ordinal);
             var isRcsi = string.Equals(request.FactKey, "RCSI", System.StringComparison.Ordinal);
+            var isClearPlan = string.Equals(request.FactKey, "CLEAR_PLAN", System.StringComparison.Ordinal);
             HeaderText.Text = isRcsi
                 ? $"Enable READ_COMMITTED_SNAPSHOT (RCSI) — a database-wide concurrency change — on {request.ServerDisplayName}?"
-                : isDbConfig
-                    ? $"Apply the always-safe database setting change(s) on {request.ServerDisplayName}?"
-                    : request.IsUnapply
-                        ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
-                        : $"Force the historical-better plan on {request.ServerDisplayName}?";
+                : isClearPlan
+                    ? $"Clear the cached plan(s) for an abnormally-expensive query (DBCC FREEPROCCACHE) on {request.ServerDisplayName}?"
+                    : isDbConfig
+                        ? $"Apply the always-safe database setting change(s) on {request.ServerDisplayName}?"
+                        : request.IsUnapply
+                            ? $"Un-apply (unforce) the forced plan on {request.ServerDisplayName}?"
+                            : $"Force the historical-better plan on {request.ServerDisplayName}?";
 
             ServerText.Text = request.ServerDisplayName;
             ExecutingText.Text = string.IsNullOrEmpty(request.ExecutingLogin)
@@ -79,6 +82,14 @@ namespace PerformanceMonitorDashboard
             {
                 CaveatBanner.Visibility = Visibility.Collapsed;
             }
+            else if (isClearPlan)
+            {
+                // One-line framing (§6); the two-sided risk sections below carry the full
+                // disclosure + the acknowledge-each-risk gate.
+                CaveatText.Text =
+                    "Clearing a cached plan forces a recompile; it may not produce a better plan — if this "
+                    + "query is parameter-sensitive or a known plan regression, prefer those fixes. Read both risk lists.";
+            }
             else if (isDbConfig)
             {
                 CaveatText.Text =
@@ -101,7 +112,9 @@ namespace PerformanceMonitorDashboard
                 ConsentSection.Visibility = Visibility.Visible;
                 ConsentBannerText.Text = isRcsi
                     ? "RCSI is a database-wide concurrency change. Read both risk lists; every box must be checked to enable Apply."
-                    : "This is a possibly-destructive change. Read both risk lists; every box must be checked to enable Apply.";
+                    : isClearPlan
+                        ? "Clearing a cached plan is possibly destructive and cannot be undone — it live-resolves and clears every currently-cached plan for this query hash. Read both risk lists; every box must be checked to enable Apply."
+                        : "This is a possibly-destructive change. Read both risk lists; every box must be checked to enable Apply.";
 
                 foreach (var r in request.Risks.RisksOfChanging)
                     _changingRisks.Add(new RiskRow(r.Text));

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -52,11 +53,13 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             _serverManager = serverManager ?? throw new ArgumentNullException(nameof(serverManager));
             if (credentialService is null) throw new ArgumentNullException(nameof(credentialService));
 
-            // B3 Phase 3 (PR-B): RcsiHandler is now LIVE. It is the only IsDestructive
-            // handler; reaching it requires the informed-consent (acknowledge-each-risk)
-            // confirm dialog returning true. Routed via the distinct "RCSI" fact key so
-            // it can never be reached through the always-safe DbConfigHandler.
-            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler() });
+            // B3 Phase 3 (PR-B): RcsiHandler is LIVE. Clear-cached-plan (PR-B): ClearPlanHandler
+            // is now LIVE too. Both are IsDestructive; reaching either requires the informed-
+            // consent (acknowledge-each-risk) confirm dialog returning true. Each is routed via
+            // its OWN distinct fact key ("RCSI" / "CLEAR_PLAN") so neither can ever be reached
+            // through the always-safe DbConfigHandler/ForcePlanHandler, and they cannot cross
+            // each other (the registry keys on FactKey).
+            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler(), new ClearPlanHandler() });
             _executorFactory = server =>
                 new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
             _auditFailureClassifier = (server, ct) =>
@@ -259,7 +262,33 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             // Branch on which target list is populated: DB_CONFIG carries
             // DbConfigTargets (action.Targets is empty for it), force-plan carries Targets.
             List<RemediationConfirmTarget> confirmTargets;
-            if (action.DbConfigTargets is { Count: > 0 } dbTargets)
+            if (action.ClearPlanTargets is { Count: > 0 } clearTargets)
+            {
+                // CLEAR_PLAN rides ClearPlanTargets (action.Targets and DbConfigTargets are
+                // empty for it). Each row is one abnormal query hash; the per-handle list
+                // (database + query_text snippet) is RESOLVED LIVE at apply (§1/§4 — the
+                // handle set is not known until then), so the confirm preview shows the
+                // per-query identity + anomaly figures the detector captured. The two-sided
+                // Risks (below) carry the per-handle blast-radius framing the operator must ack.
+                confirmTargets = new List<RemediationConfirmTarget>(clearTargets.Count);
+                for (var i = 0; i < clearTargets.Count; i++)
+                {
+                    var t = clearTargets[i];
+                    var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
+                    var dbLabel = string.IsNullOrEmpty(t.Database) ? "(server-wide)" : t.Database;
+                    var title = t.AnomalyRatio > 0
+                        ? $"[{dbLabel}] query hash {t.QueryHash} — ~{t.AnomalyRatio.ToString("0.0", CultureInfo.InvariantCulture)}x per-exec CPU (live-resolve at apply)"
+                        : $"[{dbLabel}] query hash {t.QueryHash} (live-resolve at apply)";
+                    confirmTargets.Add(new RemediationConfirmTarget
+                    {
+                        Database = t.Database,
+                        StatusTitle = title,
+                        Disposition = pf?.Disposition ?? RemediationDisposition.Error,
+                        DispositionMessage = pf?.Message
+                    });
+                }
+            }
+            else if (action.DbConfigTargets is { Count: > 0 } dbTargets)
             {
                 confirmTargets = new List<RemediationConfirmTarget>(dbTargets.Count);
                 for (var i = 0; i < dbTargets.Count; i++)

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -78,11 +78,15 @@ public static class FactAdvice
         if (tsql is not null)
             advice = advice with { RemediationTsql = tsql };
 
-        // B3 Phase 3 (§6): when the finding offers a DESTRUCTIVE remediation, append the
-        // two-sided RiskDisclosure so every read-only surface (email / webhook / MCP)
-        // SHOWS the operator the same risks they'd see in-app — they simply cannot click
-        // Apply off-app (no consent gate there; consent is enforced only by the dialog).
-        var destructiveAction = FactRemediation.BuildRcsiAction(finding);
+        // B3 Phase 3 (§6) + Clear-cached-plan (§5): when the finding offers a DESTRUCTIVE
+        // remediation, append the two-sided RiskDisclosure so every read-only surface
+        // (email / webhook / MCP) SHOWS the operator the same risks they'd see in-app —
+        // they simply cannot click Apply off-app (no consent gate there; consent is
+        // enforced only by the dialog). A finding carries exactly one root fact key, so at
+        // most ONE of these parallel builders returns non-null: a DB_CONFIG finding may
+        // offer RCSI; a CPU finding (CPU_SQL_PERCENT / CPU_SPIKE) may offer CLEAR_PLAN.
+        var destructiveAction = FactRemediation.BuildRcsiAction(finding)
+                                ?? FactRemediation.BuildClearPlanAction(finding);
         if (destructiveAction is not null)
         {
             var risks = FactRiskDisclosure.GetForAction(destructiveAction, finding);

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -177,6 +177,46 @@ public static class FactRemediation
     }
 
     /// <summary>
+    /// Renders the display-only clear-cached-plan code block for the "Clear cached plan
+    /// (advanced)" detail item (§5/§6, PR-B). It shows, per qualifying query hash, the
+    /// anomaly figures the detector captured and a NOTE that the actual plan handle(s)
+    /// are LIVE-RESOLVED at apply (the snapshot handle is display-only, never executed).
+    /// Returns null when no CLEAR_PLAN action applies. The Dashboard executor builds its
+    /// OWN single-`@plan_handle` DBCC statements at apply against the live-resolved handles
+    /// and never executes this rendered text.
+    /// </summary>
+    public static string? GenerateClearPlanPreview(AnalysisFinding finding)
+    {
+        var action = BuildClearPlanAction(finding);
+        if (action?.ClearPlanTargets is not { Count: > 0 } targets)
+            return null;
+
+        var sb = new StringBuilder();
+        var emitted = 0;
+        foreach (var t in targets)
+        {
+            if (emitted > 0)
+                sb.AppendLine();
+
+            var dbLabel = string.IsNullOrEmpty(t.Database) ? "(unknown — resolved live)" : t.Database;
+            sb.AppendLine($"-- Database: {dbLabel}");
+            sb.AppendLine($"-- query_hash = {t.QueryHash}");
+            sb.AppendLine(
+                $"--   ~{t.AnomalyRatio.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}x normal per-exec CPU " +
+                $"({t.CurrentCpuPerExecMs.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)} ms vs baseline " +
+                $"{t.BaselineCpuPerExecMs.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)} ms)");
+            if (!string.IsNullOrEmpty(t.LatestPlanHandle))
+                sb.AppendLine($"--   last-seen plan handle: {t.LatestPlanHandle} (display only — apply RE-RESOLVES live)");
+            sb.AppendLine("-- Apply live-resolves the currently-cached plan_handle(s) for this query hash and runs:");
+            sb.AppendLine("--   DBCC FREEPROCCACHE(<resolved plan_handle>);   -- per surviving handle");
+            sb.AppendLine("-- There is NO un-clear: the prior plan is gone. The recompile is not guaranteed better.");
+            emitted++;
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
     /// Builds the DESTRUCTIVE clear-cached-plan remediation action for a CPU finding
     /// (CPU_SQL_PERCENT / CPU_SPIKE), or null when it does not apply. PARALLEL to
     /// <see cref="BuildAction"/>, which stays EXACTLY as-is (it never emits CLEAR_PLAN) —

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -81,7 +81,38 @@ public record RemediationActionDto(
     string Action,
     List<ForcePlanTargetDto> Targets,
     List<DbConfigTargetDto>? DbConfigTargets = null,
-    RcsiInactionFiguresDto? RcsiFigures = null);
+    RcsiInactionFiguresDto? RcsiFigures = null,
+    List<ClearPlanTargetDto>? ClearPlanTargets = null,
+    ClearPlanFiguresDto? ClearPlanFigures = null);
+
+/// <summary>
+/// JSON mirror of <see cref="ClearPlanTarget"/> (clear-cached-plan, PR-B). The
+/// <c>QueryHash</c> is the only execution input; the remaining members are display/
+/// disclosure only. The trailing optional <c>ClearPlanTargets</c> member on
+/// <see cref="RemediationActionDto"/> keeps the round-trip backward-compatible: legacy/
+/// non-CLEAR_PLAN contextJson without it deserializes to null.
+/// </summary>
+public record ClearPlanTargetDto(
+    string Database,
+    string QueryHash,
+    double CurrentCpuPerExecMs,
+    double BaselineCpuPerExecMs,
+    double AnomalyRatio,
+    string? LatestPlanHandle);
+
+/// <summary>
+/// JSON mirror of <see cref="ClearPlanFigures"/> (clear-cached-plan, PR-B). Carried on
+/// the persisted CLEAR_PLAN action so the informed-consent dialog shows the REAL anomaly
+/// figures (incl. the window CPU%, LOW-1) at apply time, when the UI apply call site has
+/// no finding. Trailing optional → backward-compatible.
+/// </summary>
+public record ClearPlanFiguresDto(
+    double CurrentCpuPerExecMs,
+    double BaselineCpuPerExecMs,
+    double AnomalyRatio,
+    int CpuPercent,
+    bool PlanRegressionCoFired,
+    bool ParameterSensitivityCoFired);
 
 /// <summary>
 /// JSON mirror of <see cref="RcsiInactionFigures"/> (B3 Phase 3). Carried on the
@@ -202,7 +233,25 @@ public static class AlertContextSerializer
             ? new RcsiInactionFiguresDto(f.BlockingEvents, f.Deadlocks, f.ReaderWriterPct)
             : null;
 
-        return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets, rcsiFigures);
+        // Clear-cached-plan (PR-B): persist the targets + carried figures so the affordance
+        // survives the contextJson round-trip and the dialog shows the REAL numbers at apply.
+        List<ClearPlanTargetDto>? clearPlanTargets = null;
+        if (action.ClearPlanTargets is not null)
+        {
+            clearPlanTargets = new List<ClearPlanTargetDto>(action.ClearPlanTargets.Count);
+            foreach (var t in action.ClearPlanTargets)
+                clearPlanTargets.Add(new ClearPlanTargetDto(
+                    t.Database, t.QueryHash, t.CurrentCpuPerExecMs, t.BaselineCpuPerExecMs,
+                    t.AnomalyRatio, t.LatestPlanHandle));
+        }
+
+        var clearPlanFigures = action.ClearPlanFigures is { } cf
+            ? new ClearPlanFiguresDto(cf.CurrentCpuPerExecMs, cf.BaselineCpuPerExecMs, cf.AnomalyRatio,
+                cf.CpuPercent, cf.PlanRegressionCoFired, cf.ParameterSensitivityCoFired)
+            : null;
+
+        return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets,
+            rcsiFigures, clearPlanTargets, clearPlanFigures);
     }
 
     private static RemediationAction? FromDto(RemediationActionDto? dto)
@@ -248,6 +297,26 @@ public static class AlertContextSerializer
             ? new RcsiInactionFigures(f.BlockingEvents, f.Deadlocks, f.ReaderWriterPct)
             : null;
 
-        return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets, rcsiFigures);
+        // Clear-cached-plan (PR-B): rebuild the targets + carried figures from the DTO and
+        // PASS them to the ctor (the trailing ClearPlan* members default to null, so a short
+        // call would silently drop a CLEAR_PLAN action's targets on the round-trip). Legacy
+        // JSON without the fields deserializes to null → backward-compatible.
+        List<ClearPlanTarget>? clearPlanTargets = null;
+        if (dto.ClearPlanTargets is not null)
+        {
+            clearPlanTargets = new List<ClearPlanTarget>(dto.ClearPlanTargets.Count);
+            foreach (var t in dto.ClearPlanTargets)
+                clearPlanTargets.Add(new ClearPlanTarget(
+                    t.Database, t.QueryHash, t.CurrentCpuPerExecMs, t.BaselineCpuPerExecMs,
+                    t.AnomalyRatio, t.LatestPlanHandle));
+        }
+
+        var clearPlanFigures = dto.ClearPlanFigures is { } cf
+            ? new ClearPlanFigures(cf.CurrentCpuPerExecMs, cf.BaselineCpuPerExecMs, cf.AnomalyRatio,
+                cf.CpuPercent, cf.PlanRegressionCoFired, cf.ParameterSensitivityCoFired)
+            : null;
+
+        return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets, rcsiFigures,
+            clearPlanTargets, clearPlanFigures);
     }
 }

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -327,6 +327,44 @@ internal static class FindingMessageFormatter
             }
         }
 
+        /* Clear-cached-plan (§5/§6, PR-B): the DESTRUCTIVE "Clear cached plan (advanced)"
+           affordance is a SEPARATE detail item from the CPU finding's always-safe advice
+           — its own view with its own singular Remediation (FactKey "CLEAR_PLAN"), so it
+           can never cross the force-plan / DB-config / RCSI affordances (each keys on a
+           distinct FactKey). Emitted on a CPU finding (CPU_SQL_PERCENT / CPU_SPIKE) that
+           carries an abnormal_cpu_plans drill-down with >= 1 qualifying row (BuildClearPlanAction
+           returns non-null); returns null otherwise → NO item. Mirrors the RCSI second-item
+           pattern exactly. The risk-of-not-changing figures (the anomaly ratio / per-exec
+           CPU / window CPU%) are captured HERE onto the action so the in-app dialog renders
+           the REAL numbers at apply time; the in-app consent gate is what makes it live. */
+        var clearPlanAction = FactRemediation.BuildClearPlanAction(finding);
+        if (clearPlanAction is not null)
+        {
+            context.Details.Add(new AlertDetailItem
+            {
+                Heading = "Clear cached plan (advanced)",
+                Body = FactRemediation.GenerateClearPlanPreview(finding),
+                IsCodeBlock = true,
+                Remediation = clearPlanAction
+            });
+
+            /* Cross-surface disclosure (§5): the two-sided CLEAR_PLAN risk renders as
+               READ-ONLY prose on email (both bodies) / webhook (all flow from
+               context.Details). You cannot consent through an email, so there is NO
+               checkbox gate off-app; the in-app dialog renders the SAME RiskDisclosure as
+               acknowledge-each-risk checkboxes. Built from advice.Risks (FactAdvice.GetForFinding),
+               which the MCP findings output also reads. */
+            var clearRisksBody = RenderRiskDisclosureBody(advice?.Risks);
+            if (clearRisksBody is not null)
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = "Clear cached plan — risks of changing / not changing",
+                    Body = clearRisksBody
+                });
+            }
+        }
+
         /* Drill-down values are anonymous types behind object (a bare object, or a
            List<object> of them). Round-trip through System.Text.Json and walk as
            JsonElement — robust to any shape DrillDownCollector emits. */


### PR DESCRIPTION
Makes the clear-cached-plan remediation **LIVE** behind the destructive-consent gate. PR-A (#1044, merged to `dev`) shipped the privileged core UNREGISTERED/inert; this PR registers the handler and wires the in-app affordance + cross-surface disclosure, so an operator can run `DBCC FREEPROCCACHE(@plan_handle)` behind the acknowledge-each-risk gate.

## What shipped
1. **Registration (the reachability seam)** — `new ClearPlanHandler()` added to the production handler array in `RemediationApplyService.cs`. CLEAR_PLAN routes to `ClearPlanHandler` only.
2. **The affordance** — `AnalysisNotificationService.BuildContext` emits a SEPARATE "Clear cached plan (advanced)" code-block detail item on a CPU finding (`CPU_SQL_PERCENT` / `CPU_SPIKE`) carrying an `abnormal_cpu_plans` drill-down with ≥1 qualifying row (`FactRemediation.BuildClearPlanAction` non-null → item; null → no item). Mirrors the RCSI second-item pattern; not gated behind unrelated conditions. Adds `FactRemediation.GenerateClearPlanPreview`.
3. **CLEAR_PLAN confirm banner** — header + the one-line framing ("Clearing a cached plan forces a recompile; it may not produce a better plan — if this query is parameter-sensitive or a known plan regression, prefer those fixes. Read both risk lists.") + consent banner, in `RemediationConfirmWindow.xaml.cs`.
4. **Cross-surface disclosure** — `FactAdvice.GetForFinding` now populates `Risks` from `BuildClearPlanAction` too (the same `advice.Risks` seam RCSI uses), so the CLEAR_PLAN two-sided `RiskDisclosure` renders as read-only DISCLOSURE in BOTH email bodies (HTML + plain-text), webhook (Teams + Slack), and MCP. No consent UI off-app.
5. **cpu_percent fix (PR-A security review LOW-1)** — the detector hardcoded `cpu_percent = 0` (rendered "responsible for 0% of CPU", understating risk). Now computes the REAL window CPU share via a `window_total` CTE over the SAME §2a real-delta rows (divide-by-zero-safe with `NULLIF`), carried through `ClearPlanFigures.CpuPercent` to the dialog + disclosure.
6. **Serializer round-trip** — `AlertContext` DTO + mapping extended for `ClearPlanTargets` + `ClearPlanFigures` so the affordance and the real figures survive `contextJson` persistence (PR-A added the model but not the DTO). Backward-compatible (trailing optional → null).

## How the gate is enforced + proof no path bypasses it
- The privileged `handler.ApplyAsync` is reached **only** after `confirm(request)` returns true — `RemediationApplyService.cs:208-210` (THE GATE), unchanged from B3. `RequiresInformedConsent = handler.IsDestructive` (true for CLEAR_PLAN) → `RemediationApplyService.cs:306`, attaching the two-sided `Risks`.
- The confirm callback returns true only when the fail-closed `ComputeConfirmEnabled` holds (`riskBoxCount > 0 && allRiskBoxesChecked`) — `RemediationConfirmWindow.xaml.cs:218-229`, **untouched**. The CLEAR_PLAN arm always emits ≥1 risk each side, so the empty-disclosure fail-closed case is never tripped.
- **No cross-routing:** CLEAR_PLAN resolves to `ClearPlanHandler` only; the always-safe force-plan / DB-config handlers iterate their own target lists and are inert to a CLEAR_PLAN payload. Proven by `Apply_AlwaysSafe_DbConfig_CannotExecute_ClearPlanTarget` (ClearPlanCalls == 0) and `ClearPlan_Handler_IsRegistered_AndReachableThroughGate` (each FactKey → its own handler type).
- **Executor untouched:** the diff does NOT include `DatabaseService.Remediation.cs` — the `ALTER SERVER STATE` fail-closed gate, the never-bare/null-handle guard, and the live-resolve are unchanged. The cpu_percent fix flows through the carried `ClearPlanFigures` path (no live finding needed at apply).
- `CoreMachinery_OnlyReferencedInRemediationCore` + `GatedEntry_ReferencedOnlyBySanctionedUiPath` stay green (the privileged types are referenced only inside the remediation core; the UI reaches the executor only via `RemediationApplyService`).

## REAL test results
- `dotnet build Dashboard/Dashboard.csproj -c Debug` — Build succeeded, 0 Warning(s), 0 Error(s).
- **Dashboard.Tests: 228 passed, 0 failed.**
- **Lite.Tests: 349 passed, 0 failed.**
- New/updated tests: registration/reachability (`HasHandlerFor("CLEAR_PLAN")`, no cross-routing, CoreMachineryMarkers); second-item emission (+ none when no qualifying row, + CPU_SPIKE root key); HARD gate predicate (reused `Gate_*`); cross-surface disclosure in BOTH email bodies + webhook + MCP; round-trip persistence; the cpu_percent fix (figures carry a non-zero real % and the disclosure renders it; source-level guard that the hardcoded 0 is gone and the `window_total` share is computed).

## Maintainer real-server pre-merge gate (sql2022) — NOT run here
1. **PERMISSION DEFAULT FIRST (B-1, leads everything):** on the README least-privilege login (`VIEW SERVER STATE` + `db_owner`, **NO `ALTER SERVER STATE`**), confirm Apply → **PermissionDenied + `GRANT ALTER SERVER STATE` guidance, no DBCC** (the dominant production outcome). THEN `GRANT ALTER SERVER STATE` and confirm the named gate flips to 1 (and sysadmin already evaluates 1).
2. After the grant: induce a parameter-sniffing regression; confirm the affordance with real ratio figures + the per-handle list; Apply → plan(s) cleared (verify via `dm_exec_query_stats`), audit row `clear_cached_plan` / `consent_acknowledged=1`. Re-apply with the plan gone → Skip.
3. First-collection sanity (B-2): a plan that merely first-appears in the window raises NO false affordance.
4. Stable-expensive query → no affordance; PARAMETER_SENSITIVITY query → affordance + the "won't durably help" disclosure.

## Files touched
`Dashboard/Services/Remediation/RemediationApplyService.cs`, `PerformanceMonitor.Notifications/AnalysisNotificationService.cs`, `Dashboard/RemediationConfirmWindow.xaml.cs`, `PerformanceMonitor.Analysis/FactAdvice.cs`, `PerformanceMonitor.Analysis/FactRemediation.cs`, `Dashboard/Analysis/SqlServerDrillDownCollector.cs`, `PerformanceMonitor.Notifications/AlertContext.cs`, plus tests (`Dashboard.Tests/{RemediationTests,RemediationApplyServiceTests,AnalysisNotificationTests}.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)