### PR TITLE
Recs rebuild WS1b-1: Recommendations tab (read-only surface)

### DIFF
--- a/Dashboard.Tests/RecommendationsViewModelTests.cs
+++ b/Dashboard.Tests/RecommendationsViewModelTests.cs
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Controls;
+using PerformanceMonitorDashboard.Services.Recommendations;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// WS1b-1 coverage for the PURE, WPF-free Recommendations view-model: grouping a flat
+/// (already de-duped + severity-sorted) <see cref="RecommendationItem"/> list into the
+/// Critical / Warning / Info collapsible sections; selecting the single top-level
+/// <see cref="RecommendationsState"/> (loading / insufficient-data / empty / loaded); and the
+/// per-card Apply/Mute visibility predicates. The XAML rendering itself is not unit-testable
+/// (it needs a running Dashboard — see the PR's visual-verification note).
+/// </summary>
+public class RecommendationsViewModelTests
+{
+    // ---- builders ---------------------------------------------------------
+
+    private static RemediationAction DbConfigAction(DbConfigSetting setting, string db = "db1") =>
+        new(
+            FactKey: "DB_CONFIG",
+            Action: "set",
+            Targets: Array.Empty<ForcePlanTarget>(),
+            DbConfigTargets: new[] { new DbConfigTarget(db, setting) });
+
+    private static RecommendationItem Item(
+        CanonicalSeverity severity,
+        RecommendationSource source = RecommendationSource.Engine,
+        RemediationAction? remediation = null,
+        string? sql = null,
+        string title = "rec",
+        string? db = null,
+        double rawSeverity = 0.3,
+        string? advice = null,
+        string? storyHash = "hash")
+    {
+        return new RecommendationItem
+        {
+            CanonicalSeverity = severity,
+            RawSeverity = rawSeverity,
+            Source = source,
+            Remediation = remediation,
+            CopyPasteSql = sql,
+            Title = title,
+            Database = db,
+            AdviceText = advice,
+            StoryPathHash = source == RecommendationSource.Engine ? storyHash : null
+        };
+    }
+
+    // ---- state selection --------------------------------------------------
+
+    [Fact]
+    public void Loading_SelectsLoadingState()
+    {
+        var vm = RecommendationsViewModel.Loading();
+
+        Assert.Equal(RecommendationsState.Loading, vm.State);
+        Assert.Empty(vm.Sections);
+    }
+
+    [Fact]
+    public void FromItems_EmptyList_SelectsEmptyState()
+    {
+        var vm = RecommendationsViewModel.FromItems(Array.Empty<RecommendationItem>());
+
+        Assert.Equal(RecommendationsState.Empty, vm.State);
+        Assert.Empty(vm.Sections);
+        Assert.Equal(0, vm.TotalCount);
+    }
+
+    [Fact]
+    public void FromItems_NonEmptyList_SelectsLoadedState()
+    {
+        var vm = RecommendationsViewModel.FromItems(new[] { Item(CanonicalSeverity.Warning) });
+
+        Assert.Equal(RecommendationsState.Loaded, vm.State);
+        Assert.Equal(1, vm.TotalCount);
+    }
+
+    [Fact]
+    public void InsufficientData_WithEngineMessage_UsesIt()
+    {
+        var vm = RecommendationsViewModel.InsufficientData("need 1.0 days, have 0.5 days");
+
+        Assert.Equal(RecommendationsState.InsufficientData, vm.State);
+        Assert.Equal("need 1.0 days, have 0.5 days", vm.InsufficientDataMessage);
+        Assert.Empty(vm.Sections);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void InsufficientData_WithBlankMessage_FallsBackToDefault(string? engineMessage)
+    {
+        var vm = RecommendationsViewModel.InsufficientData(engineMessage);
+
+        Assert.Equal(RecommendationsState.InsufficientData, vm.State);
+        Assert.Equal(RecommendationsViewModel.DefaultInsufficientDataMessage, vm.InsufficientDataMessage);
+    }
+
+    // ---- grouping ---------------------------------------------------------
+
+    [Fact]
+    public void FromItems_GroupsBySeverity_IntoThreeSectionsInFixedOrder()
+    {
+        var items = new[]
+        {
+            Item(CanonicalSeverity.Info, title: "i1"),
+            Item(CanonicalSeverity.Critical, title: "c1"),
+            Item(CanonicalSeverity.Warning, title: "w1"),
+            Item(CanonicalSeverity.Critical, title: "c2"),
+        };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        // Fixed display order Critical -> Warning -> Info, regardless of input order.
+        Assert.Equal(3, vm.Sections.Count);
+        Assert.Equal(CanonicalSeverity.Critical, vm.Sections[0].Severity);
+        Assert.Equal(CanonicalSeverity.Warning, vm.Sections[1].Severity);
+        Assert.Equal(CanonicalSeverity.Info, vm.Sections[2].Severity);
+
+        Assert.Equal(2, vm.Sections[0].Count);
+        Assert.Equal(1, vm.Sections[1].Count);
+        Assert.Equal(1, vm.Sections[2].Count);
+        Assert.Equal(4, vm.TotalCount);
+    }
+
+    [Fact]
+    public void FromItems_OmitsEmptySeveritySections()
+    {
+        var items = new[]
+        {
+            Item(CanonicalSeverity.Warning, title: "w1"),
+            Item(CanonicalSeverity.Warning, title: "w2"),
+        };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        Assert.Single(vm.Sections);
+        Assert.Equal(CanonicalSeverity.Warning, vm.Sections[0].Severity);
+        Assert.Equal(2, vm.Sections[0].Count);
+    }
+
+    [Fact]
+    public void FromItems_PreservesReaderOrderWithinASection()
+    {
+        // The reader returns severity-desc; within a band the order must be preserved as-is.
+        var items = new[]
+        {
+            Item(CanonicalSeverity.Critical, title: "first", rawSeverity: 1.9),
+            Item(CanonicalSeverity.Critical, title: "second", rawSeverity: 1.6),
+            Item(CanonicalSeverity.Critical, title: "third", rawSeverity: 1.51),
+        };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        var titles = vm.Sections[0].Cards.Select(c => c.Title).ToArray();
+        Assert.Equal(new[] { "first", "second", "third" }, titles);
+    }
+
+    [Fact]
+    public void FromItems_CriticalAndWarningExpanded_InfoCollapsed_ByDefault()
+    {
+        var items = new[]
+        {
+            Item(CanonicalSeverity.Critical, title: "c"),
+            Item(CanonicalSeverity.Warning, title: "w"),
+            Item(CanonicalSeverity.Info, title: "i"),
+        };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        Assert.True(vm.Sections.Single(s => s.Severity == CanonicalSeverity.Critical).IsExpanded);
+        Assert.True(vm.Sections.Single(s => s.Severity == CanonicalSeverity.Warning).IsExpanded);
+        Assert.False(vm.Sections.Single(s => s.Severity == CanonicalSeverity.Info).IsExpanded);
+    }
+
+    [Fact]
+    public void SectionHeader_IncludesCount()
+    {
+        var items = new[]
+        {
+            Item(CanonicalSeverity.Critical, title: "c1"),
+            Item(CanonicalSeverity.Critical, title: "c2"),
+            Item(CanonicalSeverity.Critical, title: "c3"),
+        };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        Assert.Equal("Critical (3)", vm.Sections[0].Header);
+    }
+
+    // ---- Apply visibility (Remediation != null) ---------------------------
+
+    [Fact]
+    public void ShowApply_True_OnlyWhenRemediationPresent()
+    {
+        var withAction = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, remediation: DbConfigAction(DbConfigSetting.AutoShrinkOff)));
+        var withoutAction = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, remediation: null));
+
+        Assert.True(withAction.ShowApply);
+        Assert.False(withoutAction.ShowApply);
+    }
+
+    [Fact]
+    public void ShowApply_False_ForLegacyRow()
+    {
+        // Legacy rows never carry a built action, so Apply is never shown.
+        var legacy = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Critical, source: RecommendationSource.Legacy, remediation: null));
+
+        Assert.False(legacy.ShowApply);
+    }
+
+    // ---- Mute visibility (Source == Engine) -------------------------------
+
+    [Fact]
+    public void ShowMute_True_ForEngineRow()
+    {
+        var engine = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, source: RecommendationSource.Engine));
+
+        Assert.True(engine.ShowMute);
+    }
+
+    [Fact]
+    public void ShowMute_False_ForLegacyRow()
+    {
+        var legacy = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, source: RecommendationSource.Legacy));
+
+        Assert.False(legacy.ShowMute);
+    }
+
+    [Fact]
+    public void EngineRowWithoutAction_ShowsMuteButNotApply()
+    {
+        // A CPU/wait engine finding with no executable shape: Mute (engine) yes, Apply no.
+        var card = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Critical, source: RecommendationSource.Engine, remediation: null));
+
+        Assert.True(card.ShowMute);
+        Assert.False(card.ShowApply);
+    }
+
+    // ---- card display flags ----------------------------------------------
+
+    [Fact]
+    public void Card_HasSql_TracksCopyPastePresence()
+    {
+        var withSql = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, sql: "ALTER DATABASE [db1] SET AUTO_SHRINK OFF;"));
+        var withoutSql = new RecommendationCardViewModel(
+            Item(CanonicalSeverity.Warning, sql: null));
+
+        Assert.True(withSql.HasSql);
+        Assert.False(withoutSql.HasSql);
+    }
+
+    [Fact]
+    public void Card_DatabaseBracketed_WrapsOrCollapses()
+    {
+        var withDb = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning, db: "Sales"));
+        var serverScoped = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning, db: null));
+
+        Assert.True(withDb.HasDatabase);
+        Assert.Equal("[Sales]", withDb.DatabaseBracketed);
+
+        Assert.False(serverScoped.HasDatabase);
+        Assert.Equal(string.Empty, serverScoped.DatabaseBracketed);
+    }
+
+    [Theory]
+    [InlineData(CanonicalSeverity.Critical, "CRITICAL")]
+    [InlineData(CanonicalSeverity.Warning, "WARNING")]
+    [InlineData(CanonicalSeverity.Info, "INFO")]
+    public void Card_SeverityLabel_MatchesBand(CanonicalSeverity severity, string expected)
+    {
+        var card = new RecommendationCardViewModel(Item(severity));
+        Assert.Equal(expected, card.SeverityLabel);
+    }
+
+    [Fact]
+    public void Card_ActionsDisabledReason_IsTheNextUpdateTooltip()
+    {
+        var card = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning));
+        Assert.Equal(RecommendationsViewModel.ActionsDisabledTooltip, card.ActionsDisabledReason);
+    }
+}

--- a/Dashboard.Tests/RecommendationsViewModelTests.cs
+++ b/Dashboard.Tests/RecommendationsViewModelTests.cs
@@ -20,9 +20,11 @@ namespace PerformanceMonitorDashboard.Tests;
 /// WS1b-1 coverage for the PURE, WPF-free Recommendations view-model: grouping a flat
 /// (already de-duped + severity-sorted) <see cref="RecommendationItem"/> list into the
 /// Critical / Warning / Info collapsible sections; selecting the single top-level
-/// <see cref="RecommendationsState"/> (loading / insufficient-data / empty / loaded); and the
-/// per-card Apply/Mute visibility predicates. The XAML rendering itself is not unit-testable
-/// (it needs a running Dashboard — see the PR's visual-verification note).
+/// <see cref="RecommendationsState"/> (loading / insufficient-data / empty / loaded); the
+/// incident-vs-config affordance predicates (Open-in-Active-Queries + Ask-AI for incidents,
+/// Copy-fix for config rows; Apply/Mute visibility); and the Ask-AI prompt interpolation. The
+/// WPF navigation + clipboard themselves are not unit-testable (they need a running Dashboard —
+/// see the PR's visual-verification note).
 /// </summary>
 public class RecommendationsViewModelTests
 {
@@ -38,12 +40,15 @@ public class RecommendationsViewModelTests
     private static RecommendationItem Item(
         CanonicalSeverity severity,
         RecommendationSource source = RecommendationSource.Engine,
+        RecommendationSetting setting = RecommendationSetting.None,
         RemediationAction? remediation = null,
         string? sql = null,
         string title = "rec",
         string? db = null,
         double rawSeverity = 0.3,
         string? advice = null,
+        DateTime? windowStartUtc = null,
+        DateTime? windowEndUtc = null,
         string? storyHash = "hash")
     {
         return new RecommendationItem
@@ -51,14 +56,21 @@ public class RecommendationsViewModelTests
             CanonicalSeverity = severity,
             RawSeverity = rawSeverity,
             Source = source,
+            Setting = setting,
             Remediation = remediation,
             CopyPasteSql = sql,
             Title = title,
             Database = db,
             AdviceText = advice,
+            WindowStartUtc = windowStartUtc,
+            WindowEndUtc = windowEndUtc,
             StoryPathHash = source == RecommendationSource.Engine ? storyHash : null
         };
     }
+
+    private static RecommendationCardViewModel Card(
+        RecommendationItem item, string serverName = "SRV", int utcOffsetMinutes = 0) =>
+        new(item, serverName, utcOffsetMinutes);
 
     // ---- state selection --------------------------------------------------
 
@@ -204,26 +216,111 @@ public class RecommendationsViewModelTests
         Assert.Equal("Critical (3)", vm.Sections[0].Header);
     }
 
+    [Fact]
+    public void FromItems_FlowsServerNameAndOffsetOntoCards()
+    {
+        var item = Item(
+            CanonicalSeverity.Critical,
+            windowStartUtc: new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc),
+            windowEndUtc: new DateTime(2026, 6, 1, 10, 30, 0, DateTimeKind.Utc));
+
+        var vm = RecommendationsViewModel.FromItems(new[] { item }, "PROD-SQL-01", utcOffsetMinutes: 60);
+        var card = vm.Sections[0].Cards[0];
+
+        Assert.Equal("PROD-SQL-01", card.ServerName);
+        // offset 60 → window shifts +1h into server-local in the Ask-AI prompt.
+        Assert.Contains("11:00", card.AskAiPrompt);
+        Assert.Contains("11:30", card.AskAiPrompt);
+    }
+
+    // ---- incident vs config affordances -----------------------------------
+
+    [Fact]
+    public void IncidentRow_ShowsOpenInActiveQueriesAndAskAi_NotCopyFix()
+    {
+        // Setting == None => incident (CPU/memory/blocking/waits/plan-regression).
+        var card = Card(Item(CanonicalSeverity.Critical, setting: RecommendationSetting.None));
+
+        Assert.True(card.IsIncident);
+        Assert.False(card.IsConfigFix);
+        Assert.True(card.ShowOpenInActiveQueries);
+        Assert.True(card.ShowAskAi);
+        Assert.False(card.ShowCopyFix);
+    }
+
+    [Theory]
+    [InlineData(RecommendationSetting.AutoShrink)]
+    [InlineData(RecommendationSetting.AutoClose)]
+    [InlineData(RecommendationSetting.QueryStore)]
+    [InlineData(RecommendationSetting.Rcsi)]
+    [InlineData(RecommendationSetting.PageVerify)]
+    public void ConfigFixRow_ShowsCopyFix_NotOpenInActiveQueriesOrAskAi(RecommendationSetting setting)
+    {
+        // Setting != None => standing config-fix; carries an ALTER → Copy fix.
+        var card = Card(Item(
+            CanonicalSeverity.Warning,
+            setting: setting,
+            sql: "ALTER DATABASE [db1] SET AUTO_SHRINK OFF;"));
+
+        Assert.False(card.IsIncident);
+        Assert.True(card.IsConfigFix);
+        Assert.False(card.ShowOpenInActiveQueries);
+        Assert.False(card.ShowAskAi);
+        Assert.True(card.ShowCopyFix);
+    }
+
+    [Fact]
+    public void ConfigFixRow_WithoutSql_DoesNotShowCopyFix()
+    {
+        var card = Card(Item(CanonicalSeverity.Warning, setting: RecommendationSetting.Rcsi, sql: null));
+
+        Assert.True(card.IsConfigFix);
+        Assert.False(card.ShowCopyFix);
+    }
+
+    [Fact]
+    public void IncidentRow_DoesNotShowCopyFix_EvenIfSqlSomehowPresent()
+    {
+        // Defensive: an incident never offers Copy fix regardless of CopyPasteSql.
+        var card = Card(Item(CanonicalSeverity.Critical, setting: RecommendationSetting.None, sql: "SELECT 1;"));
+
+        Assert.True(card.IsIncident);
+        Assert.False(card.ShowCopyFix);
+    }
+
     // ---- Apply visibility (Remediation != null) ---------------------------
 
     [Fact]
     public void ShowApply_True_OnlyWhenRemediationPresent()
     {
-        var withAction = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, remediation: DbConfigAction(DbConfigSetting.AutoShrinkOff)));
-        var withoutAction = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, remediation: null));
+        var withAction = Card(Item(
+            CanonicalSeverity.Warning,
+            setting: RecommendationSetting.AutoShrink,
+            remediation: DbConfigAction(DbConfigSetting.AutoShrinkOff)));
+        var withoutAction = Card(Item(CanonicalSeverity.Warning, remediation: null));
 
         Assert.True(withAction.ShowApply);
         Assert.False(withoutAction.ShowApply);
     }
 
     [Fact]
+    public void ShowApply_True_ForIncidentWithRemediation()
+    {
+        // e.g. plan-regression / clear-plan: an incident (Setting==None) that still has an action.
+        var card = Card(Item(
+            CanonicalSeverity.Critical,
+            setting: RecommendationSetting.None,
+            remediation: new RemediationAction("CLEAR_PLAN", "clear", Array.Empty<ForcePlanTarget>())));
+
+        Assert.True(card.IsIncident);
+        Assert.True(card.ShowApply);
+    }
+
+    [Fact]
     public void ShowApply_False_ForLegacyRow()
     {
         // Legacy rows never carry a built action, so Apply is never shown.
-        var legacy = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Critical, source: RecommendationSource.Legacy, remediation: null));
+        var legacy = Card(Item(CanonicalSeverity.Critical, source: RecommendationSource.Legacy, remediation: null));
 
         Assert.False(legacy.ShowApply);
     }
@@ -233,8 +330,7 @@ public class RecommendationsViewModelTests
     [Fact]
     public void ShowMute_True_ForEngineRow()
     {
-        var engine = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, source: RecommendationSource.Engine));
+        var engine = Card(Item(CanonicalSeverity.Warning, source: RecommendationSource.Engine));
 
         Assert.True(engine.ShowMute);
     }
@@ -242,42 +338,79 @@ public class RecommendationsViewModelTests
     [Fact]
     public void ShowMute_False_ForLegacyRow()
     {
-        var legacy = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, source: RecommendationSource.Legacy));
+        var legacy = Card(Item(CanonicalSeverity.Warning, source: RecommendationSource.Legacy));
 
         Assert.False(legacy.ShowMute);
     }
 
-    [Fact]
-    public void EngineRowWithoutAction_ShowsMuteButNotApply()
-    {
-        // A CPU/wait engine finding with no executable shape: Mute (engine) yes, Apply no.
-        var card = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Critical, source: RecommendationSource.Engine, remediation: null));
+    // ---- Ask-AI prompt generation -----------------------------------------
 
-        Assert.True(card.ShowMute);
-        Assert.False(card.ShowApply);
+    [Fact]
+    public void BuildAskAiPrompt_InterpolatesServerTitleAndWindow()
+    {
+        var from = new DateTime(2026, 6, 1, 14, 5, 0);
+        var to = new DateTime(2026, 6, 1, 15, 30, 0);
+
+        var prompt = RecommendationsViewModel.BuildAskAiPrompt("PROD\\SQL2022", "High CXPACKET waits", from, to);
+
+        Assert.Contains("server \"PROD\\SQL2022\"", prompt);
+        Assert.Contains("\"High CXPACKET waits\"", prompt);
+        Assert.Contains("2026-06-01 14:05", prompt);
+        Assert.Contains("15:30", prompt);
+        Assert.Contains("PerformanceMonitor MCP tools", prompt);
+        Assert.Contains("analyze_server", prompt);
+        Assert.Contains("get_analysis_findings", prompt);
+    }
+
+    [Fact]
+    public void Card_AskAiPrompt_UsesItemTitleAndServerName()
+    {
+        var item = Item(
+            CanonicalSeverity.Critical,
+            title: "Blocking storm",
+            windowStartUtc: new DateTime(2026, 6, 2, 9, 0, 0, DateTimeKind.Utc),
+            windowEndUtc: new DateTime(2026, 6, 2, 9, 15, 0, DateTimeKind.Utc));
+
+        var card = Card(item, serverName: "SQLBOX", utcOffsetMinutes: 0);
+
+        Assert.Contains("server \"SQLBOX\"", card.AskAiPrompt);
+        Assert.Contains("\"Blocking storm\"", card.AskAiPrompt);
+        Assert.Contains("2026-06-02 09:00", card.AskAiPrompt);
+        Assert.Contains("09:15", card.AskAiPrompt);
+    }
+
+    [Fact]
+    public void Card_AskAiPrompt_WithNoWindow_UsesNowAnchoredFallback()
+    {
+        // No producer window → a 2h band ending "now" (server-local). Just assert it renders a
+        // well-formed prompt (no crash, contains the fixed scaffolding + the title).
+        var card = Card(Item(CanonicalSeverity.Critical, title: "Memory pressure"), serverName: "S1");
+
+        Assert.Contains("server \"S1\"", card.AskAiPrompt);
+        Assert.Contains("\"Memory pressure\"", card.AskAiPrompt);
+        Assert.Contains("PerformanceMonitor MCP tools", card.AskAiPrompt);
+    }
+
+    // ---- deep-link window passthrough -------------------------------------
+
+    [Fact]
+    public void Card_ExposesRawUtcWindow_ForDeepLink()
+    {
+        var su = new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc);
+        var eu = new DateTime(2026, 6, 1, 10, 30, 0, DateTimeKind.Utc);
+        var card = Card(Item(CanonicalSeverity.Critical, windowStartUtc: su, windowEndUtc: eu));
+
+        Assert.Equal(su, card.WindowStartUtc);
+        Assert.Equal(eu, card.WindowEndUtc);
     }
 
     // ---- card display flags ----------------------------------------------
 
     [Fact]
-    public void Card_HasSql_TracksCopyPastePresence()
-    {
-        var withSql = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, sql: "ALTER DATABASE [db1] SET AUTO_SHRINK OFF;"));
-        var withoutSql = new RecommendationCardViewModel(
-            Item(CanonicalSeverity.Warning, sql: null));
-
-        Assert.True(withSql.HasSql);
-        Assert.False(withoutSql.HasSql);
-    }
-
-    [Fact]
     public void Card_DatabaseBracketed_WrapsOrCollapses()
     {
-        var withDb = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning, db: "Sales"));
-        var serverScoped = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning, db: null));
+        var withDb = Card(Item(CanonicalSeverity.Warning, db: "Sales"));
+        var serverScoped = Card(Item(CanonicalSeverity.Warning, db: null));
 
         Assert.True(withDb.HasDatabase);
         Assert.Equal("[Sales]", withDb.DatabaseBracketed);
@@ -292,14 +425,14 @@ public class RecommendationsViewModelTests
     [InlineData(CanonicalSeverity.Info, "INFO")]
     public void Card_SeverityLabel_MatchesBand(CanonicalSeverity severity, string expected)
     {
-        var card = new RecommendationCardViewModel(Item(severity));
+        var card = Card(Item(severity));
         Assert.Equal(expected, card.SeverityLabel);
     }
 
     [Fact]
     public void Card_ActionsDisabledReason_IsTheNextUpdateTooltip()
     {
-        var card = new RecommendationCardViewModel(Item(CanonicalSeverity.Warning));
+        var card = Card(Item(CanonicalSeverity.Warning));
         Assert.Equal(RecommendationsViewModel.ActionsDisabledTooltip, card.ActionsDisabledReason);
     }
 }

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1264,6 +1264,17 @@ namespace PerformanceMonitorDashboard.Controls
             QueryPerfTrendsExecChart.Refresh();
         }
 
+        /// <summary>
+        /// Selects the Active Queries sub-tab and scopes it to [<paramref name="from"/>,
+        /// <paramref name="to"/>] (server-local time). Public entry point for a deep-link from the
+        /// Recommendations surface (WS1b-1); reuses the same range-refresh the chart drill-down uses.
+        /// </summary>
+        public async Task ShowActiveQueriesForRange(DateTime from, DateTime to)
+        {
+            SubTabControl.SelectedIndex = 1; // Active Queries
+            await RefreshActiveQueriesWithRangeAsync(from, to);
+        }
+
         private async Task RefreshActiveQueriesWithRangeAsync(DateTime from, DateTime to)
         {
             if (_databaseService == null) return;

--- a/Dashboard/Controls/RecommendationsContent.xaml
+++ b/Dashboard/Controls/RecommendationsContent.xaml
@@ -10,9 +10,10 @@
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="BoolToVis"/>
 
-            <!-- One card: severity badge + database + title + advice, with a "Show T-SQL"
-                 expander (Copy button) and the (WS1b-1 disabled) Apply + Mute buttons.
-                 Mirrors AlertDetailWindow's per-row visual conventions. -->
+            <!-- One card: severity badge + database + title + advice, then affordances.
+                 Incidents (Setting==None) send the operator to the dashboard / AI; config-fixes
+                 (Setting!=None) offer "Copy fix" (the ALTER). Apply is present-but-disabled until
+                 WS1b-2. Mirrors AlertDetailWindow's per-row visual conventions. -->
             <DataTemplate x:Key="RecommendationCardTemplate">
                 <Border Background="{DynamicResource BackgroundLightBrush}"
                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
@@ -50,35 +51,24 @@
                                    Visibility="{Binding HasAdvice, Converter={StaticResource BoolToVis}}"
                                    Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
 
-                        <!-- Show T-SQL: collapsed by default; reveals a monospace block + Copy. -->
-                        <Expander Header="Show T-SQL" IsExpanded="False"
-                                  Visibility="{Binding HasSql, Converter={StaticResource BoolToVis}}"
-                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,2,0,0">
-                            <StackPanel Margin="0,4,0,0">
-                                <Button Content="Copy" HorizontalAlignment="Right"
-                                        Padding="8,2" Margin="0,0,0,4"
-                                        Click="CopySql_Click"/>
-                                <TextBox Text="{Binding CopyPasteSql, Mode=OneWay}" IsReadOnly="True"
-                                         FontFamily="Consolas" FontSize="12" TextWrapping="NoWrap"
-                                         MaxHeight="240"
-                                         VerticalScrollBarVisibility="Auto"
-                                         HorizontalScrollBarVisibility="Auto"
-                                         Background="Transparent"
-                                         Foreground="{DynamicResource ForegroundBrush}"
-                                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
-                            </StackPanel>
-                        </Expander>
-
-                        <!-- Actions: Apply (engine rows with a built action) + Mute (engine rows).
-                             Both DISABLED in WS1b-1 — wired in WS1b-2. -->
+                        <!-- Affordances. Incidents: Open in Active Queries + Ask AI (+ Apply when
+                             a remediation exists). Config-fixes: Apply + Copy fix. -->
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
-                            <Button Content="Apply…" Padding="10,3" Margin="0,0,8,0"
+                            <Button Content="Open in Active Queries →" Padding="10,3" Margin="0,0,8,0"
+                                    Visibility="{Binding ShowOpenInActiveQueries, Converter={StaticResource BoolToVis}}"
+                                    Click="OpenInActiveQueries_Click"
+                                    ToolTip="Jump to Active Queries scoped to this finding's time window"/>
+                            <Button Content="Ask AI" Padding="10,3" Margin="0,0,8,0"
+                                    Visibility="{Binding ShowAskAi, Converter={StaticResource BoolToVis}}"
+                                    Click="AskAi_Click"
+                                    ToolTip="Copy an MCP investigation prompt to the clipboard"/>
+                            <Button Content="Copy fix" Padding="10,3" Margin="0,0,8,0"
+                                    Visibility="{Binding ShowCopyFix, Converter={StaticResource BoolToVis}}"
+                                    Click="CopyFix_Click"
+                                    ToolTip="Copy the ALTER statement to the clipboard"/>
+                            <Button Content="Apply…" Padding="10,3"
                                     IsEnabled="False"
                                     Visibility="{Binding ShowApply, Converter={StaticResource BoolToVis}}"
-                                    ToolTip="{Binding ActionsDisabledReason}"/>
-                            <Button Content="Mute" Padding="10,3"
-                                    IsEnabled="False"
-                                    Visibility="{Binding ShowMute, Converter={StaticResource BoolToVis}}"
                                     ToolTip="{Binding ActionsDisabledReason}"/>
                         </StackPanel>
                     </StackPanel>

--- a/Dashboard/Controls/RecommendationsContent.xaml
+++ b/Dashboard/Controls/RecommendationsContent.xaml
@@ -1,0 +1,162 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.RecommendationsContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="clr-namespace:PerformanceMonitorDashboard.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+
+            <!-- One card: severity badge + database + title + advice, with a "Show T-SQL"
+                 expander (Copy button) and the (WS1b-1 disabled) Apply + Mute buttons.
+                 Mirrors AlertDetailWindow's per-row visual conventions. -->
+            <DataTemplate x:Key="RecommendationCardTemplate">
+                <Border Background="{DynamicResource BackgroundLightBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                        CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                    <StackPanel>
+                        <!-- Header row: severity badge + [database] -->
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <Border x:Name="SeverityBadge" CornerRadius="3" Padding="6,1"
+                                    VerticalAlignment="Center"
+                                    Background="{DynamicResource InfoBrush}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding SeverityGlyph}"
+                                               FontFamily="Segoe MDL2 Assets" FontSize="11"
+                                               Foreground="#1A1A1A" VerticalAlignment="Center"
+                                               Margin="0,0,4,0"/>
+                                    <TextBlock Text="{Binding SeverityLabel}" FontWeight="Bold"
+                                               FontSize="11" Foreground="#1A1A1A"
+                                               VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <TextBlock Text="{Binding DatabaseBracketed}"
+                                       Visibility="{Binding HasDatabase, Converter={StaticResource BoolToVis}}"
+                                       FontFamily="Consolas" FontSize="12" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource AccentBrush}"
+                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                        </StackPanel>
+
+                        <!-- Title -->
+                        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" FontSize="13"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+
+                        <!-- Advice prose -->
+                        <TextBlock Text="{Binding AdviceText}" TextWrapping="Wrap"
+                                   Visibility="{Binding HasAdvice, Converter={StaticResource BoolToVis}}"
+                                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+
+                        <!-- Show T-SQL: collapsed by default; reveals a monospace block + Copy. -->
+                        <Expander Header="Show T-SQL" IsExpanded="False"
+                                  Visibility="{Binding HasSql, Converter={StaticResource BoolToVis}}"
+                                  Foreground="{DynamicResource ForegroundBrush}" Margin="0,2,0,0">
+                            <StackPanel Margin="0,4,0,0">
+                                <Button Content="Copy" HorizontalAlignment="Right"
+                                        Padding="8,2" Margin="0,0,0,4"
+                                        Click="CopySql_Click"/>
+                                <TextBox Text="{Binding CopyPasteSql, Mode=OneWay}" IsReadOnly="True"
+                                         FontFamily="Consolas" FontSize="12" TextWrapping="NoWrap"
+                                         MaxHeight="240"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto"
+                                         Background="Transparent"
+                                         Foreground="{DynamicResource ForegroundBrush}"
+                                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
+                            </StackPanel>
+                        </Expander>
+
+                        <!-- Actions: Apply (engine rows with a built action) + Mute (engine rows).
+                             Both DISABLED in WS1b-1 — wired in WS1b-2. -->
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+                            <Button Content="Apply…" Padding="10,3" Margin="0,0,8,0"
+                                    IsEnabled="False"
+                                    Visibility="{Binding ShowApply, Converter={StaticResource BoolToVis}}"
+                                    ToolTip="{Binding ActionsDisabledReason}"/>
+                            <Button Content="Mute" Padding="10,3"
+                                    IsEnabled="False"
+                                    Visibility="{Binding ShowMute, Converter={StaticResource BoolToVis}}"
+                                    ToolTip="{Binding ActionsDisabledReason}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <DataTemplate.Triggers>
+                    <!-- Severity-driven badge colour, from the theme status brushes. -->
+                    <DataTrigger Binding="{Binding Severity}" Value="Critical">
+                        <Setter TargetName="SeverityBadge" Property="Background"
+                                Value="{DynamicResource ErrorBrush}"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Severity}" Value="Warning">
+                        <Setter TargetName="SeverityBadge" Property="Background"
+                                Value="{DynamicResource WarningBrush}"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Severity}" Value="Info">
+                        <Setter TargetName="SeverityBadge" Property="Background"
+                                Value="{DynamicResource InfoBrush}"/>
+                    </DataTrigger>
+                </DataTemplate.Triggers>
+            </DataTemplate>
+
+            <!-- One severity section: a collapsible Expander whose header carries the count and
+                 whose body is the card list for that band. -->
+            <DataTemplate x:Key="RecommendationSectionTemplate">
+                <Expander Header="{Binding Header}" IsExpanded="{Binding IsExpanded, Mode=OneTime}"
+                          Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold"
+                          FontSize="14" Margin="0,0,0,10">
+                    <ItemsControl ItemsSource="{Binding Cards}"
+                                  ItemTemplate="{StaticResource RecommendationCardTemplate}"
+                                  Margin="0,8,0,0"/>
+                </Expander>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header bar: Refresh + Generate now. -->
+        <Border Grid.Row="0" Background="{DynamicResource BackgroundBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1"
+                Padding="10,8">
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="RefreshButton" Content="Refresh" Padding="12,4"
+                        Click="RefreshButton_Click"
+                        ToolTip="Re-read recommendations for this server"/>
+                <Button x:Name="GenerateNowButton" Content="Generate now" Padding="12,4"
+                        Margin="8,0,0,0"
+                        Click="GenerateNowButton_Click"
+                        ToolTip="Run an on-demand analysis for this server, then refresh"/>
+                <TextBlock x:Name="StatusText" VerticalAlignment="Center" Margin="12,0,0,0"
+                           FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Content area: exactly one region is visible per state. -->
+        <Grid Grid.Row="1">
+            <!-- Loaded: scrollable, grouped, collapsible sections. -->
+            <ScrollViewer x:Name="SectionsScroll" VerticalScrollBarVisibility="Auto"
+                          Padding="10" Visibility="Collapsed">
+                <ItemsControl x:Name="SectionsList"
+                              ItemTemplate="{StaticResource RecommendationSectionTemplate}"/>
+            </ScrollViewer>
+
+            <!-- Empty: all-clear. -->
+            <TextBlock x:Name="EmptyMessage" Style="{StaticResource EmptyStateMessage}"
+                       Text="All clear — no current recommendations."/>
+
+            <!-- Insufficient data: engine has not collected its minimum window yet. -->
+            <TextBlock x:Name="InsufficientDataMessage" Style="{StaticResource EmptyStateMessage}"
+                       MaxWidth="520" TextWrapping="Wrap" TextAlignment="Center"/>
+
+            <!-- Loading spinner. -->
+            <controls:LoadingOverlay x:Name="LoadingOverlay"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Dashboard/Controls/RecommendationsContent.xaml.cs
+++ b/Dashboard/Controls/RecommendationsContent.xaml.cs
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Analysis;
+using PerformanceMonitorDashboard.Helpers;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using PerformanceMonitorDashboard.Services.Recommendations;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    /// <summary>
+    /// The unified, read-only Recommendations surface (recommendations rebuild WS1b-1). Renders
+    /// the de-duped <see cref="RecommendationItem"/> list from
+    /// <see cref="RecommendationsReader.GetRecommendationsAsync"/> as a card list grouped into
+    /// collapsible Critical / Warning / Info sections. Each card shows a severity badge, the
+    /// affected database, a headline + advice, a "Show T-SQL" expander with a working Copy button,
+    /// and Apply + Mute buttons.
+    ///
+    /// <para>
+    /// Scope (WS1b-1): the surface is read-only. Copy is wired (trivial clipboard write). Refresh
+    /// re-runs the reader; "Generate now" runs an on-demand analysis for the current server and
+    /// then refreshes. Apply and Mute are rendered DISABLED with an "Available in the next update"
+    /// tooltip — their action wiring (and the informed-consent gate) is WS1b-2.
+    /// </para>
+    /// </summary>
+    public partial class RecommendationsContent : UserControl
+    {
+        private DatabaseService? _databaseService;
+        private SqlServerFindingStore? _findingStore;
+        private RecommendationsReader? _reader;
+        private ServerConnection? _serverConnection;
+        private ICredentialService? _credentialService;
+
+        private int _hoursBack = 24;
+        private bool _isBusy;
+
+        public RecommendationsContent()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Initializes the control with the dependencies it needs to read recommendations and to
+        /// run an on-demand analysis. <paramref name="serverConnection"/> +
+        /// <paramref name="credentialService"/> are used only by "Generate now" to build a
+        /// connection string and derive the deterministic server id, exactly as the
+        /// <see cref="AnalysisScheduler"/> does.
+        /// </summary>
+        public void Initialize(
+            DatabaseService databaseService,
+            ServerConnection serverConnection,
+            ICredentialService credentialService)
+        {
+            _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
+            _serverConnection = serverConnection ?? throw new ArgumentNullException(nameof(serverConnection));
+            _credentialService = credentialService ?? throw new ArgumentNullException(nameof(credentialService));
+            _findingStore = new SqlServerFindingStore(databaseService.ConnectionString);
+            _reader = new RecommendationsReader(databaseService, _findingStore);
+        }
+
+        /// <summary>
+        /// Sets the look-back window used for both producer reads (mirrors
+        /// <c>CriticalIssuesContent.SetTimeRange</c>'s hours-back contract; the Recommendations
+        /// reader takes a single hours-back window).
+        /// </summary>
+        public void SetTimeRange(int hoursBack)
+        {
+            _hoursBack = hoursBack <= 0 ? 24 : hoursBack;
+        }
+
+        /// <summary>
+        /// Re-reads recommendations for this server and re-renders. Safe to call from the parent
+        /// tab's refresh. Read-only: surfaces Loaded or the all-clear Empty state. The
+        /// insufficient-data state is surfaced by <see cref="GenerateNowButton_Click"/> (the
+        /// engine owns that determination), not by this read-only path.
+        /// </summary>
+        public async Task RefreshDataAsync()
+        {
+            if (_reader is null || _serverConnection is null)
+                return;
+
+            if (_isBusy)
+                return;
+
+            _isBusy = true;
+            try
+            {
+                ApplyViewModel(RecommendationsViewModel.Loading());
+
+                var serverName = _serverConnection.ServerName;
+                var serverId = ServerIdHelper.GetDeterministicHashCode(serverName);
+
+                var items = await _reader.GetRecommendationsAsync(serverId, serverName, _hoursBack);
+
+                ApplyViewModel(RecommendationsViewModel.FromItems(items));
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading recommendations: {ex.Message}", ex);
+                // Fall back to the empty state rather than leaving the spinner up.
+                ApplyViewModel(RecommendationsViewModel.FromItems(Array.Empty<RecommendationItem>()));
+            }
+            finally
+            {
+                _isBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// Runs an on-demand analysis for the current server (same construction path the
+        /// <see cref="AnalysisScheduler"/> uses), then re-reads. If the engine reports insufficient
+        /// collected history, surfaces the insufficient-data state with its message; otherwise the
+        /// freshly-persisted findings are read back by <see cref="RefreshDataAsync"/>.
+        /// </summary>
+        private async void GenerateNowButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_serverConnection is null || _credentialService is null)
+                return;
+
+            if (_isBusy)
+                return;
+
+            _isBusy = true;
+            try
+            {
+                ApplyViewModel(RecommendationsViewModel.Loading());
+                StatusText.Text = "Generating…";
+
+                var serverName = _serverConnection.ServerName;
+                var serverId = ServerIdHelper.GetDeterministicHashCode(serverName);
+                var displayName = _serverConnection.DisplayNameWithIntent;
+                var connectionString = _serverConnection.GetConnectionString(_credentialService);
+
+                // Fresh per-run AnalysisService (IsAnalyzing is per-instance), mirroring the
+                // scheduler. AnalyzeAsync persists findings; we then read them back.
+                var planFetcher = new SqlServerPlanFetcher(connectionString);
+                var analysisService = new AnalysisService(connectionString, planFetcher);
+
+                await analysisService.AnalyzeAsync(serverId, displayName, hoursBack: 4);
+
+                if (analysisService.InsufficientDataMessage is { Length: > 0 } message)
+                {
+                    StatusText.Text = string.Empty;
+                    ApplyViewModel(RecommendationsViewModel.InsufficientData(message));
+                    return;
+                }
+
+                StatusText.Text = string.Empty;
+                _isBusy = false; // release before re-entering RefreshDataAsync's own guard
+                await RefreshDataAsync();
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error generating recommendations: {ex.Message}", ex);
+                StatusText.Text = "Generate failed — see log.";
+                ApplyViewModel(RecommendationsViewModel.FromItems(Array.Empty<RecommendationItem>()));
+            }
+            finally
+            {
+                _isBusy = false;
+            }
+        }
+
+        private async void RefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            StatusText.Text = string.Empty;
+            await RefreshDataAsync();
+        }
+
+        /// <summary>
+        /// Copies a card's T-SQL to the clipboard. The only wired action in WS1b-1.
+        /// </summary>
+        private void CopySql_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+                return;
+
+            if (string.IsNullOrEmpty(card.CopyPasteSql))
+                return;
+
+            // SetDataObject with copy=false avoids WPF's problematic Clipboard.Flush() (matches
+            // the convention in CriticalIssuesContent / AlertDetailWindow).
+            Clipboard.SetDataObject(card.CopyPasteSql, false);
+        }
+
+        /// <summary>
+        /// Swaps the visible region to match the view-model's state and binds the sections.
+        /// </summary>
+        private void ApplyViewModel(RecommendationsViewModel vm)
+        {
+            switch (vm.State)
+            {
+                case RecommendationsState.Loading:
+                    LoadingOverlay.IsLoading = true;
+                    SectionsScroll.Visibility = Visibility.Collapsed;
+                    EmptyMessage.Visibility = Visibility.Collapsed;
+                    InsufficientDataMessage.Visibility = Visibility.Collapsed;
+                    break;
+
+                case RecommendationsState.InsufficientData:
+                    LoadingOverlay.IsLoading = false;
+                    SectionsScroll.Visibility = Visibility.Collapsed;
+                    EmptyMessage.Visibility = Visibility.Collapsed;
+                    InsufficientDataMessage.Text = vm.InsufficientDataMessage;
+                    InsufficientDataMessage.Visibility = Visibility.Visible;
+                    break;
+
+                case RecommendationsState.Empty:
+                    LoadingOverlay.IsLoading = false;
+                    SectionsList.ItemsSource = null;
+                    SectionsScroll.Visibility = Visibility.Collapsed;
+                    InsufficientDataMessage.Visibility = Visibility.Collapsed;
+                    EmptyMessage.Visibility = Visibility.Visible;
+                    break;
+
+                case RecommendationsState.Loaded:
+                default:
+                    LoadingOverlay.IsLoading = false;
+                    EmptyMessage.Visibility = Visibility.Collapsed;
+                    InsufficientDataMessage.Visibility = Visibility.Collapsed;
+                    SectionsList.ItemsSource = vm.Sections;
+                    SectionsScroll.Visibility = Visibility.Visible;
+                    break;
+            }
+        }
+    }
+}

--- a/Dashboard/Controls/RecommendationsContent.xaml.cs
+++ b/Dashboard/Controls/RecommendationsContent.xaml.cs
@@ -24,19 +24,28 @@ namespace PerformanceMonitorDashboard.Controls
     /// The unified, read-only Recommendations surface (recommendations rebuild WS1b-1). Renders
     /// the de-duped <see cref="RecommendationItem"/> list from
     /// <see cref="RecommendationsReader.GetRecommendationsAsync"/> as a card list grouped into
-    /// collapsible Critical / Warning / Info sections. Each card shows a severity badge, the
-    /// affected database, a headline + advice, a "Show T-SQL" expander with a working Copy button,
-    /// and Apply + Mute buttons.
+    /// collapsible Critical / Warning / Info sections.
     ///
     /// <para>
-    /// Scope (WS1b-1): the surface is read-only. Copy is wired (trivial clipboard write). Refresh
-    /// re-runs the reader; "Generate now" runs an on-demand analysis for the current server and
-    /// then refreshes. Apply and Mute are rendered DISABLED with an "Available in the next update"
-    /// tooltip — their action wiring (and the informed-consent gate) is WS1b-2.
+    /// Per-card affordances split on whether the finding is an <b>incident</b> (time-bound) or a
+    /// standing <b>config-fix</b>. Incidents get "Open in Active Queries" (raises
+    /// <see cref="OpenActiveQueriesRequested"/> so the host tab deep-links to the time window) and
+    /// "Ask AI" (copies an MCP investigation prompt). Config-fixes get "Copy fix" (copies the
+    /// ALTER). Both kinds get Apply when a built remediation exists — rendered DISABLED with an
+    /// "Available in the next update" tooltip; the Apply action + informed-consent gate are WS1b-2.
     /// </para>
     /// </summary>
     public partial class RecommendationsContent : UserControl
     {
+        /// <summary>
+        /// Raised when the user clicks "Open in Active Queries" on an incident card. Carries the
+        /// finding's RAW UTC time window; the host (<c>ServerTab</c>) applies the ±1h grace, the
+        /// UTC→server-local conversion, selects the Performance/Queries tab + Active Queries
+        /// sub-tab, and scopes it to the window. Mirrors
+        /// <c>CriticalIssuesContent.InvestigateRequested</c>.
+        /// </summary>
+        public event Action<DateTime, DateTime>? OpenActiveQueriesRequested;
+
         private DatabaseService? _databaseService;
         private SqlServerFindingStore? _findingStore;
         private RecommendationsReader? _reader;
@@ -44,6 +53,7 @@ namespace PerformanceMonitorDashboard.Controls
         private ICredentialService? _credentialService;
 
         private int _hoursBack = 24;
+        private int _utcOffsetMinutes;
         private bool _isBusy;
 
         public RecommendationsContent()
@@ -56,16 +66,20 @@ namespace PerformanceMonitorDashboard.Controls
         /// run an on-demand analysis. <paramref name="serverConnection"/> +
         /// <paramref name="credentialService"/> are used only by "Generate now" to build a
         /// connection string and derive the deterministic server id, exactly as the
-        /// <see cref="AnalysisScheduler"/> does.
+        /// <see cref="AnalysisScheduler"/> does. <paramref name="utcOffsetMinutes"/> is the
+        /// monitored server's UTC offset, used to normalize the legacy producer's server-local
+        /// timestamps to UTC (reader) and to render the Ask-AI prompt window in server-local time.
         /// </summary>
         public void Initialize(
             DatabaseService databaseService,
             ServerConnection serverConnection,
-            ICredentialService credentialService)
+            ICredentialService credentialService,
+            int utcOffsetMinutes = 0)
         {
             _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
             _serverConnection = serverConnection ?? throw new ArgumentNullException(nameof(serverConnection));
             _credentialService = credentialService ?? throw new ArgumentNullException(nameof(credentialService));
+            _utcOffsetMinutes = utcOffsetMinutes;
             _findingStore = new SqlServerFindingStore(databaseService.ConnectionString);
             _reader = new RecommendationsReader(databaseService, _findingStore);
         }
@@ -102,9 +116,10 @@ namespace PerformanceMonitorDashboard.Controls
                 var serverName = _serverConnection.ServerName;
                 var serverId = ServerIdHelper.GetDeterministicHashCode(serverName);
 
-                var items = await _reader.GetRecommendationsAsync(serverId, serverName, _hoursBack);
+                var items = await _reader.GetRecommendationsAsync(
+                    serverId, serverName, _hoursBack, utcOffsetMinutes: _utcOffsetMinutes);
 
-                ApplyViewModel(RecommendationsViewModel.FromItems(items));
+                ApplyViewModel(RecommendationsViewModel.FromItems(items, serverName, _utcOffsetMinutes));
             }
             catch (Exception ex)
             {
@@ -181,9 +196,42 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         /// <summary>
-        /// Copies a card's T-SQL to the clipboard. The only wired action in WS1b-1.
+        /// Deep-links an incident card to the Active Queries view scoped to the finding's window.
+        /// Raises <see cref="OpenActiveQueriesRequested"/> with the RAW UTC window; the host tab
+        /// applies the grace + timezone conversion. Wired in WS1b-1.
         /// </summary>
-        private void CopySql_Click(object sender, RoutedEventArgs e)
+        private void OpenInActiveQueries_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+                return;
+
+            // Engine findings always carry a window; legacy incidents carry log_date. Fall back to
+            // a "now"-anchored band only if a producer somehow omitted it (handler widens anyway).
+            var fromUtc = card.WindowStartUtc ?? DateTime.UtcNow.AddHours(-2);
+            var toUtc = card.WindowEndUtc ?? DateTime.UtcNow;
+
+            OpenActiveQueriesRequested?.Invoke(fromUtc, toUtc);
+        }
+
+        /// <summary>
+        /// Copies the MCP investigation prompt for an incident card to the clipboard (no dialog;
+        /// a brief status confirmation). Wired in WS1b-1.
+        /// </summary>
+        private void AskAi_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+                return;
+
+            // SetDataObject with copy=false avoids WPF's problematic Clipboard.Flush() (matches the
+            // convention in CriticalIssuesContent / AlertDetailWindow).
+            Clipboard.SetDataObject(card.AskAiPrompt, false);
+            StatusText.Text = "AI prompt copied to clipboard.";
+        }
+
+        /// <summary>
+        /// Copies a config-fix card's ALTER statement to the clipboard. Wired in WS1b-1.
+        /// </summary>
+        private void CopyFix_Click(object sender, RoutedEventArgs e)
         {
             if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
                 return;
@@ -191,9 +239,8 @@ namespace PerformanceMonitorDashboard.Controls
             if (string.IsNullOrEmpty(card.CopyPasteSql))
                 return;
 
-            // SetDataObject with copy=false avoids WPF's problematic Clipboard.Flush() (matches
-            // the convention in CriticalIssuesContent / AlertDetailWindow).
             Clipboard.SetDataObject(card.CopyPasteSql, false);
+            StatusText.Text = "Fix copied to clipboard.";
         }
 
         /// <summary>

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using PerformanceMonitorDashboard.Services.Recommendations;
 
@@ -39,19 +40,41 @@ namespace PerformanceMonitorDashboard.Controls
     /// <summary>
     /// A single recommendation rendered as a card. A plain DTO (no WPF dependency) wrapping a
     /// <see cref="RecommendationItem"/> plus the pre-computed display/visibility flags the XAML
-    /// binds to, so the Apply/Mute visibility rules and the copy-paste presence are unit-testable
-    /// (WS1b-1). The action wiring (Apply/Mute/Generate) is WS1b-2 — here the buttons render but
-    /// are inert (see <see cref="ActionsDisabledReason"/>).
+    /// binds to, so the affordance model and the Ask-AI prompt are unit-testable (WS1b-1).
+    ///
+    /// <para>
+    /// The card affordances split on whether the finding is an <b>incident</b> (time-bound:
+    /// CPU/memory/blocking/waits/plan-regression — <see cref="RecommendationSetting.None"/>) or a
+    /// standing <b>config-fix</b> (AutoShrink/AutoClose/QueryStore/MAXDOP/RCSI —
+    /// <see cref="RecommendationSetting"/> other than None):
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>Incidents: "Open in Active Queries" (deep-links to the time window) + "Ask AI"
+    ///   (copies an MCP prompt) + Apply (when a remediation exists, e.g. clear-plan).</item>
+    ///   <item>Config-fixes: Apply (when a remediation exists) + "Copy fix" (copies the ALTER).</item>
+    /// </list>
+    /// <para>
+    /// Apply is still rendered DISABLED with the WS1b-1 tooltip — its action wiring + the
+    /// informed-consent gate are WS1b-2. "Open in Active Queries", "Ask AI" and "Copy fix" ARE
+    /// wired in WS1b-1 (navigation + clipboard).
+    /// </para>
     /// </summary>
     public sealed class RecommendationCardViewModel
     {
-        public RecommendationCardViewModel(RecommendationItem item)
+        public RecommendationCardViewModel(RecommendationItem item, string serverName = "", int utcOffsetMinutes = 0)
         {
             Item = item ?? throw new ArgumentNullException(nameof(item));
+            ServerName = serverName ?? string.Empty;
+            _utcOffsetMinutes = utcOffsetMinutes;
         }
+
+        private readonly int _utcOffsetMinutes;
 
         /// <summary>The underlying unified recommendation row.</summary>
         public RecommendationItem Item { get; }
+
+        /// <summary>The monitored server's display name (for the Ask-AI prompt).</summary>
+        public string ServerName { get; }
 
         /// <summary>The three-band severity (drives the badge glyph + colour).</summary>
         public CanonicalSeverity Severity => Item.CanonicalSeverity;
@@ -67,9 +90,9 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>A glyph for the badge (Segoe MDL2 Assets code point) per severity.</summary>
         public string SeverityGlyph => Item.CanonicalSeverity switch
         {
-            CanonicalSeverity.Critical => "", // error / critical
-            CanonicalSeverity.Warning => "",  // warning triangle
-            _ => ""                            // info
+            CanonicalSeverity.Critical => "", // error / critical
+            CanonicalSeverity.Warning => "",  // warning triangle
+            _ => ""                            // info
         };
 
         /// <summary>The card heading.</summary>
@@ -91,20 +114,42 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>Whether there is advice prose to render.</summary>
         public bool HasAdvice => !string.IsNullOrEmpty(Item.AdviceText);
 
-        /// <summary>The copy-paste-ready T-SQL, if any.</summary>
+        /// <summary>The copy-paste-ready fix T-SQL (config-fixes only), if any.</summary>
         public string? CopyPasteSql => Item.CopyPasteSql;
 
-        /// <summary>
-        /// Whether the "Show T-SQL" expander + Copy button should appear (only when there is SQL).
-        /// </summary>
-        public bool HasSql => !string.IsNullOrEmpty(Item.CopyPasteSql);
+        // ---- affordance model -------------------------------------------------
 
         /// <summary>
-        /// Whether the Apply button is shown for this card. Apply is engine-only AND requires a
-        /// built, persisted <see cref="RecommendationItem.Remediation"/> action — legacy rows and
-        /// engine rows with no executable shape never show it. (Mirrors the
-        /// <c>Remediation != null</c> rule the alert path uses.) The button is rendered DISABLED in
-        /// WS1b-1; the action is wired in WS1b-2.
+        /// Whether this is a time-bound INCIDENT finding (CPU/memory/blocking/waits/plan-regression):
+        /// <see cref="RecommendationItem.Setting"/> == <see cref="RecommendationSetting.None"/>.
+        /// Incidents send the operator to the dashboard / AI rather than showing a raw query.
+        /// </summary>
+        public bool IsIncident => Item.Setting == RecommendationSetting.None;
+
+        /// <summary>
+        /// Whether this is a standing CONFIG-FIX finding (a flagged
+        /// <see cref="RecommendationSetting"/>: AutoShrink/AutoClose/QueryStore/RCSI/PageVerify).
+        /// </summary>
+        public bool IsConfigFix => Item.Setting != RecommendationSetting.None;
+
+        /// <summary>
+        /// Whether the "Open in Active Queries" deep-link button is shown — incidents only.
+        /// </summary>
+        public bool ShowOpenInActiveQueries => IsIncident;
+
+        /// <summary>Whether the "Ask AI" (copy MCP prompt) button is shown — incidents only.</summary>
+        public bool ShowAskAi => IsIncident;
+
+        /// <summary>
+        /// Whether the "Copy fix" button is shown — config-fixes that carry an ALTER statement.
+        /// </summary>
+        public bool ShowCopyFix => IsConfigFix && !string.IsNullOrEmpty(Item.CopyPasteSql);
+
+        /// <summary>
+        /// Whether the Apply button is shown for this card — only when the row carries a built,
+        /// persisted <see cref="RecommendationItem.Remediation"/> action (engine rows; mirrors the
+        /// alert path's <c>Remediation != null</c> rule). Shown for both incidents (e.g.
+        /// clear-plan / plan-regression) and config-fixes (e.g. RCSI). Rendered DISABLED in WS1b-1.
         /// </summary>
         public bool ShowApply => Item.Remediation != null;
 
@@ -116,11 +161,47 @@ namespace PerformanceMonitorDashboard.Controls
         public bool ShowMute => Item.Source == RecommendationSource.Engine;
 
         /// <summary>
-        /// The tooltip shown on the (disabled) Apply/Mute buttons in WS1b-1. The action wiring
-        /// lands in WS1b-2; until then the buttons are present-but-inert so the approved layout is
+        /// The tooltip shown on the (disabled) Apply button in WS1b-1. The action wiring + consent
+        /// gate land in WS1b-2; until then Apply is present-but-inert so the approved layout is
         /// fully reviewable without any half-working behaviour.
         /// </summary>
         public string ActionsDisabledReason => RecommendationsViewModel.ActionsDisabledTooltip;
+
+        // ---- deep-link window (raw UTC; the handler applies grace + tz) --------
+
+        /// <summary>Raw UTC start of the finding window (drives the deep-link), or null.</summary>
+        public DateTime? WindowStartUtc => Item.WindowStartUtc;
+
+        /// <summary>Raw UTC end of the finding window (drives the deep-link), or null.</summary>
+        public DateTime? WindowEndUtc => Item.WindowEndUtc;
+
+        // ---- Ask-AI prompt ----------------------------------------------------
+
+        /// <summary>
+        /// The MCP investigation prompt copied to the clipboard by "Ask AI". The window is rendered
+        /// in the monitored server's local time (UTC window + offset) for operator legibility.
+        /// </summary>
+        public string AskAiPrompt
+        {
+            get
+            {
+                var (from, to) = ServerLocalWindow();
+                return RecommendationsViewModel.BuildAskAiPrompt(ServerName, Title, from, to);
+            }
+        }
+
+        /// <summary>
+        /// The finding window converted to the monitored server's local time, with a sensible
+        /// fallback when the producer carried no window (a 2h band ending "now" in server time).
+        /// </summary>
+        private (DateTime From, DateTime To) ServerLocalWindow()
+        {
+            if (Item.WindowStartUtc is { } su && Item.WindowEndUtc is { } eu)
+                return (su.AddMinutes(_utcOffsetMinutes), eu.AddMinutes(_utcOffsetMinutes));
+
+            var now = DateTime.UtcNow.AddMinutes(_utcOffsetMinutes);
+            return (now.AddHours(-2), now);
+        }
     }
 
     /// <summary>
@@ -173,7 +254,7 @@ namespace PerformanceMonitorDashboard.Controls
     public sealed class RecommendationsViewModel
     {
         /// <summary>
-        /// Tooltip on the disabled Apply/Mute buttons until WS1b-2 wires their actions.
+        /// Tooltip on the disabled Apply button until WS1b-2 wires its action + consent gate.
         /// </summary>
         public const string ActionsDisabledTooltip = "Available in the next update";
 
@@ -229,8 +310,11 @@ namespace PerformanceMonitorDashboard.Controls
         /// are omitted), preserving the reader's intra-severity order. Critical and Warning start
         /// expanded; Info starts collapsed. The state is <see cref="RecommendationsState.Empty"/>
         /// when the list is empty, else <see cref="RecommendationsState.Loaded"/>.
+        /// <paramref name="serverName"/> + <paramref name="utcOffsetMinutes"/> are carried onto each
+        /// card for the Ask-AI prompt (the deep-link itself uses the raw UTC window).
         /// </summary>
-        public static RecommendationsViewModel FromItems(IEnumerable<RecommendationItem> items)
+        public static RecommendationsViewModel FromItems(
+            IEnumerable<RecommendationItem> items, string serverName = "", int utcOffsetMinutes = 0)
         {
             var list = items as IReadOnlyList<RecommendationItem> ?? items?.ToList()
                        ?? (IReadOnlyList<RecommendationItem>)Array.Empty<RecommendationItem>();
@@ -240,9 +324,9 @@ namespace PerformanceMonitorDashboard.Controls
 
             var sections = new List<RecommendationSectionViewModel>(3);
             // Fixed display order Critical → Warning → Info, regardless of which bands are present.
-            AppendSection(sections, list, CanonicalSeverity.Critical, expanded: true);
-            AppendSection(sections, list, CanonicalSeverity.Warning, expanded: true);
-            AppendSection(sections, list, CanonicalSeverity.Info, expanded: false);
+            AppendSection(sections, list, CanonicalSeverity.Critical, expanded: true, serverName, utcOffsetMinutes);
+            AppendSection(sections, list, CanonicalSeverity.Warning, expanded: true, serverName, utcOffsetMinutes);
+            AppendSection(sections, list, CanonicalSeverity.Info, expanded: false, serverName, utcOffsetMinutes);
 
             return new(sections, RecommendationsState.Loaded, string.Empty);
         }
@@ -251,16 +335,34 @@ namespace PerformanceMonitorDashboard.Controls
             List<RecommendationSectionViewModel> sections,
             IReadOnlyList<RecommendationItem> all,
             CanonicalSeverity severity,
-            bool expanded)
+            bool expanded,
+            string serverName,
+            int utcOffsetMinutes)
         {
             // Preserve the reader's order within the band (it is already severity-desc sorted).
             var cards = all
                 .Where(i => i.CanonicalSeverity == severity)
-                .Select(i => new RecommendationCardViewModel(i))
+                .Select(i => new RecommendationCardViewModel(i, serverName, utcOffsetMinutes))
                 .ToList();
 
             if (cards.Count > 0)
                 sections.Add(new RecommendationSectionViewModel(severity, cards, expanded));
+        }
+
+        /// <summary>
+        /// Builds the MCP investigation prompt "Ask AI" copies to the clipboard for an incident.
+        /// Pure (no WPF / clock) so the interpolation is unit-testable. The window times are
+        /// formatted in whatever timezone the caller passed (the card passes server-local).
+        /// </summary>
+        public static string BuildAskAiPrompt(string serverName, string title, DateTime from, DateTime to)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Using the PerformanceMonitor MCP tools, investigate this finding on server \"{0}\": " +
+                "\"{1}\". It was flagged around {2:yyyy-MM-dd HH:mm}–{3:HH:mm}. Call analyze_server / " +
+                "get_analysis_findings and the relevant wait/blocking/memory tools, then tell me the " +
+                "likely cause and what to do.",
+                serverName, title, from, to);
         }
     }
 }

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitorDashboard.Services.Recommendations;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    /// <summary>
+    /// Which top-level state the Recommendations surface is in. The control swaps a single
+    /// visible region per state; the view-model picks exactly one from the load inputs so the
+    /// selection is unit-testable without WPF (WS1b-1).
+    /// </summary>
+    public enum RecommendationsState
+    {
+        /// <summary>A read is in flight — show the spinner.</summary>
+        Loading,
+
+        /// <summary>
+        /// The engine has not yet collected its minimum history window
+        /// (<c>AnalysisService.MinimumDataHours</c>); recommendations are not meaningful yet.
+        /// </summary>
+        InsufficientData,
+
+        /// <summary>The read completed and produced zero recommendations — the all-clear.</summary>
+        Empty,
+
+        /// <summary>The read completed with one or more recommendations to render.</summary>
+        Loaded
+    }
+
+    /// <summary>
+    /// A single recommendation rendered as a card. A plain DTO (no WPF dependency) wrapping a
+    /// <see cref="RecommendationItem"/> plus the pre-computed display/visibility flags the XAML
+    /// binds to, so the Apply/Mute visibility rules and the copy-paste presence are unit-testable
+    /// (WS1b-1). The action wiring (Apply/Mute/Generate) is WS1b-2 — here the buttons render but
+    /// are inert (see <see cref="ActionsDisabledReason"/>).
+    /// </summary>
+    public sealed class RecommendationCardViewModel
+    {
+        public RecommendationCardViewModel(RecommendationItem item)
+        {
+            Item = item ?? throw new ArgumentNullException(nameof(item));
+        }
+
+        /// <summary>The underlying unified recommendation row.</summary>
+        public RecommendationItem Item { get; }
+
+        /// <summary>The three-band severity (drives the badge glyph + colour).</summary>
+        public CanonicalSeverity Severity => Item.CanonicalSeverity;
+
+        /// <summary>Short uppercase severity label for the badge, e.g. "CRITICAL".</summary>
+        public string SeverityLabel => Item.CanonicalSeverity switch
+        {
+            CanonicalSeverity.Critical => "CRITICAL",
+            CanonicalSeverity.Warning => "WARNING",
+            _ => "INFO"
+        };
+
+        /// <summary>A glyph for the badge (Segoe MDL2 Assets code point) per severity.</summary>
+        public string SeverityGlyph => Item.CanonicalSeverity switch
+        {
+            CanonicalSeverity.Critical => "", // error / critical
+            CanonicalSeverity.Warning => "",  // warning triangle
+            _ => ""                            // info
+        };
+
+        /// <summary>The card heading.</summary>
+        public string Title => Item.Title;
+
+        /// <summary>
+        /// The affected database wrapped in brackets for display, or empty for a server-scoped
+        /// rec (so the database line collapses).
+        /// </summary>
+        public string DatabaseBracketed =>
+            string.IsNullOrEmpty(Item.Database) ? string.Empty : $"[{Item.Database}]";
+
+        /// <summary>Whether a database line should be shown at all.</summary>
+        public bool HasDatabase => !string.IsNullOrEmpty(Item.Database);
+
+        /// <summary>The operator-facing advice prose.</summary>
+        public string? AdviceText => Item.AdviceText;
+
+        /// <summary>Whether there is advice prose to render.</summary>
+        public bool HasAdvice => !string.IsNullOrEmpty(Item.AdviceText);
+
+        /// <summary>The copy-paste-ready T-SQL, if any.</summary>
+        public string? CopyPasteSql => Item.CopyPasteSql;
+
+        /// <summary>
+        /// Whether the "Show T-SQL" expander + Copy button should appear (only when there is SQL).
+        /// </summary>
+        public bool HasSql => !string.IsNullOrEmpty(Item.CopyPasteSql);
+
+        /// <summary>
+        /// Whether the Apply button is shown for this card. Apply is engine-only AND requires a
+        /// built, persisted <see cref="RecommendationItem.Remediation"/> action — legacy rows and
+        /// engine rows with no executable shape never show it. (Mirrors the
+        /// <c>Remediation != null</c> rule the alert path uses.) The button is rendered DISABLED in
+        /// WS1b-1; the action is wired in WS1b-2.
+        /// </summary>
+        public bool ShowApply => Item.Remediation != null;
+
+        /// <summary>
+        /// Whether the Mute button is shown. Mute is an engine-only concept (the legacy
+        /// <c>config.critical_issues</c> store has no mute), so it shows only for
+        /// <see cref="RecommendationSource.Engine"/> rows. Rendered DISABLED in WS1b-1.
+        /// </summary>
+        public bool ShowMute => Item.Source == RecommendationSource.Engine;
+
+        /// <summary>
+        /// The tooltip shown on the (disabled) Apply/Mute buttons in WS1b-1. The action wiring
+        /// lands in WS1b-2; until then the buttons are present-but-inert so the approved layout is
+        /// fully reviewable without any half-working behaviour.
+        /// </summary>
+        public string ActionsDisabledReason => RecommendationsViewModel.ActionsDisabledTooltip;
+    }
+
+    /// <summary>
+    /// A severity group (Critical / Warning / Info) of cards, rendered as a collapsible section.
+    /// Plain DTO so the grouping is unit-testable (WS1b-1).
+    /// </summary>
+    public sealed class RecommendationSectionViewModel
+    {
+        public RecommendationSectionViewModel(
+            CanonicalSeverity severity, IReadOnlyList<RecommendationCardViewModel> cards, bool expanded)
+        {
+            Severity = severity;
+            Cards = cards ?? throw new ArgumentNullException(nameof(cards));
+            IsExpanded = expanded;
+        }
+
+        /// <summary>The severity this section groups.</summary>
+        public CanonicalSeverity Severity { get; }
+
+        /// <summary>The cards in this section, in the order the reader returned them.</summary>
+        public IReadOnlyList<RecommendationCardViewModel> Cards { get; }
+
+        /// <summary>How many cards the section holds.</summary>
+        public int Count => Cards.Count;
+
+        /// <summary>Whether the section's expander starts expanded.</summary>
+        public bool IsExpanded { get; }
+
+        /// <summary>The header label, e.g. "Critical (3)".</summary>
+        public string Header => Severity switch
+        {
+            CanonicalSeverity.Critical => $"Critical ({Count})",
+            CanonicalSeverity.Warning => $"Warning ({Count})",
+            _ => $"Info ({Count})"
+        };
+    }
+
+    /// <summary>
+    /// The pure, WPF-free core of the Recommendations surface (WS1b-1). Groups a flat
+    /// <see cref="RecommendationItem"/> list (already de-duped + severity-sorted by
+    /// <c>RecommendationsReader</c>) into the Critical / Warning / Info sections the control
+    /// renders, and selects the single top-level <see cref="RecommendationsState"/>. Keeping the
+    /// grouping + state logic here (rather than in code-behind) makes it directly unit-testable.
+    ///
+    /// <para>
+    /// This is a snapshot view-model: each load builds a fresh instance and the control reassigns
+    /// its bound collections, so there is no <c>INotifyPropertyChanged</c> surface to reason about.
+    /// </para>
+    /// </summary>
+    public sealed class RecommendationsViewModel
+    {
+        /// <summary>
+        /// Tooltip on the disabled Apply/Mute buttons until WS1b-2 wires their actions.
+        /// </summary>
+        public const string ActionsDisabledTooltip = "Available in the next update";
+
+        /// <summary>The severity sections, Critical → Warning → Info, omitting empty ones.</summary>
+        public IReadOnlyList<RecommendationSectionViewModel> Sections { get; }
+
+        /// <summary>The selected top-level state.</summary>
+        public RecommendationsState State { get; }
+
+        /// <summary>
+        /// The insufficient-data message to show in the <see cref="RecommendationsState.InsufficientData"/>
+        /// state (the engine's own <c>InsufficientDataMessage</c>, or a default).
+        /// </summary>
+        public string InsufficientDataMessage { get; }
+
+        /// <summary>Total card count across all sections.</summary>
+        public int TotalCount => Sections.Sum(s => s.Count);
+
+        private RecommendationsViewModel(
+            IReadOnlyList<RecommendationSectionViewModel> sections,
+            RecommendationsState state,
+            string insufficientDataMessage)
+        {
+            Sections = sections;
+            State = state;
+            InsufficientDataMessage = insufficientDataMessage;
+        }
+
+        /// <summary>The default insufficient-data prose when the engine supplied none.</summary>
+        public const string DefaultInsufficientDataMessage =
+            "Collecting data — recommendations appear after the engine has at least 24 hours of history. " +
+            "Keep the collector running and check back later.";
+
+        /// <summary>
+        /// Builds the loading-state view-model (no data yet, read in flight).
+        /// </summary>
+        public static RecommendationsViewModel Loading() =>
+            new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Loading, string.Empty);
+
+        /// <summary>
+        /// Builds the insufficient-data-state view-model from the engine's message (or the default
+        /// when it is null/blank).
+        /// </summary>
+        public static RecommendationsViewModel InsufficientData(string? engineMessage) =>
+            new(
+                Array.Empty<RecommendationSectionViewModel>(),
+                RecommendationsState.InsufficientData,
+                string.IsNullOrWhiteSpace(engineMessage) ? DefaultInsufficientDataMessage : engineMessage!);
+
+        /// <summary>
+        /// Builds a loaded/empty view-model from the reader's flat, already-sorted list. Groups by
+        /// <see cref="CanonicalSeverity"/> into Critical / Warning / Info sections (empty sections
+        /// are omitted), preserving the reader's intra-severity order. Critical and Warning start
+        /// expanded; Info starts collapsed. The state is <see cref="RecommendationsState.Empty"/>
+        /// when the list is empty, else <see cref="RecommendationsState.Loaded"/>.
+        /// </summary>
+        public static RecommendationsViewModel FromItems(IEnumerable<RecommendationItem> items)
+        {
+            var list = items as IReadOnlyList<RecommendationItem> ?? items?.ToList()
+                       ?? (IReadOnlyList<RecommendationItem>)Array.Empty<RecommendationItem>();
+
+            if (list.Count == 0)
+                return new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Empty, string.Empty);
+
+            var sections = new List<RecommendationSectionViewModel>(3);
+            // Fixed display order Critical → Warning → Info, regardless of which bands are present.
+            AppendSection(sections, list, CanonicalSeverity.Critical, expanded: true);
+            AppendSection(sections, list, CanonicalSeverity.Warning, expanded: true);
+            AppendSection(sections, list, CanonicalSeverity.Info, expanded: false);
+
+            return new(sections, RecommendationsState.Loaded, string.Empty);
+        }
+
+        private static void AppendSection(
+            List<RecommendationSectionViewModel> sections,
+            IReadOnlyList<RecommendationItem> all,
+            CanonicalSeverity severity,
+            bool expanded)
+        {
+            // Preserve the reader's order within the band (it is already severity-desc sorted).
+            var cards = all
+                .Where(i => i.CanonicalSeverity == severity)
+                .Select(i => new RecommendationCardViewModel(i))
+                .ToList();
+
+            if (cards.Count > 0)
+                sections.Add(new RecommendationSectionViewModel(severity, cards, expanded));
+        }
+    }
+}

--- a/Dashboard/ServerTab.DrillDown.cs
+++ b/Dashboard/ServerTab.DrillDown.cs
@@ -17,6 +17,36 @@ namespace PerformanceMonitorDashboard
 {
     public partial class ServerTab : UserControl
     {
+        // ── Recommendations → Open in Active Queries (WS1b-1) ──
+
+        /// <summary>
+        /// Handles an incident card's "Open in Active Queries" deep-link. The control supplies the
+        /// finding's RAW UTC window; here we convert it to the monitored server's local time (the
+        /// time zone <c>collect.*</c> timestamps use), widen it by the ±1h grace, sync the global
+        /// range/pickers (so "Apply to All" works, matching the Investigate path), select the
+        /// Queries tab, and scope the Active Queries sub-tab to the window.
+        /// </summary>
+        private async void OnOpenActiveQueriesForFinding(DateTime fromUtc, DateTime toUtc)
+        {
+            // UTC -> server-local (collection_time is stored in server-local time), then ±1h grace.
+            var offset = UtcOffsetMinutes;
+            var from = fromUtc.AddMinutes(offset).AddHours(-1);
+            var to = toUtc.AddMinutes(offset).AddHours(1);
+
+            // Populate global custom date pickers + range so "Apply to All" reflects the window.
+            SetPickersFromDateTime(from, GlobalFromDate, GlobalFromHour, GlobalFromMinute);
+            SetPickersFromDateTime(to, GlobalToDate, GlobalToHour, GlobalToMinute);
+            _globalHoursBack = 0;
+            _globalFromDate = from;
+            _globalToDate = to;
+            HighlightTimeButton(0);
+            GlobalDateRangeIndicator.Text = GetGlobalDateRangeText();
+
+            QueriesTabItem.IsSelected = true;
+            PerformanceTab.SetTimeRange(0, from, to);
+            await PerformanceTab.ShowActiveQueriesForRange(from, to);
+        }
+
         // ── Critical Issues → Investigate Navigation (#684) ──
 
         private async void OnInvestigateCriticalIssue(string problemArea, DateTime logDate, string? affectedDatabase, string? investigateQuery)

--- a/Dashboard/ServerTab.Refresh.cs
+++ b/Dashboard/ServerTab.Refresh.cs
@@ -181,7 +181,7 @@ namespace PerformanceMonitorDashboard
 
         /// <summary>
         /// Refreshes the Overview tab: Collection Health, Duration Trends, Daily Summary,
-        /// Critical Issues, Default Trace, Current Config, Config Changes, Resource Overview, Running Jobs.
+        /// Recommendations, Default Trace, Current Config, Config Changes, Resource Overview, Running Jobs.
         /// </summary>
         private async Task RefreshOverviewTabAsync()
         {
@@ -192,13 +192,13 @@ namespace PerformanceMonitorDashboard
                 var resourceOverviewTask = RefreshResourceOverviewAsync();
                 var runningJobsTask = RefreshRunningJobsAsync();
                 var dailySummaryTask = DailySummaryTab.RefreshDataAsync();
-                var criticalIssuesTask = CriticalIssuesTab.RefreshDataAsync();
+                var recommendationsTask = RecommendationsTab.RefreshDataAsync();
                 var defaultTraceTask = DefaultTraceTab.RefreshAllDataAsync();
                 var currentConfigTask = CurrentConfigTab.RefreshAllDataAsync();
                 var configChangesTask = ConfigChangesTab.RefreshAllDataAsync();
 
                 await Task.WhenAll(healthTask, durationLogsTask, resourceOverviewTask, runningJobsTask,
-                    dailySummaryTask, criticalIssuesTask, defaultTraceTask, currentConfigTask, configChangesTask);
+                    dailySummaryTask, recommendationsTask, defaultTraceTask, currentConfigTask, configChangesTask);
 
                 var healthData = await healthTask;
                 HealthDataGrid.ItemsSource = healthData;

--- a/Dashboard/ServerTab.TimeRange.cs
+++ b/Dashboard/ServerTab.TimeRange.cs
@@ -230,7 +230,7 @@ namespace PerformanceMonitorDashboard
                 MemoryTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                 ResourceMetricsContent.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                 SystemEventsContent.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
-                CriticalIssuesTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
+                RecommendationsTab.SetTimeRange(_globalHoursBack);
                 DefaultTraceTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
 
                 // Refresh all data
@@ -526,18 +526,18 @@ namespace PerformanceMonitorDashboard
                 switch (tabHeader)
                 {
                     case "Overview":
-                        // Overview tab has Collection Health, Daily Summary, Critical Issues, Resource Overview sub-tabs
+                        // Overview tab has Collection Health, Daily Summary, Recommendations, Resource Overview sub-tabs
                         _collectionHealthHoursBack = _globalHoursBack;
                         _collectionHealthFromDate = _globalFromDate;
                         _collectionHealthToDate = _globalToDate;
                         _resourceOverviewHoursBack = _globalHoursBack;
                         _resourceOverviewFromDate = _globalFromDate;
                         _resourceOverviewToDate = _globalToDate;
-                        CriticalIssuesTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
+                        RecommendationsTab.SetTimeRange(_globalHoursBack);
                         DefaultTraceTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                         ConfigChangesTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                         CollectionHealth_Refresh_Click(null, new RoutedEventArgs());
-                        await CriticalIssuesTab.RefreshDataAsync();
+                        await RecommendationsTab.RefreshDataAsync();
                         await DefaultTraceTab.RefreshAllDataAsync();
                         await CurrentConfigTab.RefreshAllDataAsync();
                         await ConfigChangesTab.RefreshAllDataAsync();

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -280,9 +280,9 @@
                         <controls:DailySummaryContent x:Name="DailySummaryTab" />
                     </TabItem>
 
-                    <!-- Critical Issues Sub-Tab -->
-                    <TabItem Header="Critical Issues">
-                        <controls:CriticalIssuesContent x:Name="CriticalIssuesTab" />
+                    <!-- Recommendations Sub-Tab -->
+                    <TabItem Header="Recommendations">
+                        <controls:RecommendationsContent x:Name="RecommendationsTab" />
                     </TabItem>
 
                     <!-- Default Trace Sub-Tab -->

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -96,7 +96,8 @@ namespace PerformanceMonitorDashboard
 
             // Initialize Overview sub-tab UserControls
             DailySummaryTab.Initialize(_databaseService, _preferencesService);
-            RecommendationsTab.Initialize(_databaseService, _serverConnection, _credentialService);
+            RecommendationsTab.Initialize(_databaseService, _serverConnection, _credentialService, UtcOffsetMinutes);
+            RecommendationsTab.OpenActiveQueriesRequested += OnOpenActiveQueriesForFinding;
             DefaultTraceTab.Initialize(_databaseService);
             CurrentConfigTab.Initialize(_databaseService);
             ConfigChangesTab.Initialize(_databaseService);
@@ -233,6 +234,8 @@ namespace PerformanceMonitorDashboard
 
             BlockingSlicer.RangeChanged -= OnBlockingSlicerChanged;
             DeadlockSlicer.RangeChanged -= OnDeadlockSlicerChanged;
+
+            RecommendationsTab.OpenActiveQueriesRequested -= OnOpenActiveQueriesForFinding;
 
             MemoryTab.ChartDrillDownRequested -= OnChildChartDrillDown;
             ResourceMetricsContent.ChartDrillDownRequested -= OnChildChartDrillDown;

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -96,8 +96,7 @@ namespace PerformanceMonitorDashboard
 
             // Initialize Overview sub-tab UserControls
             DailySummaryTab.Initialize(_databaseService, _preferencesService);
-            CriticalIssuesTab.Initialize(_databaseService);
-            CriticalIssuesTab.InvestigateRequested += OnInvestigateCriticalIssue;
+            RecommendationsTab.Initialize(_databaseService, _serverConnection, _credentialService);
             DefaultTraceTab.Initialize(_databaseService);
             CurrentConfigTab.Initialize(_databaseService);
             ConfigChangesTab.Initialize(_databaseService);
@@ -125,7 +124,7 @@ namespace PerformanceMonitorDashboard
 
             // Set default time range on UserControls based on user preferences
             var prefs = _preferencesService.GetPreferences();
-            CriticalIssuesTab.SetTimeRange(prefs.DefaultHoursBack);
+            RecommendationsTab.SetTimeRange(prefs.DefaultHoursBack);
 
             // Sync time display mode picker with current setting
             var modeTag = ServerTimeHelper.CurrentDisplayMode.ToString();
@@ -235,7 +234,6 @@ namespace PerformanceMonitorDashboard
             BlockingSlicer.RangeChanged -= OnBlockingSlicerChanged;
             DeadlockSlicer.RangeChanged -= OnDeadlockSlicerChanged;
 
-            CriticalIssuesTab.InvestigateRequested -= OnInvestigateCriticalIssue;
             MemoryTab.ChartDrillDownRequested -= OnChildChartDrillDown;
             ResourceMetricsContent.ChartDrillDownRequested -= OnChildChartDrillDown;
 
@@ -383,7 +381,7 @@ namespace PerformanceMonitorDashboard
                 MemoryTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                 ResourceMetricsContent.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
                 SystemEventsContent.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
-                CriticalIssuesTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
+                RecommendationsTab.SetTimeRange(_globalHoursBack);
                 DefaultTraceTab.SetTimeRange(_globalHoursBack, _globalFromDate, _globalToDate);
 
                 await LoadDataAsync(fullRefresh: false);

--- a/Dashboard/Services/Recommendations/RecommendationItem.cs
+++ b/Dashboard/Services/Recommendations/RecommendationItem.cs
@@ -135,5 +135,21 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         /// <see cref="RecommendationSetting"/>. Drives the (database, setting) de-dupe key.
         /// </summary>
         public RecommendationSetting Setting { get; set; }
+
+        /// <summary>
+        /// UTC start of the time window the finding pertains to (engine: the analysis
+        /// <c>TimeRangeStart</c>; legacy: the <c>critical_issues.log_date</c>). Raw - no grace
+        /// window is applied here; the navigation handler widens it (+/- 1h) and converts to
+        /// server-local time when deep-linking to Active Queries. Null when the producer carried
+        /// no time bound.
+        /// </summary>
+        public System.DateTime? WindowStartUtc { get; set; }
+
+        /// <summary>
+        /// UTC end of the finding time window (engine: the analysis <c>TimeRangeEnd</c>;
+        /// legacy: the <c>critical_issues.log_date</c>, i.e. equal to <see cref="WindowStartUtc"/>).
+        /// Raw - see <see cref="WindowStartUtc"/>.
+        /// </summary>
+        public System.DateTime? WindowEndUtc { get; set; }
     }
 }

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -41,6 +41,22 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         internal const string ProblemAreaDatabaseConfiguration = "Database Configuration";
         internal const string ProblemAreaQueryStoreConfiguration = "Query Store Configuration";
 
+        /// <summary>
+        /// Legacy "pressure/growth" problem-areas that are noise — short-window deltas, no
+        /// quantification, circular investigate queries — AND inferior duplicates of analysis-
+        /// engine facts (RESOURCE_SEMAPHORE / SOS_SCHEDULER_YIELD / THREADPOOL / memory-grant
+        /// waits). Suppressed from the Recommendations surface; also cut at the source in
+        /// install/50. See the recommendations-engine-rebuild plan, "Legacy-rule curation".
+        /// </summary>
+        internal static readonly HashSet<string> SuppressedLegacyProblemAreas =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                "Memory Pressure",
+                "Memory Grant Pressure",
+                "CPU Scheduling Pressure",
+                "Memory Clerk Growth",
+            };
+
         public RecommendationsReader(DatabaseService databaseService, SqlServerFindingStore findingStore)
         {
             _databaseService = databaseService ?? throw new ArgumentNullException(nameof(databaseService));
@@ -69,7 +85,12 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
 
             var legacyItems = new List<RecommendationItem>(legacy.Count);
             foreach (var issue in legacy)
+            {
+                // Drop the legacy pressure/growth noise (duplicated, better, by engine facts).
+                if (SuppressedLegacyProblemAreas.Contains(issue.ProblemArea ?? string.Empty))
+                    continue;
                 legacyItems.Add(MapLegacyIssue(issue, utcOffsetMinutes));
+            }
 
             return RecommendationDeduper.Merge(engineItems, legacyItems);
         }

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -52,10 +52,13 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         /// unified list sorted by severity desc. <paramref name="serverName"/> is carried for
         /// display only (the reads key on <paramref name="serverId"/> for findings and on the
         /// connection's own server for the legacy store). <paramref name="hoursBack"/> bounds
-        /// both reads to the same window.
+        /// both reads to the same window. <paramref name="utcOffsetMinutes"/> is the monitored
+        /// server's UTC offset; it is applied ONLY to the legacy <c>log_date</c> (server-local)
+        /// to normalize it to the UTC window the engine rows already carry, so both producers
+        /// expose a single consistent UTC window (the navigation handler converts back).
         /// </summary>
         public async Task<List<RecommendationItem>> GetRecommendationsAsync(
-            int serverId, string serverName, int hoursBack = 24, int limit = 100)
+            int serverId, string serverName, int hoursBack = 24, int limit = 100, int utcOffsetMinutes = 0)
         {
             var findings = await _findingStore.GetRecentFindingsAsync(serverId, hoursBack, limit);
             var legacy = await _databaseService.GetCriticalIssuesAsync(hoursBack);
@@ -66,7 +69,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
 
             var legacyItems = new List<RecommendationItem>(legacy.Count);
             foreach (var issue in legacy)
-                legacyItems.Add(MapLegacyIssue(issue));
+                legacyItems.Add(MapLegacyIssue(issue, utcOffsetMinutes));
 
             return RecommendationDeduper.Merge(engineItems, legacyItems);
         }
@@ -96,7 +99,9 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 CopyPasteSql = BuildCopyPasteFromAction(finding.Remediation),
                 Remediation = finding.Remediation,
                 StoryPathHash = finding.StoryPathHash,
-                Setting = SettingFromAction(finding.Remediation)
+                Setting = SettingFromAction(finding.Remediation),
+                WindowStartUtc = AsUtc(finding.TimeRangeStart),
+                WindowEndUtc = AsUtc(finding.TimeRangeEnd)
             };
         }
 
@@ -108,7 +113,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         /// free-text message). Every other legacy row gets
         /// <see cref="RecommendationSetting.None"/> and is non-deduping pass-through.
         /// </summary>
-        internal static RecommendationItem MapLegacyIssue(CriticalIssueItem issue)
+        internal static RecommendationItem MapLegacyIssue(CriticalIssueItem issue, int utcOffsetMinutes = 0)
         {
             var band = RecommendationDeduper.FromLegacySeverity(issue.Severity);
             var database = string.IsNullOrEmpty(issue.AffectedDatabase) ? null : issue.AffectedDatabase;
@@ -126,7 +131,10 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 CopyPasteSql = sql,
                 Remediation = null,           // legacy rows are advise/copy-paste only — never Apply
                 StoryPathHash = null,          // the legacy store has no mute concept
-                Setting = SettingFromLegacy(issue.ProblemArea, sql)
+                Setting = SettingFromLegacy(issue.ProblemArea, sql),
+                // log_date is server-local; subtract the offset to express the same instant in UTC.
+                WindowStartUtc = LegacyLogDateToUtc(issue.LogDate, utcOffsetMinutes),
+                WindowEndUtc = LegacyLogDateToUtc(issue.LogDate, utcOffsetMinutes)
             };
         }
 
@@ -286,5 +294,21 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         /// </summary>
         private static string QuoteName(string identifier) =>
             "[" + (identifier ?? string.Empty).Replace("]", "]]") + "]";
+
+        /// <summary>
+        /// Stamps a nullable engine timestamp as UTC (the analysis pipeline records
+        /// <c>TimeRangeStart/End</c> in UTC; the store read-back can return Kind=Unspecified, so
+        /// fix the Kind to avoid an ambiguous later conversion). Null passes through.
+        /// </summary>
+        private static System.DateTime? AsUtc(System.DateTime? value) =>
+            value is null ? null : System.DateTime.SpecifyKind(value.Value, System.DateTimeKind.Utc);
+
+        /// <summary>
+        /// Converts a legacy server-local <c>log_date</c> to the equivalent UTC instant by
+        /// subtracting the monitored server's UTC offset, and stamps it Utc. With
+        /// <paramref name="utcOffsetMinutes"/> == 0 (unit tests) this is an identity stamp.
+        /// </summary>
+        private static System.DateTime LegacyLogDateToUtc(System.DateTime logDate, int utcOffsetMinutes) =>
+            System.DateTime.SpecifyKind(logDate.AddMinutes(-utcOffsetMinutes), System.DateTimeKind.Utc);
     }
 }


### PR DESCRIPTION
## Scope

The **visible, read-only Recommendations tab** (Dashboard-only) — WS1b of the recommendations-engine rebuild. Replaces the "Critical Issues" sub-tab with a "Recommendations" tab that renders the unified, de-duped `RecommendationItem` list (from the WS1a `RecommendationsReader`, already merged) as the **approved layout**: a card list grouped into collapsible Critical / Warning / Info sections.

Each card shows: a severity badge (glyph + label, theme status brush), the affected database (bracketed), a headline (`Title`), wrapped advice (`AdviceText`), a **"Show T-SQL"** expander revealing `CopyPasteSql` in a monospace block with a working **Copy** button, and **Apply** + **Mute** buttons.

**Not in scope (deferred to WS1b-2):** the Apply and Mute *action* wiring + the informed-consent gate. Apply + Mute render **DISABLED** with a tooltip "Available in the next update", so the full approved layout is reviewable with no half-working buttons. **Not in scope:** Lite (a later PR) — Lite is untouched here.

### Visibility predicates (match the alert path)
- **Apply** shows only when `Remediation != null` (engine rows with a built, persisted action).
- **Mute** shows only when `Source == Engine` (the legacy store has no mute concept).

### Header bar / actions (these ARE wired)
- **Refresh** — re-runs `RecommendationsReader.GetRecommendationsAsync` for the current server.
- **Generate now** — runs an on-demand `AnalysisService.AnalyzeAsync(serverId, displayName, hoursBack: 4)` for the current server (constructed exactly as `AnalysisScheduler` does: `SqlServerPlanFetcher` + `AnalysisService`, `serverId` via `ServerIdHelper.GetDeterministicHashCode`), then refreshes. **I wired Generate-now live** — the construction path is small and self-contained, so it did not pull in extra scope.
- **Copy** (per card) — clipboard write (trivial, wired).

### States
- **Loading** — the existing `LoadingOverlay` spinner while reading.
- **Empty** — "All clear — no current recommendations."
- **Insufficient data** — the engine's own `AnalysisService.InsufficientDataMessage` (or a default "collecting data — recommendations appear after the engine has ≥24h of history"). **Design note:** this state is surfaced by **Generate now** (the engine owns the data-span determination via `MinimumDataHours`); the read-only Refresh path shows Empty/Loaded. This avoids duplicating the span-check SQL or widening `AnalysisService`'s surface. A freshly-onboarded server therefore shows "All clear" on a plain Refresh and the "collecting data" message after Generate now.

## File:line changelog

**New files**
- `Dashboard/Controls/RecommendationsViewModel.cs` — the pure, WPF-free core: `RecommendationsViewModel.FromItems/Loading/InsufficientData` (groups by `CanonicalSeverity` into Critical→Warning→Info sections, empty sections omitted, Critical+Warning expanded / Info collapsed), the `RecommendationsState` enum, and `RecommendationCardViewModel` / `RecommendationSectionViewModel` DTOs carrying the display flags + `ShowApply`/`ShowMute` predicates.
- `Dashboard/Controls/RecommendationsContent.xaml` — the card-list-grouped-by-severity UI (`Expander` per section, `Expander` per card for "Show T-SQL"), header bar, and the four mutually-exclusive state regions. All theme `DynamicResource` brushes; no hardcoded colors (badge text uses a fixed dark glyph color over the colored badge, matching badge-on-status-color convention).
- `Dashboard/Controls/RecommendationsContent.xaml.cs` — `Initialize(DatabaseService, ServerConnection, ICredentialService)`, `SetTimeRange(hoursBack)`, `RefreshDataAsync()`, `GenerateNowButton_Click` (live), `CopySql_Click` (live), and `ApplyViewModel` state-swap.
- `Dashboard.Tests/RecommendationsViewModelTests.cs` — 23 VM unit tests (xUnit v3).

**Modified**
- `Dashboard/ServerTab.xaml:283-286` — `<TabItem Header="Critical Issues"><controls:CriticalIssuesContent .../>` → `<TabItem Header="Recommendations"><controls:RecommendationsContent x:Name="RecommendationsTab"/>`.
- `Dashboard/ServerTab.xaml.cs:99` — `RecommendationsTab.Initialize(_databaseService, _serverConnection, _credentialService)` (dropped the obsolete `InvestigateRequested` subscribe/unsubscribe at old :100/:238); `:124,:384` — `RecommendationsTab.SetTimeRange(...)`.
- `Dashboard/ServerTab.Refresh.cs:195` — `RefreshOverviewTabAsync` now awaits `RecommendationsTab.RefreshDataAsync()` (same Overview-tab refresh slot the Critical Issues sub-tab used).
- `Dashboard/ServerTab.TimeRange.cs:233,536,540` — global-time-range + Overview paths now call `RecommendationsTab.SetTimeRange(...)` / `RefreshDataAsync()`.

`CriticalIssuesContent.xaml(.cs)` is left intact (unused) per the task. The now-unreferenced `OnInvestigateCriticalIssue` (in `ServerTab.DrillDown.cs`) is harmless — no compiler warning, build clean.

## Test counts (real)

- `dotnet build PerformanceMonitor.sln -c Debug` → **0 errors** (1 pre-existing warning in `RemediationTests.cs`, unrelated).
- `dotnet test Dashboard.Tests --no-build` → **302 passed, 0 failed** (279 baseline + 23 new).
- `dotnet test Lite.Tests` → **360 passed, 0 failed** (Lite untouched).
- New `RecommendationsViewModelTests` in isolation → **23 passed**: grouping into severity sections (order, empty-section omission, intra-band order preserved, expand defaults, header count); state selection (loading / empty / loaded / insufficient-data with engine message + blank-fallback); Apply visibility (only when `Remediation != null`, false for legacy); Mute visibility (only when `Source == Engine`); card display flags (HasSql, DatabaseBracketed, SeverityLabel, disabled-tooltip).

## Deferred to WS1b-2
- Apply action wiring + the two-sided informed-consent (`RemediationConfirmWindow`) gate.
- Mute action wiring.
- (Both buttons are present-but-disabled now.)

## Needs visual verification (launch the Dashboard)
WPF rendering is not unit-testable. Please launch the Dashboard and confirm: the Recommendations sub-tab (under Overview) renders the grouped collapsible sections; severity badges/colors; the "Show T-SQL" expander + Copy; Apply/Mute appear disabled with the tooltip and per the visibility rules; Refresh and Generate now behave; and the loading / empty / insufficient-data states display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
