### PR TITLE
Lite #933: budget query_snapshots compaction by materialized size + smaller row group

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -443,18 +443,39 @@ COPY (
                     .Select(f => Path.Combine(_archivePath, f).Replace("\\", "/"))
                     .ToList();
 
-                /* Sort smallest-first so size-budget batches fill cheaply at first. */
+                /* How we measure each file for batching. Wide-XML tables
+                   (query_snapshots) budget by *materialized* VARCHAR size, scanned
+                   from the files, because on-disk bytes badly under-count their
+                   merge memory cost and pack small-but-heavy files together (#933).
+                   Narrow tables keep on-disk sizing. */
+                Func<string, long> sizeOf;
+                if (ParquetCompaction.BudgetsByMaterializedSize(table))
+                {
+                    var materialized = ParquetCompaction.GetMaterializedVarcharSizes(sourcePaths);
+                    sizeOf = p => materialized.TryGetValue(p, out var s)
+                        ? s
+                        : new FileInfo(p.Replace("/", "\\")).Length;
+                }
+                else
+                {
+                    sizeOf = p => new FileInfo(p.Replace("/", "\\")).Length;
+                }
+
+                /* Sort smallest-first (by the same metric we budget on) so
+                   size-budget batches fill cheaply at first. */
                 var sorted = sourcePaths
-                    .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
+                    .OrderBy(sizeOf)
                     .ToList();
 
                 /* Bucket files into size-budgeted batches so a single COPY never
-                   merges an unbounded amount of expanded VARCHAR data. The budget
-                   and row-group size are per-table: query_snapshots' plan XML
-                   expands ~30x on read and OOMs a 4 GB connection at the defaults,
-                   so it gets a tighter budget (see ParquetCompaction.PerTableCompaction
-                   and #933). Narrow tables fit one batch with hundreds of files. */
-                var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, ParquetCompaction.BatchBudgetFor(table));
+                   merges an unbounded amount of expanded VARCHAR data. The budget,
+                   sizing metric, and row-group size are per-table: query_snapshots'
+                   plan XML expands ~30x on read and OOMs a 4 GB connection at the
+                   defaults, so it budgets by materialized size with a small row
+                   group (see ParquetCompaction.PerTableCompaction and #933). Narrow
+                   tables fit one batch with hundreds of files. */
+                var batches = ParquetCompaction.BuildSizeBudgetedBatches(
+                    sorted, ParquetCompaction.BatchBudgetFor(table), sizeOf);
 
                 /* Plan the output names. With one batch we keep the existing
                    YYYYMM_table.parquet name (backward compatible). With multiple

--- a/Lite/Services/ParquetCompaction.cs
+++ b/Lite/Services/ParquetCompaction.cs
@@ -28,29 +28,113 @@ public static class ParquetCompaction
 
     /* Default on-disk parquet bytes per compaction merge batch. A group whose
        files exceed this budget is merged in multiple passes, each producing a
-       _ptNNN.parquet output file. */
+       _ptNNN.parquet output file. Narrow numeric tables compress only mildly, so
+       on-disk bytes are a fine proxy for their merge memory cost. */
     public const long DefaultBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
 
-    /* Per-table compaction overrides. query_snapshots stores query-plan XML that
-       expands ~30x on read; at the default 200 MB batch / 8192 row-group size the
-       merge OOMs a 4 GB connection (#933). Validated on a real 100-file / 15 GB-
-       uncompressed backlog: 100 MB batches at ROW_GROUP_SIZE 2048 compact it in
-       ~27 s with ~1.8 GB headroom under the cap, producing ~6 monthly part files.
-       Only wide-XML tables need this; numeric tables merge fine at the defaults. */
-    private static readonly Dictionary<string, (long BatchBytes, int RowGroupSize)> PerTableCompaction = new()
+    /* Per-table compaction overrides (#933).
+
+       query_snapshots stores query-plan XML that expands ~30x on read, and that
+       expansion is concentrated in a handful of very large values (real reporter
+       data: query_plan p50 47 KB, p99 1.1 MB, max 27 MB). Two consequences:
+
+         1. On-disk bytes badly under-count the merge's memory cost. The plan XML
+            is extremely repetitive, so parquet dictionary-encodes it and ZSTD
+            shrinks it ~30x on disk — but the merge has to *materialize* every
+            value back into strings, and that materialized size is what blows the
+            4 GB cap. (Note: parquet's own "uncompressed_size" footer stat is the
+            decoded-but-still-dictionary-encoded size and is nearly as small as
+            on disk, so it is NOT a usable proxy either — only the materialized
+            VARCHAR byte count is.) Worse, the on-disk budget is *backwards* for
+            this table: large files land one-per-batch (safe), while several small
+            files get packed into one batch that concentrates the big plans (the
+            case that OOM'd a fresh 202606 group of just 3 files). So this table
+            budgets by *materialized* VARCHAR bytes instead — see
+            GetMaterializedVarcharSizes and BudgetsByMaterializedSize.
+
+         2. A large parquet row group buffers whole rows; a few multi-MB plans in
+            one group force unspillable allocations (DuckDB upstream #16482). So
+            this table uses a small ROW_GROUP_SIZE (512) to bound how many wide
+            rows are in flight at once.
+
+       Validated against the reporter's real data shape via tools/CompactionRepro.
+       Numeric tables merge fine at the defaults and are intentionally untouched. */
+    private static readonly Dictionary<string, (long BudgetBytes, int RowGroupSize, bool ByMaterialized)> PerTableCompaction = new()
     {
-        ["query_snapshots"] = (100L * 1024 * 1024, 2048)
+        ["query_snapshots"] = (1024L * 1024 * 1024, 512, true) /* 1 GB materialized, rgs 512 */
     };
 
-    /* On-disk batch budget for <paramref name="table"/> — the per-table override
-       if one exists, otherwise the default. */
+    /* Batch budget for <paramref name="table"/> — the per-table override if one
+       exists, otherwise the default. The unit is materialized VARCHAR bytes when
+       BudgetsByMaterializedSize(table) is true, on-disk bytes otherwise. */
     public static long BatchBudgetFor(string table) =>
-        PerTableCompaction.TryGetValue(table, out var c) ? c.BatchBytes : DefaultBatchInputBytes;
+        PerTableCompaction.TryGetValue(table, out var c) ? c.BudgetBytes : DefaultBatchInputBytes;
 
     /* Output ROW_GROUP_SIZE for <paramref name="table"/> — the per-table override
        if one exists, otherwise the default. */
     public static int RowGroupSizeFor(string table) =>
         PerTableCompaction.TryGetValue(table, out var c) ? c.RowGroupSize : DefaultRowGroupSize;
+
+    /* Whether <paramref name="table"/>'s batch budget is measured in materialized
+       VARCHAR bytes rather than on-disk bytes. True only for wide-XML tables whose
+       dictionary-encoded compression makes on-disk size a poor memory proxy. */
+    public static bool BudgetsByMaterializedSize(string table) =>
+        PerTableCompaction.TryGetValue(table, out var c) && c.ByMaterialized;
+
+    /* Materialized (decoded-to-string) VARCHAR bytes per file — the sum of
+       octet_length over every VARCHAR column. This is the right proxy for a
+       merge's peak memory: it's the byte volume DuckDB must hold once the
+       dictionary-encoded plan XML is expanded back into strings, which on-disk
+       (and even parquet's footer "uncompressed_size") badly under-count. (#933)
+
+       It costs one streaming read per file — seconds across a 100-file backlog,
+       and run on a connection with no tight memory_limit so the read itself
+       doesn't trip the very cap we're trying to stay under. A file that can't be
+       read maps to its on-disk length as a conservative floor rather than
+       throwing — compaction should degrade, not abort the archival cycle. */
+    public static Dictionary<string, long> GetMaterializedVarcharSizes(IEnumerable<string> paths)
+    {
+        var sizes = new Dictionary<string, long>();
+        using var con = new DuckDBConnection("DataSource=:memory:");
+        con.Open();
+        foreach (var p in paths)
+        {
+            try
+            {
+                var varcharCols = new List<string>();
+                using (var describe = con.CreateCommand())
+                {
+                    describe.CommandText = $"DESCRIBE SELECT * FROM read_parquet('{EscapeSqlPath(p)}')";
+                    using var dr = describe.ExecuteReader();
+                    while (dr.Read())
+                    {
+                        if (dr.GetString(1).Contains("VARCHAR", StringComparison.OrdinalIgnoreCase))
+                            varcharCols.Add(dr.GetString(0));
+                    }
+                }
+
+                if (varcharCols.Count == 0)
+                {
+                    sizes[p] = FileLength(p);
+                    continue;
+                }
+
+                var perRow = string.Join(" + ", varcharCols.Select(c =>
+                    $"COALESCE(octet_length(encode(\"{c.Replace("\"", "\"\"")}\")), 0)"));
+                using var cmd = con.CreateCommand();
+                cmd.CommandText = $"SELECT COALESCE(SUM({perRow}), 0)::BIGINT FROM read_parquet('{EscapeSqlPath(p)}')";
+                var val = cmd.ExecuteScalar();
+                sizes[p] = val is null or DBNull ? FileLength(p) : Convert.ToInt64(val);
+            }
+            catch
+            {
+                sizes[p] = FileLength(p);
+            }
+        }
+        return sizes;
+    }
+
+    private static long FileLength(string path) => new FileInfo(path.Replace("/", "\\")).Length;
 
     /* Columns to exclude during compaction — dead weight from legacy archives */
     private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
@@ -61,19 +145,27 @@ public static class ParquetCompaction
     private static string EscapeSqlPath(string path) => path.Replace("'", "''");
 
     /* Greedily group <paramref name="sortedPaths"/> (smallest-first) into batches
-       whose total on-disk bytes don't exceed <paramref name="maxBytes"/>. A single
-       file larger than the cap becomes its own one-element batch — that's the
+       whose total size doesn't exceed <paramref name="maxBytes"/>. A single file
+       larger than the cap becomes its own one-element batch — that's the
        degenerate case (the cap can't split an individual file) and the caller
-       handles it as a single-file pass-through merge. */
-    public static List<List<string>> BuildSizeBudgetedBatches(IReadOnlyList<string> sortedPaths, long maxBytes)
+       handles it as a single-file pass-through merge.
+
+       <paramref name="sizeOf"/> measures each file; it defaults to on-disk length.
+       Wide-XML tables pass a map of materialized sizes (GetMaterializedVarcharSizes)
+       so the budget reflects the merge's real memory cost, not its compressed size
+       (#933). For a meaningful budget the caller should sort by the same metric. */
+    public static List<List<string>> BuildSizeBudgetedBatches(
+        IReadOnlyList<string> sortedPaths, long maxBytes, Func<string, long>? sizeOf = null)
     {
+        sizeOf ??= FileLength;
+
         var batches = new List<List<string>>();
         var current = new List<string>();
         long currentBytes = 0;
 
         foreach (var p in sortedPaths)
         {
-            var size = new FileInfo(p.Replace("/", "\\")).Length;
+            var size = sizeOf(p);
             if (currentBytes + size > maxBytes && current.Count > 0)
             {
                 batches.Add(current);

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -29,18 +29,25 @@ using PerformanceMonitorLite.Services;
  * the data shape that decides whether compaction OOMs; synthetic data can't
  * fake it. Use --profile-only to get just the profile and skip the merge.
  *
- * Tuning knobs (defaults = ParquetCompaction's non-table-specific defaults):
+ * Tuning knobs (single-run defaults = ParquetCompaction's per-table production
+ * values for --table, so a bare run reproduces exactly what ships):
  *   --memory-limit <str>   DuckDB memory_limit per merge connection. Default: 4GB
  *   --threads <int>        DuckDB threads per merge connection. Default: 2
- *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: 8192
- *   --max-batch-mb <int>   Per-batch on-disk input budget (MB). Default: 200
- *   --table <name>         Table name (drives exclude-column logic). Default: query_snapshots
+ *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: per-table (query_snapshots: 512)
+ *   --max-batch-mb <int>   Per-batch input budget (MB). Default: per-table (query_snapshots: 1024)
+ *   --budget-materialized  Budget/sort by materialized VARCHAR size (scanned) —
+ *                          the #933 fix; default for query_snapshots.
+ *   --budget-ondisk        Budget/sort by on-disk (compressed) size — the old
+ *                          behavior; use it to A/B against the fix.
+ *   --table <name>         Table name (drives exclude-column + per-table tuning). Default: query_snapshots
  *
  * Other options:
  *   --profile-only         Print the source data profile and exit (no merge).
  *   --sweep                Run a matrix of configs (row-group-size x batch budget
- *                          x memory limit) against the same files and print which
- *                          ones survive. Ignores --row-group-size / --max-batch-mb.
+ *                          x memory limit x budget metric) against the same files
+ *                          and print which survive. Compares on-disk vs materialized
+ *                          budgeting. Ignores --row-group-size / --max-batch-mb /
+ *                          --budget-* .
  *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
  *   --synthetic-rows <int> Synthetic row count. Default: 30000
  *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 130
@@ -85,9 +92,19 @@ if (!string.IsNullOrEmpty(sourceFile) && !File.Exists(sourceFile))
 var table = GetArg(args, "--table", "query_snapshots");
 var memoryLimit = GetArg(args, "--memory-limit", ParquetCompaction.DefaultMemoryLimit);
 var threads = int.Parse(GetArg(args, "--threads", ParquetCompaction.DefaultThreads.ToString()));
-var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.DefaultRowGroupSize.ToString()));
-var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.DefaultBatchInputBytes / (1024 * 1024)).ToString()));
+/* Single-run defaults mirror PRODUCTION for the chosen table (row-group size,
+   batch budget, and budget metric all come from ParquetCompaction's per-table
+   config). So `--merge-files <real files>` with no other args runs exactly what
+   ships. Override any of them to experiment; --sweep ignores them. (#933) */
+var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.RowGroupSizeFor(table).ToString()));
+var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.BatchBudgetFor(table) / (1024 * 1024)).ToString()));
 var maxBatchBytes = maxBatchMb * 1024L * 1024L;
+/* Budget metric: default to the production per-table choice; let the user force
+   either way for A/B comparison. Materialized budgeting scans each file's VARCHAR
+   byte volume so the batch budget tracks real merge memory, not compressed bytes. */
+var byMaterialized = ParquetCompaction.BudgetsByMaterializedSize(table);
+if (args.Contains("--budget-ondisk")) byMaterialized = false;
+if (args.Contains("--budget-materialized")) byMaterialized = true;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
 var keep = args.Contains("--keep");
 var profileOnly = args.Contains("--profile-only");
@@ -144,7 +161,8 @@ if (sweep)
 }
 else
 {
-    Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
+    var metric = byMaterialized ? "materialized" : "on-disk";
+    Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB ({metric})");
 }
 if (mergeFiles.Count == 0)
     Console.WriteLine($"Splitting source into {numFiles} chunks");
@@ -196,29 +214,45 @@ try
         return 0;
     }
 
-    /* Sort smallest-first — mirrors ArchiveService.CompactParquetFiles. */
-    var sorted = sourcePaths
-        .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
-        .ToList();
-
     var spillDir = Path.Combine(tempDir, "duckdb_tmp").Replace("\\", "/");
     Directory.CreateDirectory(spillDir);
     var process = Process.GetCurrentProcess();
+
+    static long OnDiskLen(string p) => new FileInfo(p.Replace("/", "\\")).Length;
+
+    /* Materialized VARCHAR sizes are scanned once and cached — a sweep reuses them
+       across configs. Computed via the real production helper. */
+    Dictionary<string, long>? materializedCache = null;
+    Dictionary<string, long> MaterializedSizes() =>
+        materializedCache ??= ParquetCompaction.GetMaterializedVarcharSizes(sourcePaths);
+
+    /* The metric a config budgets/sorts on — mirrors ArchiveService. */
+    Func<string, long> SizeOf(bool byMat) => byMat
+        ? p => MaterializedSizes().TryGetValue(p, out var s) ? s : OnDiskLen(p)
+        : OnDiskLen;
 
     /* Run one full compaction (size-budget batching + per-batch merge) for a
        given config. Never throws — a merge OOM is caught and returned as
        Ok=false so a sweep can carry on to the next config. */
     (bool Ok, double StartMb, double PeakMb, double Sec, int Batches, string? Fail, List<string> Outputs)
-        RunOneConfig(int rgs, long batchBytes, string memLimit, int thr, bool verbose)
+        RunOneConfig(int rgs, long batchBytes, string memLimit, int thr, bool byMat, bool verbose)
     {
-        var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes);
+        var sizeOf = SizeOf(byMat);
+        /* Sort smallest-first by the same metric we budget on — mirrors
+           ArchiveService.CompactParquetFiles. */
+        var sorted = sourcePaths.OrderBy(sizeOf).ToList();
+        var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes, sizeOf);
         if (verbose)
         {
-            Console.WriteLine($"      {sorted.Count} files -> {batches.Count} batch(es) at {batchBytes / 1024 / 1024} MB budget");
+            var unit = byMat ? "materialized" : "on-disk";
+            Console.WriteLine($"      {sorted.Count} files -> {batches.Count} batch(es) at {batchBytes / 1024 / 1024} MB {unit} budget");
             for (var i = 0; i < batches.Count; i++)
             {
-                var bb = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
-                Console.WriteLine($"        batch {i + 1}: {batches[i].Count} files, {bb / 1024.0 / 1024.0:F1} MB on disk");
+                var diskMb = batches[i].Sum(OnDiskLen) / 1024.0 / 1024.0;
+                var budgetMb = batches[i].Sum(sizeOf) / 1024.0 / 1024.0;
+                Console.WriteLine(byMat
+                    ? $"        batch {i + 1}: {batches[i].Count} files, {budgetMb:F1} MB materialized ({diskMb:F1} MB on disk)"
+                    : $"        batch {i + 1}: {batches[i].Count} files, {diskMb:F1} MB on disk");
             }
         }
 
@@ -301,25 +335,28 @@ try
     if (sweep)
     {
         /* Matrix of merge configs run against the same source files — varies
-           row-group size, batch budget and memory cap to find which combination
-           keeps the merge within the cap on real data. (#933) */
-        var configs = new (string Label, int Rgs, int BatchMb, string Mem)[]
+           row-group size, batch budget, memory cap, and budget metric to find
+           which combination keeps the merge within the cap on real data. The
+           "unc:" rows budget by uncompressed size (the #933 fix); the on-disk
+           rows are kept for A/B comparison against the old behavior. */
+        var configs = new (string Label, int Rgs, int BatchMb, string Mem, bool ByMat)[]
         {
-            ("rgs=8192 batch=200 mem=4GB", 8192, 200, "4GB"),
-            ("rgs=2048 batch=100 mem=4GB", 2048, 100, "4GB"),
-            ("rgs=512  batch=50  mem=4GB",  512,  50, "4GB"),
-            ("rgs=512  batch=25  mem=4GB",  512,  25, "4GB"),
-            ("rgs=256  batch=25  mem=2GB",  256,  25, "2GB"),
+            ("on-disk: rgs=8192 batch=200 mem=4GB", 8192, 200, "4GB", false),
+            ("on-disk: rgs=2048 batch=100 mem=4GB", 2048, 100, "4GB", false),
+            ("on-disk: rgs=512  batch=25  mem=4GB",  512,  25, "4GB", false),
+            ("mat: rgs=512  budget=1GB   mem=4GB",   512, 1024, "4GB", true),
+            ("mat: rgs=512  budget=1.5GB mem=4GB",   512, 1536, "4GB", true),
+            ("mat: rgs=2048 budget=1GB   mem=4GB",  2048, 1024, "4GB", true),
         };
 
-        Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sorted.Count} source files.");
+        Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sourcePaths.Count} source files.");
         Console.WriteLine();
 
         var results = new List<(string Label, bool Ok, double PeakDeltaMb, double Sec, int Batches, string? Fail)>();
         foreach (var c in configs)
         {
             Console.WriteLine($"[sweep] {c.Label} ...");
-            var r = RunOneConfig(c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, verbose: false);
+            var r = RunOneConfig(c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, c.ByMat, verbose: false);
             CleanOutputs();
             var peakDelta = r.PeakMb - r.StartMb;
             results.Add((c.Label, r.Ok, peakDelta, r.Sec, r.Batches, r.Fail));
@@ -329,9 +366,9 @@ try
         }
 
         Console.WriteLine("[sweep] SUMMARY");
-        Console.WriteLine($"  {"config",-38} {"status",-6} {"peak",10} {"time",7} {"parts",6}");
+        Console.WriteLine($"  {"config",-40} {"status",-6} {"peak",10} {"time",7} {"parts",6}");
         foreach (var r in results)
-            Console.WriteLine($"  {r.Label,-38} {(r.Ok ? "OK" : "FAIL"),-6} {("+" + r.PeakDeltaMb.ToString("F0") + " MB"),10} {(r.Sec.ToString("F0") + "s"),7} {r.Batches,6}");
+            Console.WriteLine($"  {r.Label,-40} {(r.Ok ? "OK" : "FAIL"),-6} {("+" + r.PeakDeltaMb.ToString("F0") + " MB"),10} {(r.Sec.ToString("F0") + "s"),7} {r.Batches,6}");
         Console.WriteLine();
         var firstOk = results.FirstOrDefault(r => r.Ok);
         Console.WriteLine(firstOk.Label != null
@@ -342,7 +379,7 @@ try
 
     /* Single-config run. */
     Console.WriteLine($"[3/3] Running merge (real ParquetCompaction code)...");
-    var single = RunOneConfig(rowGroupSize, maxBatchBytes, memoryLimit, threads, verbose: true);
+    var single = RunOneConfig(rowGroupSize, maxBatchBytes, memoryLimit, threads, byMaterialized, verbose: true);
 
     Console.WriteLine();
     Console.WriteLine("Result:");


### PR DESCRIPTION
## Summary
Follow-up to the #933 compaction work. The size-budgeted batching (by on-disk bytes) drained the large `202605` backlog, but a fresh `202606` group of just **3 small files** still OOM'd the 4 GB compaction cap.

**Root cause:** on-disk bytes are the wrong proxy for `query_snapshots`' merge memory. Its plan XML is highly repetitive → parquet dictionary-encodes it and ZSTD shrinks it ~30× on disk (and parquet's own footer `uncompressed_size` stays tiny too, since it's still dictionary-encoded). The merge has to *materialize* every value back into strings, and that materialized volume — concentrated in a few multi-MB plans — is what blows the cap. The on-disk budget is backwards here: large files land one-per-batch (safe), while several small files get packed together, concentrating the big plans (the 3-file `202606` failure).

## Changes (query_snapshots only; numeric tables untouched)
1. **Budget + sort by materialized VARCHAR bytes** (`octet_length` scan) instead of on-disk bytes, so small-but-heavy files don't get combined. New `ParquetCompaction.GetMaterializedVarcharSizes` / `BudgetsByMaterializedSize`; `BuildSizeBudgetedBatches` gained an optional `sizeOf` selector.
2. **ROW_GROUP_SIZE 2048 → 512** so fewer wide rows buffer per group (DuckDB upstream [#16482](https://github.com/duckdb/duckdb/issues/16482): parquet COPY allocations can't spill). Per-table budget: 1 GB materialized.
3. **`tools/CompactionRepro`**: single-run defaults now mirror production per-table; `--sweep` compares on-disk vs materialized budgeting head-to-head; added `--budget-materialized` / `--budget-ondisk`.

## Test plan
- [x] `dotnet build` Lite + reproducer — 0 warnings, 0 errors.
- [x] Synthetic heavy-tailed run: materialized budgeting splits 12 tiny on-disk files (3 MB) into 3 batches of ~1 GB materialized each, where on-disk budgeting collapsed them into one. Row-count round-trip verified.
- [x] Self-contained `CompactionRepro.exe` rebuilt and published for the reporter to run `--sweep` on real data.
- [ ] Reporter confirms `--sweep` shows `on-disk:` configs FAIL and `mat:` configs pass with headroom (will lock the exact budget from their numbers before release).

Caught during testing: a first attempt budgeted by parquet's footer `total_uncompressed_size`, which is the dictionary-encoded size (~3 MB) not the materialized size (~2.6 GB) — it would not have prevented the OOM. Switched to scanning materialized bytes.