### PR TITLE
Fix #1048: show "Other: n/a" instead of "Other: 0%" on Linux

### DIFF
--- a/Dashboard/Models/ServerHealthStatus.cs
+++ b/Dashboard/Models/ServerHealthStatus.cs
@@ -205,7 +205,8 @@ namespace PerformanceMonitorDashboard.Models
             get
             {
                 if (!_cpuPercent.HasValue && !_otherCpuPercent.HasValue) return "";
-                return $"SQL: {_cpuPercent ?? 0}% Other: {_otherCpuPercent ?? 0}%";
+                string other = _otherCpuPercent.HasValue ? $"{_otherCpuPercent}%" : "n/a";
+                return $"SQL: {_cpuPercent ?? 0}% Other: {other}";
             }
         }
 


### PR DESCRIPTION
## What

On Linux, the alert engine correctly returns host/other-process CPU as `NULL` (no DMV exposes true host CPU there; `SystemIdle` is always 0 in `RING_BUFFER_SCHEDULER_MONITOR`). `CpuDisplayText` already drops the Other figure on Linux, but `CpuDetailText` coalesced the `NULL` to `0`, rendering a misleading **"Other: 0%"** that reads as a real zero measurement.

This branches `CpuDetailText` on `.HasValue` so a missing value renders **"n/a"**, matching the honest treatment already in `CpuDisplayText`.

## Why

Follow-up to #1055. The reporter (running SQL Server on OpenSUSE) confirmed the alert no longer fires, then asked whether "Other: 0%" was a real reading or a placeholder. It was a placeholder — this makes the UI say so.

## Scope

- Single file: `Dashboard/Models/ServerHealthStatus.cs`
- **No query change, no datatype change.** The value stays `int?`/`NULL` end to end; only the final display string differs.
- Dashboard-only; no schema or installer impact.

## Testing

Builds clean (0 warnings, 0 errors). Runtime path is a display-string branch; not runtime-tested (no Linux SQL host available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)