### PR TITLE
WS5: make server_properties read resilient to version skew (graceful when WS5 columns absent)

### DIFF
--- a/Dashboard.Tests/ServerPropertiesResilienceTests.cs
+++ b/Dashboard.Tests/ServerPropertiesResilienceTests.cs
@@ -1,0 +1,42 @@
+using PerformanceMonitorDashboard.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// WS5 version-skew resilience: the server_properties SELECT references the server-health columns
+/// only when the DB has them, so a not-yet-upgraded server (Dashboard updated before that server's
+/// PerformanceMonitor DB got the WS5 upgrade) reads the core hardware columns without a bind error
+/// — keeping SERVER_HARDWARE flowing — instead of the whole collector throwing.
+/// </summary>
+public class ServerPropertiesResilienceTests
+{
+    [Fact]
+    public void Query_WithHealthColumns_SelectsThemPlusCore()
+    {
+        var sql = SqlServerFactCollector.BuildServerPropertiesQuery(includeHealthColumns: true);
+
+        Assert.Contains("lock_pages_in_memory", sql);
+        Assert.Contains("instant_file_initialization_enabled", sql);
+        Assert.Contains("memory_dump_count", sql);
+        Assert.Contains("cpu_count", sql);
+        Assert.Contains("FROM collect.server_properties", sql);
+    }
+
+    [Fact]
+    public void Query_WithoutHealthColumns_OmitsThem_ButKeepsCore()
+    {
+        var sql = SqlServerFactCollector.BuildServerPropertiesQuery(includeHealthColumns: false);
+
+        // The WS5 columns must NOT be referenced — that is what avoids the bind error on a
+        // not-yet-upgraded server.
+        Assert.DoesNotContain("lock_pages_in_memory", sql);
+        Assert.DoesNotContain("instant_file_initialization_enabled", sql);
+        Assert.DoesNotContain("memory_dump_count", sql);
+
+        // The core hardware columns are still selected, so SERVER_HARDWARE keeps flowing.
+        Assert.Contains("cpu_count", sql);
+        Assert.Contains("product_version", sql);
+        Assert.Contains("FROM collect.server_properties", sql);
+    }
+}

--- a/Dashboard/Analysis/SqlServerFactCollector.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.cs
@@ -1968,15 +1968,18 @@ ORDER BY trace_flag";
     /// Collects server hardware properties: CPU count, cores, sockets, memory.
     /// Critical context for MAXDOP and memory recommendations.
     /// </summary>
-    private async Task CollectServerPropertiesFactsAsync(AnalysisContext context, List<Fact> facts)
+    /// <summary>
+    /// Builds the latest-row server_properties SELECT, including the WS5 server-health columns only
+    /// when the DB has them. Extracted for testability and so a not-yet-upgraded server (no WS5
+    /// columns) reads the core hardware columns without a bind error.
+    /// </summary>
+    internal static string BuildServerPropertiesQuery(bool includeHealthColumns)
     {
-        try
-        {
-            using var connection = new SqlConnection(_connectionString);
-            await connection.OpenAsync();
+        var healthColumns = includeHealthColumns
+            ? ",\n    lock_pages_in_memory,\n    instant_file_initialization_enabled,\n    memory_dump_count"
+            : string.Empty;
 
-            using var cmd = connection.CreateCommand();
-            cmd.CommandText = @"
+        return $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT TOP 1
@@ -1987,12 +1990,34 @@ SELECT TOP 1
     cores_per_socket,
     is_hadr_enabled,
     edition,
-    product_version,
-    lock_pages_in_memory,
-    instant_file_initialization_enabled,
-    memory_dump_count
+    product_version{healthColumns}
 FROM collect.server_properties
 ORDER BY collection_time DESC";
+    }
+
+    private async Task CollectServerPropertiesFactsAsync(AnalysisContext context, List<Fact> facts)
+    {
+        try
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            // Version-skew resilience: a server whose PerformanceMonitor DB has not yet had the WS5
+            // upgrade lacks the three server-health columns. Probe for them (COL_LENGTH returns NULL
+            // for an absent column) and reference them only when present, so the core SERVER_HARDWARE
+            // read never fails — and keeps flowing — on a not-yet-upgraded server during a rollout.
+            // The three are added together by upgrades/2.11.0-to-2.12.0/04 (memory_dump_count last),
+            // so probing the last one is sufficient.
+            bool hasHealthColumns;
+            using (var probe = connection.CreateCommand())
+            {
+                probe.CommandText = "SELECT COL_LENGTH('collect.server_properties', 'memory_dump_count');";
+                var probeResult = await probe.ExecuteScalarAsync();
+                hasHealthColumns = probeResult is not null && probeResult is not DBNull;
+            }
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = BuildServerPropertiesQuery(hasHealthColumns);
 
             using var reader = await cmd.ExecuteReaderAsync();
             if (!await reader.ReadAsync()) return;
@@ -2004,9 +2029,18 @@ ORDER BY collection_time DESC";
             var coresPerSocket = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4));
             var hadrEnabled = !reader.IsDBNull(5) && Convert.ToBoolean(reader.GetValue(5));
             var edition = reader.IsDBNull(6) ? string.Empty : reader.GetString(6);
-            bool? lpim = reader.IsDBNull(8) ? (bool?)null : Convert.ToBoolean(reader.GetValue(8));
-            bool? ifi = reader.IsDBNull(9) ? (bool?)null : Convert.ToBoolean(reader.GetValue(9));
-            int? dumpCount = reader.IsDBNull(10) ? (int?)null : Convert.ToInt32(reader.GetValue(10));
+
+            // Present only on a WS5-upgraded DB (see the probe above); null otherwise, so
+            // EmitServerHealthFacts emits nothing for a not-yet-upgraded server.
+            bool? lpim = null;
+            bool? ifi = null;
+            int? dumpCount = null;
+            if (hasHealthColumns)
+            {
+                lpim = reader.IsDBNull(8) ? (bool?)null : Convert.ToBoolean(reader.GetValue(8));
+                ifi = reader.IsDBNull(9) ? (bool?)null : Convert.ToBoolean(reader.GetValue(9));
+                dumpCount = reader.IsDBNull(10) ? (int?)null : Convert.ToInt32(reader.GetValue(10));
+            }
 
             if (cpuCount == 0) return;
 


### PR DESCRIPTION
## Why
WS5 added three columns to `collect.server_properties` and `CollectServerPropertiesFactsAsync` SELECTs them. On a server whose PerformanceMonitor DB **hasn't had the WS5 upgrade yet** (Dashboard updated before that server's schema — a real version-skew window during a rollout), the SELECT fails with an invalid-column error. It's caught, but that server **loses its `SERVER_HARDWARE` fact** and logs an error **every analysis cycle** until upgraded. (Found while testing all six in concert on dev — only sql2022 had the WS5 upgrade, so the other four spammed this.)

## Fix
- Probe with `COL_LENGTH` for the server-health columns; reference them only when present.
- Extracted `BuildServerPropertiesQuery(bool includeHealthColumns)` (unit-tested both ways).
- A not-yet-upgraded server now reads the **core hardware columns cleanly** (SERVER_HARDWARE keeps flowing) and emits no server-health facts until it's upgraded — no error, no lost facts.

Lite is unaffected (its DuckDB schema is migrated in-process on startup, so the columns always exist).

## Tests
Dashboard.Tests **453 (+2)** — query includes the WS5 columns when present, omits them (keeping the core columns) when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)