### PR TITLE
Analysis hardening: dedupe fact-key lookups (a duplicate key silently killed a whole analysis run)

### DIFF
--- a/Dashboard.Tests/FactScorerTests.cs
+++ b/Dashboard.Tests/FactScorerTests.cs
@@ -73,6 +73,44 @@ public class FactScorerTests
         Assert.Equal(2.0, cx.Severity);
     }
 
+    /* ── Regression: duplicate fact keys must not crash scoring ── */
+
+    // A duplicated fact key (e.g. a config collector returning two rows for the same setting)
+    // once aborted the ENTIRE analysis for a server: ScoreAll built its amplifier lookup with a
+    // raw ToDictionary(f => f.Key), which throws on a duplicate. The exception was swallowed
+    // upstream, silently blanking every finding. ScoreAll must now dedupe and survive.
+    [Fact]
+    public void ScoreAll_WithDuplicateFactKeys_DoesNotThrow()
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "config", Key = "CONFIG_CTFP", Value = 5 },
+            new() { Source = "config", Key = "CONFIG_CTFP", Value = 5 },   // duplicate key
+            new() { Source = "waits", Key = "CXPACKET", Value = 0.80 },
+        };
+
+        var scorer = new FactScorer();
+        var ex = Record.Exception(() => scorer.ScoreAll(facts));
+
+        Assert.Null(ex);
+    }
+
+    // The backstop helper keeps the first fact per key and never throws on duplicates.
+    [Fact]
+    public void ToFactLookup_DedupesByKey_KeepsFirst()
+    {
+        var facts = new List<Fact>
+        {
+            new() { Source = "config", Key = "CONFIG_CTFP", Value = 5 },
+            new() { Source = "config", Key = "CONFIG_CTFP", Value = 99 },
+        };
+
+        var lookup = facts.ToFactLookup();
+
+        Assert.Single(lookup);
+        Assert.Equal(5, lookup["CONFIG_CTFP"].Value);   // first wins
+    }
+
     /* ── WS3: percent-autogrowth-on-large-files config fact ── */
 
     // A FILE_AUTOGROWTH_PERCENT fact scores the 0.3 advisory base when at least one large

--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -141,4 +141,22 @@ public class InferenceEngineTests
         Assert.Contains(stories, s => s.RootFactKey == "CONFIG_MAX_MEMORY_MB");
         Assert.Contains(stories, s => s.RootFactKey == "CONFIG_MIN_MAX_MEMORY_NARROW");
     }
+
+    // Regression: a duplicated fact key (e.g. a collector returning two rows for the same
+    // setting) once aborted the entire analysis — BuildStories built its lookup with a raw
+    // ToDictionary(f => f.Key), which throws on a duplicate. It must now dedupe and survive.
+    [Fact]
+    public void BuildStories_WithDuplicateFactKeys_DoesNotThrow()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = "CONFIG_CTFP", Source = "config", Value = 5, Severity = 0.4 },
+            new() { Key = "CONFIG_CTFP", Source = "config", Value = 5, Severity = 0.4 },  // duplicate key
+        };
+
+        var ex = Record.Exception(() => engine.BuildStories(facts));
+
+        Assert.Null(ex);
+    }
 }

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -229,8 +229,8 @@ public sealed class McpAnalysisTools
             var (baselineFacts, comparisonFacts) = await analysisService.ComparePeriodsAsync(
                 serverId, resolved.Value.ServerName, baselineStart, baselineEnd, comparisonStart, now);
 
-            var baselineByKey = baselineFacts.ToDictionary(f => f.Key, f => f);
-            var comparisonByKey = comparisonFacts.ToDictionary(f => f.Key, f => f);
+            var baselineByKey = baselineFacts.ToFactLookup();
+            var comparisonByKey = comparisonFacts.ToFactLookup();
             var allKeys = baselineByKey.Keys.Union(comparisonByKey.Keys).ToHashSet();
 
             var comparisons = allKeys
@@ -287,7 +287,7 @@ public sealed class McpAnalysisTools
             var serverId = ServerIdHelper.GetDeterministicHashCode(resolved.Value.ServerName);
             var facts = await analysisService.CollectAndScoreFactsAsync(serverId, resolved.Value.ServerName, 1);
 
-            var factsByKey = facts.ToDictionary(f => f.Key, f => f);
+            var factsByKey = facts.ToFactLookup();
 
             var edition = factsByKey.TryGetValue("SERVER_EDITION", out var edFact) ? (int)edFact.Value : 0;
             var totalMemoryMb = factsByKey.TryGetValue("MEMORY_TOTAL_PHYSICAL_MB", out var memFact) ? memFact.Value : 0;

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -218,8 +218,8 @@ public sealed class McpAnalysisTools
                 baselineStart, baselineEnd,
                 comparisonStart, comparisonEnd);
 
-            var baselineByKey = baselineFacts.ToDictionary(f => f.Key, f => f);
-            var comparisonByKey = comparisonFacts.ToDictionary(f => f.Key, f => f);
+            var baselineByKey = baselineFacts.ToFactLookup();
+            var comparisonByKey = comparisonFacts.ToFactLookup();
             var allKeys = baselineByKey.Keys.Union(comparisonByKey.Keys).ToHashSet();
 
             var comparisons = allKeys
@@ -293,7 +293,7 @@ public sealed class McpAnalysisTools
             var facts = await analysisService.CollectAndScoreFactsAsync(
                 resolved.Value.ServerId, resolved.Value.ServerName, 1);
 
-            var factsByKey = facts.ToDictionary(f => f.Key, f => f);
+            var factsByKey = facts.ToFactLookup();
 
             var edition = factsByKey.TryGetValue("SERVER_EDITION", out var edFact) ? (int)edFact.Value : 0;
             var totalMemoryMb = factsByKey.TryGetValue("MEMORY_TOTAL_PHYSICAL_MB", out var memFact) ? memFact.Value : 0;

--- a/PerformanceMonitor.Analysis/FactCollectionExtensions.cs
+++ b/PerformanceMonitor.Analysis/FactCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Helpers for turning a fact list into a keyed lookup.
+/// </summary>
+public static class FactCollectionExtensions
+{
+    /// <summary>
+    /// Builds a <c>Key → Fact</c> lookup, keeping the first fact for each key.
+    /// <para>
+    /// Unlike a raw <c>ToDictionary(f =&gt; f.Key)</c>, this never throws on a duplicate key.
+    /// A duplicate fact key should not normally occur — collectors are expected to emit one fact
+    /// per key — but a collector bug or unusual source data can produce two, and a raw
+    /// <c>ToDictionary</c> then throws, aborting the ENTIRE analysis for that server. The
+    /// exception is swallowed and logged upstream, so a single duplicated key silently blanks
+    /// every finding for the run (this exact failure was observed when a config collector
+    /// returned two rows for the same setting). Deduping here keeps analysis resilient: the
+    /// misbehaving key collapses to its first occurrence instead of taking down the whole run.
+    /// Fix the duplicate at the collector; this is the backstop.
+    /// </para>
+    /// </summary>
+    public static Dictionary<string, Fact> ToFactLookup(this IEnumerable<Fact> facts) =>
+        facts.GroupBy(f => f.Key).ToDictionary(g => g.Key, g => g.First());
+}

--- a/PerformanceMonitor.Analysis/FactScorer.cs
+++ b/PerformanceMonitor.Analysis/FactScorer.cs
@@ -49,7 +49,7 @@ public class FactScorer
               "database_config", "jobs", "sessions", "disk", "bad_actor", "anomaly" };
         var factsByKey = facts
             .Where(f => f.BaseSeverity > 0 || contextSources.Contains(f.Source))
-            .ToDictionary(f => f.Key, f => f);
+            .ToFactLookup();
 
         // Layer 2: amplifiers boost base severity using corroborating facts
         foreach (var fact in facts)

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -63,7 +63,7 @@ public class InferenceEngine
         var stories = new List<AnalysisStory>();
         var factsByKey = facts
             .Where(f => f.Severity > 0)
-            .ToDictionary(f => f.Key, f => f);
+            .ToFactLookup();
         var consumed = new HashSet<string>();
 
         // Process facts in severity order. Incident facts must clear the 0.5 threshold to root;


### PR DESCRIPTION
## What

A duplicate fact key would hard-crash an entire server's analysis. `FactScorer.ScoreAll` and `InferenceEngine.BuildStories` build their key→Fact lookup with a raw `facts.ToDictionary(f => f.Key)`, which **throws** on a duplicate key. That exception is caught + logged one level up, so the symptom is silent: **every finding for that server blanks out**, with only an ERROR line in the log.

**Observed live** (during WS3 demo seeding): a server-config collector returned two rows for `cost threshold for parallelism` →
```
[ERROR] [AnalysisService] Analysis failed for SQL2022: An item with the same key has already been added. Key: CONFIG_CTFP
```
…every 5-minute cycle, while the other four servers analyzed fine.

## Fix

- New `ToFactLookup()` extension in `PerformanceMonitor.Analysis` — builds the `key → Fact` lookup keeping the **first** fact per key, never throwing on duplicates. Self-documenting so a future raw `ToDictionary(f => f.Key)` is easy to spot in review.
- Routed **all 8** fact-keyed dictionary sites through it: the 2 core scoring/inference sites (the actual crash) + 6 MCP `compare_analysis` / `audit_config` sites across Dashboard + Lite.

This is a **backstop** — the real cause should be fixed at the collector (WS3's ROW_NUMBER-per-config already did for server config). The point is that one misbehaving key degrades gracefully (collapses to its first occurrence) instead of taking down the whole run.

## Tests
- `ScoreAll` / `BuildStories` with duplicate-key facts no longer throw (regression for the exact crash).
- `ToFactLookup` dedupes by key, first wins.
- **Dashboard.Tests: 423 pass** (+3), **Lite.Tests: 362 pass**. Both apps build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)