### PR TITLE
Lite #933: skip query_snapshots compaction (best-effort)

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -421,6 +421,14 @@ COPY (
 
         foreach (var ((month, table), files) in groups)
         {
+            /* Best-effort: some tables can't be merged within the memory cap and
+               are skipped — their per-cycle files are left in place and pruned by
+               retention (see ParquetCompaction.SkipCompactionTables and #933). */
+            if (ParquetCompaction.ShouldSkipCompaction(table))
+            {
+                continue;
+            }
+
             /* If there's exactly one file and it's already in monthly format, skip.
                This regex matches both YYYYMM_table.parquet and YYYYMM_table_ptNNN.parquet. */
             if (files.Count == 1)
@@ -443,39 +451,18 @@ COPY (
                     .Select(f => Path.Combine(_archivePath, f).Replace("\\", "/"))
                     .ToList();
 
-                /* How we measure each file for batching. Wide-XML tables
-                   (query_snapshots) budget by *materialized* VARCHAR size, scanned
-                   from the files, because on-disk bytes badly under-count their
-                   merge memory cost and pack small-but-heavy files together (#933).
-                   Narrow tables keep on-disk sizing. */
-                Func<string, long> sizeOf;
-                if (ParquetCompaction.BudgetsByMaterializedSize(table))
-                {
-                    var materialized = ParquetCompaction.GetMaterializedVarcharSizes(sourcePaths);
-                    sizeOf = p => materialized.TryGetValue(p, out var s)
-                        ? s
-                        : new FileInfo(p.Replace("/", "\\")).Length;
-                }
-                else
-                {
-                    sizeOf = p => new FileInfo(p.Replace("/", "\\")).Length;
-                }
-
-                /* Sort smallest-first (by the same metric we budget on) so
-                   size-budget batches fill cheaply at first. */
+                /* Sort smallest-first so size-budget batches fill cheaply at first. */
                 var sorted = sourcePaths
-                    .OrderBy(sizeOf)
+                    .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
                     .ToList();
 
                 /* Bucket files into size-budgeted batches so a single COPY never
-                   merges an unbounded amount of expanded VARCHAR data. The budget,
-                   sizing metric, and row-group size are per-table: query_snapshots'
-                   plan XML expands ~30x on read and OOMs a 4 GB connection at the
-                   defaults, so it budgets by materialized size with a small row
-                   group (see ParquetCompaction.PerTableCompaction and #933). Narrow
-                   tables fit one batch with hundreds of files. */
+                   merges an unbounded amount of data. Wide query-plan-XML tables
+                   that can't merge within the cap are skipped above; the tables
+                   that reach here compress mildly, so the on-disk budget is a fine
+                   proxy and they fit one batch with many files (#933). */
                 var batches = ParquetCompaction.BuildSizeBudgetedBatches(
-                    sorted, ParquetCompaction.BatchBudgetFor(table), sizeOf);
+                    sorted, ParquetCompaction.DefaultBatchInputBytes);
 
                 /* Plan the output names. With one batch we keep the existing
                    YYYYMM_table.parquet name (backward compatible). With multiple
@@ -496,8 +483,7 @@ COPY (
                    place for next cycle's retry. */
                 for (var i = 0; i < batches.Count; i++)
                 {
-                    ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql,
-                        rowGroupSize: ParquetCompaction.RowGroupSizeFor(table));
+                    ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql);
                 }
 
                 /* All batches succeeded — delete originals, promote temps. */

--- a/Lite/Services/ParquetCompaction.cs
+++ b/Lite/Services/ParquetCompaction.cs
@@ -20,121 +20,40 @@ public static class ParquetCompaction
 {
     /* Production tuning for the compaction merge connections (#933).
        memoryLimit/threads/rowGroupSize are exposed as MergeBatchToFile parameters
-       so tools/CompactionRepro can sweep them; production callers pass the
-       per-table values from BatchBudgetFor / RowGroupSizeFor below. */
+       so tools/CompactionRepro can sweep them; production callers use the
+       defaults below. */
     public const string DefaultMemoryLimit = "4GB";
     public const int DefaultThreads = 2;
     public const int DefaultRowGroupSize = 8192;
 
-    /* Default on-disk parquet bytes per compaction merge batch. A group whose
-       files exceed this budget is merged in multiple passes, each producing a
-       _ptNNN.parquet output file. Narrow numeric tables compress only mildly, so
-       on-disk bytes are a fine proxy for their merge memory cost. */
+    /* On-disk parquet bytes per compaction merge batch. A group whose files
+       exceed this budget is merged in multiple passes, each producing a
+       _ptNNN.parquet output file. Parquet compresses only mildly for the numeric
+       tables this runs on, so on-disk bytes are a fine proxy for merge memory. */
     public const long DefaultBatchInputBytes = 200L * 1024 * 1024; /* 200 MB */
 
-    /* Per-table compaction overrides (#933).
+    /* Tables compaction skips entirely — best-effort (#933).
 
-       query_snapshots stores query-plan XML that expands ~30x on read, and that
-       expansion is concentrated in a handful of very large values (real reporter
-       data: query_plan p50 47 KB, p99 1.1 MB, max 27 MB). Two consequences:
+       query_snapshots stores query-plan XML that expands ~30x on read,
+       concentrated in a handful of multi-MB values (reporter data: query_plan p50
+       47 KB, p99 1.1 MB, max 27 MB). Merging it materializes gigabytes of strings
+       and OOMs the compaction memory cap, and the parquet COPY pre-reserves memory
+       in a way that batching can't get under (DuckDB upstream #16482) on memory-
+       constrained hosts. It also barely compacts — its per-cycle files are already
+       near the largest size that merges safely.
 
-         1. On-disk bytes badly under-count the merge's memory cost. The plan XML
-            is extremely repetitive, so parquet dictionary-encodes it and ZSTD
-            shrinks it ~30x on disk — but the merge has to *materialize* every
-            value back into strings, and that materialized size is what blows the
-            4 GB cap. (Note: parquet's own "uncompressed_size" footer stat is the
-            decoded-but-still-dictionary-encoded size and is nearly as small as
-            on disk, so it is NOT a usable proxy either — only the materialized
-            VARCHAR byte count is.) Worse, the on-disk budget is *backwards* for
-            this table: large files land one-per-batch (safe), while several small
-            files get packed into one batch that concentrates the big plans (the
-            case that OOM'd a fresh 202606 group of just 3 files). So this table
-            budgets by *materialized* VARCHAR bytes instead — see
-            GetMaterializedVarcharSizes and BudgetsByMaterializedSize.
-
-         2. A large parquet row group buffers whole rows; a few multi-MB plans in
-            one group force unspillable allocations (DuckDB upstream #16482). So
-            this table uses a small ROW_GROUP_SIZE (512) to bound how many wide
-            rows are in flight at once.
-
-       Validated against the reporter's real data shape via tools/CompactionRepro.
-       Numeric tables merge fine at the defaults and are intentionally untouched. */
-    private static readonly Dictionary<string, (long BudgetBytes, int RowGroupSize, bool ByMaterialized)> PerTableCompaction = new()
+       Rather than retry a doomed multi-minute merge every archival cycle (and log
+       an error each time), we skip it. Its per-cycle files are left in place and
+       pruned by the normal retention sweep, so every plan is retained for the full
+       retention window; only the monthly file-count consolidation is forgone for
+       this one table. */
+    private static readonly HashSet<string> SkipCompactionTables = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["query_snapshots"] = (1024L * 1024 * 1024, 512, true) /* 1 GB materialized, rgs 512 */
+        "query_snapshots"
     };
 
-    /* Batch budget for <paramref name="table"/> — the per-table override if one
-       exists, otherwise the default. The unit is materialized VARCHAR bytes when
-       BudgetsByMaterializedSize(table) is true, on-disk bytes otherwise. */
-    public static long BatchBudgetFor(string table) =>
-        PerTableCompaction.TryGetValue(table, out var c) ? c.BudgetBytes : DefaultBatchInputBytes;
-
-    /* Output ROW_GROUP_SIZE for <paramref name="table"/> — the per-table override
-       if one exists, otherwise the default. */
-    public static int RowGroupSizeFor(string table) =>
-        PerTableCompaction.TryGetValue(table, out var c) ? c.RowGroupSize : DefaultRowGroupSize;
-
-    /* Whether <paramref name="table"/>'s batch budget is measured in materialized
-       VARCHAR bytes rather than on-disk bytes. True only for wide-XML tables whose
-       dictionary-encoded compression makes on-disk size a poor memory proxy. */
-    public static bool BudgetsByMaterializedSize(string table) =>
-        PerTableCompaction.TryGetValue(table, out var c) && c.ByMaterialized;
-
-    /* Materialized (decoded-to-string) VARCHAR bytes per file — the sum of
-       octet_length over every VARCHAR column. This is the right proxy for a
-       merge's peak memory: it's the byte volume DuckDB must hold once the
-       dictionary-encoded plan XML is expanded back into strings, which on-disk
-       (and even parquet's footer "uncompressed_size") badly under-count. (#933)
-
-       It costs one streaming read per file — seconds across a 100-file backlog,
-       and run on a connection with no tight memory_limit so the read itself
-       doesn't trip the very cap we're trying to stay under. A file that can't be
-       read maps to its on-disk length as a conservative floor rather than
-       throwing — compaction should degrade, not abort the archival cycle. */
-    public static Dictionary<string, long> GetMaterializedVarcharSizes(IEnumerable<string> paths)
-    {
-        var sizes = new Dictionary<string, long>();
-        using var con = new DuckDBConnection("DataSource=:memory:");
-        con.Open();
-        foreach (var p in paths)
-        {
-            try
-            {
-                var varcharCols = new List<string>();
-                using (var describe = con.CreateCommand())
-                {
-                    describe.CommandText = $"DESCRIBE SELECT * FROM read_parquet('{EscapeSqlPath(p)}')";
-                    using var dr = describe.ExecuteReader();
-                    while (dr.Read())
-                    {
-                        if (dr.GetString(1).Contains("VARCHAR", StringComparison.OrdinalIgnoreCase))
-                            varcharCols.Add(dr.GetString(0));
-                    }
-                }
-
-                if (varcharCols.Count == 0)
-                {
-                    sizes[p] = FileLength(p);
-                    continue;
-                }
-
-                var perRow = string.Join(" + ", varcharCols.Select(c =>
-                    $"COALESCE(octet_length(encode(\"{c.Replace("\"", "\"\"")}\")), 0)"));
-                using var cmd = con.CreateCommand();
-                cmd.CommandText = $"SELECT COALESCE(SUM({perRow}), 0)::BIGINT FROM read_parquet('{EscapeSqlPath(p)}')";
-                var val = cmd.ExecuteScalar();
-                sizes[p] = val is null or DBNull ? FileLength(p) : Convert.ToInt64(val);
-            }
-            catch
-            {
-                sizes[p] = FileLength(p);
-            }
-        }
-        return sizes;
-    }
-
-    private static long FileLength(string path) => new FileInfo(path.Replace("/", "\\")).Length;
+    /* Whether compaction skips <paramref name="table"/> entirely (best-effort). */
+    public static bool ShouldSkipCompaction(string table) => SkipCompactionTables.Contains(table);
 
     /* Columns to exclude during compaction — dead weight from legacy archives */
     private static readonly Dictionary<string, string[]> CompactionExcludeColumns = new()
@@ -145,27 +64,19 @@ public static class ParquetCompaction
     private static string EscapeSqlPath(string path) => path.Replace("'", "''");
 
     /* Greedily group <paramref name="sortedPaths"/> (smallest-first) into batches
-       whose total size doesn't exceed <paramref name="maxBytes"/>. A single file
-       larger than the cap becomes its own one-element batch — that's the
+       whose total on-disk bytes don't exceed <paramref name="maxBytes"/>. A single
+       file larger than the cap becomes its own one-element batch — that's the
        degenerate case (the cap can't split an individual file) and the caller
-       handles it as a single-file pass-through merge.
-
-       <paramref name="sizeOf"/> measures each file; it defaults to on-disk length.
-       Wide-XML tables pass a map of materialized sizes (GetMaterializedVarcharSizes)
-       so the budget reflects the merge's real memory cost, not its compressed size
-       (#933). For a meaningful budget the caller should sort by the same metric. */
-    public static List<List<string>> BuildSizeBudgetedBatches(
-        IReadOnlyList<string> sortedPaths, long maxBytes, Func<string, long>? sizeOf = null)
+       handles it as a single-file pass-through merge. */
+    public static List<List<string>> BuildSizeBudgetedBatches(IReadOnlyList<string> sortedPaths, long maxBytes)
     {
-        sizeOf ??= FileLength;
-
         var batches = new List<List<string>>();
         var current = new List<string>();
         long currentBytes = 0;
 
         foreach (var p in sortedPaths)
         {
-            var size = sizeOf(p);
+            var size = new FileInfo(p.Replace("/", "\\")).Length;
             if (currentBytes + size > maxBytes && current.Count > 0)
             {
                 batches.Add(current);
@@ -190,19 +101,21 @@ public static class ParquetCompaction
 
        #933 replaced an incremental pairwise merge here: on a real 100-file
        backlog the pairwise path was ~5x slower (it re-read an ever-larger
-       accumulator file every step) and OOM-prone. A sweep on the reporter's
-       actual data confirmed a single COPY at the per-table row-group size is
-       both faster and stays within the memory cap.
+       accumulator file every step) and OOM-prone. A single COPY at the default
+       row-group size is both faster and stays within the memory cap for the
+       numeric tables this runs on. (Wide query-plan-XML tables can't be merged
+       within the cap at all on constrained hosts and are skipped — see
+       SkipCompactionTables.)
 
        Pragma tuning:
          - memory_limit = 4GB: parquet COPY makes allocations that bypass the
            buffer manager and can't spill; the cap is a hard ceiling, not a
-           spill trigger. Pair it with the per-table batch budget (BatchBudgetFor)
-           and row-group size (RowGroupSizeFor) so the working set stays under it.
+           spill trigger. Paired with the batch budget (DefaultBatchInputBytes)
+           so the working set stays under it.
          - threads = 2: fewer per-thread row-group buffers in flight.
          - preserve_insertion_order = false: lets DuckDB stream.
        The memoryLimit/threads/rowGroupSize parameters let tools/CompactionRepro
-       sweep them; production passes the per-table values. */
+       sweep them; production passes the defaults. */
     public static void MergeBatchToFile(
         string table,
         List<string> sourcePaths,

--- a/tools/CompactionRepro/Program.cs
+++ b/tools/CompactionRepro/Program.cs
@@ -29,25 +29,18 @@ using PerformanceMonitorLite.Services;
  * the data shape that decides whether compaction OOMs; synthetic data can't
  * fake it. Use --profile-only to get just the profile and skip the merge.
  *
- * Tuning knobs (single-run defaults = ParquetCompaction's per-table production
- * values for --table, so a bare run reproduces exactly what ships):
+ * Tuning knobs (defaults = ParquetCompaction's non-table-specific defaults):
  *   --memory-limit <str>   DuckDB memory_limit per merge connection. Default: 4GB
  *   --threads <int>        DuckDB threads per merge connection. Default: 2
- *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: per-table (query_snapshots: 512)
- *   --max-batch-mb <int>   Per-batch input budget (MB). Default: per-table (query_snapshots: 1024)
- *   --budget-materialized  Budget/sort by materialized VARCHAR size (scanned) —
- *                          the #933 fix; default for query_snapshots.
- *   --budget-ondisk        Budget/sort by on-disk (compressed) size — the old
- *                          behavior; use it to A/B against the fix.
- *   --table <name>         Table name (drives exclude-column + per-table tuning). Default: query_snapshots
+ *   --row-group-size <int> Output ROW_GROUP_SIZE. Default: 8192
+ *   --max-batch-mb <int>   Per-batch on-disk input budget (MB). Default: 200
+ *   --table <name>         Table name (drives exclude-column logic). Default: query_snapshots
  *
  * Other options:
  *   --profile-only         Print the source data profile and exit (no merge).
  *   --sweep                Run a matrix of configs (row-group-size x batch budget
- *                          x memory limit x budget metric) against the same files
- *                          and print which survive. Compares on-disk vs materialized
- *                          budgeting. Ignores --row-group-size / --max-batch-mb /
- *                          --budget-* .
+ *                          x memory limit) against the same files and print which
+ *                          ones survive. Ignores --row-group-size / --max-batch-mb.
  *   --num-files <int>      Chunks to split --source-file/--synthetic into. Default: 15
  *   --synthetic-rows <int> Synthetic row count. Default: 30000
  *   --synthetic-base-ops <n>  RelOps in a normal synthetic plan. Default: 130
@@ -92,19 +85,9 @@ if (!string.IsNullOrEmpty(sourceFile) && !File.Exists(sourceFile))
 var table = GetArg(args, "--table", "query_snapshots");
 var memoryLimit = GetArg(args, "--memory-limit", ParquetCompaction.DefaultMemoryLimit);
 var threads = int.Parse(GetArg(args, "--threads", ParquetCompaction.DefaultThreads.ToString()));
-/* Single-run defaults mirror PRODUCTION for the chosen table (row-group size,
-   batch budget, and budget metric all come from ParquetCompaction's per-table
-   config). So `--merge-files <real files>` with no other args runs exactly what
-   ships. Override any of them to experiment; --sweep ignores them. (#933) */
-var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.RowGroupSizeFor(table).ToString()));
-var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.BatchBudgetFor(table) / (1024 * 1024)).ToString()));
+var rowGroupSize = int.Parse(GetArg(args, "--row-group-size", ParquetCompaction.DefaultRowGroupSize.ToString()));
+var maxBatchMb = int.Parse(GetArg(args, "--max-batch-mb", (ParquetCompaction.DefaultBatchInputBytes / (1024 * 1024)).ToString()));
 var maxBatchBytes = maxBatchMb * 1024L * 1024L;
-/* Budget metric: default to the production per-table choice; let the user force
-   either way for A/B comparison. Materialized budgeting scans each file's VARCHAR
-   byte volume so the batch budget tracks real merge memory, not compressed bytes. */
-var byMaterialized = ParquetCompaction.BudgetsByMaterializedSize(table);
-if (args.Contains("--budget-ondisk")) byMaterialized = false;
-if (args.Contains("--budget-materialized")) byMaterialized = true;
 var numFiles = int.Parse(GetArg(args, "--num-files", "15"));
 var keep = args.Contains("--keep");
 var profileOnly = args.Contains("--profile-only");
@@ -161,8 +144,7 @@ if (sweep)
 }
 else
 {
-    var metric = byMaterialized ? "materialized" : "on-disk";
-    Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB ({metric})");
+    Console.WriteLine($"Settings: memory_limit={memoryLimit}, threads={threads}, ROW_GROUP_SIZE={rowGroupSize}, max-batch={maxBatchMb} MB");
 }
 if (mergeFiles.Count == 0)
     Console.WriteLine($"Splitting source into {numFiles} chunks");
@@ -214,45 +196,29 @@ try
         return 0;
     }
 
+    /* Sort smallest-first — mirrors ArchiveService.CompactParquetFiles. */
+    var sorted = sourcePaths
+        .OrderBy(p => new FileInfo(p.Replace("/", "\\")).Length)
+        .ToList();
+
     var spillDir = Path.Combine(tempDir, "duckdb_tmp").Replace("\\", "/");
     Directory.CreateDirectory(spillDir);
     var process = Process.GetCurrentProcess();
-
-    static long OnDiskLen(string p) => new FileInfo(p.Replace("/", "\\")).Length;
-
-    /* Materialized VARCHAR sizes are scanned once and cached — a sweep reuses them
-       across configs. Computed via the real production helper. */
-    Dictionary<string, long>? materializedCache = null;
-    Dictionary<string, long> MaterializedSizes() =>
-        materializedCache ??= ParquetCompaction.GetMaterializedVarcharSizes(sourcePaths);
-
-    /* The metric a config budgets/sorts on — mirrors ArchiveService. */
-    Func<string, long> SizeOf(bool byMat) => byMat
-        ? p => MaterializedSizes().TryGetValue(p, out var s) ? s : OnDiskLen(p)
-        : OnDiskLen;
 
     /* Run one full compaction (size-budget batching + per-batch merge) for a
        given config. Never throws — a merge OOM is caught and returned as
        Ok=false so a sweep can carry on to the next config. */
     (bool Ok, double StartMb, double PeakMb, double Sec, int Batches, string? Fail, List<string> Outputs)
-        RunOneConfig(int rgs, long batchBytes, string memLimit, int thr, bool byMat, bool verbose)
+        RunOneConfig(int rgs, long batchBytes, string memLimit, int thr, bool verbose)
     {
-        var sizeOf = SizeOf(byMat);
-        /* Sort smallest-first by the same metric we budget on — mirrors
-           ArchiveService.CompactParquetFiles. */
-        var sorted = sourcePaths.OrderBy(sizeOf).ToList();
-        var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes, sizeOf);
+        var batches = ParquetCompaction.BuildSizeBudgetedBatches(sorted, batchBytes);
         if (verbose)
         {
-            var unit = byMat ? "materialized" : "on-disk";
-            Console.WriteLine($"      {sorted.Count} files -> {batches.Count} batch(es) at {batchBytes / 1024 / 1024} MB {unit} budget");
+            Console.WriteLine($"      {sorted.Count} files -> {batches.Count} batch(es) at {batchBytes / 1024 / 1024} MB budget");
             for (var i = 0; i < batches.Count; i++)
             {
-                var diskMb = batches[i].Sum(OnDiskLen) / 1024.0 / 1024.0;
-                var budgetMb = batches[i].Sum(sizeOf) / 1024.0 / 1024.0;
-                Console.WriteLine(byMat
-                    ? $"        batch {i + 1}: {batches[i].Count} files, {budgetMb:F1} MB materialized ({diskMb:F1} MB on disk)"
-                    : $"        batch {i + 1}: {batches[i].Count} files, {diskMb:F1} MB on disk");
+                var bb = batches[i].Sum(p => new FileInfo(p.Replace("/", "\\")).Length);
+                Console.WriteLine($"        batch {i + 1}: {batches[i].Count} files, {bb / 1024.0 / 1024.0:F1} MB on disk");
             }
         }
 
@@ -335,28 +301,25 @@ try
     if (sweep)
     {
         /* Matrix of merge configs run against the same source files — varies
-           row-group size, batch budget, memory cap, and budget metric to find
-           which combination keeps the merge within the cap on real data. The
-           "unc:" rows budget by uncompressed size (the #933 fix); the on-disk
-           rows are kept for A/B comparison against the old behavior. */
-        var configs = new (string Label, int Rgs, int BatchMb, string Mem, bool ByMat)[]
+           row-group size, batch budget and memory cap to find which combination
+           keeps the merge within the cap on real data. (#933) */
+        var configs = new (string Label, int Rgs, int BatchMb, string Mem)[]
         {
-            ("on-disk: rgs=8192 batch=200 mem=4GB", 8192, 200, "4GB", false),
-            ("on-disk: rgs=2048 batch=100 mem=4GB", 2048, 100, "4GB", false),
-            ("on-disk: rgs=512  batch=25  mem=4GB",  512,  25, "4GB", false),
-            ("mat: rgs=512  budget=1GB   mem=4GB",   512, 1024, "4GB", true),
-            ("mat: rgs=512  budget=1.5GB mem=4GB",   512, 1536, "4GB", true),
-            ("mat: rgs=2048 budget=1GB   mem=4GB",  2048, 1024, "4GB", true),
+            ("rgs=8192 batch=200 mem=4GB", 8192, 200, "4GB"),
+            ("rgs=2048 batch=100 mem=4GB", 2048, 100, "4GB"),
+            ("rgs=512  batch=50  mem=4GB",  512,  50, "4GB"),
+            ("rgs=512  batch=25  mem=4GB",  512,  25, "4GB"),
+            ("rgs=256  batch=25  mem=2GB",  256,  25, "2GB"),
         };
 
-        Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sourcePaths.Count} source files.");
+        Console.WriteLine($"[sweep] Running {configs.Length} configs against the same {sorted.Count} source files.");
         Console.WriteLine();
 
         var results = new List<(string Label, bool Ok, double PeakDeltaMb, double Sec, int Batches, string? Fail)>();
         foreach (var c in configs)
         {
             Console.WriteLine($"[sweep] {c.Label} ...");
-            var r = RunOneConfig(c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, c.ByMat, verbose: false);
+            var r = RunOneConfig(c.Rgs, c.BatchMb * 1024L * 1024L, c.Mem, threads, verbose: false);
             CleanOutputs();
             var peakDelta = r.PeakMb - r.StartMb;
             results.Add((c.Label, r.Ok, peakDelta, r.Sec, r.Batches, r.Fail));
@@ -366,9 +329,9 @@ try
         }
 
         Console.WriteLine("[sweep] SUMMARY");
-        Console.WriteLine($"  {"config",-40} {"status",-6} {"peak",10} {"time",7} {"parts",6}");
+        Console.WriteLine($"  {"config",-38} {"status",-6} {"peak",10} {"time",7} {"parts",6}");
         foreach (var r in results)
-            Console.WriteLine($"  {r.Label,-40} {(r.Ok ? "OK" : "FAIL"),-6} {("+" + r.PeakDeltaMb.ToString("F0") + " MB"),10} {(r.Sec.ToString("F0") + "s"),7} {r.Batches,6}");
+            Console.WriteLine($"  {r.Label,-38} {(r.Ok ? "OK" : "FAIL"),-6} {("+" + r.PeakDeltaMb.ToString("F0") + " MB"),10} {(r.Sec.ToString("F0") + "s"),7} {r.Batches,6}");
         Console.WriteLine();
         var firstOk = results.FirstOrDefault(r => r.Ok);
         Console.WriteLine(firstOk.Label != null
@@ -379,7 +342,7 @@ try
 
     /* Single-config run. */
     Console.WriteLine($"[3/3] Running merge (real ParquetCompaction code)...");
-    var single = RunOneConfig(rowGroupSize, maxBatchBytes, memoryLimit, threads, byMaterialized, verbose: true);
+    var single = RunOneConfig(rowGroupSize, maxBatchBytes, memoryLimit, threads, verbose: true);
 
     Console.WriteLine();
     Console.WriteLine("Result:");


### PR DESCRIPTION
## Summary
Follow-up to #1046. A real sweep on the reporter's actual files showed the materialized-size budgeting from #1046 **still OOM'd** — even 1 GB materialized batches failed, because the parquet `COPY` pre-reserves memory (DuckDB upstream [#16482](https://github.com/duckdb/duckdb/issues/16482)) with a per-merge floor (~3.7 GB) that batching can't get under on a memory-constrained host (16 GB box, ~1.6 GB free). `query_snapshots` also barely compacts — its files are already near the largest size that merges safely.

Rather than keep shaping compaction around one outlier environment — or retry a doomed multi-minute merge every archival cycle and log an error each time — this makes `query_snapshots` compaction **best-effort: skipped**. Its per-cycle files are left in place and pruned by the normal retention sweep, so **every plan is retained** for the full retention window; only the monthly file-count consolidation is forgone for this one table.

## Changes
- **ParquetCompaction**: removed the materialized-budget machinery from #1046 (`GetMaterializedVarcharSizes`, `BudgetsByMaterializedSize`, per-table tuning dict, the `sizeOf` selector). Added `SkipCompactionTables` + `ShouldSkipCompaction`. `BuildSizeBudgetedBatches` is back to on-disk budgeting for the numeric tables that still compact.
- **ArchiveService**: skip `SkipCompactionTables` at the top of the compaction loop.
- **tools/CompactionRepro**: reverted to its pre-#1046 form (still useful for testing merges of other tables / future debugging).

Net vs `dev`: −224 / +86 lines (mostly removing #1046).

## What stays
The generally-valuable fixes from this issue remain: the main-connection memory cap (#955), per-merge column detection, the spill directory (#935), and size-budgeted batching for the numeric tables.

## Test plan
- [x] `dotnet build` Lite + reproducer — 0 warnings, 0 errors.
- [x] Reproducer smoke test (synthetic) still runs and round-trips row counts.
- [ ] Next nightly: confirm no more `Failed to compact .../query_snapshots` errors, and `query_snapshots` reads still work across the un-compacted per-cycle files.