### PR TITLE
Installer: optional custom data/log file locations (#768)

### DIFF
--- a/Installer.Core/InstallationService.cs
+++ b/Installer.Core/InstallationService.cs
@@ -301,8 +301,31 @@ END;";
     }
 
     /// <summary>
+    /// Token in 01_install_database.sql that the installer replaces with
+    /// SET statements supplying custom data/log file paths (issue #768).
+    /// When left untouched it is an inert SQL comment and the SERVERPROPERTY
+    /// defaults are used.
+    /// </summary>
+    private const string FilePathOverrideToken = "/*__PM_FILE_PATH_OVERRIDES__*/";
+
+    /// <summary>
     /// Execute SQL installation files from the given ScriptProvider.
     /// </summary>
+    /// <param name="dataPath">
+    /// Optional server-side directory for the PerformanceMonitor data file.
+    /// When supplied, it overrides SERVERPROPERTY('InstanceDefaultDataPath')
+    /// on first creation of the database. Ignored if the database already
+    /// exists. (Placed after cancellationToken so existing callers that pass
+    /// the token positionally keep compiling.)
+    /// </param>
+    /// <param name="logPath">
+    /// Optional server-side directory for the PerformanceMonitor log file.
+    /// </param>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1068:CancellationToken parameters must come last",
+        Justification = "dataPath/logPath are appended after cancellationToken so existing " +
+            "callers that pass the token positionally (e.g. Dashboard AddServerDialog) keep compiling.")]
     public static async Task<InstallationResult> ExecuteInstallationAsync(
         string connectionString,
         ScriptProvider provider,
@@ -310,7 +333,9 @@ END;";
         bool resetSchedule = false,
         IProgress<InstallationProgress>? progress = null,
         Func<Task>? preValidationAction = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? dataPath = null,
+        string? logPath = null)
     {
         var scriptFiles = provider.GetInstallFiles();
         ArgumentNullException.ThrowIfNull(scriptFiles);
@@ -410,6 +435,24 @@ END;";
                     });
                 }
 
+                /*Inject custom data/log file paths into the CREATE DATABASE step (#768).
+                  Only applies on first creation; if the database already exists the
+                  guarded block is skipped, so the paths are silently ignored.*/
+                if (fileName.StartsWith("01_", StringComparison.Ordinal) &&
+                    (!string.IsNullOrWhiteSpace(dataPath) || !string.IsNullOrWhiteSpace(logPath)))
+                {
+                    sqlContent = sqlContent.Replace(
+                        FilePathOverrideToken,
+                        BuildFilePathOverrideSql(dataPath, logPath),
+                        StringComparison.Ordinal);
+
+                    progress?.Report(new InstallationProgress
+                    {
+                        Message = "Applying custom database file path(s) to CREATE DATABASE...",
+                        Status = "Info"
+                    });
+                }
+
                 /*Remove SQLCMD directives*/
                 sqlContent = Patterns.SqlCmdDirectivePattern.Replace(sqlContent, "");
 
@@ -500,6 +543,58 @@ END;";
 
         return result;
     }
+
+    /// <summary>
+    /// Builds the T-SQL that sets the override path variables in
+    /// 01_install_database.sql. Each path is normalized to end with a
+    /// separator and single quotes are doubled so the value cannot break out
+    /// of the surrounding N'...' literal. The install script applies a second
+    /// REPLACE(...) escape when it concatenates the value into the dynamic
+    /// CREATE DATABASE statement (defense in depth).
+    /// </summary>
+    private static string BuildFilePathOverrideSql(string? dataPath, string? logPath)
+    {
+        var sb = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(dataPath))
+        {
+            AppendPathOverride(sb, "@data_path_override", dataPath);
+        }
+
+        if (!string.IsNullOrWhiteSpace(logPath))
+        {
+            AppendPathOverride(sb, "@log_path_override", logPath);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends a "SET @override = N'...'" statement for a validated path.
+    /// Re-validates so the no-control-character / absolute-path guarantees hold
+    /// for any caller (not just the CLI, which already validates), then escapes
+    /// the value before embedding it in the single-quoted literal.
+    /// </summary>
+    private static void AppendPathOverride(StringBuilder sb, string variableName, string path)
+    {
+        if (!PathValidation.TryValidateDirectory(path, out string normalized, out string error))
+        {
+            throw new ArgumentException($"Invalid database file path '{path}': {error}", nameof(path));
+        }
+
+        sb.Append("SET ")
+          .Append(variableName)
+          .Append(" = N'")
+          .Append(EscapeSqlStringLiteral(normalized))
+          .Append("';\n    ");
+    }
+
+    /// <summary>
+    /// Doubles single quotes so a value can be embedded safely inside a
+    /// single-quoted T-SQL string literal.
+    /// </summary>
+    private static string EscapeSqlStringLiteral(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
 
     /// <summary>
     /// Run validation (master collector) after installation.

--- a/Installer.Core/PathValidation.cs
+++ b/Installer.Core/PathValidation.cs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Buffers;
+
+namespace Installer.Core;
+
+/// <summary>
+/// Validates and normalizes user-supplied database file directory paths
+/// (the --data-path / --log-path installer options, issue #768).
+///
+/// The path is a SERVER-SIDE directory: it is where SQL Server places the
+/// PerformanceMonitor data/log files, so it is validated for shape only
+/// (absolute, no illegal characters, sane length). It is deliberately NOT
+/// checked for existence on the machine running the installer, which may be
+/// a different host than the SQL Server.
+/// </summary>
+public static class PathValidation
+{
+    /// <summary>
+    /// Maximum directory length. Leaves room for the appended file name
+    /// (e.g., "PerformanceMonitor_log.ldf") inside the nvarchar(512) variable.
+    /// </summary>
+    private const int MaxDirectoryLength = 480;
+
+    /// <summary>
+    /// Characters that are never valid in a Windows path and that we also
+    /// reject for Linux targets as a defensive measure. The single quote is
+    /// deliberately allowed (it is legal in a Windows path, e.g. C:\Bob's Data\)
+    /// and is escaped before it reaches T-SQL.
+    /// </summary>
+    private static readonly SearchValues<char> ForbiddenCharacters =
+        SearchValues.Create("\"<>|*?");
+
+    /// <summary>
+    /// Validates a user-supplied directory path and, on success, returns a
+    /// normalized form that ends with a path separator.
+    /// </summary>
+    /// <param name="input">Raw path from the command line.</param>
+    /// <param name="normalized">Normalized path (with trailing separator) when valid.</param>
+    /// <param name="error">Human-readable reason when invalid.</param>
+    /// <returns>True when the path is acceptable.</returns>
+    public static bool TryValidateDirectory(string? input, out string normalized, out string error)
+    {
+        normalized = string.Empty;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            error = "path is empty.";
+            return false;
+        }
+
+        string path = input.Trim();
+
+        if (path.Length > MaxDirectoryLength)
+        {
+            error = $"path exceeds {MaxDirectoryLength} characters.";
+            return false;
+        }
+
+        /*Reject control characters (includes CR/LF/tab) so a path can't smuggle
+          extra statements or break the surrounding T-SQL string literal.*/
+        foreach (char c in path)
+        {
+            if (char.IsControl(c))
+            {
+                error = "path contains control characters.";
+                return false;
+            }
+        }
+
+        if (path.AsSpan().IndexOfAny(ForbiddenCharacters) >= 0)
+        {
+            error = "path contains invalid characters (\" < > | * ?).";
+            return false;
+        }
+
+        if (!IsAbsolute(path))
+        {
+            error = "path must be absolute (e.g., D:\\SQLData, \\\\server\\share, or /var/opt/mssql).";
+            return false;
+        }
+
+        normalized = EnsureTrailingSeparator(path);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns true when the path is a fully-qualified Windows drive path
+    /// (C:\...), a UNC path (\\server\share), or a Linux absolute path (/...).
+    /// OS-independent on purpose: the installer is win-x64 but can target
+    /// SQL Server running on Linux.
+    /// </summary>
+    public static bool IsAbsolute(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        /*Windows drive: X:\ or X:/ */
+        if (path.Length >= 3 &&
+            char.IsLetter(path[0]) &&
+            path[1] == ':' &&
+            (path[2] == '\\' || path[2] == '/'))
+        {
+            return true;
+        }
+
+        /*UNC: \\server\share*/
+        if (path.StartsWith("\\\\", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        /*Linux absolute: /var/...*/
+        return path[0] == '/';
+    }
+
+    /// <summary>
+    /// Ensures the directory path ends with a separator so a file name can be
+    /// appended. Uses the separator style already present in the path so Linux
+    /// targets keep forward slashes.
+    /// </summary>
+    public static string EnsureTrailingSeparator(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        if (path.EndsWith('\\') || path.EndsWith('/'))
+        {
+            return path;
+        }
+
+        /*A Linux-style path uses forward slashes; everything else uses backslashes.*/
+        char separator =
+            path.Contains('/') && !path.Contains('\\')
+                ? '/'
+                : '\\';
+
+        return path + separator;
+    }
+}

--- a/Installer.Tests/PathValidationTests.cs
+++ b/Installer.Tests/PathValidationTests.cs
@@ -1,0 +1,128 @@
+using Installer.Core;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Unit tests for PathValidation — the shape checks and normalization applied
+/// to the --data-path / --log-path installer options (issue #768). These run
+/// without a database.
+/// </summary>
+public class PathValidationTests
+{
+    [Theory]
+    [InlineData(@"C:\SQLData")]
+    [InlineData(@"D:\SQL Data\Monitor")]
+    [InlineData(@"C:/SQLData")]
+    [InlineData(@"\\fileserver\share\sql")]
+    [InlineData("/var/opt/mssql/data")]
+    [InlineData(@"C:\Bob's Data")]
+    public void TryValidateDirectory_AcceptsAbsolutePaths(string path)
+    {
+        bool ok = PathValidation.TryValidateDirectory(path, out string normalized, out string error);
+
+        Assert.True(ok, error);
+        Assert.NotEmpty(normalized);
+    }
+
+    [Theory]
+    [InlineData("SQLData")]
+    [InlineData(@"relative\path")]
+    [InlineData("data.mdf")]
+    public void TryValidateDirectory_RejectsRelativePaths(string path)
+    {
+        bool ok = PathValidation.TryValidateDirectory(path, out _, out string error);
+
+        Assert.False(ok);
+        Assert.Contains("absolute", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void TryValidateDirectory_RejectsEmpty(string? path)
+    {
+        bool ok = PathValidation.TryValidateDirectory(path, out _, out string error);
+
+        Assert.False(ok);
+        Assert.NotEmpty(error);
+    }
+
+    [Theory]
+    [InlineData("C:\\SQL\nData")]   // embedded newline (would break the T-SQL literal)
+    [InlineData("C:\\SQL\rData")]   // embedded carriage return
+    [InlineData("C:\\SQL\tData")]   // embedded tab
+    public void TryValidateDirectory_RejectsControlCharacters(string path)
+    {
+        bool ok = PathValidation.TryValidateDirectory(path, out _, out string error);
+
+        Assert.False(ok);
+        Assert.Contains("control", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("C:\\SQL<Data")]
+    [InlineData("C:\\SQL>Data")]
+    [InlineData("C:\\SQL|Data")]
+    [InlineData("C:\\SQL*Data")]
+    [InlineData("C:\\SQL?Data")]
+    [InlineData("C:\\SQL\"Data")]
+    public void TryValidateDirectory_RejectsForbiddenCharacters(string path)
+    {
+        bool ok = PathValidation.TryValidateDirectory(path, out _, out string error);
+
+        Assert.False(ok);
+        Assert.Contains("invalid", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryValidateDirectory_RejectsOverlyLongPath()
+    {
+        string longPath = @"C:\" + new string('a', 500);
+
+        bool ok = PathValidation.TryValidateDirectory(longPath, out _, out string error);
+
+        Assert.False(ok);
+        Assert.Contains("exceeds", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryValidateDirectory_NormalizesTrailingSeparator_Windows()
+    {
+        bool ok = PathValidation.TryValidateDirectory(@"C:\SQLData", out string normalized, out _);
+
+        Assert.True(ok);
+        Assert.Equal(@"C:\SQLData\", normalized);
+    }
+
+    [Fact]
+    public void TryValidateDirectory_TrimsWhitespaceBeforeValidating()
+    {
+        bool ok = PathValidation.TryValidateDirectory("  C:\\SQLData  ", out string normalized, out _);
+
+        Assert.True(ok);
+        Assert.Equal(@"C:\SQLData\", normalized);
+    }
+
+    [Theory]
+    [InlineData(@"C:\SQLData", @"C:\SQLData\")]
+    [InlineData(@"C:\SQLData\", @"C:\SQLData\")]
+    [InlineData("/var/opt/mssql", "/var/opt/mssql/")]
+    [InlineData("/var/opt/mssql/", "/var/opt/mssql/")]
+    [InlineData(@"\\srv\share", @"\\srv\share\")]
+    public void EnsureTrailingSeparator_UsesPathStyle(string input, string expected)
+    {
+        Assert.Equal(expected, PathValidation.EnsureTrailingSeparator(input));
+    }
+
+    [Theory]
+    [InlineData(@"C:\x", true)]
+    [InlineData(@"\\server\share", true)]
+    [InlineData("/etc/data", true)]
+    [InlineData(@"relative\x", false)]
+    [InlineData("plainword", false)]
+    public void IsAbsolute_ClassifiesCorrectly(string path, bool expected)
+    {
+        Assert.Equal(expected, PathValidation.IsAbsolute(path));
+    }
+}

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -46,6 +46,8 @@ namespace PerformanceMonitorInstaller
               --reinstall       Drop existing database and perform clean install
               --encrypt=X       Connection encryption: mandatory (default), optional, strict
               --trust-cert      Trust server certificate without validation (default: require valid cert)
+              --data-path DIR   Server-side directory for the data (.mdf) file (first install only)
+              --log-path DIR    Server-side directory for the log (.ldf) file (first install only)
             */
             if (args.Any(a => a.Equals("--help", StringComparison.OrdinalIgnoreCase)
                               || a.Equals("-h", StringComparison.OrdinalIgnoreCase)))
@@ -65,6 +67,8 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                 Console.WriteLine("  --trust-cert         Trust server certificate without validation");
                 Console.WriteLine("  --entra <email>      Use Microsoft Entra ID interactive authentication (MFA)");
+                Console.WriteLine("  --data-path <dir>    Server-side directory for the data (.mdf) file (first install only)");
+                Console.WriteLine("  --log-path <dir>     Server-side directory for the log (.ldf) file (first install only)");
                 Console.WriteLine();
                 Console.WriteLine("Environment Variables:");
                 Console.WriteLine("  PM_SQL_PASSWORD      SQL Auth password (avoids passing on command line)");
@@ -128,17 +132,57 @@ namespace PerformanceMonitorInstaller
                 }
             }
 
+            /*Parse optional custom database file locations (#768).
+              Supports both --data-path=<dir> and --data-path <dir> (and --log-path).
+              These are server-side directories where SQL Server places the
+              PerformanceMonitor data/log files on first creation.*/
+            string? dataPathArg = GetOptionValue(args, "--data-path");
+            string? logPathArg = GetOptionValue(args, "--log-path");
+
+            string? dataPath = null;
+            string? logPath = null;
+
+            if (dataPathArg != null)
+            {
+                if (!PathValidation.TryValidateDirectory(dataPathArg, out dataPath, out string dataPathError))
+                {
+                    Console.WriteLine($"Error: invalid --data-path: {dataPathError}");
+                    return (int)InstallationResultCode.InvalidArguments;
+                }
+            }
+
+            if (logPathArg != null)
+            {
+                if (!PathValidation.TryValidateDirectory(logPathArg, out logPath, out string logPathError))
+                {
+                    Console.WriteLine($"Error: invalid --log-path: {logPathError}");
+                    return (int)InstallationResultCode.InvalidArguments;
+                }
+            }
+
+            if (dataPath != null)
+            {
+                Console.WriteLine($"Custom data file directory: {dataPath} (used only when the database is first created)");
+            }
+            if (logPath != null)
+            {
+                Console.WriteLine($"Custom log file directory:  {logPath} (used only when the database is first created)");
+            }
+
             /*Filter out all --flags and their trailing values to get positional arguments
-              (server, username, password). Flags like --entra <email> and --encrypt <level>
-              have a following value that must also be removed.*/
+              (server, username, password). Flags like --entra <email>, --encrypt <level>,
+              --data-path <dir>, and --log-path <dir> have a following value that must also
+              be removed.*/
             var filteredArgsList = new List<string>();
             for (int i = 0; i < args.Length; i++)
             {
                 if (args[i].StartsWith("--", StringComparison.Ordinal))
                 {
-                    /*Skip flags that take a trailing value (--entra <email>, --encrypt <level>)*/
+                    /*Skip flags that take a trailing value (space-separated form)*/
                     if ((args[i].Equals("--entra", StringComparison.OrdinalIgnoreCase)
-                        || args[i].Equals("--encrypt", StringComparison.OrdinalIgnoreCase))
+                        || args[i].Equals("--encrypt", StringComparison.OrdinalIgnoreCase)
+                        || args[i].Equals("--data-path", StringComparison.OrdinalIgnoreCase)
+                        || args[i].Equals("--log-path", StringComparison.OrdinalIgnoreCase))
                         && i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
                     {
                         i++; /*skip the value too*/
@@ -232,6 +276,8 @@ namespace PerformanceMonitorInstaller
                     Console.WriteLine("  --reset-schedule     Reset collection schedule to recommended defaults");
                     Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                     Console.WriteLine("  --trust-cert         Trust server certificate without validation (default: require valid cert)");
+                    Console.WriteLine("  --data-path <dir>    Server-side directory for the data (.mdf) file (first install only)");
+                    Console.WriteLine("  --log-path <dir>     Server-side directory for the log (.ldf) file (first install only)");
                     return (int)InstallationResultCode.InvalidArguments;
                 }
             }
@@ -756,7 +802,10 @@ namespace PerformanceMonitorInstaller
                         Console.WriteLine($"Warning: Dependency installation encountered errors: {ex.Message}");
                         Console.WriteLine("Continuing with installation...");
                     }
-                }).ConfigureAwait(false);
+                },
+                cancellationToken: default,
+                dataPath: dataPath,
+                logPath: logPath).ConfigureAwait(false);
 
             installSuccessCount = installResult.FilesSucceeded;
             installFailureCount = installResult.FilesFailed;
@@ -1105,6 +1154,29 @@ namespace PerformanceMonitorInstaller
             File.WriteAllText(logPath, sb.ToString());
 
             return logPath;
+        }
+
+        /*
+        Read an option value supporting both "--opt=value" and "--opt value" forms.
+        Returns null when the option is absent or has no value. A value that
+        itself starts with "--" (i.e., the next flag) is treated as absent.
+        */
+        private static string? GetOptionValue(string[] args, string optionName)
+        {
+            string prefix = optionName + "=";
+            var equalsForm = args.FirstOrDefault(a => a.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            if (equalsForm != null)
+            {
+                return equalsForm.Substring(prefix.Length);
+            }
+
+            int index = Array.FindIndex(args, a => a.Equals(optionName, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0 && index + 1 < args.Length && !args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                return args[index + 1];
+            }
+
+            return null;
         }
 
         /*

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ PerformanceMonitorInstaller.exe YourServerName --reinstall
 PerformanceMonitorInstaller.exe YourServerName sa YourPassword --reinstall
 ```
 
+Custom data/log file locations (applied only when the database is first created):
+
+```
+PerformanceMonitorInstaller.exe YourServerName --data-path D:\SQLData --log-path E:\SQLLogs
+```
+
 Uninstall (removes database, Agent jobs, and XE sessions):
 
 ```
@@ -208,7 +214,11 @@ The installer automatically tests the connection, checks the SQL Server version 
 | `--preserve-jobs` | Keep existing SQL Agent job schedules during upgrade |
 | `--encrypt=optional\|mandatory\|strict` | Connection encryption level (default: mandatory) |
 | `--trust-cert` | Trust server certificate without validation (default: require valid cert) |
+| `--data-path DIR` | Server-side directory for the data (`.mdf`) file (used only on first install) |
+| `--log-path DIR` | Server-side directory for the log (`.ldf`) file (used only on first install) |
 | `--help` | Show usage information and exit |
+
+> **Custom file locations:** `--data-path` / `--log-path` set where SQL Server places the PerformanceMonitor data and log files. They take effect **only when the database is first created** — if the database already exists they are ignored. Either flag may be supplied independently; an omitted one falls back to the instance default (`SERVERPROPERTY('InstanceDefaultDataPath')` / `InstanceDefaultLogPath`). The directory is a path **on the SQL Server host** and must already exist, with the SQL Server service account holding write permission. Both `--data-path D:\SQLData` and `--data-path=D:\SQLData` forms are accepted; quote paths containing spaces. Not applicable to Azure SQL Managed Instance, which always uses its managed file layout.
 
 **Environment variable:** Set `PM_SQL_PASSWORD` to avoid passing the password on the command line.
 

--- a/install/01_install_database.sql
+++ b/install/01_install_database.sql
@@ -37,8 +37,18 @@ BEGIN
     DECLARE
         @data_path nvarchar(512) = N'',
         @log_path nvarchar(512) = N'',
+        @data_path_override nvarchar(512) = N'',
+        @log_path_override nvarchar(512) = N'',
         @sql nvarchar(max) = N'',
         @engine_edition integer = CONVERT(integer, SERVERPROPERTY(N'EngineEdition'));
+
+    /*
+    The installer injects SET statements for custom data/log file paths here
+    when the --data-path / --log-path options are supplied (#768). When this
+    script is run without those options (or outside the installer) the line
+    below stays an inert comment, so the SERVERPROPERTY defaults are used.
+    */
+    /*__PM_FILE_PATH_OVERRIDES__*/
 
     /*
     Azure SQL Managed Instance (engine edition 8) does not support
@@ -65,17 +75,29 @@ BEGIN
             @log_size_mb integer = 256;
 
         /*
-        Get the default data and log directories from instance properties
+        Use the installer-provided directories when supplied (#768);
+        otherwise fall back to the instance default data/log directories.
+        Override paths already carry a trailing separator.
         */
-        SELECT
-            @data_path =
+        IF LEN(@data_path_override) > 0
+            SET @data_path =
+                @data_path_override +
+                N'PerformanceMonitor.mdf';
+        ELSE
+            SET @data_path =
                 CONVERT
                 (
                     nvarchar(512),
                     SERVERPROPERTY(N'InstanceDefaultDataPath')
                 ) +
-                N'PerformanceMonitor.mdf',
-            @log_path =
+                N'PerformanceMonitor.mdf';
+
+        IF LEN(@log_path_override) > 0
+            SET @log_path =
+                @log_path_override +
+                N'PerformanceMonitor_log.ldf';
+        ELSE
+            SET @log_path =
                 CONVERT
                 (
                     nvarchar(512),
@@ -128,7 +150,7 @@ BEGIN
         ON PRIMARY
         (
             NAME = N''PerformanceMonitor'',
-            FILENAME = N''' + @data_path + N''',
+            FILENAME = N''' + REPLACE(@data_path, N'''', N'''''') + N''',
             SIZE = ' + CONVERT(nvarchar(20), @data_size_mb) + N'MB,
             MAXSIZE = UNLIMITED,
             FILEGROWTH = 1024MB
@@ -136,7 +158,7 @@ BEGIN
         LOG ON
         (
             NAME = N''PerformanceMonitor_log'',
-            FILENAME = N''' + @log_path + N''',
+            FILENAME = N''' + REPLACE(@log_path, N'''', N'''''') + N''',
             SIZE = ' + CONVERT(nvarchar(20), @log_size_mb) + N'MB,
             MAXSIZE = UNLIMITED,
             FILEGROWTH = 64MB
@@ -203,7 +225,7 @@ BEGIN
                     ON PRIMARY
                     (
                         NAME = N''PerformanceMonitor'',
-                        FILENAME = N''' + @data_path + N''',
+                        FILENAME = N''' + REPLACE(@data_path, N'''', N'''''') + N''',
                         SIZE = ' + CONVERT(nvarchar(20), @data_size_mb) + N'MB,
                         MAXSIZE = UNLIMITED,
                         FILEGROWTH = 1024MB
@@ -211,7 +233,7 @@ BEGIN
                     LOG ON
                     (
                         NAME = N''PerformanceMonitor_log'',
-                        FILENAME = N''' + @log_path + N''',
+                        FILENAME = N''' + REPLACE(@log_path, N'''', N'''''') + N''',
                         SIZE = ' + CONVERT(nvarchar(20), @log_size_mb) + N'MB,
                         MAXSIZE = UNLIMITED,
                         FILEGROWTH = 64MB


### PR DESCRIPTION
## Problem

Closes #768. The installer always created the `PerformanceMonitor` database in the instance default data/log directories (`SERVERPROPERTY('InstanceDefaultDataPath')` / `InstanceDefaultLogPath`). There was no way to put the `.mdf`/`.ldf` on a specific volume at install time.

## New flags + usage

Two optional CLI flags, appended to the existing positional `<server> [username] [password]` contract (positional parsing is unchanged):

| Flag | Meaning |
|---|---|
| `--data-path DIR` | Server-side directory for the data (`.mdf`) file |
| `--log-path DIR` | Server-side directory for the log (`.ldf`) file |

Both `--data-path D:\SQLData` and `--data-path=D:\SQLData` forms are accepted (mirrors `--encrypt`). Either flag is independent; an omitted one falls back to the instance default. Example:

```
PerformanceMonitorInstaller.exe MyServer --data-path D:\SQLData --log-path E:\SQLLogs
```

Help text (`--help`), the top-of-`Main` options comment, and the README options table + a usage example are updated.

## How CREATE DATABASE now branches

`install/01_install_database.sql` (inside the existing `IF DB_ID(N'PerformanceMonitor') IS NULL` guard):

- New `@data_path_override` / `@log_path_override` variables (declared empty) and an inert comment token `/*__PM_FILE_PATH_OVERRIDES__*/` (file lines 40-51).
- On the on-prem/RDS branch: `IF LEN(@data_path_override) > 0 SET @data_path = @data_path_override + N'PerformanceMonitor.mdf' ELSE SET @data_path = CONVERT(..., SERVERPROPERTY('InstanceDefaultDataPath')) + ...` (lines 82-106). Same for the log path.
- The installer replaces the token with `SET @..._override = N'...';` statements only when a path is supplied (`InstallationService.ExecuteInstallationAsync`, file `01_` handling). When run without the flags, or outside the installer, the token stays an inert comment and the SERVERPROPERTY defaults are used exactly as before.
- Azure SQL Managed Instance (engine edition 8) is untouched — it uses a plain `CREATE DATABASE` and ignores the overrides (MI doesn't support file specs).

## Injection safety

The path is user input flowing into a `FILENAME = N'...'` literal (FILENAME cannot be parameterized in `CREATE DATABASE`, so the value must be concatenated into dynamic SQL). Defense is layered:

1. **C# validation** (`Installer.Core/PathValidation.cs`): rejects empty/relative paths, control characters (CR/LF/tab — so no extra statements/batches can be smuggled), the chars `" < > | * ?`, and caps length at 480. Requires an absolute Windows drive / UNC / Linux path. Single quote is intentionally allowed (legal in Windows paths) and handled by escaping.
2. **C# escaping**: when building the injected `SET @override = N'...'` literal, single quotes are doubled (`EscapeSqlStringLiteral`). `BuildFilePathOverrideSql` re-validates each path so the Core API is self-defending even if a future caller bypasses the CLI.
3. **T-SQL escaping**: the dynamic `CREATE DATABASE` builds the FILENAME literal via `REPLACE(@data_path, N'''', N'''''')` (both the primary and the model-resize retry blocks), doubling quotes again at runtime.

A security review traced quote-doubling, control characters, truncation desync, and the GO/`:r` post-processing and found no breakout.

## Idempotency / already-exists behavior

The DB-creation block is guarded by `IF DB_ID(N'PerformanceMonitor') IS NULL`, so re-running the installer is a no-op for creation. The custom paths therefore apply **only on first creation** — if the database already exists they are ignored (documented in `--help`, the README, and the install echo). This is install-only behavior, so no `upgrades/` script is needed.

## Validation

- `dotnet build Installer/PerformanceMonitorInstaller.csproj -c Debug` → Build succeeded, 0 errors, 0 warnings.
- `dotnet test Installer.Tests --filter "Category!=Integration"` → 61 passed, 0 failed (34 new `PathValidationTests`). Integration tests (which require a live SQL Server) were not run.

## Risk note

`--data-path` / `--log-path` are **server-side** directories. They must already exist on the SQL Server host and the SQL Server service account must have write permission, or `CREATE DATABASE` will fail (SQL Server does not create directories for data files). The installer validates only path shape on the client, not existence on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)