### PR TITLE
Perf: parse/analyze execution plans off the UI thread (Dashboard) (P5)

### DIFF
--- a/Dashboard/Controls/PlanViewerControl.Interaction.cs
+++ b/Dashboard/Controls/PlanViewerControl.Interaction.cs
@@ -160,7 +160,7 @@ public partial class PlanViewerControl
         return null;
     }
 
-    private void PlanViewerControl_PreviewKeyDown(object sender, KeyEventArgs e)
+    private async void PlanViewerControl_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key == Key.V && Keyboard.Modifiers == ModifierKeys.Control
             && e.OriginalSource is not TextBox)
@@ -171,7 +171,9 @@ public partial class PlanViewerControl
                 e.Handled = true;
                 try
                 {
-                    System.Xml.Linq.XDocument.Parse(text);
+                    /* LoadPlan parses+analyzes off the UI thread and throws XmlException for
+                       malformed XML, replacing the redundant up-front XDocument.Parse. */
+                    await LoadPlan(text, "Pasted Plan");
                 }
                 catch (System.Xml.XmlException ex)
                 {
@@ -180,9 +182,15 @@ public partial class PlanViewerControl
                         "Invalid Plan XML",
                         MessageBoxButton.OK,
                         MessageBoxImage.Warning);
-                    return;
                 }
-                LoadPlan(text, "Pasted Plan");
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Failed to load the execution plan:\n\n{ex.Message}",
+                        "Plan Load Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                }
             }
         }
     }

--- a/Dashboard/Controls/PlanViewerControl.xaml.cs
+++ b/Dashboard/Controls/PlanViewerControl.xaml.cs
@@ -84,7 +84,7 @@ public partial class PlanViewerControl : UserControl
         }
     }
 
-    public void LoadPlan(string planXml, string label, string? queryText = null)
+    public async System.Threading.Tasks.Task LoadPlan(string planXml, string label, string? queryText = null)
     {
         _label = label;
 
@@ -97,8 +97,15 @@ public partial class PlanViewerControl : UserControl
         {
             QueryTextExpander.Visibility = Visibility.Collapsed;
         }
-        _currentPlan = ShowPlanParser.Parse(planXml);
-        PlanAnalyzer.Analyze(_currentPlan);
+        /* Parse + analyze off the UI thread — a multi-MB showplan is two heavy passes that would
+           otherwise freeze the window for seconds. Only the render below touches the UI. Throws
+           XmlException for malformed plan XML; callers handle it. */
+        _currentPlan = await System.Threading.Tasks.Task.Run(() =>
+        {
+            var plan = ShowPlanParser.Parse(planXml);
+            PlanAnalyzer.Analyze(plan);
+            return plan;
+        });
 
         var allStatements = _currentPlan.Batches
             .SelectMany(b => b.Statements)

--- a/Dashboard/MainWindow.PlanViewer.cs
+++ b/Dashboard/MainWindow.PlanViewer.cs
@@ -276,9 +276,21 @@ namespace PerformanceMonitorDashboard
         /// Loads plan XML into an existing sub-tab (replacing whatever was there before).
         /// Updates the sub-tab header label and shows the viewer layer.
         /// </summary>
-        private void LoadPlanIntoSubTab(TabItem subTab, string planXml, string label, string? queryText = null)
+        private async void LoadPlanIntoSubTab(TabItem subTab, string planXml, string label, string? queryText = null)
         {
-            try { System.Xml.Linq.XDocument.Parse(planXml); }
+            if (subTab.Content is not Grid subTabContent) return;
+            if (subTabContent.Children.Count < 2) return;
+
+            var emptyState = subTabContent.Children[0] as FrameworkElement;
+            var viewer = subTabContent.Children[1] as Controls.PlanViewerControl;
+            if (viewer == null) return;
+
+            try
+            {
+                /* LoadPlan parses+analyzes off the UI thread; XmlException replaces the redundant
+                   up-front XDocument.Parse validation. */
+                await viewer.LoadPlan(planXml, label, queryText);
+            }
             catch (System.Xml.XmlException ex)
             {
                 MessageBox.Show(
@@ -288,15 +300,15 @@ namespace PerformanceMonitorDashboard
                     MessageBoxImage.Warning);
                 return;
             }
-
-            if (subTab.Content is not Grid subTabContent) return;
-            if (subTabContent.Children.Count < 2) return;
-
-            var emptyState = subTabContent.Children[0] as FrameworkElement;
-            var viewer = subTabContent.Children[1] as Controls.PlanViewerControl;
-            if (viewer == null) return;
-
-            viewer.LoadPlan(planXml, label, queryText);
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to load the execution plan:\n\n{ex.Message}",
+                    "Plan Load Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
             emptyState!.Visibility = Visibility.Collapsed;
             viewer.Visibility = Visibility.Visible;
 

--- a/Dashboard/ServerTab.Plans.cs
+++ b/Dashboard/ServerTab.Plans.cs
@@ -46,11 +46,15 @@ namespace PerformanceMonitorDashboard
             PerformanceTab.CancelActualPlan();
         }
 
-        private void OpenPlanTab(string planXml, string label, string? queryText = null)
+        private async void OpenPlanTab(string planXml, string label, string? queryText = null)
         {
+            HidePlanLoading();
+            var viewer = new Controls.PlanViewerControl();
             try
             {
-                System.Xml.Linq.XDocument.Parse(planXml);
+                /* LoadPlan parses+analyzes off the UI thread; it throws XmlException for malformed
+                   plan XML, replacing the redundant up-front XDocument.Parse validation. */
+                await viewer.LoadPlan(planXml, label, queryText);
             }
             catch (System.Xml.XmlException ex)
             {
@@ -61,10 +65,15 @@ namespace PerformanceMonitorDashboard
                     MessageBoxImage.Warning);
                 return;
             }
-
-            HidePlanLoading();
-            var viewer = new Controls.PlanViewerControl();
-            viewer.LoadPlan(planXml, label, queryText);
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"Failed to load the execution plan:\n\n{ex.Message}",
+                    "Plan Load Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
 
             var header = new StackPanel { Orientation = Orientation.Horizontal };
             header.Children.Add(new TextBlock


### PR DESCRIPTION
﻿Opening or pasting an execution plan ran `ShowPlanParser.Parse` + `PlanAnalyzer.Analyze` synchronously on the dispatcher — two heavy passes over showplan XML that's routinely multi-MB, freezing the window for seconds. Each call site also did a **redundant** up-front `XDocument.Parse` just to validate (a second full DOM parse).

- `PlanViewerControl.LoadPlan` is now async and runs Parse + Analyze in `Task.Run`; only the render touches the UI.
- All three callers (`OpenPlanTab`, `LoadPlanIntoSubTab`, Ctrl+V paste) drop the redundant validation parse and catch the `XmlException` the parser already throws for malformed XML (plus a general catch so a bad plan shows a message box instead of faulting).

Build: Dashboard clean (net10); Dashboard.Tests **482/482**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
