### PR TITLE
Fix #1048: stop alert engine fabricating 100% host CPU on Linux

### DIFF
--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -252,6 +252,22 @@ namespace PerformanceMonitorDashboard.Services
                 OPTION(MAXDOP 1);"
                 : @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
+                DECLARE @is_linux bit = 0;
+
+                /* SystemIdle is always 0 in the SCHEDULER_MONITOR ring buffer on SQL Server
+                   on Linux, so 100 - SystemIdle - ProcessUtilization fabricates a host figure
+                   that pins total CPU at 100% forever (Issue #1048). No DMV exposes true host
+                   CPU on Linux, so report other/host CPU as NULL there and let the alert engine
+                   fall back to the SQL-only figure. sys.dm_os_host_info is 2017+; referenced via
+                   sp_executesql so SQL 2016 (no Linux build) never binds it (@is_linux stays 0). */
+                IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
+                BEGIN
+                    EXEC sys.sp_executesql
+                        N'SELECT @linux = CASE WHEN hi.host_platform = N''Linux'' THEN 1 ELSE 0 END FROM sys.dm_os_host_info AS hi;',
+                        N'@linux bit OUTPUT',
+                        @linux = @is_linux OUTPUT;
+                END;
+
                 SELECT TOP (1)
                     sql_cpu_percent =
                         x.rb.value
@@ -260,17 +276,21 @@ namespace PerformanceMonitorDashboard.Services
                             'integer'
                         ),
                     other_cpu_percent =
-                        100
-                        - x.rb.value
-                        (
-                            '(./Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]',
-                            'integer'
-                        )
-                        - x.rb.value
-                        (
-                            '(./Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]',
-                            'integer'
-                        )
+                        CASE
+                            WHEN @is_linux = 1
+                            THEN NULL
+                            ELSE 100
+                                 - x.rb.value
+                                 (
+                                     '(./Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]',
+                                     'integer'
+                                 )
+                                 - x.rb.value
+                                 (
+                                     '(./Record/SchedulerMonitorEvent/SystemHealth/ProcessUtilization)[1]',
+                                     'integer'
+                                 )
+                        END
                 FROM
                 (
                     SELECT


### PR DESCRIPTION
## Problem

The reporter on #1048 installed the #1049 nightly and **still saw the host-CPU alert** on their OpenSUSE-hosted SQL Server.

#1049 corrected every path that reads CPU from the collected table (`install/18` collector, `install/47` views, `Overview.cs`/`ResourceMetrics.cs` chart reads). But the **alert engine doesn't read that table** — `DatabaseService.NocHealth.GetCpuPercentAsync` runs its own *live* query against `sys.dm_os_ring_buffers` and was never touched.

It computes `other_cpu_percent = 100 - SystemIdle - ProcessUtilization`. Since `SystemIdle` is always `0` on SQL Server on Linux, that returns `100 - sqlcpu`. `AlertHealthResult.TotalCpuPercent` then sums to a permanent **100%**, so `AlertStateService`'s `TotalCpuPercent >= CpuThresholdPercent` check fires the host-CPU alert forever. The chart was fixed; the alert badge was not.

## Fix

Apply the same Linux guard already used by `install/18`, `RemoteCollectorService.Cpu`, and `FinOps.Inventory`:
- Detect `host_platform` via `sp_executesql` behind an `OBJECT_ID(N'sys.dm_os_host_info', N'V')` check, so SQL 2016 never binds the 2017+ DMV.
- Return `NULL` for `other_cpu_percent` on Linux.

The existing `TotalCpuPercent` getter already falls back to the SQL-only figure when `OtherCpuPercent` is null, so the alert clears. **Windows behavior is unchanged.**

## Scope

Dashboard-C#-only — **no schema or installer change**. The reporter can verify with just the next nightly **Dashboard** (no DB re-install needed).

## Verification

- Rewritten query parses & runs on SQL 2022 — Windows path unchanged (SQL 0% / other 1%; Linux would yield `NULL`).
- Dashboard builds clean (0 warnings, 0 errors).
- Confirmed `NocHealth.cs` was the only remaining live `SystemIdle` computation in the Dashboard.
- Linux runtime behavior is the reporter's to confirm (no Linux SQL host available here), same as #1049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)