### PR TITLE
MCP: emit Gemini-compatible tool schemas (#1074)

### DIFF
--- a/Dashboard.Tests/McpSchemaCompatTests.cs
+++ b/Dashboard.Tests/McpSchemaCompatTests.cs
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Golden-sample tests for the Gemini-compatible MCP tool schema transform (issue #1074), covering the
+/// Dashboard tool surface. Mirrors Lite.Tests/McpSchemaCompatTests.cs against Dashboard's tool classes,
+/// which differ from Lite's. See that file for the full rationale.
+/// </summary>
+public class McpSchemaCompatTests
+{
+    /// <summary>All Dashboard MCP tool classes, discovered by their [McpServerToolType] attribute.</summary>
+    private static List<Type> DashboardToolTypes() =>
+        typeof(PerformanceMonitorDashboard.Mcp.McpAlertTools).Assembly
+            .GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+
+    private static bool IsServiceParameter(Type t) =>
+        !t.IsPrimitive && t != typeof(string) && !t.IsEnum && t != typeof(decimal) &&
+        t != typeof(DateTime) && t != typeof(DateTimeOffset) && t != typeof(Guid) && t != typeof(TimeSpan);
+
+    private static readonly MethodInfo GeminiCompatibleToolsMethod =
+        typeof(McpSchemaCompat).GetMethod(
+            nameof(McpSchemaCompat.WithGeminiCompatibleTools),
+            BindingFlags.Public | BindingFlags.Static)!;
+
+    private static readonly MethodInfo StockWithToolsMethod =
+        typeof(McpServerBuilderExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .First(m => m.Name == nameof(McpServerBuilderExtensions.WithTools)
+                && m.IsGenericMethodDefinition
+                && m.GetParameters() is { Length: 2 } p
+                && p[1].ParameterType == typeof(JsonSerializerOptions));
+
+    private static List<ModelContextProtocol.Protocol.Tool> BuildProtocolTools(MethodInfo openGenericRegister, bool stock)
+    {
+        var toolTypes = DashboardToolTypes();
+        var services = new ServiceCollection();
+
+        var serviceParamTypes = toolTypes
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .SelectMany(m => m.GetParameters())
+            .Select(p => p.ParameterType)
+            .Where(IsServiceParameter)
+            .Distinct();
+
+        foreach (var serviceType in serviceParamTypes)
+        {
+            services.AddSingleton(serviceType, _ => null!);
+        }
+
+        var builder = services.AddMcpServer();
+
+        foreach (var toolType in toolTypes)
+        {
+            var closed = openGenericRegister.MakeGenericMethod(toolType);
+            var args = stock ? new object?[] { builder, null } : new object?[] { builder };
+            closed.Invoke(null, args);
+        }
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetServices<McpServerTool>().Select(t => t.ProtocolTool).ToList();
+    }
+
+    private static List<string> FindViolations(string toolName, JsonElement schema)
+    {
+        var violations = new List<string>();
+        Walk(schema, toolName);
+        return violations;
+
+        void Walk(JsonElement element, string path)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        if (property.NameEquals("type") && property.Value.ValueKind == JsonValueKind.Array)
+                        {
+                            violations.Add($"{path}: union type {property.Value.GetRawText()}");
+                        }
+
+                        if (property.NameEquals("default"))
+                        {
+                            violations.Add($"{path}: default = {property.Value.GetRawText()}");
+                        }
+
+                        Walk(property.Value, $"{path}.{property.Name}");
+                    }
+                    break;
+
+                case JsonValueKind.Array:
+                    var index = 0;
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        Walk(item, $"{path}[{index++}]");
+                    }
+                    break;
+            }
+        }
+    }
+
+    [Fact]
+    public void GeminiCompatibleTools_EmitNoUnionTypesOrDefaultKeywords()
+    {
+        var tools = BuildProtocolTools(GeminiCompatibleToolsMethod, stock: false);
+
+        Assert.NotEmpty(tools);
+
+        var allViolations = tools
+            .SelectMany(t => FindViolations(t.Name, t.InputSchema))
+            .ToList();
+
+        Assert.True(
+            allViolations.Count == 0,
+            "Gemini-incompatible schema keywords leaked into tools/list:\n" + string.Join("\n", allViolations));
+    }
+
+    [Fact]
+    public void StockWithTools_WouldEmitUnionTypesOrDefaults_ProvingTransformIsNecessary()
+    {
+        var tools = BuildProtocolTools(StockWithToolsMethod, stock: true);
+
+        var violationCount = tools.Sum(t => FindViolations(t.Name, t.InputSchema).Count);
+
+        Assert.True(
+            violationCount > 0,
+            "Expected the stock SDK registration to emit union types / default keywords; it did not. " +
+            "If the SDK changed, McpSchemaCompat may no longer be needed.");
+    }
+
+    [Fact]
+    public void GeminiCompatibleTools_ExposeSameToolCountAsStock()
+    {
+        var gemini = BuildProtocolTools(GeminiCompatibleToolsMethod, stock: false);
+        var stock = BuildProtocolTools(StockWithToolsMethod, stock: true);
+
+        Assert.Equal(
+            stock.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal),
+            gemini.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal));
+    }
+}

--- a/Dashboard/Mcp/McpHostService.cs
+++ b/Dashboard/Mcp/McpHostService.cs
@@ -74,28 +74,31 @@ public sealed class McpHostService : BackgroundService
                    Required for clients like Google Antigravity that don't echo the session id,
                    which otherwise connect but list zero tools (issue #1074). */
                 .WithHttpTransport(options => options.Stateless = true)
-                .WithTools<McpDiscoveryTools>()
-                .WithTools<McpHealthTools>()
-                .WithTools<McpWaitTools>()
-                .WithTools<McpBlockingTools>()
-                .WithTools<McpQueryTools>()
-                .WithTools<McpCpuTools>()
-                .WithTools<McpMemoryTools>()
-                .WithTools<McpIoTools>()
-                .WithTools<McpTempDbTools>()
-                .WithTools<McpPerfmonTools>()
-                .WithTools<McpAlertTools>()
-                .WithTools<McpJobTools>()
-                .WithTools<McpPlanTools>()
-                .WithTools<McpLatchSpinlockTools>()
-                .WithTools<McpSchedulerTools>()
-                .WithTools<McpConfigHistoryTools>()
-                .WithTools<McpDiagnosticTools>()
-                .WithTools<McpActiveQueryTools>()
-                .WithTools<McpSystemEventTools>()
-                .WithTools<McpHealthParserTools>()
-                .WithTools<McpServerInventoryTools>()
-                .WithTools<McpAnalysisTools>();
+                /* WithGeminiCompatibleTools (not the SDK's WithTools) rewrites parameter schemas into
+                   the subset Gemini/Antigravity accepts — collapsing nullable type unions and
+                   dropping the default keyword. The companion to stateless transport for issue #1074. */
+                .WithGeminiCompatibleTools<McpDiscoveryTools>()
+                .WithGeminiCompatibleTools<McpHealthTools>()
+                .WithGeminiCompatibleTools<McpWaitTools>()
+                .WithGeminiCompatibleTools<McpBlockingTools>()
+                .WithGeminiCompatibleTools<McpQueryTools>()
+                .WithGeminiCompatibleTools<McpCpuTools>()
+                .WithGeminiCompatibleTools<McpMemoryTools>()
+                .WithGeminiCompatibleTools<McpIoTools>()
+                .WithGeminiCompatibleTools<McpTempDbTools>()
+                .WithGeminiCompatibleTools<McpPerfmonTools>()
+                .WithGeminiCompatibleTools<McpAlertTools>()
+                .WithGeminiCompatibleTools<McpJobTools>()
+                .WithGeminiCompatibleTools<McpPlanTools>()
+                .WithGeminiCompatibleTools<McpLatchSpinlockTools>()
+                .WithGeminiCompatibleTools<McpSchedulerTools>()
+                .WithGeminiCompatibleTools<McpConfigHistoryTools>()
+                .WithGeminiCompatibleTools<McpDiagnosticTools>()
+                .WithGeminiCompatibleTools<McpActiveQueryTools>()
+                .WithGeminiCompatibleTools<McpSystemEventTools>()
+                .WithGeminiCompatibleTools<McpHealthParserTools>()
+                .WithGeminiCompatibleTools<McpServerInventoryTools>()
+                .WithGeminiCompatibleTools<McpAnalysisTools>();
 
             _app = builder.Build();
             _app.MapMcp();

--- a/Dashboard/packages.lock.json
+++ b/Dashboard/packages.lock.json
@@ -742,7 +742,10 @@
         "type": "Project"
       },
       "performancemonitor.common": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "ModelContextProtocol": "[1.3.0, )"
+        }
       },
       "performancemonitor.notifications": {
         "type": "Project",

--- a/Lite.Tests/McpSchemaCompatTests.cs
+++ b/Lite.Tests/McpSchemaCompatTests.cs
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Golden-sample tests for the Gemini-compatible MCP tool schema transform (issue #1074).
+///
+/// Google Antigravity (Gemini) connects to the MCP server but lists zero tools when any tool's
+/// parameter schema contains a union "type" array (e.g. ["string","null"], emitted for a
+/// nullable-with-default parameter) or a "default" keyword. These tests assert against the exact
+/// JSON schema the server advertises in tools/list (McpServerTool.ProtocolTool.InputSchema) — no
+/// running server required.
+/// </summary>
+public class McpSchemaCompatTests
+{
+    /// <summary>All Lite MCP tool classes, discovered by their [McpServerToolType] attribute.</summary>
+    private static List<Type> LiteToolTypes() =>
+        typeof(PerformanceMonitorLite.Mcp.McpWaitTools).Assembly
+            .GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// A tool parameter is DI-injected (and excluded from the schema) when its type is not a simple
+    /// model-facing value. Registering these types as no-op singletons makes the SDK's
+    /// IServiceProviderIsService report them as services, exactly as production DI does.
+    /// </summary>
+    private static bool IsServiceParameter(Type t) =>
+        !t.IsPrimitive && t != typeof(string) && !t.IsEnum && t != typeof(decimal) &&
+        t != typeof(DateTime) && t != typeof(DateTimeOffset) && t != typeof(Guid) && t != typeof(TimeSpan);
+
+    private static readonly MethodInfo GeminiCompatibleToolsMethod =
+        typeof(McpSchemaCompat).GetMethod(
+            nameof(McpSchemaCompat.WithGeminiCompatibleTools),
+            BindingFlags.Public | BindingFlags.Static)!;
+
+    private static readonly MethodInfo StockWithToolsMethod =
+        typeof(McpServerBuilderExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .First(m => m.Name == nameof(McpServerBuilderExtensions.WithTools)
+                && m.IsGenericMethodDefinition
+                && m.GetParameters() is { Length: 2 } p
+                && p[1].ParameterType == typeof(JsonSerializerOptions));
+
+    /// <summary>
+    /// Builds the protocol tools as the host would, registering each tool type via the supplied
+    /// open-generic registration method (the Gemini-compatible path or the stock SDK path).
+    /// </summary>
+    private static List<ModelContextProtocol.Protocol.Tool> BuildProtocolTools(MethodInfo openGenericRegister, bool stock)
+    {
+        var toolTypes = LiteToolTypes();
+        var services = new ServiceCollection();
+
+        /* Register every service-typed tool parameter as a no-op singleton so it is excluded from the
+           schema. The test only reads schemas and never invokes a tool, so the null factory is never run. */
+        var serviceParamTypes = toolTypes
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .SelectMany(m => m.GetParameters())
+            .Select(p => p.ParameterType)
+            .Where(IsServiceParameter)
+            .Distinct();
+
+        foreach (var serviceType in serviceParamTypes)
+        {
+            services.AddSingleton(serviceType, _ => null!);
+        }
+
+        var builder = services.AddMcpServer();
+
+        foreach (var toolType in toolTypes)
+        {
+            var closed = openGenericRegister.MakeGenericMethod(toolType);
+            var args = stock ? new object?[] { builder, null } : new object?[] { builder };
+            closed.Invoke(null, args);
+        }
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetServices<McpServerTool>().Select(t => t.ProtocolTool).ToList();
+    }
+
+    /// <summary>Recursively collects every schema-violation path (union type arrays or default keywords).</summary>
+    private static List<string> FindViolations(string toolName, JsonElement schema)
+    {
+        var violations = new List<string>();
+        Walk(schema, toolName);
+        return violations;
+
+        void Walk(JsonElement element, string path)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        if (property.NameEquals("type") && property.Value.ValueKind == JsonValueKind.Array)
+                        {
+                            violations.Add($"{path}: union type {property.Value.GetRawText()}");
+                        }
+
+                        if (property.NameEquals("default"))
+                        {
+                            violations.Add($"{path}: default = {property.Value.GetRawText()}");
+                        }
+
+                        Walk(property.Value, $"{path}.{property.Name}");
+                    }
+                    break;
+
+                case JsonValueKind.Array:
+                    var index = 0;
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        Walk(item, $"{path}[{index++}]");
+                    }
+                    break;
+            }
+        }
+    }
+
+    [Fact]
+    public void GeminiCompatibleTools_EmitNoUnionTypesOrDefaultKeywords()
+    {
+        var tools = BuildProtocolTools(GeminiCompatibleToolsMethod, stock: false);
+
+        Assert.NotEmpty(tools);
+
+        var allViolations = tools
+            .SelectMany(t => FindViolations(t.Name, t.InputSchema))
+            .ToList();
+
+        Assert.True(
+            allViolations.Count == 0,
+            "Gemini-incompatible schema keywords leaked into tools/list:\n" + string.Join("\n", allViolations));
+    }
+
+    [Fact]
+    public void StockWithTools_WouldEmitUnionTypesOrDefaults_ProvingTransformIsNecessary()
+    {
+        /* Guards the premise: if a future SDK stops emitting union types / defaults, the transform
+           becomes unnecessary and this test will flag it for removal. */
+        var tools = BuildProtocolTools(StockWithToolsMethod, stock: true);
+
+        var violationCount = tools.Sum(t => FindViolations(t.Name, t.InputSchema).Count);
+
+        Assert.True(
+            violationCount > 0,
+            "Expected the stock SDK registration to emit union types / default keywords; it did not. " +
+            "If the SDK changed, McpSchemaCompat may no longer be needed.");
+    }
+
+    [Fact]
+    public void GeminiCompatibleTools_ExposeSameToolCountAsStock()
+    {
+        var gemini = BuildProtocolTools(GeminiCompatibleToolsMethod, stock: false);
+        var stock = BuildProtocolTools(StockWithToolsMethod, stock: true);
+
+        /* The transform must not drop or add tools — only rewrite their schemas. */
+        Assert.Equal(
+            stock.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal),
+            gemini.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal));
+    }
+}

--- a/Lite.Tests/packages.lock.json
+++ b/Lite.Tests/packages.lock.json
@@ -898,7 +898,10 @@
         "type": "Project"
       },
       "performancemonitor.common": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "ModelContextProtocol": "[1.3.0, )"
+        }
       },
       "performancemonitor.notifications": {
         "type": "Project",

--- a/Lite/Mcp/McpHostService.cs
+++ b/Lite/Mcp/McpHostService.cs
@@ -71,23 +71,26 @@ public sealed class McpHostService : BackgroundService
                    Required for clients like Google Antigravity that don't echo the session id,
                    which otherwise connect but list zero tools (issue #1074). */
                 .WithHttpTransport(options => options.Stateless = true)
-                .WithTools<McpDiscoveryTools>()
-                .WithTools<McpHealthTools>()
-                .WithTools<McpWaitTools>()
-                .WithTools<McpBlockingTools>()
-                .WithTools<McpQueryTools>()
-                .WithTools<McpCpuTools>()
-                .WithTools<McpMemoryTools>()
-                .WithTools<McpIoTools>()
-                .WithTools<McpTempDbTools>()
-                .WithTools<McpPerfmonTools>()
-                .WithTools<McpAlertTools>()
-                .WithTools<McpJobTools>()
-                .WithTools<McpPlanTools>()
-                .WithTools<McpConfigTools>()
-                .WithTools<McpServerInfoTools>()
-                .WithTools<McpSessionTools>()
-                .WithTools<McpAnalysisTools>();
+                /* WithGeminiCompatibleTools (not the SDK's WithTools) rewrites parameter schemas into
+                   the subset Gemini/Antigravity accepts — collapsing nullable type unions and
+                   dropping the default keyword. The companion to stateless transport for issue #1074. */
+                .WithGeminiCompatibleTools<McpDiscoveryTools>()
+                .WithGeminiCompatibleTools<McpHealthTools>()
+                .WithGeminiCompatibleTools<McpWaitTools>()
+                .WithGeminiCompatibleTools<McpBlockingTools>()
+                .WithGeminiCompatibleTools<McpQueryTools>()
+                .WithGeminiCompatibleTools<McpCpuTools>()
+                .WithGeminiCompatibleTools<McpMemoryTools>()
+                .WithGeminiCompatibleTools<McpIoTools>()
+                .WithGeminiCompatibleTools<McpTempDbTools>()
+                .WithGeminiCompatibleTools<McpPerfmonTools>()
+                .WithGeminiCompatibleTools<McpAlertTools>()
+                .WithGeminiCompatibleTools<McpJobTools>()
+                .WithGeminiCompatibleTools<McpPlanTools>()
+                .WithGeminiCompatibleTools<McpConfigTools>()
+                .WithGeminiCompatibleTools<McpServerInfoTools>()
+                .WithGeminiCompatibleTools<McpSessionTools>()
+                .WithGeminiCompatibleTools<McpAnalysisTools>();
 
             _app = builder.Build();
             _app.MapMcp();

--- a/Lite/packages.lock.json
+++ b/Lite/packages.lock.json
@@ -754,7 +754,10 @@
         "type": "Project"
       },
       "performancemonitor.common": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "ModelContextProtocol": "[1.3.0, )"
+        }
       },
       "performancemonitor.notifications": {
         "type": "Project",

--- a/PerformanceMonitor.Common/Mcp/McpSchemaCompat.cs
+++ b/PerformanceMonitor.Common/Mcp/McpSchemaCompat.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Server;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// MCP tool registration that produces JSON schemas tolerated by stricter function-calling
+/// validators (notably Google Gemini / Antigravity).
+///
+/// The stock <c>WithTools&lt;T&gt;()</c> emits parameter schemas straight from the .NET method
+/// signatures. A nullable-with-default parameter such as <c>string? server_name = null</c> becomes
+/// <c>{ "type": ["string", "null"], "default": null }</c>. Gemini's function-declaration validator
+/// rejects union <c>type</c> arrays and the <c>default</c> keyword and drops the ENTIRE tool set,
+/// so the client connects but lists zero tools (issue #1074). Claude Code / opencode are lenient
+/// and accept the same schema, which is why this only bites Gemini-based clients.
+///
+/// This registers tools identically to the SDK's <c>WithTools&lt;T&gt;()</c> (same DI-backed
+/// service-parameter exclusion, same invocation path) but installs a schema transform that:
+///   - collapses nullable type unions, e.g. <c>["string","null"]</c> → <c>"string"</c>; and
+///   - strips the <c>default</c> keyword.
+/// Optionality is still conveyed by the parameter's absence from the schema's <c>required</c> array,
+/// and the .NET default value still applies at invocation time, so nothing changes for lenient
+/// clients — the tool surface and call behavior are unchanged.
+/// </summary>
+public static class McpSchemaCompat
+{
+    /// <summary>
+    /// Shared schema-creation options applied to every Gemini-compatible tool. Immutable, so a single
+    /// instance is reused across all registrations.
+    /// </summary>
+    private static readonly AIJsonSchemaCreateOptions GeminiCompatSchemaOptions = new()
+    {
+        TransformOptions = new AIJsonSchemaTransformOptions
+        {
+            TransformSchemaNode = CollapseGeminiUnsupportedKeywords
+        }
+    };
+
+    /// <summary>
+    /// Adds all <see cref="McpServerToolAttribute"/>-marked static methods on <typeparamref name="TToolType"/>
+    /// as MCP tools, generating Gemini-compatible parameter schemas. Drop-in replacement for the SDK's
+    /// <c>WithTools&lt;TToolType&gt;()</c> for tool classes whose methods are all static.
+    /// </summary>
+    public static IMcpServerBuilder WithGeminiCompatibleTools<[DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.NonPublicMethods)] TToolType>(
+        this IMcpServerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        foreach (var toolMethod in typeof(TToolType).GetMethods(
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+        {
+            if (toolMethod.GetCustomAttribute<McpServerToolAttribute>() is null)
+            {
+                continue;
+            }
+
+            /* All Performance Monitor tools are static methods that receive their dependencies as
+               parameters resolved from DI. Instance tools would need a target factory (as the SDK's
+               WithTools does); fail loudly rather than silently skip if that ever changes. */
+            if (!toolMethod.IsStatic)
+            {
+                throw new InvalidOperationException(
+                    $"{typeof(TToolType).FullName}.{toolMethod.Name} is an instance method; " +
+                    $"{nameof(WithGeminiCompatibleTools)} only supports static tool methods.");
+            }
+
+            /* Mirror the SDK's static-method registration (McpServerBuilderExtensions.WithTools<T>):
+               Services = the DI provider so service-typed parameters are excluded from the schema and
+               resolved per-request. The only addition is SchemaCreateOptions. */
+            builder.Services.AddSingleton((Func<IServiceProvider, McpServerTool>)(services =>
+                McpServerTool.Create(
+                    toolMethod,
+                    target: null,
+                    options: new McpServerToolCreateOptions
+                    {
+                        Services = services,
+                        SchemaCreateOptions = GeminiCompatSchemaOptions
+                    })));
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Rewrites a single generated schema node into the subset Gemini's function-calling validator
+    /// accepts: collapses nullable <c>type</c> unions to the single non-null type and removes the
+    /// <c>default</c> keyword. Non-object nodes (e.g. boolean schemas) are returned unchanged.
+    /// </summary>
+    private static JsonNode CollapseGeminiUnsupportedKeywords(AIJsonSchemaTransformContext context, JsonNode node)
+    {
+        if (node is JsonObject obj)
+        {
+            /* Collapse "type": ["string","null"] -> "type": "string". */
+            if (obj["type"] is JsonArray typeArray)
+            {
+                string? singleType = null;
+                foreach (var element in typeArray)
+                {
+                    var typeName = element?.GetValue<string>();
+                    if (typeName is not null && typeName != "null")
+                    {
+                        singleType = typeName;
+                        break;
+                    }
+                }
+
+                if (singleType is not null)
+                {
+                    obj["type"] = singleType;
+                }
+            }
+
+            /* Strip the "default" keyword; Gemini rejects it. The .NET method default still applies
+               when the argument is omitted, and the description documents it. */
+            obj.Remove("default");
+        }
+
+        return node;
+    }
+}

--- a/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
+++ b/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
@@ -14,6 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- MCP SDK: required by Mcp/McpSchemaCompat.cs (Gemini-compatible tool registration, issue #1074).
+         Brings ModelContextProtocol.Core + Microsoft.Extensions.AI.Abstractions transitively. -->
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="PerformanceMonitorLite" />
     <InternalsVisibleTo Include="PerformanceMonitorDashboard" />
     <InternalsVisibleTo Include="Lite.Tests" />


### PR DESCRIPTION
## Problem

Follow-up to #1077. Stateless transport was necessary but not sufficient — Google Antigravity (Gemini) still listed **zero** MCP tools. @gotqn confirmed by testing the `dev` build that the remaining blocker is **cause #2**: parameter schema shape.

A nullable-with-default parameter like `string? server_name = null` is emitted as:

```json
{ "type": ["string", "null"], "default": null }
```

Gemini's function-declaration validator rejects union `type` arrays and the `default` keyword and drops the **entire** tool set. Claude Code / opencode are lenient and accept the same schema, which is why this only bites Gemini-based clients.

## Fix

Rather than hand-edit ~122 nullable params across the tool classes, transform the schema at registration time.

- **`PerformanceMonitor.Common/Mcp/McpSchemaCompat.cs`** — new `WithGeminiCompatibleTools<T>()`, a drop-in for the SDK's `WithTools<T>()`. Registers tools identically (same DI service-parameter exclusion and invocation path — mirrors the SDK v1.3.0 `WithTools<T>` source) but installs a `TransformSchemaNode` that collapses nullable type unions (`["string","null"]` → `"string"`) and strips the `default` keyword.
- **`Lite/Mcp/McpHostService.cs`**, **`Dashboard/Mcp/McpHostService.cs`** — register every tool class via the new helper.
- **`PerformanceMonitor.Common.csproj`** — add the `ModelContextProtocol` package reference the helper needs.

Behavior is unchanged for lenient clients: optionality is still conveyed by the schema's `required` array and the .NET default still applies when an argument is omitted — only the wire-format changes.

## Test plan

- [x] Lite, Dashboard, and Common build clean (0 warnings / 0 errors)
- [x] **Golden-sample tests** (3 in `Lite.Tests`, 3 in `Dashboard.Tests`) assert against the actual `tools/list` `InputSchema`:
  - no union `type` arrays or `default` keywords remain
  - the stock `WithTools` path *does* still emit them (proves the transform is necessary and guards against SDK drift)
  - the advertised tool set is unchanged (no tools dropped/added)
- [x] Dumped a real transformed schema — the only top-level keys across all tools are `type` / `properties` / `required`; nothing else Gemini-hostile (`$schema`, `additionalProperties`, `anyOf`, …)
- [ ] @gotqn to confirm Antigravity lists the tools on the next `dev` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)