### PR TITLE
Perf: Lite skips heavy refresh for non-selected server tabs (P6)

### DIFF
--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -62,7 +62,17 @@ public partial class ServerTab : UserControl
             }
             else
             {
-                await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
+                /* When this server tab isn't the selected one, its charts/grids aren't on screen —
+                   skip the heavy sub-tab data refresh and just keep the alert badge current. Mark
+                   dirty so the sub-tab is refreshed when the tab is selected again (IsVisibleChanged). */
+                if (IsVisible)
+                {
+                    await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
+                }
+                else
+                {
+                    _refreshPendingWhileHidden = true;
+                }
                 /* Always keep alert badge current even when Blocking tab is not visible */
                 if (MainTabControl.SelectedIndex != 8)
                     await RefreshAlertCountsAsync(hoursBack, fromDate, toDate);

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -42,6 +42,7 @@ public partial class ServerTab : UserControl
     public ServerConnection Server => _server;
     private readonly CredentialResolver _credentialResolver;
     private readonly DispatcherTimer _refreshTimer;
+    private bool _refreshPendingWhileHidden;
     private bool _isRefreshing;
     private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.IPanel?> _legendPanels = new();
     private List<SelectableItem> _waitTypeItems = new();
@@ -149,6 +150,17 @@ public partial class ServerTab : UserControl
             await RefreshAllDataAsync(fullRefresh: false);
         };
         _refreshTimer.Start();
+
+        /* When this tab isn't selected the timer skips its data refresh (see RefreshAllDataAsync);
+           refresh once when it becomes visible again so it isn't showing stale data on return. */
+        IsVisibleChanged += (s, e) =>
+        {
+            if (IsVisible && _refreshPendingWhileHidden)
+            {
+                _refreshPendingWhileHidden = false;
+                _ = RefreshAllDataAsync(fullRefresh: false);
+            }
+        };
 
         /* Show warning on Running Jobs tab if login lacks msdb access */
         if (!_hasMsdbAccess)


### PR DESCRIPTION
﻿Each open server tab's 60s `DispatcherTimer` fully refreshed its visible sub-tab — DuckDB queries + chart/grid rebuilds — every tick **even when the tab wasn't selected** (N open tabs => N query+rebuild batches/min of pure background churn).

Now a non-visible tab skips the sub-tab data refresh on tick, keeps only its alert badge current, marks itself dirty, and does one refresh when it becomes the selected tab again (`IsVisibleChanged`). Bonus: switching to a tab now shows **fresh** data instead of stale-until-next-tick.

Build: Lite clean (net10). Validate on a running Lite (tab switching + badge updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
