### PR TITLE
WS2: always pop a tray balloon for a notify-worthy analysis finding

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -163,7 +163,14 @@ namespace PerformanceMonitorDashboard
                 new LoggerAdapter<AnalysisNotificationService>(),
                 /* Suppress analysis-finding emails for servers the user silenced via
                    "Silence All Alerts" — matches the threshold-alert guard. */
-                _alertStateService.IsAnySilencingActive);
+                _alertStateService.IsAnySilencingActive,
+                /* WS2: always pop a tray balloon for a notify-worthy finding — the same visible
+                   signal threshold alerts already raise, so a local-only user with no email/webhook
+                   still sees findings. Late-bound to the _notificationService field (built later in
+                   Loaded); ShowNotification honors the notifications-enabled pref + marshals to the
+                   UI thread, so it is safe to invoke from the analysis cycle. */
+                showTrayNotification: (title, message) =>
+                    _notificationService?.ShowNotification(title, message, NotificationType.Warning));
             _analysisScheduler = new AnalysisScheduler(
                 _serverManager, _credentialService, _preferencesService, _analysisNotificationService);
 

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -44,12 +44,15 @@ public class AnalysisNotificationTests : IDisposable
     /// Builds the shared AnalysisNotificationService wired to a real Lite EmailAlertService
     /// (its IFindingAlertSender) over the test DuckDB store, with Lite's serverId resolver.
     /// </summary>
-    private AnalysisNotificationService MakeNotifier(Func<string, bool>? isServerSilenced = null)
+    private AnalysisNotificationService MakeNotifier(
+        Func<string, bool>? isServerSilenced = null,
+        Action<string, string>? showTrayNotification = null)
     {
         var webhook = new WebhookAlertService(_settings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>());
         var email = new EmailAlertService(_settings, new DuckDbAlertHistoryStore(_duckDb), webhook, new AppLoggerAdapter<EmailAlertService>());
         return new AnalysisNotificationService(
-            email, _settings, f => f.ServerId.ToString(), new AppLoggerAdapter<AnalysisNotificationService>(), isServerSilenced);
+            email, _settings, f => f.ServerId.ToString(), new AppLoggerAdapter<AnalysisNotificationService>(),
+            isServerSilenced, showTrayNotification);
     }
 
     private static AnalysisFinding MakeFinding(
@@ -393,6 +396,68 @@ public class AnalysisNotificationTests : IDisposable
         });
 
         Assert.Equal(1, await CountAlertLogRowsAsync());
+    }
+
+    /* ── WS2: always raise a tray balloon for a notify-worthy finding ── */
+
+    [Fact]
+    public async Task NotifyAsync_NotifyWorthyFinding_RaisesTrayBalloon()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var balloons = new List<(string Title, string Message)>();
+        var notifier = MakeNotifier(showTrayNotification: (t, m) => balloons.Add((t, m)));
+
+        await notifier.NotifyAsync(new[] { MakeFinding("tray000000000001", severity: 2.0, category: "cpu_pressure") });
+
+        var balloon = Assert.Single(balloons);
+        Assert.Contains("cpu_pressure", balloon.Title);
+        Assert.Contains("TestServer", balloon.Title);
+        Assert.False(string.IsNullOrWhiteSpace(balloon.Message));
+    }
+
+    [Fact]
+    public async Task NotifyAsync_BelowThreshold_RaisesNoTrayBalloon()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+
+        var balloons = new List<(string, string)>();
+        var notifier = MakeNotifier(showTrayNotification: (t, m) => balloons.Add((t, m)));
+
+        await notifier.NotifyAsync(new[] { MakeFinding("traylow000000001", severity: 1.0) });
+
+        Assert.Empty(balloons);   // sub-threshold finding -> no email, no tray
+    }
+
+    [Fact]
+    public async Task NotifyAsync_SilencedServer_RaisesNoTrayBalloon()
+    {
+        await _duckDb.InitializeAsync();
+        App.AnalysisNotifySeverity = 1.5;
+        App.AnalysisNotifyCooldownMinutes = 360;
+
+        var balloons = new List<(string, string)>();
+        var notifier = MakeNotifier(serverId => serverId == "1", showTrayNotification: (t, m) => balloons.Add((t, m)));
+
+        await notifier.NotifyAsync(new[] { MakeFinding("traysilenced0001", severity: 2.0, serverId: 1) });
+
+        Assert.Empty(balloons);   // silenced server -> no tray either
+    }
+
+    [Fact]
+    public void BalloonText_NamesCategoryAndServer_AndCarriesHeadline()
+    {
+        var finding = MakeFinding("balloon000000001", severity: 2.0, category: "blocking",
+            rootFactKey: "BLOCKING_CHAIN", rootValue: 5);
+
+        var (title, message) = FindingMessageFormatter.BalloonText(finding);
+
+        Assert.Contains("blocking", title);
+        Assert.Contains("TestServer", title);
+        Assert.Contains("BLOCKING_CHAIN", message);
     }
 
     private async Task<long> CountAlertLogRowsAsync()

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -41,6 +41,7 @@ public sealed class AnalysisNotificationService
     private readonly Func<AnalysisFinding, string> _resolveServerId;
     private readonly Func<string, bool>? _isServerSilenced;
     private readonly ILogger<AnalysisNotificationService> _logger;
+    private readonly Action<string, string>? _showTrayNotification;
 
     /// <summary>
     /// Per-finding re-notification cooldown, keyed "{serverId}:{StoryPathHash}".
@@ -64,18 +65,28 @@ public sealed class AnalysisNotificationService
     /// so "Silence All Alerts" also stops analysis-finding emails; Lite has no silencing
     /// feature and leaves this null (never silenced).
     /// </param>
+    /// <param name="showTrayNotification">
+    /// Optional <c>(title, message)</c> sink raised for every finding that notifies — the same
+    /// notify-worthy set that reaches email/webhook — so a local-only user with no channel
+    /// configured still gets a visible signal. Dashboard wires this to its tray
+    /// <c>NotificationService.ShowNotification</c> (which itself honors the global
+    /// notifications-enabled pref and marshals to the UI thread); Lite leaves it null. Best-effort:
+    /// invoked inside the per-finding try, so a sink fault is logged, not propagated.
+    /// </param>
     public AnalysisNotificationService(
         IFindingAlertSender sender,
         IAlertSettings settings,
         Func<AnalysisFinding, string> serverIdResolver,
         ILogger<AnalysisNotificationService> logger,
-        Func<string, bool>? isServerSilenced = null)
+        Func<string, bool>? isServerSilenced = null,
+        Action<string, string>? showTrayNotification = null)
     {
         _sender = sender;
         _settings = settings;
         _resolveServerId = serverIdResolver;
         _logger = logger;
         _isServerSilenced = isServerSilenced;
+        _showTrayNotification = showTrayNotification;
     }
 
     /// <summary>
@@ -156,6 +167,16 @@ public sealed class AnalysisNotificationService
                     threshold,
                     FindingMessageFormatter.DetailText(finding, threshold)));
 
+                /* Always raise the tray balloon for a notify-worthy finding (user choice), the
+                   same visible signal threshold alerts already pop — so a local-only user with no
+                   email/webhook still sees it. No-op when the host wired no sink (Lite) or tray
+                   notifications are disabled (the sink checks the pref). */
+                if (_showTrayNotification is not null)
+                {
+                    var (title, message) = FindingMessageFormatter.BalloonText(finding);
+                    _showTrayNotification(title, message);
+                }
+
                 _cooldowns[key] = now;
             }
             catch (Exception ex)
@@ -213,6 +234,24 @@ internal static class FindingMessageFormatter
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Tray-balloon title + message for a finding (WS2). Concise by design — balloons truncate.
+    /// Title names the category + server; message is the headline value (root fact + baseline
+    /// context), prefixed with the database when the finding is database-scoped.
+    /// </summary>
+    public static (string Title, string Message) BalloonText(AnalysisFinding finding)
+    {
+        var category = string.IsNullOrEmpty(finding.Category) ? "Performance finding" : finding.Category;
+        var server = string.IsNullOrEmpty(finding.ServerName) ? "this server" : finding.ServerName;
+        var title = $"Analysis: {category} on {server}";
+
+        var message = CurrentValue(finding);
+        if (!string.IsNullOrEmpty(finding.DatabaseName))
+            message = $"{finding.DatabaseName}: {message}";
+
+        return (title, message);
     }
 
     /// <summary>


### PR DESCRIPTION
## What
Analysis findings reached email / Teams / Slack + an Alerts-history row, but the **real tray balloon** (`NotificationService.ShowBalloonTip`) was wired only to the *threshold-alert* path. So a local-only user with no SMTP/webhook configured got **zero visible signal** for an analysis finding — the history row's `notificationType:"tray"` was a label, not an actual balloon.

## Change
- The shared `AnalysisNotificationService` takes an optional `Action<string,string> showTrayNotification` sink, invoked for **every finding that notifies** — the *same* gated set (severity threshold, per-finding cooldown, per-server "Silence All Alerts") that already reaches email/webhook.
- **Dashboard** wires it to `NotificationService.ShowNotification` (which honors the global notifications-enabled pref and marshals to the UI thread). **Lite** leaves it null.
- **Always-fire** (your call) — the same behavior threshold alerts already have, so the tray is a consistent local signal alongside email/webhook.
- `FindingMessageFormatter.BalloonText` composes a concise `(title, message)`.

Non-breaking: the new ctor param is optional; existing callers (incl. Lite) are unaffected.

## Tests
Added to `Lite.Tests` (where the `NotifyAsync` harness lives): the sink **fires** for a notify-worthy finding, and does **not** fire for a sub-threshold or silenced one; `BalloonText` names the category + server and carries the headline. **Dashboard.Tests 420, Lite.Tests 366 (+4)**; both apps build clean.

## Not in scope
The actual balloon *rendering* is WPF/tray UI and isn't unit-tested (the wiring + gating is). Lite keeps its existing notification behavior (sink left null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)