### PR TITLE
Perf: Dashboard timer re-entrancy guards + installed-version cache (P3)

### DIFF
--- a/Dashboard/Controls/LandingPage.xaml.cs
+++ b/Dashboard/Controls/LandingPage.xaml.cs
@@ -129,9 +129,23 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
+        private bool _isRefreshing;
+
         private async void RefreshTimer_Tick(object? sender, EventArgs e)
         {
-            await RefreshAllServersAsync();
+            /* Skip if the previous tick is still running — at the 10s minimum interval a slow
+               server (10s command timeouts, 5s connect retries) makes a tick outlast the interval,
+               so ticks overlap and stack unbounded NOC refreshes, each opening its own connections. */
+            if (_isRefreshing) return;
+            _isRefreshing = true;
+            try
+            {
+                await RefreshAllServersAsync();
+            }
+            finally
+            {
+                _isRefreshing = false;
+            }
         }
 
         private void DisplayTimer_Tick(object? sender, EventArgs e)

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -429,9 +429,16 @@ namespace PerformanceMonitorDashboard
             }
         }
 
+        private bool _isCheckingConnections;
+
         private async void ConnectionStatusTimer_Tick(object? sender, EventArgs e)
         {
-            await CheckAllConnectionsAsync();
+            /* Skip if the previous check is still running so slow servers don't stack overlapping
+               connection sweeps at the minimum interval. */
+            if (_isCheckingConnections) return;
+            _isCheckingConnections = true;
+            try { await CheckAllConnectionsAsync(); }
+            finally { _isCheckingConnections = false; }
         }
 
         private void ConfigureConnectionStatusTimer()
@@ -1427,14 +1434,27 @@ namespace PerformanceMonitorDashboard
             }
         }
 
+        private bool _isCheckingAlerts;
+
         private async void AlertCheckTimer_Tick(object? sender, EventArgs e)
         {
-            await CheckAllServerAlertsAsync();
+            /* Skip if the previous alert sweep is still running — otherwise slow ticks overlap and
+               pile up concurrent per-server query batches on the shared connections. */
+            if (_isCheckingAlerts) return;
+            _isCheckingAlerts = true;
+            try
+            {
+                await CheckAllServerAlertsAsync();
 
-            /* Auto-refresh alert history if the tab is open */
-            _alertsHistoryContent?.RefreshAlerts();
+                /* Auto-refresh alert history if the tab is open */
+                _alertsHistoryContent?.RefreshAlerts();
 
-            UpdateAlertBadge();
+                UpdateAlertBadge();
+            }
+            finally
+            {
+                _isCheckingAlerts = false;
+            }
         }
 
         private void UpdateAlertBadge()

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -593,6 +593,12 @@ ORDER BY e.database_name;", connection);
                     status.UserCancelledMfa = false; // Clear any previous cancellation flag
 
                     /* Query installed PerformanceMonitor version */
+                    /* The installed monitor version can't change mid-session — once we've learned it
+                       for this server, carry it forward instead of re-running the installation_history
+                       query on every connection-check tick. */
+                    if (previousStatus.InstalledMonitorVersion != null)
+                        status.InstalledMonitorVersion = previousStatus.InstalledMonitorVersion;
+                    else
                     try
                     {
                         using var versionCmd = new SqlCommand(@"


### PR DESCRIPTION
﻿Dashboard timer/throttle fixes (P3).

- **Re-entrancy guards** on the three `async void` `DispatcherTimer` ticks (LandingPage NOC refresh, MainWindow connection-status, MainWindow alert check). At the 10s minimum interval a slow server makes a tick outlast its interval, so ticks overlapped and stacked unbounded refresh/alert sweeps, each opening its own connections.
- **Installed-version cache**: `CheckConnectionAsync` no longer re-runs the `installation_history` query every connection-check tick — the version can't change mid-session, so it's carried forward once known.

Build: Dashboard clean (net10); Dashboard.Tests **482/482**.

**Flagged (your call):** the *NOC Refresh Interval* setting is dead — the NOC timer uses `AutoRefreshIntervalSeconds`, not `NocRefreshIntervalSeconds`. Wire it vs remove the setting+UI is a product decision. The per-tick `new DatabaseService` per server remains, but with the guards ticks no longer overlap so it no longer stacks connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
