### PR TITLE
Lite: Dismiss Selected clears the server-tab badge too (#1092)

### DIFF
--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -318,6 +318,12 @@ public partial class AlertsHistoryTab : UserControl
                 AppLogger.Warn("AlertsHistory", $"Dismiss selected: only {affected} of {liveAlerts.Count} live alert(s) were updated");
             }
             await LoadAlertsAsync();
+
+            /* Clear the matching server tab badge(s) for the servers whose alerts were dismissed,
+               matching Dismiss All's behavior (issue #1092). Selected rows can span servers when
+               the filter is "all", so acknowledge each distinct server rather than the filter. */
+            foreach (var dismissedServerId in liveAlerts.Select(a => a.ServerId).Distinct())
+                AlertsDismissed?.Invoke(dismissedServerId);
         }
         catch (TimeoutException)
         {


### PR DESCRIPTION
## #1092 — "Dismiss Selected" didn't clear the server-tab badge

The core badge-clearing work shipped in #1100 (click-to-acknowledge badge, Dismiss All, context-menu Acknowledge). One gap remained: **Dismiss Selected** dismissed the rows but never fired `AlertsDismissed`, so the server-tab badge stayed lit after dismissing individual alerts.

## Fix
After a successful Dismiss Selected, fire `AlertsDismissed` for each **distinct server** represented in the dismissed rows — selected rows can span servers when the filter is "all" — reusing the same host handler (`OnAlertHistoryDismissed` → `AcknowledgeServerBadge`) that Dismiss All already uses. 6 lines, 1 file.

## Validation
- Lite builds clean (net10, 0 errors).
- `Lite.Tests`: 434/434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
