### PR TITLE
Fix ArchiveService data-loss/corruption from Fable code review (3c)

### DIFF
--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -141,6 +141,10 @@ public class ArchiveService
                    views use glob (*_table.parquet) to pick up all files. */
                 var parquetPath = Path.Combine(_archivePath, $"{timestamp}_{table}.parquet")
                     .Replace("\\", "/");
+                /* Export to a .tmp first (excluded from the *_table.parquet glob), then promote.
+                   A mid-COPY failure (OOM/disk-full/process kill) must not leave a truncated
+                   parquet that matches the glob and breaks the archive view for the whole table. */
+                var tempParquetPath = parquetPath + ".tmp";
 
                 long rowCount;
 
@@ -156,23 +160,42 @@ public class ArchiveService
                         continue;
                     }
 
-                    await ExportToParquet(readConnection, table, timeColumn, cutoffDate, parquetPath);
+                    await ExportToParquet(readConnection, table, timeColumn, cutoffDate, tempParquetPath);
                 }
+
+                /* Promote the temp only after the COPY has fully succeeded. */
+                if (File.Exists(parquetPath))
+                {
+                    File.Delete(parquetPath);
+                }
+                File.Move(tempParquetPath, parquetPath);
 
                 /* Delete the archived rows under the write lock. The DELETE
                    modifies table data and the next CHECKPOINT reorganizes the
                    file — readers must not be mid-query when that happens or
                    they get "Reached the end of the file" errors — but the
                    DELETE itself is fast, so the UI stall is brief. */
-                using (_duckDb.AcquireWriteLock())
+                try
                 {
-                    using var writeConnection = _duckDb.CreateConnection();
-                    await writeConnection.OpenAsync();
+                    using (_duckDb.AcquireWriteLock())
+                    {
+                        using var writeConnection = _duckDb.CreateConnection();
+                        await writeConnection.OpenAsync();
 
-                    using var deleteCmd = writeConnection.CreateCommand();
-                    deleteCmd.CommandText = $"DELETE FROM {table} WHERE {timeColumn} < $1";
-                    deleteCmd.Parameters.Add(new DuckDBParameter { Value = cutoffDate });
-                    await deleteCmd.ExecuteNonQueryAsync();
+                        using var deleteCmd = writeConnection.CreateCommand();
+                        deleteCmd.CommandText = $"DELETE FROM {table} WHERE {timeColumn} < $1";
+                        deleteCmd.Parameters.Add(new DuckDBParameter { Value = cutoffDate });
+                        await deleteCmd.ExecuteNonQueryAsync();
+                    }
+                }
+                catch
+                {
+                    /* The rows are still in the table (DELETE failed), so they aren't lost —
+                       discard the archive file we just wrote so the same rows aren't counted in
+                       both the table and the parquet (double-counted by v_* views and re-exported
+                       next cycle). */
+                    try { File.Delete(parquetPath); } catch { /* best effort */ }
+                    throw;
                 }
 
                 _logger?.LogInformation("Archived {Count} rows from {Table} to {Path}", rowCount, table, parquetPath);
@@ -429,15 +452,13 @@ COPY (
                 continue;
             }
 
-            /* If there's exactly one file and it's already in monthly format, skip.
-               This regex matches both YYYYMM_table.parquet and YYYYMM_table_ptNNN.parquet. */
-            if (files.Count == 1)
+            /* If every file in the group is already in final monthly/part format
+               (YYYYMM_table or YYYYMM_table_ptNNN), there are no new per-cycle files to fold in,
+               so skip. Otherwise a month that legitimately split into N part files (input over
+               the per-batch budget) gets re-read and re-written on every archival cycle. */
+            if (files.All(f => Regex.IsMatch(Path.GetFileNameWithoutExtension(f), @"^\d{6}_.+?(_pt\d{3})?$")))
             {
-                var name = Path.GetFileNameWithoutExtension(files[0]);
-                if (Regex.IsMatch(name, @"^\d{6}_"))
-                {
-                    continue;
-                }
+                continue;
             }
 
             /* Resolve month for orphan files — use current month */
@@ -486,11 +507,34 @@ COPY (
                     ParquetCompaction.MergeBatchToFile(table, batches[i], batchOutputs[i].TempPath, spillDirSql);
                 }
 
-                /* All batches succeeded — delete originals, promote temps. */
+                /* All batches succeeded — promote temps to their final names FIRST, then delete
+                   the originals. Deleting first risked PERMANENT data loss: the temps hold the
+                   only merged copy of the just-deleted originals, and if a promote then failed
+                   (e.g. File.Delete(finalPath) throws because a UI reader has the monthly file
+                   open mid read_parquet) the catch below deletes those temps. Promoting first
+                   keeps the originals as a fallback until the new files are safely in place. */
+                var finalPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var (tempPath, finalPath) in batchOutputs)
+                {
+                    if (File.Exists(finalPath))
+                    {
+                        File.Delete(finalPath);
+                    }
+                    File.Move(tempPath, finalPath);
+                    finalPaths.Add(finalPath);
+                }
+
                 var removed = 0;
                 foreach (var f in files)
                 {
-                    var fullPath = Path.Combine(_archivePath, f);
+                    var fullPath = Path.Combine(_archivePath, f).Replace("\\", "/");
+                    /* A source file can share the name of a promoted output when the monthly file
+                       is itself re-merged; that path now holds the freshly merged data — never
+                       delete it. */
+                    if (finalPaths.Contains(fullPath))
+                    {
+                        continue;
+                    }
                     try
                     {
                         File.Delete(fullPath);
@@ -500,15 +544,6 @@ COPY (
                     {
                         _logger?.LogWarning("Could not delete {File} during compaction: {Message}", f, ex.Message);
                     }
-                }
-
-                foreach (var (tempPath, finalPath) in batchOutputs)
-                {
-                    if (File.Exists(finalPath))
-                    {
-                        File.Delete(finalPath);
-                    }
-                    File.Move(tempPath, finalPath);
                 }
 
                 totalMerged++;


### PR DESCRIPTION
⚠️ **Touches the live archive/retention data path — please validate against a running collector before merging.** This is the isolated, higher-risk chunk of the Fable code-review sweep (3c of 7).

## Fixes (contained data-loss / corruption preventions)

**[HIGH] Compaction lost data permanently on a failed promote** — `CompactParquetFiles`
The merge wrote temps, then **deleted the source parquets, then promoted the temps**. If a promote failed (most plausibly `File.Delete(finalPath)` throwing because a UI query had the monthly file open mid `read_parquet` — compaction takes no lock), the catch deletes the temps, which were the only merged copy of the already-deleted originals → permanent loss. Now **promote first, then delete** originals (skipping any source path that is also a promoted output, for the re-merge-the-monthly-file case).

**[MEDIUM] Truncated parquet poisoned the whole table's archive view** — `ArchiveOldDataAsync` / `ExportToParquet`
The per-cycle export COPYed straight to `{timestamp}_{table}.parquet`, which matches the `*_{table}.parquet` glob. A mid-COPY failure (OOM per #933, disk full, kill) left a truncated file; `CreateArchiveViewsAsync` then failed for that table and fell back to table-only, hiding **all** archived history. Now COPYs to `.parquet.tmp` (excluded from the glob) and promotes on success.

**[LOW→data] Failed DELETE duplicated rows into the archive** — `ArchiveOldDataAsync`
Export and DELETE were separate lock scopes; if the export succeeded but the DELETE threw, the rows lived in both the hot table and the new parquet (double-counted by `v_*` views, re-exported next cycle, baked in by compaction). On DELETE failure the just-written archive file is now discarded — the rows survive in the table and are retried next cycle.

**[LOW] Multi-part months re-merged every cycle** — `CompactParquetFiles`
The "already compacted, skip" check only fired for single-file groups, so a month that legitimately split into N `_ptNNN` files was re-read/re-written on every archival cycle (hundreds of MB of IO) and re-entered the delete/promote window each time. Now skips any group whose files are all already in final `YYYYMM_table[_ptNNN]` form.

## Deferred to a dedicated, live-validated follow-up
Both are latent concurrency issues whose correct fixes are redesigns I didn't want to rush into this PR:

- **[HIGH] Collector writes bypass the lock protocol.** Collector inserts open DuckDB connections with no read lock; `RunAllCollectorsForServerAsync` (tab open) runs concurrently with the background timer's `ArchiveAllAndResetAsync`. The write lock during export/reset doesn't exclude these writers, so a size-triggered reset can silently drop rows inserted between the export and `File.Delete(_databasePath)`, or abort on a file-in-use delete. Fix: have collector write paths take the read lock (the `LockedConnection` pattern the UI uses), or gate the collectors against `IsArchiving`.
- **[MEDIUM] Write lock held across a genuinely-async await.** `ResetDatabaseAsync` holds the `ReaderWriterLockSlim` write lock across `InitializeAsync`, whose retry path does `await Task.Delay(1000)` — the one await that actually resumes on another thread-pool thread. `ReaderWriterLockSlim` is thread-affine, so `ExitWriteLock` then throws on the wrong thread and the write lock stays held forever → every `AcquireReadLock` blocks → UI hangs. Fix: a non-thread-affine reader/writer primitive (SemaphoreSlim-based), or don't hold the lock around `InitializeAsync`.

## Validation
- Lite builds clean on net10 (0 errors).
- `Lite.Tests`: 417/417 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
