### PR TITLE
Perf: move Lite background pipeline + full refresh off the UI thread (P1)

### DIFF
--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -127,34 +127,39 @@ public partial class ServerTab : UserControl
     {
         var loadSw = Stopwatch.StartNew();
 
-        /* Load all tabs in parallel */
-        var snapshotsTask = _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate);
-        var cpuTask = _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate);
-        var memoryTask = _dataService.GetLatestMemoryStatsAsync(_serverId);
-        var memoryTrendTask = _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var queryStatsTask = _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes);
-        var procStatsTask = _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes);
-        var fileIoTrendTask = _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var fileIoThroughputTask = _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var tempDbTask = _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var tempDbFileIoTask = _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var deadlockTask = _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate);
-        var blockedProcessTask = _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate);
-        var waitTypesTask = _dataService.GetDistinctWaitTypesAsync(_serverId, hoursBack, fromDate, toDate);
-        var memoryClerkTypesTask = _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate);
-        var perfmonCountersTask = _dataService.GetDistinctPerfmonCountersAsync(_serverId, hoursBack, fromDate, toDate);
-        var queryStoreTask = _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate);
-        var memoryGrantTrendTask = _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate);
-        var memoryGrantChartTask = _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate);
-        var memoryPressureEventsTask = _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate);
-        var serverConfigTask = SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId));
-        var databaseConfigTask = SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId));
-        var databaseScopedConfigTask = SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId));
-        var traceFlagsTask = SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId));
-        var runningJobsTask = SafeQueryAsync(() => _dataService.GetRunningJobsAsync(_serverId));
-        var collectionHealthTask = SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId));
-        var collectionLogTask = SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack));
-        var dailySummaryTask = _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate);
+        /* Load all tabs in parallel, off the UI thread.
+           DuckDB.NET is synchronous, so calling these directly on the dispatcher would run all
+           ~36 queries serially on the UI thread (the freeze). Task.Run pushes each onto a pool
+           thread — each query's read lock is acquired AND released inside that one synchronous run,
+           so the ReaderWriterLockSlim thread affinity is respected — and the fan-out below becomes
+           genuinely parallel. The UI-update code after the awaits is unchanged. */
+        var snapshotsTask = Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate));
+        var cpuTask = Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate));
+        var memoryTask = Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId));
+        var memoryTrendTask = Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var queryStatsTask = Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
+        var procStatsTask = Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
+        var fileIoTrendTask = Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var fileIoThroughputTask = Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var tempDbTask = Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var tempDbFileIoTask = Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var deadlockTask = Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate));
+        var blockedProcessTask = Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate));
+        var waitTypesTask = Task.Run(() => _dataService.GetDistinctWaitTypesAsync(_serverId, hoursBack, fromDate, toDate));
+        var memoryClerkTypesTask = Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate));
+        var perfmonCountersTask = Task.Run(() => _dataService.GetDistinctPerfmonCountersAsync(_serverId, hoursBack, fromDate, toDate));
+        var queryStoreTask = Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate));
+        var memoryGrantTrendTask = Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var memoryGrantChartTask = Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate));
+        var memoryPressureEventsTask = Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate));
+        var serverConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId)));
+        var databaseConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId)));
+        var databaseScopedConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId)));
+        var traceFlagsTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId)));
+        var runningJobsTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetRunningJobsAsync(_serverId)));
+        var collectionHealthTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId)));
+        var collectionLogTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack)));
+        var dailySummaryTask = Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate));
         /* Core data tasks */
         await System.Threading.Tasks.Task.WhenAll(
             snapshotsTask, cpuTask, memoryTask, memoryTrendTask,
@@ -165,15 +170,15 @@ public partial class ServerTab : UserControl
             runningJobsTask, collectionHealthTask, collectionLogTask, dailySummaryTask);
 
         /* Trend chart tasks - run separately so failures don't kill the whole refresh */
-        var lockWaitTrendTask = SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var blockingTrendTask = SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var deadlockTrendTask = SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var queryDurationTrendTask = SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var procDurationTrendTask = SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var queryStoreDurationTrendTask = SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var executionCountTrendTask = SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var currentWaitsDurationTask = SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var currentWaitsBlockedTask = SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate));
+        var lockWaitTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var blockingTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var deadlockTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var queryDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var procDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var queryStoreDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var executionCountTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var currentWaitsDurationTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var currentWaitsBlockedTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate)));
 
         await System.Threading.Tasks.Task.WhenAll(
             lockWaitTrendTask, blockingTrendTask, deadlockTrendTask,

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -169,9 +169,16 @@ public partial class MainWindow : Window
                 analysisNotificationService,
                 new AppLoggerAdapter<CollectionBackgroundService>());
 
-            // Start background collection
+            // Start background collection.
+            // Off the UI thread on purpose: DuckDB.NET is synchronous and Lite has no
+            // ConfigureAwait(false), so starting this from the Loaded handler would run the entire
+            // collection/checkpoint/archive pipeline on the WPF dispatcher (per-minute jank, and a
+            // multi-second-to-minutes freeze on archive/reset). A pool thread has no
+            // SynchronizationContext, so StartAsync and every subsequent continuation stay off-UI.
+            // Safe: the pipeline only touches DuckDB + the email/webhook notification service; the
+            // UI reads data by polling DuckDB on its own timers, fully decoupled.
             _backgroundCts = new CancellationTokenSource();
-            _ = _backgroundService.StartAsync(_backgroundCts.Token);
+            _ = Task.Run(() => _backgroundService.StartAsync(_backgroundCts.Token));
 
             // Initialize system tray
             _trayService = new SystemTrayService(this, RestoreFromTray, _backgroundService);


### PR DESCRIPTION
﻿First increment of the UI-responsiveness work (P1 of the perf effort), focused on the **CRITICAL Lite finding**: DuckDB.NET is synchronous (verified — the shipped DLL has no async overrides) and Lite has zero `ConfigureAwait(false)`, so all Lite DuckDB work — UI queries **and** the background collect/checkpoint/archive pipeline — runs on the WPF dispatcher thread.

## In this PR
- **Background pipeline off the UI thread** — `Task.Run` around `CollectionBackgroundService.StartAsync`. Pool threads have no `SynchronizationContext`, so the whole collection/checkpoint/archive pipeline stays off the dispatcher. Kills the per-minute collection jank and the multi-second-to-minutes freeze on archive/reset. Verified safe: the pipeline only touches DuckDB + the email/webhook notification service; the UI polls DuckDB on its own timers (decoupled).
- **`RefreshAllTabsAsync` off the UI thread** — the first-load / manual-refresh / time-range-change path wraps each of ~36 queries in `Task.Run` (correct `ReaderWriterLockSlim` affinity: each query acquires+releases its read lock inside one synchronous run). Bonus: the fan-out is now genuinely parallel.

## Still on this effort (same pattern, not deferred)
The 60s-timer sub-tab refreshes, picker charts, status timer, drill-down, slicer, grid-selection, connect; then a bounded read lock. Then the shared-UI crosshair/hover hot path, the Dashboard timer/throttle/SQL-aggregation chunk, and the leak cluster — both apps.

## Validation
- Lite builds clean (net10).
- `Lite.Tests` 428/429 — the 1 failure (`CredentialProfileTests.SwitchToProfile_DeletesOrphanedPerServerSecret`) is a known flake: those tests hit the machine-global Windows Credential Manager and pass **13/13 in isolation**; unrelated to these edits.

⚠️ Threading change — please validate on a running Lite before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
