### PR TITLE
Fix Lite UI defects from Fable code review (3b)

### DIFF
--- a/Lite/Controls/PlanViewerControl.xaml.cs
+++ b/Lite/Controls/PlanViewerControl.xaml.cs
@@ -68,8 +68,16 @@ public partial class PlanViewerControl : UserControl
     public PlanViewerControl()
     {
         InitializeComponent();
+        /* Subscribe for the life of the control. Do NOT unsubscribe on Unloaded — a TabControl
+           fires Unloaded when you switch tabs, permanently detaching this handler. Unsubscribed in
+           Cleanup(), called from ClosePlanTab_Click when the plan tab is actually closed. */
         ThemeManager.ThemeChanged += OnThemeChanged;
-        Unloaded += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    /// <summary>Unsubscribes from theme changes. Called when the plan tab is closed.</summary>
+    public void Cleanup()
+    {
+        ThemeManager.ThemeChanged -= OnThemeChanged;
     }
 
     private void OnThemeChanged(string _)

--- a/Lite/Controls/ServerTab.Plans.cs
+++ b/Lite/Controls/ServerTab.Plans.cs
@@ -230,6 +230,7 @@ public partial class ServerTab : UserControl
     {
         if (sender is Button btn && btn.Tag is TabItem tab)
         {
+            (tab.Content as PlanViewerControl)?.Cleanup();
             PlanTabControl.Items.Remove(tab);
             if (PlanTabControl.Items.Count == 0)
             {

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -324,8 +324,11 @@ public partial class ServerTab : UserControl
         Helpers.ContextMenuHelper.SetupChartContextMenu(PerfmonChart, "Perfmon_Counters");
         Helpers.ContextMenuHelper.SetupChartContextMenu(CollectorDurationChart, "Collector_Duration");
 
+        /* Subscribe for the life of the tab. Do NOT unsubscribe on Unloaded — a TabControl fires
+           Unloaded when you switch to another tab, which would permanently detach this handler so
+           the charts stop following theme changes after the first tab switch. Unsubscribed in
+           DisposeChartHelpers (called from MainWindow.CloseServerTab) when the tab is closed. */
         ThemeManager.ThemeChanged += OnThemeChanged;
-        Unloaded += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
 
         ActiveQueriesSlicer.RangeChanged += OnActiveQueriesSlicerChanged;
         QueryStatsSlicer.RangeChanged += OnQueryStatsSlicerChanged;
@@ -1225,7 +1228,7 @@ public partial class ServerTab : UserControl
                 "TotalReads" => bucket.TotalReads,
                 "AvgReads" => bucket.TotalReads / n,
                 "TotalWrites" => bucket.TotalWrites,
-                "TotalPhysReads" => bucket.TotalLogicalReads,
+                "TotalPhysReads" => bucket.TotalPhysicalReads,
                 _ => bucket.TotalCpu,
             };
         }
@@ -1528,6 +1531,7 @@ public partial class ServerTab : UserControl
 
     public void DisposeChartHelpers()
     {
+        ThemeManager.ThemeChanged -= OnThemeChanged;
         _waitStatsHover?.Dispose();
         _perfmonHover?.Dispose();
         _cpuHover?.Dispose();

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -245,8 +245,21 @@ public partial class MainWindow : Window
         }
     }
 
+    private bool _closingCleanupStarted;
+    private bool _closingCleanupDone;
+
     private async void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
+        /* async void Closing handler: at the first await WPF would otherwise proceed to close the
+           window — and since this is the last window, begin app shutdown — so the cleanup
+           continuations below could be abandoned mid-flight (the graceful collector stop was
+           effectively dead on the common close path). Cancel this close, run the cleanup to
+           completion, then Close() again; the second pass returns early and closes for real. */
+        if (_closingCleanupDone) return;
+        e.Cancel = true;
+        if (_closingCleanupStarted) return;
+        _closingCleanupStarted = true;
+
         // Dispose system tray
         _resumeGuard?.Dispose();
         _trayService?.Dispose();
@@ -279,6 +292,9 @@ public partial class MainWindow : Window
         }
 
         _statusTimer.Stop();
+
+        _closingCleanupDone = true;
+        Close();
     }
 
     private void ServerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1429,10 +1445,16 @@ public partial class MainWindow : Window
         else if (_activeCpuAlert.TryGetValue(key, out var wasCpu) && wasCpu)
         {
             _activeCpuAlert[key] = false;
-            _trayService.ShowNotification(
-                "CPU Resolved",
-                $"{summary.DisplayName}: {cpuMetricLabel} back to {alertCpuValue:F0}%",
-                Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            /* Only announce "resolved" if the user is still watching this alert and the server
+               isn't silenced. Disabling the alert flips cpuExceeded false (it includes the enabled
+               flag) and silencing sets suppressPopups — neither means CPU actually recovered. */
+            if (!suppressPopups && App.AlertCpuEnabled)
+            {
+                _trayService.ShowNotification(
+                    "CPU Resolved",
+                    $"{summary.DisplayName}: {cpuMetricLabel} back to {alertCpuValue:F0}%",
+                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            }
         }
 
         /* Blocking alerts */
@@ -1494,10 +1516,13 @@ public partial class MainWindow : Window
         else if (_activeBlockingAlert.TryGetValue(key, out var wasBlocking) && wasBlocking)
         {
             _activeBlockingAlert[key] = false;
-            _trayService.ShowNotification(
-                "Blocking Cleared",
-                $"{summary.DisplayName}: No active blocking",
-                Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            if (!suppressPopups && App.AlertBlockingEnabled)
+            {
+                _trayService.ShowNotification(
+                    "Blocking Cleared",
+                    $"{summary.DisplayName}: No active blocking",
+                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            }
         }
 
         /* Deadlock alerts */
@@ -1557,10 +1582,13 @@ public partial class MainWindow : Window
         else if (_activeDeadlockAlert.TryGetValue(key, out var wasDeadlock) && wasDeadlock)
         {
             _activeDeadlockAlert[key] = false;
-            _trayService.ShowNotification(
-                "Deadlocks Cleared",
-                $"{summary.DisplayName}: No deadlocks in the last hour",
-                Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            if (!suppressPopups && App.AlertDeadlockEnabled)
+            {
+                _trayService.ShowNotification(
+                    "Deadlocks Cleared",
+                    $"{summary.DisplayName}: No deadlocks in the last hour",
+                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+            }
         }
 
         /* Poison wait alerts */
@@ -1617,10 +1645,13 @@ public partial class MainWindow : Window
                 else if (_activePoisonWaitAlert.TryGetValue(key, out var wasPoisonWait) && wasPoisonWait)
                 {
                     _activePoisonWaitAlert[key] = false;
-                    _trayService.ShowNotification(
-                        "Poison Waits Cleared",
-                        $"{summary.DisplayName}: Poison wait avg below threshold",
-                        Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    if (!suppressPopups)
+                    {
+                        _trayService.ShowNotification(
+                            "Poison Waits Cleared",
+                            $"{summary.DisplayName}: Poison wait avg below threshold",
+                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    }
                 }
             }
             catch (Exception ex)
@@ -1695,10 +1726,13 @@ public partial class MainWindow : Window
                 else if (_activeLongRunningQueryAlert.TryGetValue(key, out var wasLongRunning) && wasLongRunning)
                 {
                     _activeLongRunningQueryAlert[key] = false;
-                    _trayService.ShowNotification(
-                        "Long-Running Queries Cleared",
-                        $"{summary.DisplayName}: No queries over threshold",
-                        Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    if (!suppressPopups)
+                    {
+                        _trayService.ShowNotification(
+                            "Long-Running Queries Cleared",
+                            $"{summary.DisplayName}: No queries over threshold",
+                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    }
                 }
             }
             catch (Exception ex)
@@ -1753,11 +1787,14 @@ public partial class MainWindow : Window
                 else if (_activeTempDbSpaceAlert.TryGetValue(key, out var wasTempDb) && wasTempDb)
                 {
                     _activeTempDbSpaceAlert[key] = false;
-                    var pct = tempDb != null ? $"{tempDb.UsedPercent:F0}%" : "N/A";
-                    _trayService.ShowNotification(
-                        "TempDB Space Resolved",
-                        $"{summary.DisplayName}: TempDB usage back to {pct}",
-                        Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    if (!suppressPopups)
+                    {
+                        var pct = tempDb != null ? $"{tempDb.UsedPercent:F0}%" : "N/A";
+                        _trayService.ShowNotification(
+                            "TempDB Space Resolved",
+                            $"{summary.DisplayName}: TempDB usage back to {pct}",
+                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    }
                 }
             }
             catch (Exception ex)
@@ -1772,6 +1809,17 @@ public partial class MainWindow : Window
             try
             {
                 var anomalousJobs = await _dataService.GetAnomalousJobsAsync(summary.ServerId, App.AlertLongRunningJobMultiplier);
+
+                /* _lastLongRunningJobAlert is keyed per job *run* ({server}:{jobId}:{startTime}),
+                   so unlike the per-server cooldown dicts it grows without bound. Drop entries
+                   that have aged past the cooldown each pass. */
+                foreach (var staleJobKey in _lastLongRunningJobAlert
+                             .Where(kv => now - kv.Value >= alertCooldown)
+                             .Select(kv => kv.Key)
+                             .ToList())
+                {
+                    _lastLongRunningJobAlert.Remove(staleJobKey);
+                }
 
                 if (anomalousJobs.Count > 0)
                 {
@@ -1817,10 +1865,13 @@ public partial class MainWindow : Window
                 else if (_activeLongRunningJobAlert.TryGetValue(key, out var wasJob) && wasJob)
                 {
                     _activeLongRunningJobAlert[key] = false;
-                    _trayService.ShowNotification(
-                        "Long-Running Jobs Cleared",
-                        $"{summary.DisplayName}: No jobs exceeding threshold",
-                        Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    if (!suppressPopups)
+                    {
+                        _trayService.ShowNotification(
+                            "Long-Running Jobs Cleared",
+                            $"{summary.DisplayName}: No jobs exceeding threshold",
+                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    }
                 }
             }
             catch (Exception ex)

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -79,6 +79,7 @@ ORDER BY bucket";
                 TotalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
                 TotalWrites = reader.IsDBNull(5) ? 0 : ToDouble(reader.GetValue(5)),
                 TotalLogicalReads = reader.IsDBNull(4) ? 0 : ToDouble(reader.GetValue(4)),
+                TotalPhysicalReads = reader.IsDBNull(6) ? 0 : ToDouble(reader.GetValue(6)),
                 Value = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2)), // default: total CPU
             });
         }

--- a/PerformanceMonitor.Common/Models/TimeSliceBucket.cs
+++ b/PerformanceMonitor.Common/Models/TimeSliceBucket.cs
@@ -26,6 +26,7 @@ public class TimeSliceBucket
     public double TotalElapsed { get; set; }
     public double TotalReads { get; set; }
     public double TotalLogicalReads { get; set; }
+    public double TotalPhysicalReads { get; set; }
     public double TotalWrites { get; set; }
 
     /// <summary>The display value used by the slicer chart. Set by the caller based on sort column.</summary>


### PR DESCRIPTION
Lite UI fixes from the Fable code review (chunk 3b of 7).

## Fixes

**[HIGH] async void `MainWindow_Closing` raced app exit** — `Lite/MainWindow.xaml.cs`
The handler returned at the first `await` (`StopMcpServerAsync`), so WPF closed the window and began app shutdown while the graceful `_backgroundService.StopAsync(5s)` and timer teardown were still queued — making the careful shutdown effectively dead on the common close path. Now cancels the close, runs cleanup to completion, then `Close()`s for real.

**[MEDIUM] Theme changes stopped applying after a tab switch** — `Lite/Controls/ServerTab.xaml.cs`, `PlanViewerControl.xaml.cs`, `ServerTab.Plans.cs`
Both controls unsubscribed from `ThemeManager.ThemeChanged` on `Unloaded` — which a `TabControl` fires when you switch away — permanently detaching the handler. Charts/plans then ignored theme changes until a data refresh (never, with auto-refresh off). Now they stay subscribed for the control's life and unsubscribe on real close (`DisposeChartHelpers` / new `PlanViewerControl.Cleanup()` from `ClosePlanTab_Click`), matching the History windows' `Closed` pattern.

**[MEDIUM] "Total Physical Reads" slicer plotted logical reads** — `LocalDataService.QueryStats.cs`, `Common/Models/TimeSliceBucket.cs`, `ServerTab.xaml.cs`
The slicer query selected `total_physical_reads` (col 6) but the loader never read it (`TotalLogicalReads` duplicated col 4), and the sort map resolved `TotalPhysReads` → `TotalLogicalReads`. Added `TimeSliceBucket.TotalPhysicalReads`, populated it from col 6, and pointed the map at it. (The proc-stats slicer has an analogous mislabel — left for a follow-up since its loader doesn't carry the column.)

**[MEDIUM] Resolved/cleared toasts ignored silence and fired on disable** — `Lite/MainWindow.xaml.cs`
All seven "resolved/cleared" branches honored neither `suppressPopups` (acknowledge/silence) nor mute, so a silenced server still popped them. For CPU/blocking/deadlock, whose `*Exceeded` flag includes the enabled toggle, disabling the alert type while active fired a misleading "back to normal" toast. Gated all seven on `!suppressPopups`; CPU/blocking/deadlock also require their enabled flag. The active-state flag still clears either way.

**[LOW] `_lastLongRunningJobAlert` grew unbounded** — `Lite/MainWindow.xaml.cs`
Keyed per job *run* (`{server}:{jobId}:{startTime}`) and never pruned. Now drops aged-out entries each pass.

## Deferred for your call
- **[LOW] Picker double-plot**: rapidly toggling wait/clerk/perfmon checkboxes interleaves two fire-and-forget chart updates → duplicate series until the next update. Fix is a per-chart generation counter across 3 methods; self-heals, so I left it.
- **[MEDIUM] Comparison option**: "Last week" and "Same day last week" both map to `AddDays(-7)` — identical. One is wrong or dead, but the intended distinction is a product decision (same-weekday vs the prior calendar week). Which did you want?

## Validation
- Full solution builds clean on net10 (0 errors).
- `Dashboard.Tests`: 476/476, `Lite.Tests`: 411/411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
