### PR TITLE
Fix SQL view/analyzer defects from Fable code review (chunk 6)

### DIFF
--- a/install/26_blocking_deadlock_analyzer.sql
+++ b/install/26_blocking_deadlock_analyzer.sql
@@ -189,7 +189,7 @@ BEGIN
             (
                 SELECT
                     database_name = ISNULL(bl.database_name, N'UNKNOWN'),
-                    deadlock_count = COUNT_BIG(DISTINCT LEFT(bl.deadlock_group, CHARINDEX(N',', bl.deadlock_group) - 1)),
+                    deadlock_count = COUNT_BIG(DISTINCT LEFT(bl.deadlock_group, COALESCE(NULLIF(CHARINDEX(N',', bl.deadlock_group), 0) - 1, LEN(bl.deadlock_group)))),
                     total_deadlock_wait_time_ms = ISNULL(SUM(bl.wait_time), 0),
                     victim_count = SUM(CASE WHEN bl.deadlock_group LIKE N'%- VICTIM' THEN 1 ELSE 0 END)
                 FROM collect.deadlocks AS bl

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -393,7 +393,9 @@ SELECT
                 SELECT
                     1/0
                 FROM collect.cpu_utilization_stats AS cus
-                WHERE cus.total_cpu_utilization >= 90
+                /* total_cpu_utilization is NULL on SQL Server on Linux; fall back to the SQL-only
+                   figure so daily_summary can still report CPU_CRITICAL there (#1048). */
+                WHERE ISNULL(cus.total_cpu_utilization, cus.sqlserver_cpu_utilization) >= 90
                 AND   cus.collection_time >= DATEADD(HOUR, -1, SYSDATETIME())
             )
             THEN N'CPU_CRITICAL'


### PR DESCRIPTION
﻿SQL view/analyzer fixes from the Fable code review (chunk 6 of 7). Validated on SQL2016; **2017–2025 need your version testing.**

## Fixes
**[MEDIUM→crash] Deadlock analyzer aborts on a comma-less `deadlock_group`** — `install/26`
`LEFT(deadlock_group, CHARINDEX(',', ...) - 1)` throws "invalid length parameter passed to the LEFT function" when there's no comma (`CHARINDEX` returns 0 → `LEFT(x, -1)`). `deadlock_group` is free text from sp_BlitzLock, so any format drift aborts the whole analyzer transaction — taking the blocking aggregation down with it. Now falls back to the whole string when there's no comma.

**[MEDIUM] `daily_summary` never reports CPU_CRITICAL on Linux** — `install/47`
The `CPU_CRITICAL` branch tested raw `total_cpu_utilization`, which is NULL on SQL Server on Linux. Added the #1048 `ISNULL(total_cpu_utilization, sqlserver_cpu_utilization)` fallback the other CPU branches already use.

## Validation
Both scripts `CREATE OR ALTER` cleanly on SQL2016, exit 0.

## Remaining view/FinOps findings — flagged for follow-up (deeper rewrites)
- **[HIGH] 46 `expensive_queries_today`**: the Query Store branch drops multi-interval queries (the busiest ones); SUMs cumulative DMV counters across snapshots (N× inflation — siblings use MAX); and has no date filter despite "today".
- **[HIGH] 54 FinOps efficiency**: flags healthy idle servers `UNDER_PROVISIONED` (tells you to scale *up*) and rarely finds real savings — the anti-FinOps direction.
- **[HIGH] 47 `top_memory_consumers`**: SUMs a point-in-time gauge (pages_kb) over a 15-min window (~3× inflation; absolute thresholds fire early).
- **[MEDIUM]** 46/47 `query_stats_summary` mixes MAX across different plans of a hash; `query_store_regressions` filters on CPU regression but ranks/scores by duration with unweighted averages; 50 TokenAndPerm 1 GB threshold compared per NUMA node not per clerk; 12 blocking-chain view created unconditionally against a conditionally-created base view.

These are aggregation-logic rewrites I'd want your eyes on (and real version testing), so I left them rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
