### PR TITLE
Remediation contract test: every Apply-able fact key must have a registered handler

### DIFF
--- a/Dashboard.Tests/RemediationContractTests.cs
+++ b/Dashboard.Tests/RemediationContractTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using PerformanceMonitorDashboard.Services.Remediation;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Contract between the remediation BUILDERS (FactRemediation.Build*Action and the recommendations
+/// reader) and the registered HANDLERS. Every Apply-able RemediationAction carries a FactKey, and
+/// RemediationApplyService dispatches on it; a FactKey with no registered handler makes Apply
+/// silently no-op — the "shipped half-built" failure class. These tests fail loudly if the handler
+/// set drifts from the agreed Apply-able key set, forcing a conscious update whenever a builder or
+/// handler is added or removed.
+///
+/// Scope note: this locks the HANDLER side (registry integrity + the documented Apply-able set).
+/// The complementary dynamic check — feeding real detector drill-down output through each builder
+/// and asserting it still yields a non-null, dispatchable action (the autogrowth-CTE-drift class) —
+/// is a larger golden-sample follow-up that needs captured detector fixtures.
+/// </summary>
+public class RemediationContractTests
+{
+    // The agreed Apply-able fact keys. Each is produced by a FactRemediation builder or the
+    // recommendations reader: PLAN_REGRESSION, DB_CONFIG, FILE_AUTOGROWTH_PERCENT and SERVER_CONFIG
+    // are always-safe; RCSI and CLEAR_PLAN are destructive (behind the informed-consent gate).
+    // Adding or removing a builder/handler? Update this list deliberately — that is the contract.
+    private static readonly string[] ApplyableFactKeys =
+    {
+        "PLAN_REGRESSION",
+        "DB_CONFIG",
+        "FILE_AUTOGROWTH_PERCENT",
+        "SERVER_CONFIG",
+        "RCSI",
+        "CLEAR_PLAN",
+    };
+
+    [Fact]
+    public void DefaultHandlers_HaveDistinctNonEmptyFactKeys()
+    {
+        var keys = RemediationApplyService.CreateDefaultHandlers().Select(h => h.FactKey).ToList();
+
+        Assert.DoesNotContain(keys, string.IsNullOrWhiteSpace);
+        Assert.Equal(keys.Count, keys.Distinct().Count());   // no two handlers claim the same key
+    }
+
+    [Fact]
+    public void HandlerFactKeys_ExactlyMatch_ApplyableContract()
+    {
+        var handlerKeys = RemediationApplyService.CreateDefaultHandlers()
+            .Select(h => h.FactKey)
+            .ToHashSet();
+
+        var orphanBuilderKeys = ApplyableFactKeys.Except(handlerKeys).ToList(); // builder key, no handler -> silent no-op
+        var deadHandlerKeys = handlerKeys.Except(ApplyableFactKeys).ToList();    // handler, no producing builder -> dead
+
+        Assert.True(orphanBuilderKeys.Count == 0,
+            $"Apply-able fact key(s) with NO registered handler (Apply would silently no-op): {string.Join(", ", orphanBuilderKeys)}");
+        Assert.True(deadHandlerKeys.Count == 0,
+            $"Registered handler(s) with no Apply-able builder key (dead handler / contract drift): {string.Join(", ", deadHandlerKeys)}");
+    }
+
+    [Fact]
+    public void EveryApplyableFactKey_ResolvesThroughTheRegistry()
+    {
+        // The registry is the actual dispatch point used by RunAsync; prove each contract key
+        // resolves through it exactly as production constructs it.
+        var registry = new RemediationHandlerRegistry(RemediationApplyService.CreateDefaultHandlers());
+
+        foreach (var key in ApplyableFactKeys)
+            Assert.True(registry.TryGet(key) is not null, $"No handler resolves for Apply-able fact key '{key}'.");
+    }
+}

--- a/Dashboard/Services/Remediation/RemediationApplyService.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyService.cs
@@ -65,7 +65,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             // ServerConfigHandler (SERVER_CONFIG, WS3) is always-safe too (sp_configure MAXDOP/CTFP
             // + RECONFIGURE — online metadata; the advise-only memory settings never mutate) and
             // rides its OWN fact key, so it never crosses the destructive handlers either.
-            _registry = new RemediationHandlerRegistry(new IRemediationHandler[] { new ForcePlanHandler(), new DbConfigHandler(), new RcsiHandler(), new ClearPlanHandler(), new FileAutogrowthHandler(), new ServerConfigHandler() });
+            _registry = new RemediationHandlerRegistry(CreateDefaultHandlers());
             _executorFactory = server =>
                 new DatabaseServiceRemediationExecutor(new DatabaseService(server.GetConnectionString(credentialService)));
             _auditFailureClassifier = (server, ct) =>
@@ -89,6 +89,25 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             _auditFailureClassifier = auditFailureClassifier
                 ?? ((_, _) => Task.FromResult(AuditWriteFailureKind.Unknown));
         }
+
+        /// <summary>
+        /// The production set of remediation handlers — one per Apply-able fact key. Extracted from
+        /// the constructor so a contract test (InternalsVisibleTo Dashboard.Tests) can assert the
+        /// registered handler keys match the set of fact keys the FactRemediation builders / the
+        /// recommendations reader produce. A builder fact key with no handler here makes Apply
+        /// silently no-op; a handler with no producing builder is dead. Order is irrelevant — the
+        /// registry keys on FactKey — but every handler MUST expose a distinct, non-empty FactKey.
+        /// </summary>
+        internal static IRemediationHandler[] CreateDefaultHandlers() =>
+            new IRemediationHandler[]
+            {
+                new ForcePlanHandler(),
+                new DbConfigHandler(),
+                new RcsiHandler(),
+                new ClearPlanHandler(),
+                new FileAutogrowthHandler(),
+                new ServerConfigHandler(),
+            };
 
         /// <summary>
         /// Whether a registered handler exists for this fact key (one half of the


### PR DESCRIPTION
## What
`RemediationApplyService` dispatches Apply by `FactKey`. A `FactKey` produced by a builder with **no registered handler** makes Apply **silently no-op** — the exact "shipped half-built" failure class. Nothing asserted the handler set stayed in sync with the builders that produce those keys.

## Change
- Extracted the production handler list into `RemediationApplyService.CreateDefaultHandlers()` (internal; the ctor now calls it) so a test verifies the **exact production set** rather than a reconstruction.
- New `RemediationContractTests`:
  - handler `FactKey`s are **distinct + non-empty** (no dup/empty registration);
  - the registered key set **exactly matches** the documented Apply-able set — flags an **orphan builder key** (→ silent no-op) *and* a **dead handler** (no producing builder);
  - every Apply-able key **resolves through the registry** built as production builds it.

## Scope (honest)
This locks the **handler side** (registry integrity + the agreed key set), so adding/removing a handler or builder now forces a conscious update. The complementary **dynamic golden-sample** — feeding real detector drill-down output through each builder and asserting it still yields a non-null, dispatchable action (the autogrowth-CTE-drift class that shipped broken once) — is a larger follow-up needing captured detector fixtures, noted in the test file.

## Tests
Dashboard.Tests **423 pass** (+3). No production behavior change (pure refactor + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)