### PR TITLE
Collect, visualize, expose, and alert on table/index sizes, growth, usage, and locking (#1103)

### DIFF
--- a/Dashboard/Analysis/SqlServerAnomalyDetector.cs
+++ b/Dashboard/Analysis/SqlServerAnomalyDetector.cs
@@ -129,23 +129,84 @@ public class SqlServerAnomalyDetector
                 cmd.CommandText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-WITH snaps AS (SELECT TOP (2) collection_time FROM (SELECT DISTINCT collection_time FROM collect.index_object_stats) AS d ORDER BY collection_time DESC),
-boundaries AS (SELECT latest_time = MAX(collection_time), prior_time = MIN(collection_time) FROM snaps),
-cur AS (SELECT database_name, object_id, schema_name = MAX(schema_name), table_name = MAX(table_name), mb = SUM(reserved_mb)
-        FROM collect.index_object_stats WHERE collection_time = (SELECT latest_time FROM boundaries) GROUP BY database_name, object_id),
-prv AS (SELECT database_name, object_id, mb = SUM(reserved_mb)
-        FROM collect.index_object_stats WHERE collection_time = (SELECT prior_time FROM boundaries) GROUP BY database_name, object_id)
+WITH
+    snaps AS
+    (
+        SELECT TOP (2)
+            collection_time
+        FROM
+        (
+            SELECT DISTINCT
+                collection_time
+            FROM collect.index_object_stats
+        ) AS d
+        ORDER BY
+            collection_time DESC
+    ),
+    boundaries AS
+    (
+        SELECT
+            latest_time = MAX(collection_time),
+            prior_time = MIN(collection_time)
+        FROM snaps
+    ),
+    cur AS
+    (
+        SELECT
+            database_name,
+            object_id,
+            schema_name = MAX(schema_name),
+            table_name = MAX(table_name),
+            mb = SUM(reserved_mb)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT b.latest_time
+            FROM boundaries AS b
+        )
+        GROUP BY
+            database_name,
+            object_id
+    ),
+    prv AS
+    (
+        SELECT
+            database_name,
+            object_id,
+            mb = SUM(reserved_mb)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT b.prior_time
+            FROM boundaries AS b
+        )
+        GROUP BY
+            database_name,
+            object_id
+    )
 SELECT TOP (1)
-    cur.database_name, cur.schema_name, cur.table_name, prior_mb = prv.mb, current_mb = cur.mb,
+    cur.database_name,
+    cur.schema_name,
+    cur.table_name,
+    prior_mb = prv.mb,
+    current_mb = cur.mb,
     growth_mb = cur.mb - prv.mb,
-    growth_pct = CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END
+    growth_pct =
+        CASE
+            WHEN prv.mb > 0
+            THEN (cur.mb - prv.mb) * 100.0 / prv.mb
+            ELSE 0
+        END
 FROM cur
-JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id
+JOIN prv
+  ON  prv.database_name = cur.database_name
+  AND prv.object_id = cur.object_id
 CROSS JOIN boundaries AS b
 WHERE b.latest_time <> b.prior_time
 AND   cur.mb - prv.mb >= @growthMb
-AND   (CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END) >= @growthPct
-ORDER BY cur.mb - prv.mb DESC
+AND   CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END >= @growthPct
+ORDER BY
+    cur.mb - prv.mb DESC
 OPTION(MAXDOP 1, RECOMPILE);";
                 cmd.Parameters.Add(new SqlParameter("@growthMb", ObjectGrowthMbThreshold));
                 cmd.Parameters.Add(new SqlParameter("@growthPct", ObjectGrowthPctThreshold));
@@ -181,23 +242,78 @@ OPTION(MAXDOP 1, RECOMPILE);";
                 cmd.CommandText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-WITH snaps AS (SELECT TOP (2) collection_time FROM (SELECT DISTINCT collection_time FROM collect.index_object_stats) AS d ORDER BY collection_time DESC),
-boundaries AS (SELECT latest_time = MAX(collection_time), prior_time = MIN(collection_time) FROM snaps),
-cur AS (SELECT database_name, object_id, index_id, schema_name, table_name, index_name,
-               ms = ISNULL(row_lock_wait_in_ms, 0), esc = ISNULL(index_lock_promotion_count, 0)
-        FROM collect.index_object_stats WHERE collection_time = (SELECT latest_time FROM boundaries)),
-prv AS (SELECT database_name, object_id, index_id, ms = ISNULL(row_lock_wait_in_ms, 0), esc = ISNULL(index_lock_promotion_count, 0)
-        FROM collect.index_object_stats WHERE collection_time = (SELECT prior_time FROM boundaries))
+WITH
+    snaps AS
+    (
+        SELECT TOP (2)
+            collection_time
+        FROM
+        (
+            SELECT DISTINCT
+                collection_time
+            FROM collect.index_object_stats
+        ) AS d
+        ORDER BY
+            collection_time DESC
+    ),
+    boundaries AS
+    (
+        SELECT
+            latest_time = MAX(collection_time),
+            prior_time = MIN(collection_time)
+        FROM snaps
+    ),
+    cur AS
+    (
+        SELECT
+            database_name,
+            object_id,
+            index_id,
+            schema_name,
+            table_name,
+            index_name,
+            ms = ISNULL(row_lock_wait_in_ms, 0),
+            esc = ISNULL(index_lock_promotion_count, 0)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT b.latest_time
+            FROM boundaries AS b
+        )
+    ),
+    prv AS
+    (
+        SELECT
+            database_name,
+            object_id,
+            index_id,
+            ms = ISNULL(row_lock_wait_in_ms, 0),
+            esc = ISNULL(index_lock_promotion_count, 0)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT b.prior_time
+            FROM boundaries AS b
+        )
+    )
 SELECT TOP (1)
-    cur.database_name, cur.schema_name, cur.table_name, cur.index_name,
-    ms_delta = cur.ms - prv.ms, esc_delta = cur.esc - prv.esc
+    cur.database_name,
+    cur.schema_name,
+    cur.table_name,
+    cur.index_name,
+    ms_delta = cur.ms - prv.ms,
+    esc_delta = cur.esc - prv.esc
 FROM cur
-JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id AND cur.index_id = prv.index_id
+JOIN prv
+  ON  prv.database_name = cur.database_name
+  AND prv.object_id = cur.object_id
+  AND prv.index_id = cur.index_id
 CROSS JOIN boundaries AS b
 WHERE b.latest_time <> b.prior_time
 AND   cur.ms >= prv.ms
 AND   cur.ms - prv.ms >= @msDelta
-ORDER BY cur.ms - prv.ms DESC
+ORDER BY
+    cur.ms - prv.ms DESC
 OPTION(MAXDOP 1, RECOMPILE);";
                 cmd.Parameters.Add(new SqlParameter("@msDelta", ObjectLockWaitMsDeltaThreshold));
 

--- a/Dashboard/Analysis/SqlServerAnomalyDetector.cs
+++ b/Dashboard/Analysis/SqlServerAnomalyDetector.cs
@@ -101,8 +101,132 @@ public class SqlServerAnomalyDetector
         await DetectSessionAnomalies(context, anomalies);
         await DetectQueryDurationAnomalies(context, anomalies);
         await DetectMemoryAnomalies(context, anomalies);
+        await DetectObjectStatsAnomalies(context, anomalies);
 
         return anomalies;
+    }
+
+    /// <summary>
+    /// Day-over-day object/index detection (delta-based, not stddev-baseline) since the
+    /// index_object_stats collector runs daily and its counters are cumulative. Emits
+    /// ANOMALY_OBJECT_GROWTH for the biggest table grower over threshold and
+    /// ANOMALY_OBJECT_CONTENTION for the index with the largest new lock-wait time.
+    /// </summary>
+    private const decimal ObjectGrowthMbThreshold = 100m;
+    private const double ObjectGrowthPctThreshold = 20.0;
+    private const long ObjectLockWaitMsDeltaThreshold = 60000;
+
+    private async Task DetectObjectStatsAnomalies(AnalysisContext context, List<Fact> anomalies)
+    {
+        try
+        {
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            // Growth: biggest day-over-day table grower (indexes rolled up) over threshold.
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH snaps AS (SELECT TOP (2) collection_time FROM (SELECT DISTINCT collection_time FROM collect.index_object_stats) AS d ORDER BY collection_time DESC),
+boundaries AS (SELECT latest_time = MAX(collection_time), prior_time = MIN(collection_time) FROM snaps),
+cur AS (SELECT database_name, object_id, schema_name = MAX(schema_name), table_name = MAX(table_name), mb = SUM(reserved_mb)
+        FROM collect.index_object_stats WHERE collection_time = (SELECT latest_time FROM boundaries) GROUP BY database_name, object_id),
+prv AS (SELECT database_name, object_id, mb = SUM(reserved_mb)
+        FROM collect.index_object_stats WHERE collection_time = (SELECT prior_time FROM boundaries) GROUP BY database_name, object_id)
+SELECT TOP (1)
+    cur.database_name, cur.schema_name, cur.table_name, prior_mb = prv.mb, current_mb = cur.mb,
+    growth_mb = cur.mb - prv.mb,
+    growth_pct = CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END
+FROM cur
+JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id
+CROSS JOIN boundaries AS b
+WHERE b.latest_time <> b.prior_time
+AND   cur.mb - prv.mb >= @growthMb
+AND   (CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END) >= @growthPct
+ORDER BY cur.mb - prv.mb DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+                cmd.Parameters.Add(new SqlParameter("@growthMb", ObjectGrowthMbThreshold));
+                cmd.Parameters.Add(new SqlParameter("@growthPct", ObjectGrowthPctThreshold));
+
+                using var reader = await cmd.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    var db = reader.GetString(0);
+                    var growthMb = Convert.ToDouble(reader.GetValue(5));
+                    var growthPct = Convert.ToDouble(reader.GetValue(6));
+                    anomalies.Add(new Fact
+                    {
+                        Source = "anomaly",
+                        Key = "ANOMALY_OBJECT_GROWTH",
+                        Value = growthMb,
+                        ServerId = context.ServerId,
+                        DatabaseName = db,
+                        Metadata = new Dictionary<string, double>
+                        {
+                            ["prior_mb"] = Convert.ToDouble(reader.GetValue(3)),
+                            ["current_mb"] = Convert.ToDouble(reader.GetValue(4)),
+                            ["growth_mb"] = growthMb,
+                            ["growth_pct"] = growthPct,
+                            ["growth_ratio"] = growthPct / ObjectGrowthPctThreshold
+                        }
+                    });
+                }
+            }
+
+            // Contention: index with the largest new row-lock wait time (no reset).
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH snaps AS (SELECT TOP (2) collection_time FROM (SELECT DISTINCT collection_time FROM collect.index_object_stats) AS d ORDER BY collection_time DESC),
+boundaries AS (SELECT latest_time = MAX(collection_time), prior_time = MIN(collection_time) FROM snaps),
+cur AS (SELECT database_name, object_id, index_id, schema_name, table_name, index_name,
+               ms = ISNULL(row_lock_wait_in_ms, 0), esc = ISNULL(index_lock_promotion_count, 0)
+        FROM collect.index_object_stats WHERE collection_time = (SELECT latest_time FROM boundaries)),
+prv AS (SELECT database_name, object_id, index_id, ms = ISNULL(row_lock_wait_in_ms, 0), esc = ISNULL(index_lock_promotion_count, 0)
+        FROM collect.index_object_stats WHERE collection_time = (SELECT prior_time FROM boundaries))
+SELECT TOP (1)
+    cur.database_name, cur.schema_name, cur.table_name, cur.index_name,
+    ms_delta = cur.ms - prv.ms, esc_delta = cur.esc - prv.esc
+FROM cur
+JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id AND cur.index_id = prv.index_id
+CROSS JOIN boundaries AS b
+WHERE b.latest_time <> b.prior_time
+AND   cur.ms >= prv.ms
+AND   cur.ms - prv.ms >= @msDelta
+ORDER BY cur.ms - prv.ms DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+                cmd.Parameters.Add(new SqlParameter("@msDelta", ObjectLockWaitMsDeltaThreshold));
+
+                using var reader = await cmd.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    var db = reader.GetString(0);
+                    var msDelta = Convert.ToDouble(reader.GetValue(4));
+                    anomalies.Add(new Fact
+                    {
+                        Source = "anomaly",
+                        Key = "ANOMALY_OBJECT_CONTENTION",
+                        Value = msDelta,
+                        ServerId = context.ServerId,
+                        DatabaseName = db,
+                        Metadata = new Dictionary<string, double>
+                        {
+                            ["lock_wait_ms_delta"] = msDelta,
+                            ["escalation_delta"] = Convert.ToDouble(reader.GetValue(5)),
+                            ["contention_ratio"] = msDelta / ObjectLockWaitMsDeltaThreshold
+                        }
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[SqlServerAnomalyDetector] Object stats anomaly detection failed: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -913,6 +913,186 @@
             </Grid>
         </TabItem>
 
+        <!-- Object Sizes & Growth Sub-Tab (#1103) -->
+        <TabItem Header="Object Sizes &amp; Growth">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Object Sizes &amp; Growth" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="ObjectSizeGrowthRefresh_Click" Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="ObjectSizeGrowthCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="ObjectSizeGrowthDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              AutoGenerateColumns="False" IsReadOnly="True" CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal" CanUserResizeColumns="True" HeadersVisibility="Column"
+                              SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding SchemaName}" Width="90">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SchemaName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Schema" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="200">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Reserved (MB)" Binding="{Binding CurrentReservedMb, StringFormat='{}{0:N1}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Used (MB)" Binding="{Binding CurrentUsedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Indexes" Binding="{Binding IndexCount}" Width="70" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth 7d (MB)" Binding="{Binding Growth7dMb, StringFormat='{}{0:N1}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth 30d (MB)" Binding="{Binding Growth30dMb, StringFormat='{}{0:N1}'}" Width="120" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Daily Rate (MB)" Binding="{Binding DailyGrowthRateMb, StringFormat='{}{0:N2}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth % (30d)" Binding="{Binding GrowthPct30d, StringFormat='{}{0:N1}%'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="ObjectSizeGrowthNoDataMessage"
+                               Text="No object size data available. Index/object stats are collected daily."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Index Usage Sub-Tab (#1103) -->
+        <TabItem Header="Index Usage">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Index Usage" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="IndexUsageRefresh_Click" Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="IndexUsageCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Unused / write-only indexes listed first" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="IndexUsageDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              AutoGenerateColumns="False" IsReadOnly="True" CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal" CanUserResizeColumns="True" HeadersVisibility="Column"
+                              SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="170">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IndexName}" Width="180">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding Classification}" Width="90">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Classification" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Type" Binding="{Binding IndexTypeDesc}" Width="130"/>
+                            <DataGridTextColumn Header="Reserved (MB)" Binding="{Binding ReservedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Seeks" Binding="{Binding UserSeeks, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Scans" Binding="{Binding UserScans, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Lookups" Binding="{Binding UserLookups, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Total Reads" Binding="{Binding TotalReads, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Updates" Binding="{Binding UserUpdates, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Last Access" Binding="{Binding LastUserAccess, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="140"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="IndexUsageNoDataMessage"
+                               Text="No index usage data available. Index/object stats are collected daily."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Locking & Contention Sub-Tab (#1103) -->
+        <TabItem Header="Locking &amp; Contention">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Locking &amp; Contention" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="IndexLockingRefresh_Click" Margin="4,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="IndexLockingCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Cumulative since last restart; top contended objects first" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="IndexLockingDataGrid" ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                              AutoGenerateColumns="False" IsReadOnly="True" CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal" CanUserResizeColumns="True" HeadersVisibility="Column"
+                              SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="170">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IndexName}" Width="180">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexName" Click="FinOpsFilter_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Row Lock Waits" Binding="{Binding RowLockWaitCount, StringFormat='{}{0:N0}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Row Lock Wait (ms)" Binding="{Binding RowLockWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page Lock Wait (ms)" Binding="{Binding PageLockWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Lock Escalations" Binding="{Binding IndexLockPromotionCount, StringFormat='{}{0:N0}'}" Width="120" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page Latch Wait (ms)" Binding="{Binding PageLatchWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page IO Latch Wait (ms)" Binding="{Binding PageIoLatchWaitInMs, StringFormat='{}{0:N0}'}" Width="150" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Reserved (MB)" Binding="{Binding ReservedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="IndexLockingNoDataMessage"
+                               Text="No locking/contention data recorded. Index/object stats are collected daily."
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
         <!-- Database Sizes Sub-Tab -->
         <TabItem Header="Database Sizes">
             <Grid>

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -127,6 +127,9 @@ namespace PerformanceMonitorDashboard.Controls
                     LoadApplicationConnectionsAsync(),
                     LoadServerInventoryAsync(),
                     LoadStorageGrowthAsync(),
+                    LoadObjectSizeGrowthAsync(),
+                    LoadIndexUsageAsync(),
+                    LoadIndexLockingAsync(),
                     LoadIdleDatabasesAsync(),
                     LoadTempdbSummaryAsync(),
                     LoadWaitCategorySummaryAsync(),
@@ -401,6 +404,58 @@ namespace PerformanceMonitorDashboard.Controls
             catch (Exception ex)
             {
                 Logger.Error($"Error loading storage growth: {ex.Message}", ex);
+            }
+        }
+
+        // ============================================
+        // Object/Index stats (#1103)
+        // ============================================
+
+        private async Task LoadObjectSizeGrowthAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetObjectSizeGrowthAsync();
+                ObjectSizeGrowthDataGrid.ItemsSource = data;
+                ObjectSizeGrowthNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                ObjectSizeGrowthCountIndicator.Text = data.Count > 0 ? $"{data.Count} table(s)" : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading object size/growth: {ex.Message}", ex);
+            }
+        }
+
+        private async Task LoadIndexUsageAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetIndexUsageAsync();
+                IndexUsageDataGrid.ItemsSource = data;
+                IndexUsageNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                IndexUsageCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading index usage: {ex.Message}", ex);
+            }
+        }
+
+        private async Task LoadIndexLockingAsync()
+        {
+            if (_databaseService == null) return;
+            try
+            {
+                var data = await _databaseService.GetIndexLockingAsync();
+                IndexLockingDataGrid.ItemsSource = data;
+                IndexLockingNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+                IndexLockingCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading index locking: {ex.Message}", ex);
             }
         }
 
@@ -849,6 +904,21 @@ namespace PerformanceMonitorDashboard.Controls
         private async void StorageGrowthRefresh_Click(object sender, RoutedEventArgs e)
         {
             await LoadStorageGrowthAsync();
+        }
+
+        private async void ObjectSizeGrowthRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadObjectSizeGrowthAsync();
+        }
+
+        private async void IndexUsageRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadIndexUsageAsync();
+        }
+
+        private async void IndexLockingRefresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadIndexLockingAsync();
         }
 
         private async void WaitStatsTimeRange_Changed(object sender, SelectionChangedEventArgs e)

--- a/Dashboard/Mcp/McpHostService.cs
+++ b/Dashboard/Mcp/McpHostService.cs
@@ -98,6 +98,7 @@ public sealed class McpHostService : BackgroundService
                 .WithGeminiCompatibleTools<McpSystemEventTools>()
                 .WithGeminiCompatibleTools<McpHealthParserTools>()
                 .WithGeminiCompatibleTools<McpServerInventoryTools>()
+                .WithGeminiCompatibleTools<McpObjectStatsTools>()
                 .WithGeminiCompatibleTools<McpAnalysisTools>();
 
             _app = builder.Build();

--- a/Dashboard/Mcp/McpInstructions.cs
+++ b/Dashboard/Mcp/McpInstructions.cs
@@ -86,6 +86,13 @@ internal static class McpInstructions
         |------|---------|----------------|
         | `get_tempdb_trend` | TempDB space with pressure analysis and recommendations | `server_name`, `hours_back` |
 
+        ### Storage & Index Tools
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `get_table_index_sizes` | Largest tables with size, growth (7d/30d/daily), and row counts | `server_name` |
+        | `get_index_usage` | Per-index seeks/scans/lookups/updates with Unused/Write-only/Active classification (drop candidates first) | `server_name` |
+        | `get_object_locking` | Per-index lock/latch waits and lock escalations, top contended objects | `server_name` |
+
         ### Performance Counter Tools
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|

--- a/Dashboard/Mcp/McpObjectStatsTools.cs
+++ b/Dashboard/Mcp/McpObjectStatsTools.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorDashboard.Mcp;
+
+[McpServerToolType]
+public sealed class McpObjectStatsTools
+{
+    [McpServerTool(Name = "get_table_index_sizes"), Description("Gets the largest tables with per-table size, growth (7d/30d/daily rate), and row counts from the latest daily snapshot. Indexes are rolled up per table. Use to find storage hot-spots and fast-growing tables for capacity planning.")]
+    public static async Task<string> GetTableIndexSizes(
+        ServerManager serverManager,
+        DatabaseServiceRegistry registry,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, registry, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await resolved.Value.Service.GetObjectSizeGrowthAsync();
+            if (rows.Count == 0)
+            {
+                return "No object size data available. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                reserved_mb = r.CurrentReservedMb,
+                used_mb = r.CurrentUsedMb,
+                total_rows = r.TotalRows,
+                index_count = r.IndexCount,
+                growth_7d_mb = r.Growth7dMb,
+                growth_30d_mb = r.Growth30dMb,
+                daily_growth_rate_mb = r.DailyGrowthRateMb,
+                growth_pct_30d = r.GrowthPct30d
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                tables = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_table_index_sizes", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_index_usage"), Description("Gets per-index usage (seeks, scans, lookups, updates) from the latest daily snapshot, classifying each index as Unused, Write-only, or Active. Unused and write-only indexes are listed first - these are drop candidates. Counters are cumulative since the last instance restart.")]
+    public static async Task<string> GetIndexUsage(
+        ServerManager serverManager,
+        DatabaseServiceRegistry registry,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, registry, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await resolved.Value.Service.GetIndexUsageAsync();
+            if (rows.Count == 0)
+            {
+                return "No index usage data available. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                index_name = r.IndexName,
+                index_type = r.IndexTypeDesc,
+                classification = r.Classification,
+                reserved_mb = r.ReservedMb,
+                total_rows = r.TotalRows,
+                user_seeks = r.UserSeeks,
+                user_scans = r.UserScans,
+                user_lookups = r.UserLookups,
+                total_reads = r.TotalReads,
+                user_updates = r.UserUpdates,
+                last_user_access = r.LastUserAccess?.ToString("o")
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                indexes = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_index_usage", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_object_locking"), Description("Gets per-index locking and latch contention (row/page lock waits in ms, lock escalations, page-latch and page-IO-latch waits) from the latest daily snapshot, top contended objects first. Use to find tables/indexes driving blocking and contention. Counters are cumulative since the last instance restart.")]
+    public static async Task<string> GetObjectLocking(
+        ServerManager serverManager,
+        DatabaseServiceRegistry registry,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, registry, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await resolved.Value.Service.GetIndexLockingAsync();
+            if (rows.Count == 0)
+            {
+                return "No locking/contention data recorded. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                index_name = r.IndexName,
+                index_type = r.IndexTypeDesc,
+                reserved_mb = r.ReservedMb,
+                total_rows = r.TotalRows,
+                row_lock_wait_count = r.RowLockWaitCount,
+                row_lock_wait_ms = r.RowLockWaitInMs,
+                page_lock_wait_count = r.PageLockWaitCount,
+                page_lock_wait_ms = r.PageLockWaitInMs,
+                lock_escalations = r.IndexLockPromotionCount,
+                page_latch_wait_ms = r.PageLatchWaitInMs,
+                page_io_latch_wait_ms = r.PageIoLatchWaitInMs
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                objects = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_object_locking", ex);
+        }
+    }
+}

--- a/Dashboard/Services/DatabaseService.FinOps.IndexObjects.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.IndexObjects.cs
@@ -56,7 +56,11 @@ WITH
             total_rows = MAX(total_rows),
             index_count = COUNT_BIG(*)
         FROM collect.index_object_stats
-        WHERE collection_time = (SELECT latest_time FROM boundaries)
+        WHERE collection_time =
+        (
+            SELECT b.latest_time
+            FROM boundaries AS b
+        )
         GROUP BY
             database_name,
             schema_name,
@@ -108,7 +112,11 @@ WITH
             table_name,
             reserved_mb = SUM(reserved_mb)
         FROM collect.index_object_stats
-        WHERE collection_time = (SELECT earliest_time FROM boundaries)
+        WHERE collection_time =
+        (
+            SELECT b.earliest_time
+            FROM boundaries AS b
+        )
         GROUP BY
             database_name,
             schema_name,

--- a/Dashboard/Services/DatabaseService.FinOps.IndexObjects.cs
+++ b/Dashboard/Services/DatabaseService.FinOps.IndexObjects.cs
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Services
+{
+    public partial class DatabaseService
+    {
+        // ============================================
+        // FinOps — Object/Index stats (sizes+growth, usage, locking)
+        // Reads collect.index_object_stats. Sizes are absolute; usage/locking
+        // counters are cumulative since sqlserver_start_time (shown as totals).
+        // ============================================
+
+        /// <summary>
+        /// Per-table size and growth (indexes rolled up per table), comparing the latest
+        /// snapshot to 7d/30d ago, with a daily growth rate over the available history.
+        /// </summary>
+        public async Task<List<ObjectSizeGrowthRow>> GetObjectSizeGrowthAsync(int topN = 100)
+        {
+            var items = new List<ObjectSizeGrowthRow>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+WITH
+    boundaries AS
+    (
+        SELECT
+            latest_time = MAX(collection_time),
+            earliest_time = MIN(collection_time),
+            days_of_data = DATEDIFF(DAY, MIN(collection_time), MAX(collection_time))
+        FROM collect.index_object_stats
+    ),
+    latest AS
+    (
+        SELECT
+            database_name,
+            schema_name,
+            table_name,
+            current_reserved_mb = SUM(reserved_mb),
+            current_used_mb = SUM(used_mb),
+            total_rows = MAX(total_rows),
+            index_count = COUNT_BIG(*)
+        FROM collect.index_object_stats
+        WHERE collection_time = (SELECT latest_time FROM boundaries)
+        GROUP BY
+            database_name,
+            schema_name,
+            table_name
+    ),
+    past_7d AS
+    (
+        SELECT
+            database_name,
+            schema_name,
+            table_name,
+            reserved_mb = SUM(reserved_mb)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT MAX(collection_time)
+            FROM collect.index_object_stats
+            WHERE collection_time <= DATEADD(DAY, -7, SYSDATETIME())
+        )
+        GROUP BY
+            database_name,
+            schema_name,
+            table_name
+    ),
+    past_30d AS
+    (
+        SELECT
+            database_name,
+            schema_name,
+            table_name,
+            reserved_mb = SUM(reserved_mb)
+        FROM collect.index_object_stats
+        WHERE collection_time =
+        (
+            SELECT MAX(collection_time)
+            FROM collect.index_object_stats
+            WHERE collection_time <= DATEADD(DAY, -30, SYSDATETIME())
+        )
+        GROUP BY
+            database_name,
+            schema_name,
+            table_name
+    ),
+    oldest AS
+    (
+        SELECT
+            database_name,
+            schema_name,
+            table_name,
+            reserved_mb = SUM(reserved_mb)
+        FROM collect.index_object_stats
+        WHERE collection_time = (SELECT earliest_time FROM boundaries)
+        GROUP BY
+            database_name,
+            schema_name,
+            table_name
+    )
+SELECT TOP (@topN)
+    l.database_name,
+    l.schema_name,
+    l.table_name,
+    l.current_reserved_mb,
+    l.current_used_mb,
+    l.total_rows,
+    l.index_count,
+    growth_7d_mb =
+        l.current_reserved_mb - COALESCE(p7.reserved_mb, o.reserved_mb, l.current_reserved_mb),
+    growth_30d_mb =
+        l.current_reserved_mb - COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb, l.current_reserved_mb),
+    daily_growth_rate_mb =
+        CASE
+            WHEN b.days_of_data >= 1
+            THEN (l.current_reserved_mb - COALESCE(o.reserved_mb, l.current_reserved_mb)) / CAST(b.days_of_data AS decimal(10,1))
+            ELSE 0
+        END,
+    growth_pct_30d =
+        CASE
+            WHEN COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb) > 0
+            THEN (l.current_reserved_mb - COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb)) * 100.0
+                 / COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb)
+            ELSE 0
+        END
+FROM latest AS l
+CROSS JOIN boundaries AS b
+LEFT JOIN past_7d AS p7
+  ON  p7.database_name = l.database_name
+  AND p7.schema_name = l.schema_name
+  AND p7.table_name = l.table_name
+LEFT JOIN past_30d AS p30
+  ON  p30.database_name = l.database_name
+  AND p30.schema_name = l.schema_name
+  AND p30.table_name = l.table_name
+LEFT JOIN oldest AS o
+  ON  o.database_name = l.database_name
+  AND o.schema_name = l.schema_name
+  AND o.table_name = l.table_name
+ORDER BY
+    l.current_reserved_mb DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_ObjectSizeGrowth", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new ObjectSizeGrowthRow
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        CurrentReservedMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                        CurrentUsedMb = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                        TotalRows = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                        IndexCount = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
+                        Growth7dMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                        Growth30dMb = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                        DailyGrowthRateMb = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                        GrowthPct30d = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10))
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Per-index usage from the latest snapshot, surfacing unused and write-only indexes.
+        /// Counters are cumulative since the last instance restart (sqlserver_start_time).
+        /// </summary>
+        public async Task<List<IndexUsageRow>> GetIndexUsageAsync(int topN = 200)
+        {
+            var items = new List<IndexUsageRow>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP (@topN)
+    ios.database_name,
+    ios.schema_name,
+    ios.table_name,
+    ios.index_name,
+    ios.index_type_desc,
+    ios.index_id,
+    ios.reserved_mb,
+    ios.total_rows,
+    user_seeks = ISNULL(ios.user_seeks, 0),
+    user_scans = ISNULL(ios.user_scans, 0),
+    user_lookups = ISNULL(ios.user_lookups, 0),
+    total_reads = ios.total_reads,
+    user_updates = ISNULL(ios.user_updates, 0),
+    last_user_access =
+    (
+        SELECT MAX(v)
+        FROM
+        (
+            VALUES
+                (ios.last_user_seek),
+                (ios.last_user_scan),
+                (ios.last_user_lookup),
+                (ios.last_user_update)
+        ) AS x (v)
+    ),
+    classification =
+        CASE
+            WHEN ios.total_reads = 0 AND ISNULL(ios.user_updates, 0) = 0
+            THEN N'Unused'
+            WHEN ios.total_reads = 0 AND ISNULL(ios.user_updates, 0) > 0
+            THEN N'Write-only'
+            ELSE N'Active'
+        END
+FROM collect.index_object_stats AS ios
+WHERE ios.collection_time =
+(
+    SELECT MAX(collection_time)
+    FROM collect.index_object_stats
+)
+ORDER BY
+    CASE WHEN ios.total_reads = 0 THEN 0 ELSE 1 END,
+    ios.reserved_mb DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_IndexUsage", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new IndexUsageRow
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        IndexName = reader.IsDBNull(3) ? "(heap)" : reader.GetString(3),
+                        IndexTypeDesc = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                        IndexId = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                        ReservedMb = reader.IsDBNull(6) ? 0m : Convert.ToDecimal(reader.GetValue(6)),
+                        TotalRows = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                        UserSeeks = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                        UserScans = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                        UserLookups = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+                        TotalReads = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
+                        UserUpdates = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+                        LastUserAccess = reader.IsDBNull(13) ? null : reader.GetDateTime(13),
+                        Classification = reader.IsDBNull(14) ? "" : reader.GetString(14)
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Per-index locking/latch contention from the latest snapshot, top objects by lock waits.
+        /// Counters are cumulative since the metadata last entered cache (≈ instance restart).
+        /// </summary>
+        public async Task<List<IndexLockingRow>> GetIndexLockingAsync(int topN = 200)
+        {
+            var items = new List<IndexLockingRow>();
+
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP (@topN)
+    ios.database_name,
+    ios.schema_name,
+    ios.table_name,
+    ios.index_name,
+    ios.index_type_desc,
+    ios.reserved_mb,
+    ios.total_rows,
+    row_lock_count = ISNULL(ios.row_lock_count, 0),
+    row_lock_wait_count = ISNULL(ios.row_lock_wait_count, 0),
+    row_lock_wait_in_ms = ISNULL(ios.row_lock_wait_in_ms, 0),
+    page_lock_count = ISNULL(ios.page_lock_count, 0),
+    page_lock_wait_count = ISNULL(ios.page_lock_wait_count, 0),
+    page_lock_wait_in_ms = ISNULL(ios.page_lock_wait_in_ms, 0),
+    index_lock_promotion_count = ISNULL(ios.index_lock_promotion_count, 0),
+    page_latch_wait_in_ms = ISNULL(ios.page_latch_wait_in_ms, 0),
+    page_io_latch_wait_in_ms = ISNULL(ios.page_io_latch_wait_in_ms, 0)
+FROM collect.index_object_stats AS ios
+WHERE ios.collection_time =
+(
+    SELECT MAX(collection_time)
+    FROM collect.index_object_stats
+)
+AND
+(
+    ISNULL(ios.row_lock_wait_in_ms, 0) > 0
+    OR ISNULL(ios.page_lock_wait_in_ms, 0) > 0
+    OR ISNULL(ios.page_latch_wait_in_ms, 0) > 0
+    OR ISNULL(ios.page_io_latch_wait_in_ms, 0) > 0
+    OR ISNULL(ios.index_lock_promotion_count, 0) > 0
+)
+ORDER BY
+    ISNULL(ios.row_lock_wait_in_ms, 0)
+    + ISNULL(ios.page_lock_wait_in_ms, 0)
+    + ISNULL(ios.page_latch_wait_in_ms, 0)
+    + ISNULL(ios.page_io_latch_wait_in_ms, 0) DESC
+OPTION(MAXDOP 1, RECOMPILE);";
+
+            using var command = new SqlCommand(query, connection);
+            command.Parameters.AddWithValue("@topN", topN);
+            command.CommandTimeout = 120;
+
+            using (StartQueryTiming("FinOps_IndexLocking", query, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    items.Add(new IndexLockingRow
+                    {
+                        DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                        IndexName = reader.IsDBNull(3) ? "(heap)" : reader.GetString(3),
+                        IndexTypeDesc = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                        ReservedMb = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5)),
+                        TotalRows = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+                        RowLockCount = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                        RowLockWaitCount = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                        RowLockWaitInMs = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                        PageLockCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+                        PageLockWaitCount = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
+                        PageLockWaitInMs = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+                        IndexLockPromotionCount = reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)),
+                        PageLatchWaitInMs = reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)),
+                        PageIoLatchWaitInMs = reader.IsDBNull(15) ? 0L : Convert.ToInt64(reader.GetValue(15))
+                    });
+                }
+            }
+
+            return items;
+        }
+    }
+}
+
+namespace PerformanceMonitorDashboard.Models
+{
+    /// <summary>Per-table size + growth (indexes rolled up).</summary>
+    public class ObjectSizeGrowthRow
+    {
+        public string DatabaseName { get; set; } = "";
+        public string SchemaName { get; set; } = "";
+        public string TableName { get; set; } = "";
+        public decimal CurrentReservedMb { get; set; }
+        public decimal CurrentUsedMb { get; set; }
+        public long TotalRows { get; set; }
+        public int IndexCount { get; set; }
+        public decimal Growth7dMb { get; set; }
+        public decimal Growth30dMb { get; set; }
+        public decimal DailyGrowthRateMb { get; set; }
+        public decimal GrowthPct30d { get; set; }
+    }
+
+    /// <summary>Per-index usage with unused/write-only classification.</summary>
+    public class IndexUsageRow
+    {
+        public string DatabaseName { get; set; } = "";
+        public string SchemaName { get; set; } = "";
+        public string TableName { get; set; } = "";
+        public string IndexName { get; set; } = "";
+        public string IndexTypeDesc { get; set; } = "";
+        public int IndexId { get; set; }
+        public decimal ReservedMb { get; set; }
+        public long TotalRows { get; set; }
+        public long UserSeeks { get; set; }
+        public long UserScans { get; set; }
+        public long UserLookups { get; set; }
+        public long TotalReads { get; set; }
+        public long UserUpdates { get; set; }
+        public DateTime? LastUserAccess { get; set; }
+        public string Classification { get; set; } = "";
+    }
+
+    /// <summary>Per-index locking/latch contention.</summary>
+    public class IndexLockingRow
+    {
+        public string DatabaseName { get; set; } = "";
+        public string SchemaName { get; set; } = "";
+        public string TableName { get; set; } = "";
+        public string IndexName { get; set; } = "";
+        public string IndexTypeDesc { get; set; } = "";
+        public decimal ReservedMb { get; set; }
+        public long TotalRows { get; set; }
+        public long RowLockCount { get; set; }
+        public long RowLockWaitCount { get; set; }
+        public long RowLockWaitInMs { get; set; }
+        public long PageLockCount { get; set; }
+        public long PageLockWaitCount { get; set; }
+        public long PageLockWaitInMs { get; set; }
+        public long IndexLockPromotionCount { get; set; }
+        public long PageLatchWaitInMs { get; set; }
+        public long PageIoLatchWaitInMs { get; set; }
+    }
+}

--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -138,8 +138,8 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 30 tables from Schema (schema_version is created separately by DuckDbInitializer) */
-        Assert.Equal(30, tableCount);
+        /* 31 tables from Schema (schema_version is created separately by DuckDbInitializer) */
+        Assert.Equal(31, tableCount);
     }
 
     [Fact]

--- a/Lite.Tests/IndexObjectStatsTests.cs
+++ b/Lite.Tests/IndexObjectStatsTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Tests for the #1103 index/object-stats read layer (DuckDB dialect: date_diff,
+/// GREATEST, LIMIT, unused-index classification) and the delta-based growth/contention
+/// anomaly detection. Seeds two daily snapshots and exercises both paths.
+/// </summary>
+public class IndexObjectStatsTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+    private readonly LocalDataService _dataService;
+    private readonly AnomalyDetector _detector;
+
+    private const int ServerId = -777;
+    private static readonly DateTime _latest = DateTime.UtcNow;
+    private static readonly DateTime _prior = _latest.AddDays(-1);
+    private static readonly DateTime _startTime = _latest.AddDays(-10); // instance start (no reset)
+    private long _nextId = -1;
+
+    public IndexObjectStatsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "IdxObjTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        var dbPath = Path.Combine(_tempDir, "test.duckdb");
+        _duckDb = new DuckDbInitializer(dbPath);
+        _dataService = new LocalDataService(_duckDb);
+        var baselineProvider = new BaselineProvider(_duckDb);
+        _detector = new AnomalyDetector(_duckDb, baselineProvider);
+        BaselineProvider.CacheTtl = TimeSpan.FromMilliseconds(1);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
+        catch { }
+    }
+
+    // ── helpers ──
+
+    private async Task SeedScenarioAsync()
+    {
+        await _duckDb.InitializeAsync();
+
+        // BigTable (object 100): 200 MB -> 600 MB  => +400 MB / 200% growth
+        await InsertObjectStat(_prior, "AppDb", 100, 1, "dbo", "BigTable", "PK_BigTable", 200m, 1_000_000, 0, 0, 0, 0, 0, 0);
+        await InsertObjectStat(_latest, "AppDb", 100, 1, "dbo", "BigTable", "PK_BigTable", 600m, 3_000_000, 5000, 100, 10, 50, 0, 0);
+
+        // IX_unused (object 200 index 2): 0 reads, 500 updates in latest => Write-only
+        await InsertObjectStat(_prior, "AppDb", 200, 2, "dbo", "T2", "IX_unused", 50m, 500_000, 0, 0, 0, 0, 0, 0);
+        await InsertObjectStat(_latest, "AppDb", 200, 2, "dbo", "T2", "IX_unused", 50m, 500_000, 0, 0, 0, 500, 0, 0);
+
+        // HotTable (object 300 index 1): 10000ms -> 100000ms lock wait => +90000ms contention
+        await InsertObjectStat(_prior, "AppDb", 300, 1, "dbo", "HotTable", "PK_HotTable", 80m, 250_000, 100, 5, 0, 200, 10_000, 0);
+        await InsertObjectStat(_latest, "AppDb", 300, 1, "dbo", "HotTable", "PK_HotTable", 80m, 250_000, 200, 8, 0, 400, 100_000, 3);
+    }
+
+    private async Task InsertObjectStat(
+        DateTime time, string db, int objectId, int indexId, string schema, string table, string indexName,
+        decimal reservedMb, long rows, long seeks, long scans, long lookups, long updates, long lockWaitMs, long escalations)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var conn = _duckDb.CreateConnection();
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO index_object_stats
+            (collection_id, collection_time, server_id, server_name, sqlserver_start_time, database_name, database_id,
+             schema_name, object_id, table_name, index_id, index_name, index_type_desc, reserved_mb, used_mb, total_rows,
+             user_seeks, user_scans, user_lookups, user_updates, row_lock_wait_in_ms, index_lock_promotion_count)
+            VALUES ($1,$2,$3,'TestServer',$4,$5,7,$6,$7,$8,$9,$10,'NONCLUSTERED',$11,$11,$12,$13,$14,$15,$16,$17,$18)";
+        void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+        P(_nextId--); P(time); P(ServerId); P(_startTime); P(db); P(schema); P(objectId); P(table);
+        P(indexId); P(indexName); P(reservedMb); P(rows); P(seeks); P(scans); P(lookups); P(updates); P(lockWaitMs); P(escalations);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedCpuAsync(DateTime time, int cpu)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var conn = _duckDb.CreateConnection();
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO cpu_utilization_stats
+            (collection_id, collection_time, server_id, server_name, sample_time, sqlserver_cpu_utilization, other_process_cpu_utilization)
+            VALUES ($1,$2,$3,'TestServer',$2,$4,2)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId-- });
+        cmd.Parameters.Add(new DuckDBParameter { Value = time });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = cpu });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // ── read layer ──
+
+    [Fact]
+    public async Task ObjectSizeGrowth_ComputesDelta()
+    {
+        await SeedScenarioAsync();
+        var rows = await _dataService.GetObjectSizeGrowthAsync(ServerId);
+
+        var big = rows.FirstOrDefault(r => r.TableName == "BigTable");
+        Assert.NotNull(big);
+        Assert.Equal(600m, big!.CurrentReservedMb);
+        Assert.Equal(400m, big.Growth30dMb);
+        Assert.True(big.GrowthPct30d >= 199 && big.GrowthPct30d <= 201);
+    }
+
+    [Fact]
+    public async Task IndexUsage_FlagsWriteOnly()
+    {
+        await SeedScenarioAsync();
+        var rows = await _dataService.GetIndexUsageAsync(ServerId);
+
+        var unused = rows.FirstOrDefault(r => r.IndexName == "IX_unused");
+        Assert.NotNull(unused);
+        Assert.Equal("Write-only", unused!.Classification);
+        Assert.Equal(0, unused.TotalReads);
+        Assert.Equal(500, unused.UserUpdates);
+    }
+
+    [Fact]
+    public async Task IndexLocking_ReturnsContendedObjects()
+    {
+        await SeedScenarioAsync();
+        var rows = await _dataService.GetIndexLockingAsync(ServerId);
+
+        var hot = rows.FirstOrDefault(r => r.TableName == "HotTable");
+        Assert.NotNull(hot);
+        Assert.Equal(100_000, hot!.RowLockWaitInMs);
+    }
+
+    // ── anomaly detection ──
+
+    [Fact]
+    public async Task DetectObjectStatsAnomalies_FiresGrowthAndContention()
+    {
+        await SeedScenarioAsync();
+        // HasBaselineDataAsync canary: needs cpu/wait data in the last 30 days
+        for (int d = 1; d <= 5; d++)
+            await SeedCpuAsync(_latest.AddDays(-d), 10);
+
+        var context = new AnalysisContext { ServerId = ServerId, ServerName = "TestServer", TimeRangeStart = _latest.AddHours(-4), TimeRangeEnd = _latest };
+        var anomalies = await _detector.DetectAnomaliesAsync(context);
+
+        var growth = anomalies.FirstOrDefault(f => f.Key == "ANOMALY_OBJECT_GROWTH");
+        Assert.NotNull(growth);
+        Assert.Equal("AppDb", growth!.DatabaseName);
+        Assert.True(growth.Metadata["growth_mb"] >= 399);
+        Assert.True(growth.Metadata["growth_ratio"] >= 1.0);
+
+        var contention = anomalies.FirstOrDefault(f => f.Key == "ANOMALY_OBJECT_CONTENTION");
+        Assert.NotNull(contention);
+        Assert.True(contention!.Metadata["lock_wait_ms_delta"] >= 89_000);
+    }
+
+    [Fact]
+    public async Task DetectObjectStatsAnomalies_SingleSnapshot_NoFalsePositive()
+    {
+        await _duckDb.InitializeAsync();
+        // Only one snapshot — growth/contention need two distinct snapshots
+        await InsertObjectStat(_latest, "AppDb", 100, 1, "dbo", "BigTable", "PK_BigTable", 600m, 3_000_000, 5000, 100, 10, 50, 100_000, 3);
+        for (int d = 1; d <= 5; d++)
+            await SeedCpuAsync(_latest.AddDays(-d), 10);
+
+        var context = new AnalysisContext { ServerId = ServerId, ServerName = "TestServer", TimeRangeStart = _latest.AddHours(-4), TimeRangeEnd = _latest };
+        var anomalies = await _detector.DetectAnomaliesAsync(context);
+
+        Assert.DoesNotContain(anomalies, f => f.Key == "ANOMALY_OBJECT_GROWTH");
+        Assert.DoesNotContain(anomalies, f => f.Key == "ANOMALY_OBJECT_CONTENTION");
+    }
+}

--- a/Lite/Analysis/AnomalyDetector.cs
+++ b/Lite/Analysis/AnomalyDetector.cs
@@ -100,8 +100,125 @@ public class AnomalyDetector
         await DetectSessionAnomalies(context, anomalies);
         await DetectQueryDurationAnomalies(context, anomalies);
         await DetectMemoryAnomalies(context, anomalies);
+        await DetectObjectStatsAnomalies(context, anomalies);
 
         return anomalies;
+    }
+
+    /// <summary>
+    /// Day-over-day object/index detection (delta-based, not stddev-baseline) since the
+    /// index_object_stats collector runs daily and its counters are cumulative.
+    /// Emits ANOMALY_OBJECT_GROWTH for the biggest table grower over threshold and
+    /// ANOMALY_OBJECT_CONTENTION for the index with the largest new lock-wait time.
+    /// </summary>
+    private const decimal ObjectGrowthMbThreshold = 100m;   // ignore tables that grew less than 100 MB
+    private const double ObjectGrowthPctThreshold = 20.0;   // ...and less than 20% day-over-day
+    private const long ObjectLockWaitMsDeltaThreshold = 60000; // 1 minute of new lock waits
+
+    private async Task DetectObjectStatsAnomalies(AnalysisContext context, List<Fact> anomalies)
+    {
+        try
+        {
+            using var readLock = _duckDb.AcquireReadLock();
+            using var connection = _duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            // Growth: biggest day-over-day table grower (indexes rolled up) over threshold.
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = @"
+WITH snaps AS (SELECT DISTINCT collection_time FROM v_index_object_stats WHERE server_id = $1 ORDER BY collection_time DESC LIMIT 2),
+latest AS (SELECT MAX(collection_time) t FROM snaps),
+prior AS (SELECT MIN(collection_time) t FROM snaps),
+cur AS (SELECT database_name, object_id, MAX(schema_name) schema_name, MAX(table_name) table_name, SUM(reserved_mb) mb
+        FROM v_index_object_stats WHERE server_id = $1 AND collection_time = (SELECT t FROM latest) GROUP BY database_name, object_id),
+prv AS (SELECT database_name, object_id, SUM(reserved_mb) mb
+        FROM v_index_object_stats WHERE server_id = $1 AND collection_time = (SELECT t FROM prior) GROUP BY database_name, object_id)
+SELECT cur.database_name, cur.schema_name, cur.table_name, prv.mb AS prior_mb, cur.mb AS current_mb,
+       cur.mb - prv.mb AS growth_mb,
+       CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END AS growth_pct
+FROM cur JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id
+WHERE (SELECT t FROM latest) <> (SELECT t FROM prior)
+AND   cur.mb - prv.mb >= $2
+AND   (CASE WHEN prv.mb > 0 THEN (cur.mb - prv.mb) * 100.0 / prv.mb ELSE 0 END) >= $3
+ORDER BY growth_mb DESC LIMIT 1";
+                cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+                cmd.Parameters.Add(new DuckDBParameter { Value = ObjectGrowthMbThreshold });
+                cmd.Parameters.Add(new DuckDBParameter { Value = ObjectGrowthPctThreshold });
+
+                using var reader = await cmd.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    var db = reader.GetString(0);
+                    var growthMb = Convert.ToDouble(reader.GetValue(5));
+                    var growthPct = Convert.ToDouble(reader.GetValue(6));
+                    anomalies.Add(new Fact
+                    {
+                        Source = "anomaly",
+                        Key = "ANOMALY_OBJECT_GROWTH",
+                        Value = growthMb,
+                        ServerId = context.ServerId,
+                        DatabaseName = db,
+                        Metadata = new Dictionary<string, double>
+                        {
+                            ["prior_mb"] = Convert.ToDouble(reader.GetValue(3)),
+                            ["current_mb"] = Convert.ToDouble(reader.GetValue(4)),
+                            ["growth_mb"] = growthMb,
+                            ["growth_pct"] = growthPct,
+                            ["growth_ratio"] = growthPct / ObjectGrowthPctThreshold
+                        }
+                    });
+                }
+            }
+
+            // Contention: index with the largest new row-lock wait time (no reset).
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = @"
+WITH snaps AS (SELECT DISTINCT collection_time FROM v_index_object_stats WHERE server_id = $1 ORDER BY collection_time DESC LIMIT 2),
+latest AS (SELECT MAX(collection_time) t FROM snaps),
+prior AS (SELECT MIN(collection_time) t FROM snaps),
+cur AS (SELECT database_name, object_id, index_id, schema_name, table_name, index_name,
+               COALESCE(row_lock_wait_in_ms,0) ms, COALESCE(index_lock_promotion_count,0) esc
+        FROM v_index_object_stats WHERE server_id = $1 AND collection_time = (SELECT t FROM latest)),
+prv AS (SELECT database_name, object_id, index_id, COALESCE(row_lock_wait_in_ms,0) ms, COALESCE(index_lock_promotion_count,0) esc
+        FROM v_index_object_stats WHERE server_id = $1 AND collection_time = (SELECT t FROM prior))
+SELECT cur.database_name, cur.schema_name, cur.table_name, cur.index_name,
+       cur.ms - prv.ms AS ms_delta, cur.esc - prv.esc AS esc_delta
+FROM cur JOIN prv ON cur.database_name = prv.database_name AND cur.object_id = prv.object_id AND cur.index_id = prv.index_id
+WHERE (SELECT t FROM latest) <> (SELECT t FROM prior)
+AND   cur.ms >= prv.ms
+AND   cur.ms - prv.ms >= $2
+ORDER BY ms_delta DESC LIMIT 1";
+                cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
+                cmd.Parameters.Add(new DuckDBParameter { Value = ObjectLockWaitMsDeltaThreshold });
+
+                using var reader = await cmd.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    var db = reader.GetString(0);
+                    var msDelta = Convert.ToDouble(reader.GetValue(4));
+                    anomalies.Add(new Fact
+                    {
+                        Source = "anomaly",
+                        Key = "ANOMALY_OBJECT_CONTENTION",
+                        Value = msDelta,
+                        ServerId = context.ServerId,
+                        DatabaseName = db,
+                        Metadata = new Dictionary<string, double>
+                        {
+                            ["lock_wait_ms_delta"] = msDelta,
+                            ["escalation_delta"] = Convert.ToDouble(reader.GetValue(5)),
+                            ["contention_ratio"] = msDelta / ObjectLockWaitMsDeltaThreshold
+                        }
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("AnomalyDetector", $"Object stats anomaly detection failed: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -872,6 +872,183 @@
             </Grid>
         </TabItem>
 
+        <!-- Object Sizes & Growth Sub-Tab (#1103) -->
+        <TabItem Header="Object Sizes &amp; Growth">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Object Sizes &amp; Growth" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshObjectSizeGrowth_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="ObjectSizeGrowthCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="ObjectSizeGrowthDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                              HeadersVisibility="Column" SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="150">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding SchemaName}" Width="90">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SchemaName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Schema" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="200">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Reserved MB" Binding="{Binding CurrentReservedMb, StringFormat='{}{0:N1}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Used MB" Binding="{Binding CurrentUsedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Indexes" Binding="{Binding IndexCount}" Width="70" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth 7d MB" Binding="{Binding Growth7dMb, StringFormat='{}{0:N1}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth 30d MB" Binding="{Binding Growth30dMb, StringFormat='{}{0:N1}'}" Width="120" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Daily Rate MB" Binding="{Binding DailyGrowthRateMb, StringFormat='{}{0:N2}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Growth % 30d" Binding="{Binding GrowthPct30d, StringFormat='{}{0:N1}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="NoObjectSizeGrowthMessage" Text="No object size data available yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Index Usage Sub-Tab (#1103) -->
+        <TabItem Header="Index Usage">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Index Usage" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshIndexUsage_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="IndexUsageCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Unused / write-only first" Margin="12,0,0,0" VerticalAlignment="Center"
+                               FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="IndexUsageDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                              HeadersVisibility="Column" SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="170">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IndexName}" Width="180">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding Classification}" Width="90">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Classification" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Type" Binding="{Binding IndexTypeDesc}" Width="130"/>
+                            <DataGridTextColumn Header="Reserved MB" Binding="{Binding ReservedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Rows" Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Seeks" Binding="{Binding UserSeeks, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Scans" Binding="{Binding UserScans, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Lookups" Binding="{Binding UserLookups, StringFormat='{}{0:N0}'}" Width="90" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Total Reads" Binding="{Binding TotalReads, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Updates" Binding="{Binding UserUpdates, StringFormat='{}{0:N0}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Last Access" Binding="{Binding LastUserAccess, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="140"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="NoIndexUsageMessage" Text="No index usage data available yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
+        <!-- Locking & Contention Sub-Tab (#1103) -->
+        <TabItem Header="Locking &amp; Contention">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                    <TextBlock Text="Locking &amp; Contention" VerticalAlignment="Center" Margin="0,0,10,0"
+                               FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <Button Content="Refresh" Click="RefreshIndexLocking_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                    <TextBlock x:Name="IndexLockingCountIndicator" Text="" Margin="12,0,0,0"
+                               VerticalAlignment="Center" FontStyle="Italic"
+                               Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Cumulative since restart; top contended first" Margin="12,0,0,0" VerticalAlignment="Center"
+                               FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <Grid Grid.Row="1" Margin="10,0,10,10">
+                    <DataGrid x:Name="IndexLockingDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                              CanUserSortColumns="True" GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
+                              HeadersVisibility="Column" SelectionMode="Extended" RowStyle="{StaticResource DefaultRowStyle}"
+                              ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                        <DataGrid.Resources>
+                            <Style x:Key="RightAlign" TargetType="TextBlock"><Setter Property="HorizontalAlignment" Value="Right"/></Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TableName}" Width="170">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding IndexName}" Width="180">
+                                <DataGridTextColumn.Header><StackPanel Orientation="Horizontal">
+                                    <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexName" Click="FilterButton_Click" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Header="Row Lock Waits" Binding="{Binding RowLockWaitCount, StringFormat='{}{0:N0}'}" Width="110" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Row Lock Wait ms" Binding="{Binding RowLockWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page Lock Wait ms" Binding="{Binding PageLockWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Lock Escalations" Binding="{Binding IndexLockPromotionCount, StringFormat='{}{0:N0}'}" Width="120" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page Latch Wait ms" Binding="{Binding PageLatchWaitInMs, StringFormat='{}{0:N0}'}" Width="130" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Page IO Latch Wait ms" Binding="{Binding PageIoLatchWaitInMs, StringFormat='{}{0:N0}'}" Width="150" ElementStyle="{StaticResource RightAlign}"/>
+                            <DataGridTextColumn Header="Reserved MB" Binding="{Binding ReservedMb, StringFormat='{}{0:N1}'}" Width="100" ElementStyle="{StaticResource RightAlign}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock x:Name="NoIndexLockingMessage" Text="No locking/contention data recorded yet"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                </Grid>
+            </Grid>
+        </TabItem>
+
         <!-- Database Sizes Sub-Tab -->
         <TabItem Header="Database Sizes">
             <Grid>

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -50,6 +50,9 @@ public partial class FinOpsTab : UserControl
     private DataGridFilterManager<WaitCategorySummaryRow>? _waitCategoryFilterMgr;
     private DataGridFilterManager<ExpensiveQueryRow>? _expensiveQueriesFilterMgr;
     private DataGridFilterManager<MemoryGrantEfficiencyRow>? _memoryGrantFilterMgr;
+    private DataGridFilterManager<ObjectSizeGrowthRow>? _objectSizeGrowthFilterMgr;
+    private DataGridFilterManager<IndexUsageRow>? _indexUsageFilterMgr;
+    private DataGridFilterManager<IndexLockingRow>? _indexLockingFilterMgr;
 
     public FinOpsTab()
     {
@@ -147,6 +150,9 @@ public partial class FinOpsTab : UserControl
             LoadApplicationConnectionsAsync(serverId),
             LoadDatabaseSizesAsync(serverId),
             LoadStorageGrowthAsync(serverId),
+            LoadObjectSizeGrowthAsync(serverId),
+            LoadIndexUsageAsync(serverId),
+            LoadIndexLockingAsync(serverId),
             LoadIdleDatabasesAsync(serverId),
             LoadTempdbSummaryAsync(serverId),
             LoadWaitCategorySummaryAsync(serverId),
@@ -529,6 +535,76 @@ public partial class FinOpsTab : UserControl
         {
             AppLogger.Error("FinOps", $"Failed to load storage growth: {ex.Message}");
         }
+    }
+
+    // ============================================
+    // Object/Index stats (#1103)
+    // ============================================
+
+    private async System.Threading.Tasks.Task LoadObjectSizeGrowthAsync(int serverId)
+    {
+        if (_dataService == null) return;
+        try
+        {
+            var data = await _dataService.GetObjectSizeGrowthAsync(serverId);
+            _objectSizeGrowthFilterMgr!.UpdateData(data);
+            NoObjectSizeGrowthMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            ObjectSizeGrowthCountIndicator.Text = data.Count > 0 ? $"{data.Count} table(s)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load object size/growth: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadIndexUsageAsync(int serverId)
+    {
+        if (_dataService == null) return;
+        try
+        {
+            var data = await _dataService.GetIndexUsageAsync(serverId);
+            _indexUsageFilterMgr!.UpdateData(data);
+            NoIndexUsageMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            IndexUsageCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load index usage: {ex.Message}");
+        }
+    }
+
+    private async System.Threading.Tasks.Task LoadIndexLockingAsync(int serverId)
+    {
+        if (_dataService == null) return;
+        try
+        {
+            var data = await _dataService.GetIndexLockingAsync(serverId);
+            _indexLockingFilterMgr!.UpdateData(data);
+            NoIndexLockingMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            IndexLockingCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("FinOps", $"Failed to load index locking: {ex.Message}");
+        }
+    }
+
+    private async void RefreshObjectSizeGrowth_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadObjectSizeGrowthAsync(serverId);
+    }
+
+    private async void RefreshIndexUsage_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadIndexUsageAsync(serverId);
+    }
+
+    private async void RefreshIndexLocking_Click(object sender, RoutedEventArgs e)
+    {
+        var serverId = GetSelectedServerId();
+        if (serverId != 0) await LoadIndexLockingAsync(serverId);
     }
 
     private async System.Threading.Tasks.Task LoadIdleDatabasesAsync(int serverId)
@@ -973,6 +1049,9 @@ public partial class FinOpsTab : UserControl
         _waitCategoryFilterMgr = new DataGridFilterManager<WaitCategorySummaryRow>(WaitCategorySummaryDataGrid);
         _expensiveQueriesFilterMgr = new DataGridFilterManager<ExpensiveQueryRow>(ExpensiveQueriesDataGrid);
         _memoryGrantFilterMgr = new DataGridFilterManager<MemoryGrantEfficiencyRow>(MemoryGrantEfficiencyDataGrid);
+        _objectSizeGrowthFilterMgr = new DataGridFilterManager<ObjectSizeGrowthRow>(ObjectSizeGrowthDataGrid);
+        _indexUsageFilterMgr = new DataGridFilterManager<IndexUsageRow>(IndexUsageDataGrid);
+        _indexLockingFilterMgr = new DataGridFilterManager<IndexLockingRow>(IndexLockingDataGrid);
 
         _filterManagers[DatabaseResourcesDataGrid] = _dbResourcesFilterMgr;
         _filterManagers[StorageGrowthDataGrid] = _storageGrowthFilterMgr;
@@ -987,6 +1066,9 @@ public partial class FinOpsTab : UserControl
         _filterManagers[WaitCategorySummaryDataGrid] = _waitCategoryFilterMgr;
         _filterManagers[ExpensiveQueriesDataGrid] = _expensiveQueriesFilterMgr;
         _filterManagers[MemoryGrantEfficiencyDataGrid] = _memoryGrantFilterMgr;
+        _filterManagers[ObjectSizeGrowthDataGrid] = _objectSizeGrowthFilterMgr;
+        _filterManagers[IndexUsageDataGrid] = _indexUsageFilterMgr;
+        _filterManagers[IndexLockingDataGrid] = _indexLockingFilterMgr;
     }
 
     private void EnsureFilterPopup()

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 28;
+    internal const int CurrentSchemaVersion = 29;
 
     private readonly string _archivePath;
 
@@ -116,7 +116,7 @@ public class DuckDbInitializer
         "query_snapshots", "cpu_utilization_stats", "file_io_stats", "memory_stats",
         "memory_clerks", "memory_pressure_events", "tempdb_stats", "perfmon_stats",
         "deadlocks", "blocked_process_reports", "memory_grant_stats", "waiting_tasks",
-        "running_jobs", "database_size_stats", "server_properties",
+        "running_jobs", "database_size_stats", "index_object_stats", "server_properties",
         "session_stats", "server_config", "database_config",
         "database_scoped_config", "trace_flags", "config_alert_log",
         "collection_log"

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -639,6 +639,65 @@ CREATE TABLE IF NOT EXISTS database_size_stats (
     public const string CreateDatabaseSizeStatsIndex = @"
 CREATE INDEX IF NOT EXISTS idx_database_size_stats_time ON database_size_stats(server_id, collection_time)";
 
+    // Per-table/per-index size, usage, and locking stats. Sizes are point-in-time;
+    // usage/locking counters are cumulative (reset boundary in sqlserver_start_time).
+    // Column order MUST match the appender in RemoteCollectorService.IndexObjectStats.cs
+    // and the data columns in install/02_create_tables.sql (Dashboard parity).
+    public const string CreateIndexObjectStatsTable = @"
+CREATE TABLE IF NOT EXISTS index_object_stats (
+    collection_id BIGINT PRIMARY KEY,
+    collection_time TIMESTAMP NOT NULL,
+    server_id INTEGER NOT NULL,
+    server_name VARCHAR NOT NULL,
+    sqlserver_start_time TIMESTAMP,
+    database_name VARCHAR NOT NULL,
+    database_id INTEGER NOT NULL,
+    schema_name VARCHAR NOT NULL,
+    object_id INTEGER NOT NULL,
+    table_name VARCHAR NOT NULL,
+    index_id INTEGER NOT NULL,
+    index_name VARCHAR,
+    index_type_desc VARCHAR,
+    is_unique BOOLEAN,
+    is_primary_key BOOLEAN,
+    is_filtered BOOLEAN,
+    partition_count INTEGER,
+    reserved_mb DECIMAL(19,2),
+    used_mb DECIMAL(19,2),
+    in_row_data_mb DECIMAL(19,2),
+    lob_data_mb DECIMAL(19,2),
+    row_overflow_mb DECIMAL(19,2),
+    total_rows BIGINT,
+    user_seeks BIGINT,
+    user_scans BIGINT,
+    user_lookups BIGINT,
+    user_updates BIGINT,
+    last_user_seek TIMESTAMP,
+    last_user_scan TIMESTAMP,
+    last_user_lookup TIMESTAMP,
+    last_user_update TIMESTAMP,
+    leaf_insert_count BIGINT,
+    leaf_update_count BIGINT,
+    leaf_delete_count BIGINT,
+    range_scan_count BIGINT,
+    singleton_lookup_count BIGINT,
+    row_lock_count BIGINT,
+    row_lock_wait_count BIGINT,
+    row_lock_wait_in_ms BIGINT,
+    page_lock_count BIGINT,
+    page_lock_wait_count BIGINT,
+    page_lock_wait_in_ms BIGINT,
+    index_lock_promotion_attempt_count BIGINT,
+    index_lock_promotion_count BIGINT,
+    page_latch_wait_count BIGINT,
+    page_latch_wait_in_ms BIGINT,
+    page_io_latch_wait_count BIGINT,
+    page_io_latch_wait_in_ms BIGINT
+)";
+
+    public const string CreateIndexObjectStatsIndex = @"
+CREATE INDEX IF NOT EXISTS idx_index_object_stats_object ON index_object_stats(server_id, database_name, object_id, index_id, collection_time)";
+
     public const string CreateServerPropertiesTable = @"
 CREATE TABLE IF NOT EXISTS server_properties (
     collection_id BIGINT PRIMARY KEY,
@@ -762,6 +821,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateTraceFlagsTable;
         yield return CreateRunningJobsTable;
         yield return CreateDatabaseSizeStatsTable;
+        yield return CreateIndexObjectStatsTable;
         yield return CreateServerPropertiesTable;
         yield return CreateSessionStatsTable;
         yield return CreateAlertLogTable;
@@ -795,6 +855,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateTraceFlagsIndex;
         yield return CreateRunningJobsIndex;
         yield return CreateDatabaseSizeStatsIndex;
+        yield return CreateIndexObjectStatsIndex;
         yield return CreateServerPropertiesIndex;
         yield return CreateSessionStatsIndex;
         yield return CreateDismissedArchiveAlertsIndex;

--- a/Lite/Mcp/McpHostService.cs
+++ b/Lite/Mcp/McpHostService.cs
@@ -90,6 +90,7 @@ public sealed class McpHostService : BackgroundService
                 .WithGeminiCompatibleTools<McpConfigTools>()
                 .WithGeminiCompatibleTools<McpServerInfoTools>()
                 .WithGeminiCompatibleTools<McpSessionTools>()
+                .WithGeminiCompatibleTools<McpObjectStatsTools>()
                 .WithGeminiCompatibleTools<McpAnalysisTools>();
 
             _app = builder.Build();

--- a/Lite/Mcp/McpInstructions.cs
+++ b/Lite/Mcp/McpInstructions.cs
@@ -91,6 +91,13 @@ internal static class McpInstructions
         |------|---------|----------------|
         | `get_tempdb_trend` | TempDB space: user objects, internal objects, version store | `server_name`, `hours_back` |
 
+        ### Storage & Index Tools
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `get_table_index_sizes` | Largest tables with size, growth (7d/30d/daily), and row counts | `server_name` |
+        | `get_index_usage` | Per-index seeks/scans/lookups/updates with Unused/Write-only/Active classification (drop candidates first) | `server_name` |
+        | `get_object_locking` | Per-index lock/latch waits and lock escalations, top contended objects | `server_name` |
+
         ### Performance Counter Tools
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|

--- a/Lite/Mcp/McpObjectStatsTools.cs
+++ b/Lite/Mcp/McpObjectStatsTools.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorLite.Mcp;
+
+[McpServerToolType]
+public sealed class McpObjectStatsTools
+{
+    [McpServerTool(Name = "get_table_index_sizes"), Description("Gets the largest tables with per-table size, growth (7d/30d/daily rate), and row counts from the latest daily snapshot. Indexes are rolled up per table. Use to find storage hot-spots and fast-growing tables for capacity planning.")]
+    public static async Task<string> GetTableIndexSizes(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await dataService.GetObjectSizeGrowthAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+            {
+                return "No object size data available. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                reserved_mb = r.CurrentReservedMb,
+                used_mb = r.CurrentUsedMb,
+                total_rows = r.TotalRows,
+                index_count = r.IndexCount,
+                growth_7d_mb = r.Growth7dMb,
+                growth_30d_mb = r.Growth30dMb,
+                daily_growth_rate_mb = r.DailyGrowthRateMb,
+                growth_pct_30d = r.GrowthPct30d
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                tables = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_table_index_sizes", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_index_usage"), Description("Gets per-index usage (seeks, scans, lookups, updates) from the latest daily snapshot, classifying each index as Unused, Write-only, or Active. Unused and write-only indexes are listed first - these are drop candidates. Counters are cumulative since the last instance restart.")]
+    public static async Task<string> GetIndexUsage(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await dataService.GetIndexUsageAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+            {
+                return "No index usage data available. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                index_name = r.IndexName,
+                index_type = r.IndexTypeDesc,
+                classification = r.Classification,
+                reserved_mb = r.ReservedMb,
+                total_rows = r.TotalRows,
+                user_seeks = r.UserSeeks,
+                user_scans = r.UserScans,
+                user_lookups = r.UserLookups,
+                total_reads = r.TotalReads,
+                user_updates = r.UserUpdates,
+                last_user_access = r.LastUserAccess?.ToString("o")
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                indexes = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_index_usage", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_object_locking"), Description("Gets per-index locking and latch contention (row/page lock waits in ms, lock escalations, page-latch and page-IO-latch waits) from the latest daily snapshot, top contended objects first. Use to find tables/indexes driving blocking and contention. Counters are cumulative since the last instance restart.")]
+    public static async Task<string> GetObjectLocking(
+        LocalDataService dataService,
+        ServerManager serverManager,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var resolved = ServerResolver.Resolve(serverManager, server_name);
+        if (resolved == null)
+        {
+            return $"Could not resolve server. Available servers:\n{ServerResolver.ListAvailableServers(serverManager)}";
+        }
+
+        try
+        {
+            var rows = await dataService.GetIndexLockingAsync(resolved.Value.ServerId);
+            if (rows.Count == 0)
+            {
+                return "No locking/contention data recorded. Index/object stats are collected daily.";
+            }
+
+            var result = rows.Select(r => new
+            {
+                database_name = r.DatabaseName,
+                schema_name = r.SchemaName,
+                table_name = r.TableName,
+                index_name = r.IndexName,
+                index_type = r.IndexTypeDesc,
+                reserved_mb = r.ReservedMb,
+                total_rows = r.TotalRows,
+                row_lock_wait_count = r.RowLockWaitCount,
+                row_lock_wait_ms = r.RowLockWaitInMs,
+                page_lock_wait_count = r.PageLockWaitCount,
+                page_lock_wait_ms = r.PageLockWaitInMs,
+                lock_escalations = r.IndexLockPromotionCount,
+                page_latch_wait_ms = r.PageLatchWaitInMs,
+                page_io_latch_wait_ms = r.PageIoLatchWaitInMs
+            });
+
+            return JsonSerializer.Serialize(new
+            {
+                server = resolved.Value.ServerName,
+                objects = result
+            }, McpHelpers.JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_object_locking", ex);
+        }
+    }
+}

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -75,6 +75,7 @@ public class ArchiveService
         ("waiting_tasks", "collection_time"),
         ("running_jobs", "collection_time"),
         ("database_size_stats", "collection_time"),
+        ("index_object_stats", "collection_time"),
         ("server_properties", "collection_time"),
         ("session_stats", "collection_time"),
         ("server_config", "capture_time"),

--- a/Lite/Services/LocalDataService.FinOps.IndexObjects.cs
+++ b/Lite/Services/LocalDataService.FinOps.IndexObjects.cs
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    // ============================================
+    // FinOps — Object/Index stats (sizes+growth, usage, locking).
+    // Reads v_index_object_stats (hot DuckDB UNION archived parquet).
+    // ============================================
+
+    /// <summary>
+    /// Per-table size and growth (indexes rolled up per table) for a server, comparing the
+    /// latest snapshot to 7d/30d ago, with a daily growth rate over the available history.
+    /// </summary>
+    public async Task<List<ObjectSizeGrowthRow>> GetObjectSizeGrowthAsync(int serverId, int topN = 100)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var now = DateTime.UtcNow;
+        var cutoff7d = now.AddDays(-7);
+        var cutoff30d = now.AddDays(-30);
+
+        command.CommandText = $@"
+WITH boundaries AS (
+    SELECT
+        MAX(collection_time) AS latest_time,
+        MIN(collection_time) AS earliest_time,
+        date_diff('day', MIN(collection_time), MAX(collection_time)) AS days_of_data
+    FROM v_index_object_stats
+    WHERE server_id = $1
+),
+latest AS (
+    SELECT database_name, schema_name, table_name,
+        SUM(reserved_mb) AS current_reserved_mb,
+        SUM(used_mb) AS current_used_mb,
+        MAX(total_rows) AS total_rows,
+        COUNT(*) AS index_count
+    FROM v_index_object_stats
+    WHERE server_id = $1 AND collection_time = (SELECT latest_time FROM boundaries)
+    GROUP BY database_name, schema_name, table_name
+),
+past_7d AS (
+    SELECT database_name, schema_name, table_name, SUM(reserved_mb) AS reserved_mb
+    FROM v_index_object_stats
+    WHERE server_id = $1 AND collection_time = (
+        SELECT MAX(collection_time) FROM v_index_object_stats WHERE server_id = $1 AND collection_time <= $2)
+    GROUP BY database_name, schema_name, table_name
+),
+past_30d AS (
+    SELECT database_name, schema_name, table_name, SUM(reserved_mb) AS reserved_mb
+    FROM v_index_object_stats
+    WHERE server_id = $1 AND collection_time = (
+        SELECT MAX(collection_time) FROM v_index_object_stats WHERE server_id = $1 AND collection_time <= $3)
+    GROUP BY database_name, schema_name, table_name
+),
+oldest AS (
+    SELECT database_name, schema_name, table_name, SUM(reserved_mb) AS reserved_mb
+    FROM v_index_object_stats
+    WHERE server_id = $1 AND collection_time = (SELECT earliest_time FROM boundaries)
+    GROUP BY database_name, schema_name, table_name
+)
+SELECT
+    l.database_name,
+    l.schema_name,
+    l.table_name,
+    l.current_reserved_mb,
+    l.current_used_mb,
+    l.total_rows,
+    l.index_count,
+    l.current_reserved_mb - COALESCE(p7.reserved_mb, o.reserved_mb, l.current_reserved_mb) AS growth_7d_mb,
+    l.current_reserved_mb - COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb, l.current_reserved_mb) AS growth_30d_mb,
+    CASE WHEN b.days_of_data >= 1
+         THEN (l.current_reserved_mb - COALESCE(o.reserved_mb, l.current_reserved_mb)) / CAST(b.days_of_data AS DOUBLE)
+         ELSE 0 END AS daily_growth_rate_mb,
+    CASE WHEN COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb) > 0
+         THEN (l.current_reserved_mb - COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb)) * 100.0
+              / COALESCE(p30.reserved_mb, p7.reserved_mb, o.reserved_mb)
+         ELSE 0 END AS growth_pct_30d
+FROM latest l
+CROSS JOIN boundaries b
+LEFT JOIN past_7d p7 ON p7.database_name = l.database_name AND p7.schema_name = l.schema_name AND p7.table_name = l.table_name
+LEFT JOIN past_30d p30 ON p30.database_name = l.database_name AND p30.schema_name = l.schema_name AND p30.table_name = l.table_name
+LEFT JOIN oldest o ON o.database_name = l.database_name AND o.schema_name = l.schema_name AND o.table_name = l.table_name
+ORDER BY l.current_reserved_mb DESC
+LIMIT {topN}";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff7d });
+        command.Parameters.Add(new DuckDBParameter { Value = cutoff30d });
+
+        var items = new List<ObjectSizeGrowthRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new ObjectSizeGrowthRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                CurrentReservedMb = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                CurrentUsedMb = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                TotalRows = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                IndexCount = reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)),
+                Growth7dMb = reader.IsDBNull(7) ? 0m : Convert.ToDecimal(reader.GetValue(7)),
+                Growth30dMb = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                DailyGrowthRateMb = reader.IsDBNull(9) ? 0m : Convert.ToDecimal(reader.GetValue(9)),
+                GrowthPct30d = reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10))
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Per-index usage from the latest snapshot for a server, surfacing unused/write-only indexes.
+    /// </summary>
+    public async Task<List<IndexUsageRow>> GetIndexUsageAsync(int serverId, int topN = 200)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = $@"
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    index_name,
+    index_type_desc,
+    index_id,
+    reserved_mb,
+    total_rows,
+    COALESCE(user_seeks, 0) AS user_seeks,
+    COALESCE(user_scans, 0) AS user_scans,
+    COALESCE(user_lookups, 0) AS user_lookups,
+    COALESCE(user_seeks, 0) + COALESCE(user_scans, 0) + COALESCE(user_lookups, 0) AS total_reads,
+    COALESCE(user_updates, 0) AS user_updates,
+    GREATEST(last_user_seek, last_user_scan, last_user_lookup, last_user_update) AS last_user_access,
+    CASE
+        WHEN COALESCE(user_seeks, 0) + COALESCE(user_scans, 0) + COALESCE(user_lookups, 0) = 0
+             AND COALESCE(user_updates, 0) = 0 THEN 'Unused'
+        WHEN COALESCE(user_seeks, 0) + COALESCE(user_scans, 0) + COALESCE(user_lookups, 0) = 0
+             AND COALESCE(user_updates, 0) > 0 THEN 'Write-only'
+        ELSE 'Active'
+    END AS classification
+FROM v_index_object_stats
+WHERE server_id = $1
+AND   collection_time = (SELECT MAX(collection_time) FROM v_index_object_stats WHERE server_id = $1)
+ORDER BY
+    CASE WHEN COALESCE(user_seeks, 0) + COALESCE(user_scans, 0) + COALESCE(user_lookups, 0) = 0 THEN 0 ELSE 1 END,
+    reserved_mb DESC
+LIMIT {topN}";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<IndexUsageRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new IndexUsageRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                IndexName = reader.IsDBNull(3) ? "(heap)" : reader.GetString(3),
+                IndexTypeDesc = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                IndexId = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                ReservedMb = reader.IsDBNull(6) ? 0m : Convert.ToDecimal(reader.GetValue(6)),
+                TotalRows = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                UserSeeks = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                UserScans = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                UserLookups = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+                TotalReads = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
+                UserUpdates = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+                LastUserAccess = reader.IsDBNull(13) ? null : reader.GetDateTime(13),
+                Classification = reader.IsDBNull(14) ? "" : reader.GetString(14)
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Per-index locking/latch contention from the latest snapshot for a server.
+    /// </summary>
+    public async Task<List<IndexLockingRow>> GetIndexLockingAsync(int serverId, int topN = 200)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = $@"
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    index_name,
+    index_type_desc,
+    reserved_mb,
+    total_rows,
+    COALESCE(row_lock_count, 0) AS row_lock_count,
+    COALESCE(row_lock_wait_count, 0) AS row_lock_wait_count,
+    COALESCE(row_lock_wait_in_ms, 0) AS row_lock_wait_in_ms,
+    COALESCE(page_lock_count, 0) AS page_lock_count,
+    COALESCE(page_lock_wait_count, 0) AS page_lock_wait_count,
+    COALESCE(page_lock_wait_in_ms, 0) AS page_lock_wait_in_ms,
+    COALESCE(index_lock_promotion_count, 0) AS index_lock_promotion_count,
+    COALESCE(page_latch_wait_in_ms, 0) AS page_latch_wait_in_ms,
+    COALESCE(page_io_latch_wait_in_ms, 0) AS page_io_latch_wait_in_ms
+FROM v_index_object_stats
+WHERE server_id = $1
+AND   collection_time = (SELECT MAX(collection_time) FROM v_index_object_stats WHERE server_id = $1)
+AND (
+    COALESCE(row_lock_wait_in_ms, 0) > 0
+    OR COALESCE(page_lock_wait_in_ms, 0) > 0
+    OR COALESCE(page_latch_wait_in_ms, 0) > 0
+    OR COALESCE(page_io_latch_wait_in_ms, 0) > 0
+    OR COALESCE(index_lock_promotion_count, 0) > 0
+)
+ORDER BY
+    COALESCE(row_lock_wait_in_ms, 0) + COALESCE(page_lock_wait_in_ms, 0)
+    + COALESCE(page_latch_wait_in_ms, 0) + COALESCE(page_io_latch_wait_in_ms, 0) DESC
+LIMIT {topN}";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<IndexLockingRow>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new IndexLockingRow
+            {
+                DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                SchemaName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                TableName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                IndexName = reader.IsDBNull(3) ? "(heap)" : reader.GetString(3),
+                IndexTypeDesc = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                ReservedMb = reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5)),
+                TotalRows = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+                RowLockCount = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                RowLockWaitCount = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                RowLockWaitInMs = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                PageLockCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+                PageLockWaitCount = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
+                PageLockWaitInMs = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+                IndexLockPromotionCount = reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)),
+                PageLatchWaitInMs = reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)),
+                PageIoLatchWaitInMs = reader.IsDBNull(15) ? 0L : Convert.ToInt64(reader.GetValue(15))
+            });
+        }
+        return items;
+    }
+}
+
+/// <summary>Per-table size + growth (indexes rolled up).</summary>
+public class ObjectSizeGrowthRow
+{
+    public string DatabaseName { get; set; } = "";
+    public string SchemaName { get; set; } = "";
+    public string TableName { get; set; } = "";
+    public decimal CurrentReservedMb { get; set; }
+    public decimal CurrentUsedMb { get; set; }
+    public long TotalRows { get; set; }
+    public int IndexCount { get; set; }
+    public decimal Growth7dMb { get; set; }
+    public decimal Growth30dMb { get; set; }
+    public decimal DailyGrowthRateMb { get; set; }
+    public decimal GrowthPct30d { get; set; }
+}
+
+/// <summary>Per-index usage with unused/write-only classification.</summary>
+public class IndexUsageRow
+{
+    public string DatabaseName { get; set; } = "";
+    public string SchemaName { get; set; } = "";
+    public string TableName { get; set; } = "";
+    public string IndexName { get; set; } = "";
+    public string IndexTypeDesc { get; set; } = "";
+    public int IndexId { get; set; }
+    public decimal ReservedMb { get; set; }
+    public long TotalRows { get; set; }
+    public long UserSeeks { get; set; }
+    public long UserScans { get; set; }
+    public long UserLookups { get; set; }
+    public long TotalReads { get; set; }
+    public long UserUpdates { get; set; }
+    public DateTime? LastUserAccess { get; set; }
+    public string Classification { get; set; } = "";
+}
+
+/// <summary>Per-index locking/latch contention.</summary>
+public class IndexLockingRow
+{
+    public string DatabaseName { get; set; } = "";
+    public string SchemaName { get; set; } = "";
+    public string TableName { get; set; } = "";
+    public string IndexName { get; set; } = "";
+    public string IndexTypeDesc { get; set; } = "";
+    public decimal ReservedMb { get; set; }
+    public long TotalRows { get; set; }
+    public long RowLockCount { get; set; }
+    public long RowLockWaitCount { get; set; }
+    public long RowLockWaitInMs { get; set; }
+    public long PageLockCount { get; set; }
+    public long PageLockWaitCount { get; set; }
+    public long PageLockWaitInMs { get; set; }
+    public long IndexLockPromotionCount { get; set; }
+    public long PageLatchWaitInMs { get; set; }
+    public long PageIoLatchWaitInMs { get; set; }
+}

--- a/Lite/Services/RemoteCollectorService.IndexObjectStats.cs
+++ b/Lite/Services/RemoteCollectorService.IndexObjectStats.cs
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class RemoteCollectorService
+{
+    /// <summary>
+    /// Collects per-table and per-index size, usage, and locking statistics for growth
+    /// trending, unused-index detection, and contention analysis.
+    /// Size columns are absolute point-in-time values; usage and locking counters are
+    /// cumulative (reset on instance restart / DB detach / AUTO_CLOSE) - sqlserver_start_time
+    /// carries the reset boundary so deltas can be computed safely in the read layer.
+    /// All three DMVs are database-scoped: on-prem iterates databases via a cursor + cross-DB
+    /// sp_executesql into a #temp; Azure SQL DB connects to each database individually.
+    /// In-Memory OLTP (Hekaton) objects are not represented by these DMVs.
+    /// </summary>
+    private async Task<int> CollectIndexObjectStatsAsync(ServerConnection server, CancellationToken cancellationToken)
+    {
+        var serverStatus = _serverManager.GetConnectionStatus(server.Id);
+        bool isAzureSqlDb = serverStatus?.SqlEngineEdition == 5;
+
+        string onPremQuery = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SET NOCOUNT ON;
+
+DECLARE
+    @sqlserver_start_time datetime2(7) =
+        (SELECT osi.sqlserver_start_time FROM sys.dm_os_sys_info AS osi),
+    @db_name sysname,
+    @sql nvarchar(MAX);
+
+CREATE TABLE #ios
+(
+    database_name sysname NOT NULL,
+    database_id int NOT NULL,
+    schema_name sysname NOT NULL,
+    object_id int NOT NULL,
+    table_name sysname NOT NULL,
+    index_id int NOT NULL,
+    index_name sysname NULL,
+    index_type_desc nvarchar(60) NULL,
+    is_unique bit NULL,
+    is_primary_key bit NULL,
+    is_filtered bit NULL,
+    partition_count int NULL,
+    reserved_mb decimal(19,2) NULL,
+    used_mb decimal(19,2) NULL,
+    in_row_data_mb decimal(19,2) NULL,
+    lob_data_mb decimal(19,2) NULL,
+    row_overflow_mb decimal(19,2) NULL,
+    total_rows bigint NULL,
+    user_seeks bigint NULL,
+    user_scans bigint NULL,
+    user_lookups bigint NULL,
+    user_updates bigint NULL,
+    last_user_seek datetime2(7) NULL,
+    last_user_scan datetime2(7) NULL,
+    last_user_lookup datetime2(7) NULL,
+    last_user_update datetime2(7) NULL,
+    leaf_insert_count bigint NULL,
+    leaf_update_count bigint NULL,
+    leaf_delete_count bigint NULL,
+    range_scan_count bigint NULL,
+    singleton_lookup_count bigint NULL,
+    row_lock_count bigint NULL,
+    row_lock_wait_count bigint NULL,
+    row_lock_wait_in_ms bigint NULL,
+    page_lock_count bigint NULL,
+    page_lock_wait_count bigint NULL,
+    page_lock_wait_in_ms bigint NULL,
+    index_lock_promotion_attempt_count bigint NULL,
+    index_lock_promotion_count bigint NULL,
+    page_latch_wait_count bigint NULL,
+    page_latch_wait_in_ms bigint NULL,
+    page_io_latch_wait_count bigint NULL,
+    page_io_latch_wait_in_ms bigint NULL
+);
+
+DECLARE db_cursor CURSOR LOCAL FAST_FORWARD FOR
+    SELECT
+        d.name
+    FROM sys.databases AS d
+    WHERE d.state_desc = N'ONLINE'
+    AND   d.database_id > 0
+    AND   HAS_DBACCESS(d.name) = 1
+    /*EXCLUSION_FILTER_CURSOR*/
+    ORDER BY
+        d.name;
+
+OPEN db_cursor;
+FETCH NEXT FROM db_cursor INTO @db_name;
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    BEGIN TRY
+        SET @sql = N'EXECUTE ' + QUOTENAME(@db_name) + N'.sys.sp_executesql N''
+INSERT #ios
+(
+    database_name, database_id, schema_name, object_id, table_name, index_id, index_name,
+    index_type_desc, is_unique, is_primary_key, is_filtered, partition_count, reserved_mb,
+    used_mb, in_row_data_mb, lob_data_mb, row_overflow_mb, total_rows, user_seeks, user_scans,
+    user_lookups, user_updates, last_user_seek, last_user_scan, last_user_lookup, last_user_update,
+    leaf_insert_count, leaf_update_count, leaf_delete_count, range_scan_count, singleton_lookup_count,
+    row_lock_count, row_lock_wait_count, row_lock_wait_in_ms, page_lock_count, page_lock_wait_count,
+    page_lock_wait_in_ms, index_lock_promotion_attempt_count, index_lock_promotion_count,
+    page_latch_wait_count, page_latch_wait_in_ms, page_io_latch_wait_count, page_io_latch_wait_in_ms
+)
+SELECT
+    DB_NAME(), DB_ID(), s.name, o.object_id, o.name, i.index_id, i.name, i.type_desc,
+    i.is_unique, i.is_primary_key, i.has_filter, ps.partition_count,
+    CONVERT(decimal(19,2), ps.reserved_pages * 8.0 / 1024.0),
+    CONVERT(decimal(19,2), ps.used_pages * 8.0 / 1024.0),
+    CONVERT(decimal(19,2), ps.in_row_pages * 8.0 / 1024.0),
+    CONVERT(decimal(19,2), ps.lob_pages * 8.0 / 1024.0),
+    CONVERT(decimal(19,2), ps.row_overflow_pages * 8.0 / 1024.0),
+    ps.total_rows, us.user_seeks, us.user_scans, us.user_lookups, us.user_updates,
+    us.last_user_seek, us.last_user_scan, us.last_user_lookup, us.last_user_update,
+    os.leaf_insert_count, os.leaf_update_count, os.leaf_delete_count, os.range_scan_count,
+    os.singleton_lookup_count, os.row_lock_count, os.row_lock_wait_count, os.row_lock_wait_in_ms,
+    os.page_lock_count, os.page_lock_wait_count, os.page_lock_wait_in_ms,
+    os.index_lock_promotion_attempt_count, os.index_lock_promotion_count,
+    os.page_latch_wait_count, os.page_latch_wait_in_ms, os.page_io_latch_wait_count,
+    os.page_io_latch_wait_in_ms
+FROM sys.indexes AS i
+JOIN sys.objects AS o
+  ON o.object_id = i.object_id
+JOIN sys.schemas AS s
+  ON s.schema_id = o.schema_id
+LEFT JOIN
+(
+    SELECT
+        dps.object_id, dps.index_id,
+        partition_count = COUNT_BIG(*),
+        reserved_pages = SUM(dps.reserved_page_count),
+        used_pages = SUM(dps.used_page_count),
+        in_row_pages = SUM(dps.in_row_data_page_count),
+        lob_pages = SUM(dps.lob_used_page_count),
+        row_overflow_pages = SUM(dps.row_overflow_used_page_count),
+        total_rows = SUM(dps.row_count)
+    FROM sys.dm_db_partition_stats AS dps
+    GROUP BY dps.object_id, dps.index_id
+) AS ps
+  ON ps.object_id = i.object_id AND ps.index_id = i.index_id
+LEFT JOIN sys.dm_db_index_usage_stats AS us
+  ON us.database_id = DB_ID() AND us.object_id = i.object_id AND us.index_id = i.index_id
+LEFT JOIN
+(
+    SELECT
+        ios.object_id, ios.index_id,
+        leaf_insert_count = SUM(ios.leaf_insert_count),
+        leaf_update_count = SUM(ios.leaf_update_count),
+        leaf_delete_count = SUM(ios.leaf_delete_count),
+        range_scan_count = SUM(ios.range_scan_count),
+        singleton_lookup_count = SUM(ios.singleton_lookup_count),
+        row_lock_count = SUM(ios.row_lock_count),
+        row_lock_wait_count = SUM(ios.row_lock_wait_count),
+        row_lock_wait_in_ms = SUM(ios.row_lock_wait_in_ms),
+        page_lock_count = SUM(ios.page_lock_count),
+        page_lock_wait_count = SUM(ios.page_lock_wait_count),
+        page_lock_wait_in_ms = SUM(ios.page_lock_wait_in_ms),
+        index_lock_promotion_attempt_count = SUM(ios.index_lock_promotion_attempt_count),
+        index_lock_promotion_count = SUM(ios.index_lock_promotion_count),
+        page_latch_wait_count = SUM(ios.page_latch_wait_count),
+        page_latch_wait_in_ms = SUM(ios.page_latch_wait_in_ms),
+        page_io_latch_wait_count = SUM(ios.page_io_latch_wait_count),
+        page_io_latch_wait_in_ms = SUM(ios.page_io_latch_wait_in_ms)
+    FROM sys.dm_db_index_operational_stats(DB_ID(), NULL, NULL, NULL) AS ios
+    GROUP BY ios.object_id, ios.index_id
+) AS os
+  ON os.object_id = i.object_id AND os.index_id = i.index_id
+WHERE o.is_ms_shipped = 0
+AND   o.type IN (N''''U'''', N''''V'''')
+OPTION(RECOMPILE);'';';
+
+        EXECUTE sys.sp_executesql @sql;
+    END TRY
+    BEGIN CATCH
+    END CATCH;
+
+    FETCH NEXT FROM db_cursor INTO @db_name;
+END;
+
+CLOSE db_cursor;
+DEALLOCATE db_cursor;
+
+SELECT
+    sqlserver_start_time = @sqlserver_start_time,
+    x.database_name,
+    x.database_id,
+    x.schema_name,
+    x.object_id,
+    x.table_name,
+    x.index_id,
+    x.index_name,
+    x.index_type_desc,
+    x.is_unique,
+    x.is_primary_key,
+    x.is_filtered,
+    x.partition_count,
+    x.reserved_mb,
+    x.used_mb,
+    x.in_row_data_mb,
+    x.lob_data_mb,
+    x.row_overflow_mb,
+    x.total_rows,
+    x.user_seeks,
+    x.user_scans,
+    x.user_lookups,
+    x.user_updates,
+    x.last_user_seek,
+    x.last_user_scan,
+    x.last_user_lookup,
+    x.last_user_update,
+    x.leaf_insert_count,
+    x.leaf_update_count,
+    x.leaf_delete_count,
+    x.range_scan_count,
+    x.singleton_lookup_count,
+    x.row_lock_count,
+    x.row_lock_wait_count,
+    x.row_lock_wait_in_ms,
+    x.page_lock_count,
+    x.page_lock_wait_count,
+    x.page_lock_wait_in_ms,
+    x.index_lock_promotion_attempt_count,
+    x.index_lock_promotion_count,
+    x.page_latch_wait_count,
+    x.page_latch_wait_in_ms,
+    x.page_io_latch_wait_count,
+    x.page_io_latch_wait_in_ms
+FROM #ios AS x
+ORDER BY
+    x.reserved_mb DESC;";
+
+        var (exclusionClause, _) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+        onPremQuery = onPremQuery.Replace("/*EXCLUSION_FILTER_CURSOR*/", exclusionClause);
+
+        const string azureSqlDbQuery = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    sqlserver_start_time = (SELECT osi.sqlserver_start_time FROM sys.dm_os_sys_info AS osi),
+    database_name = DB_NAME(),
+    database_id = DB_ID(),
+    schema_name = s.name,
+    object_id = o.object_id,
+    table_name = o.name,
+    index_id = i.index_id,
+    index_name = i.name,
+    index_type_desc = i.type_desc,
+    is_unique = i.is_unique,
+    is_primary_key = i.is_primary_key,
+    is_filtered = i.has_filter,
+    partition_count = ps.partition_count,
+    reserved_mb = CONVERT(decimal(19,2), ps.reserved_pages * 8.0 / 1024.0),
+    used_mb = CONVERT(decimal(19,2), ps.used_pages * 8.0 / 1024.0),
+    in_row_data_mb = CONVERT(decimal(19,2), ps.in_row_pages * 8.0 / 1024.0),
+    lob_data_mb = CONVERT(decimal(19,2), ps.lob_pages * 8.0 / 1024.0),
+    row_overflow_mb = CONVERT(decimal(19,2), ps.row_overflow_pages * 8.0 / 1024.0),
+    total_rows = ps.total_rows,
+    user_seeks = us.user_seeks,
+    user_scans = us.user_scans,
+    user_lookups = us.user_lookups,
+    user_updates = us.user_updates,
+    last_user_seek = us.last_user_seek,
+    last_user_scan = us.last_user_scan,
+    last_user_lookup = us.last_user_lookup,
+    last_user_update = us.last_user_update,
+    leaf_insert_count = os.leaf_insert_count,
+    leaf_update_count = os.leaf_update_count,
+    leaf_delete_count = os.leaf_delete_count,
+    range_scan_count = os.range_scan_count,
+    singleton_lookup_count = os.singleton_lookup_count,
+    row_lock_count = os.row_lock_count,
+    row_lock_wait_count = os.row_lock_wait_count,
+    row_lock_wait_in_ms = os.row_lock_wait_in_ms,
+    page_lock_count = os.page_lock_count,
+    page_lock_wait_count = os.page_lock_wait_count,
+    page_lock_wait_in_ms = os.page_lock_wait_in_ms,
+    index_lock_promotion_attempt_count = os.index_lock_promotion_attempt_count,
+    index_lock_promotion_count = os.index_lock_promotion_count,
+    page_latch_wait_count = os.page_latch_wait_count,
+    page_latch_wait_in_ms = os.page_latch_wait_in_ms,
+    page_io_latch_wait_count = os.page_io_latch_wait_count,
+    page_io_latch_wait_in_ms = os.page_io_latch_wait_in_ms
+FROM sys.indexes AS i
+JOIN sys.objects AS o
+  ON o.object_id = i.object_id
+JOIN sys.schemas AS s
+  ON s.schema_id = o.schema_id
+LEFT JOIN
+(
+    SELECT
+        dps.object_id, dps.index_id,
+        partition_count = COUNT_BIG(*),
+        reserved_pages = SUM(dps.reserved_page_count),
+        used_pages = SUM(dps.used_page_count),
+        in_row_pages = SUM(dps.in_row_data_page_count),
+        lob_pages = SUM(dps.lob_used_page_count),
+        row_overflow_pages = SUM(dps.row_overflow_used_page_count),
+        total_rows = SUM(dps.row_count)
+    FROM sys.dm_db_partition_stats AS dps
+    GROUP BY dps.object_id, dps.index_id
+) AS ps
+  ON ps.object_id = i.object_id AND ps.index_id = i.index_id
+LEFT JOIN sys.dm_db_index_usage_stats AS us
+  ON us.database_id = DB_ID() AND us.object_id = i.object_id AND us.index_id = i.index_id
+LEFT JOIN
+(
+    SELECT
+        ios.object_id, ios.index_id,
+        leaf_insert_count = SUM(ios.leaf_insert_count),
+        leaf_update_count = SUM(ios.leaf_update_count),
+        leaf_delete_count = SUM(ios.leaf_delete_count),
+        range_scan_count = SUM(ios.range_scan_count),
+        singleton_lookup_count = SUM(ios.singleton_lookup_count),
+        row_lock_count = SUM(ios.row_lock_count),
+        row_lock_wait_count = SUM(ios.row_lock_wait_count),
+        row_lock_wait_in_ms = SUM(ios.row_lock_wait_in_ms),
+        page_lock_count = SUM(ios.page_lock_count),
+        page_lock_wait_count = SUM(ios.page_lock_wait_count),
+        page_lock_wait_in_ms = SUM(ios.page_lock_wait_in_ms),
+        index_lock_promotion_attempt_count = SUM(ios.index_lock_promotion_attempt_count),
+        index_lock_promotion_count = SUM(ios.index_lock_promotion_count),
+        page_latch_wait_count = SUM(ios.page_latch_wait_count),
+        page_latch_wait_in_ms = SUM(ios.page_latch_wait_in_ms),
+        page_io_latch_wait_count = SUM(ios.page_io_latch_wait_count),
+        page_io_latch_wait_in_ms = SUM(ios.page_io_latch_wait_in_ms)
+    FROM sys.dm_db_index_operational_stats(DB_ID(), NULL, NULL, NULL) AS ios
+    GROUP BY ios.object_id, ios.index_id
+) AS os
+  ON os.object_id = i.object_id AND os.index_id = i.index_id
+WHERE o.is_ms_shipped = 0
+AND   o.type IN (N'U', N'V')
+ORDER BY
+    reserved_mb DESC
+OPTION(RECOMPILE);";
+
+        var serverId = GetServerId(server);
+        var serverName = GetServerNameForStorage(server);
+        var collectionTime = DateTime.UtcNow;
+        var rowsCollected = 0;
+        _lastSqlMs = 0;
+        _lastDuckDbMs = 0;
+
+        var rows = new List<IndexObjectStatRow>();
+        var sqlSw = Stopwatch.StartNew();
+
+        if (isAzureSqlDb)
+        {
+            var databases = await GetAzureDatabaseListAsync(server, cancellationToken);
+            foreach (var dbName in databases)
+            {
+                try
+                {
+                    using var dbConn = await OpenAzureDatabaseConnectionAsync(server, dbName, cancellationToken);
+                    using var cmd = new SqlCommand(azureSqlDbQuery, dbConn);
+                    cmd.CommandTimeout = CommandTimeoutSeconds;
+                    using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                    while (await reader.ReadAsync(cancellationToken))
+                    {
+                        rows.Add(ReadIndexObjectStatRow(reader));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Skipping database '{Database}' for index/object stats: {Error}", dbName, ex.Message);
+                }
+            }
+        }
+        else
+        {
+            using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+            using var command = new SqlCommand(onPremQuery, sqlConnection);
+            command.CommandTimeout = CommandTimeoutSeconds;
+            var (_, exclusionParams) = BuildDatabaseExclusionFilter(server.ExcludedDatabases, "d.name");
+            foreach (var p in exclusionParams) command.Parameters.Add(p);
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                rows.Add(ReadIndexObjectStatRow(reader));
+            }
+        }
+        sqlSw.Stop();
+
+        var duckSw = Stopwatch.StartNew();
+        using (var duckConnection = _duckDb.CreateConnection())
+        {
+            await duckConnection.OpenAsync(cancellationToken);
+            using (var appender = duckConnection.CreateAppender("index_object_stats"))
+            {
+                foreach (var r in rows)
+                {
+                    appender.CreateRow()
+                       .AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(serverName)
+                       .AppendValue(r.SqlServerStartTime)
+                       .AppendValue(r.DatabaseName)
+                       .AppendValue(r.DatabaseId)
+                       .AppendValue(r.SchemaName)
+                       .AppendValue(r.ObjectId)
+                       .AppendValue(r.TableName)
+                       .AppendValue(r.IndexId)
+                       .AppendValue(r.IndexName)
+                       .AppendValue(r.IndexTypeDesc)
+                       .AppendValue(r.IsUnique)
+                       .AppendValue(r.IsPrimaryKey)
+                       .AppendValue(r.IsFiltered)
+                       .AppendValue(r.PartitionCount)
+                       .AppendValue(r.ReservedMb)
+                       .AppendValue(r.UsedMb)
+                       .AppendValue(r.InRowDataMb)
+                       .AppendValue(r.LobDataMb)
+                       .AppendValue(r.RowOverflowMb)
+                       .AppendValue(r.TotalRows)
+                       .AppendValue(r.UserSeeks)
+                       .AppendValue(r.UserScans)
+                       .AppendValue(r.UserLookups)
+                       .AppendValue(r.UserUpdates)
+                       .AppendValue(r.LastUserSeek)
+                       .AppendValue(r.LastUserScan)
+                       .AppendValue(r.LastUserLookup)
+                       .AppendValue(r.LastUserUpdate)
+                       .AppendValue(r.LeafInsertCount)
+                       .AppendValue(r.LeafUpdateCount)
+                       .AppendValue(r.LeafDeleteCount)
+                       .AppendValue(r.RangeScanCount)
+                       .AppendValue(r.SingletonLookupCount)
+                       .AppendValue(r.RowLockCount)
+                       .AppendValue(r.RowLockWaitCount)
+                       .AppendValue(r.RowLockWaitInMs)
+                       .AppendValue(r.PageLockCount)
+                       .AppendValue(r.PageLockWaitCount)
+                       .AppendValue(r.PageLockWaitInMs)
+                       .AppendValue(r.IndexLockPromotionAttemptCount)
+                       .AppendValue(r.IndexLockPromotionCount)
+                       .AppendValue(r.PageLatchWaitCount)
+                       .AppendValue(r.PageLatchWaitInMs)
+                       .AppendValue(r.PageIoLatchWaitCount)
+                       .AppendValue(r.PageIoLatchWaitInMs)
+                       .EndRow();
+                    rowsCollected++;
+                }
+            }
+        }
+        duckSw.Stop();
+
+        _lastSqlMs = sqlSw.ElapsedMilliseconds;
+        _lastDuckDbMs = duckSw.ElapsedMilliseconds;
+
+        _logger?.LogDebug("Collected {RowCount} index/object stat rows for server '{Server}'", rowsCollected, server.DisplayName);
+        return rowsCollected;
+    }
+
+    private static IndexObjectStatRow ReadIndexObjectStatRow(SqlDataReader reader)
+    {
+        long? L(int i) => reader.IsDBNull(i) ? null : Convert.ToInt64(reader.GetValue(i));
+        int? I(int i) => reader.IsDBNull(i) ? null : Convert.ToInt32(reader.GetValue(i));
+        decimal? D(int i) => reader.IsDBNull(i) ? null : reader.GetDecimal(i);
+        DateTime? T(int i) => reader.IsDBNull(i) ? null : reader.GetDateTime(i);
+        bool? B(int i) => reader.IsDBNull(i) ? null : (bool?)(Convert.ToInt32(reader.GetValue(i)) == 1);
+
+        return new IndexObjectStatRow
+        {
+            SqlServerStartTime = T(0),
+            DatabaseName = reader.GetString(1),
+            DatabaseId = Convert.ToInt32(reader.GetValue(2)),
+            SchemaName = reader.GetString(3),
+            ObjectId = Convert.ToInt32(reader.GetValue(4)),
+            TableName = reader.GetString(5),
+            IndexId = Convert.ToInt32(reader.GetValue(6)),
+            IndexName = reader.IsDBNull(7) ? null : reader.GetString(7),
+            IndexTypeDesc = reader.IsDBNull(8) ? null : reader.GetString(8),
+            IsUnique = B(9),
+            IsPrimaryKey = B(10),
+            IsFiltered = B(11),
+            PartitionCount = I(12),
+            ReservedMb = D(13),
+            UsedMb = D(14),
+            InRowDataMb = D(15),
+            LobDataMb = D(16),
+            RowOverflowMb = D(17),
+            TotalRows = L(18),
+            UserSeeks = L(19),
+            UserScans = L(20),
+            UserLookups = L(21),
+            UserUpdates = L(22),
+            LastUserSeek = T(23),
+            LastUserScan = T(24),
+            LastUserLookup = T(25),
+            LastUserUpdate = T(26),
+            LeafInsertCount = L(27),
+            LeafUpdateCount = L(28),
+            LeafDeleteCount = L(29),
+            RangeScanCount = L(30),
+            SingletonLookupCount = L(31),
+            RowLockCount = L(32),
+            RowLockWaitCount = L(33),
+            RowLockWaitInMs = L(34),
+            PageLockCount = L(35),
+            PageLockWaitCount = L(36),
+            PageLockWaitInMs = L(37),
+            IndexLockPromotionAttemptCount = L(38),
+            IndexLockPromotionCount = L(39),
+            PageLatchWaitCount = L(40),
+            PageLatchWaitInMs = L(41),
+            PageIoLatchWaitCount = L(42),
+            PageIoLatchWaitInMs = L(43)
+        };
+    }
+
+    private sealed class IndexObjectStatRow
+    {
+        public DateTime? SqlServerStartTime { get; set; }
+        public string DatabaseName { get; set; } = "";
+        public int DatabaseId { get; set; }
+        public string SchemaName { get; set; } = "";
+        public int ObjectId { get; set; }
+        public string TableName { get; set; } = "";
+        public int IndexId { get; set; }
+        public string? IndexName { get; set; }
+        public string? IndexTypeDesc { get; set; }
+        public bool? IsUnique { get; set; }
+        public bool? IsPrimaryKey { get; set; }
+        public bool? IsFiltered { get; set; }
+        public int? PartitionCount { get; set; }
+        public decimal? ReservedMb { get; set; }
+        public decimal? UsedMb { get; set; }
+        public decimal? InRowDataMb { get; set; }
+        public decimal? LobDataMb { get; set; }
+        public decimal? RowOverflowMb { get; set; }
+        public long? TotalRows { get; set; }
+        public long? UserSeeks { get; set; }
+        public long? UserScans { get; set; }
+        public long? UserLookups { get; set; }
+        public long? UserUpdates { get; set; }
+        public DateTime? LastUserSeek { get; set; }
+        public DateTime? LastUserScan { get; set; }
+        public DateTime? LastUserLookup { get; set; }
+        public DateTime? LastUserUpdate { get; set; }
+        public long? LeafInsertCount { get; set; }
+        public long? LeafUpdateCount { get; set; }
+        public long? LeafDeleteCount { get; set; }
+        public long? RangeScanCount { get; set; }
+        public long? SingletonLookupCount { get; set; }
+        public long? RowLockCount { get; set; }
+        public long? RowLockWaitCount { get; set; }
+        public long? RowLockWaitInMs { get; set; }
+        public long? PageLockCount { get; set; }
+        public long? PageLockWaitCount { get; set; }
+        public long? PageLockWaitInMs { get; set; }
+        public long? IndexLockPromotionAttemptCount { get; set; }
+        public long? IndexLockPromotionCount { get; set; }
+        public long? PageLatchWaitCount { get; set; }
+        public long? PageLatchWaitInMs { get; set; }
+        public long? PageIoLatchWaitCount { get; set; }
+        public long? PageIoLatchWaitInMs { get; set; }
+    }
+}

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -501,6 +501,7 @@ public partial class RemoteCollectorService
                 "trace_flags" => await CollectTraceFlagsAsync(server, cancellationToken),
                 "running_jobs" => await CollectRunningJobsAsync(server, cancellationToken),
                 "database_size_stats" => await CollectDatabaseSizeStatsAsync(server, cancellationToken),
+                "index_object_stats" => await CollectIndexObjectStatsAsync(server, cancellationToken),
                 "server_properties" => await CollectServerPropertiesAsync(server, cancellationToken),
                 "session_stats" => await CollectSessionStatsAsync(server, cancellationToken),
                 _ => throw new ArgumentException($"Unknown collector: {collectorName}")

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -755,6 +755,7 @@ public class ScheduleManager
             new() { Name = "trace_flags", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Active trace flags via DBCC TRACESTATUS (on-load only)" },
             new() { Name = "running_jobs", Enabled = true, FrequencyMinutes = 5, RetentionDays = 7, Description = "Currently running SQL Agent jobs with duration comparison" },
             new() { Name = "database_size_stats", Enabled = true, FrequencyMinutes = 60, RetentionDays = 90, Description = "Database file sizes for growth trending and capacity planning" },
+            new() { Name = "index_object_stats", Enabled = true, FrequencyMinutes = 1440, RetentionDays = 90, Description = "Per-object table/index size, usage, and locking stats for growth, unused-index, and contention analysis (daily collection)" },
             new() { Name = "server_properties", Enabled = true, FrequencyMinutes = 0, RetentionDays = 365, Description = "Server edition, licensing, CPU/memory hardware metadata (on-load only)" },
             new() { Name = "session_stats", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Per-application session counts from sys.dm_exec_sessions" }
         };

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -626,6 +626,22 @@ public static class FactAdvice
             Remediation:
                 "Match the fix to the shape. Buffer-pool-driven (PLE crash): find the scan and add the missing index — the PERFMON_PLE playbook applies, `top_cpu_queries` ordered by `logical_reads` per execution names the candidates. Grant-driven: the offender is consuming a too-large grant because of a bad cardinality estimate — `analyze_query_plan` on the worst `query_hash` shows the estimate-vs-actual divergence, FULLSCAN statistics or a filtered index fixes it. Anomalies that resolve on their own are typically one-time reporting queries; sustained ones become standard PERFMON_PLE or RESOURCE_SEMAPHORE findings on the next window.");
 
+        t["ANOMALY_OBJECT_GROWTH"] = new AdviceBlock(
+            Headline:
+                "A table grew sharply day-over-day — its reserved size jumped well above its recent footprint",
+            Investigation:
+                "Computed from the two most recent daily index/object-size snapshots: the named table's total reserved MB (all indexes summed) rose by more than the trip threshold in both percentage and absolute terms. The finding's metadata carries `database_name`, `schema_table`, `prior_mb`, `current_mb`, `growth_mb`, and `growth_pct`. Open FinOps → Object Sizes & Growth and sort by Growth 30d / Daily Rate to see the trend and the next-largest growers; call `get_table_index_sizes` for the full ranked list. Distinguish a one-time load (archive import, backfill, index rebuild that temporarily doubles space) from sustained organic growth — the daily-rate column over several days tells you which.",
+            Remediation:
+                "If it's expected load, no action beyond capacity awareness — confirm the volume has headroom (FinOps → Database Sizes shows volume free space). If it's unexpected: check for a runaway process inserting without cleanup, a disabled or broken purge job, an index rebuild leaving the old allocation, or a heap that needs a clustered index. For genuinely large, fast-growing tables, evaluate PAGE compression and partitioning. Persistent steep growth against limited volume free space is the early warning for an out-of-space outage — act before the file fills.");
+
+        t["ANOMALY_OBJECT_CONTENTION"] = new AdviceBlock(
+            Headline:
+                "An index accrued significant new lock-wait time — contention on this object jumped since the last snapshot",
+            Investigation:
+                "Computed from consecutive daily index/object snapshots (same instance start time, so not a counter reset): the named index's cumulative row-lock wait time grew by more than the trip threshold day-over-day. Metadata carries `database_name`, `schema_table`, `index_name`, `lock_wait_ms_delta`, and `escalation_delta`. Open FinOps → Locking & Contention to see this object and the other top-contended indexes; call `get_object_locking` for the ranked list. Cross-reference Blocking → Blocked Process Reports for the same window to see the actual blocking chains, and check whether a lock-escalation spike (`escalation_delta`) accompanied it — escalation to a table lock serializes the whole object.",
+            Remediation:
+                "Find the queries hitting this object (Query Performance filtered to the database/table) and reduce how long they hold locks: shorten transactions, add the missing index so writers touch fewer rows, or batch large modifications. Reader/writer contention (S vs X) is eliminated by RCSI on the database. If lock escalation is the driver, either fix the query touching too many rows or, as a last resort, disable escalation on the specific table (ALTER TABLE ... SET (LOCK_ESCALATION = DISABLE)) after confirming memory headroom for the extra row locks.");
+
         return t;
     }
 }

--- a/PerformanceMonitor.Analysis/FactScorer.cs
+++ b/PerformanceMonitor.Analysis/FactScorer.cs
@@ -431,6 +431,22 @@ public class FactScorer
             return 0.5 + 0.5 * Math.Min((ratio - 3.0) / 7.0, 1.0);
         }
 
+        if (fact.Key.StartsWith("ANOMALY_OBJECT_GROWTH", StringComparison.OrdinalIgnoreCase))
+        {
+            // Ratio of growth vs the trip threshold: 1x = 0.4, 5x = 1.0 (day-over-day table growth)
+            var ratio = fact.Metadata.GetValueOrDefault("growth_ratio");
+            if (ratio < 1.0) return 0.0;
+            return 0.4 + 0.6 * Math.Min((ratio - 1.0) / 4.0, 1.0);
+        }
+
+        if (fact.Key.StartsWith("ANOMALY_OBJECT_CONTENTION", StringComparison.OrdinalIgnoreCase))
+        {
+            // Ratio of new lock-wait ms vs the trip threshold: 1x = 0.4, 10x = 1.0
+            var ratio = fact.Metadata.GetValueOrDefault("contention_ratio");
+            if (ratio < 1.0) return 0.0;
+            return 0.4 + 0.6 * Math.Min((ratio - 1.0) / 9.0, 1.0);
+        }
+
         return 0.0;
     }
 

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1476,6 +1476,84 @@ BEGIN
 END;
 
 /*
+Index/Object Statistics Table (FinOps)
+Per-table and per-index size, usage, and locking stats for growth trending,
+unused-index detection, and contention analysis. Size columns are absolute
+point-in-time values; usage and locking counters are cumulative (reset on
+instance restart / DB detach / AUTO_CLOSE) - sqlserver_start_time carries the
+reset boundary so deltas can be computed safely in the read layer.
+*/
+IF OBJECT_ID(N'collect.index_object_stats', N'U') IS NULL
+BEGIN
+    CREATE TABLE
+        collect.index_object_stats
+    (
+        collection_id bigint IDENTITY NOT NULL,
+        collection_time datetime2(7) NOT NULL
+            DEFAULT SYSDATETIME(),
+        sqlserver_start_time datetime2(7) NULL,
+        database_name sysname NOT NULL,
+        database_id integer NOT NULL,
+        schema_name sysname NOT NULL,
+        object_id integer NOT NULL,
+        table_name sysname NOT NULL,
+        index_id integer NOT NULL,
+        index_name sysname NULL,
+        index_type_desc nvarchar(60) NULL,
+        is_unique bit NULL,
+        is_primary_key bit NULL,
+        is_filtered bit NULL,
+        partition_count integer NULL,
+        reserved_mb decimal(19,2) NULL,
+        used_mb decimal(19,2) NULL,
+        in_row_data_mb decimal(19,2) NULL,
+        lob_data_mb decimal(19,2) NULL,
+        row_overflow_mb decimal(19,2) NULL,
+        total_rows bigint NULL,
+        user_seeks bigint NULL,
+        user_scans bigint NULL,
+        user_lookups bigint NULL,
+        user_updates bigint NULL,
+        last_user_seek datetime2(7) NULL,
+        last_user_scan datetime2(7) NULL,
+        last_user_lookup datetime2(7) NULL,
+        last_user_update datetime2(7) NULL,
+        leaf_insert_count bigint NULL,
+        leaf_update_count bigint NULL,
+        leaf_delete_count bigint NULL,
+        range_scan_count bigint NULL,
+        singleton_lookup_count bigint NULL,
+        row_lock_count bigint NULL,
+        row_lock_wait_count bigint NULL,
+        row_lock_wait_in_ms bigint NULL,
+        page_lock_count bigint NULL,
+        page_lock_wait_count bigint NULL,
+        page_lock_wait_in_ms bigint NULL,
+        index_lock_promotion_attempt_count bigint NULL,
+        index_lock_promotion_count bigint NULL,
+        page_latch_wait_count bigint NULL,
+        page_latch_wait_in_ms bigint NULL,
+        page_io_latch_wait_count bigint NULL,
+        page_io_latch_wait_in_ms bigint NULL,
+        /*Analysis helpers - computed columns*/
+        total_reads AS
+        (
+            ISNULL(user_seeks, 0) +
+            ISNULL(user_scans, 0) +
+            ISNULL(user_lookups, 0)
+        ),
+        CONSTRAINT
+            PK_index_object_stats
+        PRIMARY KEY CLUSTERED
+            (collection_time, collection_id)
+        WITH
+            (DATA_COMPRESSION = PAGE)
+    );
+
+    PRINT 'Created collect.index_object_stats table';
+END;
+
+/*
 Server Properties Table (FinOps)
 */
 IF OBJECT_ID(N'collect.server_properties', N'U') IS NULL
@@ -1592,6 +1670,26 @@ BEGIN
         (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
     EXEC sys.sp_executesql @index_sql;
     PRINT 'Created collect.query_store_data.IX_query_store_data_id_lookup index';
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'collect.index_object_stats')
+    AND   name = N'IX_index_object_stats_object_lookup'
+)
+BEGIN
+    SET @index_sql = N'
+    CREATE NONCLUSTERED INDEX
+        IX_index_object_stats_object_lookup
+    ON collect.index_object_stats
+        (database_name, object_id, index_id, collection_time DESC)
+    WITH
+        (SORT_IN_TEMPDB = ON, DATA_COMPRESSION = PAGE' + @online_option + N');';
+    EXEC sys.sp_executesql @index_sql;
+    PRINT 'Created collect.index_object_stats.IX_index_object_stats_object_lookup index';
 END;
 
 PRINT 'All collection tables created successfully';

--- a/install/04_create_schedule_table.sql
+++ b/install/04_create_schedule_table.sql
@@ -76,6 +76,7 @@ FROM
     (N'waiting_tasks_collector', 1, 1, 2, 30, N'Currently waiting tasks - blocking chains and wait analysis'),
     (N'running_jobs_collector', 1, 1, 2, 7, N'Currently running SQL Agent jobs with historical duration comparison'),
     (N'database_size_stats_collector', 1, 60, 10, 90, N'Database file sizes for growth trending and capacity planning'),
+    (N'index_object_stats_collector', 1, 1440, 15, 90, N'Per-object table/index size, usage, and locking stats for growth, unused-index, and contention analysis (daily collection)'),
     (N'server_properties_collector', 1, 1440, 5, 365, N'Server edition, licensing, CPU/memory hardware metadata for license audit')
 ) AS v (collector_name, enabled, frequency_minutes, max_duration_minutes, retention_days, description)
 WHERE NOT EXISTS

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -1134,6 +1134,73 @@ BEGIN
             );
 
         END;
+        ELSE IF @table_name = N'index_object_stats'
+        BEGIN
+            CREATE TABLE
+                collect.index_object_stats
+            (
+                collection_id bigint IDENTITY NOT NULL,
+                collection_time datetime2(7) NOT NULL
+                    DEFAULT SYSDATETIME(),
+                sqlserver_start_time datetime2(7) NULL,
+                database_name sysname NOT NULL,
+                database_id integer NOT NULL,
+                schema_name sysname NOT NULL,
+                object_id integer NOT NULL,
+                table_name sysname NOT NULL,
+                index_id integer NOT NULL,
+                index_name sysname NULL,
+                index_type_desc nvarchar(60) NULL,
+                is_unique bit NULL,
+                is_primary_key bit NULL,
+                is_filtered bit NULL,
+                partition_count integer NULL,
+                reserved_mb decimal(19,2) NULL,
+                used_mb decimal(19,2) NULL,
+                in_row_data_mb decimal(19,2) NULL,
+                lob_data_mb decimal(19,2) NULL,
+                row_overflow_mb decimal(19,2) NULL,
+                total_rows bigint NULL,
+                user_seeks bigint NULL,
+                user_scans bigint NULL,
+                user_lookups bigint NULL,
+                user_updates bigint NULL,
+                last_user_seek datetime2(7) NULL,
+                last_user_scan datetime2(7) NULL,
+                last_user_lookup datetime2(7) NULL,
+                last_user_update datetime2(7) NULL,
+                leaf_insert_count bigint NULL,
+                leaf_update_count bigint NULL,
+                leaf_delete_count bigint NULL,
+                range_scan_count bigint NULL,
+                singleton_lookup_count bigint NULL,
+                row_lock_count bigint NULL,
+                row_lock_wait_count bigint NULL,
+                row_lock_wait_in_ms bigint NULL,
+                page_lock_count bigint NULL,
+                page_lock_wait_count bigint NULL,
+                page_lock_wait_in_ms bigint NULL,
+                index_lock_promotion_attempt_count bigint NULL,
+                index_lock_promotion_count bigint NULL,
+                page_latch_wait_count bigint NULL,
+                page_latch_wait_in_ms bigint NULL,
+                page_io_latch_wait_count bigint NULL,
+                page_io_latch_wait_in_ms bigint NULL,
+                total_reads AS
+                (
+                    ISNULL(user_seeks, 0) +
+                    ISNULL(user_scans, 0) +
+                    ISNULL(user_lookups, 0)
+                ),
+                CONSTRAINT
+                    PK_index_object_stats
+                PRIMARY KEY CLUSTERED
+                    (collection_time, collection_id)
+                WITH
+                    (DATA_COMPRESSION = PAGE)
+            );
+
+        END;
         ELSE IF @table_name = N'server_properties'
         BEGIN
             CREATE TABLE
@@ -1172,7 +1239,7 @@ BEGIN
         END;
         ELSE
         BEGIN
-            SET @error_message = N'Unknown table name: ' + @table_name + N'. Valid table names are: wait_stats, query_stats, memory_stats, memory_pressure_events, deadlock_xml, blocked_process_xml, procedure_stats, query_snapshots, query_store_data, trace_analysis, default_trace_events, file_io_stats, memory_grant_stats, cpu_scheduler_stats, memory_clerks_stats, perfmon_stats, cpu_utilization_stats, blocking_deadlock_stats, latch_stats, spinlock_stats, tempdb_stats, plan_cache_stats, session_stats, waiting_tasks, running_jobs, database_size_stats, server_properties';
+            SET @error_message = N'Unknown table name: ' + @table_name + N'. Valid table names are: wait_stats, query_stats, memory_stats, memory_pressure_events, deadlock_xml, blocked_process_xml, procedure_stats, query_snapshots, query_store_data, trace_analysis, default_trace_events, file_io_stats, memory_grant_stats, cpu_scheduler_stats, memory_clerks_stats, perfmon_stats, cpu_utilization_stats, blocking_deadlock_stats, latch_stats, spinlock_stats, tempdb_stats, plan_cache_stats, session_stats, waiting_tasks, running_jobs, database_size_stats, index_object_stats, server_properties';
             RAISERROR(@error_message, 16, 1);
             RETURN;
         END;

--- a/install/42_scheduled_master_collector.sql
+++ b/install/42_scheduled_master_collector.sql
@@ -325,6 +325,10 @@ BEGIN
                 BEGIN
                     EXECUTE collect.database_size_stats_collector @debug = @debug;
                 END;
+                ELSE IF @collector_name = N'index_object_stats_collector'
+                BEGIN
+                    EXECUTE collect.index_object_stats_collector @debug = @debug;
+                END;
                 ELSE IF @collector_name = N'server_properties_collector'
                 BEGIN
                     EXECUTE collect.server_properties_collector @debug = @debug;

--- a/install/55_collect_index_object_stats.sql
+++ b/install/55_collect_index_object_stats.sql
@@ -1,0 +1,581 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+/*******************************************************************************
+Collector: index_object_stats_collector
+Purpose: Captures per-table and per-index size, usage, and locking statistics
+         for growth trending, unused-index detection, and contention analysis.
+Collection Type: Point-in-time snapshot for sizes; cumulative counters for
+         usage/locking (deltas derived in the read layer using
+         sqlserver_start_time as the reset boundary).
+Target Table: collect.index_object_stats
+Frequency: Every 1440 minutes (daily) - object grain is high volume.
+Dependencies: sys.dm_db_partition_stats, sys.dm_db_index_usage_stats,
+         sys.dm_db_index_operational_stats, sys.indexes, sys.objects, sys.schemas
+Notes: All three DMVs are database-scoped, so the full join executes inside each
+       database's context via dynamic SQL. Azure SQL DB (engine edition 5)
+       collects only the connected database (no cross-database enumeration).
+       In-Memory OLTP (Hekaton) objects are not represented by these DMVs.
+*******************************************************************************/
+
+IF OBJECT_ID(N'collect.index_object_stats_collector', N'P') IS NULL
+BEGIN
+    EXECUTE(N'CREATE PROCEDURE collect.index_object_stats_collector AS RETURN 138;');
+END;
+GO
+
+ALTER PROCEDURE
+    collect.index_object_stats_collector
+(
+    @debug bit = 0 /*Print debugging information*/
+)
+WITH RECOMPILE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+    DECLARE
+        @rows_collected bigint = 0,
+        @start_time datetime2(7) = SYSDATETIME(),
+        @sqlserver_start_time datetime2(7),
+        @error_message nvarchar(4000),
+        @engine_edition integer =
+            CONVERT(integer, SERVERPROPERTY(N'EngineEdition'));
+
+    BEGIN TRY
+        /*
+        Ensure target table exists
+        */
+        IF OBJECT_ID(N'collect.index_object_stats', N'U') IS NULL
+        BEGIN
+            INSERT INTO
+                config.collection_log
+            (
+                collection_time,
+                collector_name,
+                collection_status,
+                rows_collected,
+                duration_ms,
+                error_message
+            )
+            VALUES
+            (
+                @start_time,
+                N'index_object_stats_collector',
+                N'TABLE_MISSING',
+                0,
+                0,
+                N'Table collect.index_object_stats does not exist, calling ensure procedure'
+            );
+
+            EXECUTE config.ensure_collection_table
+                @table_name = N'index_object_stats',
+                @debug = @debug;
+
+            IF OBJECT_ID(N'collect.index_object_stats', N'U') IS NULL
+            BEGIN
+                RAISERROR(N'Table collect.index_object_stats still missing after ensure procedure', 16, 1);
+                RETURN;
+            END;
+        END;
+
+        /*
+        Reset boundary for cumulative usage/locking counters
+        */
+        SELECT
+            @sqlserver_start_time = osi.sqlserver_start_time
+        FROM sys.dm_os_sys_info AS osi;
+
+        /*
+        Azure SQL DB: single database scope (no cross-database enumeration)
+        */
+        IF @engine_edition = 5
+        BEGIN
+            INSERT INTO
+                collect.index_object_stats
+            (
+                collection_time,
+                sqlserver_start_time,
+                database_name,
+                database_id,
+                schema_name,
+                object_id,
+                table_name,
+                index_id,
+                index_name,
+                index_type_desc,
+                is_unique,
+                is_primary_key,
+                is_filtered,
+                partition_count,
+                reserved_mb,
+                used_mb,
+                in_row_data_mb,
+                lob_data_mb,
+                row_overflow_mb,
+                total_rows,
+                user_seeks,
+                user_scans,
+                user_lookups,
+                user_updates,
+                last_user_seek,
+                last_user_scan,
+                last_user_lookup,
+                last_user_update,
+                leaf_insert_count,
+                leaf_update_count,
+                leaf_delete_count,
+                range_scan_count,
+                singleton_lookup_count,
+                row_lock_count,
+                row_lock_wait_count,
+                row_lock_wait_in_ms,
+                page_lock_count,
+                page_lock_wait_count,
+                page_lock_wait_in_ms,
+                index_lock_promotion_attempt_count,
+                index_lock_promotion_count,
+                page_latch_wait_count,
+                page_latch_wait_in_ms,
+                page_io_latch_wait_count,
+                page_io_latch_wait_in_ms
+            )
+            SELECT
+                collection_time = @start_time,
+                sqlserver_start_time = @sqlserver_start_time,
+                database_name = DB_NAME(),
+                database_id = DB_ID(),
+                schema_name = s.name,
+                object_id = o.object_id,
+                table_name = o.name,
+                index_id = i.index_id,
+                index_name = i.name,
+                index_type_desc = i.type_desc,
+                is_unique = i.is_unique,
+                is_primary_key = i.is_primary_key,
+                is_filtered = i.has_filter,
+                partition_count = ps.partition_count,
+                reserved_mb = CONVERT(decimal(19,2), ps.reserved_pages * 8.0 / 1024.0),
+                used_mb = CONVERT(decimal(19,2), ps.used_pages * 8.0 / 1024.0),
+                in_row_data_mb = CONVERT(decimal(19,2), ps.in_row_pages * 8.0 / 1024.0),
+                lob_data_mb = CONVERT(decimal(19,2), ps.lob_pages * 8.0 / 1024.0),
+                row_overflow_mb = CONVERT(decimal(19,2), ps.row_overflow_pages * 8.0 / 1024.0),
+                total_rows = ps.total_rows,
+                user_seeks = us.user_seeks,
+                user_scans = us.user_scans,
+                user_lookups = us.user_lookups,
+                user_updates = us.user_updates,
+                last_user_seek = us.last_user_seek,
+                last_user_scan = us.last_user_scan,
+                last_user_lookup = us.last_user_lookup,
+                last_user_update = us.last_user_update,
+                leaf_insert_count = os.leaf_insert_count,
+                leaf_update_count = os.leaf_update_count,
+                leaf_delete_count = os.leaf_delete_count,
+                range_scan_count = os.range_scan_count,
+                singleton_lookup_count = os.singleton_lookup_count,
+                row_lock_count = os.row_lock_count,
+                row_lock_wait_count = os.row_lock_wait_count,
+                row_lock_wait_in_ms = os.row_lock_wait_in_ms,
+                page_lock_count = os.page_lock_count,
+                page_lock_wait_count = os.page_lock_wait_count,
+                page_lock_wait_in_ms = os.page_lock_wait_in_ms,
+                index_lock_promotion_attempt_count = os.index_lock_promotion_attempt_count,
+                index_lock_promotion_count = os.index_lock_promotion_count,
+                page_latch_wait_count = os.page_latch_wait_count,
+                page_latch_wait_in_ms = os.page_latch_wait_in_ms,
+                page_io_latch_wait_count = os.page_io_latch_wait_count,
+                page_io_latch_wait_in_ms = os.page_io_latch_wait_in_ms
+            FROM sys.indexes AS i
+            JOIN sys.objects AS o
+              ON o.object_id = i.object_id
+            JOIN sys.schemas AS s
+              ON s.schema_id = o.schema_id
+            LEFT JOIN
+            (
+                SELECT
+                    dps.object_id,
+                    dps.index_id,
+                    partition_count = COUNT_BIG(*),
+                    reserved_pages = SUM(dps.reserved_page_count),
+                    used_pages = SUM(dps.used_page_count),
+                    in_row_pages = SUM(dps.in_row_data_page_count),
+                    lob_pages = SUM(dps.lob_used_page_count),
+                    row_overflow_pages = SUM(dps.row_overflow_used_page_count),
+                    total_rows = SUM(dps.row_count)
+                FROM sys.dm_db_partition_stats AS dps
+                GROUP BY
+                    dps.object_id,
+                    dps.index_id
+            ) AS ps
+              ON  ps.object_id = i.object_id
+              AND ps.index_id = i.index_id
+            LEFT JOIN sys.dm_db_index_usage_stats AS us
+              ON  us.database_id = DB_ID()
+              AND us.object_id = i.object_id
+              AND us.index_id = i.index_id
+            LEFT JOIN
+            (
+                SELECT
+                    ios.object_id,
+                    ios.index_id,
+                    leaf_insert_count = SUM(ios.leaf_insert_count),
+                    leaf_update_count = SUM(ios.leaf_update_count),
+                    leaf_delete_count = SUM(ios.leaf_delete_count),
+                    range_scan_count = SUM(ios.range_scan_count),
+                    singleton_lookup_count = SUM(ios.singleton_lookup_count),
+                    row_lock_count = SUM(ios.row_lock_count),
+                    row_lock_wait_count = SUM(ios.row_lock_wait_count),
+                    row_lock_wait_in_ms = SUM(ios.row_lock_wait_in_ms),
+                    page_lock_count = SUM(ios.page_lock_count),
+                    page_lock_wait_count = SUM(ios.page_lock_wait_count),
+                    page_lock_wait_in_ms = SUM(ios.page_lock_wait_in_ms),
+                    index_lock_promotion_attempt_count = SUM(ios.index_lock_promotion_attempt_count),
+                    index_lock_promotion_count = SUM(ios.index_lock_promotion_count),
+                    page_latch_wait_count = SUM(ios.page_latch_wait_count),
+                    page_latch_wait_in_ms = SUM(ios.page_latch_wait_in_ms),
+                    page_io_latch_wait_count = SUM(ios.page_io_latch_wait_count),
+                    page_io_latch_wait_in_ms = SUM(ios.page_io_latch_wait_in_ms)
+                FROM sys.dm_db_index_operational_stats(DB_ID(), NULL, NULL, NULL) AS ios
+                GROUP BY
+                    ios.object_id,
+                    ios.index_id
+            ) AS os
+              ON  os.object_id = i.object_id
+              AND os.index_id = i.index_id
+            WHERE o.is_ms_shipped = 0
+            AND   o.type IN (N'U', N'V')
+            OPTION(RECOMPILE);
+
+            SET @rows_collected = ROWCOUNT_BIG();
+        END;
+        ELSE
+        BEGIN
+            /*
+            On-prem / Azure MI / AWS RDS: cursor over all online databases.
+            All three DMVs are database-scoped, so the entire join runs inside
+            each database's context and inserts into the fully-qualified target.
+            */
+            DECLARE
+                @db_name sysname,
+                @db_id integer,
+                @sql nvarchar(max),
+                @exec_sql nvarchar(max);
+
+            DECLARE db_cursor CURSOR LOCAL FAST_FORWARD FOR
+                SELECT
+                    d.name,
+                    d.database_id
+                FROM sys.databases AS d
+                WHERE d.state = 0 /*ONLINE only - skip RESTORING (mirroring/AG secondary)*/
+                AND   d.database_id > 0
+                AND   HAS_DBACCESS(d.name) = 1
+                AND   NOT EXISTS
+                (
+                    SELECT
+                        1/0
+                    FROM config.collector_database_exclusions AS e
+                    WHERE e.database_name = d.name
+                )
+                ORDER BY
+                    d.database_id;
+
+            OPEN db_cursor;
+            FETCH NEXT FROM db_cursor INTO @db_name, @db_id;
+
+            WHILE @@FETCH_STATUS = 0
+            BEGIN
+                BEGIN TRY
+                    SET @sql = N'
+                    INSERT INTO
+                        PerformanceMonitor.collect.index_object_stats
+                    (
+                        collection_time,
+                        sqlserver_start_time,
+                        database_name,
+                        database_id,
+                        schema_name,
+                        object_id,
+                        table_name,
+                        index_id,
+                        index_name,
+                        index_type_desc,
+                        is_unique,
+                        is_primary_key,
+                        is_filtered,
+                        partition_count,
+                        reserved_mb,
+                        used_mb,
+                        in_row_data_mb,
+                        lob_data_mb,
+                        row_overflow_mb,
+                        total_rows,
+                        user_seeks,
+                        user_scans,
+                        user_lookups,
+                        user_updates,
+                        last_user_seek,
+                        last_user_scan,
+                        last_user_lookup,
+                        last_user_update,
+                        leaf_insert_count,
+                        leaf_update_count,
+                        leaf_delete_count,
+                        range_scan_count,
+                        singleton_lookup_count,
+                        row_lock_count,
+                        row_lock_wait_count,
+                        row_lock_wait_in_ms,
+                        page_lock_count,
+                        page_lock_wait_count,
+                        page_lock_wait_in_ms,
+                        index_lock_promotion_attempt_count,
+                        index_lock_promotion_count,
+                        page_latch_wait_count,
+                        page_latch_wait_in_ms,
+                        page_io_latch_wait_count,
+                        page_io_latch_wait_in_ms
+                    )
+                    SELECT
+                        collection_time = @start_time,
+                        sqlserver_start_time = @sqlserver_start_time,
+                        database_name = DB_NAME(),
+                        database_id = DB_ID(),
+                        schema_name = s.name,
+                        object_id = o.object_id,
+                        table_name = o.name,
+                        index_id = i.index_id,
+                        index_name = i.name,
+                        index_type_desc = i.type_desc,
+                        is_unique = i.is_unique,
+                        is_primary_key = i.is_primary_key,
+                        is_filtered = i.has_filter,
+                        partition_count = ps.partition_count,
+                        reserved_mb = CONVERT(decimal(19,2), ps.reserved_pages * 8.0 / 1024.0),
+                        used_mb = CONVERT(decimal(19,2), ps.used_pages * 8.0 / 1024.0),
+                        in_row_data_mb = CONVERT(decimal(19,2), ps.in_row_pages * 8.0 / 1024.0),
+                        lob_data_mb = CONVERT(decimal(19,2), ps.lob_pages * 8.0 / 1024.0),
+                        row_overflow_mb = CONVERT(decimal(19,2), ps.row_overflow_pages * 8.0 / 1024.0),
+                        total_rows = ps.total_rows,
+                        user_seeks = us.user_seeks,
+                        user_scans = us.user_scans,
+                        user_lookups = us.user_lookups,
+                        user_updates = us.user_updates,
+                        last_user_seek = us.last_user_seek,
+                        last_user_scan = us.last_user_scan,
+                        last_user_lookup = us.last_user_lookup,
+                        last_user_update = us.last_user_update,
+                        leaf_insert_count = os.leaf_insert_count,
+                        leaf_update_count = os.leaf_update_count,
+                        leaf_delete_count = os.leaf_delete_count,
+                        range_scan_count = os.range_scan_count,
+                        singleton_lookup_count = os.singleton_lookup_count,
+                        row_lock_count = os.row_lock_count,
+                        row_lock_wait_count = os.row_lock_wait_count,
+                        row_lock_wait_in_ms = os.row_lock_wait_in_ms,
+                        page_lock_count = os.page_lock_count,
+                        page_lock_wait_count = os.page_lock_wait_count,
+                        page_lock_wait_in_ms = os.page_lock_wait_in_ms,
+                        index_lock_promotion_attempt_count = os.index_lock_promotion_attempt_count,
+                        index_lock_promotion_count = os.index_lock_promotion_count,
+                        page_latch_wait_count = os.page_latch_wait_count,
+                        page_latch_wait_in_ms = os.page_latch_wait_in_ms,
+                        page_io_latch_wait_count = os.page_io_latch_wait_count,
+                        page_io_latch_wait_in_ms = os.page_io_latch_wait_in_ms
+                    FROM sys.indexes AS i
+                    JOIN sys.objects AS o
+                      ON o.object_id = i.object_id
+                    JOIN sys.schemas AS s
+                      ON s.schema_id = o.schema_id
+                    LEFT JOIN
+                    (
+                        SELECT
+                            dps.object_id,
+                            dps.index_id,
+                            partition_count = COUNT_BIG(*),
+                            reserved_pages = SUM(dps.reserved_page_count),
+                            used_pages = SUM(dps.used_page_count),
+                            in_row_pages = SUM(dps.in_row_data_page_count),
+                            lob_pages = SUM(dps.lob_used_page_count),
+                            row_overflow_pages = SUM(dps.row_overflow_used_page_count),
+                            total_rows = SUM(dps.row_count)
+                        FROM sys.dm_db_partition_stats AS dps
+                        GROUP BY
+                            dps.object_id,
+                            dps.index_id
+                    ) AS ps
+                      ON  ps.object_id = i.object_id
+                      AND ps.index_id = i.index_id
+                    LEFT JOIN sys.dm_db_index_usage_stats AS us
+                      ON  us.database_id = DB_ID()
+                      AND us.object_id = i.object_id
+                      AND us.index_id = i.index_id
+                    LEFT JOIN
+                    (
+                        SELECT
+                            ios.object_id,
+                            ios.index_id,
+                            leaf_insert_count = SUM(ios.leaf_insert_count),
+                            leaf_update_count = SUM(ios.leaf_update_count),
+                            leaf_delete_count = SUM(ios.leaf_delete_count),
+                            range_scan_count = SUM(ios.range_scan_count),
+                            singleton_lookup_count = SUM(ios.singleton_lookup_count),
+                            row_lock_count = SUM(ios.row_lock_count),
+                            row_lock_wait_count = SUM(ios.row_lock_wait_count),
+                            row_lock_wait_in_ms = SUM(ios.row_lock_wait_in_ms),
+                            page_lock_count = SUM(ios.page_lock_count),
+                            page_lock_wait_count = SUM(ios.page_lock_wait_count),
+                            page_lock_wait_in_ms = SUM(ios.page_lock_wait_in_ms),
+                            index_lock_promotion_attempt_count = SUM(ios.index_lock_promotion_attempt_count),
+                            index_lock_promotion_count = SUM(ios.index_lock_promotion_count),
+                            page_latch_wait_count = SUM(ios.page_latch_wait_count),
+                            page_latch_wait_in_ms = SUM(ios.page_latch_wait_in_ms),
+                            page_io_latch_wait_count = SUM(ios.page_io_latch_wait_count),
+                            page_io_latch_wait_in_ms = SUM(ios.page_io_latch_wait_in_ms)
+                        FROM sys.dm_db_index_operational_stats(DB_ID(), NULL, NULL, NULL) AS ios
+                        GROUP BY
+                            ios.object_id,
+                            ios.index_id
+                    ) AS os
+                      ON  os.object_id = i.object_id
+                      AND os.index_id = i.index_id
+                    WHERE o.is_ms_shipped = 0
+                    AND   o.type IN (N''U'', N''V'')
+                    OPTION(RECOMPILE);';
+
+                    SET @exec_sql = QUOTENAME(@db_name) + N'.sys.sp_executesql';
+
+                    EXECUTE @exec_sql
+                        @sql,
+                        N'@start_time datetime2(7), @sqlserver_start_time datetime2(7)',
+                        @start_time = @start_time,
+                        @sqlserver_start_time = @sqlserver_start_time;
+
+                    SET @rows_collected = @rows_collected + ROWCOUNT_BIG();
+                END TRY
+                BEGIN CATCH
+                    /*
+                    Log per-database errors but continue with remaining databases
+                    */
+                    IF @debug = 1
+                    BEGIN
+                        DECLARE @db_error_message nvarchar(4000) = ERROR_MESSAGE();
+                        RAISERROR(N'Error collecting index/object stats for database [%s]: %s', 0, 1, @db_name, @db_error_message) WITH NOWAIT;
+                    END;
+                END CATCH;
+
+                FETCH NEXT FROM db_cursor INTO @db_name, @db_id;
+            END;
+
+            CLOSE db_cursor;
+            DEALLOCATE db_cursor;
+        END;
+
+        /*
+        Debug output
+        */
+        IF @debug = 1
+        BEGIN
+            RAISERROR(N'Collected %I64d index/object stat rows', 0, 1, @rows_collected) WITH NOWAIT;
+
+            SELECT TOP (20)
+                ios.database_name,
+                ios.schema_name,
+                ios.table_name,
+                ios.index_name,
+                ios.index_type_desc,
+                ios.reserved_mb,
+                ios.total_rows,
+                ios.total_reads,
+                ios.user_updates,
+                ios.row_lock_wait_in_ms,
+                ios.index_lock_promotion_count
+            FROM collect.index_object_stats AS ios
+            WHERE ios.collection_time = @start_time
+            ORDER BY
+                ios.reserved_mb DESC;
+        END;
+
+        /*
+        Log successful collection
+        */
+        INSERT INTO
+            config.collection_log
+        (
+            collector_name,
+            collection_status,
+            rows_collected,
+            duration_ms
+        )
+        VALUES
+        (
+            N'index_object_stats_collector',
+            N'SUCCESS',
+            @rows_collected,
+            DATEDIFF(MILLISECOND, @start_time, SYSDATETIME())
+        );
+
+    END TRY
+    BEGIN CATCH
+        IF @@TRANCOUNT > 0
+        BEGIN
+            ROLLBACK TRANSACTION;
+        END;
+
+        /*
+        Clean up cursor if open
+        */
+        IF CURSOR_STATUS(N'local', N'db_cursor') >= 0
+        BEGIN
+            CLOSE db_cursor;
+            DEALLOCATE db_cursor;
+        END;
+
+        SET @error_message = ERROR_MESSAGE();
+
+        /*
+        Log the error
+        */
+        INSERT INTO
+            config.collection_log
+        (
+            collector_name,
+            collection_status,
+            duration_ms,
+            error_message
+        )
+        VALUES
+        (
+            N'index_object_stats_collector',
+            N'ERROR',
+            DATEDIFF(MILLISECOND, @start_time, SYSDATETIME()),
+            @error_message
+        );
+
+        RAISERROR(N'Error in index/object stats collector: %s', 16, 1, @error_message);
+    END CATCH;
+END;
+GO
+
+PRINT 'Index/object stats collector created successfully';
+PRINT 'Captures per-table/per-index size, usage, and locking stats for trending and contention analysis';
+PRINT 'Use: EXECUTE collect.index_object_stats_collector @debug = 1;';
+GO


### PR DESCRIPTION
Closes #1103.

Adds time-series **collection + visualization + MCP + alerting** for per-table / per-index **size, growth, index usage, and locking/contention**, across **both** Dashboard and Lite. All from stock DMVs (`sys.dm_db_partition_stats`, `sys.dm_db_index_usage_stats`, `sys.dm_db_index_operational_stats`), verified stable 2016 → 2025 / Azure SQL DB / MI.

### What's included (6 commits, by layer)
- **Collection** — Dashboard collector `install/55_collect_index_object_stats.sql` (cross-DB cursor + Azure EngineEdition=5 branch) → `collect.index_object_stats` (`02`/`06`, NC index), scheduled **daily / 90-day** (`04`/`42`); dynamic retention picks it up. Lite `RemoteCollectorService.IndexObjectStats.cs` → DuckDB schema v29 + archival in **both** `ArchivableTables` arrays + schedule.
- **Read layer** — `GetObjectSizeGrowthAsync` (per-table size + 7d/30d growth + daily rate), `GetIndexUsageAsync` (Unused / Write-only / Active classification), `GetIndexLockingAsync` (top contended) in both apps.
- **UI** — three FinOps sub-tabs in both apps: *Object Sizes & Growth*, *Index Usage*, *Locking & Contention*.
- **MCP** — `get_table_index_sizes`, `get_index_usage`, `get_object_locking` in both apps.
- **Alerting** — daily data is cumulative, so detection is **delta-based** (two most recent snapshots, not stddev-baseline): `ANOMALY_OBJECT_GROWTH` (table grew >100 MB + 20% day-over-day) and `ANOMALY_OBJECT_CONTENTION` (index gained ≥60s new row-lock wait, reset-guarded). Flows through the existing anomaly→`AnalysisNotificationService` path; `FactScorer` + `FactAdvice` extended.

### Verification done
- **Live on SQL 2016** (oldest supported): collector returns 148 rows / 6 DBs / SUCCESS log; all three read queries return correct data; growth detector fires correctly against a synthetic prior snapshot (Posts 2278→6835 MB, 200%) and cleans up.
- **Builds**: Dashboard + Lite clean.
- **Tests**: Lite **434** / Dashboard **482**, 0 failures. New `IndexObjectStatsTests` (5) cover the Lite DuckDB read dialect + the anomaly detector (incl. single-snapshot no-false-positive). MCP schema-compat tests pass (3/3 each).
- **Self-review**: code-reviewer (correctness) and security-reviewer both clean; T-SQL style findings applied.

### ⚠️ Not yet validated live (needs a reviewer with the apps running)
- **The WPF UI** (both apps) was build-verified only — not visually run. The new tabs mirror the existing Storage Growth grid pattern.
- **Alerting end-to-end** (fact → notification → email/tray) was unit-tested but never fired against a live server; **thresholds are constants** (100 MB / 20% / 60s), not yet user-configurable.
- **Lite collection→DuckDB** end-to-end and the **Azure SQL DB** EngineEdition=5 branch were not run against a live instance (only sql2016 was available).

### Open items for follow-up (flagged, not silently dropped)
- Make alert thresholds user-configurable (Settings UI + `IAlertSettings`).
- Optional: bind `topN` as a DuckDB parameter in the Lite read layer (currently a safe `int` interpolation) for defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
