### PR TITLE
MCP: enable stateless HTTP transport for broader client compat (#1074)

### DIFF
--- a/Dashboard/Mcp/McpHostService.cs
+++ b/Dashboard/Mcp/McpHostService.cs
@@ -70,7 +70,10 @@ public sealed class McpHostService : BackgroundService
                     };
                     options.ServerInstructions = McpInstructions.Text;
                 })
-                .WithHttpTransport()
+                /* Stateless mode: each request is self-contained (no Mcp-Session-Id round-trip).
+                   Required for clients like Google Antigravity that don't echo the session id,
+                   which otherwise connect but list zero tools (issue #1074). */
+                .WithHttpTransport(options => options.Stateless = true)
                 .WithTools<McpDiscoveryTools>()
                 .WithTools<McpHealthTools>()
                 .WithTools<McpWaitTools>()

--- a/Lite/Mcp/McpHostService.cs
+++ b/Lite/Mcp/McpHostService.cs
@@ -67,7 +67,10 @@ public sealed class McpHostService : BackgroundService
                     };
                     options.ServerInstructions = McpInstructions.Text;
                 })
-                .WithHttpTransport()
+                /* Stateless mode: each request is self-contained (no Mcp-Session-Id round-trip).
+                   Required for clients like Google Antigravity that don't echo the session id,
+                   which otherwise connect but list zero tools (issue #1074). */
+                .WithHttpTransport(options => options.Stateless = true)
                 .WithTools<McpDiscoveryTools>()
                 .WithTools<McpHealthTools>()
                 .WithTools<McpWaitTools>()


### PR DESCRIPTION
## Summary
Fixes the server-side half of #1074 — Google Antigravity (Gemini) connects to the MCP server but lists **zero tools**.

Both `Dashboard/Mcp/McpHostService.cs` and `Lite/Mcp/McpHostService.cs` hosted the server with bare `.WithHttpTransport()`, which defaults to **stateful** sessions: the server issues an `Mcp-Session-Id` the client must echo on every request, plus strict `Accept: application/json, text/event-stream` negotiation. Claude Code and opencode handle this; Antigravity's HTTP client doesn't, so post-`initialize` calls fail and no tools are returned.

Switching to **stateless** mode makes each request self-contained and is far more forgiving of newer/varied MCP clients. For these read-only request/response tools (no streaming/progress notifications) there's no functional downside.

```csharp
.WithHttpTransport(options => options.Stateless = true)
```

Verified `HttpServerTransportOptions.Stateless` exists in the pinned `ModelContextProtocol.AspNetCore` 1.3.0.

## Scope note
The reporter identified a **second** potential cause (Gemini rejecting nullable-union param schemas like `["string","null"]` + `default`, ~128 sites). That is intentionally **out of scope** here — stateless is the smallest, most-likely single fix. If Antigravity still lists zero tools after this lands, we'll chase the schema-collapse fix as a follow-up.

## Test plan
- [x] `dotnet build Dashboard/Dashboard.csproj -c Debug` — succeeds, 0 warnings
- [x] `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` — succeeds, 0 warnings
- [ ] Reporter (gotqn) to confirm tools now list in Google Antigravity (can't be verified from our environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)