### PR TITLE
Perf: off-thread alert-check DuckDB queries (Lite UI freeze under load)

### DIFF
--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -121,7 +121,7 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var (blockingCount, deadlockCount, latestEventTime) = await _dataService.GetAlertCountsAsync(_serverId, hoursBack, fromDate, toDate);
+            var (blockingCount, deadlockCount, latestEventTime) = await Task.Run(() => _dataService.GetAlertCountsAsync(_serverId, hoursBack, fromDate, toDate));
             AlertCountsChanged?.Invoke(blockingCount, deadlockCount, latestEventTime);
         }
         catch (Exception ex)

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1549,7 +1549,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var blockingRows = await _dataService.GetRecentBlockedProcessReportsAsync(summary.ServerId, hoursBack: 1);
+                var blockingRows = await Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(summary.ServerId, hoursBack: 1));
                 effectiveBlockingCount = blockingRows
                     .Count(r => string.IsNullOrEmpty(r.DatabaseName) ||
                         !App.AlertExcludedDatabases.Any(e =>
@@ -1622,7 +1622,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var deadlockRows = await _dataService.GetRecentDeadlocksAsync(summary.ServerId, hoursBack: 1);
+                var deadlockRows = await Task.Run(() => _dataService.GetRecentDeadlocksAsync(summary.ServerId, hoursBack: 1));
                 effectiveDeadlockCount = deadlockRows
                     .Count(r => !IsDeadlockExcluded(r, App.AlertExcludedDatabases));
             }
@@ -1691,7 +1691,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var poisonWaits = await _dataService.GetLatestPoisonWaitAvgsAsync(summary.ServerId);
+                var poisonWaits = await Task.Run(() => _dataService.GetLatestPoisonWaitAvgsAsync(summary.ServerId));
                 var triggered = poisonWaits.FindAll(w => w.AvgMsPerWait >= App.AlertPoisonWaitThresholdMs);
 
                 if (triggered.Count > 0)
@@ -1760,7 +1760,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var longRunning = await _dataService.GetLongRunningQueriesAsync(summary.ServerId, App.AlertLongRunningQueryThresholdMinutes, App.AlertLongRunningQueryMaxResults, App.AlertLongRunningQueryExcludeSpServerDiagnostics, App.AlertLongRunningQueryExcludeWaitFor, App.AlertLongRunningQueryExcludeBackups, App.AlertLongRunningQueryExcludeMiscWaits, App.AlertLongRunningQueryExcludeCdc);
+                var longRunning = await Task.Run(() => _dataService.GetLongRunningQueriesAsync(summary.ServerId, App.AlertLongRunningQueryThresholdMinutes, App.AlertLongRunningQueryMaxResults, App.AlertLongRunningQueryExcludeSpServerDiagnostics, App.AlertLongRunningQueryExcludeWaitFor, App.AlertLongRunningQueryExcludeBackups, App.AlertLongRunningQueryExcludeMiscWaits, App.AlertLongRunningQueryExcludeCdc));
 
                 if (App.AlertExcludedDatabases.Count > 0)
                 {
@@ -1841,7 +1841,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var tempDb = await _dataService.GetLatestTempDbSpaceAsync(summary.ServerId);
+                var tempDb = await Task.Run(() => _dataService.GetLatestTempDbSpaceAsync(summary.ServerId));
 
                 if (tempDb != null && tempDb.UsedPercent >= App.AlertTempDbSpaceThresholdPercent)
                 {
@@ -1903,7 +1903,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                var anomalousJobs = await _dataService.GetAnomalousJobsAsync(summary.ServerId, App.AlertLongRunningJobMultiplier);
+                var anomalousJobs = await Task.Run(() => _dataService.GetAnomalousJobsAsync(summary.ServerId, App.AlertLongRunningJobMultiplier));
 
                 /* _lastLongRunningJobAlert is keyed per job *run* ({server}:{jobId}:{startTime}),
                    so unlike the per-server cooldown dicts it grows without bound. Drop entries
@@ -2003,7 +2003,7 @@ public partial class MainWindow : Window
             {
                 if (_dataService == null) return null;
 
-                var events = await _dataService.GetRecentBlockedProcessReportsAsync(serverId, hoursBack: 1);
+                var events = await Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(serverId, hoursBack: 1));
                 if (events == null || events.Count == 0) return null;
 
                 if (App.AlertExcludedDatabases.Count > 0)
@@ -2063,7 +2063,7 @@ public partial class MainWindow : Window
             {
                 if (_dataService == null) return null;
 
-                var deadlocks = await _dataService.GetRecentDeadlocksAsync(serverId, hoursBack: 1);
+                var deadlocks = await Task.Run(() => _dataService.GetRecentDeadlocksAsync(serverId, hoursBack: 1));
                 if (deadlocks == null || deadlocks.Count == 0) return null;
 
                 if (App.AlertExcludedDatabases.Count > 0)


### PR DESCRIPTION
## Problem
Active UI profiling under a HammerDB TPC-C load against SQL2025 surfaced intermittent **~1s UI freezes** in Lite (an external dispatcher-latency probe caught blocks of 842–1174ms while the app was otherwise at p99 < 4ms).

## Root cause
Found with **`dotnet-trace --profile dotnet-sampled-thread-time`** (wall-clock thread-time sampling — catches blocked/native frames a CPU profiler misses). The **alert-check paths run synchronous DuckDB queries directly on the WPF dispatcher**:

- `MainWindow.CheckPerformanceAlerts` → `GetLatestPoisonWaitAvgs`, `GetRecentBlockedProcessReports`, `GetRecentDeadlocks`, `GetLongRunningQueries`, `GetLatestTempDbSpace`, `GetAnomalousJobs`
- `ServerTab.RefreshAlertCountsAsync` → `GetAlertCounts`

DuckDB.NET is synchronous, so `await _dataService.X()` completes on the calling thread. Under load a **single DuckDB connection open is ~766ms**. These fire on the **60s overview auto-refresh** and on **every Blocking-tab refresh**, so they freeze whatever tab the user is on (the timing coincidence sent me chasing the Queries and Blocking tabs first — see below). The earlier off-thread sweep (#1110–1120) missed the alert/overview paths.

## Fix
Wrap the 9 calls in `Task.Run(() => _dataService.X(...))` — the same off-thread pattern used across the other refresh paths. 9 insertions / 9 deletions, 2 files.

## How it was ruled in
Method-level `Stopwatch` instrumentation first **disproved** the obvious suspects — chart build + `.Refresh()` = 0–3ms (even 1,362 pts × 6 series), GC = 0 collections, grid bind < 30ms, DataGrid columns fixed-width. Only thread-time tracing revealed the synchronous DuckDB on the UI thread, which is invisible to method timers because `await sync_call()` doesn't show as a stall in the awaiting method.

## Proof (Lite vs SQL2025 under HammerDB TPC-C, 75s spanning the overview auto-refresh)
| metric | before | after |
|---|---|---|
| dispatcher latency **MAX** | **1174 ms** | **9.2 ms** |
| p99 | 2.0 ms | 1.5 ms |
| stalls > 250 ms | 2 | **0** |
| stalls > 1 s | 1 | **0** |

1,584 samples, nothing over 9.2 ms.

## Validation
- Lite builds clean (net10, 0 errors).
- `Lite.Tests`: **434/434** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
