### PR TITLE
Perf: offload FinOps/Recommendations + Dashboard ServerTab data path (P7)

### DIFF
--- a/Dashboard/ServerTab.Refresh.cs
+++ b/Dashboard/ServerTab.Refresh.cs
@@ -63,7 +63,7 @@ namespace PerformanceMonitorDashboard
                 StatusText.Text = GetLoadingMessage();
                 RefreshButton.IsEnabled = false;
 
-                bool connected = await _databaseService.TestConnectionAsync();
+                bool connected = await Task.Run(() => _databaseService.TestConnectionAsync());
                 if (!connected)
                 {
                     StatusText.Text = $"Failed to connect to {_serverConnection.DisplayName}";
@@ -187,8 +187,8 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                var healthTask = _databaseService.GetCollectionHealthAsync();
-                var durationLogsTask = _databaseService.GetCollectionDurationLogsAsync();
+                var healthTask = Task.Run(() => _databaseService.GetCollectionHealthAsync());
+                var durationLogsTask = Task.Run(() => _databaseService.GetCollectionDurationLogsAsync());
                 var resourceOverviewTask = RefreshResourceOverviewAsync();
                 var runningJobsTask = RefreshRunningJobsAsync();
                 var dailySummaryTask = DailySummaryTab.RefreshDataAsync();
@@ -269,12 +269,12 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                var blockingEventsTask = _databaseService.GetBlockingEventsAsync();
-                var deadlocksTask = _databaseService.GetDeadlocksAsync();
-                var blockingStatsTask = _databaseService.GetBlockingDeadlockStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate);
-                var lockWaitStatsTask = _databaseService.GetLockWaitStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate);
-                var currentWaitsDurationTask = _databaseService.GetWaitingTaskTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate);
-                var currentWaitsBlockedTask = _databaseService.GetBlockedSessionTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate);
+                var blockingEventsTask = Task.Run(() => _databaseService.GetBlockingEventsAsync());
+                var deadlocksTask = Task.Run(() => _databaseService.GetDeadlocksAsync());
+                var blockingStatsTask = Task.Run(() => _databaseService.GetBlockingDeadlockStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
+                var lockWaitStatsTask = Task.Run(() => _databaseService.GetLockWaitStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
+                var currentWaitsDurationTask = Task.Run(() => _databaseService.GetWaitingTaskTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
+                var currentWaitsBlockedTask = Task.Run(() => _databaseService.GetBlockedSessionTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
 
                 await Task.WhenAll(blockingEventsTask, deadlocksTask, blockingStatsTask, lockWaitStatsTask, currentWaitsDurationTask, currentWaitsBlockedTask);
 
@@ -349,10 +349,10 @@ namespace PerformanceMonitorDashboard
             try
             {
                 // Load all four charts in parallel
-                var cpuTask = _databaseService.GetCpuDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate);
-                var memoryTask = _databaseService.GetMemoryDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate);
-                var ioTask = _databaseService.GetFileIoDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate);
-                var waitTask = _databaseService.GetWaitStatsDataAsync(_resourceOverviewHoursBack, 5, _resourceOverviewFromDate, _resourceOverviewToDate);
+                var cpuTask = Task.Run(() => _databaseService.GetCpuDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
+                var memoryTask = Task.Run(() => _databaseService.GetMemoryDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
+                var ioTask = Task.Run(() => _databaseService.GetFileIoDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
+                var waitTask = Task.Run(() => _databaseService.GetWaitStatsDataAsync(_resourceOverviewHoursBack, 5, _resourceOverviewFromDate, _resourceOverviewToDate));
 
                 await Task.WhenAll(cpuTask, memoryTask, ioTask, waitTask);
 
@@ -380,7 +380,7 @@ namespace PerformanceMonitorDashboard
 
             try
             {
-                var runningJobs = await _databaseService.GetRunningJobsAsync();
+                var runningJobs = await Task.Run(() => _databaseService.GetRunningJobsAsync());
                 RunningJobsDataGrid.ItemsSource = runningJobs;
                 RunningJobsNoDataMessage.Visibility = runningJobs.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             }

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -173,7 +173,7 @@ public partial class FinOpsTab : UserControl
             if (string.IsNullOrEmpty(connectionString)) return;
 
             var utilityConnectionString = _credentialResolver.GetUtilityConnectionString(selectedServer!);
-            var data = await _dataService.GetRecommendationsAsync(serverId, connectionString, utilityConnectionString, _currentServerMonthlyCost);
+            var data = await Task.Run(() => _dataService.GetRecommendationsAsync(serverId, connectionString, utilityConnectionString, _currentServerMonthlyCost));
             RecommendationsDataGrid.ItemsSource = data;
             RecommendationsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             RecommendationsCountIndicator.Text = data.Count > 0 ? $"{data.Count} recommendation(s)" : "";
@@ -190,14 +190,14 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetUtilizationEfficiencyAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetUtilizationEfficiencyAsync(serverId));
 
             if (data != null)
             {
                 data.MonthlyCost = _currentServerMonthlyCost;
 
                 // Compute free space % for health score from database sizes
-                var dbSizes = await _dataService.GetDatabaseSizeLatestAsync(serverId);
+                var dbSizes = await Task.Run(() => _dataService.GetDatabaseSizeLatestAsync(serverId));
                 var totalStorageMb = dbSizes.Sum(d => d.TotalSizeMb);
                 var totalFreeMb = dbSizes.Sum(d => (d.FreeSpaceMb ?? 0m));
                 data.FreeSpacePct = totalStorageMb > 0 ? totalFreeMb / totalStorageMb * 100m : 100m;
@@ -209,10 +209,10 @@ public partial class FinOpsTab : UserControl
 
             if (data != null)
             {
-                TopTotalGrid.ItemsSource = await _dataService.GetTopResourceConsumersByTotalAsync(serverId);
-                TopAvgGrid.ItemsSource = await _dataService.GetTopResourceConsumersByAvgAsync(serverId);
-                DbSizeChart.ItemsSource = await _dataService.GetDatabaseSizeSummaryAsync(serverId);
-                ProvisioningTrendGrid.ItemsSource = await _dataService.GetProvisioningTrendAsync(serverId);
+                TopTotalGrid.ItemsSource = await Task.Run(() => _dataService.GetTopResourceConsumersByTotalAsync(serverId));
+                TopAvgGrid.ItemsSource = await Task.Run(() => _dataService.GetTopResourceConsumersByAvgAsync(serverId));
+                DbSizeChart.ItemsSource = await Task.Run(() => _dataService.GetDatabaseSizeSummaryAsync(serverId));
+                ProvisioningTrendGrid.ItemsSource = await Task.Run(() => _dataService.GetProvisioningTrendAsync(serverId));
             }
             else
             {
@@ -383,7 +383,7 @@ public partial class FinOpsTab : UserControl
         try
         {
             var hoursBack = GetResourceUsageHoursBack();
-            var data = await _dataService.GetDatabaseResourceUsageAsync(serverId, hoursBack);
+            var data = await Task.Run(() => _dataService.GetDatabaseResourceUsageAsync(serverId, hoursBack));
             _dbResourcesFilterMgr!.UpdateData(data);
             NoDatabaseResourcesMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             DbResourcesCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
@@ -400,7 +400,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetApplicationConnectionsAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetApplicationConnectionsAsync(serverId));
             _appConnectionsFilterMgr!.UpdateData(data);
             NoAppConnectionsMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             AppConnectionsCountIndicator.Text = data.Count > 0 ? $"{data.Count} application(s)" : "";
@@ -417,7 +417,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetDatabaseSizeLatestAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetDatabaseSizeLatestAsync(serverId));
 
             // Compute proportional cost shares
             if (_currentServerMonthlyCost > 0 && data.Count > 0)
@@ -475,7 +475,7 @@ public partial class FinOpsTab : UserControl
                     try
                     {
                         var serverId = RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(server));
-                        var (avgCpu, storageGb, idleDbs, status) = await _dataService!.GetServerMetricsAsync(serverId);
+                        var (avgCpu, storageGb, idleDbs, status) = await Task.Run(() => _dataService!.GetServerMetricsAsync(serverId));
                         if (avgCpu.HasValue) item.AvgCpuPct = avgCpu;
                         if (storageGb.HasValue) item.StorageTotalGb = storageGb;
                         if (idleDbs.HasValue) item.IdleDbCount = idleDbs;
@@ -526,7 +526,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetStorageGrowthAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetStorageGrowthAsync(serverId));
             _storageGrowthFilterMgr!.UpdateData(data);
             NoStorageGrowthMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             StorageGrowthCountIndicator.Text = data.Count > 0 ? $"{data.Count} database(s)" : "";
@@ -546,7 +546,7 @@ public partial class FinOpsTab : UserControl
         if (_dataService == null) return;
         try
         {
-            var data = await _dataService.GetObjectSizeGrowthAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetObjectSizeGrowthAsync(serverId));
             _objectSizeGrowthFilterMgr!.UpdateData(data);
             NoObjectSizeGrowthMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             ObjectSizeGrowthCountIndicator.Text = data.Count > 0 ? $"{data.Count} table(s)" : "";
@@ -562,7 +562,7 @@ public partial class FinOpsTab : UserControl
         if (_dataService == null) return;
         try
         {
-            var data = await _dataService.GetIndexUsageAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetIndexUsageAsync(serverId));
             _indexUsageFilterMgr!.UpdateData(data);
             NoIndexUsageMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             IndexUsageCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
@@ -578,7 +578,7 @@ public partial class FinOpsTab : UserControl
         if (_dataService == null) return;
         try
         {
-            var data = await _dataService.GetIndexLockingAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetIndexLockingAsync(serverId));
             _indexLockingFilterMgr!.UpdateData(data);
             NoIndexLockingMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             IndexLockingCountIndicator.Text = data.Count > 0 ? $"{data.Count} index(es)" : "";
@@ -613,7 +613,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetIdleDatabasesAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetIdleDatabasesAsync(serverId));
             _idleDbsFilterMgr!.UpdateData(data);
             IdleDatabasesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             IdleDatabasesCountIndicator.Text = data.Count > 0 ? $"{data.Count} idle database(s)" : "";
@@ -630,7 +630,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetTempdbSummaryAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetTempdbSummaryAsync(serverId));
             _tempdbFilterMgr!.UpdateData(data);
             TempdbPressureNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         }
@@ -660,7 +660,7 @@ public partial class FinOpsTab : UserControl
         try
         {
             var hoursBack = GetHighImpactHoursBack();
-            var data = await _dataService.GetHighImpactQueriesAsync(serverId, hoursBack);
+            var data = await Task.Run(() => _dataService.GetHighImpactQueriesAsync(serverId, hoursBack));
             _highImpactFilterMgr!.UpdateData(data);
             HighImpactNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             HighImpactCountIndicator.Text = data.Count > 0 ? $"{data.Count} high-impact query(s)" : "";
@@ -704,7 +704,7 @@ public partial class FinOpsTab : UserControl
         try
         {
             var hoursBack = GetWaitStatsHoursBack();
-            var data = await _dataService.GetWaitCategorySummaryAsync(serverId, hoursBack);
+            var data = await Task.Run(() => _dataService.GetWaitCategorySummaryAsync(serverId, hoursBack));
 
             // Compute proportional cost shares — scaled to time window
             if (_currentServerMonthlyCost > 0 && data.Count > 0)
@@ -734,7 +734,7 @@ public partial class FinOpsTab : UserControl
         try
         {
             var hoursBack = GetExpensiveQueriesHoursBack();
-            var data = await _dataService.GetExpensiveQueriesAsync(serverId, hoursBack);
+            var data = await Task.Run(() => _dataService.GetExpensiveQueriesAsync(serverId, hoursBack));
 
             // Compute proportional cost shares — scaled to time window
             if (_currentServerMonthlyCost > 0 && data.Count > 0)
@@ -764,7 +764,7 @@ public partial class FinOpsTab : UserControl
 
         try
         {
-            var data = await _dataService.GetMemoryGrantEfficiencyAsync(serverId);
+            var data = await Task.Run(() => _dataService.GetMemoryGrantEfficiencyAsync(serverId));
             _memoryGrantFilterMgr!.UpdateData(data);
             MemoryGrantEfficiencyNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         }

--- a/Lite/Controls/RecommendationsTab.xaml.cs
+++ b/Lite/Controls/RecommendationsTab.xaml.cs
@@ -142,7 +142,7 @@ public partial class RecommendationsTab : UserControl
             var serverId = GetSelectedServerId();
             var serverName = server.DisplayNameWithIntent;
 
-            var items = await _reader.GetRecommendationsAsync(serverId, serverName, _hoursBack);
+            var items = await Task.Run(() => _reader.GetRecommendationsAsync(serverId, serverName, _hoursBack));
 
             ApplyViewModel(LiteRecommendationsViewModel.FromItems(items, ServerTimeHelper.UtcOffsetMinutes));
         }
@@ -186,7 +186,7 @@ public partial class RecommendationsTab : UserControl
             var planFetcher = new SqlPlanFetcher(_serverManager);
             var analysisService = new AnalysisService(_duckDb, planFetcher);
 
-            var findings = await analysisService.AnalyzeAsync(serverId, serverName, hoursBack: 4);
+            var findings = await Task.Run(() => analysisService.AnalyzeAsync(serverId, serverName, hoursBack: 4));
 
             if (analysisService.InsufficientDataMessage is { Length: > 0 } message)
             {


### PR DESCRIPTION
﻿Follow-up after **measuring** (you asked whether we'd actually profiled — we hadn't, properly). A dispatcher-latency probe (`SendMessageTimeout` with `SMTO_ABORTIFHUNG`) caught a real **~827 ms UI-thread stall** on a Lite FinOps refresh: `FinOpsTab`/`RecommendationsTab` DuckDB reads ran synchronously on the dispatcher (those paths were outside the earlier off-thread scope). The Dashboard ServerTab uses async `SqlClient`, but its row materialization still ran on the UI thread in the await continuation.

- **Lite FinOpsTab** — wrap all 21 `_dataService.Get*` DuckDB calls in `Task.Run`.
- **Lite RecommendationsTab** — wrap the findings read + the heavy `AnalyzeAsync` (`Generate now`) in `Task.Run`.
- **Dashboard ServerTab.Refresh** — wrap the 12 query task-creations + 2 direct awaits so `SqlClient` materialization runs off the dispatcher.

## Measured before/after (dispatcher-latency probe)
| Path | Before | After |
|---|---|---|
| Lite FinOps refresh | **827 ms** UI-block | **0 ms** (max 22 ms), 18.8k probes |
| Dashboard server-tab open | n/a | **0 ms** (max 156 ms), 17.9k probes |
| Idle CPU (both) | — | **0%** |

Build: solution clean (net10); **Lite.Tests 434/434, Dashboard.Tests 482/482**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
