### PR TITLE
Fix high-impact SQL collector defects from Fable code review (chunk 5)

### DIFF
--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -1157,6 +1157,9 @@ BEGIN
                 is_clustered bit NULL,
                 enterprise_features nvarchar(max) NULL,
                 service_objective sysname NULL,
+                lock_pages_in_memory bit NULL,
+                instant_file_initialization_enabled bit NULL,
+                memory_dump_count integer NULL,
                 row_hash binary(32) NULL,
                 CONSTRAINT
                     PK_server_properties

--- a/install/09_collect_query_store.sql
+++ b/install/09_collect_query_store.sql
@@ -662,8 +662,12 @@ BEGIN
                     avg_tempdb_space_used,
                     min_tempdb_space_used,
                     max_tempdb_space_used,
-                    plan_type,
+                    /* Order must match the dynamic SELECT, which is bound by ordinal by
+                       INSERT...EXEC: the 2017+ block emits plan_forcing_type before the 2022+
+                       block emits plan_type. Swapping these silently stores each in the other's
+                       column. */
                     plan_forcing_type,
+                    plan_type,
                     is_forced_plan,
                     force_failure_count,
                     last_force_failure_reason_desc,

--- a/install/23_process_blocked_process_xml.sql
+++ b/install/23_process_blocked_process_xml.sql
@@ -75,7 +75,7 @@ BEGIN
             SET @sql = N'
             IF OBJECT_ID(N''' + QUOTENAME(@procedure_database) + N'.dbo.sp_HumanEventsBlockViewer'', N''P'') IS NOT NULL
             BEGIN
-                SELECT @blockviewer_database = N''' + QUOTENAME(@procedure_database) + N''';
+                SELECT @blockviewer_database = N''' + REPLACE(@procedure_database, '''', '''''') + N''';
             END;';
 
             EXECUTE sys.sp_executesql

--- a/install/25_process_deadlock_xml.sql
+++ b/install/25_process_deadlock_xml.sql
@@ -73,7 +73,7 @@ BEGIN
             SET @sql = N'
             IF OBJECT_ID(N''' + QUOTENAME(@procedure_database) + N'.dbo.sp_BlitzLock'', N''P'') IS NOT NULL
             BEGIN
-                SELECT @blitzlock_database = N''' + QUOTENAME(@procedure_database) + N''';
+                SELECT @blitzlock_database = N''' + REPLACE(@procedure_database, '''', '''''') + N''';
             END;';
 
             EXECUTE sys.sp_executesql

--- a/install/28_collect_system_health_wrapper.sql
+++ b/install/28_collect_system_health_wrapper.sql
@@ -69,7 +69,7 @@ BEGIN
             SET @sql = N'
             IF OBJECT_ID(N''' + QUOTENAME(@procedure_database) + N'.dbo.sp_HealthParser'', N''P'') IS NOT NULL
             BEGIN
-                SELECT @healthparser_database = N''' + QUOTENAME(@procedure_database) + N''';
+                SELECT @healthparser_database = N''' + REPLACE(@procedure_database, '''', '''''') + N''';
             END;';
 
             EXECUTE sys.sp_executesql


### PR DESCRIPTION
﻿High-impact SQL **collector** fixes from the Fable code review (chunk 5 of 7). Validated on SQL2016 (the minimum supported version was the only instance reachable); **2017–2025 still need your version testing.**

## Fixes
**[HIGH] Query Store `plan_type` ↔ `plan_forcing_type` swapped** — `install/09`
The dynamic SELECT emits `plan_forcing_type` (2017+ block) before `plan_type` (2022+ block), but the `INSERT...EXEC` column list had `plan_type` first. `INSERT...EXEC` binds by ordinal, so every Query Store row stored each value in the other's column. Reordered the INSERT list to match the SELECT.

**[HIGH] Double-`QUOTENAME` broke the explicit-database path** — `install/23, 25, 28`
With an explicit `@procedure_database`, the proc stored `QUOTENAME(name)` (`[master]`) in the `*_database` variable and then `QUOTENAME`'d it again at the `EXECUTE` site → `[[master]]]`. The default (NULL) path stores the raw name. Now the explicit path also stores the raw name (quote-escaped via `REPLACE`) so the single call-site `QUOTENAME` brackets once — consistent with the default path. (The `OBJECT_ID` existence check keeps its own `QUOTENAME`.)

**[MEDIUM] `server_properties` self-heal drift** — `install/06`
`ensure_collection_table` recreated `collect.server_properties` without `lock_pages_in_memory` / `instant_file_initialization_enabled` / `memory_dump_count` (present in 02, inserted by 53's collector), so a self-healed table failed every collection with "invalid column name". Added the three columns.

## Validation
All five changed scripts `CREATE OR ALTER` cleanly on SQL2016 (2.12.0.0), exit 0 (e.g. "Query Store collector created successfully").

## Remaining collector findings — flagged for follow-up (your version testing)
29/31 dedup window shorter than the collection sweep (recurring duplicate rows); 05 gauge metrics (memory_clerks, perfmon, blocking-max) run through monotonic-counter delta math → phantom spikes when values drop (needs `cntr_type` gating for perfmon); 23 marks unparsed blocked-process rows `is_processed=1` past the 1000-event cap (silent loss); 38 trace-flag removal detection compares to the last change-batch not last-known-state; 10 procedure_stats omits tempdb (dbid 2) and the FUNCTION branch ignores DB exclusions; 08 first-run check defeated by the TABLE_MISSING log row; 11 raw `@procedure_database` literal (injection/quote); 27 memory_pressure self-heal unreachable (read in DECLARE before the TRY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
