### PR TITLE
Fix crosshair crash on out-of-range hover (FromOADate)

### DIFF
--- a/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
+++ b/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
@@ -238,6 +238,13 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         var mouseCoords = sourceLane.Chart.Plot.GetCoordinates(pixel);
         double xValue = mouseCoords.X;
 
+        /* The mouse can sit over a region whose X-coordinate is outside the legal OLE-Automation
+           date range (empty/auto-scaled chart, or hovering past the plotted data). FromOADate
+           throws "Not a legal OleAut date" for anything outside year 0100-9999, so bail out of the
+           crosshair update rather than crashing to the dispatcher handler. */
+        if (double.IsNaN(xValue) || xValue <= -657435.0 || xValue >= 2958466.0)
+            return;
+
         _tooltipText.Inlines.Clear();
         var time = DateTime.FromOADate(xValue);
         var displayTime = UiTimeContext.ConvertForDisplay(time);


### PR DESCRIPTION
## Problem

`CorrelatedCrosshairManager.OnMouseMove` feeds the **raw mouse X-coordinate** straight into `DateTime.FromOADate(xValue)` with no bounds check. `FromOADate` throws `ArgumentException: "Not a legal OleAut date"` for any value outside year 0100–9999 (the double range `-657435.0 … 2958466.0`).

Hovering past the plotted data — or over a chart whose axis is auto-scaled wide/empty — produces a coordinate outside that range and crashes. Because this handler (unlike `ChartHoverHelper`) has no `try/catch`, the exception escapes to the dispatcher handler and surfaces a modal **"An error occurred… Not a legal OleAut date"** dialog.

## Fix

Guard `xValue` against `NaN` and the legal OADate range immediately after it's computed, and bail out of the crosshair update rather than throwing. One 7-line guard; no behavior change for in-range hovers.

The other two `FromOADate` call sites (`ChartHoverHelper.cs:143/225`) are already safe — they convert a real plotted-data-point X and are wrapped in `try/catch`.

## Notes

- Found incidentally while building `dev` to investigate #1050 (unrelated sleep/wake bug). This is a pre-existing crosshair crash, **not** caused by the #1050 `SoftwareOnly` change.
- Builds clean (Lite, Debug): 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)