### PR TITLE
Recommendations WS3: server-config cards (MAXDOP/CTFP/memory) + Apply via sp_configure

### DIFF
--- a/Dashboard.Tests/FactScorerTests.cs
+++ b/Dashboard.Tests/FactScorerTests.cs
@@ -123,4 +123,119 @@ public class FactScorerTests
         Assert.False(string.IsNullOrWhiteSpace(advice.Investigation));
         Assert.False(string.IsNullOrWhiteSpace(advice.Remediation));
     }
+
+    /* ── WS3: server-level config facts (MAXDOP / CTFP / max & min memory) ── */
+
+    // Each per-setting CONFIG_* fact scores the 0.4 advisory base ONLY when the value is bad, and
+    // 0 otherwise — so audit_config still sees every CONFIG_* fact (it reads the raw value) but
+    // only a BAD one roots a recommendation card.
+    [Theory]
+    // MAXDOP: 0 is bad (unlimited); any other value is operator-chosen.
+    [InlineData("CONFIG_MAXDOP", 0, 0.4)]
+    [InlineData("CONFIG_MAXDOP", 4, 0.0)]
+    [InlineData("CONFIG_MAXDOP", 8, 0.0)]
+    // CTFP: <= 5 is bad (default-and-below); above is fine.
+    [InlineData("CONFIG_CTFP", 5, 0.4)]
+    [InlineData("CONFIG_CTFP", 1, 0.4)]
+    [InlineData("CONFIG_CTFP", 50, 0.0)]
+    [InlineData("CONFIG_CTFP", 6, 0.0)]
+    // max server memory: the 2 PB default (2147483647) is bad; a real cap is fine.
+    [InlineData("CONFIG_MAX_MEMORY_MB", 2147483647, 0.4)]
+    [InlineData("CONFIG_MAX_MEMORY_MB", 28672, 0.0)]
+    public void ServerConfigFact_ScoresBadValueOnly(string key, long value, double expected)
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "config", Key = key, Value = value,
+                    Metadata = new() { ["value_in_use"] = value } }
+        };
+
+        var scorer = new FactScorer();
+        scorer.ScoreAll(facts);
+
+        Assert.Equal(expected, facts[0].BaseSeverity, precision: 4);
+    }
+
+    // CONFIG_MIN_MAX_MEMORY_NARROW is emitted by the collector ONLY when bad, so any presence of
+    // the fact scores 0.4 (the fact's existence is the flag).
+    [Fact]
+    public void NarrowMemoryFact_AlwaysScoresAdvisoryBase()
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "config", Key = "CONFIG_MIN_MAX_MEMORY_NARROW", Value = 24000,
+                    Metadata = new() { ["min_memory_mb"] = 24000, ["max_memory_mb"] = 28672 } }
+        };
+
+        var scorer = new FactScorer();
+        scorer.ScoreAll(facts);
+
+        Assert.Equal(0.4, facts[0].BaseSeverity, precision: 4);
+    }
+
+    // CONFIG_MIN_MEMORY_MB and CONFIG_MAX_WORKER_THREADS are leaf/context facts — never scored
+    // (they feed audit_config / the narrow-memory derivation, not a card of their own).
+    [Theory]
+    [InlineData("CONFIG_MIN_MEMORY_MB")]
+    [InlineData("CONFIG_MAX_WORKER_THREADS")]
+    public void ServerConfigLeafFacts_ScoreZero(string key)
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "config", Key = key, Value = 1024, Metadata = new() { ["value_in_use"] = 1024 } }
+        };
+
+        var scorer = new FactScorer();
+        scorer.ScoreAll(facts);
+
+        Assert.Equal(0.0, facts[0].BaseSeverity, precision: 4);
+    }
+
+    // Advice exists for each of the four server-config root keys (dead-fact guard).
+    [Theory]
+    [InlineData("CONFIG_MAXDOP")]
+    [InlineData("CONFIG_CTFP")]
+    [InlineData("CONFIG_MAX_MEMORY_MB")]
+    [InlineData("CONFIG_MIN_MAX_MEMORY_NARROW")]
+    public void ServerConfigKeys_HaveAdviceBlocks(string key)
+    {
+        var advice = FactAdvice.GetForFactKey(key);
+
+        Assert.NotNull(advice);
+        Assert.False(string.IsNullOrWhiteSpace(advice!.Headline));
+        Assert.False(string.IsNullOrWhiteSpace(advice.Investigation));
+        Assert.False(string.IsNullOrWhiteSpace(advice.Remediation));
+    }
+
+    // The shared narrow-memory builder: emitted only when max is CONFIGURED and min >= 80% of max.
+    [Theory]
+    [InlineData(28672, 24000, true)]    // min 83.7% of max -> narrow
+    [InlineData(28672, 22938, true)]    // just over 80% (threshold 22937.6) -> narrow
+    [InlineData(28672, 22000, false)]   // ~76.7% -> just under 80%, not narrow
+    [InlineData(28672, 14000, false)]   // min ~49% -> not narrow
+    [InlineData(2147483647, 2000000000, false)] // max unconfigured -> never narrow
+    [InlineData(0, 0, false)]           // max 0 -> guard
+    public void BuildNarrowMemoryFact_FollowsThreshold(long maxMb, long minMb, bool emitted)
+    {
+        var fact = FactRemediation.BuildNarrowMemoryFact(1, maxMb, minMb);
+
+        if (!emitted)
+        {
+            Assert.Null(fact);
+            return;
+        }
+
+        Assert.NotNull(fact);
+        Assert.Equal("CONFIG_MIN_MAX_MEMORY_NARROW", fact!.Key);
+        Assert.Equal(minMb, fact.Value);
+        Assert.Equal(minMb, fact.Metadata["min_memory_mb"]);
+        Assert.Equal(maxMb, fact.Metadata["max_memory_mb"]);
+    }
+
+    [Fact]
+    public void BuildNarrowMemoryFact_NullInputs_ReturnsNull()
+    {
+        Assert.Null(FactRemediation.BuildNarrowMemoryFact(1, null, 24000));
+        Assert.Null(FactRemediation.BuildNarrowMemoryFact(1, 28672, null));
+    }
 }

--- a/Dashboard.Tests/FileAutogrowthHandlerTests.cs
+++ b/Dashboard.Tests/FileAutogrowthHandlerTests.cs
@@ -323,5 +323,11 @@ public class FileAutogrowthHandlerTests
 
         public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
             => Task.FromResult(new ClearPlanOutcome { QueryHash = queryHash, Status = RemediationStatus.Success });
+
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => Task.FromResult(new ServerConfigPreflight { Setting = setting, RecommendedValue = recommendedValue, HasPermission = true });
+
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ServerConfigOutcome { Setting = setting, Status = RemediationStatus.Success });
     }
 }

--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -98,4 +98,47 @@ public class InferenceEngineTests
 
         Assert.Contains(stories, s => s.RootFactKey == "FILE_AUTOGROWTH_PERCENT");
     }
+
+    // WS3: each bad server-level config fact at its 0.4 advisory base roots a standalone
+    // recommendation, below the 0.5 incident threshold — because each is a config-advisory root
+    // key. One finding per CONFIG_* fact (they are leaves with no edges between them).
+    [Theory]
+    [InlineData("CONFIG_MAXDOP")]
+    [InlineData("CONFIG_CTFP")]
+    [InlineData("CONFIG_MAX_MEMORY_MB")]
+    [InlineData("CONFIG_MIN_MAX_MEMORY_NARROW")]
+    public void ServerConfigFact_RootsStandalone_BelowMinimumSeverity(string key)
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = key, Source = "config", Value = 0, Severity = 0.4 }
+        };
+
+        var stories = engine.BuildStories(facts);
+
+        Assert.Contains(stories, s => s.RootFactKey == key);
+    }
+
+    // All four bad server-config facts together root four distinct standalone findings (no edges
+    // between them, so none consumes another).
+    [Fact]
+    public void ServerConfigFacts_AllFour_RootFourDistinctFindings()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = "CONFIG_MAXDOP", Source = "config", Value = 0, Severity = 0.4 },
+            new() { Key = "CONFIG_CTFP", Source = "config", Value = 5, Severity = 0.4 },
+            new() { Key = "CONFIG_MAX_MEMORY_MB", Source = "config", Value = 2147483647, Severity = 0.4 },
+            new() { Key = "CONFIG_MIN_MAX_MEMORY_NARROW", Source = "config", Value = 24000, Severity = 0.4 },
+        };
+
+        var stories = engine.BuildStories(facts);
+
+        Assert.Contains(stories, s => s.RootFactKey == "CONFIG_MAXDOP");
+        Assert.Contains(stories, s => s.RootFactKey == "CONFIG_CTFP");
+        Assert.Contains(stories, s => s.RootFactKey == "CONFIG_MAX_MEMORY_MB");
+        Assert.Contains(stories, s => s.RootFactKey == "CONFIG_MIN_MAX_MEMORY_NARROW");
+    }
 }

--- a/Dashboard.Tests/RemediationApplyServiceTests.cs
+++ b/Dashboard.Tests/RemediationApplyServiceTests.cs
@@ -793,6 +793,27 @@ public class RemediationApplyServiceTests
             });
         }
 
+        public int SetServerConfigCalls;
+
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => Task.FromResult(new ServerConfigPreflight
+            {
+                Setting = setting, RecommendedValue = recommendedValue,
+                Executable = setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold,
+                HasPermission = true, AlreadyInDesiredState = false, ExecutingLogin = "PerfMonLogin", CurrentValue = 0
+            });
+
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+        {
+            SetServerConfigCalls++;
+            return Task.FromResult(new ServerConfigOutcome
+            {
+                Setting = setting, Status = RemediationStatus.Success, Applied = true, ExecutingLogin = "PerfMonLogin",
+                PriorValue = 0, GeneratedSql = "EXEC sys.sp_configure N'show advanced options', 1; RECONFIGURE; EXEC sys.sp_configure N'max degree of parallelism', @value; RECONFIGURE;",
+                GateSpid = 55, ExecSpid = 55
+            });
+        }
+
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
         {
             AuditRecords.Add(record);
@@ -830,6 +851,15 @@ public class RemediationApplyServiceTests
             });
         public Task<FileGrowthOutcome> SetFileGrowthAsync(string database, string logicalFileName, int growthMb, RemediationIdentity identity, CancellationToken ct)
             => Task.FromResult(new FileGrowthOutcome { Database = database, LogicalFileName = logicalFileName, Status = RemediationStatus.Skipped });
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => Task.FromResult(new ServerConfigPreflight
+            {
+                Setting = setting, RecommendedValue = recommendedValue,
+                Executable = setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold,
+                HasPermission = true, AlreadyInDesiredState = true, ExecutingLogin = "PerfMonLogin", CurrentValue = recommendedValue
+            });
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ServerConfigOutcome { Setting = setting, Status = RemediationStatus.Skipped });
         public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct) => Task.FromResult(true);
     }
 }

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1849,6 +1849,9 @@ public class RemediationTests
         // WS3 percent-autogrowth always-safe core: the new handler + the DISTINCTIVE
         // executor method name. Reachable ONLY through the gate, exactly like DbConfigHandler.
         "FileAutogrowthHandler", "SetFileGrowthAsync", "PreflightFileGrowthAsync",
+        // WS3 server-level config always-safe core (MAXDOP/CTFP sp_configure): the new handler + the
+        // DISTINCTIVE executor method names. Reachable ONLY through the gate, exactly like DbConfigHandler.
+        "ServerConfigHandler", "SetServerConfigAsync", "PreflightServerConfigAsync",
     };
 
     [Fact]
@@ -2016,6 +2019,26 @@ public class RemediationTests
                 GateSpid = 55, ExecSpid = 55
             });
         }
+
+        // ── Server-config seam (sp_configure MAXDOP/CTFP + RECONFIGURE) ───────────
+        // Default-only here; the behavioural server-config coverage (and its own injectable
+        // fake) lives in ServerConfigHandlerTests. These satisfy the interface so this shared
+        // fake still compiles.
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => Task.FromResult(new ServerConfigPreflight
+            {
+                Setting = setting, RecommendedValue = recommendedValue,
+                Executable = setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold,
+                HasPermission = true, AlreadyInDesiredState = false, ExecutingLogin = "sa", CurrentValue = 0
+            });
+
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ServerConfigOutcome
+            {
+                Setting = setting, Status = RemediationStatus.Success, Applied = true, ExecutingLogin = "sa",
+                PriorValue = 0, GeneratedSql = "EXEC sys.sp_configure N'show advanced options', 1; RECONFIGURE; EXEC sys.sp_configure N'max degree of parallelism', @value; RECONFIGURE;",
+                GateSpid = 55, ExecSpid = 55
+            });
 
         // ── Percent-autogrowth seam (ALTER DATABASE … MODIFY FILE FILEGROWTH) ─────
         // Default-only here; the behavioural file-growth coverage (and its own injectable

--- a/Dashboard.Tests/ServerConfigHandlerTests.cs
+++ b/Dashboard.Tests/ServerConfigHandlerTests.cs
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Services.Remediation;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Coverage for the always-safe server-config handler (SERVER_CONFIG, WS3): the self-gating
+/// <see cref="ServerConfigHandler"/> against a faked executor — audit-table hard block for the
+/// executable settings (no mutation), the happy path running sp_configure for MAXDOP/CTFP and
+/// writing one audit row per attempt, the advise-only memory settings recording an outcome WITHOUT
+/// running sp_configure (and without needing the audit table), per-target independence, the
+/// preflight dispositions, and the apply-only un-apply restriction. Mirrors the DB-config /
+/// file-autogrowth handler tests; the single-connection (R2-MOD-1) guarantee is an executor concern
+/// (SPID equality) not provable here.
+/// </summary>
+public class ServerConfigHandlerTests
+{
+    private static readonly RemediationIdentity Identity =
+        new("TESTDOMAIN\\tester", "Analysis: server_config [abcd1234]");
+
+    private static RemediationAction ServerAction(params ServerConfigTarget[] targets) =>
+        new("SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            ServerConfigTargets: targets.ToList());
+
+    private static ServerConfigTarget MaxdopTarget(long current = 0, long recommended = 8) =>
+        new(ServerConfigSetting.Maxdop, current, recommended);
+
+    private static ServerConfigTarget CtfpTarget(long current = 5, long recommended = 50) =>
+        new(ServerConfigSetting.CostThreshold, current, recommended);
+
+    private static ServerConfigTarget MaxMemTarget() =>
+        new(ServerConfigSetting.MaxServerMemory, 2147483647, 2147483647);
+
+    private static ServerConfigTarget MinMemTarget() =>
+        new(ServerConfigSetting.MinServerMemory, 24000, 24000);
+
+    // ── Handler contract ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FactKey_IsServerConfig()
+    {
+        Assert.Equal("SERVER_CONFIG", new ServerConfigHandler().FactKey);
+    }
+
+    [Fact]
+    public void NotDestructive_AndApplyOnly()
+    {
+        var handler = new ServerConfigHandler();
+        Assert.False(handler.IsDestructive);     // sp_configure MAXDOP/CTFP is online metadata
+        Assert.False(handler.SupportsUnapply);   // no sensible reverse for MAXDOP/CTFP
+    }
+
+    [Fact]
+    public async Task UnapplyAsync_Throws()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            new ServerConfigHandler().UnapplyAsync(
+                ServerAction(MaxdopTarget()), new FakeServerConfigExecutor(), Identity, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Registry_ResolvesServerConfigHandler()
+    {
+        var registry = new RemediationHandlerRegistry(
+            new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new ServerConfigHandler() });
+        Assert.IsType<ServerConfigHandler>(registry.TryGet("SERVER_CONFIG"));
+    }
+
+    // ── Apply: executable settings (MAXDOP / CTFP) ────────────────────────────────
+
+    [Fact]
+    public async Task HappyPath_RunsSpConfigure_ForMaxdopAndCtfp_AndAudits()
+    {
+        var exec = new FakeServerConfigExecutor();   // default success
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget(0, 8), CtfpTarget(5, 50)), exec, Identity, CancellationToken.None);
+
+        // One SetServerConfigAsync per executable target, each with its own recommended value.
+        Assert.Equal(2, exec.SetCalls);
+        Assert.Contains((ServerConfigSetting.Maxdop, 8L), exec.SetArgs);
+        Assert.Contains((ServerConfigSetting.CostThreshold, 50L), exec.SetArgs);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.All(result.Outcomes, o =>
+        {
+            Assert.Equal(RemediationStatus.Success, o.Status);
+            Assert.True(o.AuditWritten);
+            Assert.False(o.AppliedButUnlogged);
+        });
+
+        // Audit rows: one per attempt, the precise taxonomy, server sentinel db, non-consent.
+        Assert.Equal(2, exec.AuditRecords.Count);
+        Assert.All(exec.AuditRecords, r =>
+        {
+            Assert.Equal("SERVER_CONFIG", r.FactKey);
+            Assert.Equal("success", r.Result);
+            Assert.False(r.ConsentAcknowledged);
+            Assert.Null(r.QueryId);
+            Assert.Null(r.PlanId);
+            Assert.False(string.IsNullOrEmpty(r.TargetDatabase)); // NOT NULL column sentinel
+        });
+        Assert.Contains(exec.AuditRecords, r => r.Action == "set_maxdop");
+        Assert.Contains(exec.AuditRecords, r => r.Action == "set_cost_threshold");
+    }
+
+    [Fact]
+    public async Task AuditTableAbsent_HardBlocks_ExecutableTargets_NoMutation()
+    {
+        var exec = new FakeServerConfigExecutor { AuditTableExists = false };
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget(), CtfpTarget()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.All(result.Outcomes, o =>
+        {
+            Assert.Equal(RemediationStatus.Blocked, o.Status);
+            Assert.False(o.AuditWritten);
+            Assert.Contains("2.12.0", o.Message);
+        });
+        Assert.Equal(0, exec.SetCalls);          // NOT mutated
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task PermissionDenied_FailsClosed_AuditSkipped()
+    {
+        var exec = new FakeServerConfigExecutor
+        {
+            SetFunc = (setting, value) => new ServerConfigOutcome
+            {
+                Setting = setting, Status = RemediationStatus.PermissionDenied, Applied = false,
+                Message = "lacks ALTER SETTINGS", PriorValue = 0
+            }
+        };
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget()), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.PermissionDenied, o.Status);
+        Assert.False(o.AppliedButUnlogged);
+        Assert.Equal("skipped", Assert.Single(exec.AuditRecords).Result);
+        Assert.Equal(1, exec.SetCalls);
+    }
+
+    [Fact]
+    public async Task AppliesButAuditFails_FlagsAppliedButUnlogged()
+    {
+        var exec = new FakeServerConfigExecutor { AuditWriteResult = false };
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget()), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Success, o.Status);
+        Assert.False(o.AuditWritten);
+        Assert.True(o.AppliedButUnlogged);
+    }
+
+    [Fact]
+    public async Task OneTargetThrows_OthersStillRun()
+    {
+        var exec = new FakeServerConfigExecutor
+        {
+            SetFunc = (setting, value) =>
+            {
+                if (setting == ServerConfigSetting.Maxdop) throw new InvalidOperationException("boom");
+                return new ServerConfigOutcome { Setting = setting, Status = RemediationStatus.Success, Applied = true, PriorValue = 5 };
+            }
+        };
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget(), CtfpTarget()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.Contains(result.Outcomes, o => o.Status == RemediationStatus.Error);
+        Assert.Contains(result.Outcomes, o => o.Status == RemediationStatus.Success);
+        Assert.Equal(2, exec.AuditRecords.Count); // error target still audited
+    }
+
+    // ── Advise-only memory settings: NEVER run sp_configure ───────────────────────
+
+    [Fact]
+    public async Task MemoryTargets_AreAdviseOnly_NoMutation_NoAudit()
+    {
+        var exec = new FakeServerConfigExecutor();
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxMemTarget(), MinMemTarget()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.All(result.Outcomes, o =>
+        {
+            Assert.Equal(RemediationStatus.Skipped, o.Status);
+            Assert.Contains("advise-only", o.Message);
+            Assert.False(o.AuditWritten);
+        });
+        Assert.Equal(0, exec.SetCalls);          // executor never touched for memory
+        Assert.Empty(exec.AuditRecords);
+    }
+
+    [Fact]
+    public async Task MemoryTargets_AdviseOnly_EvenWhenAuditTableAbsent()
+    {
+        // Advise-only targets never mutate and never need the audit table, so an absent table must
+        // still yield a clean advise-only result (not a spurious block).
+        var exec = new FakeServerConfigExecutor { AuditTableExists = false };
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxMemTarget()), exec, Identity, CancellationToken.None);
+
+        var o = Assert.Single(result.Outcomes);
+        Assert.Equal(RemediationStatus.Skipped, o.Status);
+        Assert.Contains("advise-only", o.Message);
+        Assert.Equal(0, exec.SetCalls);
+    }
+
+    [Fact]
+    public async Task MixedTargets_MaxdopApplied_MemoryAdviseOnly()
+    {
+        var exec = new FakeServerConfigExecutor();
+
+        var result = await new ServerConfigHandler().ApplyAsync(
+            ServerAction(MaxdopTarget(0, 8), MaxMemTarget()), exec, Identity, CancellationToken.None);
+
+        Assert.Equal(2, result.Outcomes.Count);
+        Assert.Equal(1, exec.SetCalls); // only MAXDOP ran sp_configure
+        Assert.Contains((ServerConfigSetting.Maxdop, 8L), exec.SetArgs);
+        Assert.DoesNotContain(exec.SetArgs, a => a.Item1 == ServerConfigSetting.MaxServerMemory);
+        // One success audit (MAXDOP); memory advise-only writes nothing.
+        Assert.Single(exec.AuditRecords);
+        Assert.Equal("set_maxdop", exec.AuditRecords[0].Action);
+    }
+
+    // ── Preflight dispositions ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(true, false, RemediationDisposition.Ok)]            // has perm, not already -> ready
+    [InlineData(true, true, RemediationDisposition.AlreadyInDesiredState)] // already at recommended
+    [InlineData(false, false, RemediationDisposition.BlockNoAlter)] // no permission
+    public async Task Preflight_ClassifiesExecutableDisposition(bool hasPerm, bool alreadyDesired, RemediationDisposition expected)
+    {
+        var exec = new FakeServerConfigExecutor
+        {
+            PreflightFunc = (setting, rec) => new ServerConfigPreflight
+            {
+                Setting = setting, RecommendedValue = rec, Executable = true,
+                HasPermission = hasPerm, AlreadyInDesiredState = alreadyDesired, CurrentValue = 0
+            }
+        };
+
+        var pre = await new ServerConfigHandler().PreflightAsync(
+            ServerAction(MaxdopTarget()), exec, CancellationToken.None);
+        Assert.Equal(expected, pre.Targets.Single().Disposition);
+    }
+
+    [Fact]
+    public async Task Preflight_MemoryTarget_IsAdviseOnlyDisposition()
+    {
+        var exec = new FakeServerConfigExecutor();
+
+        var pre = await new ServerConfigHandler().PreflightAsync(
+            ServerAction(MaxMemTarget()), exec, CancellationToken.None);
+
+        Assert.Equal(RemediationDisposition.AdviseOnly, pre.Targets.Single().Disposition);
+    }
+
+    [Fact]
+    public async Task Preflight_AuditTableAbsent_OverridesExecutableDisposition_NotAdviseOnly()
+    {
+        var exec = new FakeServerConfigExecutor { AuditTableExists = false };
+
+        var pre = await new ServerConfigHandler().PreflightAsync(
+            ServerAction(MaxdopTarget(), MaxMemTarget()), exec, CancellationToken.None);
+
+        Assert.False(pre.AuditTableExists);
+        // Executable MAXDOP blocked by absent table; advise-only memory stays AdviseOnly.
+        Assert.Contains(pre.Targets, t => t.Disposition == RemediationDisposition.BlockAuditTableAbsent);
+        Assert.Contains(pre.Targets, t => t.Disposition == RemediationDisposition.AdviseOnly);
+    }
+
+    /// <summary>
+    /// A standalone fake of <see cref="IRemediationExecutor"/> exercising only the audit + the
+    /// server-config seam; the other members return harmless defaults.
+    /// </summary>
+    private sealed class FakeServerConfigExecutor : IRemediationExecutor
+    {
+        public bool AuditTableExists = true;
+        public bool AuditWriteResult = true;
+
+        public Func<ServerConfigSetting, long, ServerConfigPreflight>? PreflightFunc;
+        public Func<ServerConfigSetting, long, ServerConfigOutcome>? SetFunc;
+        public int SetCalls;
+        public readonly List<(ServerConfigSetting Setting, long Value)> SetArgs = new();
+        public readonly List<RemediationAuditRecord> AuditRecords = new();
+
+        public Task<bool> AuditTableExistsAsync(CancellationToken ct) => Task.FromResult(AuditTableExists);
+
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => Task.FromResult(PreflightFunc?.Invoke(setting, recommendedValue) ?? new ServerConfigPreflight
+            {
+                Setting = setting, RecommendedValue = recommendedValue,
+                Executable = setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold,
+                HasPermission = true, AlreadyInDesiredState = false, ExecutingLogin = "sa", CurrentValue = 0
+            });
+
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+        {
+            SetCalls++;
+            SetArgs.Add((setting, value));
+            return Task.FromResult(SetFunc?.Invoke(setting, value) ?? new ServerConfigOutcome
+            {
+                Setting = setting, Status = RemediationStatus.Success, Applied = true, ExecutingLogin = "sa",
+                PriorValue = 0, GeneratedSql = $"EXEC sys.sp_configure N'...', {value}; RECONFIGURE;",
+                GateSpid = 55, ExecSpid = 55
+            });
+        }
+
+        public Task<bool> WriteAuditAsync(RemediationAuditRecord record, CancellationToken ct)
+        {
+            AuditRecords.Add(record);
+            return Task.FromResult(AuditWriteResult);
+        }
+
+        // ── Unused seams (harmless defaults) ──────────────────────────────────────
+        public Task<TargetPreflight> PreflightForcePlanAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(new TargetPreflight { Database = database, QueryId = queryId, PlanId = planId });
+        public Task<bool> HasPriorForceAsync(string database, long queryId, long planId, CancellationToken ct)
+            => Task.FromResult(false);
+        public Task<ForcePlanOutcome> ForcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ForcePlanOutcome { Database = database, QueryId = queryId, PlanId = planId, Status = RemediationStatus.Success });
+        public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ForcePlanOutcome { Database = database, QueryId = queryId, PlanId = planId, Status = RemediationStatus.Success });
+        public Task<DbConfigPreflight> PreflightDbConfigAsync(string database, DbConfigSetting setting, CancellationToken ct)
+            => Task.FromResult(new DbConfigPreflight { Database = database, Setting = setting });
+        public Task<DbConfigOutcome> SetDatabaseOptionAsync(string database, DbConfigSetting setting, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new DbConfigOutcome { Database = database, Setting = setting, Status = RemediationStatus.Success });
+        public Task<FileGrowthPreflight> PreflightFileGrowthAsync(string database, string logicalFileName, int growthMb, CancellationToken ct)
+            => Task.FromResult(new FileGrowthPreflight { Database = database, LogicalFileName = logicalFileName, RecommendedGrowthMb = growthMb });
+        public Task<FileGrowthOutcome> SetFileGrowthAsync(string database, string logicalFileName, int growthMb, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new FileGrowthOutcome { Database = database, LogicalFileName = logicalFileName, Status = RemediationStatus.Success });
+        public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
+            => Task.FromResult(new ClearPlanOutcome { QueryHash = queryHash, Status = RemediationStatus.Success });
+    }
+}

--- a/Dashboard.Tests/ServerConfigRecommendationTests.cs
+++ b/Dashboard.Tests/ServerConfigRecommendationTests.cs
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Controls;
+using PerformanceMonitorDashboard.Services.Recommendations;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// WS3 server-level config: the FactRemediation builder (edition-aware capped MAXDOP / flat CTFP /
+/// advise-only memory), the persisted-action DTO round-trip, the Recommendations reader fan-out
+/// (one card per ServerConfigTarget; MAXDOP/CTFP carry Apply, memory cards are copy-paste only), and
+/// the card affordance model (Copy + Apply / Copy-only, NOT incidents).
+/// </summary>
+public class ServerConfigRecommendationTests
+{
+    // ── Builder: edition-aware capped MAXDOP, flat CTFP, advise-only memory ────────
+
+    private static AnalysisFinding ServerConfigFinding(string rootKey, object row) => new()
+    {
+        ServerId = 1,
+        ServerName = "SQL2022",
+        Category = "config",
+        StoryPath = rootKey,
+        StoryPathHash = "sc000001",
+        RootFactKey = rootKey,
+        DrillDown = new Dictionary<string, object>
+        {
+            ["server_config"] = new List<object> { row }
+        }
+    };
+
+    [Theory]
+    // Enterprise (3) -> 8, capped at cores-per-socket when smaller.
+    [InlineData(3, 16, 8)]   // 8 <= 16 cores -> 8
+    [InlineData(3, 4, 4)]    // 8 capped to 4 cores
+    [InlineData(3, 0, 8)]    // cores unknown -> edition value stands
+    // Standard (2) / unknown -> 4.
+    [InlineData(2, 16, 4)]
+    [InlineData(0, 16, 4)]
+    [InlineData(2, 2, 2)]    // 4 capped to 2 cores
+    // Express (4) -> 1.
+    [InlineData(4, 16, 1)]
+    public void BuildServerConfig_Maxdop_EditionAware_CappedAtCores(int edition, int cores, long expectedRecommended)
+    {
+        var finding = ServerConfigFinding("CONFIG_MAXDOP",
+            new { setting = "maxdop", current_value = 0, edition, cores_per_socket = cores });
+
+        var action = FactRemediation.BuildServerConfigAction(finding);
+
+        Assert.NotNull(action);
+        Assert.Equal("SERVER_CONFIG", action!.FactKey);
+        var t = Assert.Single(action.ServerConfigTargets!);
+        Assert.Equal(ServerConfigSetting.Maxdop, t.Setting);
+        Assert.Equal(0, t.CurrentValue);
+        Assert.Equal(expectedRecommended, t.RecommendedValue);
+    }
+
+    [Fact]
+    public void BuildServerConfig_Ctfp_RecommendsFifty()
+    {
+        var finding = ServerConfigFinding("CONFIG_CTFP",
+            new { setting = "ctfp", current_value = 5, edition = 2, cores_per_socket = 8 });
+
+        var action = FactRemediation.BuildServerConfigAction(finding);
+
+        var t = Assert.Single(action!.ServerConfigTargets!);
+        Assert.Equal(ServerConfigSetting.CostThreshold, t.Setting);
+        Assert.Equal(5, t.CurrentValue);
+        Assert.Equal(50, t.RecommendedValue);
+    }
+
+    [Fact]
+    public void BuildServerConfig_MaxMemory_AdviseOnly_CarriesCurrent()
+    {
+        var finding = ServerConfigFinding("CONFIG_MAX_MEMORY_MB",
+            new { setting = "max_memory", current_value = 2147483647L, edition = 2, cores_per_socket = 8 });
+
+        var action = FactRemediation.BuildServerConfigAction(finding);
+
+        var t = Assert.Single(action!.ServerConfigTargets!);
+        Assert.Equal(ServerConfigSetting.MaxServerMemory, t.Setting);
+        // Advise-only: recommended carries current (the executor refuses to apply it).
+        Assert.Equal(2147483647L, t.CurrentValue);
+        Assert.Equal(2147483647L, t.RecommendedValue);
+    }
+
+    [Fact]
+    public void BuildServerConfig_MinMemory_AdviseOnly()
+    {
+        var finding = ServerConfigFinding("CONFIG_MIN_MAX_MEMORY_NARROW",
+            new { setting = "min_memory", current_value = 24000L, edition = 2, cores_per_socket = 8 });
+
+        var action = FactRemediation.BuildServerConfigAction(finding);
+
+        var t = Assert.Single(action!.ServerConfigTargets!);
+        Assert.Equal(ServerConfigSetting.MinServerMemory, t.Setting);
+        Assert.Equal(24000L, t.CurrentValue);
+    }
+
+    [Fact]
+    public void BuildServerConfig_NoDrillDown_ReturnsNull()
+    {
+        var finding = new AnalysisFinding { ServerId = 1, ServerName = "S", RootFactKey = "CONFIG_MAXDOP" };
+        Assert.Null(FactRemediation.BuildServerConfigAction(finding));
+    }
+
+    [Fact]
+    public void BuildSpConfigureStatement_RendersHardcodedNameAndValue()
+    {
+        Assert.Equal(
+            "EXEC sys.sp_configure N'max degree of parallelism', 8;\nRECONFIGURE;",
+            FactRemediation.BuildSpConfigureStatement(ServerConfigSetting.Maxdop, 8));
+        Assert.Equal(
+            "EXEC sys.sp_configure N'cost threshold for parallelism', 50;\nRECONFIGURE;",
+            FactRemediation.BuildSpConfigureStatement(ServerConfigSetting.CostThreshold, 50));
+    }
+
+    // ── DTO round-trip (persisted remediation_action_json) ────────────────────────
+
+    [Fact]
+    public void ServerConfigAction_RoundTripsThroughDto()
+    {
+        var action = new RemediationAction(
+            "SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            ServerConfigTargets: new[]
+            {
+                new ServerConfigTarget(ServerConfigSetting.Maxdop, 0, 8),
+                new ServerConfigTarget(ServerConfigSetting.MaxServerMemory, 2147483647, 2147483647)
+            });
+
+        var json = AlertContextSerializer.SerializeAction(action);
+        Assert.NotNull(json);
+        var restored = AlertContextSerializer.DeserializeAction(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal("SERVER_CONFIG", restored!.FactKey);
+        Assert.NotNull(restored.ServerConfigTargets);
+        Assert.Equal(2, restored.ServerConfigTargets!.Count);
+
+        var maxdop = Assert.Single(restored.ServerConfigTargets, t => t.Setting == ServerConfigSetting.Maxdop);
+        Assert.Equal(0, maxdop.CurrentValue);
+        Assert.Equal(8, maxdop.RecommendedValue);
+
+        var mem = Assert.Single(restored.ServerConfigTargets, t => t.Setting == ServerConfigSetting.MaxServerMemory);
+        Assert.Equal(2147483647L, mem.CurrentValue);
+    }
+
+    [Fact]
+    public void LegacyActionWithoutServerConfig_DeserializesNull()
+    {
+        // A force-plan action (no ServerConfigTargets) must round-trip with the new field null —
+        // backward compatibility for legacy persisted contexts.
+        var action = new RemediationAction("PLAN_REGRESSION", "force",
+            new[] { new ForcePlanTarget("Db", 1, 2) });
+        var restored = AlertContextSerializer.DeserializeAction(AlertContextSerializer.SerializeAction(action));
+        Assert.NotNull(restored);
+        Assert.Null(restored!.ServerConfigTargets);
+    }
+
+    // ── Reader fan-out: one card per target; MAXDOP/CTFP Apply, memory copy-only ───
+
+    private static AnalysisFinding RootedFinding(string rootKey, RemediationAction action) => new()
+    {
+        ServerId = 1,
+        ServerName = "SQL2022",
+        DatabaseName = null,            // server-scoped
+        Severity = 0.4,
+        Category = "config",
+        RootFactKey = rootKey,
+        StoryPathHash = "h",
+        StoryPath = "p",
+        Remediation = action
+    };
+
+    [Fact]
+    public void Reader_FansAllFourServerConfigCards_WithCorrectAffordances()
+    {
+        // One synthetic finding carrying all four targets — exercises the reader's fan loop directly
+        // (each CONFIG_* roots its own finding in production; the loop turns N targets into N cards).
+        var action = new RemediationAction(
+            "SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            ServerConfigTargets: new[]
+            {
+                new ServerConfigTarget(ServerConfigSetting.Maxdop, 0, 8),
+                new ServerConfigTarget(ServerConfigSetting.CostThreshold, 5, 50),
+                new ServerConfigTarget(ServerConfigSetting.MaxServerMemory, 2147483647, 2147483647),
+                new ServerConfigTarget(ServerConfigSetting.MinServerMemory, 24000, 24000),
+            });
+
+        var items = RecommendationsReader.MapEngineFindings(RootedFinding("CONFIG_MAXDOP", action));
+
+        Assert.Equal(4, items.Count);
+        Assert.All(items, i =>
+        {
+            Assert.Equal(RecommendationSource.Engine, i.Source);
+            Assert.Null(i.Database);                          // server-scoped
+            Assert.Equal(RecommendationSetting.None, i.Setting); // never de-dupes
+            Assert.True(i.IsServerConfigAdvisory);
+            Assert.False(string.IsNullOrEmpty(i.CopyPasteSql)); // every card has copy-paste
+            Assert.Contains("SQL2022", i.Title);                // title names the server
+        });
+
+        // MAXDOP card: Apply present (single-target SERVER_CONFIG action), title + copy-paste.
+        var maxdop = Assert.Single(items, i => i.Title.StartsWith("MAXDOP is 0"));
+        Assert.NotNull(maxdop.Remediation);
+        Assert.Equal("SERVER_CONFIG", maxdop.Remediation!.FactKey);
+        var mt = Assert.Single(maxdop.Remediation.ServerConfigTargets!);
+        Assert.Equal(ServerConfigSetting.Maxdop, mt.Setting);
+        Assert.Equal(8, mt.RecommendedValue);
+        Assert.Contains("max degree of parallelism", maxdop.CopyPasteSql);
+
+        // CTFP card: Apply present.
+        var ctfp = Assert.Single(items, i => i.Title.StartsWith("Cost Threshold for Parallelism is 5"));
+        Assert.NotNull(ctfp.Remediation);
+        Assert.Equal(ServerConfigSetting.CostThreshold, Assert.Single(ctfp.Remediation!.ServerConfigTargets!).Setting);
+        Assert.Contains("cost threshold for parallelism", ctfp.CopyPasteSql);
+
+        // max memory card: NO Apply (advise-only), copy-paste only.
+        var maxMem = Assert.Single(items, i => i.Title.StartsWith("max server memory is unconfigured"));
+        Assert.Null(maxMem.Remediation);
+        Assert.Contains("max server memory (MB)", maxMem.CopyPasteSql);
+
+        // min memory card: NO Apply.
+        var minMem = Assert.Single(items, i => i.Title.StartsWith("min server memory is pinned near max"));
+        Assert.Null(minMem.Remediation);
+        Assert.Contains("min server memory (MB)", minMem.CopyPasteSql);
+    }
+
+    // ── Affordance model: Copy + Apply (MAXDOP/CTFP), Copy-only (memory), NOT incidents ──
+
+    private static RecommendationCardViewModel Card(RecommendationItem item) => new(item, "SQL2022");
+
+    [Fact]
+    public void MaxdopCard_ShowsCopyFixAndApply_NotIncident()
+    {
+        var item = new RecommendationItem
+        {
+            CanonicalSeverity = CanonicalSeverity.Warning,
+            RawSeverity = 0.4,
+            Source = RecommendationSource.Engine,
+            Setting = RecommendationSetting.None,
+            IsServerConfigAdvisory = true,
+            Title = "MAXDOP is 0 — SQL2022",
+            CopyPasteSql = "EXEC sys.sp_configure N'max degree of parallelism', 8;\nRECONFIGURE;",
+            Remediation = new RemediationAction("SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+                ServerConfigTargets: new[] { new ServerConfigTarget(ServerConfigSetting.Maxdop, 0, 8) }),
+            StoryPathHash = "h"
+        };
+        var card = Card(item);
+
+        Assert.False(card.IsIncident);
+        Assert.False(card.ShowOpenInActiveQueries);
+        Assert.False(card.ShowAskAi);
+        Assert.True(card.ShowCopyFix);
+        Assert.True(card.ShowApply);
+    }
+
+    [Fact]
+    public void MaxMemoryCard_ShowsCopyFixOnly_NoApply_NotIncident()
+    {
+        // The advise-only memory card carries NO Remediation, but IsServerConfigAdvisory keeps it a
+        // config fix (Copy fix) rather than a time-bound incident — and Apply is hidden (no action).
+        var item = new RecommendationItem
+        {
+            CanonicalSeverity = CanonicalSeverity.Warning,
+            RawSeverity = 0.4,
+            Source = RecommendationSource.Engine,
+            Setting = RecommendationSetting.None,
+            IsServerConfigAdvisory = true,
+            Title = "max server memory is unconfigured — SQL2022",
+            CopyPasteSql = "EXEC sys.sp_configure N'max server memory (MB)', 28672;\nRECONFIGURE;",
+            Remediation = null,
+            StoryPathHash = "h"
+        };
+        var card = Card(item);
+
+        Assert.False(card.IsIncident);               // NOT a time-bound incident
+        Assert.False(card.ShowOpenInActiveQueries);  // no incident affordances
+        Assert.False(card.ShowAskAi);
+        Assert.True(card.ShowCopyFix);               // copy-paste shown
+        Assert.False(card.ShowApply);                // advise-only — no Apply
+    }
+}

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -210,7 +210,8 @@ public class AnalysisService
                     FactRemediation.BuildAction(finding)
                     ?? FactRemediation.BuildRcsiAction(finding)
                     ?? FactRemediation.BuildClearPlanAction(finding)
-                    ?? FactRemediation.BuildFileAutogrowthAction(finding); // WS3: advisory only (no handler -> no Apply); carried for the read-time copy-paste
+                    ?? FactRemediation.BuildFileAutogrowthAction(finding) // WS3: advisory only (no handler -> no Apply); carried for the read-time copy-paste
+                    ?? FactRemediation.BuildServerConfigAction(finding); // WS3: server-level config — MAXDOP/CTFP Apply-able, memory advise-only
             }
 
             // 7. Insert the survivors in one batched pass, persisting remediation_action_json

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -62,6 +62,15 @@ public class SqlServerDrillDownCollector
                 if (pathKeys.Contains("FILE_AUTOGROWTH_PERCENT"))
                     await CollectAutogrowthPercentFiles(finding, context);
 
+                /* WS3: the server-config drill-down is a single cheap config-table read and is
+                   required to build the SERVER_CONFIG Apply/copy-paste action for a CONFIG_*
+                   finding, which scores 0.4 (advisory). Collect it regardless of the 0.5 display
+                   gate, like the two config drill-downs above. Only the bad setting that rooted
+                   THIS finding is emitted (the engine roots one CONFIG_* fact per finding). */
+                if (pathKeys.Contains("CONFIG_MAXDOP") || pathKeys.Contains("CONFIG_CTFP")
+                    || pathKeys.Contains("CONFIG_MAX_MEMORY_MB") || pathKeys.Contains("CONFIG_MIN_MAX_MEMORY_NARROW"))
+                    await CollectServerConfig(finding, context, pathKeys);
+
                 // Below the 0.5 display gate, only the cheap config drill-down above runs;
                 // the expensive collectors (plan fetches, multi-row reads) are skipped.
                 if (finding.Severity < 0.5)
@@ -882,6 +891,99 @@ ORDER BY total_size_mb DESC;";
 
         if (items.Count > 0)
             finding.DrillDown!["autogrowth_percent_files"] = items;
+    }
+
+    /// <summary>
+    /// Emits the <c>server_config</c> drill-down for a CONFIG_* finding (WS3): the single bad
+    /// server-level setting that rooted this finding, with its latest <c>value_in_use</c> plus the
+    /// server's <c>engine_edition</c> and <c>cores_per_socket</c> (needed to compute the
+    /// edition-aware, core-capped MAXDOP recommendation in
+    /// <see cref="FactRemediation.ExtractServerConfigTargets"/>). The structured fields
+    /// (<c>setting</c>, <c>current_value</c>, <c>edition</c>, <c>cores_per_socket</c>) are what the
+    /// shared extractor reads; nothing here is executed. The four CONFIG_* keys root SEPARATE
+    /// findings, so each finding emits exactly the one row for its own setting.
+    /// </summary>
+    private async Task CollectServerConfig(AnalysisFinding finding, AnalysisContext context, HashSet<string> pathKeys)
+    {
+        using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        // Latest value per requested config (ROW_NUMBER, not TOP N — same dedup correctness as the
+        // fact collector), plus the latest server_properties row for edition + cores-per-socket.
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+;WITH latest_config AS (
+    SELECT
+        configuration_name,
+        CAST(value_in_use AS BIGINT) AS value_in_use,
+        ROW_NUMBER() OVER (PARTITION BY configuration_name ORDER BY collection_time DESC) AS rn
+    FROM config.server_configuration_history
+    WHERE configuration_name IN (
+        'cost threshold for parallelism',
+        'max degree of parallelism',
+        'max server memory (MB)',
+        'min server memory (MB)'
+    )
+)
+SELECT
+    configuration_name,
+    value_in_use
+FROM latest_config
+WHERE rn = 1;
+
+SELECT TOP (1)
+    engine_edition,
+    cores_per_socket
+FROM collect.server_properties
+ORDER BY collection_time DESC;";
+
+        long? ctfp = null, maxdop = null, maxMem = null, minMem = null;
+        int edition = 0, coresPerSocket = 0;
+
+        using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                var name = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                var value = reader.IsDBNull(1) ? 0L : Convert.ToInt64(reader.GetValue(1));
+                switch (name)
+                {
+                    case "cost threshold for parallelism": ctfp = value; break;
+                    case "max degree of parallelism": maxdop = value; break;
+                    case "max server memory (MB)": maxMem = value; break;
+                    case "min server memory (MB)": minMem = value; break;
+                }
+            }
+
+            if (await reader.NextResultAsync() && await reader.ReadAsync())
+            {
+                edition = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
+                coresPerSocket = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
+            }
+        }
+
+        var items = new List<object>();
+
+        // Emit ONLY the setting that rooted this finding (the engine roots one CONFIG_* per finding).
+        // edition / cores_per_socket ride every row (the extractor uses them only for MAXDOP).
+        if (pathKeys.Contains("CONFIG_MAXDOP") && maxdop is { } md)
+            items.Add(new { setting = "maxdop", current_value = md, edition, cores_per_socket = coresPerSocket });
+
+        if (pathKeys.Contains("CONFIG_CTFP") && ctfp is { } ct)
+            items.Add(new { setting = "ctfp", current_value = ct, edition, cores_per_socket = coresPerSocket });
+
+        if (pathKeys.Contains("CONFIG_MAX_MEMORY_MB") && maxMem is { } mx)
+            items.Add(new { setting = "max_memory", current_value = mx, edition, cores_per_socket = coresPerSocket });
+
+        // For the narrow-memory finding the bad value the operator acts on is MIN server memory
+        // (lower it); carry it as the min_memory target.
+        if (pathKeys.Contains("CONFIG_MIN_MAX_MEMORY_NARROW") && minMem is { } mn)
+            items.Add(new { setting = "min_memory", current_value = mn, edition, cores_per_socket = coresPerSocket });
+
+        if (items.Count > 0)
+            finding.DrillDown!["server_config"] = items;
     }
 
     private sealed class ConfigIssueRow

--- a/Dashboard/Analysis/SqlServerFactCollector.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.cs
@@ -259,50 +259,79 @@ AND   collection_time <= @endTime";
             await connection.OpenAsync();
 
             using var cmd = connection.CreateCommand();
+            // Latest value PER configuration_name (ROW_NUMBER, not TOP N): server_configuration_history
+            // accumulates a row per collection, so a naive TOP-N-ORDER-BY-time returns the newest N
+            // ROWS — which collapses to one config when collections are frequent, silently dropping
+            // settings. Partition by name and take rn = 1 so each requested setting is its latest value.
             cmd.CommandText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT TOP 4
-    configuration_name,
-    CAST(value_in_use AS BIGINT) AS value_in_use
-FROM config.server_configuration_history
-WHERE configuration_name IN (
-    'cost threshold for parallelism',
-    'max degree of parallelism',
-    'max server memory (MB)',
-    'max worker threads'
+;WITH latest AS (
+    SELECT
+        configuration_name,
+        CAST(value_in_use AS BIGINT) AS value_in_use,
+        ROW_NUMBER() OVER (PARTITION BY configuration_name ORDER BY collection_time DESC) AS rn
+    FROM config.server_configuration_history
+    WHERE configuration_name IN (
+        'cost threshold for parallelism',
+        'max degree of parallelism',
+        'max server memory (MB)',
+        'min server memory (MB)',
+        'max worker threads'
+    )
 )
-ORDER BY collection_time DESC";
+SELECT
+    configuration_name,
+    value_in_use
+FROM latest
+WHERE rn = 1";
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            // max/min server memory are read alongside the rooted CONFIG_* facts so the
+            // narrow-memory derivation below can compare them without a second query.
+            double? maxMemoryMb = null;
+            double? minMemoryMb = null;
+
+            using (var reader = await cmd.ExecuteReaderAsync())
             {
-                var configName = reader.GetString(0);
-                var value = Convert.ToDouble(reader.GetValue(1));
-
-                var factKey = configName switch
+                while (await reader.ReadAsync())
                 {
-                    "cost threshold for parallelism" => "CONFIG_CTFP",
-                    "max degree of parallelism" => "CONFIG_MAXDOP",
-                    "max server memory (MB)" => "CONFIG_MAX_MEMORY_MB",
-                    "max worker threads" => "CONFIG_MAX_WORKER_THREADS",
-                    _ => null
-                };
+                    var configName = reader.GetString(0);
+                    var value = Convert.ToDouble(reader.GetValue(1));
 
-                if (factKey == null) continue;
+                    if (configName == "max server memory (MB)") maxMemoryMb = value;
+                    if (configName == "min server memory (MB)") minMemoryMb = value;
 
-                facts.Add(new Fact
-                {
-                    Source = "config",
-                    Key = factKey,
-                    Value = value,
-                    ServerId = context.ServerId,
-                    Metadata = new Dictionary<string, double>
+                    var factKey = configName switch
                     {
-                        ["value_in_use"] = value
-                    }
-                });
+                        "cost threshold for parallelism" => "CONFIG_CTFP",
+                        "max degree of parallelism" => "CONFIG_MAXDOP",
+                        "max server memory (MB)" => "CONFIG_MAX_MEMORY_MB",
+                        "min server memory (MB)" => "CONFIG_MIN_MEMORY_MB",
+                        "max worker threads" => "CONFIG_MAX_WORKER_THREADS",
+                        _ => null
+                    };
+
+                    if (factKey == null) continue;
+
+                    facts.Add(new Fact
+                    {
+                        Source = "config",
+                        Key = factKey,
+                        Value = value,
+                        ServerId = context.ServerId,
+                        Metadata = new Dictionary<string, double>
+                        {
+                            ["value_in_use"] = value
+                        }
+                    });
+                }
             }
+
+            // CONFIG_MIN_MAX_MEMORY_NARROW: emitted only when max is configured AND min is pinned
+            // near it (shared rule so Dashboard/Lite agree).
+            var narrow = FactRemediation.BuildNarrowMemoryFact(context.ServerId, maxMemoryMb, minMemoryMb);
+            if (narrow is not null)
+                facts.Add(narrow);
         }
         catch (Exception ex)
         {

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -146,7 +146,12 @@ namespace PerformanceMonitorDashboard.Controls
         /// </summary>
         private bool HasStructuredFixAction =>
             (Item.Remediation?.DbConfigTargets is { Count: > 0 }) ||
-            (Item.Remediation?.FileGrowthTargets is { Count: > 0 });
+            (Item.Remediation?.FileGrowthTargets is { Count: > 0 }) ||
+            // WS3 server-level config (MAXDOP/CTFP carry a typed ServerConfigTargets Apply action;
+            // the advise-only memory cards carry no action but set IsServerConfigAdvisory so they
+            // still read as Copy-only config fixes, not incidents).
+            (Item.Remediation?.ServerConfigTargets is { Count: > 0 }) ||
+            Item.IsServerConfigAdvisory;
 
         /// <summary>
         /// Whether the "Open in Active Queries" deep-link button is shown — incidents only.

--- a/Dashboard/Services/DatabaseService.Remediation.cs
+++ b/Dashboard/Services/DatabaseService.Remediation.cs
@@ -957,6 +957,263 @@ AND   qs.collection_time =
             }
         }
 
+        // ── WS3: server-level config (sp_configure + RECONFIGURE) ───────────────────
+        //
+        // The sharp edges (get these EXACTLY right):
+        //
+        //  1. The sp_configure NAME is a HARDCODED compile-time literal selected by the
+        //     ServerConfigSetting enum (SpConfigureNameLiteral) — NEVER built from data. The value
+        //     is bound as an @value INT parameter (range-validated in C# first). There is no path
+        //     that concatenates either into the batch.
+        //
+        //  2. ONLY Maxdop + CostThreshold are executable. MaxServerMemory / MinServerMemory throw
+        //     before any gate/mutation — their right value is RAM/workload-dependent and must never
+        //     be applied from a guessed number (advise-only; the card is copy-paste only).
+        //
+        //  3. Permission gate = the NAMED server permission ALTER SETTINGS (fail-closed), OR the
+        //     sysadmin / serveradmin fixed roles (which can sp_configure even without the named
+        //     perm). Deny → PermissionDenied with grant guidance, no elevation, no retry. The
+        //     generic (NULL,NULL,'ALTER') token returns NULL even for sysadmin
+        //     (project_has_perms_by_name_alter_form), so it is NOT used here.
+        //
+        // Single-connection self-gating (R2-MOD-1): the gate read + the show-advanced-options +
+        // RECONFIGURE + the sp_configure of the target + RECONFIGURE all run on ONE open connection
+        // to the TARGET server (server-scoped — no InitialCatalog retarget). GateSpid == ExecSpid
+        // proves it. Plain RECONFIGURE (not WITH OVERRIDE).
+
+        /// <summary>The sane inclusive value range for an executable server-config setting (defense-in-depth before binding @value).</summary>
+        private static (long Min, long Max) ServerConfigValueRange(ServerConfigSetting setting) => setting switch
+        {
+            ServerConfigSetting.Maxdop => (0, 32767),
+            ServerConfigSetting.CostThreshold => (0, 32767),
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Only MAXDOP / CostThreshold are executable.")
+        };
+
+        /// <summary>
+        /// The HARDCODED <c>sp_configure</c> name literal for the two EXECUTABLE settings. This is
+        /// the entire selection surface (§1) — nothing here comes from data. Memory settings throw:
+        /// they are advise-only and must never reach the executor.
+        /// </summary>
+        internal static string SpConfigureNameLiteral(ServerConfigSetting setting) => setting switch
+        {
+            ServerConfigSetting.Maxdop => "max degree of parallelism",
+            ServerConfigSetting.CostThreshold => "cost threshold for parallelism",
+            ServerConfigSetting.MaxServerMemory => throw new ArgumentOutOfRangeException(nameof(setting), setting, "max server memory is advise-only — never applied."),
+            ServerConfigSetting.MinServerMemory => throw new ArgumentOutOfRangeException(nameof(setting), setting, "min server memory is advise-only — never applied."),
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown ServerConfigSetting")
+        };
+
+        /// <summary>Whether a server-config setting can be applied (Maxdop / CostThreshold) vs advise-only (memory).</summary>
+        internal static bool IsExecutableServerConfig(ServerConfigSetting setting) =>
+            setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold;
+
+        /// <summary>
+        /// Read-only display probe (advisory only). Runs on the monitoring connection to the target
+        /// server (no retarget); reads the named/role permission + the live current value. Mirrors
+        /// <see cref="PreflightDbConfigAsync"/>. Advise-only settings report Executable = false.
+        /// </summary>
+        internal async Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            var gate = await ReadServerConfigGateAsync(connection, setting, ct).ConfigureAwait(false);
+            var executable = IsExecutableServerConfig(setting);
+
+            return new ServerConfigPreflight
+            {
+                Setting = setting,
+                RecommendedValue = recommendedValue,
+                Executable = executable,
+                HasPermission = gate.HasPermission,
+                CurrentValue = gate.CurrentValue,
+                ExecutingLogin = gate.ExecutingLogin,
+                // "Already desired" only applies to executable settings (we never apply memory).
+                AlreadyInDesiredState = executable && gate.CurrentValue == recommendedValue
+            };
+        }
+
+        /// <summary>
+        /// Self-gating server-config apply (R2-MOD-1). The gate (named ALTER SETTINGS / sysadmin /
+        /// serveradmin + live current value) and the
+        /// <c>sp_configure 'show advanced options',1; RECONFIGURE; sp_configure '&lt;hardcoded&gt;',@value; RECONFIGURE;</c>
+        /// batch run on ONE open connection to the target server, no re-open between gate and
+        /// mutation (closes the TOCTOU). The name is a HARDCODED literal selected by
+        /// <paramref name="setting"/>; the value is bound as @value INT (range-validated first).
+        /// IsDestructive context = false (online metadata change). Only Maxdop / CostThreshold are
+        /// executable — memory settings return an error outcome WITHOUT touching the server.
+        /// </summary>
+        internal async Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+        {
+            // (0) Advise-only guard — BEFORE any connection. max/min server memory must never be
+            // applied from a guessed value; the handler also blocks them, this is defense-in-depth.
+            if (!IsExecutableServerConfig(setting))
+            {
+                return new ServerConfigOutcome
+                {
+                    Setting = setting,
+                    Status = RemediationStatus.Blocked,
+                    Applied = false,
+                    Message = $"{FactRemediation.SpConfigureName(setting)} is advise-only — its correct value is RAM/workload-dependent and is never applied automatically. Copy the statement and set the value you choose.",
+                    PriorValue = null
+                };
+            }
+
+            // (0b) Range validation — defense-in-depth before binding @value, where the literal is
+            // sent. A future producer change can never push an out-of-range value to sp_configure.
+            var (min, max) = ServerConfigValueRange(setting);
+            if (value < min || value > max)
+            {
+                return new ServerConfigOutcome
+                {
+                    Setting = setting,
+                    Status = RemediationStatus.Error,
+                    Applied = false,
+                    Message = $"Recommended value {value} for {FactRemediation.SpConfigureName(setting)} is outside the valid range [{min}, {max}]; no change made.",
+                    PriorValue = null
+                };
+            }
+
+            // ONE connection to the target server (server-scoped — no InitialCatalog retarget). Gate
+            // + RECONFIGUREs + sp_configure all ride this one open connection (R2-MOD-1).
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await ApplySessionOptionsAsync(connection, ct).ConfigureAwait(false);
+
+            var gate = await ReadServerConfigGateAsync(connection, setting, ct).ConfigureAwait(false);
+
+            // (1) Permission — fail closed with grant guidance, no elevation, no retry.
+            if (!gate.HasPermission)
+            {
+                return new ServerConfigOutcome
+                {
+                    Setting = setting,
+                    Status = RemediationStatus.PermissionDenied,
+                    Applied = false,
+                    ExecutingLogin = gate.ExecutingLogin,
+                    PriorValue = gate.CurrentValue,
+                    Message = $"The monitoring login '{gate.ExecutingLogin}' lacks ALTER SETTINGS on this server, which sp_configure requires. " +
+                              $"GRANT ALTER SETTINGS TO [{gate.ExecutingLogin}]; on the target server (or use a sysadmin/serveradmin login). No change was made.",
+                    GateSpid = gate.Spid
+                };
+            }
+
+            // (2) Freshness / idempotency — already at the recommended value => skip, no sp_configure.
+            if (gate.CurrentValue == value)
+            {
+                return new ServerConfigOutcome
+                {
+                    Setting = setting,
+                    Status = RemediationStatus.Skipped,
+                    Applied = false,
+                    ExecutingLogin = gate.ExecutingLogin,
+                    PriorValue = gate.CurrentValue,
+                    Message = $"{FactRemediation.SpConfigureName(setting)} is already {value}; nothing to do.",
+                    GateSpid = gate.Spid
+                };
+            }
+
+            // Gate passed. Build the batch: the name is a HARDCODED literal selected by the enum;
+            // the value is bound as @value INT. show advanced options is required because both
+            // MAXDOP and CTFP are advanced. Plain RECONFIGURE (not WITH OVERRIDE).
+            var nameLiteral = SpConfigureNameLiteral(setting);
+            var statement =
+                "EXEC sys.sp_configure N'show advanced options', 1; RECONFIGURE; " +
+                $"EXEC sys.sp_configure N'{nameLiteral}', @value; RECONFIGURE;";
+
+            int? execSpid;
+            try
+            {
+                using var exec = connection.CreateCommand();
+                exec.CommandTimeout = RemediationCommandTimeoutSeconds;
+                exec.CommandText = statement + " SELECT exec_spid = @@SPID;";
+                exec.Parameters.Add(new SqlParameter("@value", SqlDbType.Int) { Value = (int)value });
+                var raw = await exec.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                execSpid = raw is null || raw is DBNull ? (int?)null : Convert.ToInt32(raw);
+            }
+            catch (SqlException ex)
+            {
+                var status = ex.Number is 297 or 15247 or 229 ? RemediationStatus.PermissionDenied : RemediationStatus.Error;
+                return new ServerConfigOutcome
+                {
+                    Setting = setting,
+                    Status = status,
+                    Applied = false,
+                    ExecutingLogin = gate.ExecutingLogin,
+                    PriorValue = gate.CurrentValue,
+                    Message = $"sp_configure '{FactRemediation.SpConfigureName(setting)}' failed (error {ex.Number}): {ex.Message}",
+                    GeneratedSql = statement,
+                    GateSpid = gate.Spid
+                };
+            }
+
+            return new ServerConfigOutcome
+            {
+                Setting = setting,
+                Status = RemediationStatus.Success,
+                Applied = true,
+                ExecutingLogin = gate.ExecutingLogin,
+                PriorValue = gate.CurrentValue,
+                Message = $"Set {FactRemediation.SpConfigureName(setting)} to {value} (was {gate.CurrentValue}).",
+                GeneratedSql = statement,
+                GateSpid = gate.Spid,
+                ExecSpid = execSpid
+            };
+        }
+
+        /// <summary>
+        /// The server-config gate read: identity + named ALTER SETTINGS / sysadmin / serveradmin
+        /// permission + the live current value_in_use for the setting, in one round-trip on the open
+        /// connection. The configuration NAME used in the live-value lookup is a HARDCODED literal
+        /// selected by the enum (constant SQL, never data), bound only as the @config_name read
+        /// parameter (read-only lookup — not the mutation path). Fail-closed permission.
+        /// </summary>
+        private static async Task<ServerConfigGateReading> ReadServerConfigGateAsync(SqlConnection connection, ServerConfigSetting setting, CancellationToken ct)
+        {
+            // The configuration name for the read-only current-value lookup. For advise-only memory
+            // settings (which never apply) we still want a correct prior-value, so use the shared
+            // display name; for executable settings this equals the hardcoded literal.
+            var configName = FactRemediation.SpConfigureName(setting);
+
+            using var command = connection.CreateCommand();
+            command.CommandTimeout = RemediationCommandTimeoutSeconds;
+            // Named ALTER SETTINGS (fail-closed via ISNULL) OR the sysadmin/serveradmin fixed roles
+            // (which can sp_configure without the named perm). The generic (NULL,NULL,'ALTER') token
+            // is intentionally NOT used (returns NULL even for sysadmin).
+            command.CommandText = @"
+SELECT
+    executing_login = SUSER_SNAME(),
+    has_permission = CONVERT(int,
+        CASE WHEN ISNULL(HAS_PERMS_BY_NAME(NULL, NULL, 'ALTER SETTINGS'), 0) = 1
+                  OR IS_SRVROLEMEMBER('sysadmin') = 1
+                  OR IS_SRVROLEMEMBER('serveradmin') = 1
+             THEN 1 ELSE 0 END),
+    current_value = ISNULL((SELECT CONVERT(bigint, c.value_in_use) FROM sys.configurations AS c WHERE c.name = @config_name), 0),
+    spid = @@SPID;";
+            command.Parameters.Add(new SqlParameter("@config_name", SqlDbType.NVarChar, 128) { Value = configName });
+
+            using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                return new ServerConfigGateReading();
+
+            return new ServerConfigGateReading
+            {
+                ExecutingLogin = reader.IsDBNull(0) ? null : reader.GetString(0),
+                HasPermission = !reader.IsDBNull(1) && reader.GetInt32(1) == 1,
+                CurrentValue = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2)),
+                Spid = reader.IsDBNull(3) ? (int?)null : Convert.ToInt32(reader.GetInt16(3))
+            };
+        }
+
+        private sealed class ServerConfigGateReading
+        {
+            public string? ExecutingLogin { get; init; }
+            public bool HasPermission { get; init; }
+            public long CurrentValue { get; init; }
+            public int? Spid { get; init; }
+        }
+
         /// <summary>
         /// The DB-config gate read: identity + parameterized sys.databases existence +
         /// ALTER permission + the live current setting value, in one round-trip on the

--- a/Dashboard/Services/Recommendations/RecommendationItem.cs
+++ b/Dashboard/Services/Recommendations/RecommendationItem.cs
@@ -145,6 +145,17 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         public RecommendationSetting Setting { get; set; }
 
         /// <summary>
+        /// True for the four SERVER-LEVEL config cards (WS3: MAXDOP / CTFP / max &amp; min server
+        /// memory). These are server-scoped (<see cref="Setting"/> stays
+        /// <see cref="RecommendationSetting.None"/> so they never de-dupe with legacy per-db rows),
+        /// but they are standing CONFIG FIXES — Copy fix (and, for MAXDOP/CTFP, Apply) — NOT
+        /// time-bound incidents. The view-model treats this flag as a structured-fix signal so the
+        /// two advise-only memory cards (which carry no <see cref="Remediation"/>) still read as
+        /// config fixes (Copy fix, no incident affordances) rather than incidents.
+        /// </summary>
+        public bool IsServerConfigAdvisory { get; set; }
+
+        /// <summary>
         /// UTC start of the time window the finding pertains to (engine: the analysis
         /// <c>TimeRangeStart</c>; legacy: the <c>critical_issues.log_date</c>). Raw - no grace
         /// window is applied here; the navigation handler widens it (+/- 1h) and converts to

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -135,6 +135,51 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         /// </summary>
         internal static IReadOnlyList<RecommendationItem> MapEngineFindings(AnalysisFinding finding)
         {
+            // WS3 server-level config: a CONFIG_* finding whose persisted action carries
+            // ServerConfigTargets fans into one card per target. MAXDOP/CTFP cards carry a
+            // single-target SERVER_CONFIG Apply; the two advise-only memory cards carry only
+            // CopyPasteSql (no Apply). All four are server-scoped (Setting stays None — they don't
+            // de-dupe with legacy per-db rows) but are flagged IsServerConfigAdvisory so the
+            // view-model treats them as Copy/Apply config fixes, not incidents.
+            if (finding.Remediation is { ServerConfigTargets: { Count: > 0 } serverTargets } serverAction &&
+                string.Equals(serverAction.FactKey, "SERVER_CONFIG", StringComparison.Ordinal))
+            {
+                var band = RecommendationDeduper.FromEngineSeverity(finding.Severity);
+                var adviceText = ComposeEngineAdvice(FactAdvice.GetForFactKey(finding.RootFactKey));
+                var items = new List<RecommendationItem>(serverTargets.Count);
+
+                foreach (var target in serverTargets)
+                {
+                    var executable = target.Setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold;
+                    items.Add(new RecommendationItem
+                    {
+                        Source = RecommendationSource.Engine,
+                        CanonicalSeverity = band,
+                        RawSeverity = finding.Severity,
+                        Database = null,                       // server-scoped
+                        Title = ServerConfigCardTitle(target, finding.ServerName),
+                        ProblemArea = finding.Category,
+                        AdviceText = adviceText,
+                        CopyPasteSql = FactRemediation.BuildSpConfigureStatement(target.Setting, target.RecommendedValue),
+                        // MAXDOP/CTFP carry a single-target Apply (FactKey SERVER_CONFIG, routed to the
+                        // server-config handler); the memory cards carry no action (advise-only → no Apply button).
+                        Remediation = executable
+                            ? new RemediationAction("SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+                                ServerConfigTargets: new[] { target })
+                            : null,
+                        StoryPathHash = finding.StoryPathHash,
+                        StoryPath = finding.StoryPath,
+                        Setting = RecommendationSetting.None,  // server-level — never de-dupes with legacy
+                        IsServerConfigAdvisory = true,
+                        WindowStartUtc = AsUtc(finding.TimeRangeStart),
+                        WindowEndUtc = AsUtc(finding.TimeRangeEnd)
+                    });
+                }
+
+                if (items.Count > 0)
+                    return items;
+            }
+
             if (string.Equals(finding.RootFactKey, "DB_CONFIG", StringComparison.Ordinal) &&
                 finding.Remediation is { } remediation &&
                 ((remediation.DbConfigTargets is { Count: > 0 }) || (remediation.RcsiTargets is { Count: > 0 })))
@@ -258,6 +303,24 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 _ => "Database configuration issue"
             };
             return string.IsNullOrEmpty(target.Database) ? what : $"{what} — {target.Database}";
+        }
+
+        /// <summary>
+        /// The per-card title for a fanned-out SERVER_CONFIG target (WS3):
+        /// "&lt;what&gt; — &lt;server&gt;" (e.g. "MAXDOP is 0 — SQL2022"), so each server-level
+        /// card reads as its own specific misconfiguration. The server name is appended when known.
+        /// </summary>
+        private static string ServerConfigCardTitle(ServerConfigTarget target, string? serverName)
+        {
+            var what = target.Setting switch
+            {
+                ServerConfigSetting.Maxdop => $"MAXDOP is {target.CurrentValue}",
+                ServerConfigSetting.CostThreshold => $"Cost Threshold for Parallelism is {target.CurrentValue}",
+                ServerConfigSetting.MaxServerMemory => "max server memory is unconfigured",
+                ServerConfigSetting.MinServerMemory => "min server memory is pinned near max",
+                _ => "Server configuration issue"
+            };
+            return string.IsNullOrEmpty(serverName) ? what : $"{what} — {serverName}";
         }
 
         /// <summary>

--- a/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/DatabaseServiceRemediationExecutor.cs
@@ -58,6 +58,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public Task<FileGrowthOutcome> SetFileGrowthAsync(string database, string logicalFileName, int growthMb, RemediationIdentity identity, CancellationToken ct)
             => _databaseService.SetFileGrowthAsync(database, logicalFileName, growthMb, identity, ct);
 
+        public Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct)
+            => _databaseService.PreflightServerConfigAsync(setting, recommendedValue, ct);
+
+        public Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct)
+            => _databaseService.SetServerConfigAsync(setting, value, identity, ct);
+
         public Task<ClearPlanOutcome> ClearProcCacheAsync(string queryHash, RemediationIdentity identity, CancellationToken ct)
             => _databaseService.ClearProcCacheAsync(queryHash, identity, ct);
 

--- a/Dashboard/Services/Remediation/IRemediationExecutor.cs
+++ b/Dashboard/Services/Remediation/IRemediationExecutor.cs
@@ -104,6 +104,25 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         Task<FileGrowthOutcome> SetFileGrowthAsync(string database, string logicalFileName, int growthMb, RemediationIdentity identity, CancellationToken ct);
 
         /// <summary>
+        /// Read-only display probe for one server-config target (named/role permission, live
+        /// current value, executable flag). Advisory only — does NOT authorise a mutation. Runs on
+        /// the monitoring connection to the target server (server-scoped, no retarget).
+        /// </summary>
+        Task<ServerConfigPreflight> PreflightServerConfigAsync(ServerConfigSetting setting, long recommendedValue, CancellationToken ct);
+
+        /// <summary>
+        /// Self-gating server-config apply (WS3). R2-MOD-1: the gate (named ALTER SETTINGS /
+        /// sysadmin / serveradmin + live current value) and the
+        /// <c>sp_configure 'show advanced options',1; RECONFIGURE; sp_configure '&lt;hardcoded&gt;',@value; RECONFIGURE;</c>
+        /// batch run on ONE open connection to the target server (server-scoped — no retarget, no
+        /// re-open between gate and mutation). The sp_configure NAME is a HARDCODED literal selected
+        /// by <paramref name="setting"/>; the value is bound as @value INT (range-validated first).
+        /// ONLY Maxdop / CostThreshold are executable; the two memory settings return an error
+        /// outcome WITHOUT touching the server (advise-only). Emits GateSpid/ExecSpid.
+        /// </summary>
+        Task<ServerConfigOutcome> SetServerConfigAsync(ServerConfigSetting setting, long value, RemediationIdentity identity, CancellationToken ct);
+
+        /// <summary>
         /// Self-gating clear-cached-plan (DBCC FREEPROCCACHE). On ONE open monitoring
         /// connection to the TARGET server (FREEPROCCACHE is server-scoped — no
         /// InitialCatalog retarget), in order: the NAMED ALTER SERVER STATE permission

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -62,7 +62,10 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             // FileAutogrowthHandler (FILE_AUTOGROWTH_PERCENT) is always-safe (metadata-only,
             // online, non-destructive — same class as DbConfigHandler) and rides its own fact
             // key, so it never crosses the destructive RCSI/CLEAR_PLAN handlers.
-            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler(), new ClearPlanHandler(), new FileAutogrowthHandler() });
+            // ServerConfigHandler (SERVER_CONFIG, WS3) is always-safe too (sp_configure MAXDOP/CTFP
+            // + RECONFIGURE — online metadata; the advise-only memory settings never mutate) and
+            // rides its OWN fact key, so it never crosses the destructive handlers either.
+            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler(), new ClearPlanHandler(), new FileAutogrowthHandler(), new ServerConfigHandler() });
             _executorFactory = server =>
                 new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
             _auditFailureClassifier = (server, ct) =>
@@ -326,6 +329,26 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                     });
                 }
             }
+            else if (action.ServerConfigTargets is { Count: > 0 } serverTargets)
+            {
+                // SERVER_CONFIG (WS3) rides ServerConfigTargets (the other target lists are empty for
+                // it). One row per setting; the always-safe sp_configure fix is non-destructive, so no
+                // two-sided Risks (RequiresInformedConsent stays false). Memory targets render with an
+                // advise-only disposition (they never run).
+                confirmTargets = new List<RemediationConfirmTarget>(serverTargets.Count);
+                for (var i = 0; i < serverTargets.Count; i++)
+                {
+                    var t = serverTargets[i];
+                    var pf = i < preflight.Targets.Count ? preflight.Targets[i] : null;
+                    confirmTargets.Add(new RemediationConfirmTarget
+                    {
+                        Database = "",   // server-scoped — no database column
+                        StatusTitle = $"{ServerConfigHandler.SettingTitle(t.Setting)} {t.CurrentValue} → {t.RecommendedValue}",
+                        Disposition = pf?.Disposition ?? RemediationDisposition.Error,
+                        DispositionMessage = pf?.Message
+                    });
+                }
+            }
             else
             {
                 confirmTargets = new List<RemediationConfirmTarget>(action.Targets.Count);
@@ -408,6 +431,21 @@ namespace PerformanceMonitorDashboard.Services.Remediation
                        .Append('\n');
                 }
                 return sb3.ToString().TrimEnd('\n');
+            }
+
+            // SERVER_CONFIG: render one sp_configure + RECONFIGURE per setting (apply-only — no
+            // un-apply branch). Display only; the executor builds its own batch with a bound @value
+            // and never executes this text. The shared renderer keeps it byte-identical to the
+            // reader copy-paste.
+            if (action.ServerConfigTargets is { Count: > 0 } serverTargets)
+            {
+                var sb4 = new StringBuilder();
+                foreach (var t in serverTargets)
+                {
+                    sb4.Append(FactRemediation.BuildSpConfigureStatement(t.Setting, t.RecommendedValue))
+                       .Append('\n');
+                }
+                return sb4.ToString().TrimEnd('\n');
             }
 
             var proc = isUnapply ? "sp_query_store_unforce_plan" : "sp_query_store_force_plan";

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -60,6 +60,12 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// <summary>DB_CONFIG: the target database was not found on the server (renamed/dropped) — blocked, no ALTER.</summary>
         BlockDatabaseNotFound,
 
+        /// <summary>
+        /// SERVER_CONFIG: the setting is advise-only (max/min server memory) — the executor refuses
+        /// to apply a guessed value, so the card is copy-paste only and never runs sp_configure.
+        /// </summary>
+        AdviseOnly,
+
         Error
     }
 
@@ -230,6 +236,63 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         public string? PriorValue { get; init; }
 
         /// <summary>The exact ALTER DATABASE … MODIFY FILE statement executed (audited generated_sql).</summary>
+        public string? GeneratedSql { get; init; }
+        public int? GateSpid { get; init; }
+        public int? ExecSpid { get; init; }
+    }
+
+    /// <summary>
+    /// Read-only display probe for one server-config target (advisory only — never the
+    /// authoritative gate; <see cref="IRemediationExecutor.SetServerConfigAsync"/> re-derives its
+    /// own gate on the mutating connection before any sp_configure). Mirrors
+    /// <see cref="DbConfigPreflight"/>. Memory settings are advise-only — <see cref="Executable"/>
+    /// is false and the executor refuses them.
+    /// </summary>
+    public sealed class ServerConfigPreflight
+    {
+        public ServerConfigSetting Setting { get; init; }
+
+        /// <summary>The recommended value WS3 would apply (MAXDOP/CTFP) or display (memory).</summary>
+        public long RecommendedValue { get; init; }
+
+        /// <summary>True for MAXDOP/CostThreshold; false for the advise-only memory settings.</summary>
+        public bool Executable { get; init; }
+
+        /// <summary>ISNULL(HAS_PERMS_BY_NAME(NULL,NULL,'ALTER SETTINGS'),0)=1 OR sysadmin/serveradmin.</summary>
+        public bool HasPermission { get; init; }
+
+        /// <summary>True when the live read shows the setting already at the recommended value (executable settings only).</summary>
+        public bool AlreadyInDesiredState { get; init; }
+
+        public string? ExecutingLogin { get; init; }
+
+        /// <summary>The current value read live (display/audit prior value).</summary>
+        public long CurrentValue { get; init; }
+
+        public RemediationDisposition Disposition { get; set; }
+        public string? Message { get; set; }
+    }
+
+    /// <summary>
+    /// Outcome of a single server-config <c>sp_configure</c>+<c>RECONFIGURE</c> attempt. The gate
+    /// (permission + live freshness) and the mutation run on ONE open connection;
+    /// <see cref="GateSpid"/>/<see cref="ExecSpid"/> prove they shared it (R2-MOD-1).
+    /// <see cref="GeneratedSql"/> is the exact batch executed. Mirrors <see cref="DbConfigOutcome"/>.
+    /// </summary>
+    public sealed class ServerConfigOutcome
+    {
+        public ServerConfigSetting Setting { get; init; }
+        public RemediationStatus Status { get; init; }
+
+        /// <summary>True only when an sp_configure actually ran and succeeded.</summary>
+        public bool Applied { get; init; }
+        public string? ExecutingLogin { get; init; }
+        public string? Message { get; init; }
+
+        /// <summary>The prior value, captured at the gate read (audit prior_value).</summary>
+        public long? PriorValue { get; init; }
+
+        /// <summary>The exact sp_configure + RECONFIGURE batch executed (audited generated_sql).</summary>
         public string? GeneratedSql { get; init; }
         public int? GateSpid { get; init; }
         public int? ExecSpid { get; init; }

--- a/Dashboard/Services/Remediation/ServerConfigHandler.cs
+++ b/Dashboard/Services/Remediation/ServerConfigHandler.cs
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Services.Remediation
+{
+    /// <summary>
+    /// Handler for SERVER_CONFIG findings (WS3): applies the two ALWAYS-SAFE server-level settings
+    /// — MAXDOP and Cost Threshold for Parallelism — one target at a time via
+    /// <c>sp_configure</c>+<c>RECONFIGURE</c>. max/min server memory are ADVISE-ONLY: their right
+    /// value is RAM/workload-dependent, so the handler records an advise-only outcome and NEVER runs
+    /// sp_configure for them (the executor refuses them too — defense-in-depth). This is APPLY-ONLY
+    /// for the executable settings: there is no sensible reverse (you would never re-introduce
+    /// MAXDOP 0 / CTFP 5), <see cref="SupportsUnapply"/> is false, and the prior value is recorded
+    /// in the audit row for any manual reversal.
+    ///
+    /// <para>
+    /// Structurally self-gating, exactly like <see cref="DbConfigHandler"/> /
+    /// <see cref="FileAutogrowthHandler"/>: <see cref="ApplyAsync"/> takes no preflight disposition
+    /// and trusts none. It hard-blocks every target when the audit table is absent (no mutation),
+    /// then delegates each executable target to <c>exec.SetServerConfigAsync</c>, which re-derives
+    /// the authoritative gate (named ALTER SETTINGS / sysadmin / serveradmin + live freshness) and
+    /// the sp_configure on ONE connection. One audit row is written per attempt.
+    /// </para>
+    /// </summary>
+    public sealed class ServerConfigHandler : IRemediationHandler
+    {
+        public string FactKey => "SERVER_CONFIG";
+
+        // sp_configure MAXDOP/CTFP + RECONFIGURE is an online metadata change — not destructive.
+        public bool IsDestructive => false;
+
+        // Apply-only: there is no sensible reverse (you would never re-introduce MAXDOP 0 / CTFP 5);
+        // the prior value is recorded in the audit row for manual back-out.
+        public bool SupportsUnapply => false;
+
+        /// <summary>Sentinel for the NOT-NULL target_database column (server-config rows have no database).</summary>
+        private const string ServerScopeSentinel = "(server)";
+
+        public async Task<PreflightResult> PreflightAsync(RemediationAction action, IRemediationExecutor exec, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+
+            var targets = new List<TargetPreflight>();
+            foreach (var t in ServerTargets(action))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                TargetPreflight pf;
+                try
+                {
+                    var probe = await exec.PreflightServerConfigAsync(t.Setting, t.RecommendedValue, ct).ConfigureAwait(false);
+                    pf = ToTargetPreflight(t, probe);
+                }
+                catch (Exception ex)
+                {
+                    pf = new TargetPreflight
+                    {
+                        Database = ServerScopeSentinel,
+                        Disposition = RemediationDisposition.Error,
+                        Message = ex.Message
+                    };
+                    targets.Add(pf);
+                    continue;
+                }
+
+                // Audit-table-absent is a server-wide hard block; it overrides any per-target
+                // disposition (no apply can be audited there). An advise-only target is never
+                // applied, so the absent-table block does not apply to it — it stays AdviseOnly.
+                if (!auditTableExists && IsExecutable(t.Setting))
+                {
+                    pf.Disposition = RemediationDisposition.BlockAuditTableAbsent;
+                    pf.Message = AuditAbsentMessage;
+                }
+
+                targets.Add(pf);
+            }
+
+            return new PreflightResult { Targets = targets, AuditTableExists = auditTableExists };
+        }
+
+        public Task<ApplyResult> ApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            if (action is null) throw new ArgumentNullException(nameof(action));
+            if (exec is null) throw new ArgumentNullException(nameof(exec));
+            if (identity is null) throw new ArgumentNullException(nameof(identity));
+            return RunApplyAsync(action, exec, identity, ct);
+        }
+
+        // Apply-only. Defensive: the UI gates Un-apply on SupportsUnapply==false, and
+        // RemediationApplyService short-circuits an un-apply for a non-supporting handler to a clean
+        // report (m-C), so this is never reached in practice.
+        public Task<ApplyResult> UnapplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+            => throw new NotSupportedException("Server-config fixes are apply-only; there is no un-apply for MAXDOP/CTFP.");
+
+        private static async Task<ApplyResult> RunApplyAsync(RemediationAction action, IRemediationExecutor exec, RemediationIdentity identity, CancellationToken ct)
+        {
+            var outcomes = new List<TargetOutcome>();
+            var serverTargets = ServerTargets(action);
+
+            // Advise-only memory targets never mutate and never need the audit table; record their
+            // outcome FIRST, independent of the audit-table state, so an absent table still yields a
+            // clean "advise-only" result for them (not a spurious block).
+            var executableTargets = new List<ServerConfigTarget>();
+            foreach (var t in serverTargets)
+            {
+                if (IsExecutable(t.Setting))
+                {
+                    executableTargets.Add(t);
+                    continue;
+                }
+
+                outcomes.Add(new TargetOutcome
+                {
+                    Database = ServerScopeSentinel,
+                    Status = RemediationStatus.Skipped,
+                    Message = AdviseOnlyMessage(t.Setting),
+                    AuditWritten = false,        // nothing ran — nothing to audit
+                    AppliedButUnlogged = false
+                });
+            }
+
+            if (executableTargets.Count == 0)
+                return new ApplyResult { Outcomes = outcomes };
+
+            // R2-MOD-2: audit-table-absent is a HARD BLOCK before any executable mutation. No
+            // sp_configure is attempted; no audit row is written (nowhere to write it).
+            var auditTableExists = await exec.AuditTableExistsAsync(ct).ConfigureAwait(false);
+            if (!auditTableExists)
+            {
+                foreach (var t in executableTargets)
+                {
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = ServerScopeSentinel,
+                        Status = RemediationStatus.Blocked,
+                        Message = AuditAbsentMessage,
+                        AuditWritten = false,
+                        AppliedButUnlogged = false
+                    });
+                }
+                return new ApplyResult { Outcomes = outcomes };
+            }
+
+            foreach (var t in executableTargets)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    // The executor re-derives the authoritative gate and runs sp_configure on one
+                    // connection — the handler cannot hand it a forged all-clear. The value is the
+                    // already-computed RecommendedValue (never recomputed here).
+                    var outcome = await exec.SetServerConfigAsync(t.Setting, t.RecommendedValue, identity, ct).ConfigureAwait(false);
+
+                    var written = await WriteAuditAsync(exec, identity, t, outcome.Status, outcome.Message, outcome.PriorValue, outcome.GeneratedSql, outcome.ExecutingLogin, ct).ConfigureAwait(false);
+
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = ServerScopeSentinel,
+                        Status = outcome.Status,
+                        Message = outcome.Message,
+                        ExecutingLogin = outcome.ExecutingLogin,
+                        AuditWritten = written,
+                        AppliedButUnlogged = outcome.Applied && !written
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Per-target independence: one target's failure never aborts the rest.
+                    var record = BuildRecord(identity, t, RemediationStatus.Error, ex.Message, priorValue: t.CurrentValue, generatedSql: null, executingLogin: null);
+                    var written = await RemediationAuditHelpers.TryWriteAuditSafeAsync(exec, record, ct).ConfigureAwait(false);
+                    outcomes.Add(new TargetOutcome
+                    {
+                        Database = ServerScopeSentinel,
+                        Status = RemediationStatus.Error,
+                        Message = ex.Message,
+                        AuditWritten = written,
+                        AppliedButUnlogged = false
+                    });
+                }
+            }
+
+            return new ApplyResult { Outcomes = outcomes };
+        }
+
+        private static async Task<bool> WriteAuditAsync(
+            IRemediationExecutor exec,
+            RemediationIdentity identity,
+            ServerConfigTarget target,
+            RemediationStatus status,
+            string? message,
+            long? priorValue,
+            string? generatedSql,
+            string? executingLogin,
+            CancellationToken ct)
+        {
+            var record = BuildRecord(identity, target, status, message, priorValue, generatedSql, executingLogin);
+            return await exec.WriteAuditAsync(record, ct).ConfigureAwait(false);
+        }
+
+        private static RemediationAuditRecord BuildRecord(
+            RemediationIdentity identity,
+            ServerConfigTarget target,
+            RemediationStatus status,
+            string? message,
+            long? priorValue,
+            string? generatedSql,
+            string? executingLogin)
+            => new()
+            {
+                OperatorIdentity = identity.OperatorIdentity,
+                ExecutingLogin = executingLogin,
+                TargetDatabase = ServerScopeSentinel,   // server-scoped; target_database is NOT NULL
+                FactKey = "SERVER_CONFIG",
+                QueryId = null,                          // SERVER_CONFIG rows have no query_id/plan_id
+                PlanId = null,
+                Action = AuditAction(target.Setting),
+                PriorValue = priorValue?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                GeneratedSql = generatedSql,
+                Result = RemediationAuditHelpers.AuditResult(status),
+                ErrorMessage = RemediationAuditHelpers.IsErrorish(status) ? message : null,
+                // The MAXDOP/CTFP fix is not destructive — never went through the informed-consent
+                // gate (regression-guard: explicit false).
+                ConsentAcknowledged = false,
+                SourceAlertRef = identity.SourceAlertRef
+            };
+
+        /// <summary>The precise audit <c>action</c> taxonomy value per setting (fits varchar(32)).</summary>
+        private static string AuditAction(ServerConfigSetting setting) => setting switch
+        {
+            ServerConfigSetting.Maxdop => "set_maxdop",
+            ServerConfigSetting.CostThreshold => "set_cost_threshold",
+            ServerConfigSetting.MaxServerMemory => "advise_max_memory",
+            ServerConfigSetting.MinServerMemory => "advise_min_memory",
+            _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown ServerConfigSetting")
+        };
+
+        private static TargetPreflight ToTargetPreflight(ServerConfigTarget t, ServerConfigPreflight probe)
+        {
+            var pf = new TargetPreflight
+            {
+                Database = ServerScopeSentinel,
+                HasAlter = probe.HasPermission,
+                CurrentDatabase = ServerScopeSentinel,
+                ExecutingLogin = probe.ExecutingLogin
+            };
+            pf.Disposition = Classify(t, probe);
+            pf.Message = DispositionMessage(pf.Disposition, t, probe);
+            return pf;
+        }
+
+        private static RemediationDisposition Classify(ServerConfigTarget t, ServerConfigPreflight probe)
+        {
+            if (!IsExecutable(t.Setting)) return RemediationDisposition.AdviseOnly;
+            if (!probe.HasPermission) return RemediationDisposition.BlockNoAlter;
+            if (probe.AlreadyInDesiredState) return RemediationDisposition.AlreadyInDesiredState;
+            return RemediationDisposition.Ok;
+        }
+
+        private static string DispositionMessage(RemediationDisposition d, ServerConfigTarget t, ServerConfigPreflight probe) => d switch
+        {
+            RemediationDisposition.Ok => $"Ready to set {SettingTitle(t.Setting)} to {t.RecommendedValue} (currently {probe.CurrentValue}).",
+            RemediationDisposition.AlreadyInDesiredState => "Already at the recommended value — will be skipped.",
+            RemediationDisposition.BlockNoAlter => "The monitoring login lacks ALTER SETTINGS — will fail closed (no change).",
+            RemediationDisposition.AdviseOnly => AdviseOnlyMessage(t.Setting),
+            RemediationDisposition.BlockAuditTableAbsent => AuditAbsentMessage,
+            _ => "Unable to determine target state."
+        };
+
+        /// <summary>Short human title for a server-config setting (display only).</summary>
+        public static string SettingTitle(ServerConfigSetting setting) => setting switch
+        {
+            ServerConfigSetting.Maxdop => "MAXDOP",
+            ServerConfigSetting.CostThreshold => "Cost Threshold for Parallelism",
+            ServerConfigSetting.MaxServerMemory => "max server memory",
+            ServerConfigSetting.MinServerMemory => "min server memory",
+            _ => setting.ToString()
+        };
+
+        private static bool IsExecutable(ServerConfigSetting setting) =>
+            setting is ServerConfigSetting.Maxdop or ServerConfigSetting.CostThreshold;
+
+        private static string AdviseOnlyMessage(ServerConfigSetting setting) =>
+            $"{SettingTitle(setting)} is advise-only — its correct value is RAM/workload-dependent and is not applied automatically. Copy the statement and set the value you choose.";
+
+        private static IReadOnlyList<ServerConfigTarget> ServerTargets(RemediationAction action) =>
+            action.ServerConfigTargets ?? Array.Empty<ServerConfigTarget>();
+
+        private const string AuditAbsentMessage =
+            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+    }
+}

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -336,50 +336,78 @@ AND   collection_time <= $3";
         await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
+        // Latest value PER configuration_name (ROW_NUMBER, not LIMIT N): server_config accumulates
+        // a row per capture, so LIMIT-N-ORDER-BY-time returns the newest N ROWS — which collapses to
+        // one config when captures are frequent, silently dropping settings. Partition by name and
+        // take rn = 1 so each requested setting is its latest value.
         cmd.CommandText = @"
-SELECT configuration_name, value_in_use
-FROM server_config
-WHERE server_id = $1
-AND   configuration_name IN (
-    'cost threshold for parallelism',
-    'max degree of parallelism',
-    'max server memory (MB)',
-    'max worker threads'
+WITH latest AS (
+    SELECT
+        configuration_name,
+        value_in_use,
+        ROW_NUMBER() OVER (PARTITION BY configuration_name ORDER BY capture_time DESC) AS rn
+    FROM server_config
+    WHERE server_id = $1
+    AND   configuration_name IN (
+        'cost threshold for parallelism',
+        'max degree of parallelism',
+        'max server memory (MB)',
+        'min server memory (MB)',
+        'max worker threads'
+    )
 )
-ORDER BY capture_time DESC
-LIMIT 4";
+SELECT configuration_name, value_in_use
+FROM latest
+WHERE rn = 1";
 
         cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        // max/min server memory are read alongside the rooted CONFIG_* facts so the
+        // narrow-memory derivation below can compare them without a second query.
+        double? maxMemoryMb = null;
+        double? minMemoryMb = null;
+
+        using (var reader = await cmd.ExecuteReaderAsync())
         {
-            var configName = reader.GetString(0);
-            var value = Convert.ToDouble(reader.GetValue(1));
-
-            var factKey = configName switch
+            while (await reader.ReadAsync())
             {
-                "cost threshold for parallelism" => "CONFIG_CTFP",
-                "max degree of parallelism" => "CONFIG_MAXDOP",
-                "max server memory (MB)" => "CONFIG_MAX_MEMORY_MB",
-                "max worker threads" => "CONFIG_MAX_WORKER_THREADS",
-                _ => null
-            };
+                var configName = reader.GetString(0);
+                var value = Convert.ToDouble(reader.GetValue(1));
 
-            if (factKey == null) continue;
+                if (configName == "max server memory (MB)") maxMemoryMb = value;
+                if (configName == "min server memory (MB)") minMemoryMb = value;
 
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = factKey,
-                Value = value,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
+                var factKey = configName switch
                 {
-                    ["value_in_use"] = value
-                }
-            });
+                    "cost threshold for parallelism" => "CONFIG_CTFP",
+                    "max degree of parallelism" => "CONFIG_MAXDOP",
+                    "max server memory (MB)" => "CONFIG_MAX_MEMORY_MB",
+                    "min server memory (MB)" => "CONFIG_MIN_MEMORY_MB",
+                    "max worker threads" => "CONFIG_MAX_WORKER_THREADS",
+                    _ => null
+                };
+
+                if (factKey == null) continue;
+
+                facts.Add(new Fact
+                {
+                    Source = "config",
+                    Key = factKey,
+                    Value = value,
+                    ServerId = context.ServerId,
+                    Metadata = new Dictionary<string, double>
+                    {
+                        ["value_in_use"] = value
+                    }
+                });
+            }
         }
+
+        // CONFIG_MIN_MAX_MEMORY_NARROW: emitted only when max is configured AND min is pinned
+        // near it (shared rule so Dashboard/Lite agree).
+        var narrow = FactRemediation.BuildNarrowMemoryFact(context.ServerId, maxMemoryMb, minMemoryMb);
+        if (narrow is not null)
+            facts.Add(narrow);
     }
 
     /// <summary>

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -432,6 +432,43 @@ public static class FactAdvice
                 "The drill-down `autogrowth_percent_files` lists each offending file (database, logical name, type, size, configured percent). Percentage growth on a large file means an ever-larger single allocation — 10% of a 200 GB file is a 20 GB extend, and every transaction that triggers it waits for the whole allocation. Log growths are always zeroed, so a large percentage log growth stalls every writer until it finishes.",
             Remediation:
                 "Switch the flagged files to a fixed-MB autogrowth so each growth is bounded and predictable: 1024 MB for data files, 64 MB for log files. The attached `alter_statement` per file applies exactly that. This is a metadata-only change and is safe to run online.");
+
+        // ─────────────────────────────────────────────────────────────────
+        // Server config (WS3) — one advisory per per-setting CONFIG_* root key
+        // ─────────────────────────────────────────────────────────────────
+
+        t["CONFIG_MAXDOP"] = new AdviceBlock(
+            Headline:
+                "MAXDOP is 0 — every query can use every core",
+            Investigation:
+                "`max degree of parallelism` at 0 means an individual query is allowed unlimited parallelism — it can fan out across all schedulers, so one big query starves everything else and CXPACKET/SOS_SCHEDULER_YIELD waits pile up. Open Configuration → Server Configuration in-app, or call `audit_config`, for the current value alongside the server's socket/core layout.",
+            Remediation:
+                "Set MAXDOP to a sensible cap: 8 on Enterprise, 4 on Standard, 1 on Express, and never higher than the number of cores in a single NUMA node (cores-per-socket). The Apply button runs `sp_configure 'max degree of parallelism'` to the edition-aware value (capped at this server's cores-per-socket) followed by RECONFIGURE — an online metadata change. Cost Threshold for Parallelism (the next finding, if it fired) should be raised in the same pass; the two work together.");
+
+        t["CONFIG_CTFP"] = new AdviceBlock(
+            Headline:
+                "Cost Threshold for Parallelism is at (or below) the default 5",
+            Investigation:
+                "`cost threshold for parallelism` is the optimizer-cost cutoff above which a query gets a parallel plan. The shipped default of 5 is from the 1990s: on modern hardware it sends trivial queries parallel, paying thread-coordination overhead (CXPACKET) for no gain. Call `audit_config` for the current value.",
+            Remediation:
+                "Raise CTFP to 50 as a starting point (then tune up if CXPACKET persists on genuinely large queries). The Apply button runs `sp_configure 'cost threshold for parallelism', 50` + RECONFIGURE — an online metadata change. Pair it with a sane MAXDOP (the companion finding).");
+
+        t["CONFIG_MAX_MEMORY_MB"] = new AdviceBlock(
+            Headline:
+                "max server memory is unconfigured — SQL Server can consume all the RAM",
+            Investigation:
+                "`max server memory (MB)` is at its ~2 PB default, so SQL Server will grow its buffer pool until the OS is under memory pressure — which can page out SQL's own working set and destabilize the whole host (and any other instances). Call `audit_config` / open Server Configuration for the current value and the server's total physical RAM.",
+            Remediation:
+                "Cap max server memory below total RAM, leaving headroom for the OS, the SQL Server thread stacks, and anything else on the box (a common starting point is total RAM minus 4 GB for the OS plus ~1 GB per 4 GB beyond 16 GB, but the right number depends on what else runs here). This is intentionally NOT auto-applied — the correct value is workload- and host-specific. Copy the statement, set the value you've chosen, and run `sp_configure 'max server memory (MB)', <your MB>` + RECONFIGURE.");
+
+        t["CONFIG_MIN_MAX_MEMORY_NARROW"] = new AdviceBlock(
+            Headline:
+                "min server memory is pinned near max server memory",
+            Investigation:
+                "`min server memory (MB)` is set within ~20% of `max server memory (MB)`. min server memory is a floor SQL will not release BELOW once reached — pinning it near max means SQL effectively never gives memory back to the OS, which starves other processes and defeats the OS's ability to reclaim under pressure. The finding's metadata carries the configured min and max. Call `audit_config` for context.",
+            Remediation:
+                "Lower min server memory well below max so SQL can grow into the cap under load but release memory back to the OS when idle (min is best left at the default 0, or a modest floor only if you have a specific reason). This is NOT auto-applied — how low to set it is a workload judgement. Copy the statement, choose your floor, and run `sp_configure 'min server memory (MB)', <your MB>` + RECONFIGURE.");
+
         // ─────────────────────────────────────────────────────────────────
         // Jobs / disk / bad actors
         // ─────────────────────────────────────────────────────────────────

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -107,6 +107,205 @@ public static class FactRemediation
             : new RemediationAction("FILE_AUTOGROWTH_PERCENT", "set", Array.Empty<ForcePlanTarget>(),
                                     FileGrowthTargets: fileTargets);
     }
+
+    // ── WS3: server-level config (MAXDOP / CTFP / max & min server memory) ──────────
+    //
+    // The per-setting CONFIG_* facts (CONFIG_MAXDOP / CONFIG_CTFP / CONFIG_MAX_MEMORY_MB /
+    // CONFIG_MIN_MAX_MEMORY_NARROW) each root their OWN advisory finding. The drill-down
+    // attaches a `server_config` array carrying ONLY the bad setting(s) for that finding plus
+    // the edition + cores-per-socket needed to compute the recommended MAXDOP. The recommended
+    // value is computed HERE (not in the collector) so the edition-aware MAXDOP cap is unit-
+    // testable without a server. CTFP is a flat 50; the two memory settings are advise-only and
+    // carry their current value as "recommended" (the executor refuses to apply them).
+
+    /// <summary>The CTFP value WS3 recommends — the canonical AuditConfig figure.</summary>
+    public const long RecommendedCostThreshold = 50;
+
+    /// <summary>The MAXDOP default (0) WS3 flags as bad — unlimited parallelism.</summary>
+    public const long BadMaxdopValue = 0;
+
+    /// <summary>The "max server memory (MB)" default (~2 PB) WS3 flags as unconfigured.</summary>
+    public const long UnconfiguredMaxMemoryMb = 2147483647;
+
+    /// <summary>
+    /// The edition-aware recommended MAXDOP starting point, BEFORE the cores-per-socket cap:
+    /// Enterprise (engine_edition 3) → 8, Express (4) → 1, everything else (incl. Standard 2 /
+    /// unknown) → 4. Mirrors the AuditConfig MAXDOP suggestion exactly.
+    /// </summary>
+    public static long RecommendedMaxdopForEdition(int engineEdition) => engineEdition switch
+    {
+        3 => 8,   // Enterprise
+        4 => 1,   // Express
+        _ => 4    // Standard / unknown
+    };
+
+    /// <summary>
+    /// The recommended MAXDOP value: the edition-aware starting point
+    /// (<see cref="RecommendedMaxdopForEdition"/>) capped at cores-per-socket when that is
+    /// known (&gt; 0). On a 2-core box "MAXDOP 8" is nonsense, so cap to the socket's core
+    /// count — the same guidance AuditConfig gives. With cores unknown (0) the edition value
+    /// stands.
+    /// </summary>
+    public static long RecommendedMaxdop(int engineEdition, int coresPerSocket)
+    {
+        var byEdition = RecommendedMaxdopForEdition(engineEdition);
+        if (coresPerSocket > 0 && coresPerSocket < byEdition)
+            return coresPerSocket;
+        return byEdition;
+    }
+
+    /// <summary>
+    /// Builds the server-level config action for a CONFIG_* finding (WS3), or null when the
+    /// drill-down carries no bad server-config setting. Parallel to <see cref="BuildAction"/> —
+    /// a SEPARATE entry point so neither switch grows. The action carries FactKey
+    /// "SERVER_CONFIG" and the "set" verb. MAXDOP / CTFP targets are APPLY-able
+    /// (ServerConfigHandler runs <c>sp_configure</c>+<c>RECONFIGURE</c>); the two memory targets
+    /// are advise-only (the executor refuses them) but still ride the persisted-action round-trip
+    /// so the Recommendations reader can render their copy-paste on read (the drill-down is
+    /// ephemeral). Each finding roots on a single CONFIG_* key, so its drill-down carries a
+    /// single bad setting → a single target; the reader's fan loop turns each into one card.
+    /// </summary>
+    public static RemediationAction? BuildServerConfigAction(AnalysisFinding finding)
+    {
+        var targets = ExtractServerConfigTargets(finding);
+        return targets.Count == 0
+            ? null
+            : new RemediationAction("SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+                                    ServerConfigTargets: targets);
+    }
+
+    /// <summary>
+    /// Extracts the server-config target(s) from a CONFIG_* finding's drill-down
+    /// <c>server_config</c> array. Each row carries the structured fields <c>setting</c>
+    /// (canonical id), <c>current_value</c>, and (for MAXDOP) <c>edition</c> +
+    /// <c>cores_per_socket</c> — never parsing human prose. The recommended value is computed
+    /// per setting (edition-aware capped MAXDOP / flat CTFP / current for the advise-only memory
+    /// settings). A defensive cap of 8 mirrors the other extractors.
+    /// </summary>
+    public static IReadOnlyList<ServerConfigTarget> ExtractServerConfigTargets(AnalysisFinding finding)
+    {
+        var targets = new List<ServerConfigTarget>();
+
+        if (finding?.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("server_config", out var raw) ||
+            raw is null)
+            return targets;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return targets;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return targets;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (targets.Count >= 8) break;
+            if (row.ValueKind != JsonValueKind.Object) continue;
+
+            var settingId = GetString(row, "setting");
+            if (string.IsNullOrEmpty(settingId))
+                continue;
+
+            var current = GetInt64(row, "current_value");
+            var edition = GetInt(row, "edition");
+            var cores = GetInt(row, "cores_per_socket");
+
+            switch (settingId)
+            {
+                case "maxdop":
+                    targets.Add(new ServerConfigTarget(
+                        ServerConfigSetting.Maxdop, current, RecommendedMaxdop(edition, cores)));
+                    break;
+                case "ctfp":
+                    targets.Add(new ServerConfigTarget(
+                        ServerConfigSetting.CostThreshold, current, RecommendedCostThreshold));
+                    break;
+                case "max_memory":
+                    // Advise-only: the right value is RAM-dependent. Carry current as
+                    // "recommended" — the executor never applies it; the card is copy-paste only.
+                    targets.Add(new ServerConfigTarget(
+                        ServerConfigSetting.MaxServerMemory, current, current));
+                    break;
+                case "min_memory":
+                    // Advise-only (pinned near max). Carry current as "recommended".
+                    targets.Add(new ServerConfigTarget(
+                        ServerConfigSetting.MinServerMemory, current, current));
+                    break;
+            }
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// The fraction of max server memory at/above which min server memory is "pinned near max"
+    /// (WS3): min &gt;= 80% of max. Pinning the floor that high stops SQL releasing memory back to
+    /// the OS. Single source of truth so Dashboard and Lite collectors agree.
+    /// </summary>
+    public const double MinMaxMemoryNarrowFraction = 0.80;
+
+    /// <summary>
+    /// Builds the CONFIG_MIN_MAX_MEMORY_NARROW fact, or null when it does not apply — shared by
+    /// the Dashboard and Lite collectors so the "pinned near max" rule never drifts. Emitted ONLY
+    /// when max server memory is CONFIGURED (not the ~2 PB default) AND min &gt;=
+    /// <see cref="MinMaxMemoryNarrowFraction"/> of max. Carries the configured min + max in
+    /// metadata for the advice/disclosure. The fact's presence is itself the "bad" flag
+    /// (FactScorer scores it 0.4 unconditionally).
+    /// </summary>
+    public static Fact? BuildNarrowMemoryFact(int serverId, double? maxMemoryMb, double? minMemoryMb)
+    {
+        if (maxMemoryMb is not double max || minMemoryMb is not double min)
+            return null;
+
+        // Only meaningful once max is actually configured below the 2 PB default; an unconfigured
+        // max is its OWN finding (CONFIG_MAX_MEMORY_MB) and min-vs-2PB is never "narrow".
+        if (max >= UnconfiguredMaxMemoryMb || max <= 0)
+            return null;
+
+        if (min < max * MinMaxMemoryNarrowFraction)
+            return null;
+
+        return new Fact
+        {
+            Source = "config",
+            Key = "CONFIG_MIN_MAX_MEMORY_NARROW",
+            Value = min,
+            ServerId = serverId,
+            Metadata = new Dictionary<string, double>
+            {
+                ["min_memory_mb"] = min,
+                ["max_memory_mb"] = max
+            }
+        };
+    }
+
+    /// <summary>The hardcoded <c>sp_configure</c> name for a server-config setting (display + executor share the taxonomy).</summary>
+    public static string SpConfigureName(ServerConfigSetting setting) => setting switch
+    {
+        ServerConfigSetting.Maxdop => "max degree of parallelism",
+        ServerConfigSetting.CostThreshold => "cost threshold for parallelism",
+        ServerConfigSetting.MaxServerMemory => "max server memory (MB)",
+        ServerConfigSetting.MinServerMemory => "min server memory (MB)",
+        _ => throw new ArgumentOutOfRangeException(nameof(setting), setting, "Unknown ServerConfigSetting")
+    };
+
+    /// <summary>
+    /// Renders one copy-paste <c>EXEC sys.sp_configure N'&lt;name&gt;', &lt;value&gt;; RECONFIGURE;</c>
+    /// statement for a server-config target. The name is a hardcoded literal selected by the enum;
+    /// the value is the recommended value. Advisory text only — the executor builds its OWN
+    /// statement with a bound @value parameter and never executes this rendered string.
+    /// </summary>
+    public static string BuildSpConfigureStatement(ServerConfigSetting setting, long value)
+    {
+        return $"EXEC sys.sp_configure N'{SpConfigureName(setting)}', {value};\nRECONFIGURE;";
+    }
     /// <summary>
     /// Builds the DESTRUCTIVE RCSI remediation action for a DB_CONFIG finding, or null
     /// when it does not apply (B3 Phase 3). Parallel to <see cref="BuildAction"/>, which

--- a/PerformanceMonitor.Analysis/FactScorer.cs
+++ b/PerformanceMonitor.Analysis/FactScorer.cs
@@ -233,22 +233,44 @@ public class FactScorer
     }
 
     /// <summary>
-    /// Scores config-source advisory facts. Today the only scored key is
-    /// FILE_AUTOGROWTH_PERCENT (WS3): large data/log files set to grow in PERCENTAGE
-    /// steps. It is an advisory at base 0.3 (mirrors DB_CONFIG's single-misconfig base) —
-    /// below the 0.5 incident threshold, so it only surfaces because it is a
-    /// config-advisory root key (see InferenceEngine.ConfigAdvisoryRootKeys). Every other
-    /// "config"-source fact (CONFIG_MAXDOP / CONFIG_CTFP / SERVER_* / DATABASE_TOTAL_SIZE_MB
-    /// / SERVER_HARDWARE) is a leaf/amplifier with no base severity of its own and scores 0
-    /// here, exactly as it did before this arm existed (it contributes only via amplifiers).
+    /// Scores config-source advisory facts. FILE_AUTOGROWTH_PERCENT (WS3) is a base-0.3
+    /// advisory; the four server-level config keys (WS3) score 0.4 ONLY when the value is bad,
+    /// and 0 otherwise — so audit_config still sees every CONFIG_* fact (it reads the raw value),
+    /// but only a BAD one roots a recommendation card (via InferenceEngine.ConfigAdvisoryRootKeys).
+    /// Edition is NOT needed to decide "bad" — only later for the recommended MAXDOP value.
+    /// Every other "config"-source fact (SERVER_* / DATABASE_TOTAL_SIZE_MB / SERVER_HARDWARE /
+    /// CONFIG_MAX_WORKER_THREADS / CONFIG_MIN_MEMORY_MB) is a leaf/amplifier with no base severity
+    /// of its own and scores 0 here, exactly as before (it contributes only via amplifiers / the
+    /// audit tool / the narrow-memory derivation).
     /// </summary>
     private static double ScoreConfigFact(Fact fact)
     {
-        if (fact.Key != "FILE_AUTOGROWTH_PERCENT") return 0.0;
+        switch (fact.Key)
+        {
+            case "FILE_AUTOGROWTH_PERCENT":
+                // Base 0.3 when at least one large percent-growth file was found; 0 otherwise.
+                return fact.Metadata.GetValueOrDefault("file_count") > 0 ? 0.3 : 0.0;
 
-        // Base 0.3 when at least one large percent-growth file was found; 0 otherwise.
-        var fileCount = fact.Metadata.GetValueOrDefault("file_count");
-        return fileCount > 0 ? 0.3 : 0.0;
+            // MAXDOP at 0 = unlimited parallelism — bad. Any other value is operator-chosen.
+            case "CONFIG_MAXDOP":
+                return fact.Value == 0 ? 0.4 : 0.0;
+
+            // CTFP <= 5 (the default 5 and below) is too low for almost any workload.
+            case "CONFIG_CTFP":
+                return fact.Value <= 5 ? 0.4 : 0.0;
+
+            // max server memory left at the 2 PB default = SQL can take all RAM, starving the OS.
+            case "CONFIG_MAX_MEMORY_MB":
+                return fact.Value == 2147483647 ? 0.4 : 0.0;
+
+            // min server memory pinned near max — emitted by the collector ONLY when bad, so any
+            // presence of this fact is a flag.
+            case "CONFIG_MIN_MAX_MEMORY_NARROW":
+                return 0.4;
+
+            default:
+                return 0.0;
+        }
     }
 
     /// <summary>

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -38,6 +38,13 @@ public class InferenceEngine
         "DB_CONFIG",
         "SERVER_CONFIG",
         "FILE_AUTOGROWTH_PERCENT",
+        // WS3: bad server-level config. Each per-setting CONFIG_* fact scores 0.4 ONLY when
+        // bad (FactScorer) and roots its own standalone advisory card here, bypassing the 0.5
+        // incident threshold — a standing misconfig should surface on a quiet, healthy server.
+        "CONFIG_MAXDOP",
+        "CONFIG_CTFP",
+        "CONFIG_MAX_MEMORY_MB",
+        "CONFIG_MIN_MAX_MEMORY_NARROW",
     };
 
     private readonly RelationshipGraph _graph;

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -34,7 +34,56 @@ public sealed record RemediationAction(
     IReadOnlyList<ClearPlanTarget>? ClearPlanTargets = null, // clear-cached-plan targets (null for the other fact keys)
     ClearPlanFigures? ClearPlanFigures = null,   // clear-cached-plan risk-of-not-changing figures carried on the persisted action
     IReadOnlyList<FileGrowthTarget>? FileGrowthTargets = null, // WS3: percent-autogrowth files — Apply-able (FileAutogrowthHandler: MODIFY FILE FILEGROWTH) + copy-paste
-    IReadOnlyList<RcsiTarget>? RcsiTargets = null); // per-DB RCSI targets CARRIED on a DB_CONFIG action so the reader can fan per-db RCSI cards on read — NEVER executed from here (see RcsiTarget)
+    IReadOnlyList<RcsiTarget>? RcsiTargets = null, // per-DB RCSI targets CARRIED on a DB_CONFIG action so the reader can fan per-db RCSI cards on read — NEVER executed from here (see RcsiTarget)
+    IReadOnlyList<ServerConfigTarget>? ServerConfigTargets = null); // WS3: bad server-level config (MAXDOP/CTFP Apply-able via ServerConfigHandler; max/min memory advise-only) — one card per target
+
+/// <summary>
+/// The fixed, hardcoded set of SERVER-LEVEL configuration settings WS3 surfaces (and, for
+/// the first two, can apply). This enum — NOT any data/operator-supplied string — selects the
+/// HARDCODED <c>sp_configure</c> name literal in the executor (see
+/// DatabaseService.Remediation server-config arm). <see cref="Maxdop"/> and
+/// <see cref="CostThreshold"/> are executable (an online metadata change, not destructive).
+/// <see cref="MaxServerMemory"/> and <see cref="MinServerMemory"/> are ADVISE-ONLY: their
+/// correct value is RAM/workload-dependent, so the executor REFUSES to apply a guessed value —
+/// the cards carry only copy-paste SQL.
+/// </summary>
+public enum ServerConfigSetting
+{
+    /// <summary>EXEC sys.sp_configure N'max degree of parallelism', N; RECONFIGURE; — executable.</summary>
+    Maxdop,
+
+    /// <summary>EXEC sys.sp_configure N'cost threshold for parallelism', N; RECONFIGURE; — executable.</summary>
+    CostThreshold,
+
+    /// <summary>
+    /// max server memory (MB) — ADVISE-ONLY. The right value depends on total RAM, other
+    /// instances, and the OS footprint; the executor never applies a guessed value.
+    /// </summary>
+    MaxServerMemory,
+
+    /// <summary>
+    /// min server memory (MB) — ADVISE-ONLY. Recommended only when pinned near max (which
+    /// starves the OS / stops SQL releasing memory); lowering it is workload-judgement, so the
+    /// executor never applies a value.
+    /// </summary>
+    MinServerMemory
+}
+
+/// <summary>
+/// One server-level config target (WS3): a (setting, current, recommended) triple. Each maps
+/// 1:1 onto a Recommendations card and — for <see cref="ServerConfigSetting.Maxdop"/> /
+/// <see cref="ServerConfigSetting.CostThreshold"/> — an independent
+/// <c>sp_configure</c>+<c>RECONFIGURE</c> Apply and audit row.
+/// <see cref="CurrentValue"/> is a display/audit prior-value snapshot; the executor re-reads
+/// the live value at apply. <see cref="RecommendedValue"/> is the already-computed target used
+/// verbatim as the bound <c>@value</c> (MAXDOP: edition-aware, capped at cores-per-socket;
+/// CTFP: 50). For the two memory settings <see cref="RecommendedValue"/> is carried for the
+/// copy-paste/advice only — the executor refuses to apply it.
+/// </summary>
+public sealed record ServerConfigTarget(
+    ServerConfigSetting Setting,
+    long CurrentValue,
+    long RecommendedValue);
 
 /// <summary>
 /// One per-database RCSI target — a (database, inaction-figures) pair carried on the

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -85,7 +85,8 @@ public record RemediationActionDto(
     List<ClearPlanTargetDto>? ClearPlanTargets = null,
     ClearPlanFiguresDto? ClearPlanFigures = null,
     List<FileGrowthTargetDto>? FileGrowthTargets = null,
-    List<RcsiTargetDto>? RcsiTargets = null);
+    List<RcsiTargetDto>? RcsiTargets = null,
+    List<ServerConfigTargetDto>? ServerConfigTargets = null);
 
 /// <summary>
 /// JSON mirror of <see cref="RcsiTarget"/>. The per-database RCSI targets are carried on a
@@ -175,6 +176,19 @@ public record FileGrowthTargetDto(
     double CurrentSizeMb,
     int CurrentGrowthPercent,
     int RecommendedGrowthMb);
+
+/// <summary>
+/// JSON mirror of <see cref="ServerConfigTarget"/> (WS3 server-level config). <see cref="Setting"/>
+/// is persisted as the enum's int value. The trailing optional <c>ServerConfigTargets</c> member on
+/// <see cref="RemediationActionDto"/> keeps the round-trip backward-compatible: legacy/non-
+/// SERVER_CONFIG contextJson without it deserializes to null. Carried so the Recommendations reader
+/// can fan the server-config cards on read (the drill-down is ephemeral); MAXDOP/CTFP drive Apply,
+/// the two memory targets are copy-paste only.
+/// </summary>
+public record ServerConfigTargetDto(
+    int Setting,
+    long CurrentValue,
+    long RecommendedValue);
 
 /// <summary>
 /// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
@@ -341,8 +355,20 @@ public static class AlertContextSerializer
                     new RcsiInactionFiguresDto(t.Figures.BlockingEvents, t.Figures.Deadlocks, t.Figures.ReaderWriterPct)));
         }
 
+        // WS3 (server-level config): persist the targets so the Recommendations reader can fan the
+        // server-config cards on read (the drill-down is ephemeral) AND the ServerConfigHandler can
+        // re-derive the MAXDOP/CTFP target at apply. Null for every other fact key -> backward-compatible.
+        List<ServerConfigTargetDto>? serverConfigTargets = null;
+        if (action.ServerConfigTargets is not null)
+        {
+            serverConfigTargets = new List<ServerConfigTargetDto>(action.ServerConfigTargets.Count);
+            foreach (var t in action.ServerConfigTargets)
+                serverConfigTargets.Add(new ServerConfigTargetDto((int)t.Setting, t.CurrentValue, t.RecommendedValue));
+        }
+
         return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets,
-            rcsiFigures, clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets);
+            rcsiFigures, clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets,
+            serverConfigTargets);
     }
 
     private static RemediationAction? FromDto(RemediationActionDto? dto)
@@ -433,7 +459,20 @@ public static class AlertContextSerializer
                     new RcsiInactionFigures(t.Figures.BlockingEvents, t.Figures.Deadlocks, t.Figures.ReaderWriterPct)));
         }
 
+        // WS3: rebuild the server-config targets from the DTO and PASS them to the ctor (the trailing
+        // ServerConfigTargets member defaults to null, so a short call would silently drop them on the
+        // round-trip — the reader would then fan no server-config cards and the handler could not
+        // re-derive the MAXDOP/CTFP target). Legacy JSON without the field deserializes to null →
+        // backward-compatible.
+        List<ServerConfigTarget>? serverConfigTargets = null;
+        if (dto.ServerConfigTargets is not null)
+        {
+            serverConfigTargets = new List<ServerConfigTarget>(dto.ServerConfigTargets.Count);
+            foreach (var t in dto.ServerConfigTargets)
+                serverConfigTargets.Add(new ServerConfigTarget((ServerConfigSetting)t.Setting, t.CurrentValue, t.RecommendedValue));
+        }
+
         return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets, rcsiFigures,
-            clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets);
+            clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets, serverConfigTargets);
     }
 }


### PR DESCRIPTION
## WS3 — server-level config recommendations

Surfaces bad **SERVER**-level config as per-setting Recommendation cards. The `CONFIG_*` facts already existed (feeding `audit_config`) but were never rooted into findings; this scores + roots them, adds advice + copy-paste, and a working **Apply** for the two with canonical values.

### What lands
- **Facts:** added `CONFIG_MIN_MEMORY_MB` + `CONFIG_MIN_MAX_MEMORY_NARROW` (min ≥ 80% of a configured max). **Fixed** a dedup bug in the server-config collector — `TOP 4 ORDER BY collection_time` was not per-config and would drop settings as the set grew (now ROW_NUMBER per config). Mirrored in Lite.
- **Score / root / advise:** `FactScorer` scores the four bad-config conditions to an advisory severity (else 0, so `audit_config` still sees every fact); `InferenceEngine.ConfigAdvisoryRootKeys` roots them below the 0.5 threshold; `FactAdvice` text.
- **Reader fan-out:** a server-wide `SERVER_CONFIG` finding fans into one card per setting. **MAXDOP (=0)** and **CTFP (≤5)** get a working **Apply**; **max server memory** (unconfigured) and **min ≥ max** are advise + copy-paste only — their right value is RAM/workload-dependent and is **never** auto-applied.
- **Privileged executor** `SetServerConfigAsync` (`sp_configure` + `RECONFIGURE`): single open connection, self-gating **fail-closed** on `ALTER SETTINGS` / sysadmin / serveradmin, the `sp_configure` **name hardcoded by enum** (never data), `@value` bound + range-validated (0–32767), plain `RECONFIGURE` (no `WITH OVERRIDE`), audited. Memory settings refused **before** any connection opens. New `ServerConfigHandler` (`IsDestructive = false` → single-confirm path).

### Verification
- **420 Dashboard.Tests pass** (+62 new), Dashboard + Lite build clean (0 warnings).
- **security-reviewer: CLEAN on all 8 invariants** — no injection, advise-only memory, range-validated, fail-closed gate, no TOCTOU, consent + audit, no `WITH OVERRIDE`, handler isolated (existing destructive handlers untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)