### PR TITLE
Fix #1050: restore window via WPF Show() on relaunch, not raw Win32 ShowWindow

### DIFF
--- a/Lite.Tests/SingleInstanceSignalTests.cs
+++ b/Lite.Tests/SingleInstanceSignalTests.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Coverage for <see cref="SingleInstanceSignal"/> — the cross-process "surface the window" channel
+/// (#769, #1050). A second launch signals the named event and the owning instance restores its window
+/// through WPF's Show() path instead of a raw Win32 ShowWindow (which leaves a tray-hidden window
+/// blank). These exercise the handshake without WPF: that a signal wakes the owner's callback, that
+/// each launch delivers exactly one restore, and that there is nothing to signal once the owner exits.
+/// </summary>
+public class SingleInstanceSignalTests
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(2);
+
+    /* Unique per test so concurrent runs (and leftover machine-global kernel objects) can't collide. */
+    private static string UniqueName() => "PMLite_Test_" + Guid.NewGuid().ToString("N");
+
+    [Fact]
+    public void TrySignal_NoOwner_ReturnsFalse()
+    {
+        Assert.False(SingleInstanceSignal.TrySignal(UniqueName()));
+    }
+
+    [Fact]
+    public void TrySignal_WithOwner_InvokesCallback()
+    {
+        var name = UniqueName();
+        using var fired = new AutoResetEvent(false);
+        using var owner = new SingleInstanceSignal(name, () => fired.Set());
+
+        Assert.True(SingleInstanceSignal.TrySignal(name));
+        Assert.True(fired.WaitOne(WaitTimeout), "the owner's callback should fire after a signal");
+    }
+
+    [Fact]
+    public void TrySignal_DeliversOneCallbackPerSignal()
+    {
+        var name = UniqueName();
+        var count = 0;
+        using var fired = new AutoResetEvent(false);
+        using var owner = new SingleInstanceSignal(name, () =>
+        {
+            Interlocked.Increment(ref count);
+            fired.Set();
+        });
+
+        /* Sequentially: send, wait for the callback to be consumed, send again. AutoReset means each
+           launch maps to exactly one restore. */
+        Assert.True(SingleInstanceSignal.TrySignal(name));
+        Assert.True(fired.WaitOne(WaitTimeout));
+
+        Assert.True(SingleInstanceSignal.TrySignal(name));
+        Assert.True(fired.WaitOne(WaitTimeout));
+
+        Assert.Equal(2, Volatile.Read(ref count));
+    }
+
+    [Fact]
+    public void Dispose_ReleasesChannel_NothingLeftToSignal()
+    {
+        var name = UniqueName();
+        var owner = new SingleInstanceSignal(name, () => { });
+        owner.Dispose();
+
+        /* The owner held the only handle on the named event; once disposed the kernel object is gone,
+           so a later launch finds no one to surface. */
+        Assert.False(SingleInstanceSignal.TrySignal(name));
+    }
+
+    [Fact]
+    public void Constructor_NullCallback_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SingleInstanceSignal(UniqueName(), null!));
+    }
+
+    [Fact]
+    public void Constructor_EmptyEventName_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new SingleInstanceSignal("", () => { }));
+    }
+}

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -33,24 +33,18 @@ public partial class App : Application
     [DllImport("shell32.dll", SetLastError = true)]
     private static extern void SetCurrentProcessExplicitAppUserModelID([MarshalAs(UnmanagedType.LPWStr)] string appId);
 
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern IntPtr FindWindow(string? lpClassName, string lpWindowName);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsIconic(IntPtr hWnd);
-
-    private const int SW_RESTORE = 9;
-
     private const string MutexName = "PerformanceMonitorLite_SingleInstance";
     private Mutex? _singleInstanceMutex;
     private bool _ownsMutex;
+
+    /* Single-instance "surface the window" channel (#769, #1050). A second launch signals this named
+       event and exits; the owning instance restores its window through WPF's own Show() path
+       (MainWindow.RestoreFromTray). The old approach poked the HWND with raw Win32 ShowWindow, which
+       leaves a tray-hidden (WPF Visibility.Hidden) window visible but blank — the root cause of the
+       "blank window after relaunch" reports. */
+    private const string ShowWindowEventName = "PerformanceMonitorLite_ShowWindow";
+    private SingleInstanceSignal? _instanceSignal;
+    private MainWindow? _mainWindow;
 
     /// <summary>
     /// Gets the application data directory where config and data files are stored.
@@ -261,17 +255,20 @@ public partial class App : Application
 
         if (!_ownsMutex)
         {
-            /* Bring the existing instance's window to the foreground instead of showing an error (#769) */
-            var hWnd = FindWindow(null, "Performance Monitor Lite");
-            if (hWnd != IntPtr.Zero)
-            {
-                if (IsIconic(hWnd))
-                    ShowWindow(hWnd, SW_RESTORE);
-                SetForegroundWindow(hWnd);
-            }
+            /* Ask the running instance to surface its window, then exit (#769). We signal a named
+               event rather than poking its HWND with Win32 ShowWindow: the owning instance restores
+               through WPF's own Show() path, which is the only thing that un-blanks a tray-hidden
+               window (#1050). Best-effort — if the first instance is still mid-startup the channel
+               may not exist yet, but it's already coming up visible anyway. */
+            SingleInstanceSignal.TrySignal(ShowWindowEventName);
             Shutdown();
             return;
         }
+
+        /* Own the "surface me" channel before anything slow runs, so a fast second launch finds it.
+           The callback null-checks _mainWindow, so a signal that lands before the window exists is a
+           harmless no-op (the window is about to show regardless). */
+        _instanceSignal = new SingleInstanceSignal(ShowWindowEventName, OnSurfaceWindowRequested);
 
         base.OnStartup(e);
 
@@ -325,13 +322,25 @@ public partial class App : Application
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
         // Create and show main window (StartupUri removed for Velopack custom Main)
-        var mainWindow = new MainWindow();
-        mainWindow.Show();
+        _mainWindow = new MainWindow();
+        _mainWindow.Show();
+    }
+
+    /// <summary>
+    /// Invoked on <see cref="SingleInstanceSignal"/>'s background thread when a second launch asks us
+    /// to surface the window. Marshals to the UI thread and restores via WPF's Show() path (#1050).
+    /// </summary>
+    private void OnSurfaceWindowRequested()
+    {
+        Dispatcher.BeginInvoke(new Action(() => _mainWindow?.RestoreFromTray()));
     }
 
     protected override void OnExit(ExitEventArgs e)
     {
         AppLogger.Info("App", "Shutting down");
+
+        _instanceSignal?.Dispose();
+
         AppLogger.Shutdown();
 
         if (_ownsMutex)

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -115,6 +115,22 @@ public partial class MainWindow : Window
         ServerTabControl.SelectionChanged += ServerTabControl_SelectionChanged;
     }
 
+    /// <summary>
+    /// The one true window-restore path. Minimize-to-tray calls <see cref="Window.Hide"/>, which
+    /// sets WPF <see cref="UIElement.Visibility"/> = Hidden. Only <see cref="Window.Show"/> reconciles
+    /// that state and re-runs layout/render — a raw Win32 ShowWindow leaves the HWND visible but the
+    /// WPF tree un-arranged, i.e. a blank window (#1050). Every restore entry point — tray double-click,
+    /// the "Show Window" menu, the sleep/unlock resume guard, and the second-instance signal — routes
+    /// here so the window can never be left visible-but-blank. Must be called on the UI thread.
+    /// </summary>
+    public void RestoreFromTray()
+    {
+        Show();
+        ShowInTaskbar = true;
+        WindowState = WindowState.Normal;
+        Activate();
+    }
+
     private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
         try
@@ -150,12 +166,12 @@ public partial class MainWindow : Window
             _ = _backgroundService.StartAsync(_backgroundCts.Token);
 
             // Initialize system tray
-            _trayService = new SystemTrayService(this, _backgroundService);
+            _trayService = new SystemTrayService(this, RestoreFromTray, _backgroundService);
             _trayService.Initialize();
 
             /* #1050: restore the window from the tray on resume/unlock if a sleep- or lock-driven
                minimize hid it. ??= so a repeated Loaded can't double-subscribe (static SystemEvents). */
-            _resumeGuard ??= new WindowResumeGuard(this, _trayService.ShowMainWindow);
+            _resumeGuard ??= new WindowResumeGuard(this, RestoreFromTray);
 
             // Initialize data service for overview
             _dataService = new LocalDataService(_databaseInitializer);

--- a/Lite/Services/SystemTrayService.cs
+++ b/Lite/Services/SystemTrayService.cs
@@ -25,14 +25,21 @@ public class SystemTrayService : IDisposable
 {
     private TaskbarIcon? _trayIcon;
     private readonly Window _mainWindow;
+    private readonly Action _restoreWindow;
     private readonly CollectionBackgroundService? _backgroundService;
     private bool _disposed;
     private MenuItem? _pauseResumeItem;
     private TextBlock? _tooltipText;
 
-    public SystemTrayService(Window mainWindow, CollectionBackgroundService? backgroundService = null)
+    /// <param name="restoreWindow">
+    /// The window's own WPF restore (e.g. <c>MainWindow.RestoreFromTray</c>). The tray must restore
+    /// through WPF's <see cref="Window.Show"/> path, never a raw Win32 ShowWindow, or a tray-hidden
+    /// window comes back blank (#1050).
+    /// </param>
+    public SystemTrayService(Window mainWindow, Action restoreWindow, CollectionBackgroundService? backgroundService = null)
     {
         _mainWindow = mainWindow;
+        _restoreWindow = restoreWindow ?? throw new ArgumentNullException(nameof(restoreWindow));
         _backgroundService = backgroundService;
         ThemeManager.ThemeChanged += OnThemeChanged;
     }
@@ -89,7 +96,7 @@ public class SystemTrayService : IDisposable
         var contextMenu = new ContextMenu();
 
         var showItem = new MenuItem { Header = "Show Window", Icon = new TextBlock { Text = "📊", Background = Brushes.Transparent } };
-        showItem.Click += (s, e) => ShowMainWindow();
+        showItem.Click += (s, e) => _restoreWindow();
         contextMenu.Items.Add(showItem);
 
         contextMenu.Items.Add(new Separator());
@@ -107,7 +114,7 @@ public class SystemTrayService : IDisposable
         _trayIcon.ContextMenu = contextMenu;
 
         /* Double-click to show window */
-        _trayIcon.TrayMouseDoubleClick += (s, e) => ShowMainWindow();
+        _trayIcon.TrayMouseDoubleClick += (s, e) => _restoreWindow();
 
         /* Handle minimize to tray */
         _mainWindow.StateChanged += MainWindow_StateChanged;
@@ -119,18 +126,6 @@ public class SystemTrayService : IDisposable
         {
             _mainWindow.Hide();
         }
-    }
-
-    /// <summary>
-    /// Restores the main window from the tray. Also used as the #1050 resume-restore callback,
-    /// so it must set ShowInTaskbar = true (the tray-hide path only calls Hide()).
-    /// </summary>
-    internal void ShowMainWindow()
-    {
-        _mainWindow.Show();
-        _mainWindow.ShowInTaskbar = true;
-        _mainWindow.WindowState = WindowState.Normal;
-        _mainWindow.Activate();
     }
 
     private void ToggleCollection()

--- a/PerformanceMonitor.Ui/SingleInstanceSignal.cs
+++ b/PerformanceMonitor.Ui/SingleInstanceSignal.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// Cross-process "surface the existing window" channel for a single-instance app (#769, #1050).
+    ///
+    /// The first (owning) instance constructs one of these with a callback and keeps it for the life
+    /// of the process. A later launch calls the static <see cref="TrySignal"/> and exits; the owning
+    /// instance wakes and invokes the callback.
+    ///
+    /// The callback runs on this class's background listener thread — the owner is responsible for
+    /// marshalling to its UI thread and restoring the window through WPF's own <c>Window.Show()</c>
+    /// path. The bug this exists to prevent (#1050): the old approach poked the running window's HWND
+    /// with raw Win32 <c>ShowWindow(SW_RESTORE)</c>, which un-minimizes the native window but does NOT
+    /// reconcile WPF's <c>Visibility.Hidden</c> state left by a minimize-to-tray <c>Hide()</c> — so the
+    /// window comes back visible but blank. Routing the restore back through the owner lets it use
+    /// <c>Show()</c>, the only path that re-arranges and re-renders the WPF tree.
+    ///
+    /// The named event uses <see cref="EventResetMode.AutoReset"/>, so each launch delivers exactly one
+    /// restore. <see cref="Dispose"/> stops the listener; callers MUST dispose on app exit.
+    /// </summary>
+    public sealed class SingleInstanceSignal : IDisposable
+    {
+        private readonly EventWaitHandle _handle;
+        private readonly Thread _listener;
+        private readonly Action _onSignal;
+        private volatile bool _disposed;
+
+        public SingleInstanceSignal(string eventName, Action onSignal)
+        {
+            if (string.IsNullOrEmpty(eventName))
+                throw new ArgumentException("Event name is required.", nameof(eventName));
+
+            _onSignal = onSignal ?? throw new ArgumentNullException(nameof(onSignal));
+            _handle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
+            _listener = new Thread(ListenLoop)
+            {
+                IsBackground = true,
+                Name = "SingleInstanceSignal"
+            };
+            _listener.Start();
+        }
+
+        /// <summary>
+        /// Best-effort wake of an already-running owner. Returns true if an instance was listening on
+        /// <paramref name="eventName"/> and was signaled; false when no instance owns the channel
+        /// (nothing to surface) or the owner is mid start-up/tear-down.
+        /// </summary>
+        public static bool TrySignal(string eventName)
+        {
+            try
+            {
+                if (EventWaitHandle.TryOpenExisting(eventName, out var existing))
+                {
+                    using (existing)
+                        existing.Set();
+                    return true;
+                }
+            }
+            catch
+            {
+                /* Owner is starting up or shutting down — treat as "no one to tell". */
+            }
+
+            return false;
+        }
+
+        /* Poll with a timeout so the thread can observe _disposed and exit promptly on shutdown,
+           instead of blocking forever on a WaitOne that will never be signaled again. A single bad
+           callback must not kill the channel, so non-disposal exceptions are swallowed and we keep
+           listening. */
+        private void ListenLoop()
+        {
+            while (!_disposed)
+            {
+                try
+                {
+                    if (!_handle.WaitOne(500))
+                        continue;
+                    if (_disposed)
+                        return;
+
+                    _onSignal();
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+                catch
+                {
+                    /* Keep listening — one failed restore shouldn't disable the channel. */
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            /* Nudge the listener out of WaitOne so it sees _disposed now rather than after the poll
+               timeout, then wait briefly for it to unwind before disposing the handle it waits on. */
+            try { _handle.Set(); }
+            catch { /* already disposed */ }
+
+            _listener.Join(TimeSpan.FromSeconds(1));
+            _handle.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to #1050. The shipped `ProcessRenderMode = SoftwareOnly` fix did not resolve the blank-window report from `bbishop-neovest`, and their latest diagnostics reframed the bug:

- Same Modern Standby (S0) sleep type as the maintainer → sleep mode isn't the variable.
- **Reproduces with no sleep at all** — just minimize-to-tray on a fresh launch, then relaunch the exe.
- **Double-clicking the tray icon always restores the full UI**; the relaunch / taskbar path gives a blank window.
- Resizing/dragging the blank window does nothing (so it's never laid out, not a stale GPU surface).

## Root cause

The single-instance relaunch path (#769) surfaced the running window by poking its HWND with raw Win32 `ShowWindow(SW_RESTORE)`. Minimize-to-tray calls `Window.Hide()`, which sets WPF `Visibility = Hidden`. A raw `ShowWindow` un-minimizes the **native** window but never reconciles WPF's visibility state, so the WPF tree stays un-arranged → a visible-but-blank window. The tray double-click path worked because it calls WPF `Window.Show()`.

## Fix

Replace HWND poking with a named-event channel (`SingleInstanceSignal`): a second launch signals it and exits; the owning instance restores through its own WPF `Show()` path. All restore entry points (tray double-click, "Show Window" menu, sleep/unlock resume guard, second-instance signal) now funnel through `MainWindow.RestoreFromTray()`.

Also removes a latent secondary bug: `FindWindow` matched the exact window title, which silently failed whenever the "Update available" banner had mutated it.

## Changes

- **`PerformanceMonitor.Ui/SingleInstanceSignal.cs`** *(new)* — testable cross-process channel (named `EventWaitHandle`, AutoReset, background listener, clean dispose); mirrors the `WindowResumeGuard` extract-for-testability pattern.
- **`Lite/App.xaml.cs`** — drop 4 Win32 P/Invokes + `SW_RESTORE`; signal instead of poke; restore via `RestoreFromTray`.
- **`Lite/MainWindow.xaml.cs`** — new canonical `RestoreFromTray()`.
- **`Lite/Services/SystemTrayService.cs`** — injected restore action; dropped duplicate `ShowMainWindow()`.
- **`Lite.Tests/SingleInstanceSignalTests.cs`** *(new)* — 6 handshake tests.

## Test plan

- [x] `dotnet build Lite.Tests` — succeeds, warning-clean
- [x] `dotnet test` — 14 passed (6 new + 8 existing `WindowResumeGuardTests`)
- [ ] Local repro: launch Lite → minimize to tray → relaunch exe → window returns fully rendered (not blank), no second instance
- [ ] Nightly retest by reporter on hybrid-GPU docked machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)