### PR TITLE
Fix Lite analysis defects from Fable code review (3d)

### DIFF
--- a/Lite/Analysis/AnomalyDetector.cs
+++ b/Lite/Analysis/AnomalyDetector.cs
@@ -333,18 +333,27 @@ SELECT
             var currentBlocking = Convert.ToInt64(reader.GetValue(0));
             var currentDeadlocks = Convert.ToInt64(reader.GetValue(1));
 
-            // Baseline mean = events per day for this hour+dow bucket
+            /* Baseline mean is events per hour-of-day/dow bucket (≈ events per hour at this time of
+               day). current_* are raw counts over the whole analysis window (hoursBack, default 4),
+               so normalize them to per-hour before the ratio — otherwise the ratio scales with the
+               window length, not the workload, and a steady event rate trips the spike threshold. */
+            var windowHours = (context.TimeRangeEnd - context.TimeRangeStart).TotalHours;
+            if (windowHours <= 0) windowHours = 1;
+            var currentBlockingPerHour = currentBlocking / windowHours;
+            var currentDeadlocksPerHour = currentDeadlocks / windowHours;
+
+            // Baseline mean = events per hour for this hour+dow bucket
             var baselineBlockingRate = blockingBaseline.SampleCount > 0 ? blockingBaseline.Mean : 0;
             var baselineDeadlockRate = deadlockBaseline.SampleCount > 0 ? deadlockBaseline.Mean : 0;
 
-            // Blocking spike: at least 5 events AND 3x baseline rate (or no baseline)
-            if (currentBlocking >= 5 && (baselineBlockingRate <= 0 || currentBlocking / Math.Max(baselineBlockingRate, 1) >= DefaultEventRatioThreshold))
+            // Blocking spike: at least 5 events in the window AND per-hour rate >= 3x baseline (or no baseline)
+            if (currentBlocking >= 5 && (baselineBlockingRate <= 0 || currentBlockingPerHour / Math.Max(baselineBlockingRate, 1) >= DefaultEventRatioThreshold))
             {
                 var metadata = new Dictionary<string, double>
                 {
                     ["current_count"] = currentBlocking,
                     ["baseline_rate"] = baselineBlockingRate,
-                    ["ratio"] = baselineBlockingRate > 0 ? currentBlocking / baselineBlockingRate : 100.0
+                    ["ratio"] = baselineBlockingRate > 0 ? currentBlockingPerHour / baselineBlockingRate : 100.0
                 };
                 AddBaselineContext(metadata, blockingBaseline);
 
@@ -358,14 +367,14 @@ SELECT
                 });
             }
 
-            // Deadlock spike: at least 3 events AND 3x baseline rate (or no baseline)
-            if (currentDeadlocks >= 3 && (baselineDeadlockRate <= 0 || currentDeadlocks / Math.Max(baselineDeadlockRate, 1) >= DefaultEventRatioThreshold))
+            // Deadlock spike: at least 3 events in the window AND per-hour rate >= 3x baseline (or no baseline)
+            if (currentDeadlocks >= 3 && (baselineDeadlockRate <= 0 || currentDeadlocksPerHour / Math.Max(baselineDeadlockRate, 1) >= DefaultEventRatioThreshold))
             {
                 var metadata = new Dictionary<string, double>
                 {
                     ["current_count"] = currentDeadlocks,
                     ["baseline_rate"] = baselineDeadlockRate,
-                    ["ratio"] = baselineDeadlockRate > 0 ? currentDeadlocks / baselineDeadlockRate : 100.0
+                    ["ratio"] = baselineDeadlockRate > 0 ? currentDeadlocksPerHour / baselineDeadlockRate : 100.0
                 };
                 AddBaselineContext(metadata, deadlockBaseline);
 

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -58,6 +58,7 @@ public class FindingStore
                 AnalysisTime = analysisTime,
                 ServerId = context.ServerId,
                 ServerName = context.ServerName,
+                DatabaseName = story.DatabaseName,
                 TimeRangeStart = context.TimeRangeStart,
                 TimeRangeEnd = context.TimeRangeEnd,
                 Severity = story.Severity,

--- a/PerformanceMonitor.Analysis/AnalysisModels.cs
+++ b/PerformanceMonitor.Analysis/AnalysisModels.cs
@@ -78,6 +78,12 @@ public class AnalysisStory
     /// Ephemeral — copied onto the finding for the notification layer, not persisted.
     /// </summary>
     public Dictionary<string, double>? RootFactMetadata { get; set; }
+
+    /// <summary>
+    /// Database the root fact pertains to, if any (e.g. BAD_ACTOR_* facts). Copied onto the
+    /// finding so recommendation cards can show a database. Null for server-scope stories.
+    /// </summary>
+    public string? DatabaseName { get; set; }
 }
 
 /// <summary>

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -189,7 +189,9 @@ public class InferenceEngine
             LeafFactValue = leafFact?.Severity,
             FactCount = path.Count,
             IsAbsolution = false,
-            RootFactMetadata = rootFact?.Metadata
+            RootFactMetadata = rootFact?.Metadata,
+            // Carry the root fact's database through so findings/recommendation cards can show it.
+            DatabaseName = rootFact?.DatabaseName
         };
     }
 


### PR DESCRIPTION
﻿Lite analysis fixes from the Fable code review (3d of 7, final Lite chunk).

## Fixes
**[MEDIUM] Blocking/deadlock anomaly ratio scaled with window length, not workload** — `AnomalyDetector.cs`
The baseline mean is events per hour-of-day/dow bucket (events / distinct days, per bucket), but the detector compared a raw event count over the whole analysis window (`hoursBack`, default 4h) to it. A steady ~10 events/hour read as ratio 4 → false `ANOMALY_BLOCKING_SPIKE`. Now normalizes the current counts to per-hour before the ratio. Absolute floors (>= 5 blocking / >= 3 deadlocks in the window) unchanged.

**[MEDIUM] `finding.DatabaseName` always NULL** — `InferenceEngine.cs`, `AnalysisModels.cs`, `FindingStore.cs`
`AnalysisStory` had no `DatabaseName` and `BuildStory` dropped the root fact's database, so every finding inserted `database_name = NULL` and recommendation cards could never show a database — even `BAD_ACTOR_*` findings whose root fact carries one. Added `AnalysisStory.DatabaseName`, set it from the root fact, and copy it onto the finding. Shared `InferenceEngine` fix, so the Dashboard finding path benefits too.

## Deferred (flagged)
- **[HIGH] Wait anomaly ratio mixes units AND scopes**: compares one wait type's ms/hour to an all-types ms/collection-interval baseline. A correct fix needs a per-wait-type baseline (`BaselineProvider` schema redesign), so I left it.
- **[MEDIUM] Raced timing fields**: `_lastSqlMs`/`_lastDuckDbMs` are instance fields written by parallel per-server collectors, so `collection_log` timings cross-contaminate. Fix is to return `(rows, sqlMs, duckMs)` from each collector instead of stashing in fields — invasive across ~15 collectors.
- **[MEDIUM] TestDataSeeder edition/version**: `SeedServerEditionAsync` writes `servers` columns nothing reads while facts read `server_properties` (hardcoded version, default edition), so edition-aware test scenarios run against the wrong edition. Test-only; the clean fix touches the seed call pattern.

## Validation
- Solution builds clean on net10 (0 errors).
- `Dashboard.Tests`: 482/482, `Lite.Tests`: 429/429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
