### PR TITLE
Add low volume free space alert to Lite and Dashboard (#754)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -97,6 +97,8 @@ namespace PerformanceMonitorDashboard
         private readonly ConcurrentDictionary<string, bool> _activeLongRunningQueryAlert = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastTempDbSpaceAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeTempDbSpaceAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastLowDiskAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activeLowDiskAlert = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastLongRunningJobAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeLongRunningJobAlert = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastCaptureDownAlert = new();
@@ -1960,6 +1962,59 @@ namespace PerformanceMonitorDashboard
                     pct, $"{prefs.TempDbSpaceThresholdPercent}%", true, "tray");
             }
 
+            /* Low volume free space alerts — not applicable to Azure SQL DB (health.Volumes is empty there) */
+            var breachedVolumes = prefs.NotifyOnLowDisk
+                ? GetBreachedVolumes(health.Volumes, prefs)
+                : new List<VolumeFreeSpaceInfo>();
+
+            if (breachedVolumes.Count > 0)
+            {
+                var worst = breachedVolumes[0];
+                _activeLowDiskAlert[serverId] = true;
+                if (!_lastLowDiskAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= alertCooldown)
+                {
+                    var muteCtx = new AlertMuteContext { ServerName = serverName, MetricName = "Volume Free Space" };
+                    bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
+                    _lastLowDiskAlert[serverId] = now;
+                    var lowDiskContext = BuildVolumeFreeSpaceContext(breachedVolumes);
+                    var detailText = ContextToDetailText(lowDiskContext);
+                    var currentValue = $"{worst.MountPoint} {worst.FreePercent:F0}% free ({worst.FreeGb:F1} GB)";
+                    var thresholdValue = FormatLowDiskThreshold(prefs);
+
+                    if (!isMuted)
+                    {
+                        _notificationService?.ShowSnoozableNotification(
+                            "Volume Free Space",
+                            $"{serverName}: {currentValue}",
+                            NotificationType.Warning,
+                            serverName,
+                            "Volume Free Space",
+                            _muteRuleService);
+                    }
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "Volume Free Space",
+                        currentValue, thresholdValue, !isMuted, isMuted ? "muted" : "tray", muted: isMuted, detailText: detailText);
+
+                    if (!isMuted)
+                    {
+                        await _emailAlertService.TrySendAlertEmailAsync(
+                            "Volume Free Space",
+                            serverName,
+                            currentValue,
+                            thresholdValue,
+                            serverId,
+                            lowDiskContext);
+                    }
+                }
+            }
+            else if (_activeLowDiskAlert.TryRemove(serverId, out var wasLowDisk) && wasLowDisk)
+            {
+                _notificationService?.ShowNotification("Volume Free Space Resolved",
+                    $"{serverName}: All volumes back above threshold");
+                _emailAlertService.RecordAlert(serverId, serverName, "Volume Free Space Resolved",
+                    "OK", FormatLowDiskThreshold(prefs), true, "tray");
+            }
+
             /* Anomalous Agent job alerts */
             bool anomalousJobsTriggered = prefs.NotifyOnLongRunningJobs
                 && health.AnomalousJobs.Count > 0;
@@ -2276,6 +2331,47 @@ namespace PerformanceMonitorDashboard
             if (seconds < 60) return $"{seconds}s";
             if (seconds < 3600) return $"{seconds / 60}m {seconds % 60}s";
             return $"{seconds / 3600}h {(seconds % 3600) / 60}m";
+        }
+
+        /* Returns the volumes whose free space is under the configured % or GB threshold (a 0 threshold
+           disables that dimension), worst (lowest free %) first, so the alert names the tightest volume. */
+        private static List<VolumeFreeSpaceInfo> GetBreachedVolumes(List<VolumeFreeSpaceInfo> volumes, UserPreferences prefs)
+        {
+            int pct = prefs.LowDiskThresholdPercent;
+            int gb = prefs.LowDiskThresholdGb;
+            return volumes
+                .Where(v => (pct > 0 && v.FreePercent < pct) || (gb > 0 && v.FreeGb < gb))
+                .OrderBy(v => v.FreePercent)
+                .ToList();
+        }
+
+        private static string FormatLowDiskThreshold(UserPreferences prefs)
+        {
+            var parts = new List<string>();
+            if (prefs.LowDiskThresholdPercent > 0) parts.Add($"{prefs.LowDiskThresholdPercent}%");
+            if (prefs.LowDiskThresholdGb > 0) parts.Add($"{prefs.LowDiskThresholdGb} GB");
+            return parts.Count > 0 ? string.Join(" / ", parts) : "—";
+        }
+
+        private static AlertContext? BuildVolumeFreeSpaceContext(List<VolumeFreeSpaceInfo> volumes)
+        {
+            if (volumes.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var v in volumes.GetRange(0, Math.Min(5, volumes.Count)))
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = $"{v.MountPoint} — {v.FreePercent:F0}% Free",
+                    Fields = new()
+                    {
+                        ("Free Space", $"{v.FreeGb:F1} GB"),
+                        ("Total Size", $"{v.TotalMb / 1024.0:F1} GB"),
+                        ("Used", $"{(v.TotalMb - v.FreeMb) / 1024.0:F1} GB")
+                    }
+                });
+            }
+            return context;
         }
 
         private static AlertContext? BuildTempDbSpaceContext(TempDbSpaceInfo tempDb)

--- a/Dashboard/Models/AlertHealthResult.cs
+++ b/Dashboard/Models/AlertHealthResult.cs
@@ -34,6 +34,12 @@ namespace PerformanceMonitorDashboard.Models
         public List<PoisonWaitDelta> PoisonWaits { get; set; } = new();
         public List<LongRunningQueryInfo> LongRunningQueries { get; set; } = new();
         public TempDbSpaceInfo? TempDbSpace { get; set; }
+
+        /// <summary>
+        /// Free space per distinct volume on the server, ordered worst (lowest free %) first.
+        /// Empty on Azure SQL DB (no volume stats collected). Used by the low-disk alert.
+        /// </summary>
+        public List<VolumeFreeSpaceInfo> Volumes { get; set; } = new();
         public List<AnomalousJobInfo> AnomalousJobs { get; set; } = new();
         public bool IsOnline { get; set; } = true;
 

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -105,6 +105,9 @@ namespace PerformanceMonitorDashboard.Models
         public bool LongRunningQueryExcludeCdc { get; set; } = true; // Exclude CDC capture jobs (sp_MScdc_capture_job / sp_cdc_scan)
         public bool NotifyOnTempDbSpace { get; set; } = true;
         public int TempDbSpaceThresholdPercent { get; set; } = 80; // Alert when TempDB used > X%
+        public bool NotifyOnLowDisk { get; set; } = true;
+        public int LowDiskThresholdPercent { get; set; } = 10; // Alert when a volume's free space < X% (0 disables this check)
+        public int LowDiskThresholdGb { get; set; } = 5;        // Alert when a volume's free space < X GB (0 disables this check)
         public bool NotifyOnLongRunningJobs { get; set; } = true;
         public int LongRunningJobMultiplier { get; set; } = 3; // Alert when job runs > Nx historical average
         private int _alertCooldownMinutes = 5;

--- a/Dashboard/Models/VolumeFreeSpaceInfo.cs
+++ b/Dashboard/Models/VolumeFreeSpaceInfo.cs
@@ -1,0 +1,23 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+namespace PerformanceMonitorDashboard.Models
+{
+    /// <summary>
+    /// Free space for a single distinct volume (mount point) on a monitored server,
+    /// used by the low-disk alert. Azure SQL DB has no volume stats, so no rows are
+    /// produced there and the alert never fires.
+    /// </summary>
+    public class VolumeFreeSpaceInfo
+    {
+        public string MountPoint { get; set; } = "";
+        public double TotalMb { get; set; }
+        public double FreeMb { get; set; }
+
+        public double FreePercent => TotalMb > 0 ? FreeMb / TotalMb * 100 : 0;
+        public double FreeGb => FreeMb / 1024.0;
+    }
+}

--- a/Dashboard/MuteRuleDialog.xaml
+++ b/Dashboard/MuteRuleDialog.xaml
@@ -72,6 +72,7 @@
             <ComboBoxItem Content="Poison Wait"/>
             <ComboBoxItem Content="Long-Running Query"/>
             <ComboBoxItem Content="TempDB Space"/>
+            <ComboBoxItem Content="Volume Free Space"/>
             <ComboBoxItem Content="Long-Running Job"/>
         </ComboBox>
 

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -152,12 +152,13 @@ namespace PerformanceMonitorDashboard.Services
                 var poisonWaitTask = GetPoisonWaitDeltasAsync(connection);
                 var longRunningTask = GetLongRunningQueriesAsync(connection, longRunningQueryThresholdMinutes, longRunningQueryMaxResults, excludeSpServerDiagnostics, excludeWaitFor, excludeBackups, excludeMiscWaits, excludeCdc);
                 var tempDbTask = GetTempDbSpaceAsync(connection);
+                var volumeTask = GetVolumeFreeSpaceAsync(connection);
                 var anomalousJobTask = GetAnomalousJobsAsync(connection, longRunningJobMultiplier);
                 var missingCaptureTask = GetMissingCaptureSessionsAsync(connection);
 
                 var allTasks = filteredDeadlockTask != null
-                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, missingCaptureTask }
-                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, missingCaptureTask };
+                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, missingCaptureTask }
+                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, missingCaptureTask };
                 await Task.WhenAll(allTasks);
 
                 var cpuResult = await cpuTask;
@@ -174,6 +175,7 @@ namespace PerformanceMonitorDashboard.Services
                 result.PoisonWaits = await poisonWaitTask;
                 result.LongRunningQueries = await longRunningTask;
                 result.TempDbSpace = await tempDbTask;
+                result.Volumes = await volumeTask;
                 result.AnomalousJobs = await anomalousJobTask;
                 result.MissingCaptureSessions = await missingCaptureTask;
             }
@@ -957,6 +959,61 @@ namespace PerformanceMonitorDashboard.Services
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns latest free space for each distinct volume (mount point), worst (lowest free %)
+        /// first, for the low-disk alert. Files on the same volume collapse to one row. Volumes with
+        /// no mount point (Azure SQL DB has no volume stats) are excluded, so Azure yields no rows.
+        /// </summary>
+        private async Task<List<VolumeFreeSpaceInfo>> GetVolumeFreeSpaceAsync(SqlConnection connection)
+        {
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT
+                    volume_mount_point,
+                    volume_total_mb =
+                        MAX(volume_total_mb),
+                    volume_free_mb =
+                        MIN(volume_free_mb)
+                FROM collect.database_size_stats
+                WHERE collection_time =
+                (
+                    SELECT MAX(collection_time)
+                    FROM collect.database_size_stats
+                )
+                AND   volume_mount_point IS NOT NULL
+                AND   volume_total_mb > 0
+                GROUP BY
+                    volume_mount_point
+                ORDER BY
+                    MIN(volume_free_mb) / MAX(volume_total_mb)
+                OPTION(MAXDOP 1);";
+
+            var results = new List<VolumeFreeSpaceInfo>();
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    results.Add(new VolumeFreeSpaceInfo
+                    {
+                        MountPoint = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                        TotalMb = reader.IsDBNull(1) ? 0 : Convert.ToDouble(reader.GetValue(1), System.Globalization.CultureInfo.InvariantCulture),
+                        FreeMb = reader.IsDBNull(2) ? 0 : Convert.ToDouble(reader.GetValue(2), System.Globalization.CultureInfo.InvariantCulture)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to get volume free space: {ex.Message}");
+            }
+
+            return results;
         }
     }
 }

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -264,6 +264,25 @@
                                 <TextBlock Text="%" VerticalAlignment="Center"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnLowDiskCheckBox"
+                                          Content="Volume free space under"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnLowDiskCheckBox_Changed"
+                                          Unchecked="NotifyOnLowDiskCheckBox_Changed"/>
+                                <TextBox x:Name="LowDiskThresholdPercentTextBox"
+                                         Width="50"
+                                         Margin="8,0,4,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="% or" VerticalAlignment="Center"/>
+                                <TextBox x:Name="LowDiskThresholdGbTextBox"
+                                         Width="50"
+                                         Margin="8,0,4,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="GB free (Azure SQL DB excluded)" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <CheckBox x:Name="NotifyOnLongRunningJobsCheckBox"
                                           Content="Agent jobs running over"
                                           VerticalAlignment="Center"

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -190,6 +190,9 @@ namespace PerformanceMonitorDashboard
             AlertExcludedDatabasesTextBox.Text = string.Join(", ", prefs.AlertExcludedDatabases);
             NotifyOnTempDbSpaceCheckBox.IsChecked = prefs.NotifyOnTempDbSpace;
             TempDbSpaceThresholdTextBox.Text = prefs.TempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
+            NotifyOnLowDiskCheckBox.IsChecked = prefs.NotifyOnLowDisk;
+            LowDiskThresholdPercentTextBox.Text = prefs.LowDiskThresholdPercent.ToString(CultureInfo.InvariantCulture);
+            LowDiskThresholdGbTextBox.Text = prefs.LowDiskThresholdGb.ToString(CultureInfo.InvariantCulture);
             NotifyOnLongRunningJobsCheckBox.IsChecked = prefs.NotifyOnLongRunningJobs;
             LongRunningJobMultiplierTextBox.Text = prefs.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
             AlertCooldownTextBox.Text = prefs.AlertCooldownMinutes.ToString(CultureInfo.InvariantCulture);
@@ -354,6 +357,12 @@ namespace PerformanceMonitorDashboard
             UpdateAlertNotificationStates();
         }
 
+        private void NotifyOnLowDiskCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
         private void NotifyOnLongRunningJobsCheckBox_Changed(object sender, RoutedEventArgs e)
         {
             if (_isLoading) return;
@@ -368,6 +377,8 @@ namespace PerformanceMonitorDashboard
             PoisonWaitThresholdTextBox.Text = "500";
             LongRunningQueryThresholdTextBox.Text = "30";
             TempDbSpaceThresholdTextBox.Text = "80";
+            LowDiskThresholdPercentTextBox.Text = "10";
+            LowDiskThresholdGbTextBox.Text = "5";
             LongRunningJobMultiplierTextBox.Text = "3";
             AlertCooldownTextBox.Text = "5";
             EmailCooldownTextBox.Text = "15";
@@ -399,6 +410,8 @@ namespace PerformanceMonitorDashboard
                 parts.Add($"queries > {LongRunningQueryThresholdTextBox.Text}min");
             if (NotifyOnTempDbSpaceCheckBox.IsChecked == true)
                 parts.Add($"TempDB > {TempDbSpaceThresholdTextBox.Text}%");
+            if (NotifyOnLowDiskCheckBox.IsChecked == true)
+                parts.Add($"disk free < {LowDiskThresholdPercentTextBox.Text}% or {LowDiskThresholdGbTextBox.Text}GB");
             if (NotifyOnLongRunningJobsCheckBox.IsChecked == true)
                 parts.Add($"jobs > {LongRunningJobMultiplierTextBox.Text}x avg");
 
@@ -423,6 +436,9 @@ namespace PerformanceMonitorDashboard
             LongRunningQueryThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningQueriesCheckBox.IsChecked == true;
             NotifyOnTempDbSpaceCheckBox.IsEnabled = notificationsEnabled;
             TempDbSpaceThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnTempDbSpaceCheckBox.IsChecked == true;
+            NotifyOnLowDiskCheckBox.IsEnabled = notificationsEnabled;
+            LowDiskThresholdPercentTextBox.IsEnabled = notificationsEnabled && NotifyOnLowDiskCheckBox.IsChecked == true;
+            LowDiskThresholdGbTextBox.IsEnabled = notificationsEnabled && NotifyOnLowDiskCheckBox.IsChecked == true;
             NotifyOnLongRunningJobsCheckBox.IsEnabled = notificationsEnabled;
             LongRunningJobMultiplierTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningJobsCheckBox.IsChecked == true;
             UpdateAlertPreviewText();
@@ -696,6 +712,16 @@ namespace PerformanceMonitorDashboard
                 prefs.TempDbSpaceThresholdPercent = tempDbThreshold;
             else if (prefs.NotifyOnTempDbSpace)
                 validationErrors.Add("TempDB space threshold must be between 1 and 100");
+
+            prefs.NotifyOnLowDisk = NotifyOnLowDiskCheckBox.IsChecked == true;
+            if (int.TryParse(LowDiskThresholdPercentTextBox.Text, out int lowDiskPct) && lowDiskPct >= 0 && lowDiskPct <= 100)
+                prefs.LowDiskThresholdPercent = lowDiskPct;
+            else if (prefs.NotifyOnLowDisk)
+                validationErrors.Add("Volume free space percent threshold must be between 0 and 100");
+            if (int.TryParse(LowDiskThresholdGbTextBox.Text, out int lowDiskGb) && lowDiskGb >= 0)
+                prefs.LowDiskThresholdGb = lowDiskGb;
+            else if (prefs.NotifyOnLowDisk)
+                validationErrors.Add("Volume free space GB threshold must be 0 or greater");
 
             prefs.NotifyOnLongRunningJobs = NotifyOnLongRunningJobsCheckBox.IsChecked == true;
             if (int.TryParse(LongRunningJobMultiplierTextBox.Text, out int jobMultiplier) && jobMultiplier > 0)

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -105,6 +105,9 @@ public partial class App : Application
     public static List<string> AlertExcludedDatabases { get; set; } = new();
     public static bool AlertTempDbSpaceEnabled { get; set; } = true;
     public static int AlertTempDbSpaceThresholdPercent { get; set; } = 80;
+    public static bool AlertLowDiskEnabled { get; set; } = true;
+    public static int AlertLowDiskThresholdPercent { get; set; } = 10; // Alert when a volume's free space < X% (0 disables this check)
+    public static int AlertLowDiskThresholdGb { get; set; } = 5;        // Alert when a volume's free space < X GB (0 disables this check)
     public static bool AlertLongRunningJobEnabled { get; set; } = true;
     public static int AlertLongRunningJobMultiplier { get; set; } = 3;
     public static int AlertCooldownMinutes { get; set; } = 5;  // Tray notification cooldown between repeated alerts
@@ -485,6 +488,9 @@ public partial class App : Application
             }
             if (root.TryGetProperty("alert_tempdb_space_enabled", out v)) AlertTempDbSpaceEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.GetInt32();
+            if (root.TryGetProperty("alert_low_disk_enabled", out v)) AlertLowDiskEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_low_disk_threshold_percent", out v)) AlertLowDiskThresholdPercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
+            if (root.TryGetProperty("alert_low_disk_threshold_gb", out v)) AlertLowDiskThresholdGb = (int)Math.Max(0, v.GetInt64());
             if (root.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.GetInt32();
             if (root.TryGetProperty("alert_cooldown_minutes", out v)) AlertCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 1, 120);

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -51,6 +51,7 @@ public partial class MainWindow : Window
     private readonly Dictionary<string, DateTime> _lastPoisonWaitAlert = new();
     private readonly Dictionary<string, DateTime> _lastLongRunningQueryAlert = new();
     private readonly Dictionary<string, DateTime> _lastTempDbSpaceAlert = new();
+    private readonly Dictionary<string, DateTime> _lastLowDiskAlert = new();
     private readonly Dictionary<string, DateTime> _lastLongRunningJobAlert = new();
     private readonly DispatcherTimer _statusTimer;
     private LocalDataService? _dataService;
@@ -67,6 +68,7 @@ public partial class MainWindow : Window
     private readonly Dictionary<string, bool> _activePoisonWaitAlert = new();
     private readonly Dictionary<string, bool> _activeLongRunningQueryAlert = new();
     private readonly Dictionary<string, bool> _activeTempDbSpaceAlert = new();
+    private readonly Dictionary<string, bool> _activeLowDiskAlert = new();
     private readonly Dictionary<string, bool> _activeLongRunningJobAlert = new();
 
     /* Edge-trigger watermarks (#1091): the rolling 1-hour blocking/deadlock counts stay
@@ -1898,6 +1900,69 @@ public partial class MainWindow : Window
             }
         }
 
+        /* Low volume free space alerts — not applicable to Azure SQL DB (no volume stats collected) */
+        if (App.AlertLowDiskEnabled && _dataService != null)
+        {
+            try
+            {
+                var volumes = await Task.Run(() => _dataService.GetVolumeFreeSpaceAsync(summary.ServerId));
+                var breached = GetBreachedVolumes(volumes);
+
+                if (breached.Count > 0)
+                {
+                    var worst = breached[0];
+                    _activeLowDiskAlert[key] = true;
+                    if (!suppressPopups && (!_lastLowDiskAlert.TryGetValue(key, out var lastLowDisk) || now - lastLowDisk >= alertCooldown))
+                    {
+                        var muteCtx = new AlertMuteContext { ServerName = summary.DisplayName, MetricName = "Volume Free Space" };
+                        bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
+                        _lastLowDiskAlert[key] = now;
+
+                        if (!isMuted)
+                        {
+                            _trayService.ShowSnoozableNotification(
+                                "Volume Free Space",
+                                $"{summary.DisplayName}: {worst.MountPoint} {worst.FreePercent:F0}% free ({worst.FreeGb:F1} GB)",
+                                Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Warning,
+                                summary.DisplayName,
+                                "Volume Free Space",
+                                _muteRuleService);
+                        }
+
+                        var lowDiskContext = BuildVolumeFreeSpaceContext(breached);
+                        var detailText = ContextToDetailText(lowDiskContext);
+
+                        await _emailAlertService.TrySendAlertEmailAsync(
+                            "Volume Free Space",
+                            summary.DisplayName,
+                            $"{worst.MountPoint} {worst.FreePercent:F0}% free ({worst.FreeGb:F1} GB)",
+                            FormatLowDiskThreshold(),
+                            summary.ServerId,
+                            lowDiskContext,
+                            numericCurrentValue: worst.FreePercent,
+                            numericThresholdValue: App.AlertLowDiskThresholdPercent,
+                            muted: isMuted,
+                            detailText: detailText);
+                    }
+                }
+                else if (_activeLowDiskAlert.TryGetValue(key, out var wasLowDisk) && wasLowDisk)
+                {
+                    _activeLowDiskAlert[key] = false;
+                    if (!suppressPopups)
+                    {
+                        _trayService.ShowNotification(
+                            "Volume Free Space Resolved",
+                            $"{summary.DisplayName}: All volumes back above threshold",
+                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error("Alerts", $"Failed to check volume free space for {summary.DisplayName}: {ex.Message}");
+            }
+        }
+
         /* Anomalous Agent job alerts */
         if (App.AlertLongRunningJobEnabled && _dataService != null)
         {
@@ -2175,6 +2240,47 @@ public partial class MainWindow : Window
                     item.Fields.Add(("Blocked By", $"Session #{q.BlockingSessionId.Value}"));
 
                 context.Details.Add(item);
+            }
+            return context;
+        }
+
+        /* Returns the volumes whose free space is under the configured % or GB threshold (a 0 threshold
+           disables that dimension), worst (lowest free %) first, so the alert names the tightest volume. */
+        private static List<VolumeFreeSpaceInfo> GetBreachedVolumes(List<VolumeFreeSpaceInfo> volumes)
+        {
+            int pct = App.AlertLowDiskThresholdPercent;
+            int gb = App.AlertLowDiskThresholdGb;
+            return volumes
+                .Where(v => (pct > 0 && v.FreePercent < pct) || (gb > 0 && v.FreeGb < gb))
+                .OrderBy(v => v.FreePercent)
+                .ToList();
+        }
+
+        private static string FormatLowDiskThreshold()
+        {
+            var parts = new List<string>();
+            if (App.AlertLowDiskThresholdPercent > 0) parts.Add($"{App.AlertLowDiskThresholdPercent}%");
+            if (App.AlertLowDiskThresholdGb > 0) parts.Add($"{App.AlertLowDiskThresholdGb} GB");
+            return parts.Count > 0 ? string.Join(" / ", parts) : "—";
+        }
+
+        private static AlertContext? BuildVolumeFreeSpaceContext(List<VolumeFreeSpaceInfo> volumes)
+        {
+            if (volumes.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var v in volumes.GetRange(0, Math.Min(5, volumes.Count)))
+            {
+                context.Details.Add(new AlertDetailItem
+                {
+                    Heading = $"{v.MountPoint} — {v.FreePercent:F0}% Free",
+                    Fields = new()
+                    {
+                        ("Free Space", $"{v.FreeGb:F1} GB"),
+                        ("Total Size", $"{v.TotalMb / 1024.0:F1} GB"),
+                        ("Used", $"{(v.TotalMb - v.FreeMb) / 1024.0:F1} GB")
+                    }
+                });
             }
             return context;
         }

--- a/Lite/Services/LocalDataService.VolumeSpace.cs
+++ b/Lite/Services/LocalDataService.VolumeSpace.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class LocalDataService
+{
+    /// <summary>
+    /// Gets the latest free space for each distinct volume on the server, ordered worst (lowest free %)
+    /// first, for low-disk alert checking. Files on the same volume share one row. Volumes with no
+    /// mount point (Azure SQL DB has no volume stats) are excluded, so the result is empty there.
+    /// </summary>
+    public async Task<List<VolumeFreeSpaceInfo>> GetVolumeFreeSpaceAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT
+    volume_mount_point,
+    MAX(volume_total_mb) AS volume_total_mb,
+    MIN(volume_free_mb) AS volume_free_mb
+FROM v_database_size_stats
+WHERE server_id = $1
+AND   collection_time = (
+    SELECT MAX(collection_time)
+    FROM v_database_size_stats
+    WHERE server_id = $1
+)
+AND   volume_mount_point IS NOT NULL
+AND   volume_total_mb > 0
+GROUP BY volume_mount_point
+ORDER BY MIN(volume_free_mb) / MAX(volume_total_mb)";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var items = new List<VolumeFreeSpaceInfo>();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            items.Add(new VolumeFreeSpaceInfo
+            {
+                MountPoint = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                TotalMb = reader.IsDBNull(1) ? 0 : ToDouble(reader.GetValue(1)),
+                FreeMb = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2))
+            });
+        }
+
+        return items;
+    }
+}
+
+public class VolumeFreeSpaceInfo
+{
+    public string MountPoint { get; set; } = "";
+    public double TotalMb { get; set; }
+    public double FreeMb { get; set; }
+
+    public double FreePercent => TotalMb > 0 ? FreeMb / TotalMb * 100 : 0;
+    public double FreeGb => FreeMb / 1024.0;
+}

--- a/Lite/Windows/MuteRuleDialog.xaml
+++ b/Lite/Windows/MuteRuleDialog.xaml
@@ -73,6 +73,7 @@
             <ComboBoxItem Content="Poison Wait"/>
             <ComboBoxItem Content="Long-Running Query"/>
             <ComboBoxItem Content="TempDB Space"/>
+            <ComboBoxItem Content="Volume Free Space"/>
             <ComboBoxItem Content="Long-Running Job"/>
         </ComboBox>
 

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -223,6 +223,16 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLowDiskCheckBox" Content="Volume free space under" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLowDiskThresholdPercentBox" Width="45" Text="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% or" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLowDiskThresholdGbBox" Width="45" Text="5" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="GB free (Azure SQL DB excluded)" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertLongRunningJobCheckBox" Content="Agent jobs running over" VerticalAlignment="Center"
                               Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="AlertLongRunningJobMultiplierBox" Width="35" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -597,6 +597,9 @@ public partial class SettingsWindow : Window
         AlertExcludedDatabasesBox.Text = string.Join(", ", App.AlertExcludedDatabases);
         AlertTempDbSpaceCheckBox.IsChecked = App.AlertTempDbSpaceEnabled;
         AlertTempDbSpaceThresholdBox.Text = App.AlertTempDbSpaceThresholdPercent.ToString();
+        AlertLowDiskCheckBox.IsChecked = App.AlertLowDiskEnabled;
+        AlertLowDiskThresholdPercentBox.Text = App.AlertLowDiskThresholdPercent.ToString();
+        AlertLowDiskThresholdGbBox.Text = App.AlertLowDiskThresholdGb.ToString();
         AlertLongRunningJobCheckBox.IsChecked = App.AlertLongRunningJobEnabled;
         AlertLongRunningJobMultiplierBox.Text = App.AlertLongRunningJobMultiplier.ToString();
         AlertCooldownBox.Text = App.AlertCooldownMinutes.ToString();
@@ -652,6 +655,11 @@ public partial class SettingsWindow : Window
         App.AlertTempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true;
         if (int.TryParse(AlertTempDbSpaceThresholdBox.Text, out var tempDb) && tempDb > 0 && tempDb <= 100)
             App.AlertTempDbSpaceThresholdPercent = tempDb;
+        App.AlertLowDiskEnabled = AlertLowDiskCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLowDiskThresholdPercentBox.Text, out var lowDiskPct) && lowDiskPct >= 0 && lowDiskPct <= 100)
+            App.AlertLowDiskThresholdPercent = lowDiskPct;
+        if (int.TryParse(AlertLowDiskThresholdGbBox.Text, out var lowDiskGb) && lowDiskGb >= 0)
+            App.AlertLowDiskThresholdGb = lowDiskGb;
         App.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
         if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult >= 2 && jobMult <= 20)
             App.AlertLongRunningJobMultiplier = jobMult;
@@ -717,6 +725,9 @@ public partial class SettingsWindow : Window
             root["alert_excluded_databases"] = dbArray;
             root["alert_tempdb_space_enabled"] = App.AlertTempDbSpaceEnabled;
             root["alert_tempdb_space_threshold_percent"] = App.AlertTempDbSpaceThresholdPercent;
+            root["alert_low_disk_enabled"] = App.AlertLowDiskEnabled;
+            root["alert_low_disk_threshold_percent"] = App.AlertLowDiskThresholdPercent;
+            root["alert_low_disk_threshold_gb"] = App.AlertLowDiskThresholdGb;
             root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
             root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
             root["alert_cooldown_minutes"] = App.AlertCooldownMinutes;
@@ -762,6 +773,8 @@ public partial class SettingsWindow : Window
         AlertPoisonWaitThresholdBox.Text = "500";
         AlertLongRunningQueryThresholdBox.Text = "30";
         AlertTempDbSpaceThresholdBox.Text = "80";
+        AlertLowDiskThresholdPercentBox.Text = "10";
+        AlertLowDiskThresholdGbBox.Text = "5";
         AlertLongRunningJobMultiplierBox.Text = "3";
         AlertCooldownBox.Text = "5";
         EmailCooldownBox.Text = "15";
@@ -798,6 +811,8 @@ public partial class SettingsWindow : Window
             parts.Add($"queries > {AlertLongRunningQueryThresholdBox.Text}min");
         if (AlertTempDbSpaceCheckBox.IsChecked == true)
             parts.Add($"TempDB > {AlertTempDbSpaceThresholdBox.Text}%");
+        if (AlertLowDiskCheckBox.IsChecked == true)
+            parts.Add($"disk free < {AlertLowDiskThresholdPercentBox.Text}% or {AlertLowDiskThresholdGbBox.Text}GB");
         if (AlertLongRunningJobCheckBox.IsChecked == true)
             parts.Add($"jobs > {AlertLongRunningJobMultiplierBox.Text}x avg");
 
@@ -823,6 +838,9 @@ public partial class SettingsWindow : Window
         AlertLongRunningQueryThresholdBox.IsEnabled = enabled;
         AlertTempDbSpaceCheckBox.IsEnabled = enabled;
         AlertTempDbSpaceThresholdBox.IsEnabled = enabled;
+        AlertLowDiskCheckBox.IsEnabled = enabled;
+        AlertLowDiskThresholdPercentBox.IsEnabled = enabled;
+        AlertLowDiskThresholdGbBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
         UpdateAlertPreviewText();


### PR DESCRIPTION
## Problem

Closes #754. Neither app alerted when a monitored server's disk volume was running low on free space, even though per-volume size/free data is already collected. Users wanted an alert with **fixed values and/or percentages**.

## What changed

The new alert is a precise clone of the existing tempdb-space alert in both apps: a Settings toggle + thresholds, a live check inside the same alert-evaluation method (with cooldown, mute support, alert-history record, tray + email notification), an active/resolved state, and a structured context payload. Metric name: **"Volume Free Space"**.

A volume breaches when its free space is **below the % OR below the fixed GB** (either threshold set to `0` disables that dimension; if both are set, either breach fires). The check evaluates all of a server's volumes, fires **one alert per server** naming the worst (lowest-free) volume, and the context lists the breaching volumes (up to 5).

### Lite
- `Lite/Services/LocalDataService.VolumeSpace.cs` (new) — `GetVolumeFreeSpaceAsync(serverId)` reads `v_database_size_stats`, aggregates files to distinct volumes, worst-first; `VolumeFreeSpaceInfo` model.
- `Lite/MainWindow.xaml.cs` — `_lastLowDiskAlert`/`_activeLowDiskAlert` dicts, the alert block in `CheckPerformanceAlerts` (off-threaded via `Task.Run`, matching the tempdb read), and `GetBreachedVolumes`/`FormatLowDiskThreshold`/`BuildVolumeFreeSpaceContext` helpers.
- `Lite/App.xaml.cs` — settings + JSON persistence keys `alert_low_disk_*`.
- `Lite/Windows/SettingsWindow.xaml(.cs)` — checkbox + two threshold inputs, with load/save/persist/reset/preview/enable wiring.
- `Lite/Windows/MuteRuleDialog.xaml` — "Volume Free Space" metric option.

### Dashboard
- `Dashboard/Models/VolumeFreeSpaceInfo.cs` (new) — model; `Dashboard/Models/AlertHealthResult.cs` gains `Volumes`.
- `Dashboard/Services/DatabaseService.NocHealth.cs` — `GetVolumeFreeSpaceAsync(connection)` reads `collect.database_size_stats` (latest snapshot), wired into `GetAlertHealthAsync`'s `Task.WhenAll` exactly like `GetTempDbSpaceAsync`.
- `Dashboard/MainWindow.xaml.cs` — `_lastLowDiskAlert`/`_activeLowDiskAlert` dicts, the alert block in `EvaluateAlertConditionsAsync`, and the same three helpers (reading thresholds from `UserPreferences`).
- `Dashboard/Models/UserPreferences.cs` — `NotifyOnLowDisk` / `LowDiskThresholdPercent` / `LowDiskThresholdGb`.
- `Dashboard/SettingsWindow.xaml(.cs)` — checkbox + two inputs with full wiring.
- `Dashboard/MuteRuleDialog.xaml` — "Volume Free Space" metric option.

## New settings + defaults (default enabled, matching tempdb-space)

| Lite (`App`) | Dashboard (`UserPreferences`) | Default |
|---|---|---|
| `AlertLowDiskEnabled` | `NotifyOnLowDisk` | `true` |
| `AlertLowDiskThresholdPercent` | `LowDiskThresholdPercent` | `10` |
| `AlertLowDiskThresholdGb` | `LowDiskThresholdGb` | `5` |

## Azure SQL DB gating

The collector writes NULL volume columns for Azure SQL DB (no `sys.dm_os_volume_stats`). Both read queries filter `volume_mount_point IS NOT NULL AND volume_total_mb > 0`, so Azure servers produce no volume rows and the alert never fires there.

## Validation

- `dotnet build` Lite + Dashboard (Debug): **Build succeeded, 0 errors** (both).
- `Lite.Tests`: **434 passed, 0 failed**.
- `Dashboard.Tests`: **482 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)