### PR TITLE
Fix Dashboard timezone/CPU-path defects from Fable code review (chunk 2)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -1493,7 +1493,13 @@ namespace PerformanceMonitorDashboard
                 return;
             }
 
-            var now = ServerTimeHelper.ServerNow;
+            /* Cooldowns measure elapsed wall-clock time, so use a clock that does not shift when
+               the user switches server tabs. ServerTimeHelper.ServerNow is derived from a process-wide
+               UTC offset that is reassigned on every tab change; using it here makes (now - lastAlert)
+               jump by the timezone delta whenever the selected tab changes between alert ticks, which
+               either suppresses alerts (offset went back) or bypasses the cooldown (offset went
+               forward) for every server. UTC is offset-independent. Display strings keep server time. */
+            var now = DateTime.UtcNow;
 
             /* Blocking alerts */
             bool blockingExceeded = prefs.NotifyOnBlocking

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -541,7 +541,9 @@ namespace PerformanceMonitorDashboard.Services
                     filtered_deadlock_count =
                         COALESCE(SUM(bds.deadlock_count_delta), 0)
                 FROM collect.blocking_deadlock_stats AS bds
-                WHERE bds.collection_time >= DATEADD(MINUTE, -5, SYSUTCDATETIME())
+                /* collection_time is server-local (SYSDATETIME default); match that clock, not UTC,
+                   or the window is hours off and the COALESCE(...,0) silently zeroes deadlock alerts. */
+                WHERE bds.collection_time >= DATEADD(MINUTE, -5, SYSDATETIME())
                 AND   bds.deadlock_count_delta IS NOT NULL
                 {dbFilter}
                 OPTION(MAXDOP 1, RECOMPILE);";

--- a/Dashboard/Services/DatabaseService.ResourceMetrics.cs
+++ b/Dashboard/Services/DatabaseService.ResourceMetrics.cs
@@ -680,7 +680,9 @@ namespace PerformanceMonitorDashboard.Services
                             sample_time,
                             sqlserver_cpu_utilization,
                             other_process_cpu_utilization,
-                            total_cpu_utilization
+                            /* total_cpu_utilization is NULL on SQL Server on Linux; fall back to the
+                               SQL-only figure so the value isn't reported as 0 (#1048). */
+                            total_cpu_utilization = ISNULL(total_cpu_utilization, sqlserver_cpu_utilization)
                         FROM collect.cpu_utilization_stats
                         WHERE collection_time >= DATEADD(HOUR, @HoursBack, SYSDATETIME())
                         ORDER BY collection_time ASC;";
@@ -1269,7 +1271,8 @@ namespace PerformanceMonitorDashboard.Services
             event_time = cus.sample_time,
             sql_server_cpu = cus.sqlserver_cpu_utilization,
             other_process_cpu = cus.other_process_cpu_utilization,
-            total_cpu = cus.total_cpu_utilization,
+            /* total_cpu_utilization is NULL on SQL Server on Linux; fall back to SQL-only (#1048). */
+            total_cpu = ISNULL(cus.total_cpu_utilization, cus.sqlserver_cpu_utilization),
             severity =
                 CASE
                     WHEN cus.sqlserver_cpu_utilization >= 90

--- a/Dashboard/Services/DatabaseService.cs
+++ b/Dashboard/Services/DatabaseService.cs
@@ -212,7 +212,9 @@ namespace PerformanceMonitorDashboard.Services
                 FROM config.collection_log
                 WHERE collection_status = 'SUCCESS'
                     AND duration_ms IS NOT NULL
-                    AND collection_time >= DATEADD(HOUR, -@hours_back, GETUTCDATE())
+                    /* collection_time is server-local (SYSDATETIME); match that clock, not UTC,
+                       or the requested window is truncated/widened by the server's UTC offset. */
+                    AND collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())
                 ORDER BY
                     collection_time;";
 


### PR DESCRIPTION
Dashboard fixes from the Fable parallel code review (chunk 2 of 7). Each finding was independently verified against the code, including confirming `collect.blocking_deadlock_stats.collection_time` defaults to `SYSDATETIME()` like every collect table.

## Fixes

**[HIGH] Deadlock alerts silently dead in the Americas when a database is excluded** — `DatabaseService.NocHealth.cs`
`GetFilteredDeadlockCountAsync` filtered local `collection_time` against `SYSUTCDATETIME()`. West of UTC the 5-minute window matched nothing, `COALESCE(SUM(...),0)` returned **0**, and `MainWindow` did `FilteredDeadlockCount ?? deadlockDelta` — so 0 *replaced* the real raw delta. Net effect: configuring even one excluded database permanently killed deadlock alerts. Now uses `SYSDATETIME()` (matching the sibling `GetPoisonWaitDeltasAsync`).

**[MEDIUM] Collection-duration chart window off by the server's UTC offset** — `DatabaseService.cs`
`GetCollectionDurationLogsAsync` filtered local `collection_time` against `GETUTCDATE()`; a "24 hours" chart on a US server showed ~18. Now `SYSDATETIME()`.

**[MEDIUM] Alert cooldown clock shifts when you switch tabs** — `MainWindow.xaml.cs`
Cooldown math used `ServerTimeHelper.ServerNow`, whose UTC offset is a process-wide static reassigned on every tab switch. Switching tabs between alert ticks shifted `now` by the timezone delta, so cooldowns were either bypassed (duplicate alerts) or over-extended (suppressed alerts) for every server. Cooldowns are elapsed wall-clock, so they now use `DateTime.UtcNow`. Display strings keep server time.

**[MEDIUM] Two CPU readers carry the pre-#1048 logic** — `DatabaseService.ResourceMetrics.cs`
`GetCpuUtilizationHistoryAsync` and `GetCpuSpikesAsync` selected raw `total_cpu_utilization`, missing the `ISNULL(...,sqlserver_cpu_utilization)` Linux fallback the live readers got in #1048 — exactly the "fix one CPU path, miss the other" pattern. Applied the fallback. **Note:** both methods currently have **zero callers** repo-wide; I applied the fallback rather than delete them, but they're candidates for removal if you'd prefer (`code-simplifier`).

## Deferred for your call
**[LOW] NOC health fires ~9 concurrent commands on one MARS connection.** `GetNocHealthStatusAsync` / `RefreshNocHealthStatusAsync` / `GetAlertHealthAsync` start all health queries with `Task.WhenAll` on a single `SqlConnection` ("parallel for speed"). MARS interleaves rather than parallelizes, and concurrent async ops on one connection are not safe even with MARS — a documented race/hang surface. Sequentializing is the fix, but it reverses an intentional design choice you commented, so I left it. Want it sequentialized?

## Validation
- Dashboard builds clean on net10 (0 errors).
- `Dashboard.Tests`: 476/476 pass.

No shared-lib or SQL changes; isolated to the Dashboard project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
