### PR TITLE
Perf: offload Lite picker charts, overview sweep, connect, timeline lanes (P1c)

### DIFF
--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -79,19 +79,19 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         {
             _crosshairManager?.PrepareForRefresh();
 
-            var cpuTask = _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate);
-            var waitTask = _dataService.GetTotalWaitTrendAsync(_serverId, hoursBack, fromDate, toDate);
-            var blockingTask = _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate);
-            var deadlockTask = _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate);
-            var memoryTask = _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate);
-            var fileIoTask = _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate);
+            var cpuTask = Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate));
+            var waitTask = Task.Run(() => _dataService.GetTotalWaitTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var blockingTask = Task.Run(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var deadlockTask = Task.Run(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var memoryTask = Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var fileIoTask = Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate));
 
             // Fetch baselines for band rendering — chart-unit-matched metrics
             var referenceTime = fromDate ?? DateTime.UtcNow.AddHours(-hoursBack);
-            var cpuBaselineTask = _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.Cpu, referenceTime);
-            var waitBaselineTask = _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.WaitMsPerSec, referenceTime);
-            var ioBaselineTask = _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.IoLatency, referenceTime);
-            var blockingBaselineTask = _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.BlockingPerMinute, referenceTime);
+            var cpuBaselineTask = Task.Run(() => _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.Cpu, referenceTime));
+            var waitBaselineTask = Task.Run(() => _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.WaitMsPerSec, referenceTime));
+            var ioBaselineTask = Task.Run(() => _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.IoLatency, referenceTime));
+            var blockingBaselineTask = Task.Run(() => _dataService.GetBaselineForLaneAsync(_serverId, MetricNames.BlockingPerMinute, referenceTime));
 
             try
             {
@@ -165,11 +165,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 // Time shift: offset to align reference data with current chart X axis
                 var timeShift = (fromDate ?? DateTime.UtcNow.AddHours(-hoursBack)) - refFrom;
 
-                var refCpuTask = _dataService.GetCpuUtilizationAsync(_serverId, 0, refFrom, refTo);
-                var refWaitTask = _dataService.GetTotalWaitTrendAsync(_serverId, 0, refFrom, refTo);
-                var refBlockingTask = _dataService.GetBlockingTrendAsync(_serverId, 0, refFrom, refTo);
-                var refMemoryTask = _dataService.GetMemoryTrendAsync(_serverId, 0, refFrom, refTo);
-                var refIoTask = _dataService.GetFileIoLatencyTrendAsync(_serverId, 0, refFrom, refTo);
+                var refCpuTask = Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, 0, refFrom, refTo));
+                var refWaitTask = Task.Run(() => _dataService.GetTotalWaitTrendAsync(_serverId, 0, refFrom, refTo));
+                var refBlockingTask = Task.Run(() => _dataService.GetBlockingTrendAsync(_serverId, 0, refFrom, refTo));
+                var refMemoryTask = Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, 0, refFrom, refTo));
+                var refIoTask = Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, 0, refFrom, refTo));
 
                 try { await Task.WhenAll(refCpuTask, refWaitTask, refBlockingTask, refMemoryTask, refIoTask); }
                 catch (Exception ex) { AppLogger.Info("CorrelatedLanes", $"Comparison fetch failed: {ex.Message}"); }

--- a/Lite/Controls/ServerTab.Pickers.cs
+++ b/Lite/Controls/ServerTab.Pickers.cs
@@ -137,8 +137,14 @@ public partial class ServerTab : UserControl
         _ = UpdateWaitStatsChartFromPickerAsync();
     }
 
+    private int _waitStatsPickerGen;
+
     private async System.Threading.Tasks.Task UpdateWaitStatsChartFromPickerAsync()
     {
+        /* Bump a generation on entry; after each (now genuinely async) query, bail if a newer
+           invocation has started — rapid checkbox toggling otherwise interleaves two runs and
+           double-plots the series. */
+        var gen = ++_waitStatsPickerGen;
         try
         {
             var selected = _waitTypeItems.Where(i => i.IsSelected).Take(20).ToList();
@@ -169,7 +175,8 @@ public partial class ServerTab : UserControl
 
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await _dataService.GetWaitStatsTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate);
+                var trend = await Task.Run(() => _dataService.GetWaitStatsTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
+                if (gen != _waitStatsPickerGen) return;
                 if (trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
@@ -284,8 +291,11 @@ public partial class ServerTab : UserControl
         _ = UpdateMemoryClerksChartFromPickerAsync();
     }
 
+    private int _memoryClerksPickerGen;
+
     private async System.Threading.Tasks.Task UpdateMemoryClerksChartFromPickerAsync()
     {
+        var gen = ++_memoryClerksPickerGen;
         try
         {
             var selected = _memoryClerkItems.Where(i => i.IsSelected).Take(20).ToList();
@@ -323,7 +333,8 @@ public partial class ServerTab : UserControl
 
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await _dataService.GetMemoryClerkTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate);
+                var trend = await Task.Run(() => _dataService.GetMemoryClerkTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
+                if (gen != _memoryClerksPickerGen) return;
                 if (trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
@@ -500,8 +511,11 @@ public partial class ServerTab : UserControl
         _ = UpdatePerfmonChartFromPickerAsync();
     }
 
+    private int _perfmonPickerGen;
+
     private async System.Threading.Tasks.Task UpdatePerfmonChartFromPickerAsync()
     {
+        var gen = ++_perfmonPickerGen;
         try
         {
             var selected = _perfmonCounterItems.Where(i => i.IsSelected).Take(12).ToList();
@@ -529,7 +543,8 @@ public partial class ServerTab : UserControl
 
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await _dataService.GetPerfmonTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate);
+                var trend = await Task.Run(() => _dataService.GetPerfmonTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
+                if (gen != _perfmonPickerGen) return;
                 if (trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -555,7 +555,7 @@ public partial class MainWindow : Window
                 try
                 {
                     var serverId = RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(server));
-                    var summary = await _dataService.GetServerSummaryAsync(serverId, server.DisplayNameWithIntent);
+                    var summary = await Task.Run(() => _dataService.GetServerSummaryAsync(serverId, server.DisplayNameWithIntent));
                     if (summary != null)
                     {
                         summary.ServerName = server.ServerName;
@@ -705,7 +705,7 @@ public partial class MainWindow : Window
             StatusText.Text = $"Collecting data from {server.DisplayNameWithIntent}...";
             try
             {
-                await _collectorService.RunAllCollectorsForServerAsync(server);
+                await Task.Run(() => _collectorService.RunAllCollectorsForServerAsync(server));
                 StatusText.Text = $"Connected to {server.DisplayNameWithIntent} - Data loaded";
                 serverTab.RefreshData();
                 UpdateCollectorHealth();


### PR DESCRIPTION
﻿Continues the Lite off-thread work (P1c).

- **Picker charts** (wait/clerk/perfmon): per-series `GetXTrendAsync` wrapped in `Task.Run` + a per-picker **generation guard** (bail after each now-async query if a newer invocation started). The guard also fixes the latent **double-plot** on rapid checkbox toggling — which the offload would otherwise have made real.
- **30s overview sweep** (`RefreshOverviewAsync`): each server's `GetServerSummaryAsync` runs on a pool thread.
- **Connect path**: `RunAllCollectorsForServerAsync` now runs off the dispatcher (scheduled path already did).
- **Overview timeline lanes**: 6 lane queries + 4 baselines + 5 comparison queries on pool threads.

Build: Lite clean (net10). Threading change — validate on a running Lite.

Remaining: drill-down, slicer-change handlers, grid selection, bounded read lock; then shared-UI crosshair, Dashboard chunk, leak cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
