### PR TITLE
Fix shared-lib defects from Fable code review (chunk 1)

### DIFF
--- a/PerformanceMonitor.Notifications/AlertSeverity.cs
+++ b/PerformanceMonitor.Notifications/AlertSeverity.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Single source of truth for per-metric alert severity styling: accent/hex color, badge text,
+/// and the webhook emoji. Both the email body (<see cref="EmailTemplateBuilder"/>) and the
+/// webhook payloads (<see cref="WebhookAlertService"/>) consume this so the two maps cannot
+/// drift apart (adding a metric to one and forgetting the other was a real foot-gun).
+/// </summary>
+internal static class AlertSeverity
+{
+    /// <returns>
+    /// (HexColor, BadgeText, Emoji) for the metric. Unknown metrics fall back to INFO-blue.
+    /// Email ignores the emoji; webhooks use all three.
+    /// </returns>
+    public static (string HexColor, string BadgeText, string Emoji) ForMetric(string metricName) => metricName switch
+    {
+        "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
+        "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
+        "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
+        "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
+        "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
+        "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
+        "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
+        _ => ("#2eaef1", "INFO", "\U0001F535")
+    };
+}

--- a/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
+++ b/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
@@ -35,13 +35,13 @@ internal static class EmailTemplateBuilder
     {
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
-        var (accentColor, badgeText) = GetSeverity(metricName);
+        var (accentColor, badgeText, _) = AlertSeverity.ForMetric(metricName);
 
         var html = BuildHtmlBody(metricName, serverName, currentValue,
             thresholdValue, utcNow, localNow, accentColor, badgeText, branding, context: context, emailCooldownMinutes: emailCooldownMinutes);
 
         var plain = BuildPlainTextBody(metricName, serverName, currentValue,
-            thresholdValue, utcNow, localNow, branding, context);
+            thresholdValue, utcNow, localNow, emailCooldownMinutes, branding, context);
 
         return (html, plain);
     }
@@ -64,23 +64,6 @@ internal static class EmailTemplateBuilder
                     $"Sent at: {localNow:yyyy-MM-dd HH:mm:ss}\r\n";
 
         return (html, plain);
-    }
-
-    private static (string AccentColor, string BadgeText) GetSeverity(string metricName)
-    {
-        return metricName switch
-        {
-            "Blocking Detected" => ("#D97706", "ALERT"),
-            "Deadlocks Detected" => ("#DC2626", "ALERT"),
-            "High CPU" => ("#F59E0B", "WARNING"),
-            "Poison Wait" => ("#DC2626", "CRITICAL"),
-            "Long-Running Query" => ("#D97706", "WARNING"),
-            "TempDB Space" => ("#D97706", "WARNING"),
-            "Long-Running Job" => ("#D97706", "WARNING"),
-            "Server Unreachable" => ("#DC2626", "CRITICAL"),
-            "Server Restored" => ("#16A34A", "RESOLVED"),
-            _ => ("#2eaef1", "INFO")
-        };
     }
 
     private static string BuildHtmlBody(
@@ -282,6 +265,7 @@ internal static class EmailTemplateBuilder
         string thresholdValue,
         DateTime utcNow,
         DateTime localNow,
+        int emailCooldownMinutes,
         AlertBranding branding,
         AlertContext? context = null)
     {
@@ -334,6 +318,10 @@ internal static class EmailTemplateBuilder
         {
             sb.Append($"\r\nAttached: {context.AttachmentFileName}\r\n");
         }
+
+        /* Footer — mirrors the HTML body's cooldown disclosure (BuildHtmlBody). The HTML and
+           plain-text bodies are maintained in parallel; a footer change must touch both. */
+        sb.Append($"\r\nSent by {branding.EditionName} - {emailCooldownMinutes}-minute cooldown between repeat alerts\r\n");
 
         if (branding.SnoozeHint is not null)
         {

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -202,7 +202,7 @@ public class WebhookAlertService
         bool isTest = false,
         AlertContext? context = null)
     {
-        var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName);
         var themeColor = hexColor.TrimStart('#');
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
@@ -237,13 +237,16 @@ public class WebhookAlertService
                 if (!string.IsNullOrEmpty(detail.Body))
                 {
                     /* Advice prose: one "Advice" fact for the headline, then a fact per
-                       Investigation/Remediation paragraph (split on the blank line). */
+                       Investigation/Remediation paragraph (split on the blank line).
+                       Body is exclusive with Fields, matching the email and Slack surfaces
+                       which skip Fields when Body is present. */
                     facts.Add(new { name = "Advice", value = detail.Heading });
                     foreach (var para in detail.Body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
                     {
                         var (label, text) = SplitProseLabel(para);
                         facts.Add(new { name = label, value = text });
                     }
+                    continue;
                 }
 
                 foreach (var (label, value) in detail.Fields)
@@ -346,7 +349,7 @@ public class WebhookAlertService
         bool isTest = false,
         AlertContext? context = null)
     {
-        var (hexColor, badgeText, emoji) = GetSeverity(metricName);
+        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName);
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
 
@@ -444,20 +447,6 @@ public class WebhookAlertService
 
     #region Shared
 
-    private static (string HexColor, string BadgeText, string Emoji) GetSeverity(string metricName) => metricName switch
-    {
-        "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
-        "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
-        "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
-        "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
-        "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
-        "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
-        _ => ("#2eaef1", "INFO", "\U0001F535")
-    };
-
     /// <summary>
     /// Splits a synthesized advice paragraph ("Investigation: ..." / "Remediation: ...") into a
     /// (label, value) pair on the first ": ". Falls back to ("Detail", paragraph) when there is no
@@ -475,19 +464,37 @@ public class WebhookAlertService
         return ("Detail", paragraph);
     }
 
+    /* Reuse HttpClients instead of newing one (plus a handler) per send. A fresh
+       HttpClient/handler per request leaks sockets into TIME_WAIT and can exhaust
+       the ephemeral port range when many servers alert. One pooled client covers the
+       no-proxy case; proxied clients are cached per proxy address. */
+    private static readonly HttpClient s_defaultClient =
+        new(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(5) })
+        { Timeout = TimeSpan.FromSeconds(30) };
+
+    private static readonly ConcurrentDictionary<string, HttpClient> s_proxyClients = new();
+
+    private static HttpClient GetHttpClient(string? proxyAddress)
+    {
+        if (string.IsNullOrWhiteSpace(proxyAddress))
+            return s_defaultClient;
+
+        return s_proxyClients.GetOrAdd(proxyAddress, addr =>
+            new HttpClient(new SocketsHttpHandler
+            {
+                Proxy = new WebProxy(addr),
+                UseProxy = true,
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            })
+            { Timeout = TimeSpan.FromSeconds(30) });
+    }
+
     /// <summary>
     /// Posts a JSON payload to a webhook URL. Returns null on success, error message on failure.
     /// </summary>
     private static async Task<string?> PostWebhookAsync(string webhookUrl, string jsonPayload, string? proxyAddress)
     {
-        var handler = new HttpClientHandler();
-        if (!string.IsNullOrWhiteSpace(proxyAddress))
-        {
-            handler.Proxy = new WebProxy(proxyAddress);
-            handler.UseProxy = true;
-        }
-
-        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+        var client = GetHttpClient(proxyAddress);
         using var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
 
         var response = await client.PostAsync(webhookUrl, content);

--- a/PerformanceMonitor.PlanAnalysis/ShowPlanParser.cs
+++ b/PerformanceMonitor.PlanAnalysis/ShowPlanParser.cs
@@ -1811,11 +1811,18 @@ public static class ShowPlanParser
         // Skip trailing hex digits (0-9, A-F, a-f)
         while (i > 0 && IsHexDigit(name[i])) i--;
 
+        // Real SQL-internal #temp names always carry underscore padding between the visible
+        // name and the hex suffix. If there is no underscore right after the hex run, this is
+        // not that pattern (e.g. a user name that is itself all hex, like "#deadbeef1") — leave
+        // it untouched rather than stripping it down to "#".
+        if (i == 0 || name[i] != '_') return name;
+
         // Skip trailing underscores (the padding)
         while (i > 0 && name[i] == '_') i--;
 
-        // Only clean if we actually removed a meaningful amount (at least 8 chars of padding+hex)
-        if (name.Length - i > 8)
+        // Only clean if we removed a meaningful amount (at least 8 chars of padding+hex) and a
+        // real name still remains — never collapse to just "#".
+        if (i > 0 && name.Length - i > 8)
             return name[..(i + 1)];
         return name;
     }
@@ -1833,6 +1840,7 @@ public static class ShowPlanParser
     private static long ParseLong(string? value)
     {
         if (string.IsNullOrEmpty(value)) return 0;
-        return long.TryParse(value, out var result) ? result : 0;
+        return long.TryParse(value, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out var result) ? result : 0;
     }
 }

--- a/PerformanceMonitor.Ui/AxesExtensions.cs
+++ b/PerformanceMonitor.Ui/AxesExtensions.cs
@@ -29,9 +29,19 @@ internal static class AxesExtensions
         if (axes.Bottom.TickGenerator is ScottPlot.TickGenerators.DateTimeAutomatic gen)
         {
             DateTime? lastDate = null;
+            DateTime? prevTick = null;
             var culture = CultureInfo.CurrentCulture;
             gen.LabelFormatter = dt =>
             {
+                /* ScottPlot re-invokes this formatter from the leftmost tick on every render
+                   pass, but lastDate persists across passes. Without resetting it, the first
+                   tick stops printing its date after the first render — and a single-day window
+                   then shows no date at all. Ticks are generated left-to-right, so a tick value
+                   that does not increase marks the start of a new pass: reset there. */
+                if (prevTick is null || dt <= prevTick.Value)
+                    lastDate = null;
+                prevTick = dt;
+
                 var time = dt.ToString("t", culture);
                 if (lastDate is null || dt.Date != lastDate.Value)
                 {

--- a/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
+++ b/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
@@ -67,8 +67,14 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
             Unit = unit
         };
 
-        chart.MouseMove += (s, e) => OnMouseMove(lane, e);
-        chart.MouseLeave += (s, e) => OnMouseLeave();
+        /* Store the lambdas so Dispose can unsubscribe them — otherwise the chart keeps the
+           manager (and every lane closure) alive after dispose. Matches ChartHoverHelper. */
+        MouseEventHandler moveHandler = (s, e) => OnMouseMove(lane, e);
+        MouseEventHandler leaveHandler = (s, e) => OnMouseLeave();
+        lane.MouseMoveHandler = moveHandler;
+        lane.MouseLeaveHandler = leaveHandler;
+        chart.MouseMove += moveHandler;
+        chart.MouseLeave += leaveHandler;
 
         /* Tab switching can leave the popup wedged: WPF unloads the parent TabItem
            without firing MouseLeave, so IsOpen stays true with a stale anchor.
@@ -400,6 +406,10 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         _tooltip.IsOpen = false;
         foreach (var lane in _lanes)
         {
+            if (lane.MouseMoveHandler != null)
+                lane.Chart.MouseMove -= lane.MouseMoveHandler;
+            if (lane.MouseLeaveHandler != null)
+                lane.Chart.MouseLeave -= lane.MouseLeaveHandler;
             lane.Chart.IsVisibleChanged -= OnLaneVisibilityChanged;
             lane.Chart.Unloaded -= OnLaneUnloaded;
             lane.Chart.Loaded -= OnLaneLoaded;
@@ -424,6 +434,8 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         public string Label { get; set; } = "";
         public string Unit { get; set; } = "";
         public ScottPlot.Plottables.VerticalLine? VLine { get; set; }
+        public MouseEventHandler? MouseMoveHandler { get; set; }
+        public MouseEventHandler? MouseLeaveHandler { get; set; }
         public List<DataSeries> Series { get; set; } = new();
         public double? BaselineUpper { get; set; }
         public double? BaselineLower { get; set; }

--- a/PerformanceMonitor.Ui/WaitDrillDownHelper.cs
+++ b/PerformanceMonitor.Ui/WaitDrillDownHelper.cs
@@ -116,7 +116,11 @@ public static class WaitDrillDownHelper
                 continue;
 
             var head = FindHeadBlocker(waiter, sessionsAtTime);
-            if (head == null)
+            // head == waiter means the waiter is its own head: it is not blocked by another
+            // session (BlockingSessionId <= 0, blocked-by-self, or the blocker is absent from
+            // this snapshot). Recording it would render "Head SPID X blocking 1 session(s)"
+            // where that one session is X itself.
+            if (head == null || head.SessionId == waiter.SessionId)
                 continue;
 
             var key = (waiter.CollectionTime, head.SessionId);


### PR DESCRIPTION
Fixes for the shared library projects (Notifications, PlanAnalysis, Ui), surfaced by the Fable parallel code review. Each finding was independently verified against the code before fixing.

## Notifications
- **Email two-bodies drift**: the plain-text body never printed the repeat-alert cooldown disclosure the HTML body shows. `BuildPlainTextBody` now emits it (and the comment flags the parallel-bodies contract).
- **Duplicated severity map**: the email and webhook builders each hand-maintained an identical metric→(color/badge/emoji) switch. Extracted to a single `AlertSeverity.ForMetric` so they cannot drift.
- **Teams Body+Fields**: the Teams payload rendered `Body` *and* fell through to the `Fields` loop, unlike email/Slack which treat `Body` as exclusive. Added `continue` to match.
- **HttpClient per send**: `PostWebhookAsync` newed an `HttpClient`+handler per request (socket/TIME_WAIT exhaustion). Now reuses a pooled default client plus a per-proxy cache.

## PlanAnalysis
- **CleanTempTableName**: an all-hex temp name (e.g. `#deadbeef1`) was stripped down to `"#"`, which then flowed into generated `CREATE INDEX` text. Now requires underscore padding before stripping and never collapses to `"#"`.
- **ParseLong**: parsed with the current culture while `ParseDouble` used InvariantCulture. Now consistent.

## Ui
- **Date axis label**: `DateTimeTicksBottomDateChange` kept stale closure state across render passes, so the date line vanished after the first render (a single-day window showed no date at all). Resets the tracker at each pass.
- **CorrelatedCrosshairManager leak**: `Dispose` left the `MouseMove`/`MouseLeave` lambdas subscribed, keeping the manager alive via the chart. Now stores and unsubscribes them (matching `ChartHoverHelper`).
- **WaitDrillDownHelper self-blocker**: a waiter with no resolvable blocker was recorded as blocking itself ("Head SPID X blocking 1 session(s)" where the session is X). Now skipped.

## Validation
- Solution builds clean on net10 (0 errors).
- `Dashboard.Tests`: 476/476 pass.
- `Lite.Tests`: 411/411 pass.

Part of a 7-chunk code-review sweep; this is chunk 1 (shared libs). No SQL or app-behavior changes outside these libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
