### PR TITLE
Fix #1092: clearable server tab alert badge (Lite + Dashboard)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -693,12 +693,23 @@ namespace PerformanceMonitorDashboard
             {
                 Style = (Style)FindResource("AlertBadge"),
                 Visibility = Visibility.Collapsed,
+                Cursor = Cursors.Hand,
+                ToolTip = "Click to dismiss · Right-click for options",
                 Child = new TextBlock
                 {
                     Text = "!",
                     FontWeight = FontWeights.Bold,
                     Foreground = Brushes.White
                 }
+            };
+
+            /* Left-click the badge to acknowledge/clear it — the right-click menu was
+               undiscoverable, so a plain click is the obvious affordance (issue #1092,
+               matching the Lite app). */
+            badge.MouseLeftButtonUp += (s, e) =>
+            {
+                AcknowledgeServerAlerts(server.Id);
+                e.Handled = true;
             };
 
             headerPanel.Children.Add(headerText);
@@ -2242,30 +2253,40 @@ namespace PerformanceMonitorDashboard
         {
             if (sender is MenuItem menuItem && menuItem.Tag is string serverId)
             {
-                // Look up cached health status for baseline snapshot
-                _latestHealthStatus.TryGetValue(serverId, out var status);
-                _alertStateService.AcknowledgeAllAlerts(serverId, status);
+                AcknowledgeServerAlerts(serverId);
+            }
+        }
 
-                // Hide badge immediately
-                if (_tabBadges.TryGetValue(serverId, out var badge))
-                {
-                    badge.Visibility = Visibility.Collapsed;
-                }
+        /// <summary>
+        /// Acknowledges all alerts for a server and clears its tab badge (and sub-tab badges).
+        /// Shared by the tab badge left-click and the right-click "Acknowledge Alerts" menu so both
+        /// paths behave identically (issue #1092 — parity with the Lite app's clearable badge).
+        /// </summary>
+        private void AcknowledgeServerAlerts(string serverId)
+        {
+            // Look up cached health status for baseline snapshot
+            _latestHealthStatus.TryGetValue(serverId, out var status);
+            _alertStateService.AcknowledgeAllAlerts(serverId, status);
 
-                // Also update sub-tab badges in the ServerTab if it's open
-                if (_openTabs.TryGetValue(serverId, out var tabItem) && tabItem.Content is ServerTab serverTab)
-                {
-                    serverTab.UpdateBadges(null, _alertStateService);
-                }
+            // Hide badge immediately
+            if (_tabBadges.TryGetValue(serverId, out var badge))
+            {
+                badge.Visibility = Visibility.Collapsed;
+            }
 
-                // Hide alerts in the email alert log so the sidebar badge updates
-                var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == serverId);
-                if (server != null)
-                {
-                    _alertHistoryStore.HideAllAlerts(8760, server.DisplayNameWithIntent);
-                    UpdateAlertBadge();
-                    _alertsHistoryContent?.RefreshAlerts();
-                }
+            // Also update sub-tab badges in the ServerTab if it's open
+            if (_openTabs.TryGetValue(serverId, out var tabItem) && tabItem.Content is ServerTab serverTab)
+            {
+                serverTab.UpdateBadges(null, _alertStateService);
+            }
+
+            // Hide alerts in the email alert log so the sidebar badge updates
+            var server = _serverManager.GetAllServers().FirstOrDefault(s => s.Id == serverId);
+            if (server != null)
+            {
+                _alertHistoryStore.HideAllAlerts(8760, server.DisplayNameWithIntent);
+                UpdateAlertBadge();
+                _alertsHistoryContent?.RefreshAlerts();
             }
         }
 

--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -38,6 +38,13 @@ public partial class AlertsHistoryTab : UserControl
 
     public MuteRuleService? MuteRuleService { get; set; }
 
+    /// <summary>
+    /// Raised after "Dismiss All" clears the visible alerts, so the host can acknowledge the
+    /// matching server tab badge(s). The argument is the server_id filter in effect at the time
+    /// (null = all servers were shown). See issue #1092.
+    /// </summary>
+    public event Action<int?>? AlertsDismissed;
+
     public AlertsHistoryTab()
     {
         InitializeComponent();
@@ -369,6 +376,9 @@ public partial class AlertsHistoryTab : UserControl
                 AppLogger.Warn("AlertsHistory", $"Dismiss all: only {affected} of {liveCount} live alert(s) were updated");
             }
             await LoadAlertsAsync();
+
+            /* Clear the matching server tab badge(s) so the indicator matches the cleared list (issue #1092). */
+            AlertsDismissed?.Invoke(serverId);
         }
         catch (TimeoutException)
         {

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -166,6 +166,7 @@ public partial class MainWindow : Window
             // Initialize alerts history tab
             AlertsHistoryContent.Initialize(_dataService);
             AlertsHistoryContent.MuteRuleService = _muteRuleService;
+            AlertsHistoryContent.AlertsDismissed += OnAlertHistoryDismissed;
 
             // Initialize FinOps tab
             FinOpsContent.Initialize(_dataService, _serverManager);
@@ -687,6 +688,7 @@ public partial class MainWindow : Window
             Margin = new Thickness(0, 0, 4, 0),
             VerticalAlignment = VerticalAlignment.Center,
             Visibility = Visibility.Collapsed,
+            Cursor = Cursors.Hand,
             Child = new TextBlock
             {
                 FontSize = 10,
@@ -742,6 +744,15 @@ public partial class MainWindow : Window
         };
 
         badge.ContextMenu = contextMenu;
+
+        /* Left-click the badge to acknowledge/clear it — the right-click menu was
+           undiscoverable, so a plain click is the obvious affordance (issue #1092). */
+        badge.MouseLeftButtonUp += (s, e) =>
+        {
+            AcknowledgeServerBadge(serverId);
+            e.Handled = true;
+        };
+
         panel.Children.Add(badge);
 
         var closeButton = new Button
@@ -781,7 +792,7 @@ public partial class MainWindow : Window
                     if (border.Child is TextBlock text)
                     {
                         text.Text = totalAlerts > 99 ? "99+" : totalAlerts.ToString();
-                        text.ToolTip = $"Blocking: {blockingCount}, Deadlocks: {deadlockCount}\nRight-click to dismiss";
+                        text.ToolTip = $"Blocking: {blockingCount}, Deadlocks: {deadlockCount}\nClick to dismiss · Right-click for options";
                     }
                 }
                 else
@@ -797,19 +808,54 @@ public partial class MainWindow : Window
     {
         if (sender is MenuItem menuItem && menuItem.Tag is string serverId)
         {
-            _alertStateService.AcknowledgeAlert(serverId);
+            AcknowledgeServerBadge(serverId);
+        }
+    }
 
-            /* Find and hide the badge for this server */
-            if (_openServerTabs.TryGetValue(serverId, out var tab) && tab.Header is StackPanel panel)
+    /// <summary>
+    /// Acknowledges a server's alerts and immediately hides its tab badge.
+    /// Shared by the badge left-click, the right-click "Acknowledge" menu, and
+    /// Alert History "Dismiss All" so every path clears the badge consistently (issue #1092).
+    /// </summary>
+    private void AcknowledgeServerBadge(string serverId)
+    {
+        _alertStateService.AcknowledgeAlert(serverId);
+        HideServerBadge(serverId);
+    }
+
+    /// <summary>
+    /// Collapses the alert badge on a server's tab header, if one is present.
+    /// </summary>
+    private void HideServerBadge(string serverId)
+    {
+        if (_openServerTabs.TryGetValue(serverId, out var tab) && tab.Header is StackPanel panel)
+        {
+            foreach (var child in panel.Children)
             {
-                foreach (var child in panel.Children)
+                if (child is System.Windows.Controls.Border border && border.Tag as string == "AlertBadge")
                 {
-                    if (child is System.Windows.Controls.Border border && border.Tag as string == "AlertBadge")
-                    {
-                        border.Visibility = Visibility.Collapsed;
-                        break;
-                    }
+                    border.Visibility = Visibility.Collapsed;
+                    break;
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// When alerts are cleared from Alert History via "Dismiss All", acknowledge the matching
+    /// server tab badge(s) so the at-a-glance indicator stays consistent with the cleared list
+    /// (issue #1092). The argument is the DB server_id filter that was in effect; null means the
+    /// list spanned all servers, so every open tab is acknowledged. The badge tracks blocking/
+    /// deadlock counts (a separate system from the notification alerts the list shows), so this
+    /// uses the same acknowledge-until-new-event semantics as the badge's own context menu.
+    /// </summary>
+    private void OnAlertHistoryDismissed(int? dbServerId)
+    {
+        foreach (var kvp in _openServerTabs)
+        {
+            if (kvp.Value.Content is ServerTab st && (dbServerId == null || st.ServerId == dbServerId.Value))
+            {
+                AcknowledgeServerBadge(kvp.Key);
             }
         }
     }


### PR DESCRIPTION
Closes #1092.

## Problem
The red alert badge on a server tab could only be cleared via an undiscoverable right-click menu. Left-clicking the badge, clicking the tab, and Alert History **Dismiss All** all left it unchanged.

## Lite
- **Left-click the badge** → acknowledges/clears it (hand cursor + clearer `Click to dismiss · Right-click for options` tooltip).
- **Alert History "Dismiss All"** now acknowledges the matching server tab badge(s) via a new `AlertsDismissed` event, so the indicator stays consistent with the cleared list. (The badge counts blocking/deadlock rows — a separate system from the notification alerts the list shows — so it uses the same acknowledge-until-new-event semantics as the badge's context menu.)
- Dismiss **Selected** intentionally left un-wired: selecting one notification row shouldn't nuke a whole server's badge.

## Dashboard
The Dashboard's alert model is richer and was already ahead of Lite (right-click on the whole tab, live/auto-resolving badges, and the aggregate sidebar badge already cleared on dismiss). The only parity gap was the missing left-click affordance:
- **Left-click the badge** → acknowledges all alerts for that server, sharing the existing right-click "Acknowledge Alerts" path; hand cursor + matching tooltip.

Two deliberate divergences from Lite (model-appropriate, not gaps):
- Sub-tab badges (Locking/Memory/Resource Metrics) left right-click-only — those sit on navigational tabs where left-click should *open* the tab, not silently dismiss.
- No Dismiss-All → live-tab-badge coupling — the per-tab badge reflects current conditions and auto-clears; the aggregate count badge already clears on dismiss.

## Testing
Both projects build clean (0 warnings, 0 errors). Not yet live-tested — UI interaction + needs real blocking/deadlock data to surface a badge.