### PR TITLE
Analysis: server-local analysis window + null-safe blocking analyzer

### DIFF
--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -68,12 +68,53 @@ public class AnalysisService
     }
 
     /// <summary>
+    /// Probes the MONITORED server's clock so the analysis window is built in the SAME clock the
+    /// collectors stamp rows with (SYSDATETIME, server-local). Returns the server's local "now"
+    /// and its UTC offset (SYSDATETIME − SYSUTCDATETIME). Falls back to host UTC + zero offset
+    /// when the server is unreachable — degrading to the prior (host-UTC-window) behavior rather
+    /// than introducing a new hard failure (the collectors that follow would fail anyway).
+    /// </summary>
+    private async Task<(DateTime LocalNow, TimeSpan UtcOffset)> GetServerClockAsync()
+    {
+        try
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT SYSDATETIME(), SYSUTCDATETIME();";
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                var local = reader.GetDateTime(0);
+                var utc = reader.GetDateTime(1);
+                return (local, local - utc);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[AnalysisService] Server clock probe failed; using host UTC: {ex.Message}");
+        }
+        return (DateTime.UtcNow, TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// The monitored server's current LOCAL time, for callers that compute their own analysis
+    /// windows (e.g. period comparison). See <see cref="GetServerClockAsync"/>.
+    /// </summary>
+    public async Task<DateTime> GetServerLocalNowAsync() => (await GetServerClockAsync()).LocalNow;
+
+    /// <summary>
     /// Runs the full analysis pipeline for a server.
     /// Default time range is the last 4 hours.
     /// </summary>
     public async Task<List<AnalysisFinding>> AnalyzeAsync(int serverId, string serverName, int hoursBack = 4)
     {
-        var timeRangeEnd = DateTime.UtcNow;
+        // The collectors stamp rows with the SERVER's clock (SYSDATETIME, server-local), so the
+        // analysis window MUST be in that same clock — otherwise every windowed read filters
+        // server-local data against a host-UTC window and silently misses it on any non-UTC
+        // server. The captured offset converts this window back to UTC at persistence time.
+        var (serverNow, serverUtcOffset) = await GetServerClockAsync();
+        var timeRangeEnd = serverNow;
         var timeRangeStart = timeRangeEnd.AddHours(-hoursBack);
 
         var context = new AnalysisContext
@@ -81,7 +122,8 @@ public class AnalysisService
             ServerId = serverId,
             ServerName = serverName,
             TimeRangeStart = timeRangeStart,
-            TimeRangeEnd = timeRangeEnd
+            TimeRangeEnd = timeRangeEnd,
+            ServerUtcOffset = serverUtcOffset
         };
 
         return await AnalyzeAsync(context);
@@ -212,7 +254,9 @@ public class AnalysisService
     /// </summary>
     public async Task<List<Fact>> CollectAndScoreFactsAsync(int serverId, string serverName, int hoursBack = 4)
     {
-        var timeRangeEnd = DateTime.UtcNow;
+        // Server-local window (see AnalyzeAsync) so windowed fact reads match the collectors.
+        var (serverNow, serverUtcOffset) = await GetServerClockAsync();
+        var timeRangeEnd = serverNow;
         var timeRangeStart = timeRangeEnd.AddHours(-hoursBack);
 
         var context = new AnalysisContext
@@ -220,7 +264,8 @@ public class AnalysisService
             ServerId = serverId,
             ServerName = serverName,
             TimeRangeStart = timeRangeStart,
-            TimeRangeEnd = timeRangeEnd
+            TimeRangeEnd = timeRangeEnd,
+            ServerUtcOffset = serverUtcOffset
         };
 
         try

--- a/Dashboard/Analysis/SqlServerFindingStore.cs
+++ b/Dashboard/Analysis/SqlServerFindingStore.cs
@@ -134,8 +134,13 @@ IF COL_LENGTH(N'config.analysis_findings', N'remediation_action_json') IS NULL
                     AnalysisTime = analysisTime,
                     ServerId = context.ServerId,
                     ServerName = context.ServerName,
-                    TimeRangeStart = context.TimeRangeStart,
-                    TimeRangeEnd = context.TimeRangeEnd,
+                    // The context window is in the SERVER's local clock (so windowed reads match
+                    // the collectors' SYSDATETIME rows); convert back to UTC for persistence so the
+                    // stored time_range_* stay UTC — the reader's AsUtc, the deep-link offset math,
+                    // and the retention purge all continue to assume UTC. (offset = SYSDATETIME −
+                    // SYSUTCDATETIME, so local − offset = UTC.)
+                    TimeRangeStart = context.TimeRangeStart - context.ServerUtcOffset,
+                    TimeRangeEnd = context.TimeRangeEnd - context.ServerUtcOffset,
                     Severity = story.Severity,
                     Confidence = story.Confidence,
                     Category = story.Category,

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -219,7 +219,9 @@ public sealed class McpAnalysisTools
             var analysisService = CreateAnalysisService(resolved.Value.Service);
             var serverId = ServerIdHelper.GetDeterministicHashCode(resolved.Value.ServerName);
 
-            var now = DateTime.UtcNow;
+            // Server-local clock so the comparison windows match the collectors' SYSDATETIME rows
+            // (compare returns facts only — it does not persist, so no UTC conversion is needed).
+            var now = await analysisService.GetServerLocalNowAsync();
             var comparisonStart = now.AddHours(-hours_back);
             var baselineEnd = now.AddHours(-baseline_hours_back + hours_back);
             var baselineStart = now.AddHours(-baseline_hours_back);

--- a/PerformanceMonitor.Analysis/AnalysisContext.cs
+++ b/PerformanceMonitor.Analysis/AnalysisContext.cs
@@ -12,6 +12,17 @@ public class AnalysisContext
     public string ServerName { get; set; } = string.Empty;
     public DateTime TimeRangeStart { get; set; }
     public DateTime TimeRangeEnd { get; set; }
+
+    /// <summary>
+    /// The monitored SERVER's UTC offset (SYSDATETIME − SYSUTCDATETIME), captured once at
+    /// analysis start. <see cref="TimeRangeStart"/>/<see cref="TimeRangeEnd"/> are in the
+    /// server's LOCAL clock so every windowed read matches the collectors (which stamp rows
+    /// with SYSDATETIME, server-local); this offset converts that window back to UTC for
+    /// persistence/display. <see cref="TimeSpan.Zero"/> when the clock probe was unavailable
+    /// (the window is then host-UTC — the prior behavior).
+    /// </summary>
+    public TimeSpan ServerUtcOffset { get; set; }
+
     public List<AnalysisExclusion> Exclusions { get; set; } = [];
 
     /// <summary>

--- a/install/26_blocking_deadlock_analyzer.sql
+++ b/install/26_blocking_deadlock_analyzer.sql
@@ -135,8 +135,11 @@ BEGIN
             SELECT
                 database_name = ISNULL(bg.database_name, N'UNKNOWN'),
                 blocking_event_count = COUNT_BIG(*),
-                total_blocking_duration_ms = SUM(bg.wait_time_ms),
-                max_blocking_duration_ms = MAX(bg.wait_time_ms),
+                /* wait_time_ms is nullable; SUM/MAX over an all-NULL group is NULL and these
+                   target columns are NOT NULL — ISNULL so a blocked-process report missing the
+                   duration can't fail the whole insert. */
+                total_blocking_duration_ms = ISNULL(SUM(bg.wait_time_ms), 0),
+                max_blocking_duration_ms = ISNULL(MAX(bg.wait_time_ms), 0),
                 avg_blocking_duration_ms = AVG(CONVERT(decimal(19,2), bg.wait_time_ms)),
                 deadlock_count = 0,
                 total_deadlock_wait_time_ms = 0,
@@ -187,7 +190,7 @@ BEGIN
                 SELECT
                     database_name = ISNULL(bl.database_name, N'UNKNOWN'),
                     deadlock_count = COUNT_BIG(DISTINCT LEFT(bl.deadlock_group, CHARINDEX(N',', bl.deadlock_group) - 1)),
-                    total_deadlock_wait_time_ms = SUM(bl.wait_time),
+                    total_deadlock_wait_time_ms = ISNULL(SUM(bl.wait_time), 0),
                     victim_count = SUM(CASE WHEN bl.deadlock_group LIKE N'%- VICTIM' THEN 1 ELSE 0 END)
                 FROM collect.deadlocks AS bl
                 WHERE bl.collection_time >= @last_deadlock_collection


### PR DESCRIPTION
## The bug (server-local window)
`AnalysisService` built the analysis window from `DateTime.UtcNow`, but every collector stamps rows with `SYSDATETIME()` (server-local). So all **102 windowed reads** (wait/CPU/blocking facts, anomaly detection, every drill-down enrichment) filtered server-local data against a **UTC** window and silently matched nothing on any non-UTC server — the entire windowed half of the analysis engine was dark there.

**Proven on sql2022 (UTC−7):** the UTC window saw **0** wait-stats and **0** CPU rows; the server-local window saw **11,050** wait rows + **293** CPU rows.

## The fix
- `AnalyzeAsync` / `CollectAndScoreFactsAsync` probe the monitored server's clock (`SELECT SYSDATETIME(), SYSUTCDATETIME()`) and build a **server-local** window, capturing the UTC offset on `AnalysisContext`. The 102 windowed reads are unchanged (they consume the context window).
- `SqlServerFindingStore` converts the window **back to UTC** for persistence, so stored `time_range_*`/`analysis_time` stay UTC — the reader's `AsUtc`, the deep-link offset math, and the retention purge are all unchanged.
- `compare_analysis` uses the server clock too. Falls back to host UTC if the probe fails (prior behavior; no new hard-failure mode).

## Bundled: null-safe `blocking_deadlock_analyzer` (install/26)
`SUM(wait_time_ms)`/`MAX(...)` and `SUM(wait_time)` feed **NOT NULL** columns, but those source columns are nullable — a report missing the duration made the aggregate NULL and failed the whole insert (it was failing on sql2022). Wrapped in `ISNULL(..., 0)`.

## Verification
- `get_analysis_facts` now returns **292 wait facts** (vs 0 before); persisted `time_range_end` = server `SYSUTCDATETIME` (UTC), not server-local.
- Analyzer aggregates a NULL-`wait_time_ms` row to `0` instead of erroring (deployed + tested on sql2022).
- Dashboard + Lite build clean; **346 Dashboard.Tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)