### PR TITLE
Fix CLI installer version-detection / failure-handling (chunk 4)

### DIFF
--- a/Installer.Core/InstallationService.cs
+++ b/Installer.Core/InstallationService.cs
@@ -830,6 +830,7 @@ END;";
     public static async Task<string?> GetInstalledVersionAsync(
         string connectionString,
         IProgress<InstallationProgress>? progress = null,
+        bool throwOnError = false,
         CancellationToken cancellationToken = default)
     {
         LogDebug(progress, "GetInstalledVersionAsync: checking for existing installation");
@@ -890,11 +891,17 @@ END;";
         catch (SqlException ex)
         {
             LogDebug(progress, $"GetInstalledVersionAsync: SqlException — {ex.Number}: {ex.Message}");
+            /* The installer passes throwOnError=true so a transient/permission error can't be
+               mistaken for "database absent" and silently trigger a fresh install over an
+               existing database (no upgrades, then logged as SUCCESS — the #538 hazard). Soft
+               callers (Dashboard version column, adversarial tests) keep the null fallback. */
+            if (throwOnError) throw;
             return null;
         }
         catch (Exception ex)
         {
             LogDebug(progress, $"GetInstalledVersionAsync: {ex.GetType().Name} — {ex.Message}");
+            if (throwOnError) throw;
             return null;
         }
     }
@@ -1047,6 +1054,14 @@ END;";
 
             totalSuccessCount += success;
             totalFailureCount += failure;
+
+            /* Stop at the first failed hop. Later hops assume this one's schema changes applied;
+               running them against a partially-upgraded database compounds the damage. The caller
+               aborts the whole install when totalFailureCount > 0. */
+            if (failure > 0)
+            {
+                break;
+            }
         }
 
         return (totalSuccessCount, totalFailureCount, upgrades.Count);

--- a/Installer.Core/Models/InstallationResultCode.cs
+++ b/Installer.Core/Models/InstallationResultCode.cs
@@ -14,5 +14,6 @@ public enum InstallationResultCode
     VersionCheckFailed = 5,
     SqlFilesNotFound = 6,
     UninstallFailed = 7,
-    UpgradesFailed = 8
+    UpgradesFailed = 8,
+    CleanInstallFailed = 9
 }

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -533,8 +533,22 @@ namespace PerformanceMonitorInstaller
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Warning: Could not complete cleanup: {ex.Message}");
-                    Console.WriteLine("Continuing with installation...");
+                    Console.WriteLine();
+                    Console.WriteLine("================================================================================");
+                    WriteError($"Clean install failed: {ex.Message}");
+                    Console.WriteLine("The database was NOT dropped/reset, so continuing would install over an");
+                    Console.WriteLine("inconsistent database with neither a clean drop nor upgrade scripts. Aborting.");
+                    Console.WriteLine("Fix the error above and re-run the installer.");
+                    Console.WriteLine("================================================================================");
+
+                    string errorLogPath = WriteErrorLog(ex, serverName!, infoVersion);
+                    Console.WriteLine($"Error log written to: {errorLogPath}");
+
+                    if (!automatedMode)
+                    {
+                        WaitForExit();
+                    }
+                    return (int)InstallationResultCode.CleanInstallFailed;
                 }
             }
             else
@@ -545,7 +559,7 @@ namespace PerformanceMonitorInstaller
                 string? currentVersion = null;
                 try
                 {
-                    currentVersion = await InstallationService.GetInstalledVersionAsync(connectionString).ConfigureAwait(false);
+                    currentVersion = await InstallationService.GetInstalledVersionAsync(connectionString, throwOnError: true).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
﻿CLI installer (Installer + Installer.Core — **not** the retired InstallerGui) fixes from the Fable code review (chunk 4 of 7).

> ⚠️ The Installer.Tests **integration** suite (AdversarialTests/VersionDetectionTests/IdempotencyTests) covers this changed behavior but could not run — SQL2022 was unreachable during this work. 27/27 **unit** tests pass and the solution builds clean. Please run Installer.Tests against a live SQL Server before relying on it.

## Fixes
**[HIGH] Version check swallowed errors → silent fresh-install over an existing DB** — `InstallationService.cs`, `Program.cs`
`GetInstalledVersionAsync` caught `SqlException`/`Exception` and returned `null` — the same value as "database absent" — so a transient drop or a permissions error made the installer run `install/*` over the existing DB with **zero upgrades**, then log SUCCESS (the #538 hazard the 1.0.0 fallback was meant to prevent). The installer's elaborate abort path (`VersionCheckFailed`) was dead code.

**The agent's suggested fix (remove the catches / rethrow) was wrong** and verification caught it: `GetInstalledVersionAsync` is also the Dashboard's per-server "installed version" probe (`ServerManager.cs`) and is covered by `AdversarialTests`, both of which rely on the soft `null`-on-error. So this adds an opt-in `throwOnError` flag — the installer passes `true` (its existing abort path now fires), the Dashboard/tests keep `null`.

**[HIGH] Clean-install failure downgraded to a warning** — `Program.cs`
`--reinstall` / interactive "drop" failure printed "Warning: continuing" and then installed over the **un-dropped** database with neither a clean drop nor upgrade scripts. Now aborts with a new `CleanInstallFailed` (exit 9) and writes an error log.

**[MEDIUM] Upgrade hops continued after a failure** — `InstallationService.cs`
`ExecuteAllUpgradesAsync` ran every later hop even after an earlier one failed, against a partially-upgraded schema. Now stops at the first failed hop (the caller already aborts the whole install when any upgrade failed).

## Deferred / flagged
- **[MEDIUM]** Critical-file failure early-returns without writing installation history or the summary report (the artifact users attach to bug reports).
- **[MEDIUM]** Existing DB with no `installation_history` table is treated as fresh — but a test (`DatabaseExists_NoHistoryTable_ReturnsNull`) endorses this, so left as-is.
- **[LOW]** Interactive encryption defaults to `Optional` while `--help`/automated default to `Mandatory`; success banner prints "Initial collection completed" even when validation was skipped; minor dead code (self-replace, unused `fileName`, unreachable `GetStringAsync`).

## Validation
- Solution builds clean on net10 (0 errors).
- Installer.Tests: 27/27 unit tests pass; 19 integration tests blocked on an unreachable SQL2022 (see warning above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
