### PR TITLE
WS3 foundation: config-advisory facts root below the 0.5 threshold

### DIFF
--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -47,4 +47,37 @@ public class InferenceEngineTests
         var edges = graph.GetActiveEdges("CXPACKET", facts);
         Assert.DoesNotContain(edges, e => e.Destination == "SOS_SCHEDULER_YIELD");
     }
+
+    // WS3: a config-advisory fact (DB_CONFIG/SERVER_CONFIG) roots a standalone recommendation
+    // at its base severity (e.g. RCSI-off = 0.3), below the 0.5 incident threshold — so a
+    // standing misconfig surfaces on a quiet, healthy server. An incident fact at the same
+    // severity does NOT root.
+    [Fact]
+    public void ConfigFact_RootsStandalone_BelowMinimumSeverity()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = "DB_CONFIG", Source = "config", Value = 1, Severity = 0.3,
+                    Metadata = new Dictionary<string, double> { ["rcsi_off_count"] = 9 } }
+        };
+
+        var stories = engine.BuildStories(facts);
+
+        Assert.Contains(stories, s => s.RootFactKey == "DB_CONFIG");
+    }
+
+    [Fact]
+    public void IncidentFact_BelowMinimumSeverity_DoesNotRoot()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = "CPU_SQL_PERCENT", Source = "cpu", Value = 60, Severity = 0.3 }
+        };
+
+        var stories = engine.BuildStories(facts);
+
+        Assert.DoesNotContain(stories, s => s.RootFactKey == "CPU_SQL_PERCENT");
+    }
 }

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -24,6 +24,21 @@ public class InferenceEngine
     private const double MinimumSeverityThreshold = 0.5;
     private const int MaxPathDepth = 10; // Safety limit
 
+    /// <summary>
+    /// Config-advisory fact keys that root a finding at ANY positive severity, bypassing the
+    /// MinimumSeverityThreshold. A standing misconfiguration (RCSI off, auto-shrink on, MAXDOP at
+    /// a silly default) is an advisory the operator should see regardless of current load — unlike
+    /// an incident fact, which must clear 0.5 to be worth surfacing. The existing severity-ordered
+    /// <c>consumed</c> traversal still suppresses duplicates: a higher-severity incident story that
+    /// consumes the config fact (e.g. CXPACKET → CONFIG_MAXDOP, or LCK_M_S → DB_CONFIG) wins, and
+    /// only an UN-consumed config fact roots a standalone recommendation.
+    /// </summary>
+    private static readonly HashSet<string> ConfigAdvisoryRootKeys = new(StringComparer.Ordinal)
+    {
+        "DB_CONFIG",
+        "SERVER_CONFIG",
+    };
+
     private readonly RelationshipGraph _graph;
 
     public InferenceEngine(RelationshipGraph graph)
@@ -43,9 +58,14 @@ public class InferenceEngine
             .ToDictionary(f => f.Key, f => f);
         var consumed = new HashSet<string>();
 
-        // Process facts in severity order
+        // Process facts in severity order. Incident facts must clear the 0.5 threshold to root;
+        // config-advisory facts (DB_CONFIG/SERVER_CONFIG) root at any positive severity so a
+        // standing misconfig surfaces on a quiet, healthy server (it would otherwise never reach
+        // 0.5 without contention — e.g. RCSI-off is base 0.3). Severity ordering + `consumed`
+        // (below) keep an incident story from being shadowed by, or duplicating, its config leaf.
         var entryPoints = facts
-            .Where(f => f.Severity >= MinimumSeverityThreshold)
+            .Where(f => f.Severity >= MinimumSeverityThreshold
+                     || (ConfigAdvisoryRootKeys.Contains(f.Key) && f.Severity > 0))
             .OrderByDescending(f => f.Severity)
             .ToList();
 


### PR DESCRIPTION
## What
`InferenceEngine.BuildStories` only rooted facts with `Severity >= 0.5`. Config facts (`DB_CONFIG`, and the `SERVER_CONFIG` facts coming in WS3) score ~0.3 for a standing misconfig, so they **never rooted a finding on a quiet server** — they only appeared when an incident amplified them past 0.5 (e.g. `LCK_M_S` contention for RCSI). That's the root cause of the "healthy server shows 0 recommendations despite 9 RCSI-off DBs" sparseness.

## Change
Config-advisory fact keys (`DB_CONFIG`, `SERVER_CONFIG`) now root at **any positive severity** — a standing misconfiguration is an advisory, not a severity-gated incident. The existing severity-ordered `consumed` traversal still de-dupes: an incident story that consumes the config fact (CXPACKET → CONFIG_MAXDOP) wins; only an un-consumed config fact roots standalone (this also resolves the D6 leaf-fact double-display concern).

Unit-tested both directions: `ConfigFact_RootsStandalone_BelowMinimumSeverity` and `IncidentFact_BelowMinimumSeverity_DoesNotRoot`.

## Effect
With this, `DB_CONFIG` recommendations surface on any server that has the issue — e.g. SQL2022's RCSI-off DBs now produce a recommendation (with the Apply path, since D7+D2 already give it the drill-down + persisted action). The remaining WS3 work (new `SERVER_CONFIG` fact for MAXDOP/CTFP/memory, etc.) builds on this.

## Tests
Dashboard.Tests 317/317, Lite.Tests 360/360 — no existing inference scenario shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)