### PR TITLE
Exclude CDC capture jobs from long-running query alerts (Dashboard + Lite) (#1096)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -1454,7 +1454,7 @@ namespace PerformanceMonitorDashboard
                     var connectionString = server.GetConnectionString(_credentialService);
                     var databaseService = new DatabaseService(connectionString);
                     var connStatus = _serverManager.GetConnectionStatus(server.Id);
-                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition, prefs.LongRunningQueryThresholdMinutes, prefs.LongRunningJobMultiplier, prefs.LongRunningQueryMaxResults, prefs.LongRunningQueryExcludeSpServerDiagnostics, prefs.LongRunningQueryExcludeWaitFor, prefs.LongRunningQueryExcludeBackups, prefs.LongRunningQueryExcludeMiscWaits, prefs.AlertExcludedDatabases);
+                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition, prefs.LongRunningQueryThresholdMinutes, prefs.LongRunningJobMultiplier, prefs.LongRunningQueryMaxResults, prefs.LongRunningQueryExcludeSpServerDiagnostics, prefs.LongRunningQueryExcludeWaitFor, prefs.LongRunningQueryExcludeBackups, prefs.LongRunningQueryExcludeMiscWaits, prefs.LongRunningQueryExcludeCdc, prefs.AlertExcludedDatabases);
 
                     if (health.IsOnline)
                     {

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -102,6 +102,7 @@ namespace PerformanceMonitorDashboard.Models
         public bool LongRunningQueryExcludeWaitFor { get; set; } = true;
         public bool LongRunningQueryExcludeBackups { get; set; } = true;
         public bool LongRunningQueryExcludeMiscWaits { get; set; } = true;
+        public bool LongRunningQueryExcludeCdc { get; set; } = true; // Exclude CDC capture jobs (sp_MScdc_capture_job / sp_cdc_scan)
         public bool NotifyOnTempDbSpace { get; set; } = true;
         public int TempDbSpaceThresholdPercent { get; set; } = 80; // Alert when TempDB used > X%
         public bool NotifyOnLongRunningJobs { get; set; } = true;

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -131,6 +131,7 @@ namespace PerformanceMonitorDashboard.Services
             bool excludeWaitFor = true,
             bool excludeBackups = true,
             bool excludeMiscWaits = true,
+            bool excludeCdc = true,
             IReadOnlyList<string>? excludedDatabases = null)
         {
             var result = new AlertHealthResult();
@@ -149,7 +150,7 @@ namespace PerformanceMonitorDashboard.Services
                     ? GetFilteredDeadlockCountAsync(connection, excludedDatabases)
                     : null;
                 var poisonWaitTask = GetPoisonWaitDeltasAsync(connection);
-                var longRunningTask = GetLongRunningQueriesAsync(connection, longRunningQueryThresholdMinutes, longRunningQueryMaxResults, excludeSpServerDiagnostics, excludeWaitFor, excludeBackups, excludeMiscWaits);
+                var longRunningTask = GetLongRunningQueriesAsync(connection, longRunningQueryThresholdMinutes, longRunningQueryMaxResults, excludeSpServerDiagnostics, excludeWaitFor, excludeBackups, excludeMiscWaits, excludeCdc);
                 var tempDbTask = GetTempDbSpaceAsync(connection);
                 var anomalousJobTask = GetAnomalousJobsAsync(connection, longRunningJobMultiplier);
                 var missingCaptureTask = GetMissingCaptureSessionsAsync(connection);
@@ -751,7 +752,8 @@ namespace PerformanceMonitorDashboard.Services
             bool excludeSpServerDiagnostics = true,
             bool excludeWaitFor = true,
             bool excludeBackups = true,
-            bool excludeMiscWaits = true)
+            bool excludeMiscWaits = true,
+            bool excludeCdc = true)
         {
             maxResults = Math.Clamp(maxResults, 1, 1000);
 
@@ -763,6 +765,12 @@ namespace PerformanceMonitorDashboard.Services
                 ? "AND r.wait_type NOT IN (N'BACKUPTHREAD', N'BACKUPIO')" : "";
             string miscWaitsFilter = excludeMiscWaits
                 ? "AND r.wait_type NOT IN (N'XE_LIVE_TARGET_TVF')" : "";
+            // CDC capture runs continuously as a SQL Agent job (EXEC sys.sp_MScdc_capture_job -> sys.sp_cdc_scan),
+            // so it permanently exceeds the duration threshold. Filter on request text, not program_name, to stay
+            // CDC-specific and avoid hiding unrelated Agent jobs (ETL, index maintenance). Keep NULL text (encrypted
+            // modules) visible -- only drop rows we can positively identify as CDC.
+            string cdcFilter = excludeCdc
+                ? "AND (t.text IS NULL OR (t.text NOT LIKE N'%sp_MScdc_capture_job%' AND t.text NOT LIKE N'%sp_cdc_scan%'))" : "";
 
             string query = @$"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -787,6 +795,7 @@ namespace PerformanceMonitorDashboard.Services
                     {waitForFilter}
                     {backupsFilter}
                     {miscWaitsFilter}
+                    {cdcFilter}
                 ORDER BY r.total_elapsed_time DESC
                 OPTION(MAXDOP 1, RECOMPILE);";
 

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -766,14 +766,44 @@ namespace PerformanceMonitorDashboard.Services
             string miscWaitsFilter = excludeMiscWaits
                 ? "AND r.wait_type NOT IN (N'XE_LIVE_TARGET_TVF')" : "";
             // CDC capture runs continuously as a SQL Agent job (EXEC sys.sp_MScdc_capture_job -> sys.sp_cdc_scan),
-            // so it permanently exceeds the duration threshold. Filter on request text, not program_name, to stay
-            // CDC-specific and avoid hiding unrelated Agent jobs (ETL, index maintenance). Keep NULL text (encrypted
-            // modules) visible -- only drop rows we can positively identify as CDC.
-            string cdcFilter = excludeCdc
-                ? "AND (t.text IS NULL OR (t.text NOT LIKE N'%sp_MScdc_capture_job%' AND t.text NOT LIKE N'%sp_cdc_scan%'))" : "";
+            // so it permanently exceeds the duration threshold and none of the wait_type filters above catch it.
+            //
+            // Primary signal: resolve the capture job_id(s) from msdb.dbo.cdc_jobs and match the running session via
+            // its SQL Agent program_name ('SQLAgent - TSQL JobStep (Job 0x<job_id> : Step N)'). This is CDC-specific
+            // and never hides unrelated Agent jobs. The msdb reference is deferred through sp_executesql inside
+            // TRY/CATCH so a login without msdb access gets a *catchable* error (not an uncatchable cross-db 916) and
+            // cleanly falls back to a text match on the whole batch/object text.
+            string cdcSetup = excludeCdc ? @"
+                DECLARE @cdc_capture_jobs TABLE (job_id uniqueidentifier PRIMARY KEY);
+                DECLARE @cdc_readable bit = 0;
+                BEGIN TRY
+                    INSERT @cdc_capture_jobs (job_id)
+                    EXEC sys.sp_executesql N'SELECT cj.job_id FROM msdb.dbo.cdc_jobs AS cj WHERE cj.job_type = N''capture'';';
+                    SET @cdc_readable = 1;
+                END TRY
+                BEGIN CATCH
+                    SET @cdc_readable = 0;
+                END CATCH;
+" : "";
+            string cdcFilter = excludeCdc ? @"
+                    AND NOT
+                    (
+                        (
+                            @cdc_readable = 1
+                            AND s.program_name LIKE N'SQLAgent - TSQL JobStep (Job 0x%'
+                            AND TRY_CONVERT(uniqueidentifier, TRY_CONVERT(binary(16), SUBSTRING(s.program_name, 32, 32), 2))
+                                IN (SELECT j.job_id FROM @cdc_capture_jobs AS j)
+                        )
+                        OR
+                        (
+                            @cdc_readable = 0
+                            AND t.text IS NOT NULL
+                            AND (t.text LIKE N'%sp_MScdc_capture_job%' OR t.text LIKE N'%sp_cdc_scan%')
+                        )
+                    )" : "";
 
             string query = @$"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
+                {cdcSetup}
                 SELECT TOP(@maxResults)
                     r.session_id,
                     DB_NAME(r.database_id) AS database_name,

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -246,6 +246,9 @@
                                       Margin="0,0,0,4"/>
                             <CheckBox x:Name="LrqExcludeMiscWaitsCheckBox"
                                       Content="Exclude miscellaneous waits (XE_LIVE_TARGET_TVF)"
+                                      Margin="0,0,0,4"/>
+                            <CheckBox x:Name="LrqExcludeCdcCheckBox"
+                                      Content="Exclude CDC capture jobs (sp_MScdc_capture_job, sp_cdc_scan)"
                                       Margin="0,0,0,0"/>
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <CheckBox x:Name="NotifyOnTempDbSpaceCheckBox"

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -186,6 +186,7 @@ namespace PerformanceMonitorDashboard
             LrqExcludeWaitForCheckBox.IsChecked = prefs.LongRunningQueryExcludeWaitFor;
             LrqExcludeBackupsCheckBox.IsChecked = prefs.LongRunningQueryExcludeBackups;
             LrqExcludeMiscWaitsCheckBox.IsChecked = prefs.LongRunningQueryExcludeMiscWaits;
+            LrqExcludeCdcCheckBox.IsChecked = prefs.LongRunningQueryExcludeCdc;
             AlertExcludedDatabasesTextBox.Text = string.Join(", ", prefs.AlertExcludedDatabases);
             NotifyOnTempDbSpaceCheckBox.IsChecked = prefs.NotifyOnTempDbSpace;
             TempDbSpaceThresholdTextBox.Text = prefs.TempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
@@ -683,6 +684,7 @@ namespace PerformanceMonitorDashboard
             prefs.LongRunningQueryExcludeWaitFor = LrqExcludeWaitForCheckBox.IsChecked == true;
             prefs.LongRunningQueryExcludeBackups = LrqExcludeBackupsCheckBox.IsChecked == true;
             prefs.LongRunningQueryExcludeMiscWaits = LrqExcludeMiscWaitsCheckBox.IsChecked == true;
+            prefs.LongRunningQueryExcludeCdc = LrqExcludeCdcCheckBox.IsChecked == true;
             prefs.AlertExcludedDatabases = AlertExcludedDatabasesTextBox.Text
                 .Split(',')
                 .Select(s => s.Trim())

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -107,6 +107,7 @@ public partial class App : Application
     public static bool AlertLongRunningQueryExcludeWaitFor { get; set; } = true;
     public static bool AlertLongRunningQueryExcludeBackups { get; set; } = true;
     public static bool AlertLongRunningQueryExcludeMiscWaits { get; set; } = true;
+    public static bool AlertLongRunningQueryExcludeCdc { get; set; } = true;
     public static List<string> AlertExcludedDatabases { get; set; } = new();
     public static bool AlertTempDbSpaceEnabled { get; set; } = true;
     public static int AlertTempDbSpaceThresholdPercent { get; set; } = 80;
@@ -463,6 +464,7 @@ public partial class App : Application
             if (root.TryGetProperty("alert_long_running_query_exclude_waitfor", out v)) AlertLongRunningQueryExcludeWaitFor = v.GetBoolean();
             if (root.TryGetProperty("alert_long_running_query_exclude_backups", out v)) AlertLongRunningQueryExcludeBackups = v.GetBoolean();
             if (root.TryGetProperty("alert_long_running_query_exclude_misc_waits", out v)) AlertLongRunningQueryExcludeMiscWaits = v.GetBoolean();
+            if (root.TryGetProperty("alert_long_running_query_exclude_cdc", out v)) AlertLongRunningQueryExcludeCdc = v.GetBoolean();
             if (root.TryGetProperty("alert_excluded_databases", out v) && v.ValueKind == System.Text.Json.JsonValueKind.Array)
             {
                 AlertExcludedDatabases = new List<string>();

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 27;
+    internal const int CurrentSchemaVersion = 28;
 
     private readonly string _archivePath;
 
@@ -730,6 +730,23 @@ public class DuckDbInitializer
             {
                 _logger?.LogError(ex, "Migration to v27 failed");
                 throw;
+            }
+        }
+
+        if (fromVersion < 28)
+        {
+            /* v28: Added is_cdc_capture flag to query_snapshots so the long-running query
+                    alert can exclude CDC capture sessions. The collector computes the flag
+                    server-side (program_name -> job_id via msdb.dbo.cdc_jobs, text fallback).
+                    Appended at the end to match the DuckDB appender's positional order. */
+            _logger?.LogInformation("Running migration to v28: adding is_cdc_capture column to query_snapshots");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS is_cdc_capture BOOLEAN DEFAULT false");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v28 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -346,7 +346,8 @@ CREATE TABLE IF NOT EXISTS query_snapshots (
     host_name VARCHAR,
     program_name VARCHAR,
     open_transaction_count INTEGER,
-    percent_complete DECIMAL(5,2)
+    percent_complete DECIMAL(5,2),
+    is_cdc_capture BOOLEAN DEFAULT false
 )";
 
     public const string CreateTempdbStatsTable = @"

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1634,7 +1634,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var longRunning = await _dataService.GetLongRunningQueriesAsync(summary.ServerId, App.AlertLongRunningQueryThresholdMinutes, App.AlertLongRunningQueryMaxResults, App.AlertLongRunningQueryExcludeSpServerDiagnostics, App.AlertLongRunningQueryExcludeWaitFor, App.AlertLongRunningQueryExcludeBackups, App.AlertLongRunningQueryExcludeMiscWaits);
+                var longRunning = await _dataService.GetLongRunningQueriesAsync(summary.ServerId, App.AlertLongRunningQueryThresholdMinutes, App.AlertLongRunningQueryMaxResults, App.AlertLongRunningQueryExcludeSpServerDiagnostics, App.AlertLongRunningQueryExcludeWaitFor, App.AlertLongRunningQueryExcludeBackups, App.AlertLongRunningQueryExcludeMiscWaits, App.AlertLongRunningQueryExcludeCdc);
 
                 if (App.AlertExcludedDatabases.Count > 0)
                 {

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -436,7 +436,8 @@ LIMIT 2000";
         bool excludeSpServerDiagnostics = true,
         bool excludeWaitFor = true,
         bool excludeBackups = true,
-        bool excludeMiscWaits = true)
+        bool excludeMiscWaits = true,
+        bool excludeCdc = true)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
@@ -451,6 +452,10 @@ LIMIT 2000";
             ? "AND r.wait_type NOT IN (N'BACKUPTHREAD', N'BACKUPIO')" : "";
         string miscWaitsFilter = excludeMiscWaits
             ? "AND r.wait_type NOT IN (N'XE_LIVE_TARGET_TVF')" : "";
+        // CDC capture sessions are flagged server-side by the collector (is_cdc_capture). COALESCE
+        // guards pre-migration / archived rows where the column is NULL.
+        string cdcFilter = excludeCdc
+            ? "AND COALESCE(r.is_cdc_capture, FALSE) = FALSE" : "";
         maxResults = Math.Clamp(maxResults, 1, 1000);
 
         command.CommandText = @$"
@@ -473,6 +478,7 @@ LIMIT 2000";
                     {waitForFilter}
                     {backupsFilter}
                     {miscWaitsFilter}
+                    {cdcFilter}
                     AND r.total_elapsed_time_ms >= $2
                 ORDER BY r.total_elapsed_time_ms DESC
                 LIMIT $3;";

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -25,6 +25,17 @@ public partial class RemoteCollectorService
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LOCK_TIMEOUT 1000;
 
+DECLARE @cdc_capture_jobs TABLE (job_id uniqueidentifier PRIMARY KEY);
+DECLARE @cdc_readable bit = 0;
+BEGIN TRY
+    INSERT @cdc_capture_jobs (job_id)
+    EXEC sys.sp_executesql N'SELECT cj.job_id FROM msdb.dbo.cdc_jobs AS cj WHERE cj.job_type = N''capture'';';
+    SET @cdc_readable = 1;
+END TRY
+BEGIN CATCH
+    SET @cdc_readable = 0;
+END CATCH;
+
 SELECT /* PerformanceMonitorLite */
     der.session_id,
     database_name = d.name,
@@ -68,7 +79,21 @@ SELECT /* PerformanceMonitorLite */
     des.host_name,
     des.program_name,
     des.open_transaction_count,
-    der.percent_complete
+    der.percent_complete,
+    is_cdc_capture =
+        CONVERT(bit,
+            CASE
+                WHEN @cdc_readable = 1
+                     AND des.program_name LIKE N'SQLAgent - TSQL JobStep (Job 0x%'
+                     AND TRY_CONVERT(uniqueidentifier, TRY_CONVERT(binary(16), SUBSTRING(des.program_name, 32, 32), 2))
+                         IN (SELECT j.job_id FROM @cdc_capture_jobs AS j)
+                THEN 1
+                WHEN @cdc_readable = 0
+                     AND dest.text IS NOT NULL
+                     AND (dest.text LIKE N'%sp_MScdc_capture_job%' OR dest.text LIKE N'%sp_cdc_scan%')
+                THEN 1
+                ELSE 0
+            END)
 FROM sys.dm_exec_requests AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -174,7 +199,9 @@ SELECT /* PerformanceMonitorLite */
     des.host_name,
     des.program_name,
     des.open_transaction_count,
-    der.percent_complete
+    der.percent_complete,
+    /* Azure SQL Database has no SQL Agent / msdb.dbo.cdc_jobs (CDC there is scheduler-based), so no capture job to exclude. */
+    is_cdc_capture = CONVERT(bit, 0)
 FROM #req AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -300,6 +327,7 @@ DROP TABLE #req;
                    .AppendValue(reader.IsDBNull(22) ? (string?)null : reader.GetString(22))                /* program_name */
                    .AppendValue(reader.IsDBNull(23) ? 0 : Convert.ToInt32(reader.GetValue(23)))            /* open_transaction_count */
                    .AppendValue(reader.IsDBNull(24) ? 0m : Convert.ToDecimal(reader.GetValue(24)))        /* percent_complete */
+                   .AppendValue(!reader.IsDBNull(25) && Convert.ToBoolean(reader.GetValue(25)))           /* is_cdc_capture */
                    .EndRow();
 
                 rowsCollected++;

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -211,6 +211,9 @@
                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
                 <CheckBox x:Name="LrqExcludeMiscWaitsCheckBox"
                           Content="Exclude miscellaneous waits (XE_LIVE_TARGET_TVF)"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
+                <CheckBox x:Name="LrqExcludeCdcCheckBox"
+                          Content="Exclude CDC capture jobs (sp_MScdc_capture_job, sp_cdc_scan)"
                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,0"/>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertTempDbSpaceCheckBox" Content="TempDB space usage over" VerticalAlignment="Center"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -593,6 +593,7 @@ public partial class SettingsWindow : Window
         LrqExcludeWaitForCheckBox.IsChecked = App.AlertLongRunningQueryExcludeWaitFor;
         LrqExcludeBackupsCheckBox.IsChecked = App.AlertLongRunningQueryExcludeBackups;
         LrqExcludeMiscWaitsCheckBox.IsChecked = App.AlertLongRunningQueryExcludeMiscWaits;
+        LrqExcludeCdcCheckBox.IsChecked = App.AlertLongRunningQueryExcludeCdc;
         AlertExcludedDatabasesBox.Text = string.Join(", ", App.AlertExcludedDatabases);
         AlertTempDbSpaceCheckBox.IsChecked = App.AlertTempDbSpaceEnabled;
         AlertTempDbSpaceThresholdBox.Text = App.AlertTempDbSpaceThresholdPercent.ToString();
@@ -642,6 +643,7 @@ public partial class SettingsWindow : Window
         App.AlertLongRunningQueryExcludeWaitFor = LrqExcludeWaitForCheckBox.IsChecked == true;
         App.AlertLongRunningQueryExcludeBackups = LrqExcludeBackupsCheckBox.IsChecked == true;
         App.AlertLongRunningQueryExcludeMiscWaits = LrqExcludeMiscWaitsCheckBox.IsChecked == true;
+        App.AlertLongRunningQueryExcludeCdc = LrqExcludeCdcCheckBox.IsChecked == true;
         App.AlertExcludedDatabases = AlertExcludedDatabasesBox.Text
             .Split(',')
             .Select(s => s.Trim())
@@ -709,6 +711,7 @@ public partial class SettingsWindow : Window
             root["alert_long_running_query_exclude_waitfor"] = App.AlertLongRunningQueryExcludeWaitFor;
             root["alert_long_running_query_exclude_backups"] = App.AlertLongRunningQueryExcludeBackups;
             root["alert_long_running_query_exclude_misc_waits"] = App.AlertLongRunningQueryExcludeMiscWaits;
+            root["alert_long_running_query_exclude_cdc"] = App.AlertLongRunningQueryExcludeCdc;
             var dbArray = new System.Text.Json.Nodes.JsonArray();
             foreach (var db in App.AlertExcludedDatabases) dbArray.Add(db);
             root["alert_excluded_databases"] = dbArray;


### PR DESCRIPTION
Closes #1096. Reported in discussion #1090.

Adds an **"Exclude CDC capture jobs"** toggle (default **on**) to the long-running-query alert in **both Dashboard and Lite**, so the continuously-running CDC capture session (`sp_MScdc_capture_job` → `sp_cdc_scan`) stops permanently tripping the alert. The four existing exclusions are all `wait_type`-based and none catch CDC.

## CDC signal (identical in both apps)

Two-tier, computed **server-side** against the whole batch/object text:

1. **Primary — `program_name` → `job_id` → `msdb.dbo.cdc_jobs`** (`job_type = 'capture'`). Match the running session by decoding its SQL Agent program name. CDC-specific; never hides other Agent jobs. Decode validated by round-trip + against a live Agent-job session:
   ```sql
   CONVERT(uniqueidentifier, CONVERT(binary(16), SUBSTRING(program_name, 32, 32), 2))
   ```
2. **Fallback — whole-text match** (`sp_MScdc_capture_job` / `sp_cdc_scan`) when `msdb.dbo.cdc_jobs` is unreadable, or absent (it's created lazily on first CDC config).

The `msdb.dbo.cdc_jobs` reference is **deferred through `sp_executesql` inside `TRY/CATCH`**, so an inaccessible/absent msdb raises a *catchable* error (not an uncatchable cross-db 916) and degrades to the text path.

## Dashboard
Inline in `GetLongRunningQueriesAsync` (live DMV query). Pref + settings checkbox + call site.

## Lite
Lite reads collected DuckDB snapshots storing only **statement-level** text (can't carry the proc name), so detection runs in the **collector** (whole text + msdb available) and is stored as a per-row flag:
- `query_snapshots.is_cdc_capture BOOLEAN` — **schema v28** migration (`ALTER … ADD COLUMN IF NOT EXISTS`, appended last to match the appender); fresh installs get it in `Schema.cs`.
- Non-Azure collector template computes it with the same two-tier logic; Azure SQL DB hard-codes `0` (no Agent/msdb).
- `GetLongRunningQueriesAsync` filters `COALESCE(is_cdc_capture, FALSE) = FALSE`. Archive views (`UNION ALL BY NAME` + `union_by_name=true`) keep old parquet compatible.
- Settings checkbox + `App` static + JSON load/save.

## Verification (SQL 2016 SP3)
- [x] Dashboard + Lite build: 0 errors
- [x] **Dashboard tests 476/476, Lite tests 411/411**
- [x] `program_name` → `job_id` decode round-trips; **live Agent-job session correctly excluded** (`CORRECTLY EXCLUDED`)
- [x] msdb-absent fallback proven: `TRY/CATCH` sets `@cdc_readable=0`, batch completes, text path engages (no uncatchable error) — in both the Dashboard and Lite collector SQL
- [ ] **Live real-CDC match** — pending a CDC-enabled server with a running capture job (local sql2016 blocked by a stale `@@SERVERNAME` that prevents CDC job creation). Mechanism is identical to the validated Agent-job stand-in; only the job_id source differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
