### PR TITLE
Recs rebuild D7: split drill-down enrichment severity gate

### DIFF
--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -43,12 +43,26 @@ public class SqlServerDrillDownCollector
     {
         foreach (var finding in findings)
         {
-            if (finding.Severity < 0.5) continue;
-
             try
             {
                 finding.DrillDown = new Dictionary<string, object>();
                 var pathKeys = finding.StoryPath.Split(" → ", StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+
+                /* D7: the config drill-down is a single cheap config-table read and is
+                   required to build config/RCSI/db-config Apply actions, which legitimately
+                   score below 0.5 (RCSI-off base severity is 0.3). Collect it regardless of
+                   the 0.5 display gate. */
+                if (pathKeys.Contains("DB_CONFIG"))
+                    await CollectConfigIssues(finding, context);
+
+                // Below the 0.5 display gate, only the cheap config drill-down above runs;
+                // the expensive collectors (plan fetches, multi-row reads) are skipped.
+                if (finding.Severity < 0.5)
+                {
+                    if (finding.DrillDown.Count == 0)
+                        finding.DrillDown = null;
+                    continue;
+                }
 
                 if (pathKeys.Contains("DEADLOCKS"))
                     await CollectTopDeadlocks(finding, context);
@@ -81,9 +95,6 @@ public class SqlServerDrillDownCollector
                     || pathKeys.Contains("LCK_M_IS")
                     )
                     await CollectLockModeBreakdown(finding, context);
-
-                if (pathKeys.Contains("DB_CONFIG"))
-                    await CollectConfigIssues(finding, context);
 
                 if (pathKeys.Contains("TEMPDB_USAGE"))
                     await CollectTempDbBreakdown(finding, context);

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -40,12 +40,27 @@ public class DrillDownCollector
     {
         foreach (var finding in findings)
         {
-            if (finding.Severity < 0.5) continue;
-
             try
             {
                 finding.DrillDown = new Dictionary<string, object>();
                 var pathKeys = finding.StoryPath.Split(" → ", StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+
+                /* D7: the config drill-down is a single cheap config-table read and is
+                   required to build config/RCSI/db-config advice, which legitimately scores
+                   below 0.5 (RCSI-off base severity is 0.3). Collect it regardless of the
+                   0.5 display gate. (Lite is advise/copy-paste only — no Apply — but still
+                   needs the config drill-down to render the recommendation.) */
+                if (pathKeys.Contains("DB_CONFIG"))
+                    await CollectConfigIssues(finding, context);
+
+                // Below the 0.5 display gate, only the cheap config drill-down above runs;
+                // the expensive collectors (plan fetches, multi-row reads) are skipped.
+                if (finding.Severity < 0.5)
+                {
+                    if (finding.DrillDown.Count == 0)
+                        finding.DrillDown = null;
+                    continue;
+                }
 
                 if (pathKeys.Contains("DEADLOCKS"))
                     await CollectTopDeadlocks(finding, context);
@@ -70,9 +85,6 @@ public class DrillDownCollector
 
                 if (pathKeys.Contains("LCK") || pathKeys.Contains("LCK_M_S") || pathKeys.Contains("LCK_M_IS"))
                     await CollectLockModeBreakdown(finding, context);
-
-                if (pathKeys.Contains("DB_CONFIG"))
-                    await CollectConfigIssues(finding, context);
 
                 if (pathKeys.Contains("TEMPDB_USAGE"))
                     await CollectTempDbBreakdown(finding, context);


### PR DESCRIPTION
## What

`EnrichFindingsAsync` short-circuited at `if (finding.Severity < 0.5) continue;`, skipping **all** drill-down collectors. That includes the cheap `CollectConfigIssues` (one read of `config.database_configuration_history`), which the config/RCSI/db-config **Apply actions require** — but those findings legitimately score below 0.5 (RCSI-off base severity is **0.3** by design, `FactScorer.cs`), so their config drill-down was never collected and their Apply/advice could never be built.

## Change

Split the gate (Dashboard `SqlServerDrillDownCollector` + Lite `DrillDownCollector`):
- The cheap `CollectConfigIssues` runs **regardless** of severity.
- The expensive collectors (plan fetches, multi-row `collect.*` reads) stay behind the 0.5 display gate.

No behavior change for findings ≥ 0.5. Below 0.5, only `DB_CONFIG` findings now gain a config drill-down. Lite is advise/copy-paste only but still needs the config drill-down to render the recommendation.

## Context

Prerequisite for the persist-built-action work (P2+D2) in the recommendations-engine rebuild; without it, config/RCSI Apply would be unreachable at their true severity.

## Tests

Build clean (0 errors); **Dashboard.Tests 234/234**, **Lite.Tests 360/360**. `EnrichFindingsAsync` has no unit-test harness (its collectors require a live DB/DuckDB connection), so the behavior (a sub-0.5 DB_CONFIG finding gains config drill-down) is integration-verified; the suites confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)