### PR TITLE
Fix Lite services/analysis defects from Fable code review (3a)

### DIFF
--- a/Lite/Analysis/BaselineProvider.cs
+++ b/Lite/Analysis/BaselineProvider.cs
@@ -179,9 +179,11 @@ public class BaselineProvider
                     Mean = mean,
                     StdDev = stddev,
                     SampleCount = count,
-                    Tier = count >= RestoreThreshold ? BaselineTier.Full
-                         : count >= CollapseThreshold ? BaselineTier.Full
-                         : BaselineTier.HourOnly
+                    // Every bucket here is a full (hour, day-of-week) bucket; the HourOnly/Flat
+                    // tiers are assigned only on the collapse/flat paths below. A sparse full
+                    // bucket is still Full, just low-sample. (Was a copy-paste of two identical
+                    // Full branches that mislabeled sparse buckets HourOnly in baseline_tier.)
+                    Tier = BaselineTier.Full
                 };
             }
 

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -24,9 +24,13 @@ public class SqlPlanFetcher : IPlanFetcher
     {
         if (string.IsNullOrEmpty(planHandle)) return null;
 
-        // serverId is a hash — find the server by matching the hash
+        // serverId is the deterministic FNV hash of the storage name (host[:db][:RO]) produced by
+        // RemoteCollectorService.GetServerId. Match with the same function — string.GetHashCode()
+        // is randomized per process and also ignores the db/RO suffixes, so it would never match.
         var server = _serverManager.GetAllServers()
-            .FirstOrDefault(s => s.ServerName.GetHashCode() == serverId);
+            .FirstOrDefault(s =>
+                RemoteCollectorService.GetDeterministicHashCode(
+                    RemoteCollectorService.GetServerNameForStorage(s)) == serverId);
         if (server == null) return null;
 
         try

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -362,7 +362,11 @@ public class ServerConnection : INotifyPropertyChanged
         {
             "Mandatory" => SqlConnectionEncryptOption.Mandatory,
             "Strict" => SqlConnectionEncryptOption.Strict,
-            _ => SqlConnectionEncryptOption.Optional
+            "Optional" => SqlConnectionEncryptOption.Optional,
+            // Fail closed: an unknown/blank EncryptMode (legacy or hand-edited servers.json) must
+            // not silently drop to an unencrypted, cert-unvalidated connection. The UI default is
+            // Mandatory and the Dashboard builders also default to Mandatory — match that.
+            _ => SqlConnectionEncryptOption.Mandatory
         };
 
         // The tuple is atomic: every auth field comes from the SAME source (profile or server).

--- a/Lite/Services/AppLogger.cs
+++ b/Lite/Services/AppLogger.cs
@@ -24,6 +24,7 @@ public static class AppLogger
     private static readonly Timer s_flushTimer;
     private static string s_logDirectory = "";
     private static bool s_initialized;
+    private static readonly object s_flushLock = new();
 
     static AppLogger()
     {
@@ -111,23 +112,29 @@ public static class AppLogger
     {
         if (!s_initialized || s_buffer.IsEmpty) return;
 
-        try
+        /* Serialize flushes: the 5s timer and Shutdown() can call Flush concurrently, and two
+           File.AppendAllText calls to the same file throw — which the catch below would swallow,
+           silently dropping the lines already dequeued from the buffer. */
+        lock (s_flushLock)
         {
-            var sb = new StringBuilder();
-            while (s_buffer.TryDequeue(out var line))
+            try
             {
-                sb.AppendLine(line);
-            }
+                var sb = new StringBuilder();
+                while (s_buffer.TryDequeue(out var line))
+                {
+                    sb.AppendLine(line);
+                }
 
-            if (sb.Length > 0)
-            {
-                var logFile = Path.Combine(s_logDirectory, $"lite_{DateTime.Now:yyyyMMdd}.log");
-                File.AppendAllText(logFile, sb.ToString());
+                if (sb.Length > 0)
+                {
+                    var logFile = Path.Combine(s_logDirectory, $"lite_{DateTime.Now:yyyyMMdd}.log");
+                    File.AppendAllText(logFile, sb.ToString());
+                }
             }
-        }
-        catch
-        {
-            /* Don't let logging failures crash the app */
+            catch
+            {
+                /* Don't let logging failures crash the app */
+            }
         }
     }
 

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -109,7 +109,9 @@ public partial class RemoteCollectorService
     private static long s_idCounter = DateTime.UtcNow.Ticks;
 
     /// <summary>
-    /// Limits concurrent SQL connections to avoid overwhelming target servers.
+    /// Limits how many SQL connections are <em>opened</em> at once — the semaphore is released
+    /// when OpenAsync returns, not when the connection is disposed — smoothing the login storm
+    /// when many servers are polled together. It does not cap the number of open connections.
     /// </summary>
     private static readonly SemaphoreSlim s_connectionThrottle = new(7, 7);
 


### PR DESCRIPTION
Lite services/analysis surgical fixes from the Fable code review (chunk 3a of 7). Lite is split into 3a (this), 3b (UI), 3c (ArchiveService data-integrity — isolated, needs live-collector validation), 3d (anomaly-ratio math + raced timing + finding.DatabaseName).

## Fixes

**[HIGH] Plan-analysis drill-down silently dead** — `Lite/Analysis/SqlPlanFetcher.cs`
`FetchPlanXmlAsync` resolved the server with `s.ServerName.GetHashCode() == serverId`. But every `server_id` in the system is `RemoteCollectorService.GetDeterministicHashCode(GetServerNameForStorage(...))` — an FNV-1a hash over the storage name (with `:db`/`:RO` suffixes). `string.GetHashCode()` is randomized per process and a different algorithm, so the match never succeeded and the bad-actor `plan_analysis` drill-down returned null with no error. Now uses the same hash function.

**[SECURITY] EncryptMode failed open** — `Lite/Models/ServerConnection.cs`
The switch mapped only `Mandatory`/`Strict`; the default arm returned `Optional` (permits an unencrypted, cert-unvalidated connection). Any `servers.json` with a null/blank/legacy `EncryptMode` silently downgraded — leaking DMV data (query text, plans, logins) in cleartext and allowing MITM. Now fails closed to `Mandatory` (matching the UI default and the Dashboard builders); explicit `Optional` is still honored.

**[LOW] AppLogger.Flush concurrency** — `Lite/Services/AppLogger.cs`
The 5s flush timer and `Shutdown()` can call `Flush` concurrently; two `File.AppendAllText` to the same file throw, the catch swallows it, and the already-dequeued lines are lost. Now serialized under a lock.

**[LOW] BaselineProvider tier copy-paste** — `Lite/Analysis/BaselineProvider.cs`
The tier ternary had two identical `Full` branches and labeled sparse `(hour, dow)` buckets `HourOnly`, misreporting `baseline_tier` metadata (read only at `AnomalyDetector.cs:77`). Every bucket built there is a full bucket → `Full`.

**[LOW] Connection-throttle comment** — `Lite/Services/RemoteCollectorService.cs`
Doc comment claimed it limits concurrent connections; it's released right after `OpenAsync`, so it limits concurrent *opens*. Comment corrected (no behavior change).

## Validation
- Lite builds clean on net10 (0 errors).
- `Lite.Tests`: 411/411 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
