### PR TITLE
WS4: missing-index CREATE statements as copy-paste on Recommendations cards

### DIFF
--- a/Dashboard.Tests/MissingIndexAdvisoryTests.cs
+++ b/Dashboard.Tests/MissingIndexAdvisoryTests.cs
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Controls;
+using PerformanceMonitorDashboard.Services.Recommendations;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// WS4: missing-index advisory — the COPY-PASTE-ONLY recommendation. A MISSING_INDEX finding's
+/// drill-down carries the SQL Server-suggested CREATE INDEX statement(s); the drill-down is
+/// ephemeral (not persisted / not read back), so the statements ride the persisted
+/// <see cref="RemediationAction"/> (FactKey "MISSING_INDEX") through to the reader — exactly like the
+/// autogrowth advisory, but with NO handler so it never offers Apply. These tests cover the builder,
+/// the persisted-action round-trip, the reader mapping (copy-paste set, Remediation null), and the
+/// card affordances (Copy fix shown, Apply hidden, incident affordances preserved).
+/// </summary>
+public class MissingIndexAdvisoryTests
+{
+    private const string CreateStmt =
+        "CREATE NONCLUSTERED INDEX [ix_Orders_CustomerId] ON [dbo].[Orders] ([CustomerId]) INCLUDE ([OrderDate]);";
+
+    private static AnalysisFinding MissingIndexFinding(List<object>? rows = null) => new()
+    {
+        ServerId = 1,
+        ServerName = "TestServer",
+        Category = "missing_index",
+        StoryPath = "MISSING_INDEX",
+        StoryPathHash = "missingidx000001",
+        RootFactKey = "MISSING_INDEX",
+        Severity = 0.4,
+        DrillDown = new Dictionary<string, object>
+        {
+            // SqlServerDrillDownCollector "missing_indexes": { table, impact, create_statement }.
+            ["missing_indexes"] = rows ?? new List<object>
+            {
+                new { table = "dbo.Orders", impact = 87.3, create_statement = CreateStmt }
+            }
+        }
+    };
+
+    // ── Builder + extractor ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildMissingIndexAction_ProducesAdviseActionWithTargets()
+    {
+        var action = FactRemediation.BuildMissingIndexAction(MissingIndexFinding());
+
+        Assert.NotNull(action);
+        Assert.Equal("MISSING_INDEX", action!.FactKey);
+        Assert.Equal("advise", action.Action);
+        Assert.Empty(action.Targets);                       // not a force-plan action
+        Assert.NotNull(action.MissingIndexTargets);
+        var t = Assert.Single(action.MissingIndexTargets!);
+        Assert.Equal("dbo.Orders", t.Table);
+        Assert.Equal(87.3, t.Impact);
+        Assert.Equal(CreateStmt, t.CreateStatement);
+    }
+
+    [Fact]
+    public void BuildMissingIndexAction_WrongRootFactKey_ReturnsNull()
+    {
+        var finding = MissingIndexFinding();
+        finding.RootFactKey = "PLAN_WARNING";               // a sibling advisory, not missing-index
+        Assert.Null(FactRemediation.BuildMissingIndexAction(finding));
+    }
+
+    [Fact]
+    public void BuildMissingIndexAction_NoDrillDownOrEmpty_ReturnsNull()
+    {
+        Assert.Null(FactRemediation.BuildMissingIndexAction(new AnalysisFinding { RootFactKey = "MISSING_INDEX" }));
+        Assert.Null(FactRemediation.BuildMissingIndexAction(MissingIndexFinding(new List<object>())));
+    }
+
+    [Fact]
+    public void ExtractMissingIndexTargets_SkipsRowsWithoutCreateStatement_AndCapsAtFive()
+    {
+        // A row with no create_statement has nothing to copy → skipped.
+        var noStmt = FactRemediation.ExtractMissingIndexTargets(MissingIndexFinding(new List<object>
+        {
+            new { table = "dbo.A", impact = 10.0, create_statement = "" }
+        }));
+        Assert.Empty(noStmt);
+
+        var many = Enumerable.Range(1, 8)
+            .Select(i => (object)new { table = $"dbo.T{i}", impact = (double)i, create_statement = $"CREATE INDEX ix{i} ON dbo.T{i}(c);" })
+            .ToList();
+        Assert.Equal(5, FactRemediation.ExtractMissingIndexTargets(MissingIndexFinding(many)).Count);
+    }
+
+    // ── Persisted-action round-trip (the drill-down is ephemeral; the action must survive) ──
+
+    [Fact]
+    public void SerializeAction_RoundTrips_MissingIndexTargets()
+    {
+        var action = FactRemediation.BuildMissingIndexAction(MissingIndexFinding());
+        var json = AlertContextSerializer.SerializeAction(action);
+        var back = AlertContextSerializer.DeserializeAction(json);
+
+        Assert.NotNull(back);
+        Assert.Equal("MISSING_INDEX", back!.FactKey);
+        var t = Assert.Single(back.MissingIndexTargets!);
+        Assert.Equal("dbo.Orders", t.Table);
+        Assert.Equal(87.3, t.Impact);
+        Assert.Equal(CreateStmt, t.CreateStatement);
+    }
+
+    // ── Reader: copy-paste set, Remediation deliberately null (no Apply) ────────────
+
+    [Fact]
+    public void MapEngineFinding_MissingIndex_IsCopyOnly()
+    {
+        var finding = MissingIndexFinding();
+        // Mirror AnalysisService: the built action is attached before persistence/read.
+        finding.Remediation = FactRemediation.BuildMissingIndexAction(finding);
+
+        var item = RecommendationsReader.MapEngineFinding(finding);
+
+        Assert.Contains(CreateStmt, item.CopyPasteSql);     // the CREATE is the copy-paste payload
+        Assert.Null(item.Remediation);                       // copy-only — never Apply
+        Assert.True(item.IsMissingIndexAdvisory);
+        Assert.Equal(RecommendationSetting.None, item.Setting);  // stays a non-de-duping incident
+    }
+
+    [Fact]
+    public void MapEngineFinding_MissingIndex_JoinsMultipleCreateStatements()
+    {
+        var finding = MissingIndexFinding(new List<object>
+        {
+            new { table = "dbo.A", impact = 50.0, create_statement = "CREATE INDEX ixa ON dbo.A(c);" },
+            new { table = "dbo.B", impact = 40.0, create_statement = "CREATE INDEX ixb ON dbo.B(c);" }
+        });
+        finding.Remediation = FactRemediation.BuildMissingIndexAction(finding);
+
+        var item = RecommendationsReader.MapEngineFinding(finding);
+        Assert.Contains("CREATE INDEX ixa ON dbo.A(c);", item.CopyPasteSql);
+        Assert.Contains("CREATE INDEX ixb ON dbo.B(c);", item.CopyPasteSql);
+    }
+
+    // ── Card affordances: Copy fix shown, Apply hidden, incident affordances preserved ──
+
+    [Fact]
+    public void CardViewModel_MissingIndex_ShowsCopyFix_NotApply_StillIncident()
+    {
+        var finding = MissingIndexFinding();
+        finding.Remediation = FactRemediation.BuildMissingIndexAction(finding);
+        var vm = new RecommendationCardViewModel(RecommendationsReader.MapEngineFinding(finding));
+
+        Assert.True(vm.ShowCopyFix);                 // the CREATE INDEX is copyable
+        Assert.False(vm.ShowApply);                  // copy-only — no handler, no Apply button
+        Assert.True(vm.IsIncident);                  // stays an incident...
+        Assert.True(vm.ShowAskAi);                   // ...so Ask-AI...
+        Assert.True(vm.ShowOpenInActiveQueries);     // ...and Open-in-Active-Queries remain
+    }
+}

--- a/Dashboard.Tests/RemediationGoldenSampleTests.cs
+++ b/Dashboard.Tests/RemediationGoldenSampleTests.cs
@@ -250,6 +250,42 @@ public class RemediationGoldenSampleTests
         Assert.Equal(ServerConfigSetting.Maxdop, action.ServerConfigTargets!.Single().Setting);
     }
 
+    // ── MISSING_INDEX → BuildMissingIndexAction → FactKey "MISSING_INDEX" (WS4; COPY-ONLY) ─────────
+    // The drill-down → builder drift guard for the one COPY-PASTE-ONLY advisory: a non-null action
+    // carrying its CREATE-statement targets, but deliberately NOT registry-dispatchable — creating an
+    // index is a judgement call, so there is no handler and no Apply (the reader renders the CREATE as
+    // copy-paste and leaves the card's Remediation null). Drill-down: SqlServerDrillDownCollector /
+    // Lite DrillDownCollector "missing_indexes" ({ table, impact, create_statement }).
+    private static AnalysisFinding MissingIndex() => new()
+    {
+        ServerId = 1, ServerName = "GoldenServer", Category = "missing_index",
+        StoryPath = "MISSING_INDEX", StoryPathHash = "golden_missidx01",
+        RootFactKey = "MISSING_INDEX",
+        DrillDown = new Dictionary<string, object>
+        {
+            ["missing_indexes"] = new List<object>
+            {
+                new
+                {
+                    table = "dbo.Orders", impact = 87.3,
+                    create_statement = "CREATE NONCLUSTERED INDEX [ix_Orders_CustomerId] ON [dbo].[Orders] ([CustomerId]);"
+                }
+            }
+        }
+    };
+
+    [Fact]
+    public void MissingIndex_DrillDown_BuildsCopyOnlyAdvisoryAction_NotDispatchable()
+    {
+        var action = FactRemediation.BuildMissingIndexAction(MissingIndex());
+        Assert.NotNull(action);
+        Assert.Equal("MISSING_INDEX", action!.FactKey);
+        Assert.NotNull(action.MissingIndexTargets);
+        Assert.NotEmpty(action.MissingIndexTargets!);
+        // Copy-only: NO handler resolves it — the reader surfaces copy-paste and shows no Apply.
+        Assert.Null(Registry.TryGet(action.FactKey));
+    }
+
     // ── Completeness: every registered Apply-able key has a golden fixture ─────────────────────────
     [Fact]
     public void EveryRegisteredHandlerKey_IsExercisedByAGoldenFixture()

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -211,7 +211,8 @@ public class AnalysisService
                     ?? FactRemediation.BuildRcsiAction(finding)
                     ?? FactRemediation.BuildClearPlanAction(finding)
                     ?? FactRemediation.BuildFileAutogrowthAction(finding) // WS3: advisory only (no handler -> no Apply); carried for the read-time copy-paste
-                    ?? FactRemediation.BuildServerConfigAction(finding); // WS3: server-level config — MAXDOP/CTFP Apply-able, memory advise-only
+                    ?? FactRemediation.BuildServerConfigAction(finding) // WS3: server-level config — MAXDOP/CTFP Apply-able, memory advise-only
+                    ?? FactRemediation.BuildMissingIndexAction(finding); // WS4: missing-index CREATE — copy-paste only (no handler -> no Apply); carried for the read-time copy-paste
             }
 
             // 7. Insert the survivors in one batched pass, persisting remediation_action_json

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -162,20 +162,25 @@ namespace PerformanceMonitorDashboard.Controls
         public bool ShowAskAi => IsIncident;
 
         /// <summary>
-        /// Whether the "Copy fix" button is shown — config-fixes (a flagged setting) or
-        /// structured standing fixes (DB_CONFIG / FILE_AUTOGROWTH_PERCENT) that carry an ALTER
-        /// statement to copy.
+        /// Whether the "Copy fix" button is shown — config-fixes (a flagged setting), structured
+        /// standing fixes (DB_CONFIG / FILE_AUTOGROWTH_PERCENT) that carry an ALTER statement, or a
+        /// MISSING_INDEX advisory (WS4) carrying a SQL Server-suggested CREATE INDEX to copy. The
+        /// missing-index case deliberately stays an incident (it keeps Open-in-Active-Queries / Ask-AI
+        /// and shows no Apply), so it is gated on its own flag rather than reclassifying the card as a
+        /// structured fix.
         /// </summary>
         public bool ShowCopyFix =>
-            !string.IsNullOrEmpty(Item.CopyPasteSql) && (IsConfigFix || HasStructuredFixAction);
+            !string.IsNullOrEmpty(Item.CopyPasteSql) && (IsConfigFix || HasStructuredFixAction || Item.IsMissingIndexAdvisory);
 
         /// <summary>
         /// Whether the Apply button is shown for this card — whenever the row carries a built,
         /// persisted <see cref="RecommendationItem.Remediation"/> action (engine rows; mirrors the
-        /// alert path's <c>Remediation != null</c> rule). Every persisted action now has a
-        /// registered handler (plan-regression, DB-config, RCSI, clear-plan, file-autogrowth), so
-        /// there is no non-executable action to exclude. Shown for incidents (e.g. clear-plan /
-        /// plan-regression), config-fixes (e.g. RCSI), and structured standing fixes (autogrowth).
+        /// alert path's <c>Remediation != null</c> rule). Every Remediation that reaches a CARD has a
+        /// registered handler (plan-regression, DB-config, RCSI, clear-plan, file-autogrowth,
+        /// server-config); the one non-executable persisted action — the WS4 MISSING_INDEX advisory —
+        /// is mapped by the reader to a copy-paste card with Remediation left null, so it never shows
+        /// Apply. Shown for incidents (e.g. clear-plan / plan-regression), config-fixes (e.g. RCSI),
+        /// and structured standing fixes (autogrowth).
         /// Drives the Apply button + (for destructive fixes) the two-sided informed-consent gate.
         /// </summary>
         public bool ShowApply => Item.Remediation != null;

--- a/Dashboard/Services/Recommendations/RecommendationItem.cs
+++ b/Dashboard/Services/Recommendations/RecommendationItem.cs
@@ -156,6 +156,17 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         public bool IsServerConfigAdvisory { get; set; }
 
         /// <summary>
+        /// True for a MISSING_INDEX advisory card (WS4). Like the advise-only server-config memory
+        /// cards it is COPY-PASTE ONLY — the SQL Server-suggested CREATE INDEX rides
+        /// <see cref="CopyPasteSql"/> while <see cref="Remediation"/> stays null (creating an index is
+        /// a judgement call, so there is deliberately no Apply button). The card stays a
+        /// <see cref="RecommendationSetting.None"/> incident with no structured fix action, so it keeps
+        /// its Open-in-Active-Queries / Ask-AI affordances; this flag only tells the view-model to ALSO
+        /// surface "Copy fix" for the CREATE statement.
+        /// </summary>
+        public bool IsMissingIndexAdvisory { get; set; }
+
+        /// <summary>
         /// UTC start of the time window the finding pertains to (engine: the analysis
         /// <c>TimeRangeStart</c>; legacy: the <c>critical_issues.log_date</c>). Raw - no grace
         /// window is applied here; the navigation handler widens it (+/- 1h) and converts to

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -338,6 +338,14 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
             var band = RecommendationDeduper.FromEngineSeverity(finding.Severity);
             var advice = FactAdvice.GetForFactKey(finding.RootFactKey);
 
+            // WS4: a MISSING_INDEX action is COPY-PASTE ONLY. Render its CREATE statements as the
+            // card's copy-paste SQL (via BuildCopyPasteFromAction below), but DON'T carry it as the
+            // card's Remediation — creating an index is a judgement call, so there is no Apply button
+            // (and no registered handler). IsMissingIndexAdvisory tells the view-model to show
+            // "Copy fix" while the card stays an incident (keeps Open-in-Active-Queries / Ask-AI).
+            var isMissingIndex =
+                string.Equals(finding.Remediation?.FactKey, "MISSING_INDEX", StringComparison.Ordinal);
+
             return new RecommendationItem
             {
                 Source = RecommendationSource.Engine,
@@ -348,7 +356,8 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 ProblemArea = finding.Category,
                 AdviceText = ComposeEngineAdvice(advice),
                 CopyPasteSql = BuildCopyPasteFromAction(finding.Remediation),
-                Remediation = finding.Remediation,
+                Remediation = isMissingIndex ? null : finding.Remediation,
+                IsMissingIndexAdvisory = isMissingIndex,
                 StoryPathHash = finding.StoryPathHash,
                 StoryPath = finding.StoryPath,
                 Setting = SettingFromAction(finding.Remediation),
@@ -493,6 +502,23 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                         target.Database, target.LogicalFileName, target.RecommendedGrowthMb));
                 }
                 return fsb.Length == 0 ? null : fsb.ToString();
+            }
+
+            // WS4: a missing-index advisory action carries the SQL Server-suggested CREATE statements
+            // (no DB-config targets). Surface them verbatim, one per line — copy-paste only; the
+            // caller (MapEngineFinding) leaves the card's Remediation null so no Apply button appears.
+            if (action.MissingIndexTargets is { Count: > 0 } indexTargets)
+            {
+                var isb = new StringBuilder();
+                foreach (var target in indexTargets)
+                {
+                    if (string.IsNullOrWhiteSpace(target.CreateStatement))
+                        continue;
+                    if (isb.Length > 0)
+                        isb.AppendLine();
+                    isb.Append(target.CreateStatement);
+                }
+                return isb.Length == 0 ? null : isb.ToString();
             }
 
             if (action.DbConfigTargets is not { Count: > 0 } targets)

--- a/PerformanceMonitor.Analysis/FactRemediation.cs
+++ b/PerformanceMonitor.Analysis/FactRemediation.cs
@@ -108,6 +108,29 @@ public static class FactRemediation
                                     FileGrowthTargets: fileTargets);
     }
 
+    /// <summary>
+    /// Builds the missing-index advisory action for a MISSING_INDEX finding (WS4), or null when the
+    /// drill-down carries no suggested index. Parallel to <see cref="BuildAction"/> — a SEPARATE
+    /// entry point so neither switch grows. The action carries FactKey "MISSING_INDEX" and is
+    /// COPY-PASTE ONLY: there is deliberately NO registered handler, so it never drives Apply
+    /// (creating an index is a judgement call — over-indexing, write + storage cost — so the operator
+    /// copies the suggested statement and decides). It carries the SQL Server-suggested CREATE
+    /// statements through the persisted-action round-trip so the Recommendations reader can render
+    /// them on read (the <c>missing_indexes</c> drill-down they come from is ephemeral). The reader
+    /// surfaces them as the card's copy-paste SQL and leaves the card's Remediation null (no Apply).
+    /// </summary>
+    public static RemediationAction? BuildMissingIndexAction(AnalysisFinding finding)
+    {
+        if (finding is null || !string.Equals(finding.RootFactKey, "MISSING_INDEX", StringComparison.Ordinal))
+            return null;
+
+        var indexTargets = ExtractMissingIndexTargets(finding);
+        return indexTargets.Count == 0
+            ? null
+            : new RemediationAction("MISSING_INDEX", "advise", Array.Empty<ForcePlanTarget>(),
+                                    MissingIndexTargets: indexTargets);
+    }
+
     // ── WS3: server-level config (MAXDOP / CTFP / max & min server memory) ──────────
     //
     // The per-setting CONFIG_* facts (CONFIG_MAXDOP / CONFIG_CTFP / CONFIG_MAX_MEMORY_MB /
@@ -904,6 +927,57 @@ public static class FactRemediation
             var fileType = GetString(row, "file_type");
             targets.Add(new FileGrowthTarget(
                 database, logical, sizeMb, growthPct, RecommendedGrowthMbFor(fileType)));
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Extracts the missing-index suggestions from a MISSING_INDEX finding's drill-down
+    /// <c>missing_indexes</c> array (WS4). For each row with a non-empty <c>create_statement</c> it
+    /// emits one <see cref="MissingIndexTarget"/> carrying the schema-qualified <c>table</c>, the
+    /// <c>impact</c> estimate, and the SQL Server-suggested <c>create_statement</c> (the copy-paste
+    /// payload — never parsed or executed, only surfaced). The structured fields are exactly those
+    /// the drill-down collectors emit (<c>SqlServerDrillDownCollector</c> / Lite
+    /// <c>DrillDownCollector</c> "missing_indexes"). A defensive cap of 5 mirrors the drill-down's
+    /// own Take(5) and the other extractors.
+    /// </summary>
+    public static IReadOnlyList<MissingIndexTarget> ExtractMissingIndexTargets(AnalysisFinding finding)
+    {
+        var targets = new List<MissingIndexTarget>();
+
+        if (finding?.DrillDown is null ||
+            !finding.DrillDown.TryGetValue("missing_indexes", out var raw) ||
+            raw is null)
+            return targets;
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(raw);
+        }
+        catch
+        {
+            return targets;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+            return targets;
+
+        foreach (var row in element.EnumerateArray())
+        {
+            if (targets.Count >= 5) break;
+            if (row.ValueKind != JsonValueKind.Object) continue;
+
+            // The CREATE statement is the whole point — skip a row that has none to copy.
+            var createStatement = GetString(row, "create_statement");
+            if (string.IsNullOrWhiteSpace(createStatement))
+                continue;
+
+            targets.Add(new MissingIndexTarget(
+                Table: GetString(row, "table"),
+                Impact: GetDouble(row, "impact"),
+                CreateStatement: createStatement));
         }
 
         return targets;

--- a/PerformanceMonitor.Analysis/RemediationAction.cs
+++ b/PerformanceMonitor.Analysis/RemediationAction.cs
@@ -35,7 +35,8 @@ public sealed record RemediationAction(
     ClearPlanFigures? ClearPlanFigures = null,   // clear-cached-plan risk-of-not-changing figures carried on the persisted action
     IReadOnlyList<FileGrowthTarget>? FileGrowthTargets = null, // WS3: percent-autogrowth files — Apply-able (FileAutogrowthHandler: MODIFY FILE FILEGROWTH) + copy-paste
     IReadOnlyList<RcsiTarget>? RcsiTargets = null, // per-DB RCSI targets CARRIED on a DB_CONFIG action so the reader can fan per-db RCSI cards on read — NEVER executed from here (see RcsiTarget)
-    IReadOnlyList<ServerConfigTarget>? ServerConfigTargets = null); // WS3: bad server-level config (MAXDOP/CTFP Apply-able via ServerConfigHandler; max/min memory advise-only) — one card per target
+    IReadOnlyList<ServerConfigTarget>? ServerConfigTargets = null, // WS3: bad server-level config (MAXDOP/CTFP Apply-able via ServerConfigHandler; max/min memory advise-only) — one card per target
+    IReadOnlyList<MissingIndexTarget>? MissingIndexTargets = null); // WS4: missing-index CREATE statements — COPY-PASTE ONLY (no handler -> never Apply); carried so the reader can render the CREATE on read (the drill-down is ephemeral)
 
 /// <summary>
 /// The fixed, hardcoded set of SERVER-LEVEL configuration settings WS3 surfaces (and, for
@@ -232,6 +233,23 @@ public sealed record FileGrowthTarget(
     double CurrentSizeMb,                       // total_size_mb — display only
     int CurrentGrowthPercent,                   // growth_pct — display only
     int RecommendedGrowthMb);                   // already-computed fixed-MB FILEGROWTH (1024 data / 64 log)
+
+/// <summary>
+/// One missing-index suggestion (WS4): the SQL Server-generated <c>CREATE INDEX</c> statement
+/// for a query plan's missing-index request, surfaced as COPY-PASTE ONLY. Unlike
+/// <see cref="FileGrowthTarget"/>, this carries NO handler and is NEVER Apply-able — creating an
+/// index is a judgement call (over-indexing, write/storage cost), so the operator copies the
+/// suggested statement and decides. It rides the persisted <see cref="RemediationAction"/> (FactKey
+/// "MISSING_INDEX") purely so the Recommendations reader can render <see cref="CreateStatement"/>
+/// on read; the drill-down it was extracted from (<c>missing_indexes</c>) is ephemeral. The reader
+/// surfaces the statement as the card's copy-paste SQL and leaves the card's <c>Remediation</c>
+/// null so no Apply button appears. <see cref="Table"/> (schema-qualified) and <see cref="Impact"/>
+/// are display only.
+/// </summary>
+public sealed record MissingIndexTarget(
+    string Table,                               // "schema.table" (display)
+    double Impact,                             // estimated % improvement (display)
+    string CreateStatement);                    // the SQL Server-suggested CREATE INDEX — the copy-paste payload
 
 /// <summary>
 /// One force-plan target. <see cref="Database"/>, <see cref="QueryId"/> and

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -86,7 +86,8 @@ public record RemediationActionDto(
     ClearPlanFiguresDto? ClearPlanFigures = null,
     List<FileGrowthTargetDto>? FileGrowthTargets = null,
     List<RcsiTargetDto>? RcsiTargets = null,
-    List<ServerConfigTargetDto>? ServerConfigTargets = null);
+    List<ServerConfigTargetDto>? ServerConfigTargets = null,
+    List<MissingIndexTargetDto>? MissingIndexTargets = null);
 
 /// <summary>
 /// JSON mirror of <see cref="RcsiTarget"/>. The per-database RCSI targets are carried on a
@@ -189,6 +190,18 @@ public record ServerConfigTargetDto(
     int Setting,
     long CurrentValue,
     long RecommendedValue);
+
+/// <summary>
+/// JSON mirror of <see cref="MissingIndexTarget"/> (WS4 missing-index advisory). The trailing
+/// optional <c>MissingIndexTargets</c> member on <see cref="RemediationActionDto"/> keeps the
+/// round-trip backward-compatible: legacy/non-MISSING_INDEX contextJson without it deserializes to
+/// null. Carried so the Recommendations reader can render the suggested CREATE on read (the
+/// drill-down is ephemeral). Copy-paste only — there is no handler, so it never drives Apply.
+/// </summary>
+public record MissingIndexTargetDto(
+    string Table,
+    double Impact,
+    string CreateStatement);
 
 /// <summary>
 /// Maps <see cref="AlertContext"/> to/from the <see cref="AlertContextDto"/> JSON projection
@@ -366,9 +379,20 @@ public static class AlertContextSerializer
                 serverConfigTargets.Add(new ServerConfigTargetDto((int)t.Setting, t.CurrentValue, t.RecommendedValue));
         }
 
+        // WS4 (missing-index advisory): persist the suggested CREATE statements so the Recommendations
+        // reader can render them as copy-paste on read (the drill-down is ephemeral). Copy-paste only —
+        // no handler, never Apply. Null for every other fact key -> backward-compatible.
+        List<MissingIndexTargetDto>? missingIndexTargets = null;
+        if (action.MissingIndexTargets is not null)
+        {
+            missingIndexTargets = new List<MissingIndexTargetDto>(action.MissingIndexTargets.Count);
+            foreach (var t in action.MissingIndexTargets)
+                missingIndexTargets.Add(new MissingIndexTargetDto(t.Table, t.Impact, t.CreateStatement));
+        }
+
         return new RemediationActionDto(action.FactKey, action.Action, targets, dbConfigTargets,
             rcsiFigures, clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets,
-            serverConfigTargets);
+            serverConfigTargets, missingIndexTargets);
     }
 
     private static RemediationAction? FromDto(RemediationActionDto? dto)
@@ -472,7 +496,20 @@ public static class AlertContextSerializer
                 serverConfigTargets.Add(new ServerConfigTarget((ServerConfigSetting)t.Setting, t.CurrentValue, t.RecommendedValue));
         }
 
+        // WS4: rebuild the missing-index targets from the DTO and PASS them to the ctor (the trailing
+        // MissingIndexTargets member defaults to null, so a short call would silently drop them on the
+        // round-trip — the reader would then render no missing-index copy-paste). Legacy JSON without
+        // the field deserializes to null → backward-compatible.
+        List<MissingIndexTarget>? missingIndexTargets = null;
+        if (dto.MissingIndexTargets is not null)
+        {
+            missingIndexTargets = new List<MissingIndexTarget>(dto.MissingIndexTargets.Count);
+            foreach (var t in dto.MissingIndexTargets)
+                missingIndexTargets.Add(new MissingIndexTarget(t.Table, t.Impact, t.CreateStatement));
+        }
+
         return new RemediationAction(dto.FactKey, dto.Action, targets, dbConfigTargets, rcsiFigures,
-            clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets, serverConfigTargets);
+            clearPlanTargets, clearPlanFigures, fileGrowthTargets, rcsiTargets, serverConfigTargets,
+            missingIndexTargets);
     }
 }


### PR DESCRIPTION
## What

Surfaces the SQL Server-suggested **CREATE INDEX** statement(s) on a MISSING_INDEX Recommendations card as **"Copy fix"**. Previously the card showed advice + Ask-AI but no way to copy the suggested index.

## Why it needed shared-library work (not just a reader tweak)

The `missing_indexes` drill-down (where `create_statement` lives) is **ephemeral** — `config.analysis_findings` has no drill-down column and `ReadFinding` only rehydrates the built `RemediationAction`. So the reader never saw the CREATE text. This carries it on the **persisted action** (FactKey `MISSING_INDEX`) through the round-trip — exactly the pattern the autogrowth / server-config-memory advisories already use.

## Copy-only by design

There is **deliberately no handler** for `MISSING_INDEX` — creating an index is a judgement call (over-indexing, write + storage cost), matching the rebuild plan's "advise, over-indexing caveats" stance. So:
- **Copy fix** ✅ (the CREATE statement)
- **Apply** ❌ (the reader leaves the card's `Remediation` null → `ShowApply` stays false)
- Stays an **incident** — keeps Open-in-Active-Queries / Ask-AI. A new `IsMissingIndexAdvisory` flag gates **only** `ShowCopyFix`, so the card isn't reclassified.

## Changes

**Shared (`PerformanceMonitor.Analysis` / `.Notifications`)**
- `RemediationAction`: + `MissingIndexTarget` record + `MissingIndexTargets` field
- `FactRemediation`: + `BuildMissingIndexAction` / `ExtractMissingIndexTargets` (reads `missing_indexes`: `table` / `impact` / `create_statement`)
- `AlertContext`: + `MissingIndexTargetDto` + `ToDto`/`FromDto` round-trip (trailing-optional → backward-compatible)

**Dashboard**
- `AnalysisService`: + `BuildMissingIndexAction` in the build chain
- `RecommendationsReader`: render the CREATEs as `CopyPasteSql`, leave `Remediation` null
- `RecommendationItem` / `RecommendationsViewModel`: `IsMissingIndexAdvisory` → `ShowCopyFix`

## Tests

`MissingIndexAdvisoryTests` (builder, extractor skip/cap, **serializer round-trip**, reader copy-only mapping, card affordances) + a MISSING_INDEX copy-only case in `RemediationGoldenSampleTests` (drill-down → builder drift guard: non-null + targets + **not** registry-dispatchable). **Dashboard.Tests 476 / 0, Lite.Tests 406 / 0.**

## Scope notes

- **Lite + read-only surfaces (email/webhook/MCP)** render copy-paste via the shared `FactRemediation.GenerateForFinding`, which doesn't yet handle MISSING_INDEX — **Lite parity is a one-switch-case follow-up**, out of scope for this Dashboard-card PR.
- **Live verification**: the dev servers are well-indexed (no MISSING_INDEX finding fires), so the card won't appear naturally — covered by the round-trip + golden-sample tests instead. Happy to seed a missing-index scenario to demo it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)