### PR TITLE
Recs rebuild WS1b-2: wire Apply (consent) + Mute actions

### DIFF
--- a/Dashboard.Tests/RecommendationDeduperTests.cs
+++ b/Dashboard.Tests/RecommendationDeduperTests.cs
@@ -385,6 +385,7 @@ public class RecommendationDeduperTests
             StoryText = "AUTO_SHRINK is on",
             RootFactKey = "DB_CONFIG",
             StoryPathHash = "abc123",
+            StoryPath = "config>db_config>MyDb",
             Remediation = action
         };
 
@@ -395,6 +396,7 @@ public class RecommendationDeduperTests
         Assert.Equal(CanonicalSeverity.Info, item.CanonicalSeverity); // 0.3 -> Info
         Assert.Same(action, item.Remediation);
         Assert.Equal("abc123", item.StoryPathHash);
+        Assert.Equal("config>db_config>MyDb", item.StoryPath); // carried for the mute record
         Assert.NotNull(item.CopyPasteSql);
         Assert.Contains("AUTO_SHRINK OFF", item.CopyPasteSql);
     }
@@ -418,6 +420,7 @@ public class RecommendationDeduperTests
         Assert.Equal(CanonicalSeverity.Critical, item.CanonicalSeverity);
         Assert.Null(item.Remediation);
         Assert.Null(item.StoryPathHash);
+        Assert.Null(item.StoryPath); // legacy rows have no mute concept
         Assert.Null(item.Database); // empty AffectedDatabase -> null
         Assert.Equal("Memory pressure detected", item.AdviceText);
         Assert.Equal("SELECT * FROM sys.dm_os_memory_clerks;", item.CopyPasteSql);

--- a/Dashboard.Tests/RecommendationsViewModelTests.cs
+++ b/Dashboard.Tests/RecommendationsViewModelTests.cs
@@ -49,7 +49,8 @@ public class RecommendationsViewModelTests
         string? advice = null,
         DateTime? windowStartUtc = null,
         DateTime? windowEndUtc = null,
-        string? storyHash = "hash")
+        string? storyHash = "hash",
+        string? storyPath = "root>leaf")
     {
         return new RecommendationItem
         {
@@ -64,7 +65,8 @@ public class RecommendationsViewModelTests
             AdviceText = advice,
             WindowStartUtc = windowStartUtc,
             WindowEndUtc = windowEndUtc,
-            StoryPathHash = source == RecommendationSource.Engine ? storyHash : null
+            StoryPathHash = source == RecommendationSource.Engine ? storyHash : null,
+            StoryPath = source == RecommendationSource.Engine ? storyPath : null
         };
     }
 
@@ -430,9 +432,29 @@ public class RecommendationsViewModelTests
     }
 
     [Fact]
-    public void Card_ActionsDisabledReason_IsTheNextUpdateTooltip()
+    public void EngineCard_ExposesMuteKeyInputs_HashAndPath()
     {
-        var card = Card(Item(CanonicalSeverity.Warning));
-        Assert.Equal(RecommendationsViewModel.ActionsDisabledTooltip, card.ActionsDisabledReason);
+        // The Mute handler keys on the underlying item's StoryPathHash (the mute key) and carries
+        // StoryPath (the operator-facing label). Both must round-trip through the card for engine rows.
+        var card = Card(Item(
+            CanonicalSeverity.Warning,
+            source: RecommendationSource.Engine,
+            storyHash: "h-42",
+            storyPath: "blocking>rcsi>Sales"));
+
+        Assert.True(card.ShowMute);
+        Assert.Equal("h-42", card.Item.StoryPathHash);
+        Assert.Equal("blocking>rcsi>Sales", card.Item.StoryPath);
+    }
+
+    [Fact]
+    public void LegacyCard_HasNoMuteKeyInputs()
+    {
+        // Legacy rows never mute: no hash, no path, no Mute button.
+        var card = Card(Item(CanonicalSeverity.Warning, source: RecommendationSource.Legacy));
+
+        Assert.False(card.ShowMute);
+        Assert.Null(card.Item.StoryPathHash);
+        Assert.Null(card.Item.StoryPath);
     }
 }

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1832,6 +1832,8 @@ public class RemediationTests
             "Controls/AlertsHistoryContent.xaml.cs", // threads it into the alert detail dialog
             "AlertDetailWindow.xaml.cs",             // invokes Apply/Un-apply via the service
             "RemediationConfirmWindow.xaml.cs",      // the confirm modal (gate UI)
+            "ServerTab.xaml.cs",                     // forwards it to the Recommendations sub-tab (WS1b-2)
+            "Controls/RecommendationsContent.xaml.cs", // invokes Apply via the service (WS1b-2)
         };
 
         var offenders = new List<string>();

--- a/Dashboard/Controls/RecommendationsContent.xaml
+++ b/Dashboard/Controls/RecommendationsContent.xaml
@@ -12,8 +12,9 @@
 
             <!-- One card: severity badge + database + title + advice, then affordances.
                  Incidents (Setting==None) send the operator to the dashboard / AI; config-fixes
-                 (Setting!=None) offer "Copy fix" (the ALTER). Apply is present-but-disabled until
-                 WS1b-2. Mirrors AlertDetailWindow's per-row visual conventions. -->
+                 (Setting!=None) offer "Copy fix" (the ALTER). Apply (live: confirm gate +
+                 two-sided informed consent for destructive fixes) and Mute (engine rows) are wired
+                 in WS1b-2. Mirrors AlertDetailWindow's per-row visual conventions. -->
             <DataTemplate x:Key="RecommendationCardTemplate">
                 <Border Background="{DynamicResource BackgroundLightBrush}"
                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
@@ -52,7 +53,8 @@
                                    Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
 
                         <!-- Affordances. Incidents: Open in Active Queries + Ask AI (+ Apply when
-                             a remediation exists). Config-fixes: Apply + Copy fix. -->
+                             a remediation exists). Config-fixes: Apply + Copy fix. Engine rows also
+                             offer Mute. Apply opens the confirm gate (two-sided consent if destructive). -->
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
                             <Button Content="Open in Active Queries →" Padding="10,3" Margin="0,0,8,0"
                                     Visibility="{Binding ShowOpenInActiveQueries, Converter={StaticResource BoolToVis}}"
@@ -66,10 +68,14 @@
                                     Visibility="{Binding ShowCopyFix, Converter={StaticResource BoolToVis}}"
                                     Click="CopyFix_Click"
                                     ToolTip="Copy the ALTER statement to the clipboard"/>
-                            <Button Content="Apply…" Padding="10,3"
-                                    IsEnabled="False"
+                            <Button Content="Apply…" Padding="10,3" Margin="0,0,8,0"
                                     Visibility="{Binding ShowApply, Converter={StaticResource BoolToVis}}"
-                                    ToolTip="{Binding ActionsDisabledReason}"/>
+                                    Click="ApplyButton_Click"
+                                    ToolTip="Apply this fix — you review and confirm before anything runs"/>
+                            <Button Content="Mute" Padding="10,3"
+                                    Visibility="{Binding ShowMute, Converter={StaticResource BoolToVis}}"
+                                    Click="MuteButton_Click"
+                                    ToolTip="Stop showing this recommendation (mutes the pattern for this server)"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>

--- a/Dashboard/Controls/RecommendationsContent.xaml.cs
+++ b/Dashboard/Controls/RecommendationsContent.xaml.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -17,6 +19,7 @@ using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Services.Recommendations;
+using PerformanceMonitorDashboard.Services.Remediation;
 
 namespace PerformanceMonitorDashboard.Controls
 {
@@ -51,6 +54,20 @@ namespace PerformanceMonitorDashboard.Controls
         private RecommendationsReader? _reader;
         private ServerConnection? _serverConnection;
         private ICredentialService? _credentialService;
+        private RemediationApplyService? _remediationApplyService;
+
+        /// <summary>
+        /// The shared, gated remediation entry point (constructed once in <c>MainWindow</c> and
+        /// threaded MainWindow -> ServerTab -> here, mirroring how <c>AlertsHistoryContent</c>
+        /// receives it). Drives the Apply button: server resolution, the two-sided informed-
+        /// consent gate for destructive fixes (RCSI / clear-plan), and the audit write. Null in
+        /// contexts where no service was supplied, which leaves Apply inert.
+        /// </summary>
+        public RemediationApplyService? RemediationApplyService
+        {
+            get => _remediationApplyService;
+            set => _remediationApplyService = value;
+        }
 
         private int _hoursBack = 24;
         private int _utcOffsetMinutes;
@@ -241,6 +258,209 @@ namespace PerformanceMonitorDashboard.Controls
 
             Clipboard.SetDataObject(card.CopyPasteSql, false);
             StatusText.Text = "Fix copied to clipboard.";
+        }
+
+        // ── Apply (gated remediation, mirrors AlertDetailWindow) ───────────────────
+
+        /// <summary>
+        /// Applies the card's built remediation through the gated <see cref="RemediationApplyService"/>.
+        /// Mirrors <c>AlertDetailWindow</c> exactly: fail-closed server resolution, the handler-for-fact
+        /// gate, then <c>ApplyAsync</c> with a confirm callback that news up the (two-sided when
+        /// destructive) <see cref="RemediationConfirmWindow"/>. On a run, refreshes so the action-log
+        /// outcome is reflected. <c>finding: null</c> is correct — the disclosure renders from the
+        /// persisted action's carried figures, exactly as on the alert path.
+        /// </summary>
+        private async void ApplyButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+                return;
+
+            await RunApplyAsync(card);
+        }
+
+        private async Task RunApplyAsync(RecommendationCardViewModel card)
+        {
+            var item = card.Item;
+            if (_remediationApplyService is null || item.Remediation is null || _serverConnection is null)
+                return;
+
+            if (_isBusy)
+                return;
+
+            // M3 fail-closed resolution: exact GUID match on this tab's connection Id, falling back to a
+            // unique ServerName match. Ambiguous/unresolved disables Apply (the reason is surfaced).
+            var resolution = _remediationApplyService.ResolveServer(_serverConnection.Id, _serverConnection.ServerName);
+            if (!resolution.IsResolved || resolution.Server is null)
+            {
+                StatusText.Text = resolution.Reason ?? "Apply is unavailable — the source server could not be resolved.";
+                return;
+            }
+
+            if (!_remediationApplyService.HasHandlerFor(item.Remediation.FactKey))
+            {
+                StatusText.Text = "No remediation handler is registered for this recommendation.";
+                return;
+            }
+
+            _isBusy = true;
+            try
+            {
+                StatusText.Text = "Applying…";
+
+                var operatorIdentity = ResolveOperatorIdentity();
+                // Audit provenance (RemediationIdentity doc: "the alert's metric name / story hash").
+                var sourceRef = $"Recommendations: {item.StoryPathHash ?? item.Title}";
+
+                // previewSql may be null for RCSI/clear-plan (no DB-config ALTER) — ApplyAsync then
+                // renders the canonical EXEC/ALTER preview itself, exactly as on the alert path.
+                var report = await _remediationApplyService.ApplyAsync(
+                    item.Remediation, resolution.Server, item.CopyPasteSql, operatorIdentity, sourceRef,
+                    request => ConfirmAsync(request, resolution), CancellationToken.None, finding: null);
+
+                StatusText.Text = FormatApplyStatus(report);
+                _isBusy = false; // release before re-entering RefreshDataAsync's own guard
+                await RefreshDataAsync();
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error applying recommendation: {ex.Message}", ex);
+                StatusText.Text = $"Apply failed: {ex.Message}";
+            }
+            finally
+            {
+                _isBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// The confirm gate. Invoked by the service from a background continuation, so it marshals to
+        /// the UI thread to show the modal. Returning true is the only thing that lets the privileged
+        /// handler run. For a destructive action the request carries the two-sided risks and the dialog
+        /// renders the acknowledge-each-risk checkboxes automatically (no special-casing here).
+        /// </summary>
+        private async Task<bool> ConfirmAsync(RemediationConfirmRequest request, ServerResolution resolution)
+        {
+            return await Dispatcher.InvokeAsync(() =>
+            {
+                var dialog = new RemediationConfirmWindow(request, resolution.ResolvedByName, resolution.Reason)
+                {
+                    Owner = Window.GetWindow(this)
+                };
+                return dialog.ShowDialog() == true;
+            });
+        }
+
+        /// <summary>
+        /// A compact one-line outcome for the status strip (the alert path renders a per-target detail
+        /// block; the Recommendations surface refreshes the cards, so a summary line suffices).
+        /// </summary>
+        private static string FormatApplyStatus(RemediationRunReport report)
+        {
+            switch (report.Status)
+            {
+                case RemediationRunStatus.NotConfirmed:
+                    return "Cancelled — no change was made.";
+                case RemediationRunStatus.NoHandler:
+                    return "No remediation handler is registered for this recommendation.";
+                case RemediationRunStatus.UnapplyNotSupported:
+                    return "This fix type cannot be un-applied — no change was made.";
+            }
+
+            var succeeded = report.Targets.Count(t => t.Status == RemediationStatus.Success);
+            var failed = report.Targets.Count(t =>
+                t.Status is RemediationStatus.Error or RemediationStatus.Blocked or RemediationStatus.PermissionDenied);
+            var skipped = report.Targets.Count(t => t.Status == RemediationStatus.Skipped);
+
+            if (report.Targets.Any(t => t.AppliedButUnlogged && t.AuditFailureKind == AuditWriteFailureKind.Permanent))
+                return $"Applied ({succeeded}), but the audit row could NOT be written — the monitoring login " +
+                       "lacks INSERT on config.remediation_action_log. Fix this grant.";
+
+            if (failed > 0)
+                return $"Apply finished with issues — {succeeded} succeeded, {failed} failed" +
+                       (skipped > 0 ? $", {skipped} skipped." : ".");
+
+            if (succeeded > 0)
+                return $"Applied — {succeeded} target(s) succeeded" + (skipped > 0 ? $", {skipped} skipped." : ".");
+
+            if (skipped > 0)
+                return $"Nothing to apply — {skipped} target(s) skipped.";
+
+            return "Apply finished — no targets were processed.";
+        }
+
+        // ── Mute (engine rows only) ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Mutes an engine recommendation's story pattern via the finding store, keyed on
+        /// (serverId, <c>story_path_hash</c>) — the lower-level story mute, because the card carries a
+        /// <see cref="RecommendationItem"/> rather than a full <c>AnalysisFinding</c>. After muting,
+        /// refreshes so the row drops out (the next read filters it). Legacy rows have no mute concept
+        /// and never reach here (the button is engine-only).
+        /// </summary>
+        private async void MuteButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+                return;
+
+            await RunMuteAsync(card);
+        }
+
+        private async Task RunMuteAsync(RecommendationCardViewModel card)
+        {
+            var item = card.Item;
+            if (_findingStore is null || _serverConnection is null
+                || item.Source != RecommendationSource.Engine
+                || string.IsNullOrEmpty(item.StoryPathHash))
+                return;
+
+            if (_isBusy)
+                return;
+
+            _isBusy = true;
+            try
+            {
+                StatusText.Text = "Muting…";
+
+                // Same deterministic server id the reader/scheduler use.
+                var serverId = ServerIdHelper.GetDeterministicHashCode(_serverConnection.ServerName);
+                await _findingStore.MuteStoryAsync(
+                    serverId, item.StoryPathHash, item.StoryPath ?? item.StoryPathHash,
+                    reason: "Muted from Recommendations");
+
+                StatusText.Text = "Recommendation muted.";
+                _isBusy = false; // release before re-entering RefreshDataAsync's own guard
+                await RefreshDataAsync();
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error muting recommendation: {ex.Message}", ex);
+                StatusText.Text = $"Mute failed: {ex.Message}";
+            }
+            finally
+            {
+                _isBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// The OS / Windows user running the Dashboard, recorded as the audit <c>operator_identity</c>
+        /// (mirrors <c>AlertDetailWindow.ResolveOperatorIdentity</c>; not a credential).
+        /// </summary>
+        private static string ResolveOperatorIdentity()
+        {
+            try
+            {
+                var name = System.Security.Principal.WindowsIdentity.GetCurrent()?.Name;
+                if (!string.IsNullOrEmpty(name))
+                    return name;
+            }
+            catch
+            {
+                /* WindowsIdentity can throw in constrained contexts — fall back. */
+            }
+            return Environment.UserName;
         }
 
         /// <summary>

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -54,8 +54,8 @@ namespace PerformanceMonitorDashboard.Controls
     ///   <item>Config-fixes: Apply (when a remediation exists) + "Copy fix" (copies the ALTER).</item>
     /// </list>
     /// <para>
-    /// Apply is still rendered DISABLED with the WS1b-1 tooltip — its action wiring + the
-    /// informed-consent gate are WS1b-2. "Open in Active Queries", "Ask AI" and "Copy fix" ARE
+    /// Apply (the gated remediation + two-sided informed consent for destructive fixes) and Mute
+    /// (engine rows) are wired in WS1b-2; "Open in Active Queries", "Ask AI" and "Copy fix" were
     /// wired in WS1b-1 (navigation + clipboard).
     /// </para>
     /// </summary>
@@ -149,23 +149,18 @@ namespace PerformanceMonitorDashboard.Controls
         /// Whether the Apply button is shown for this card — only when the row carries a built,
         /// persisted <see cref="RecommendationItem.Remediation"/> action (engine rows; mirrors the
         /// alert path's <c>Remediation != null</c> rule). Shown for both incidents (e.g.
-        /// clear-plan / plan-regression) and config-fixes (e.g. RCSI). Rendered DISABLED in WS1b-1.
+        /// clear-plan / plan-regression) and config-fixes (e.g. RCSI). Drives the Apply button +
+        /// (for destructive fixes) the two-sided informed-consent gate, wired in WS1b-2.
         /// </summary>
         public bool ShowApply => Item.Remediation != null;
 
         /// <summary>
         /// Whether the Mute button is shown. Mute is an engine-only concept (the legacy
         /// <c>config.critical_issues</c> store has no mute), so it shows only for
-        /// <see cref="RecommendationSource.Engine"/> rows. Rendered DISABLED in WS1b-1.
+        /// <see cref="RecommendationSource.Engine"/> rows. Drives the Mute button (mutes the
+        /// story pattern for this server), wired in WS1b-2.
         /// </summary>
         public bool ShowMute => Item.Source == RecommendationSource.Engine;
-
-        /// <summary>
-        /// The tooltip shown on the (disabled) Apply button in WS1b-1. The action wiring + consent
-        /// gate land in WS1b-2; until then Apply is present-but-inert so the approved layout is
-        /// fully reviewable without any half-working behaviour.
-        /// </summary>
-        public string ActionsDisabledReason => RecommendationsViewModel.ActionsDisabledTooltip;
 
         // ---- deep-link window (raw UTC; the handler applies grace + tz) --------
 
@@ -253,11 +248,6 @@ namespace PerformanceMonitorDashboard.Controls
     /// </summary>
     public sealed class RecommendationsViewModel
     {
-        /// <summary>
-        /// Tooltip on the disabled Apply button until WS1b-2 wires its action + consent gate.
-        /// </summary>
-        public const string ActionsDisabledTooltip = "Available in the next update";
-
         /// <summary>The severity sections, Critical → Warning → Info, omitting empty ones.</summary>
         public IReadOnlyList<RecommendationSectionViewModel> Sections { get; }
 

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -653,6 +653,11 @@ namespace PerformanceMonitorDashboard
                     System.Windows.MessageBoxImage.Error);
                 return;
             }
+
+            // WS1b-2: thread the shared gated remediation service to the Recommendations sub-tab
+            // (the same instance the Alerts tab uses), enabling Apply + the informed-consent gate.
+            serverTab.RemediationApplyService = _remediationApplyService;
+
             EventHandler alertHandler = (_, _) =>
             {
                 _alertHistoryStore.HideAllAlerts(8760, server.DisplayNameWithIntent);

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -26,6 +26,18 @@ namespace PerformanceMonitorDashboard
         public int UtcOffsetMinutes { get; }
 
         public DatabaseService DatabaseService => _databaseService;
+
+        /// <summary>
+        /// The shared, gated remediation entry point. Threaded from <c>MainWindow</c> after
+        /// construction and forwarded to the Recommendations sub-tab (its Apply button reads it
+        /// lazily at click time), mirroring how the Alerts tab receives the same instance.
+        /// </summary>
+        public Services.Remediation.RemediationApplyService? RemediationApplyService
+        {
+            get => RecommendationsTab.RemediationApplyService;
+            set => RecommendationsTab.RemediationApplyService = value;
+        }
+
         private static string GetLoadingMessage() => LoadingMessages.GetRandom();
 
 

--- a/Dashboard/Services/Recommendations/RecommendationItem.cs
+++ b/Dashboard/Services/Recommendations/RecommendationItem.cs
@@ -131,6 +131,14 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         public string? StoryPathHash { get; set; }
 
         /// <summary>
+        /// The engine finding's <c>story_path</c> — the human-readable pattern path persisted on
+        /// the mute record alongside <see cref="StoryPathHash"/> (the hash is the mute key; the
+        /// path is the operator-facing label for any future un-mute UI). Engine rows only; null
+        /// for legacy rows (the legacy store has no mute concept).
+        /// </summary>
+        public string? StoryPath { get; set; }
+
+        /// <summary>
         /// The canonical de-dupe setting (or <see cref="RecommendationSetting.None"/>). See
         /// <see cref="RecommendationSetting"/>. Drives the (database, setting) de-dupe key.
         /// </summary>

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -120,6 +120,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 CopyPasteSql = BuildCopyPasteFromAction(finding.Remediation),
                 Remediation = finding.Remediation,
                 StoryPathHash = finding.StoryPathHash,
+                StoryPath = finding.StoryPath,
                 Setting = SettingFromAction(finding.Remediation),
                 WindowStartUtc = AsUtc(finding.TimeRangeStart),
                 WindowEndUtc = AsUtc(finding.TimeRangeEnd)


### PR DESCRIPTION
## Scope (Dashboard-only)
Wires the Recommendations tab's **Apply** and **Mute** buttons live, replacing the WS1b-1 disabled "Available in the next update" affordances. Apply mirrors the existing `AlertDetailWindow` path exactly — fail-closed server resolution, the handler-for-fact gate, then `RemediationApplyService.ApplyAsync` with a confirm callback that news up `RemediationConfirmWindow`. Destructive fixes (RCSI / clear-plan) set `RequiresInformedConsent`, so the two-sided acknowledge-each-risk gate renders automatically (no special-casing); the inaction disclosure draws on the persisted action's carried figures (`finding: null`, exactly as on the alert path). Mute is engine-only via the lower-level story mute. No Lite changes (apply stack is Dashboard-only).

## File:line changelog
- **`Dashboard/Services/Recommendations/RecommendationItem.cs:133-139`** — add `StoryPath` (operator-facing label for the mute record).
- **`Dashboard/Services/Recommendations/RecommendationsReader.cs:123`** — populate `StoryPath = finding.StoryPath` in `MapEngineFinding` (the store already reads `story_path` back).
- **`Dashboard/Controls/RecommendationsContent.xaml.cs`**
  - `:57-70` — `_remediationApplyService` field + public `RemediationApplyService` property (mirrors `AlertsHistoryContent`).
  - `:9-12, :20` — add `using System.Linq; System.Threading; …Services.Remediation;`.
  - `:273-334` — `ApplyButton_Click` / `RunApplyAsync`: `ResolveServer(_serverConnection.Id, ServerName)`, `HasHandlerFor`, `ApplyAsync(item.Remediation, resolution.Server, item.CopyPasteSql, operatorIdentity, sourceRef, ConfirmAsync, ct, finding: null)`; refresh on run.
  - `:342-352` — `ConfirmAsync`: `Dispatcher.InvokeAsync` → `new RemediationConfirmWindow(request, resolution.ResolvedByName, resolution.Reason) { Owner = Window.GetWindow(this) }`.
  - `:358-390` — `FormatApplyStatus` (compact status-strip summary).
  - `:401-445` — `MuteButton_Click` / `RunMuteAsync`: `_findingStore.MuteStoryAsync(serverId, item.StoryPathHash, item.StoryPath ?? hash, …)`; refresh on success.
  - `:451-464` — `ResolveOperatorIdentity` (mirrors `AlertDetailWindow`).
- **`Dashboard/Controls/RecommendationsContent.xaml:55-78`** — Apply button enabled + `Click="ApplyButton_Click"` (removed `IsEnabled="False"` + `ActionsDisabledReason` tooltip); new **Mute** button bound to `ShowMute` + `Click="MuteButton_Click"`.
- **`Dashboard/Controls/RecommendationsViewModel.cs`** — refreshed `ShowApply`/`ShowMute` doc comments; removed now-dead `ActionsDisabledReason` property + `ActionsDisabledTooltip` const.
- **`Dashboard/ServerTab.xaml.cs:35-39`** — forwarding `RemediationApplyService` property → `RecommendationsTab`.
- **`Dashboard/MainWindow.xaml.cs:659`** — `serverTab.RemediationApplyService = _remediationApplyService;` (same instance as the Alerts tab).
- **`Dashboard.Tests/RemediationTests.cs:1835-1836`** — add `ServerTab.xaml.cs` + `Controls/RecommendationsContent.xaml.cs` to the sanctioned `RemediationApplyService` allowlist guard (`GatedEntry_ReferencedOnlyBySanctionedUiPath`).
- **`Dashboard.Tests/RecommendationDeduperTests.cs:399, :423`** — assert `StoryPath` maps (engine) / is null (legacy).
- **`Dashboard.Tests/RecommendationsViewModelTests.cs`** — builder gains `storyPath`; replaced the obsolete disabled-tooltip test with `EngineCard_ExposesMuteKeyInputs_HashAndPath` + `LegacyCard_HasNoMuteKeyInputs`.

## Test counts (real, this machine)
- `dotnet build PerformanceMonitor.sln -c Debug` → **0 errors** (1 pre-existing unrelated CS0649 warning in `RemediationTests.cs`).
- `dotnet test Dashboard.Tests --no-build` → **315 passed, 0 failed, 0 skipped**.
- `dotnet test Lite.Tests --no-build` → **360 passed, 0 failed, 0 skipped** (incl. the order-dependent Azure-auth test, which passed in-suite here).

## Needs visual / integration verification (live DB + WPF)
The unit tests cover the VM enablement predicates (`ShowApply`/`ShowMute`) and the reader's `StoryPath` mapping. The runtime behaviors need the orchestrator to launch the Dashboard:
- **An Apply through the two-sided RCSI consent gate** — confirm the acknowledge-each-risk checkboxes render with the persisted figures and Apply stays disabled until all are checked; confirm the `config.remediation_action_log` row is written and the recommendations refresh.
- A non-destructive DB-config Apply (single confirm) end-to-end.
- **Mute** an engine recommendation → row drops out after refresh; verify the `config.analysis_muted` row (serverId + story_path_hash + story_path).
- Fail-closed paths: Apply on an unresolvable/ambiguous server surfaces the reason and runs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)