### PR TITLE
Add configurable failed SQL Agent job alert to Lite and Dashboard (#749)

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -99,6 +99,14 @@ namespace PerformanceMonitorDashboard
         private readonly ConcurrentDictionary<string, bool> _activeTempDbSpaceAlert = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastLongRunningJobAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeLongRunningJobAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastFailedJobAlert = new();
+        /* Watermark of the most-recent failed-job run time already alerted per server. A failed
+           run lingers in the lookback window for the whole window, so a plain level check would
+           re-fire every cooldown; we only notify when a strictly newer failure appears. Bounded
+           by server count, so no pruning needed. (Server-local run times mean a fall-back DST hour
+           / NTP step could let one new failure tie the watermark and be skipped — a once-a-year,
+           one-hour edge.) */
+        private readonly ConcurrentDictionary<string, DateTime> _lastAlertedFailedJobTime = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastCaptureDownAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeCaptureDownAlert = new();
         private readonly ConcurrentDictionary<string, long> _previousDeadlockCounts = new();
@@ -1493,7 +1501,7 @@ namespace PerformanceMonitorDashboard
                     var connectionString = server.GetConnectionString(_credentialService);
                     var databaseService = new DatabaseService(connectionString);
                     var connStatus = _serverManager.GetConnectionStatus(server.Id);
-                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition, prefs.LongRunningQueryThresholdMinutes, prefs.LongRunningJobMultiplier, prefs.LongRunningQueryMaxResults, prefs.LongRunningQueryExcludeSpServerDiagnostics, prefs.LongRunningQueryExcludeWaitFor, prefs.LongRunningQueryExcludeBackups, prefs.LongRunningQueryExcludeMiscWaits, prefs.LongRunningQueryExcludeCdc, prefs.AlertExcludedDatabases);
+                    var health = await databaseService.GetAlertHealthAsync(connStatus.SqlEngineEdition, prefs.LongRunningQueryThresholdMinutes, prefs.LongRunningJobMultiplier, prefs.LongRunningQueryMaxResults, prefs.LongRunningQueryExcludeSpServerDiagnostics, prefs.LongRunningQueryExcludeWaitFor, prefs.LongRunningQueryExcludeBackups, prefs.LongRunningQueryExcludeMiscWaits, prefs.LongRunningQueryExcludeCdc, prefs.FailedJobLookbackMinutes, prefs.AlertExcludedDatabases);
 
                     if (health.IsOnline)
                     {
@@ -2023,6 +2031,56 @@ namespace PerformanceMonitorDashboard
                 _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Jobs Cleared",
                     "0", $"{prefs.LongRunningJobMultiplier}x avg", true, "tray");
             }
+
+            /* Failed Agent job alerts — live msdb query for runs that failed in the lookback window.
+               Failures are point-in-time events (not a sustained state), so there is no "cleared"
+               notification; the per-server watermark below dedups so the same failure never re-fires. */
+            if (prefs.NotifyOnFailedJobs && health.RecentlyFailedJobs.Count > 0)
+            {
+                var newestFailure = health.RecentlyFailedJobs.Max(j => j.RunDateTime);
+                bool hasWatermark = _lastAlertedFailedJobTime.TryGetValue(serverId, out var lastFailure);
+                bool hasNewFailure = !hasWatermark || newestFailure > lastFailure;
+
+                if (hasNewFailure
+                    && (!_lastFailedJobAlert.TryGetValue(serverId, out var lastFailedAlert) || (now - lastFailedAlert) >= alertCooldown))
+                {
+                    var mostRecent = health.RecentlyFailedJobs[0]; // ORDER BY run_datetime DESC
+                    var jobNames = string.Join(", ", health.RecentlyFailedJobs.Select(j => j.JobName).Distinct().Take(3));
+
+                    var muteCtx = new AlertMuteContext { ServerName = serverName, MetricName = "Failed Agent Job", JobName = mostRecent.JobName };
+                    bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
+                    _lastFailedJobAlert[serverId] = now;
+                    _lastAlertedFailedJobTime[serverId] = newestFailure;
+                    var jobContext = BuildFailedJobContext(health.RecentlyFailedJobs);
+                    var detailText = ContextToDetailText(jobContext);
+
+                    if (!isMuted)
+                    {
+                        _notificationService?.ShowSnoozableNotification(
+                            "Failed Agent Job",
+                            $"{serverName}: {health.RecentlyFailedJobs.Count} job failure(s) — {jobNames}",
+                            NotificationType.Warning,
+                            serverName,
+                            "Failed Agent Job",
+                            _muteRuleService);
+                    }
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "Failed Agent Job",
+                        $"{health.RecentlyFailedJobs.Count} failure(s) — {jobNames}",
+                        $"last {prefs.FailedJobLookbackMinutes}m", !isMuted, isMuted ? "muted" : "tray", muted: isMuted, detailText: detailText);
+
+                    if (!isMuted)
+                    {
+                        await _emailAlertService.TrySendAlertEmailAsync(
+                            "Failed Agent Job",
+                            serverName,
+                            $"{health.RecentlyFailedJobs.Count} job failure(s) in last {prefs.FailedJobLookbackMinutes}m — {jobNames}",
+                            $"last {prefs.FailedJobLookbackMinutes}m",
+                            serverId,
+                            jobContext);
+                    }
+                }
+            }
         }
 
         private static string Truncate(string text, int maxLength = 300)
@@ -2267,6 +2325,23 @@ namespace PerformanceMonitorDashboard
                         ("Started", j.StartTime.ToString("yyyy-MM-dd HH:mm:ss"))
                     }
                 });
+            }
+            return context;
+        }
+
+        private static AlertContext? BuildFailedJobContext(List<FailedJobInfo> jobs)
+        {
+            if (jobs.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var j in jobs.GetRange(0, Math.Min(5, jobs.Count)))
+            {
+                var item = new AlertDetailItem { Heading = j.JobName, Fields = new() };
+                item.Fields.Add(("Job", j.JobName));
+                item.Fields.Add(("Failed At", j.RunDateTimeFormatted));
+                if (!string.IsNullOrEmpty(j.Message))
+                    item.Fields.Add(("Message", Truncate(j.Message, 300)));
+                context.Details.Add(item);
             }
             return context;
         }

--- a/Dashboard/Models/AlertHealthResult.cs
+++ b/Dashboard/Models/AlertHealthResult.cs
@@ -35,6 +35,13 @@ namespace PerformanceMonitorDashboard.Models
         public List<LongRunningQueryInfo> LongRunningQueries { get; set; } = new();
         public TempDbSpaceInfo? TempDbSpace { get; set; }
         public List<AnomalousJobInfo> AnomalousJobs { get; set; } = new();
+
+        /// <summary>
+        /// SQL Agent job runs that failed within the failed-job lookback window. Live
+        /// msdb query — empty on Azure SQL DB (no Agent) or when the login lacks msdb /
+        /// SQLAgentReaderRole access.
+        /// </summary>
+        public List<FailedJobInfo> RecentlyFailedJobs { get; set; } = new();
         public bool IsOnline { get; set; } = true;
 
         /// <summary>

--- a/Dashboard/Models/FailedJobInfo.cs
+++ b/Dashboard/Models/FailedJobInfo.cs
@@ -1,0 +1,29 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+
+namespace PerformanceMonitorDashboard.Models
+{
+    /// <summary>
+    /// A SQL Agent job run (step_id = 0 outcome row) that FAILED within the alert
+    /// lookback window. Sourced from a live msdb.dbo.sysjobhistory query at alert-check
+    /// time — failure outcomes are not part of the collected running_jobs snapshot.
+    /// </summary>
+    public class FailedJobInfo
+    {
+        public string JobName { get; set; } = "";
+        public string JobId { get; set; } = "";
+
+        /// <summary>Server-local time the failed run started (from run_date/run_time).</summary>
+        public DateTime RunDateTime { get; set; }
+        public int StepId { get; set; }
+        public string StepName { get; set; } = "";
+        public string Message { get; set; } = "";
+
+        public string RunDateTimeFormatted => RunDateTime.ToString("yyyy-MM-dd HH:mm:ss");
+    }
+}

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -107,6 +107,8 @@ namespace PerformanceMonitorDashboard.Models
         public int TempDbSpaceThresholdPercent { get; set; } = 80; // Alert when TempDB used > X%
         public bool NotifyOnLongRunningJobs { get; set; } = true;
         public int LongRunningJobMultiplier { get; set; } = 3; // Alert when job runs > Nx historical average
+        public bool NotifyOnFailedJobs { get; set; } = true; // Alert when a SQL Agent job has recently failed
+        public int FailedJobLookbackMinutes { get; set; } = 60; // Look back this many minutes for failed Agent job runs
         private int _alertCooldownMinutes = 5;
         public int AlertCooldownMinutes
         {

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -132,6 +132,7 @@ namespace PerformanceMonitorDashboard.Services
             bool excludeBackups = true,
             bool excludeMiscWaits = true,
             bool excludeCdc = true,
+            int failedJobLookbackMinutes = 60,
             IReadOnlyList<string>? excludedDatabases = null)
         {
             var result = new AlertHealthResult();
@@ -153,11 +154,17 @@ namespace PerformanceMonitorDashboard.Services
                 var longRunningTask = GetLongRunningQueriesAsync(connection, longRunningQueryThresholdMinutes, longRunningQueryMaxResults, excludeSpServerDiagnostics, excludeWaitFor, excludeBackups, excludeMiscWaits, excludeCdc);
                 var tempDbTask = GetTempDbSpaceAsync(connection);
                 var anomalousJobTask = GetAnomalousJobsAsync(connection, longRunningJobMultiplier);
+                /* Azure SQL DB has no SQL Agent, so msdb.dbo.sysjobhistory doesn't exist there —
+                   skip the live failed-job query entirely (the other queries already gate Azure
+                   the same way via engineEdition). */
+                var failedJobTask = engineEdition == 5
+                    ? Task.FromResult(new List<FailedJobInfo>())
+                    : GetRecentlyFailedJobsAsync(connection, failedJobLookbackMinutes);
                 var missingCaptureTask = GetMissingCaptureSessionsAsync(connection);
 
                 var allTasks = filteredDeadlockTask != null
-                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, missingCaptureTask }
-                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, missingCaptureTask };
+                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, failedJobTask, missingCaptureTask }
+                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, anomalousJobTask, failedJobTask, missingCaptureTask };
                 await Task.WhenAll(allTasks);
 
                 var cpuResult = await cpuTask;
@@ -175,6 +182,7 @@ namespace PerformanceMonitorDashboard.Services
                 result.LongRunningQueries = await longRunningTask;
                 result.TempDbSpace = await tempDbTask;
                 result.AnomalousJobs = await anomalousJobTask;
+                result.RecentlyFailedJobs = await failedJobTask;
                 result.MissingCaptureSessions = await missingCaptureTask;
             }
             catch (Exception ex)
@@ -910,6 +918,85 @@ namespace PerformanceMonitorDashboard.Services
             catch (Exception ex)
             {
                 Logger.Warning($"Failed to get anomalous jobs: {ex.Message}");
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Live query against the monitored server's msdb for SQL Agent job runs (step_id = 0
+        /// outcome row, run_status = 0 = Failed) that failed within the lookback window.
+        /// run_date/run_time integers are converted to a server-local datetime and filtered to the
+        /// last N minutes. Degrades gracefully: a login without msdb / SQLAgentReaderRole access
+        /// raises a catchable SqlException (916/229/297/300) that returns an empty list rather than
+        /// failing the alert cycle. Azure SQL DB (no Agent) is skipped by the caller.
+        /// </summary>
+        private async Task<List<FailedJobInfo>> GetRecentlyFailedJobsAsync(SqlConnection connection, int lookbackMinutes)
+        {
+            var results = new List<FailedJobInfo>();
+
+            const string query = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                SELECT TOP (50)
+                    job_name = j.name,
+                    job_id = CONVERT(varchar(36), j.job_id),
+                    run_datetime =
+                        DATEADD
+                        (
+                            SECOND,
+                            (jh.run_time / 10000) * 3600 +
+                            ((jh.run_time / 100) % 100) * 60 +
+                            (jh.run_time % 100),
+                            CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
+                        ),
+                    step_id = jh.step_id,
+                    step_name = jh.step_name,
+                    message = jh.message
+                FROM msdb.dbo.sysjobhistory AS jh
+                JOIN msdb.dbo.sysjobs AS j
+                  ON j.job_id = jh.job_id
+                WHERE jh.step_id = 0
+                AND   jh.run_status = 0
+                AND   jh.run_date >= CONVERT(integer, CONVERT(varchar(8), DATEADD(MINUTE, -@lookback_minutes, GETDATE()), 112))
+                AND   DATEADD
+                      (
+                          SECOND,
+                          (jh.run_time / 10000) * 3600 +
+                          ((jh.run_time / 100) % 100) * 60 +
+                          (jh.run_time % 100),
+                          CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
+                      ) >= DATEADD(MINUTE, -@lookback_minutes, GETDATE())
+                ORDER BY
+                    run_datetime DESC
+                OPTION(RECOMPILE);";
+
+            try
+            {
+                using var cmd = new SqlCommand(query, connection);
+                cmd.CommandTimeout = 10;
+                cmd.Parameters.Add(new SqlParameter("@lookback_minutes", SqlDbType.Int) { Value = lookbackMinutes });
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    results.Add(new FailedJobInfo
+                    {
+                        JobName = reader.GetString(0),
+                        JobId = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                        RunDateTime = reader.GetDateTime(2),
+                        StepId = reader.IsDBNull(3) ? 0 : Convert.ToInt32(reader.GetValue(3), System.Globalization.CultureInfo.InvariantCulture),
+                        StepName = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                        Message = reader.IsDBNull(5) ? "" : reader.GetString(5)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                /* No msdb access / not SQLAgentReaderRole, or any other server-side error —
+                   skip silently so a single permission gap doesn't fail the whole alert cycle.
+                   Logged at Info, not Warning: a read-only monitoring login without msdb access
+                   hits this every alert cycle, so a Warning would bury real warnings. */
+                Logger.Info($"Skipping recently-failed-job check (msdb/SQLAgentReaderRole access needed): {ex.Message}");
             }
 
             return results;

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -276,6 +276,19 @@
                                          TextAlignment="Center"/>
                                 <TextBlock Text="x historical average" VerticalAlignment="Center"/>
                             </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnFailedJobsCheckBox"
+                                          Content="Agent job failed in the last"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnFailedJobsCheckBox_Changed"
+                                          Unchecked="NotifyOnFailedJobsCheckBox_Changed"/>
+                                <TextBox x:Name="FailedJobLookbackTextBox"
+                                         Width="50"
+                                         Margin="8,0,8,0"
+                                         VerticalAlignment="Center"
+                                         TextAlignment="Center"/>
+                                <TextBlock Text="minutes" VerticalAlignment="Center"/>
+                            </StackPanel>
                             <TextBlock x:Name="AlertPreviewText" FontSize="11" FontStyle="Italic" Foreground="Gray"
                                        TextWrapping="Wrap" Margin="0,12,0,0"/>
                             <StackPanel Orientation="Horizontal" Margin="0,12,0,0">

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -192,6 +192,8 @@ namespace PerformanceMonitorDashboard
             TempDbSpaceThresholdTextBox.Text = prefs.TempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
             NotifyOnLongRunningJobsCheckBox.IsChecked = prefs.NotifyOnLongRunningJobs;
             LongRunningJobMultiplierTextBox.Text = prefs.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
+            NotifyOnFailedJobsCheckBox.IsChecked = prefs.NotifyOnFailedJobs;
+            FailedJobLookbackTextBox.Text = prefs.FailedJobLookbackMinutes.ToString(CultureInfo.InvariantCulture);
             AlertCooldownTextBox.Text = prefs.AlertCooldownMinutes.ToString(CultureInfo.InvariantCulture);
             EmailCooldownTextBox.Text = prefs.EmailCooldownMinutes.ToString(CultureInfo.InvariantCulture);
             MuteRuleDefaultExpirationCombo.SelectedIndex = prefs.MuteRuleDefaultExpiration switch
@@ -360,6 +362,12 @@ namespace PerformanceMonitorDashboard
             UpdateAlertNotificationStates();
         }
 
+        private void NotifyOnFailedJobsCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
         private void RestoreAlertDefaultsButton_Click(object sender, RoutedEventArgs e)
         {
             BlockingThresholdTextBox.Text = "30";
@@ -369,6 +377,7 @@ namespace PerformanceMonitorDashboard
             LongRunningQueryThresholdTextBox.Text = "30";
             TempDbSpaceThresholdTextBox.Text = "80";
             LongRunningJobMultiplierTextBox.Text = "3";
+            FailedJobLookbackTextBox.Text = "60";
             AlertCooldownTextBox.Text = "5";
             EmailCooldownTextBox.Text = "15";
             AlertExcludedDatabasesTextBox.Text = "";
@@ -401,6 +410,8 @@ namespace PerformanceMonitorDashboard
                 parts.Add($"TempDB > {TempDbSpaceThresholdTextBox.Text}%");
             if (NotifyOnLongRunningJobsCheckBox.IsChecked == true)
                 parts.Add($"jobs > {LongRunningJobMultiplierTextBox.Text}x avg");
+            if (NotifyOnFailedJobsCheckBox.IsChecked == true)
+                parts.Add($"failed jobs (last {FailedJobLookbackTextBox.Text}m)");
 
             AlertPreviewText.Text = parts.Count > 0
                 ? $"Will alert when: {string.Join(", ", parts)}"
@@ -425,6 +436,8 @@ namespace PerformanceMonitorDashboard
             TempDbSpaceThresholdTextBox.IsEnabled = notificationsEnabled && NotifyOnTempDbSpaceCheckBox.IsChecked == true;
             NotifyOnLongRunningJobsCheckBox.IsEnabled = notificationsEnabled;
             LongRunningJobMultiplierTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningJobsCheckBox.IsChecked == true;
+            NotifyOnFailedJobsCheckBox.IsEnabled = notificationsEnabled;
+            FailedJobLookbackTextBox.IsEnabled = notificationsEnabled && NotifyOnFailedJobsCheckBox.IsChecked == true;
             UpdateAlertPreviewText();
         }
 
@@ -702,6 +715,12 @@ namespace PerformanceMonitorDashboard
                 prefs.LongRunningJobMultiplier = jobMultiplier;
             else if (prefs.NotifyOnLongRunningJobs)
                 validationErrors.Add("Job multiplier must be a positive number");
+
+            prefs.NotifyOnFailedJobs = NotifyOnFailedJobsCheckBox.IsChecked == true;
+            if (int.TryParse(FailedJobLookbackTextBox.Text, out int failedJobLookback) && failedJobLookback >= 1 && failedJobLookback <= 1440)
+                prefs.FailedJobLookbackMinutes = failedJobLookback;
+            else if (prefs.NotifyOnFailedJobs)
+                validationErrors.Add("Failed-job lookback must be between 1 and 1440 minutes");
 
             if (int.TryParse(AlertCooldownTextBox.Text, out int alertCooldown) && alertCooldown >= 1 && alertCooldown <= 120)
                 prefs.AlertCooldownMinutes = alertCooldown;

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -107,6 +107,8 @@ public partial class App : Application
     public static int AlertTempDbSpaceThresholdPercent { get; set; } = 80;
     public static bool AlertLongRunningJobEnabled { get; set; } = true;
     public static int AlertLongRunningJobMultiplier { get; set; } = 3;
+    public static bool AlertFailedJobEnabled { get; set; } = true;
+    public static int AlertFailedJobLookbackMinutes { get; set; } = 60;  // Look back this many minutes for failed Agent job runs
     public static int AlertCooldownMinutes { get; set; } = 5;  // Tray notification cooldown between repeated alerts
     public static int EmailCooldownMinutes { get; set; } = 15; // Email cooldown between repeated alerts
     public static string MuteRuleDefaultExpiration { get; set; } = "24 hours"; // Default expiration for new mute rules
@@ -487,6 +489,8 @@ public partial class App : Application
             if (root.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.GetInt32();
             if (root.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.GetInt32();
+            if (root.TryGetProperty("alert_failed_job_enabled", out v)) AlertFailedJobEnabled = v.GetBoolean();
+            if (root.TryGetProperty("alert_failed_job_lookback_minutes", out v)) AlertFailedJobLookbackMinutes = (int)Math.Clamp(v.GetInt64(), 1, 1440);
             if (root.TryGetProperty("alert_cooldown_minutes", out v)) AlertCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 1, 120);
             if (root.TryGetProperty("email_cooldown_minutes", out v)) EmailCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 1, 120);
             if (root.TryGetProperty("mute_rule_default_expiration", out v))

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -68,6 +68,13 @@ public partial class MainWindow : Window
     private readonly Dictionary<string, bool> _activeLongRunningQueryAlert = new();
     private readonly Dictionary<string, bool> _activeTempDbSpaceAlert = new();
     private readonly Dictionary<string, bool> _activeLongRunningJobAlert = new();
+    private readonly Dictionary<string, DateTime> _lastFailedJobAlert = new();
+    /* Watermark of the most-recent failed-job run time already alerted per server. A failed run
+       lingers in the lookback window for the whole window, so a plain level check would re-fire
+       every cooldown; we only notify when a strictly newer failure appears. Bounded by server
+       count, so no pruning needed. (Server-local run times mean a fall-back DST hour / NTP step
+       could let one new failure tie the watermark and be skipped — a once-a-year, one-hour edge.) */
+    private readonly Dictionary<string, DateTime> _lastAlertedFailedJobTime = new();
 
     /* Edge-trigger watermarks (#1091): the rolling 1-hour blocking/deadlock counts stay
        above the threshold for the whole hour an event lingers in the window, so a plain
@@ -1974,6 +1981,83 @@ public partial class MainWindow : Window
                 AppLogger.Error("Alerts", $"Failed to check anomalous jobs for {summary.DisplayName}: {ex.Message}");
             }
         }
+
+        /* Failed Agent job alerts — live msdb query for runs that failed in the lookback window.
+           Failure outcomes aren't part of the collected running_jobs snapshot, so this queries the
+           monitored server directly (mirrors the long-running-query live pattern). Failures are
+           point-in-time events, so there is no "cleared" notification; the per-server watermark
+           dedups so the same failure never re-fires. */
+        if (App.AlertFailedJobEnabled && _collectorService != null)
+        {
+            try
+            {
+                var server = _serverManager.GetAllServers().FirstOrDefault(s =>
+                    RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(s)).ToString() == key);
+                var connStatus = server != null ? _serverManager.GetConnectionStatus(server.Id) : null;
+
+                /* Only query online, non-Azure-SQL-DB servers whose login has msdb access.
+                   Azure SQL DB has no SQL Agent; a login without msdb can't read sysjobhistory. */
+                if (server != null
+                    && connStatus != null
+                    && connStatus.IsOnline == true
+                    && connStatus.SqlEngineEdition != 5
+                    && connStatus.HasMsdbAccess)
+                {
+                    /* Live msdb read via the collector's connection path (async SqlClient, already
+                       off the UI thread; MFA serialization / throttle / retry handled inside). */
+                    var failedJobs = await _collectorService.GetRecentlyFailedJobsAsync(server, App.AlertFailedJobLookbackMinutes);
+
+                    if (failedJobs.Count > 0)
+                    {
+                        var newestFailure = failedJobs.Max(j => j.RunDateTime);
+                        bool hasWatermark = _lastAlertedFailedJobTime.TryGetValue(key, out var lastFailure);
+                        bool hasNewFailure = !hasWatermark || newestFailure > lastFailure;
+
+                        if (hasNewFailure && !suppressPopups &&
+                            (!_lastFailedJobAlert.TryGetValue(key, out var lastFailedAlert) || now - lastFailedAlert >= alertCooldown))
+                        {
+                            var mostRecent = failedJobs[0]; // ORDER BY run_datetime DESC
+                            var jobNames = string.Join(", ", failedJobs.Select(j => j.JobName).Distinct().Take(3));
+
+                            var muteCtx = new AlertMuteContext { ServerName = summary.DisplayName, MetricName = "Failed Agent Job", JobName = mostRecent.JobName };
+                            bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
+                            _lastFailedJobAlert[key] = now;
+                            _lastAlertedFailedJobTime[key] = newestFailure;
+
+                            if (!isMuted)
+                            {
+                                _trayService.ShowSnoozableNotification(
+                                    "Failed Agent Job",
+                                    $"{summary.DisplayName}: {failedJobs.Count} job failure(s) — {jobNames}",
+                                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Warning,
+                                    summary.DisplayName,
+                                    "Failed Agent Job",
+                                    _muteRuleService);
+                            }
+
+                            var failedJobContext = BuildFailedJobContext(failedJobs);
+                            var detailText = ContextToDetailText(failedJobContext);
+
+                            await _emailAlertService.TrySendAlertEmailAsync(
+                                "Failed Agent Job",
+                                summary.DisplayName,
+                                $"{failedJobs.Count} job failure(s) in last {App.AlertFailedJobLookbackMinutes}m — {jobNames}",
+                                $"last {App.AlertFailedJobLookbackMinutes}m",
+                                summary.ServerId,
+                                failedJobContext,
+                                numericCurrentValue: failedJobs.Count,
+                                numericThresholdValue: 0,
+                                muted: isMuted,
+                                detailText: detailText);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error("Alerts", $"Failed to check failed jobs for {summary.DisplayName}: {ex.Message}");
+            }
+        }
     }
 
         private static string TruncateText(string text, int maxLength = 300)
@@ -2219,6 +2303,23 @@ public partial class MainWindow : Window
                         ("Started", j.StartTime.ToString("yyyy-MM-dd HH:mm:ss"))
                     }
                 });
+            }
+            return context;
+        }
+
+        private static AlertContext? BuildFailedJobContext(List<FailedJobInfo> jobs)
+        {
+            if (jobs.Count == 0) return null;
+
+            var context = new AlertContext();
+            foreach (var j in jobs.GetRange(0, Math.Min(5, jobs.Count)))
+            {
+                var item = new AlertDetailItem { Heading = j.JobName, Fields = new() };
+                item.Fields.Add(("Job", j.JobName));
+                item.Fields.Add(("Failed At", j.RunDateTimeFormatted));
+                if (!string.IsNullOrEmpty(j.Message))
+                    item.Fields.Add(("Message", TruncateText(j.Message, 300)));
+                context.Details.Add(item);
             }
             return context;
         }

--- a/Lite/Services/LocalDataService.RunningJobs.cs
+++ b/Lite/Services/LocalDataService.RunningJobs.cs
@@ -121,6 +121,20 @@ LIMIT 5";
     }
 }
 
+public class FailedJobInfo
+{
+    public string JobName { get; set; } = "";
+    public string JobId { get; set; } = "";
+
+    /// <summary>Server-local time the failed run started (from run_date/run_time).</summary>
+    public DateTime RunDateTime { get; set; }
+    public int StepId { get; set; }
+    public string StepName { get; set; } = "";
+    public string Message { get; set; } = "";
+
+    public string RunDateTimeFormatted => RunDateTime.ToString("yyyy-MM-dd HH:mm:ss");
+}
+
 public class AnomalousJobInfo
 {
     public string JobName { get; set; } = "";

--- a/Lite/Services/RemoteCollectorService.RunningJobs.cs
+++ b/Lite/Services/RemoteCollectorService.RunningJobs.cs
@@ -189,4 +189,89 @@ OPTION(RECOMPILE);";
         _logger?.LogDebug("Collected {RowCount} running job rows for server '{Server}'", rowsCollected, server.DisplayName);
         return rowsCollected;
     }
+
+    /// <summary>
+    /// Live query against the monitored server's msdb for SQL Agent job runs (step_id = 0 outcome
+    /// row, run_status = 0 = Failed) that failed within the lookback window.
+    /// Runs at alert-check time — failure outcomes are not part of the collected running_jobs
+    /// snapshot. run_date/run_time integers are converted to a server-local datetime and filtered
+    /// to the last N minutes. Reuses the collector's connection path (MFA serialization, throttle,
+    /// retry) and degrades gracefully: any error (a login without msdb / SQLAgentReaderRole access,
+    /// a transient failure, etc.) returns an empty list rather than failing the alert cycle. The
+    /// caller skips Azure SQL DB (no Agent) and no-msdb logins before calling.
+    /// </summary>
+    public async Task<List<FailedJobInfo>> GetRecentlyFailedJobsAsync(
+        ServerConnection server,
+        int lookbackMinutes,
+        CancellationToken cancellationToken = default)
+    {
+        const string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP (50)
+    job_name = j.name,
+    job_id = CONVERT(varchar(36), j.job_id),
+    run_datetime =
+        DATEADD
+        (
+            SECOND,
+            (jh.run_time / 10000) * 3600 +
+            ((jh.run_time / 100) % 100) * 60 +
+            (jh.run_time % 100),
+            CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
+        ),
+    step_id = jh.step_id,
+    step_name = jh.step_name,
+    message = jh.message
+FROM msdb.dbo.sysjobhistory AS jh
+JOIN msdb.dbo.sysjobs AS j
+  ON j.job_id = jh.job_id
+WHERE jh.step_id = 0
+AND   jh.run_status = 0
+AND   jh.run_date >= CONVERT(integer, CONVERT(varchar(8), DATEADD(MINUTE, -@lookback_minutes, GETDATE()), 112))
+AND   DATEADD
+      (
+          SECOND,
+          (jh.run_time / 10000) * 3600 +
+          ((jh.run_time / 100) % 100) * 60 +
+          (jh.run_time % 100),
+          CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
+      ) >= DATEADD(MINUTE, -@lookback_minutes, GETDATE())
+ORDER BY
+    run_datetime DESC
+OPTION(RECOMPILE);";
+
+        var items = new List<FailedJobInfo>();
+
+        try
+        {
+            using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+            using var command = new SqlCommand(query, sqlConnection);
+            command.CommandTimeout = CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@lookback_minutes", lookbackMinutes);
+
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                items.Add(new FailedJobInfo
+                {
+                    JobName = reader.GetString(0),
+                    JobId = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    RunDateTime = reader.GetDateTime(2),
+                    StepId = reader.IsDBNull(3) ? 0 : Convert.ToInt32(reader.GetValue(3)),
+                    StepName = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                    Message = reader.IsDBNull(5) ? "" : reader.GetString(5)
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            /* No msdb access / not SQLAgentReaderRole, or any other server-side error —
+               skip silently so a single permission gap doesn't fail the whole alert cycle. */
+            _logger?.LogDebug("Skipping failed-job check for '{Server}': {Message}", server.DisplayName, ex.Message);
+            return new List<FailedJobInfo>();
+        }
+
+        return items;
+    }
 }

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -229,6 +229,13 @@
                     <TextBlock Text="x historical average" VerticalAlignment="Center" Margin="2,0,0,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertFailedJobCheckBox" Content="Agent job failed in the last" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFailedJobLookbackBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,10,0,0">
                     <TextBlock Text="Tray notification cooldown:" VerticalAlignment="Center" Margin="0,0,8,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -599,6 +599,8 @@ public partial class SettingsWindow : Window
         AlertTempDbSpaceThresholdBox.Text = App.AlertTempDbSpaceThresholdPercent.ToString();
         AlertLongRunningJobCheckBox.IsChecked = App.AlertLongRunningJobEnabled;
         AlertLongRunningJobMultiplierBox.Text = App.AlertLongRunningJobMultiplier.ToString();
+        AlertFailedJobCheckBox.IsChecked = App.AlertFailedJobEnabled;
+        AlertFailedJobLookbackBox.Text = App.AlertFailedJobLookbackMinutes.ToString();
         AlertCooldownBox.Text = App.AlertCooldownMinutes.ToString();
         EmailCooldownBox.Text = App.EmailCooldownMinutes.ToString();
         MuteRuleDefaultExpirationCombo.SelectedIndex = App.MuteRuleDefaultExpiration switch
@@ -655,6 +657,9 @@ public partial class SettingsWindow : Window
         App.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
         if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult >= 2 && jobMult <= 20)
             App.AlertLongRunningJobMultiplier = jobMult;
+        App.AlertFailedJobEnabled = AlertFailedJobCheckBox.IsChecked == true;
+        if (int.TryParse(AlertFailedJobLookbackBox.Text, out var failedJobLookback) && failedJobLookback >= 1 && failedJobLookback <= 1440)
+            App.AlertFailedJobLookbackMinutes = failedJobLookback;
         var validationErrors = new List<string>();
         if (int.TryParse(AlertCooldownBox.Text, out var alertCooldown) && alertCooldown >= 1 && alertCooldown <= 120)
             App.AlertCooldownMinutes = alertCooldown;
@@ -719,6 +724,8 @@ public partial class SettingsWindow : Window
             root["alert_tempdb_space_threshold_percent"] = App.AlertTempDbSpaceThresholdPercent;
             root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
             root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
+            root["alert_failed_job_enabled"] = App.AlertFailedJobEnabled;
+            root["alert_failed_job_lookback_minutes"] = App.AlertFailedJobLookbackMinutes;
             root["alert_cooldown_minutes"] = App.AlertCooldownMinutes;
             root["email_cooldown_minutes"] = App.EmailCooldownMinutes;
             root["mute_rule_default_expiration"] = App.MuteRuleDefaultExpiration;
@@ -763,6 +770,7 @@ public partial class SettingsWindow : Window
         AlertLongRunningQueryThresholdBox.Text = "30";
         AlertTempDbSpaceThresholdBox.Text = "80";
         AlertLongRunningJobMultiplierBox.Text = "3";
+        AlertFailedJobLookbackBox.Text = "60";
         AlertCooldownBox.Text = "5";
         EmailCooldownBox.Text = "15";
         AnalysisIntervalBox.Text = "30";
@@ -800,6 +808,8 @@ public partial class SettingsWindow : Window
             parts.Add($"TempDB > {AlertTempDbSpaceThresholdBox.Text}%");
         if (AlertLongRunningJobCheckBox.IsChecked == true)
             parts.Add($"jobs > {AlertLongRunningJobMultiplierBox.Text}x avg");
+        if (AlertFailedJobCheckBox.IsChecked == true)
+            parts.Add($"failed jobs (last {AlertFailedJobLookbackBox.Text}m)");
 
         AlertPreviewText.Text = parts.Count > 0
             ? $"Will alert when: {string.Join(", ", parts)}"
@@ -825,6 +835,8 @@ public partial class SettingsWindow : Window
         AlertTempDbSpaceThresholdBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
+        AlertFailedJobCheckBox.IsEnabled = enabled;
+        AlertFailedJobLookbackBox.IsEnabled = enabled;
         UpdateAlertPreviewText();
     }
 


### PR DESCRIPTION
## Problem

Both apps already alert on SQL Agent job *duration* (long-running and anomalous-vs-historical), but there is no alert on job **failure outcome**. Closes #749 by adding a user-configurable "Failed Agent Job" alert to **both** Lite and Dashboard, at full parity.

## The failed-job query + permission/Azure gating

Recently-failed jobs are **not** part of the collected `running_jobs` snapshot, so the check issues a **live query against the monitored server at alert-check time** (mirroring how the long-running alerts read the live server). Identical T-SQL in both apps:

```sql
SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;

SELECT TOP (50)
    job_name = j.name,
    job_id = CONVERT(varchar(36), j.job_id),
    run_datetime =
        DATEADD(SECOND,
            (jh.run_time / 10000) * 3600 +
            ((jh.run_time / 100) % 100) * 60 +
            (jh.run_time % 100),
            CONVERT(datetime, CONVERT(varchar(8), jh.run_date))),
    step_id = jh.step_id,
    step_name = jh.step_name,
    message = jh.message
FROM msdb.dbo.sysjobhistory AS jh
JOIN msdb.dbo.sysjobs AS j
  ON j.job_id = jh.job_id
WHERE jh.step_id = 0        /* job outcome row */
AND   jh.run_status = 0     /* 0 = Failed */
AND   jh.run_date >= CONVERT(integer, CONVERT(varchar(8), DATEADD(MINUTE, -@lookback_minutes, GETDATE()), 112))
AND   DATEADD(SECOND, ...same arithmetic... , CONVERT(datetime, CONVERT(varchar(8), jh.run_date))) >= DATEADD(MINUTE, -@lookback_minutes, GETDATE())
ORDER BY run_datetime DESC
OPTION(RECOMPILE);
```

- `step_id = 0` is the job-level outcome row; `run_status = 0` = Failed. `run_date`/`run_time` integers are converted to a **server-local** datetime (Agent stores server-local; threshold uses server-local `GETDATE()`, so no skew). A coarse sargable `run_date >=` pre-filter narrows the scan, then the precise datetime filter handles the midnight boundary. The arithmetic matches the existing `run_duration` idiom in `CollectRunningJobsAsync`.
- **Graceful degradation:** the whole read is wrapped so a login without msdb / `SQLAgentReaderRole` access (916/229/297/300) returns an empty list and **never faults the alert cycle**. Lite additionally pre-gates on `connStatus.HasMsdbAccess`; Dashboard logs the skip at Info (not Warning) so a read-only monitoring login doesn't bury the Warning log every cycle.
- **Azure SQL DB** has no SQL Agent, so the query is skipped entirely when `engineEdition == 5`.

Lives in:
- Lite: `RemoteCollectorService.RunningJobs.cs` → `GetRecentlyFailedJobsAsync(ServerConnection, lookbackMinutes)` (routes through the collector's `CreateConnectionAsync`, reusing MFA serialization / throttle / retry — Lite's only live-connection idiom).
- Dashboard: `DatabaseService.NocHealth.cs` → `GetRecentlyFailedJobsAsync(SqlConnection, lookbackMinutes)`, added to the existing concurrent `GetAlertHealthAsync` fan-out (per-server MARS connection).

## Settings + defaults

| | Lite (`App` static, persisted `alert_failed_job_*`) | Dashboard (`UserPreferences`) |
|---|---|---|
| Enable | `AlertFailedJobEnabled = true` | `NotifyOnFailedJobs = true` |
| Lookback | `AlertFailedJobLookbackMinutes = 60` | `FailedJobLookbackMinutes = 60` |

Minimal by design — just enable + lookback, no speculative per-job exclude lists. A checkbox + "minutes" box is wired under the existing alert-thresholds section in both Settings windows (load/save/reset/preview/enable-state all wired).

## Dedup (avoid re-firing the same failure)

One alert per server summarizing the failed job name(s) — not one per job. A failure lingers in the lookback window for the whole window, so a level check would re-fire every cooldown. Two per-server maps gate it: the standard cooldown (`_lastFailedJobAlert`) plus a **run-time watermark** (`_lastAlertedFailedJobTime`) that only lets a *strictly newer* failure re-notify. Watermark is bounded by server count (no pruning). Alert history metric name: **"Failed Agent Job"**. Mute-rule + email/webhook routing matches the adjacent long-running-job block.

## Per-app changes

**Lite:** `App.xaml.cs` (settings + load), `Windows/SettingsWindow.xaml`(.cs) (UI + save/load/reset/preview/enable), `MainWindow.xaml.cs` (alert block + `BuildFailedJobContext` + dedup fields), `Services/RemoteCollectorService.RunningJobs.cs` (live query), `Services/LocalDataService.RunningJobs.cs` (`FailedJobInfo` model).

**Dashboard:** `Models/UserPreferences.cs` (settings), `Models/FailedJobInfo.cs` (new), `Models/AlertHealthResult.cs` (`RecentlyFailedJobs`), `Services/DatabaseService.NocHealth.cs` (live query + `GetAlertHealthAsync` wiring + Azure gate), `MainWindow.xaml.cs` (alert block + `BuildFailedJobContext` + dedup fields + call-site lookback arg), `SettingsWindow.xaml`(.cs) (UI + save/load/reset/preview/enable).

## Validation

- `dotnet build` Lite + Dashboard (Debug): **Build succeeded, 0 warnings, 0 errors** (both).
- `dotnet test Lite.Tests`: **434 passed, 0 failed**.
- `dotnet test Dashboard.Tests`: **482 passed, 0 failed**.
- T-SQL reviewed against the house style guide (clean); diff reviewed for dedup correctness, gating, and idiom parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)