### PR TITLE
Perf: fix long-session leaks in both apps (P4)

### DIFF
--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -57,6 +57,17 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         /// <summary>
+        /// Stops the stale-data timer. Call when the Alerts tab is closed — the timer is
+        /// Dispatcher-rooted, so without this the whole control (and its alert list) leaks on every
+        /// open/close cycle and keeps ticking forever.
+        /// </summary>
+        public void Cleanup()
+        {
+            _staleDataTimer.Stop();
+            _staleDataTimer.Tick -= StaleDataTimer_Tick;
+        }
+
+        /// <summary>
         /// Refreshes the alert history from the in-memory log.
         /// </summary>
         public void RefreshAlerts()

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -976,6 +976,7 @@ namespace PerformanceMonitorDashboard
                     {
                         ServerTabControl.Items.Remove(_alertsTab);
                         _alertsTab = null;
+                        _alertsHistoryContent?.Cleanup();
                         _alertsHistoryContent = null;
                     }
                 }
@@ -1966,6 +1967,15 @@ namespace PerformanceMonitorDashboard
             if (anomalousJobsTriggered)
             {
                 _activeLongRunningJobAlert[serverId] = true;
+                /* Prune aged-out per-run keys ({server}:{job}:{start}) — like Lite, this dict
+                   otherwise grows one entry per anomalous job run for the whole session. */
+                foreach (var staleJobKey in _lastLongRunningJobAlert
+                             .Where(kv => now - kv.Value >= alertCooldown)
+                             .Select(kv => kv.Key)
+                             .ToList())
+                {
+                    _lastLongRunningJobAlert.TryRemove(staleJobKey, out _);
+                }
                 var worst = health.AnomalousJobs[0];
                 var jobKey = $"{serverId}:{worst.JobId}:{worst.StartTime:O}";
 

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -1532,6 +1532,11 @@ public partial class ServerTab : UserControl
     public void DisposeChartHelpers()
     {
         ThemeManager.ThemeChanged -= OnThemeChanged;
+        /* Closing the server tab with plan tabs still open would leak each PlanViewerControl via the
+           static ThemeChanged event — clean them up here too (ClosePlanTab_Click only handles the
+           per-tab close-button path). */
+        foreach (var item in PlanTabControl.Items)
+            if (item is TabItem { Content: PlanViewerControl pv }) pv.Cleanup();
         _waitStatsHover?.Dispose();
         _perfmonHover?.Dispose();
         _cpuHover?.Dispose();

--- a/Lite/Services/SystemTrayService.cs
+++ b/Lite/Services/SystemTrayService.cs
@@ -116,7 +116,9 @@ public class SystemTrayService : IDisposable
         /* Double-click to show window */
         _trayIcon.TrayMouseDoubleClick += (s, e) => _restoreWindow();
 
-        /* Handle minimize to tray */
+        /* Handle minimize to tray. Unsubscribe first: Initialize re-runs on theme change, so a
+           plain += would stack a duplicate StateChanged handler on the app-lifetime window each time. */
+        _mainWindow.StateChanged -= MainWindow_StateChanged;
         _mainWindow.StateChanged += MainWindow_StateChanged;
     }
 


### PR DESCRIPTION
﻿Long-session leak fixes in both apps (P4) — these progressively degrade responsiveness over a multi-hour/day session.

- **Dashboard AlertsHistoryContent**: 10s `DispatcherTimer` started in ctor, never stopped → closing the Alerts tab leaked the whole control per open/close and kept ticking. Added `Cleanup()` from `CloseTab_Click`.
- **Dashboard `_lastLongRunningJobAlert`**: per-run keys never pruned (Lite already had this); now prunes aged-out entries.
- **Lite SystemTrayService**: `Initialize` re-runs on theme change and re-subscribed `StateChanged` without removing the old handler; now `-=` first.
- **Lite plan viewers**: closing a server tab with plan tabs open leaked each `PlanViewerControl` via the static `ThemeChanged` event; `DisposeChartHelpers` now cleans them up.

Build: solution clean (net10); Dashboard.Tests **482/482**.

**Flagged (design approval):** Lite `DeltaCalculator` accumulates dead `plan_handle` keys for the session. Correct fix = retain only keys seen each collection pass; getting it wrong evicts live deltas → false spikes, so I want your nod before touching the collector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
