### PR TITLE
Fix DB_CONFIG fact dead on Dashboard (setting_type filter mismatch)

### DIFF
--- a/Dashboard/Analysis/SqlServerFactCollector.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.cs
@@ -1474,7 +1474,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
         setting_value,
         ROW_NUMBER() OVER (PARTITION BY database_name, setting_name ORDER BY collection_time DESC) AS rn
     FROM config.database_configuration_history
-    WHERE setting_type = 'database_option'
+    WHERE setting_type = 'DATABASE_PROPERTY' /* collector writes 'DATABASE_PROPERTY' (install/39); 'database_option' matched 0 rows → DB_CONFIG fact never fired */
     AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')
 ),
 pivoted AS (


### PR DESCRIPTION
## Bug

`SqlServerFactCollector.CollectDatabaseConfigFactsAsync` filters `config.database_configuration_history` on `setting_type = 'database_option'`, but the collector (`install/39_collect_database_configuration.sql:89`) writes `setting_type = 'DATABASE_PROPERTY'`. The filter matches **zero rows**, so:
- the `DB_CONFIG` fact is never produced on Dashboard,
- no `DB_CONFIG` finding → no auto_shrink / auto_close / RCSI database-config recommendations,
- the RCSI Apply path can never surface on Dashboard.

## Fix

One line: `'database_option'` → `'DATABASE_PROPERTY'` (the value the collector actually writes; `install/50` and the drill-down's `CollectConfigIssues` already use it).

## Verification (real data, sql2022)

`config.database_configuration_history` setting_type breakdown: `DATABASE_PROPERTY` = 414 rows, `DATABASE_SCOPED_CONFIG` = 315 rows.
- Broken filter `'database_option'` → **0 rows**.
- Corrected filter `'DATABASE_PROPERTY'` → **414 rows**.

Dashboard builds clean. **Lite is unaffected** — `DuckDbFactCollector` reads a typed `database_config` table, not the `setting_type` EAV model.

## Test note

The SQL-side fact collectors require a live connection and have no unit-test harness today; a fact-emission regression test (seed `DATABASE_PROPERTY` rows → assert a `DB_CONFIG` fact is produced) is scoped into the recommendations-engine rebuild's test workstream (WS7), which builds that harness. This PR is the standalone correctness fix, verified against a real server as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)