### PR TITLE
Fix #1048 (follow-up): nullable other_process_cpu in config.ensure_collection_table

### DIFF
--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -802,7 +802,7 @@ BEGIN
         collection_time datetime2(7) NOT NULL DEFAULT SYSDATETIME(),
         sample_time datetime2(7) NOT NULL,
         sqlserver_cpu_utilization integer NOT NULL,
-        other_process_cpu_utilization integer NOT NULL,
+        other_process_cpu_utilization integer NULL, /* #1048: NULL on Linux (host CPU not derivable); matches install/02 + upgrade 02 */
         total_cpu_utilization AS (sqlserver_cpu_utilization + other_process_cpu_utilization) PERSISTED,
         CONSTRAINT PK_cpu_utilization_stats PRIMARY KEY CLUSTERED (collection_time, collection_id) WITH (DATA_COMPRESSION = PAGE)
     );


### PR DESCRIPTION
## What

`config.ensure_collection_table` (install/06) — the proc that recreates a collection table on demand if it's missing — still declared `collect.cpu_utilization_stats.other_process_cpu_utilization` as `NOT NULL`, even though the #1048 Linux host-CPU fix (#1049) made that column nullable everywhere else (install/02 CREATE TABLE + the 2.11.0→2.12.0 upgrade ALTER).

If that proc ever recreates the table, the Linux collector's `NULL` insert (host CPU isn't derivable on Linux) would fail again — silently re-introducing #1048 on the recreate path.

## Change

One line in `install/06_ensure_collection_table.sql`: `NOT NULL` → `NULL` on `other_process_cpu_utilization`, matching install/02 and upgrade 02. The persisted computed `total_cpu_utilization` already tolerates a NULL base column (NULL propagates).

## Context

Caught during 2.12.0 release prep (which was subsequently shelved); salvaged as a standalone fix since it's an independent completion of #1048, unrelated to the shelved work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)