### PR TITLE
Decouple analysis production from notification delivery (D0 + cost prereqs)

### DIFF
--- a/Dashboard.Tests/AnalysisEnabledPreferenceTests.cs
+++ b/Dashboard.Tests/AnalysisEnabledPreferenceTests.cs
@@ -1,0 +1,92 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System.Text.Json;
+using PerformanceMonitorDashboard.Models;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Recommendations rebuild PR-1 (D0): the new <see cref="UserPreferences.AnalysisEnabled"/>
+/// setting gates analysis *production* and is independent of the notification *delivery*
+/// gate (<see cref="UserPreferences.AnalysisNotificationsEnabled"/>). These tests pin the
+/// defaults and the JSON persistence contract that UserPreferencesService relies on
+/// (it serializes/deserializes the whole UserPreferences object with the same options).
+/// </summary>
+public class AnalysisEnabledPreferenceTests
+{
+    /// <summary>Serializer options matching UserPreferencesService (WriteIndented = true).</summary>
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    [Fact]
+    public void AnalysisEnabled_DefaultsToTrue()
+    {
+        var prefs = new UserPreferences();
+        Assert.True(prefs.AnalysisEnabled);
+    }
+
+    [Fact]
+    public void AnalysisNotificationsEnabled_StillDefaultsToFalse()
+    {
+        // D0 keeps delivery opt-in: production is on by default, notifications are not.
+        var prefs = new UserPreferences();
+        Assert.False(prefs.AnalysisNotificationsEnabled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AnalysisEnabled_RoundTripsThroughJson(bool value)
+    {
+        // This is exactly what UserPreferencesService.SavePreferences/LoadPreferences do:
+        // JsonSerializer.Serialize(prefs) -> file -> JsonSerializer.Deserialize<UserPreferences>.
+        var prefs = new UserPreferences { AnalysisEnabled = value };
+
+        var json = JsonSerializer.Serialize(prefs, s_jsonOptions);
+        var loaded = JsonSerializer.Deserialize<UserPreferences>(json);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(value, loaded!.AnalysisEnabled);
+    }
+
+    [Fact]
+    public void AnalysisEnabled_AbsentFromExistingJson_DeserializesToTrueDefault()
+    {
+        // An existing preferences.json written before this PR has no "AnalysisEnabled" key.
+        // The default initializer (= true) must apply so upgraded installs get analysis on.
+        const string legacyJson = """
+        {
+            "AnalysisNotificationsEnabled": false,
+            "AnalysisIntervalMinutes": 30
+        }
+        """;
+
+        var loaded = JsonSerializer.Deserialize<UserPreferences>(legacyJson);
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.AnalysisEnabled);
+        Assert.False(loaded.AnalysisNotificationsEnabled);
+    }
+
+    [Fact]
+    public void AnalysisEnabled_AndNotifications_AreIndependentInJson()
+    {
+        // Production on, delivery off — the canonical D0 default-on/notify-off state.
+        var prefs = new UserPreferences
+        {
+            AnalysisEnabled = true,
+            AnalysisNotificationsEnabled = false
+        };
+
+        var json = JsonSerializer.Serialize(prefs, s_jsonOptions);
+        var loaded = JsonSerializer.Deserialize<UserPreferences>(json);
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.AnalysisEnabled);
+        Assert.False(loaded.AnalysisNotificationsEnabled);
+    }
+}

--- a/Dashboard/Analysis/SqlServerFindingStore.cs
+++ b/Dashboard/Analysis/SqlServerFindingStore.cs
@@ -93,44 +93,60 @@ END;";
     public async Task<List<AnalysisFinding>> SaveFindingsAsync(
         List<AnalysisStory> stories, AnalysisContext context)
     {
-        var mutedHashes = await GetMutedHashesAsync(context.ServerId);
         var analysisTime = DateTime.UtcNow;
         var saved = new List<AnalysisFinding>();
 
-        foreach (var story in stories)
+        try
         {
-            // Skip absolution stories (severity 0) -- they confirm health, not problems
-            if (story.Severity <= 0)
-                continue;
+            /* One connection per save call. EnsureTablesExistAsync runs ONCE here (not
+               per finding) and the muted-hash read + every insert reuse this connection.
+               Mandatory under D0's default-on analysis: the previous per-finding pattern
+               opened a fresh connection AND re-checked the schema for every row. */
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+            await EnsureTablesExistAsync(connection);
 
-            if (mutedHashes.Contains(story.StoryPathHash))
-                continue;
+            var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId);
 
-            var finding = new AnalysisFinding
+            foreach (var story in stories)
             {
-                FindingId = _nextId++,
-                AnalysisTime = analysisTime,
-                ServerId = context.ServerId,
-                ServerName = context.ServerName,
-                TimeRangeStart = context.TimeRangeStart,
-                TimeRangeEnd = context.TimeRangeEnd,
-                Severity = story.Severity,
-                Confidence = story.Confidence,
-                Category = story.Category,
-                StoryPath = story.StoryPath,
-                StoryPathHash = story.StoryPathHash,
-                StoryText = story.StoryText,
-                RootFactKey = story.RootFactKey,
-                RootFactValue = story.RootFactValue,
-                LeafFactKey = story.LeafFactKey,
-                LeafFactValue = story.LeafFactValue,
-                FactCount = story.FactCount,
-                // Carried in-memory only; no analysis_findings column for it.
-                RootFactMetadata = story.RootFactMetadata
-            };
+                // Skip absolution stories (severity 0) -- they confirm health, not problems
+                if (story.Severity <= 0)
+                    continue;
 
-            await InsertFindingAsync(finding);
-            saved.Add(finding);
+                if (mutedHashes.Contains(story.StoryPathHash))
+                    continue;
+
+                var finding = new AnalysisFinding
+                {
+                    FindingId = _nextId++,
+                    AnalysisTime = analysisTime,
+                    ServerId = context.ServerId,
+                    ServerName = context.ServerName,
+                    TimeRangeStart = context.TimeRangeStart,
+                    TimeRangeEnd = context.TimeRangeEnd,
+                    Severity = story.Severity,
+                    Confidence = story.Confidence,
+                    Category = story.Category,
+                    StoryPath = story.StoryPath,
+                    StoryPathHash = story.StoryPathHash,
+                    StoryText = story.StoryText,
+                    RootFactKey = story.RootFactKey,
+                    RootFactValue = story.RootFactValue,
+                    LeafFactKey = story.LeafFactKey,
+                    LeafFactValue = story.LeafFactValue,
+                    FactCount = story.FactCount,
+                    // Carried in-memory only; no analysis_findings column for it.
+                    RootFactMetadata = story.RootFactMetadata
+                };
+
+                await InsertFindingAsync(connection, finding);
+                saved.Add(finding);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[SqlServerFindingStore] SaveFindingsAsync failed: {ex.Message}");
         }
 
         return saved;
@@ -302,16 +318,17 @@ VALUES (@muteId, @serverId, @storyPathHash, @storyPath, @mutedDate, @reason);";
         }
     }
 
-    private async Task<HashSet<string>> GetMutedHashesAsync(int serverId)
+    /// <summary>
+    /// Reads muted story hashes for a server on an already-open connection. The caller
+    /// owns the connection and is responsible for EnsureTablesExistAsync. Used by
+    /// SaveFindingsAsync so the mute-filter read reuses the save connection.
+    /// </summary>
+    private static async Task<HashSet<string>> GetMutedHashesAsync(SqlConnection connection, int serverId)
     {
         var hashes = new HashSet<string>();
 
         try
         {
-            using var connection = new SqlConnection(_connectionString);
-            await connection.OpenAsync();
-            await EnsureTablesExistAsync(connection);
-
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -333,14 +350,15 @@ WHERE server_id = @serverId OR server_id IS NULL;";
         return hashes;
     }
 
-    private async Task InsertFindingAsync(AnalysisFinding finding)
+    /// <summary>
+    /// Inserts one finding on an already-open connection. The caller owns the connection
+    /// and has already run EnsureTablesExistAsync, so a batch of inserts in one
+    /// SaveFindingsAsync call shares a single connection and a single schema check.
+    /// </summary>
+    private static async Task InsertFindingAsync(SqlConnection connection, AnalysisFinding finding)
     {
         try
         {
-            using var connection = new SqlConnection(_connectionString);
-            await connection.OpenAsync();
-            await EnsureTablesExistAsync(connection);
-
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
 INSERT INTO config.analysis_findings

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -143,6 +143,13 @@ namespace PerformanceMonitorDashboard.Models
         public bool McpEnabled { get; set; } = false;
         public int McpPort { get; set; } = 5150;
 
+        // Automated analysis production (D0): run the triage engine and persist
+        // findings on the independent AnalysisIntervalMinutes cadence. Decoupled from
+        // notification *delivery* (AnalysisNotificationsEnabled) — analysis runs and
+        // persists regardless of whether findings are delivered. Default ON so the
+        // Recommendations surface has data without the user opting in to alerts.
+        public bool AnalysisEnabled { get; set; } = true;
+
         // Automated analysis notifications (Stage 2)
         // Bounds are enforced where these are consumed (the scheduler and the
         // notification service), not here — keeps the prefs surface simple and

--- a/Dashboard/Services/AnalysisScheduler.cs
+++ b/Dashboard/Services/AnalysisScheduler.cs
@@ -24,9 +24,12 @@ namespace PerformanceMonitorDashboard.Services
     /// in MainWindow's lifetime; entirely separate cadence and gating.
     ///
     /// <para>
-    /// Gated by <see cref="UserPreferences.AnalysisNotificationsEnabled"/> — zero cost
-    /// when off. Per-server in-flight tracking prevents a hung connection from piling
-    /// up overlapping analysis tasks for the same server.
+    /// Production is gated by <see cref="UserPreferences.AnalysisEnabled"/> (default ON):
+    /// when enabled the timer runs and <c>AnalyzeAsync</c> persists findings every cycle.
+    /// Notification *delivery* is the inner gate — <c>NotifyAsync</c> is only called when
+    /// <see cref="UserPreferences.AnalysisNotificationsEnabled"/> is also on. Per-server
+    /// in-flight tracking prevents a hung connection from piling up overlapping analysis
+    /// tasks for the same server.
     /// </para>
     /// </summary>
     public sealed class AnalysisScheduler
@@ -72,7 +75,10 @@ namespace PerformanceMonitorDashboard.Services
         {
             var prefs = _preferencesService.GetPreferences();
 
-            if (!prefs.AnalysisNotificationsEnabled)
+            /* D0: analysis *production* is gated by AnalysisEnabled, NOT by the
+               notification toggle. The timer runs (and AnalyzeAsync persists findings)
+               whenever analysis is enabled; NotifyAsync is gated separately in the cycle. */
+            if (!prefs.AnalysisEnabled)
             {
                 _timer.Stop();
                 return;
@@ -126,8 +132,12 @@ namespace PerformanceMonitorDashboard.Services
         private async Task RunCycleAsync(CancellationToken cancellationToken)
         {
             var prefs = _preferencesService.GetPreferences();
-            if (!prefs.AnalysisNotificationsEnabled)
+            if (!prefs.AnalysisEnabled)
                 return;
+
+            /* D0: deliver findings only when notifications are also enabled. Analysis
+               runs+persists regardless; this inner gate controls delivery alone. */
+            var notify = prefs.AnalysisNotificationsEnabled;
 
             var timeoutSeconds = Math.Clamp(prefs.AnalysisTimeoutSeconds, 30, 600);
             var timeout = TimeSpan.FromSeconds(timeoutSeconds);
@@ -181,7 +191,11 @@ namespace PerformanceMonitorDashboard.Services
                     }
 
                     var findings = await analyzeTask;
-                    await _notificationService.NotifyAsync(findings);
+
+                    /* Analysis already persisted via SaveFindingsAsync inside AnalyzeAsync.
+                       Only route findings to the notification channels when delivery is on. */
+                    if (notify)
+                        await _notificationService.NotifyAsync(findings);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -374,13 +374,16 @@
                             </StackPanel>
                         </StackPanel>
 
-                        <!-- Automated Analysis Notifications -->
-                        <TextBlock Text="Automated Analysis Notifications" FontWeight="Bold" FontSize="13" Margin="0,20,0,5"/>
-                        <TextBlock Text="Runs the diagnostic inference engine on a schedule and routes high-severity findings to your configured channels (email, Teams, Slack)."
+                        <!-- Automated Analysis -->
+                        <TextBlock Text="Automated Analysis" FontWeight="Bold" FontSize="13" Margin="0,20,0,5"/>
+                        <TextBlock Text="Runs the diagnostic inference engine on a schedule and records findings. Notifications are optional — analysis runs and persists findings even with notifications off. When notifications are on, high-severity findings are also routed to your configured channels (email, Teams, Slack)."
                                    TextWrapping="Wrap" Margin="0,0,0,10" FontStyle="Italic" Foreground="Gray"/>
                         <StackPanel>
+                            <CheckBox x:Name="AnalysisEnabledCheckBox"
+                                      Content="Enable automated analysis"
+                                      Margin="0,0,0,8"/>
                             <CheckBox x:Name="AnalysisNotificationsEnabledCheckBox"
-                                      Content="Enable automated analysis notifications"
+                                      Content="Send automated analysis notifications"
                                       Margin="0,0,0,8"/>
                             <Grid Margin="20,0,0,0">
                                 <Grid.ColumnDefinitions>

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -155,8 +155,10 @@ namespace PerformanceMonitorDashboard
             McpPortTextBox.IsEnabled = prefs.McpEnabled;
             UpdateMcpStatus(prefs);
 
-            // Automated analysis notifications (Stage 2). Cooldown and timeout are
-            // intentionally not exposed in the UI — preferences.json only.
+            // Automated analysis. Production (AnalysisEnabled, default on) is decoupled
+            // from notification delivery (AnalysisNotificationsEnabled). Cooldown and
+            // timeout are intentionally not exposed in the UI — preferences.json only.
+            AnalysisEnabledCheckBox.IsChecked = prefs.AnalysisEnabled;
             AnalysisNotificationsEnabledCheckBox.IsChecked = prefs.AnalysisNotificationsEnabled;
             AnalysisIntervalMinutesTextBox.Text = prefs.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
             AnalysisNotifySeverityTextBox.Text = prefs.AnalysisNotifySeverity.ToString("F1", CultureInfo.InvariantCulture);
@@ -764,9 +766,11 @@ namespace PerformanceMonitorDashboard
             else
                 validationErrors.Add($"MCP port must be between 1024 and {IPEndPoint.MaxPort}.\nPorts 0–1023 are well-known privileged ports reserved by the operating system.");
 
-            // Automated analysis notifications (Stage 2). Bounds are also enforced at
-            // consumption (AnalysisScheduler.Configure, AnalysisNotificationService.NotifyAsync),
-            // but validating here catches typos early.
+            // Automated analysis. Production gate (AnalysisEnabled) is independent of the
+            // notification delivery gate (AnalysisNotificationsEnabled). Bounds are also
+            // enforced at consumption (AnalysisScheduler.Configure,
+            // AnalysisNotificationService.NotifyAsync), but validating here catches typos early.
+            prefs.AnalysisEnabled = AnalysisEnabledCheckBox.IsChecked == true;
             prefs.AnalysisNotificationsEnabled = AnalysisNotificationsEnabledCheckBox.IsChecked == true;
 
             if (int.TryParse(AnalysisIntervalMinutesTextBox.Text?.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int analysisInterval)

--- a/Lite.Tests/AnalysisEnabledSettingTests.cs
+++ b/Lite.Tests/AnalysisEnabledSettingTests.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitorLite;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Recommendations rebuild PR-1 (D0): App.AnalysisEnabled gates analysis *production*
+/// (run + persist on the independent AnalysisIntervalMinutes cadence) and is independent
+/// of App.AnalysisNotificationsEnabled, which gates notification *delivery* only.
+///
+/// Note: App.* are process-wide mutable statics that other parallel test classes also
+/// touch. This test asserts the AnalysisEnabled default once and otherwise only reads it,
+/// to avoid flaking sibling classes — matching the discipline documented in
+/// AppAlertSettingsTests.
+/// </summary>
+public class AnalysisEnabledSettingTests
+{
+    [Fact]
+    public void AnalysisEnabled_And_NotificationsEnabled_AreSeparateProperties()
+    {
+        // Setting one must not move the other — they are independent gates (production vs delivery).
+        App.AnalysisEnabled = true;
+        App.AnalysisNotificationsEnabled = false;
+
+        Assert.True(App.AnalysisEnabled);
+        Assert.False(App.AnalysisNotificationsEnabled);
+
+        App.AnalysisEnabled = false;
+        App.AnalysisNotificationsEnabled = true;
+
+        Assert.False(App.AnalysisEnabled);
+        Assert.True(App.AnalysisNotificationsEnabled);
+
+        // Restore the shipped default so sibling test classes observe the production default.
+        App.AnalysisEnabled = true;
+    }
+}

--- a/Lite.Tests/FindingStoreTests.cs
+++ b/Lite.Tests/FindingStoreTests.cs
@@ -167,6 +167,88 @@ public class FindingStoreTests : IDisposable
         Assert.Equal(firstSaved.StoryPathHash, firstRetrieved.StoryPathHash);
     }
 
+    [Fact]
+    public async Task SaveFindings_BatchedSingleCall_PersistsAllRows()
+    {
+        // D0 cost prereq: SaveFindingsAsync now uses ONE read lock + ONE connection per
+        // call, reused for the mute read and every insert. This exercises a batch larger
+        // than the two-story helper to confirm the connection-reuse path persists every
+        // surviving row (and preserves severity-desc ordering on read-back).
+        await InitializeWithAnalysisAsync();
+
+        var store = new FindingStore(_duckDb);
+        var context = TestDataSeeder.CreateTestContext();
+
+        var stories = new System.Collections.Generic.List<AnalysisStory>();
+        for (int i = 0; i < 10; i++)
+        {
+            stories.Add(new AnalysisStory
+            {
+                RootFactKey = $"FACT_{i}",
+                RootFactValue = 0.1 * (i + 1),
+                Severity = 0.1 * (i + 1),
+                Confidence = 1.0,
+                Category = "waits",
+                Path = [$"FACT_{i}"],
+                StoryPath = $"FACT_{i}",
+                StoryPathHash = $"hash_{i:D4}",
+                StoryText = $"Batched story {i}.",
+                FactCount = 1
+            });
+        }
+
+        var saved = await store.SaveFindingsAsync(stories, context);
+        Assert.Equal(10, saved.Count);
+
+        var retrieved = await store.GetLatestFindingsAsync(context.ServerId);
+        Assert.Equal(10, retrieved.Count);
+
+        // Ordered by severity descending on read-back.
+        for (int i = 1; i < retrieved.Count; i++)
+            Assert.True(retrieved[i - 1].Severity >= retrieved[i].Severity);
+
+        // Every hash survived the batched insert.
+        var savedHashes = new System.Collections.Generic.HashSet<string>();
+        foreach (var f in saved) savedHashes.Add(f.StoryPathHash);
+        Assert.Equal(10, savedHashes.Count);
+    }
+
+    [Fact]
+    public async Task SaveFindings_BatchedCall_StillFiltersMutedAndAbsolution()
+    {
+        // The batching refactor must preserve mute filtering and the severity<=0 skip
+        // within the single-connection loop.
+        await InitializeWithAnalysisAsync();
+
+        var store = new FindingStore(_duckDb);
+        var context = TestDataSeeder.CreateTestContext();
+        var stories = CreateTestStories();
+
+        // Add an absolution story (severity 0) that must be skipped.
+        stories.Add(new AnalysisStory
+        {
+            RootFactKey = "HEALTHY",
+            RootFactValue = 0.0,
+            Severity = 0.0,
+            Confidence = 1.0,
+            Category = "waits",
+            Path = ["HEALTHY"],
+            StoryPath = "HEALTHY",
+            StoryPathHash = "healthy_hash",
+            StoryText = "All clear.",
+            FactCount = 1
+        });
+
+        // Mute the first real story.
+        await store.MuteStoryAsync(context.ServerId, stories[0].StoryPathHash, stories[0].StoryPath, "Test mute");
+
+        var saved = await store.SaveFindingsAsync(stories, context);
+
+        // Only the second real story survives (first muted, absolution skipped).
+        Assert.Single(saved);
+        Assert.Equal(stories[1].StoryPathHash, saved[0].StoryPathHash);
+    }
+
     private static System.Collections.Generic.List<AnalysisStory> CreateTestStories()
     {
         return

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -30,9 +30,18 @@ public class FindingStore
     public async Task<List<AnalysisFinding>> SaveFindingsAsync(
         List<AnalysisStory> stories, AnalysisContext context)
     {
-        var mutedHashes = await GetMutedHashesAsync(context.ServerId);
         var analysisTime = DateTime.UtcNow;
         var saved = new List<AnalysisFinding>();
+
+        /* One read lock + one connection per save call, reused for the mute-filter read
+           and every insert. The previous per-finding pattern acquired the lock and opened
+           a fresh connection for each row. The lock is NoRecursion, so the helpers below
+           operate on the passed connection and must NOT re-acquire it. */
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+
+        var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId);
 
         foreach (var story in stories)
         {
@@ -65,7 +74,7 @@ public class FindingStore
                 RootFactMetadata = story.RootFactMetadata
             };
 
-            await InsertFindingAsync(finding);
+            await InsertFindingAsync(connection, finding);
             saved.Add(finding);
         }
 
@@ -238,13 +247,14 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         await cmd.ExecuteNonQueryAsync();
     }
 
-    private async Task<HashSet<string>> GetMutedHashesAsync(int serverId)
+    /// <summary>
+    /// Reads muted story hashes on an already-open connection. The caller owns the read
+    /// lock and connection (NoRecursion lock — do not re-acquire here). Used by
+    /// SaveFindingsAsync so the mute-filter read reuses the save connection.
+    /// </summary>
+    private static async Task<HashSet<string>> GetMutedHashesAsync(DuckDBConnection connection, int serverId)
     {
         var hashes = new HashSet<string>();
-
-        using var readLock = _duckDb.AcquireReadLock();
-        using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -260,12 +270,13 @@ WHERE server_id = $1 OR server_id IS NULL";
         return hashes;
     }
 
-    private async Task InsertFindingAsync(AnalysisFinding finding)
+    /// <summary>
+    /// Inserts one finding on an already-open connection. The caller owns the read lock
+    /// and connection, so a batch of inserts in one SaveFindingsAsync call shares a
+    /// single lock acquisition and connection.
+    /// </summary>
+    private static async Task InsertFindingAsync(DuckDBConnection connection, AnalysisFinding finding)
     {
-        using var readLock = _duckDb.AcquireReadLock();
-        using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
-
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
 INSERT INTO analysis_findings

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -117,8 +117,13 @@ public partial class App : Application
     public static string MuteRuleDefaultExpiration { get; set; } = "24 hours"; // Default expiration for new mute rules
     public static bool LogAlertDismissals { get; set; } = true; // Log alert dismiss/mute actions to file
 
+    /* Automated analysis production (D0): run the triage engine and persist findings on
+       the independent AnalysisIntervalMinutes cadence. Decoupled from notification delivery
+       (AnalysisNotificationsEnabled). Default ON so the recommendations data exists. */
+    public static bool AnalysisEnabled { get; set; } = true;
+
     /* Automated analysis notifications (scheduled triage) */
-    public static bool AnalysisNotificationsEnabled { get; set; } = false;  // Master switch — also gates the scheduler
+    public static bool AnalysisNotificationsEnabled { get; set; } = false;  // Delivery gate — analysis runs regardless
     public static int AnalysisIntervalMinutes { get; set; } = 30;           // How often scheduled analysis runs
     public static double AnalysisNotifySeverity { get; set; } = 1.5;        // Minimum finding severity (0.0-2.0) to notify on
     public static int AnalysisNotifyCooldownMinutes { get; set; } = 360;    // Re-notify gap per finding (keyed by StoryPathHash)
@@ -559,6 +564,7 @@ public partial class App : Application
             if (root.TryGetProperty("smtp_from_address", out v)) SmtpFromAddress = v.GetString() ?? "";
             if (root.TryGetProperty("smtp_recipients", out v)) SmtpRecipients = v.GetString() ?? "";
 
+            if (root.TryGetProperty("analysis_enabled", out v)) AnalysisEnabled = v.GetBoolean();
             if (root.TryGetProperty("analysis_notifications_enabled", out v)) AnalysisNotificationsEnabled = v.GetBoolean();
             if (root.TryGetProperty("analysis_interval_minutes", out v)) AnalysisIntervalMinutes = (int)Math.Clamp(v.GetInt64(), 5, 360);
             if (root.TryGetProperty("analysis_notify_severity", out v)) AnalysisNotifySeverity = Math.Clamp(v.GetDouble(), 0.0, 2.0);

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -206,18 +206,24 @@ public class CollectionBackgroundService : BackgroundService
     }
 
     /// <summary>
-    /// Runs the triage engine for each enabled server on a configurable interval and
-    /// routes high-severity findings to the notification channels. Gated by
-    /// App.AnalysisNotificationsEnabled — zero cost when off.
+    /// Runs the triage engine for each enabled server on the independent
+    /// AnalysisIntervalMinutes cadence and persists findings to DuckDB. Production is
+    /// gated by App.AnalysisEnabled (default ON, D0); findings are only routed to the
+    /// notification channels when App.AnalysisNotificationsEnabled is also on.
     /// </summary>
     private async Task RunAnalysisIfDueAsync(CancellationToken stoppingToken)
     {
-        /* Feature off, or dependencies not injected in this construction path. */
-        if (!App.AnalysisNotificationsEnabled ||
+        /* Analysis production is gated by AnalysisEnabled, NOT by the notification toggle
+           (D0). Skip when disabled, or when dependencies aren't injected in this path. */
+        if (!App.AnalysisEnabled ||
             _duckDb == null || _serverManager == null || _notificationService == null)
         {
             return;
         }
+
+        /* D0: deliver findings only when notifications are also enabled. Analysis
+           runs+persists regardless; this inner gate controls delivery alone. */
+        var notify = App.AnalysisNotificationsEnabled;
 
         if (DateTime.UtcNow - _lastAnalysisTime < TimeSpan.FromMinutes(App.AnalysisIntervalMinutes))
         {
@@ -274,7 +280,13 @@ public class CollectionBackgroundService : BackgroundService
                     continue;
                 }
 
-                await _notificationService.NotifyAsync(await analyzeTask);
+                /* Analysis already persisted via SaveFindingsAsync inside AnalyzeAsync.
+                   Only route findings to the notification channels when delivery is on. */
+                var findings = await analyzeTask;
+                if (notify)
+                {
+                    await _notificationService.NotifyAsync(findings);
+                }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -274,13 +274,15 @@
                 <CheckBox x:Name="LogAlertDismissalsCheckBox" Content="Log alert dismiss and mute actions"
                           Margin="20,8,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
 
-                <!-- Automated Analysis Notifications -->
-                <TextBlock Text="Automated Analysis Notifications" FontWeight="SemiBold" FontSize="12"
+                <!-- Automated Analysis -->
+                <TextBlock Text="Automated Analysis" FontWeight="SemiBold" FontSize="12"
                            Foreground="{DynamicResource ForegroundBrush}" Margin="20,14,0,4"/>
-                <TextBlock Text="Periodically run the triage engine and send high-severity findings through the channels above."
+                <TextBlock Text="Periodically run the triage engine and record findings in the Alerts tab. Notifications below are optional — analysis runs and stores findings even with notifications off."
                            FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
                            Margin="20,0,0,4" TextWrapping="Wrap"/>
-                <CheckBox x:Name="AnalysisNotificationsCheckBox" Content="Enable scheduled analysis notifications"
+                <CheckBox x:Name="AnalysisEnabledCheckBox" Content="Enable automated analysis"
+                          Margin="20,4,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                <CheckBox x:Name="AnalysisNotificationsCheckBox" Content="Send scheduled analysis notifications"
                           Margin="20,4,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <TextBlock Text="Run analysis every" VerticalAlignment="Center" Margin="0,0,8,0"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -608,6 +608,7 @@ public partial class SettingsWindow : Window
             _ => 3
         };
         LogAlertDismissalsCheckBox.IsChecked = App.LogAlertDismissals;
+        AnalysisEnabledCheckBox.IsChecked = App.AnalysisEnabled;
         AnalysisNotificationsCheckBox.IsChecked = App.AnalysisNotificationsEnabled;
         AnalysisIntervalBox.Text = App.AnalysisIntervalMinutes.ToString();
         AnalysisNotifySeverityBox.Text = App.AnalysisNotifySeverity.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture);
@@ -663,6 +664,7 @@ public partial class SettingsWindow : Window
             validationErrors.Add("Email alert cooldown must be between 1 and 120 minutes.");
         App.MuteRuleDefaultExpiration = (MuteRuleDefaultExpirationCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "24 hours";
         App.LogAlertDismissals = LogAlertDismissalsCheckBox.IsChecked == true;
+        App.AnalysisEnabled = AnalysisEnabledCheckBox.IsChecked == true;
         App.AnalysisNotificationsEnabled = AnalysisNotificationsCheckBox.IsChecked == true;
         if (int.TryParse(AnalysisIntervalBox.Text, out var analysisInterval) && analysisInterval >= 5 && analysisInterval <= 360)
             App.AnalysisIntervalMinutes = analysisInterval;
@@ -718,6 +720,7 @@ public partial class SettingsWindow : Window
             root["email_cooldown_minutes"] = App.EmailCooldownMinutes;
             root["mute_rule_default_expiration"] = App.MuteRuleDefaultExpiration;
             root["log_alert_dismissals"] = App.LogAlertDismissals;
+            root["analysis_enabled"] = App.AnalysisEnabled;
             root["analysis_notifications_enabled"] = App.AnalysisNotificationsEnabled;
             root["analysis_interval_minutes"] = App.AnalysisIntervalMinutes;
             root["analysis_notify_severity"] = App.AnalysisNotifySeverity;


### PR DESCRIPTION
## PR-1: D0 (decouple analysis from notify) + cost prerequisites

First PR of the recommendations engine rebuild. Today analysis **production** is wrongly gated by the **notification** toggle (`AnalysisNotificationsEnabled`, default off), so `config.analysis_findings` / DuckDB `analysis_findings` is empty by default. This PR decouples production from delivery and bounds the per-save cost so default-on analysis is cheap.

Scope is **D0 + its cost prerequisites only** — no P2/D2/D7/WS1, no catalog/UI/surface/persist-action work (those are later PRs).

### Changes (file:line)

**New setting — `AnalysisEnabled` (default `true`), separate from `AnalysisNotificationsEnabled` (stays default `false`)**
- `Dashboard/Models/UserPreferences.cs:151` — `public bool AnalysisEnabled { get; set; } = true;` (mirrors `AnalysisNotificationsEnabled` at :158). Round-trips automatically via `UserPreferencesService` (whole-object `JsonSerializer`).
- `Lite/App.xaml.cs:123` — `public static bool AnalysisEnabled { get; set; } = true;`
- `Lite/App.xaml.cs:567` — load `analysis_enabled` from settings.json (absent ⇒ default true).

**Gate production on `AnalysisEnabled`; gate delivery on `AnalysisNotificationsEnabled`**
- `Dashboard/Services/AnalysisScheduler.cs:78,135` — `Configure()` starts the timer and `RunCycleAsync()` runs when `AnalysisEnabled` (was `AnalysisNotificationsEnabled`).
- `Dashboard/Services/AnalysisScheduler.cs:194` — `NotifyAsync` now called only when `AnalysisNotificationsEnabled` (inner `notify` gate; `AnalyzeAsync`/`SaveFindingsAsync` already ran+persisted).
- `Lite/Services/CollectionBackgroundService.cs:218` — `RunAnalysisIfDueAsync` early-returns on `!AnalysisEnabled`; `:284` notifies only when `AnalysisNotificationsEnabled`.
- Independent `AnalysisIntervalMinutes` (default 30) cadence unchanged — analysis is **not** bound to collection cadence.

**Cost prerequisite — one connection per `SaveFindingsAsync`, `EnsureTablesExistAsync`/lock once, batched inserts (behavior preserved)**
- `Dashboard/Analysis/SqlServerFindingStore.cs:99-153` — `SaveFindingsAsync` opens one `SqlConnection`, runs `EnsureTablesExistAsync` once, then the mute read (`GetMutedHashesAsync(connection, …)` :326) and every insert (`InsertFindingAsync(connection, …)` :358) reuse it. Previously each insert opened a new connection **and** re-ran `EnsureTablesExistAsync`.
- `Lite/Analysis/FindingStore.cs:40-79` — `SaveFindingsAsync` takes one `AcquireReadLock()` + one connection (lock is `NoRecursion`), reused by `GetMutedHashesAsync(connection,…)` :255 and `InsertFindingAsync(connection,…)` :278. Previously each helper acquired its own lock + connection per row.
- Mute filtering, severity≤0 (absolution) skip, and severity-desc read ordering preserved.

**Settings UI — "Enable automated analysis" checkbox bound to `AnalysisEnabled`**
- `Dashboard/SettingsWindow.xaml:381` (`AnalysisEnabledCheckBox`), wired in `Dashboard/SettingsWindow.xaml.cs:159` (load) / `:771` (save).
- `Lite/Windows/SettingsWindow.xaml:281` (`AnalysisEnabledCheckBox`), wired in `Lite/Windows/SettingsWindow.xaml.cs:611` (load) / `:667` (save) / `:723` (persist).

**Tests**
- `Dashboard.Tests/AnalysisEnabledPreferenceTests.cs` — `AnalysisEnabled` defaults true; `AnalysisNotificationsEnabled` stays false; JSON round-trip (the exact serialize/deserialize `UserPreferencesService` uses); legacy preferences.json without the key ⇒ true; independence.
- `Lite.Tests/AnalysisEnabledSettingTests.cs` — production/delivery gate independence on `App` statics (default-true is covered authoritatively by the Dashboard fresh-instance test; not re-asserted on the shared static to avoid parallel-class flake).
- `Lite.Tests/FindingStoreTests.cs` — batched single-call save persists all 10 rows with correct ordering; batched save still filters muted + absolution.

### Test results (real)
- Build: `dotnet build PerformanceMonitor.sln -c Debug` ⇒ **0 errors**, 1 pre-existing unrelated warning (CS0649 in `RemediationTests.cs`).
- `Dashboard.Tests` (`--no-build`): **234 passed, 0 failed, 0 skipped**.
- `Lite.Tests` (`--no-build`): **360 passed, 0 failed, 0 skipped**.

### Needs integration verification (not unit-tested here)
The following require a live SQL Server / running app and were **not** unit-tested in this PR — flagged for the orchestrator:
1. **D0 end-to-end**: with `AnalysisEnabled = true` and `AnalysisNotificationsEnabled = false`, the scheduler timer runs and `AnalyzeAsync`→`SaveFindingsAsync` **persists** rows to `config.analysis_findings` (Dashboard) / DuckDB `analysis_findings` (Lite) while **no** notification is delivered.
2. **Dashboard batched insert opens exactly one connection per `SaveFindingsAsync`** and runs `EnsureTablesExistAsync` once (the Dashboard store needs a live SQL connection — no in-memory harness; the Lite batching is unit-covered via the DuckDB harness but "one connection per save" is not directly assertable there either).
3. **Behavior change to flag**: Dashboard `SaveFindingsAsync` now wraps the whole batch in a single try/catch (was per-insert). A mid-batch exception aborts remaining inserts (rather than logging-and-continuing per row); `saved` reflects rows inserted before the failure. Worth a glance during review.
4. Settings UI: toggling "Enable automated analysis" persists and is honored after `AnalysisScheduler.Configure()` re-runs on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
