### PR TITLE
Recs rebuild D2: persist the built RemediationAction (P2 reorder)

### DIFF
--- a/Dashboard.Tests/AnalysisNotificationTests.cs
+++ b/Dashboard.Tests/AnalysisNotificationTests.cs
@@ -543,4 +543,97 @@ public class AnalysisNotificationTests
         Assert.Null(item.Remediation);
         Assert.Contains("sp_query_store_force_plan", item.Body);
     }
+
+    // ── Recommendations rebuild D2: persist the BUILT RemediationAction on a finding ──
+    // SerializeAction/DeserializeAction wrap the SAME private ToDto/FromDto the alert
+    // path uses, so a finding's persisted action round-trips byte-identically. These
+    // mirror the RCSI/clear-plan ContextJson round-trips above, but exercise the new
+    // single-action seam the Recommendations reader uses.
+
+    [Fact]
+    public void SerializeAction_RcsiAction_RoundTripsFiguresAndTargets()
+    {
+        // Build a real RCSI action from a finding whose config_issues row is rcsi:false
+        // with the inaction enrichment, then round-trip ONLY the action (the finding seam).
+        var action = FactRemediation.BuildRcsiAction(DbConfigRcsiFinding());
+        Assert.NotNull(action);
+        Assert.Equal("RCSI", action!.FactKey);
+
+        var json = AlertContextSerializer.SerializeAction(action);
+        Assert.NotNull(json);
+        var restored = AlertContextSerializer.DeserializeAction(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal("RCSI", restored!.FactKey);
+        var t = Assert.Single(restored.DbConfigTargets!);
+        Assert.Equal(DbConfigSetting.ReadCommittedSnapshotOn, t.Setting);
+        // The RcsiInactionFigures survive the persist round-trip.
+        Assert.NotNull(restored.RcsiFigures);
+        Assert.Equal(12, restored.RcsiFigures!.BlockingEvents);
+        Assert.Equal(3, restored.RcsiFigures.Deadlocks);
+        Assert.Equal(80, restored.RcsiFigures.ReaderWriterPct);
+    }
+
+    [Fact]
+    public void SerializeAction_ClearPlanAction_RoundTripsFiguresAndTargets()
+    {
+        var action = FactRemediation.BuildClearPlanAction(CpuFindingWithAbnormalPlans());
+        Assert.NotNull(action);
+        Assert.Equal("CLEAR_PLAN", action!.FactKey);
+
+        var json = AlertContextSerializer.SerializeAction(action);
+        Assert.NotNull(json);
+        var restored = AlertContextSerializer.DeserializeAction(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal("CLEAR_PLAN", restored!.FactKey);
+        var t = Assert.Single(restored.ClearPlanTargets!);
+        Assert.Equal("0xABCDEF0123456789", t.QueryHash);
+        // The ClearPlanFigures survive the persist round-trip.
+        Assert.NotNull(restored.ClearPlanFigures);
+        Assert.Equal(62, restored.ClearPlanFigures!.CpuPercent);
+        Assert.Equal(5.0, restored.ClearPlanFigures.AnomalyRatio);
+    }
+
+    [Fact]
+    public void SerializeAction_NullAction_SerializesAndDeserializesToNull()
+    {
+        // A finding with no execution shape persists a NULL column → no Apply affordance.
+        Assert.Null(AlertContextSerializer.SerializeAction(null));
+        Assert.Null(AlertContextSerializer.DeserializeAction(null));
+        Assert.Null(AlertContextSerializer.DeserializeAction(""));
+        // Garbage JSON degrades to null (try-catch), never throws.
+        Assert.Null(AlertContextSerializer.DeserializeAction("{ not json"));
+    }
+
+    [Fact]
+    public void PersistedRcsiAction_RendersTwoSidedConsentGate_WithFindingNull()
+    {
+        // THE C1 GATING TEST. The Recommendations Apply surface reconstructs the action from
+        // the persisted remediation_action_json and has NO finding in hand, then asks
+        // FactRiskDisclosure.GetForAction(action, finding: null) for the consent gate. This
+        // proves the gate renders the REAL inaction figures from the PERSISTED ACTION ALONE.
+        var built = FactRemediation.BuildRcsiAction(DbConfigRcsiFinding(blocking: 12, deadlocks: 3, rwPct: 80));
+        Assert.NotNull(built);
+
+        // Round-trip through the exact persistence seam the store row uses.
+        var json = AlertContextSerializer.SerializeAction(built);
+        var action = AlertContextSerializer.DeserializeAction(json);
+        Assert.NotNull(action);
+
+        // finding: null — exactly how the real Apply call site invokes it.
+        var disclosure = FactRiskDisclosure.GetForAction(action!, finding: null);
+
+        Assert.NotNull(disclosure);
+        Assert.NotEmpty(disclosure!.RisksOfChanging);       // two-sided: risk OF changing
+        Assert.NotEmpty(disclosure.RisksOfNotChanging);     // two-sided: risk of NOT changing
+
+        // The original inaction figures (carried on the action) are present in the rendered
+        // inaction side — proving they survived persistence and drive the gate with no finding.
+        var inaction = string.Join(" ", disclosure.RisksOfNotChanging.Select(r => r.Text));
+        Assert.Contains("12 blocked-process events", inaction);
+        Assert.Contains("3 deadlocks", inaction);
+        Assert.Contains("80%", inaction);                   // 80% reader/writer
+        Assert.Contains("RCSI eliminates", inaction);       // the >=50% reader/writer arm
+    }
 }

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -142,15 +142,44 @@ public class AnalysisService
             // 3. Build stories via graph traversal
             var stories = _engine.BuildStories(facts);
 
-            // 4. Persist findings (filtering out muted)
-            var findings = await _findingStore.SaveFindingsAsync(stories, context);
+            // 4. Mute-filter the stories into the surviving findings (P2 reorder) — WITHOUT
+            //    inserting yet, so enrichment + action-build happen on the survivors first
+            //    and the BUILT RemediationAction is persisted on each row (D2). Muted/
+            //    absolution findings are dropped here and never enriched (no enrich-then-
+            //    discard; round-3 MODERATE-2).
+            var findings = await _findingStore.FilterMutedFindingsAsync(stories, context);
 
-            // 5. Enrich findings with drill-down data (ephemeral, not persisted)
+            // 5. Enrich the survivors with drill-down data (ephemeral, not persisted). The
+            //    cheap config drill-down runs regardless of severity (D7), so config/RCSI/
+            //    db-config actions can build at their true 0.3 severity; the expensive
+            //    plan-fetch enrichment stays behind the 0.5 gate inside the collector.
             await _drillDown.EnrichFindingsAsync(findings, context);
+
+            // 6. Build + attach each finding's RemediationAction from the now drill-down-
+            //    populated finding (D2). The builders REQUIRE finding.DrillDown, which the
+            //    store read-back does not return — so the BUILT action is persisted, exactly
+            //    the artifact the alert path serializes into ContextJson. Try the always-safe/
+            //    db-config force action first, then the two destructive entry points (each
+            //    gates internally on RootFactKey + drill-down and returns null when N/A);
+            //    attach the first non-null.
+            foreach (var finding in findings)
+            {
+                finding.Remediation =
+                    FactRemediation.BuildAction(finding)
+                    ?? FactRemediation.BuildRcsiAction(finding)
+                    ?? FactRemediation.BuildClearPlanAction(finding);
+            }
+
+            // 7. Insert the survivors in one batched pass, persisting remediation_action_json
+            //    (D2). Reuses PR-1's single-connection + single-schema-check discipline.
+            await _findingStore.InsertFindingsAsync(findings, context);
 
             LastAnalysisTime = DateTime.UtcNow;
 
-            // 6. Notify listeners
+            // 8. Notify listeners — the returned/enriched findings (now action-bearing) flow
+            //    to the AnalysisCompleted event and, via the scheduler, to NotifyAsync, which
+            //    builds its own context from the drill-down. The reorder did not change which
+            //    list notify receives.
             AnalysisCompleted?.Invoke(this, new AnalysisCompletedEventArgs
             {
                 ServerId = context.ServerId,

--- a/Dashboard/Analysis/SqlServerFindingStore.cs
+++ b/Dashboard/Analysis/SqlServerFindingStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Helpers;
 
 namespace PerformanceMonitorDashboard.Analysis;
@@ -55,6 +56,7 @@ BEGIN
         leaf_fact_key nvarchar(256) NULL,
         leaf_fact_value float NULL,
         fact_count integer NOT NULL,
+        remediation_action_json nvarchar(max) NULL,
         CONSTRAINT PK_analysis_findings PRIMARY KEY CLUSTERED (finding_id)
             WITH (DATA_COMPRESSION = PAGE)
     );
@@ -81,27 +83,36 @@ BEGIN
     CREATE INDEX IX_analysis_muted_server_hash
     ON config.analysis_muted (server_id, story_path_hash)
         WITH (DATA_COMPRESSION = PAGE);
-END;";
+END;
+
+/* Recommendations rebuild D2: existing DBs created before this column get it added
+   idempotently. The Recommendations surface reads it back to drive Apply + the
+   two-sided consent gate (the built RemediationAction, not raw drill-down). */
+IF COL_LENGTH(N'config.analysis_findings', N'remediation_action_json') IS NULL
+    ALTER TABLE config.analysis_findings ADD remediation_action_json nvarchar(max) NULL;";
 
         await cmd.ExecuteNonQueryAsync();
     }
 
     /// <summary>
-    /// Saves analysis stories as findings, filtering out any that match muted hashes.
-    /// Returns the list of findings that were actually saved (non-muted).
+    /// Mute-filters the stories and materializes the SURVIVING findings, WITHOUT inserting
+    /// them (recommendations rebuild D2 / P2 reorder). The orchestrator then enriches these
+    /// survivors and builds + attaches each finding's RemediationAction before calling
+    /// <see cref="InsertFindingsAsync"/>, so the BUILT action is persisted on the row.
+    /// Mute/dedup/ordering and the <c>_nextId</c> sequencing are identical to the previous
+    /// single-pass save; only the insert is deferred. Muted (and absolution) findings are
+    /// dropped here and never enriched (no enrich-then-discard).
     /// </summary>
-    public async Task<List<AnalysisFinding>> SaveFindingsAsync(
+    public async Task<List<AnalysisFinding>> FilterMutedFindingsAsync(
         List<AnalysisStory> stories, AnalysisContext context)
     {
         var analysisTime = DateTime.UtcNow;
-        var saved = new List<AnalysisFinding>();
+        var survivors = new List<AnalysisFinding>();
 
         try
         {
-            /* One connection per save call. EnsureTablesExistAsync runs ONCE here (not
-               per finding) and the muted-hash read + every insert reuse this connection.
-               Mandatory under D0's default-on analysis: the previous per-finding pattern
-               opened a fresh connection AND re-checked the schema for every row. */
+            /* One connection for the mute read. EnsureTablesExistAsync runs ONCE here (not
+               per finding). Mandatory under D0's default-on analysis. */
             using var connection = new SqlConnection(_connectionString);
             await connection.OpenAsync();
             await EnsureTablesExistAsync(connection);
@@ -117,7 +128,7 @@ END;";
                 if (mutedHashes.Contains(story.StoryPathHash))
                     continue;
 
-                var finding = new AnalysisFinding
+                survivors.Add(new AnalysisFinding
                 {
                     FindingId = _nextId++,
                     AnalysisTime = analysisTime,
@@ -138,18 +149,46 @@ END;";
                     FactCount = story.FactCount,
                     // Carried in-memory only; no analysis_findings column for it.
                     RootFactMetadata = story.RootFactMetadata
-                };
-
-                await InsertFindingAsync(connection, finding);
-                saved.Add(finding);
+                });
             }
         }
         catch (Exception ex)
         {
-            Logger.Error($"[SqlServerFindingStore] SaveFindingsAsync failed: {ex.Message}");
+            Logger.Error($"[SqlServerFindingStore] FilterMutedFindingsAsync failed: {ex.Message}");
         }
 
-        return saved;
+        return survivors;
+    }
+
+    /// <summary>
+    /// Inserts the (already mute-filtered, enriched, and action-attached) findings in one
+    /// batched pass (recommendations rebuild D2 / P2 reorder). Each row persists its BUILT
+    /// <see cref="AnalysisFinding.Remediation"/> as <c>remediation_action_json</c> via the
+    /// shared <see cref="AlertContextSerializer"/>. One connection + one
+    /// EnsureTablesExistAsync for the whole batch (PR-1's discipline). Returns the same list
+    /// for caller convenience; the in-memory findings are unchanged.
+    /// </summary>
+    public async Task<List<AnalysisFinding>> InsertFindingsAsync(
+        List<AnalysisFinding> findings, AnalysisContext context)
+    {
+        if (findings.Count == 0)
+            return findings;
+
+        try
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+            await EnsureTablesExistAsync(connection);
+
+            foreach (var finding in findings)
+                await InsertFindingAsync(connection, finding);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[SqlServerFindingStore] InsertFindingsAsync failed: {ex.Message}");
+        }
+
+        return findings;
     }
 
     /// <summary>
@@ -174,7 +213,8 @@ SELECT TOP (@limit)
     finding_id, analysis_time, server_id, server_name, database_name,
     time_range_start, time_range_end, severity, confidence, category,
     story_path, story_path_hash, story_text,
-    root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count
+    root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count,
+    remediation_action_json
 FROM config.analysis_findings
 WHERE server_id = @serverId
 AND   analysis_time >= @cutoff
@@ -321,7 +361,7 @@ VALUES (@muteId, @serverId, @storyPathHash, @storyPath, @mutedDate, @reason);";
     /// <summary>
     /// Reads muted story hashes for a server on an already-open connection. The caller
     /// owns the connection and is responsible for EnsureTablesExistAsync. Used by
-    /// SaveFindingsAsync so the mute-filter read reuses the save connection.
+    /// FilterMutedFindingsAsync so the mute-filter read reuses its connection.
     /// </summary>
     private static async Task<HashSet<string>> GetMutedHashesAsync(SqlConnection connection, int serverId)
     {
@@ -353,7 +393,7 @@ WHERE server_id = @serverId OR server_id IS NULL;";
     /// <summary>
     /// Inserts one finding on an already-open connection. The caller owns the connection
     /// and has already run EnsureTablesExistAsync, so a batch of inserts in one
-    /// SaveFindingsAsync call shares a single connection and a single schema check.
+    /// InsertFindingsAsync call shares a single connection and a single schema check.
     /// </summary>
     private static async Task InsertFindingAsync(SqlConnection connection, AnalysisFinding finding)
     {
@@ -365,12 +405,14 @@ INSERT INTO config.analysis_findings
     (finding_id, analysis_time, server_id, server_name, database_name,
      time_range_start, time_range_end, severity, confidence, category,
      story_path, story_path_hash, story_text,
-     root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count)
+     root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count,
+     remediation_action_json)
 VALUES
     (@findingId, @analysisTime, @serverId, @serverName, @databaseName,
      @timeRangeStart, @timeRangeEnd, @severity, @confidence, @category,
      @storyPath, @storyPathHash, @storyText,
-     @rootFactKey, @rootFactValue, @leafFactKey, @leafFactValue, @factCount);";
+     @rootFactKey, @rootFactValue, @leafFactKey, @leafFactValue, @factCount,
+     @remediationActionJson);";
 
             cmd.Parameters.Add(new SqlParameter("@findingId", finding.FindingId));
             cmd.Parameters.Add(new SqlParameter("@analysisTime", finding.AnalysisTime));
@@ -390,6 +432,10 @@ VALUES
             cmd.Parameters.Add(new SqlParameter("@leafFactKey", (object?)finding.LeafFactKey ?? DBNull.Value));
             cmd.Parameters.Add(new SqlParameter("@leafFactValue", (object?)finding.LeafFactValue ?? DBNull.Value));
             cmd.Parameters.Add(new SqlParameter("@factCount", finding.FactCount));
+            // D2: persist the BUILT action (mirrors the alert path's ContextJson) so the
+            // Recommendations reader can drive Apply + consent from a stored finding.
+            cmd.Parameters.Add(new SqlParameter("@remediationActionJson",
+                (object?)AlertContextSerializer.SerializeAction(finding.Remediation) ?? DBNull.Value));
 
             await cmd.ExecuteNonQueryAsync();
         }
@@ -404,7 +450,7 @@ VALUES
     /// </summary>
     private static AnalysisFinding ReadFinding(SqlDataReader reader)
     {
-        return new AnalysisFinding
+        var finding = new AnalysisFinding
         {
             FindingId = reader.GetInt64(0),
             AnalysisTime = reader.GetDateTime(1),
@@ -425,5 +471,14 @@ VALUES
             LeafFactValue = reader.IsDBNull(16) ? null : reader.GetDouble(16),
             FactCount = reader.GetInt32(17)
         };
+
+        // D2: only GetRecentFindingsAsync selects remediation_action_json (ordinal 18);
+        // GetLatestFindingsAsync omits it, so guard by field count before reading. The
+        // BUILT action is deserialized via the SAME serializer the alert path uses, so the
+        // Recommendations surface can drive Apply + the two-sided consent gate from storage.
+        if (reader.FieldCount > 18 && !reader.IsDBNull(18))
+            finding.Remediation = AlertContextSerializer.DeserializeAction(reader.GetString(18));
+
+        return finding;
     }
 }

--- a/Dashboard/Services/AnalysisScheduler.cs
+++ b/Dashboard/Services/AnalysisScheduler.cs
@@ -192,7 +192,7 @@ namespace PerformanceMonitorDashboard.Services
 
                     var findings = await analyzeTask;
 
-                    /* Analysis already persisted via SaveFindingsAsync inside AnalyzeAsync.
+                    /* Analysis already persisted via the batched insert inside AnalyzeAsync.
                        Only route findings to the notification channels when delivery is on. */
                     if (notify)
                         await _notificationService.NotifyAsync(findings);

--- a/PerformanceMonitor.Analysis/AnalysisModels.cs
+++ b/PerformanceMonitor.Analysis/AnalysisModels.cs
@@ -112,6 +112,20 @@ public class AnalysisFinding
     public Dictionary<string, object>? DrillDown { get; set; }
 
     /// <summary>
+    /// The built remediation action for this finding (recommendations rebuild D2).
+    /// Ephemeral, like <see cref="DrillDown"/>: populated post-enrich on the WRITE path
+    /// (AnalysisService builds it from the drill-down-populated finding via FactRemediation),
+    /// serialized into the analysis_findings <c>remediation_action_json</c> column, and
+    /// deserialized back here on READ. It is NOT a scored field and takes no part in story
+    /// scoring/traversal; it exists so the Recommendations surface can drive Apply + the
+    /// two-sided consent gate from a finding read back from storage (the builders require a
+    /// drill-down that GetRecentFindingsAsync does not return, so the BUILT action is
+    /// persisted instead, mirroring the alert path's ContextJson). Null when no execution
+    /// shape applies. <see cref="RemediationAction"/> lives in this same assembly.
+    /// </summary>
+    public RemediationAction? Remediation { get; set; }
+
+    /// <summary>
     /// Metadata from the root fact carried in from <see cref="AnalysisStory.RootFactMetadata"/>.
     /// Ephemeral — used by the notification layer for diagnosis context; not persisted.
     /// In practice this is anomaly-detector baseline context: mean, stddev, tier, hour, dow.

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -166,6 +166,42 @@ public static class AlertContextSerializer
         return JsonSerializer.Serialize(dto);
     }
 
+    /// <summary>
+    /// Serializes a single <see cref="RemediationAction"/> to JSON for persistence on a
+    /// finding row (recommendations rebuild D2). Reuses the SAME private
+    /// <see cref="ToDto(RemediationAction?)"/> projection the alert-context write already
+    /// uses, so a finding's persisted action round-trips byte-identically to one carried
+    /// in an alert's ContextJson (incl. RcsiInactionFigures / ClearPlanFigures / all
+    /// target lists). Returns null when the action is null.
+    /// </summary>
+    public static string? SerializeAction(RemediationAction? action)
+    {
+        if (action is null)
+            return null;
+        return JsonSerializer.Serialize(ToDto(action));
+    }
+
+    /// <summary>
+    /// Deserializes a finding's persisted <c>remediation_action_json</c> back into a
+    /// <see cref="RemediationAction"/> via the SAME private
+    /// <see cref="FromDto(RemediationActionDto?)"/> the alert-context read uses. Returns
+    /// null for null/blank/garbage JSON (try-catch, mirroring <see cref="TryDeserialize"/>),
+    /// so a corrupt column degrades to "no Apply affordance" rather than throwing.
+    /// </summary>
+    public static RemediationAction? DeserializeAction(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+        try
+        {
+            return FromDto(JsonSerializer.Deserialize<RemediationActionDto>(json));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public static bool TryDeserialize(string? json, out AlertContext context)
     {
         context = new AlertContext();


### PR DESCRIPTION
## Scope
Implements **D2 (persist the built RemediationAction)** + **P2 (pipeline reorder)** of the recommendations engine rebuild. **Dashboard-only.** Lite is unchanged (advise/copy-paste only; it renders advice from the fact-key and needs no persisted action). Does NOT build the Recommendations UI (WS1) or new config facts (WS3).

The (later) Recommendations surface must show Apply + the two-sided consent gate for findings read back from storage. The remediation builders REQUIRE `finding.DrillDown`, but `GetRecentFindingsAsync` returns findings with `DrillDown == null`. So — exactly as the existing Alert path does with `ContextJson` — we persist the **BUILT `RemediationAction`** on the finding row and deserialize it on read. (D7, already merged, ensures config/RCSI findings carry their `config_issues` drill-down below severity 0.5 so their actions can be built.)

## File:line changelog
- **`PerformanceMonitor.Notifications/AlertContext.cs`** (+36): added public `AlertContextSerializer.SerializeAction(RemediationAction?)` (`:169`) and `DeserializeAction(string?)` (`:184`) that wrap the EXISTING private `ToDto`/`FromDto` (the proven round-trip for `RcsiInactionFigures`/`ClearPlanFigures`/all target lists). `DeserializeAction` is null/try-catch on bad json, mirroring `TryDeserialize`.
- **`PerformanceMonitor.Analysis/AnalysisModels.cs`** (+14): `AnalysisFinding.Remediation` (`:126`) — ephemeral like `DrillDown` (built post-enrich on write, deserialized on read; not a scored field). `RemediationAction` is in the same assembly.
- **`Dashboard/Analysis/SqlServerFindingStore.cs`** (net +63):
  - `remediation_action_json nvarchar(max) NULL` added to the canonical `CREATE TABLE` (`:59`) AND an idempotent `IF COL_LENGTH(...) IS NULL ALTER TABLE ... ADD` migration in `EnsureTablesExistAsync` (`:88-92`). App-managed schema — nothing added to `install/` or `upgrades/`.
  - Split `SaveFindingsAsync` → `FilterMutedFindingsAsync` (`:106`, mute-filter survivors, NO insert) + `InsertFindingsAsync` (`:171`, batched insert persisting the action json). Mute/dedup/ordering + `_nextId` sequencing identical; both keep PR-1's single-connection + single-`EnsureTablesExistAsync` discipline.
  - `InsertFindingAsync` (`:404-438`): added the column/param; persists `AlertContextSerializer.SerializeAction(finding.Remediation)`.
  - `GetRecentFindingsAsync` SELECT (`:216`) + `ReadFinding` (`:451`): selects/deserializes ordinal 18, **field-count-guarded** (`reader.FieldCount > 18`) so `GetLatestFindingsAsync` (which does not select it) is unaffected.
- **`Dashboard/Analysis/AnalysisService.cs`** (net +35): `AnalyzeAsync` reorder (`:145-175`) — filter survivors → enrich survivors → build+attach `RemediationAction` (try `BuildAction` ?? `BuildRcsiAction` ?? `BuildClearPlanAction`) → batched insert. The returned/enriched (now action-bearing) list still flows to `AnalysisCompleted` + (via the scheduler) `NotifyAsync` unchanged.
- **`Dashboard/Services/AnalysisScheduler.cs`** (+1/-1): stale `SaveFindingsAsync` comment reference updated (no behavior change; notify path verified intact at `:193-198`).
- **`Dashboard.Tests/AnalysisNotificationTests.cs`** (+93): 4 new tests (below).

## Tests (real results)
- `dotnet build PerformanceMonitor.sln -c Debug` → **0 errors** (1 pre-existing unrelated CS0649 in `RemediationTests.cs`).
- **`Dashboard.Tests`: 238 passed / 0 failed / 0 skipped.**
- **`Lite.Tests`: 360 passed / 0 failed / 0 skipped.**
- New tests (all green, confirmed present via `--list-tests`):
  - `SerializeAction_RcsiAction_RoundTripsFiguresAndTargets` — RCSI action through `SerializeAction`/`DeserializeAction`; asserts `RcsiInactionFigures` (BlockingEvents/Deadlocks/ReaderWriterPct) survive.
  - `SerializeAction_ClearPlanAction_RoundTripsFiguresAndTargets` — clear-plan action; asserts `ClearPlanFigures` (CpuPercent/AnomalyRatio) survive.
  - `SerializeAction_NullAction_SerializesAndDeserializesToNull` — null/empty/garbage json → null, no throw.
  - **`PersistedRcsiAction_RendersTwoSidedConsentGate_WithFindingNull` (the C1 gating test)** — synth RCSI finding (`rcsi:false` + inaction enrichment) → serialize → deserialize → `FactRiskDisclosure.GetForAction(action, finding: null)` returns a non-null two-sided `RiskDisclosure` with BOTH `RisksOfChanging` and `RisksOfNotChanging` non-empty AND the original inaction figures present ("12 blocked-process events", "3 deadlocks", "80%", "RCSI eliminates"). Proves the consent gate renders from the persisted action alone — exactly how the real Apply surface calls it.

## Needs integration verification (not unit-testable)
`config.analysis_findings` is SQL Server; there is no in-memory harness for the store, so the following require a real DB and are NOT claimed as covered by unit tests:
1. **Full persist → reload round-trip:** run `AnalyzeAsync` against a server with an RCSI-off / config finding; confirm a row is written with non-null `remediation_action_json`, then `GetRecentFindingsAsync` reads it back with `finding.Remediation != null` and the consent gate renders.
2. **Idempotent migration on a pre-existing DB:** against a `config.analysis_findings` created before this change, confirm `EnsureTablesExistAsync` adds the column once and is a no-op on subsequent runs (and that fresh-create DBs already have it, so the ALTER is skipped).
3. **Notify path end-to-end** with `AnalysisNotificationsEnabled` on: confirm `NotifyAsync` still receives the enriched findings after the reorder.
4. **Cost** at the default-on 30-min interval across N servers (one extra connection-open per cycle from the filter/insert split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
