### PR TITLE
Replace stale 2.12.0 version strings with 3.0.0

### DIFF
--- a/Dashboard.Tests/FileAutogrowthHandlerTests.cs
+++ b/Dashboard.Tests/FileAutogrowthHandlerTests.cs
@@ -92,7 +92,7 @@ public class FileAutogrowthHandlerTests
         {
             Assert.Equal(RemediationStatus.Blocked, o.Status);
             Assert.False(o.AuditWritten);
-            Assert.Contains("2.12.0", o.Message);
+            Assert.Contains("3.0.0", o.Message);
         });
         Assert.Equal(0, exec.SetFileCalls);          // NOT mutated
         Assert.Empty(exec.AuditRecords);             // nowhere to write

--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -209,7 +209,7 @@ public class RemediationTests
             Assert.Equal(RemediationStatus.Blocked, o.Status);
             Assert.False(o.AuditWritten);
             Assert.False(o.AppliedButUnlogged);
-            Assert.Contains("2.12.0", o.Message);
+            Assert.Contains("3.0.0", o.Message);
         });
         Assert.Equal(0, exec.ForceCalls);
         Assert.Empty(exec.AuditRecords);
@@ -517,7 +517,7 @@ public class RemediationTests
         {
             Assert.Equal(RemediationStatus.Blocked, o.Status);
             Assert.False(o.AuditWritten);
-            Assert.Contains("2.12.0", o.Message);
+            Assert.Contains("3.0.0", o.Message);
         });
         Assert.Equal(0, exec.SetDbCalls);
         Assert.Empty(exec.AuditRecords);

--- a/Dashboard.Tests/ServerConfigHandlerTests.cs
+++ b/Dashboard.Tests/ServerConfigHandlerTests.cs
@@ -131,7 +131,7 @@ public class ServerConfigHandlerTests
         {
             Assert.Equal(RemediationStatus.Blocked, o.Status);
             Assert.False(o.AuditWritten);
-            Assert.Contains("2.12.0", o.Message);
+            Assert.Contains("3.0.0", o.Message);
         });
         Assert.Equal(0, exec.SetCalls);          // NOT mutated
         Assert.Empty(exec.AuditRecords);

--- a/Dashboard/RemediationConfirmWindow.xaml.cs
+++ b/Dashboard/RemediationConfirmWindow.xaml.cs
@@ -135,9 +135,9 @@ namespace PerformanceMonitorDashboard
             {
                 AuditAbsentBanner.Visibility = Visibility.Visible;
                 AuditAbsentText.Text =
-                    "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). "
+                    "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). "
                     + "Apply Fix is hard-blocked here — no change will be made. Upgrade this server to "
-                    + "2.12.0 to enable audited Apply Fix.";
+                    + "3.0.0 to enable audited Apply Fix.";
                 ConfirmButton.Content = request.IsUnapply ? "Un-apply" : "Apply";
                 _baseActionable = false;
                 ConfirmButton.ToolTip = AuditAbsentText.Text;
@@ -314,7 +314,7 @@ namespace PerformanceMonitorDashboard
                     RemediationDisposition.BlockQueryStoreOff => "Query Store is not READ_WRITE — cannot force.",
                     RemediationDisposition.BlockNoAlter => "Monitoring login lacks ALTER — will fail closed (no change).",
                     RemediationDisposition.BlockWrongDatabase => "Connected DB does not match the target — will not proceed.",
-                    RemediationDisposition.BlockAuditTableAbsent => "Audit table absent (pre-2.12.0) — hard-blocked.",
+                    RemediationDisposition.BlockAuditTableAbsent => "Audit table absent (pre-3.0.0) — hard-blocked.",
                     RemediationDisposition.AlreadyInDesiredState => "Already in the desired state — will be skipped.",
                     RemediationDisposition.BlockDatabaseNotFound => "Database not found on the server — will not proceed.",
                     _ => t.DispositionMessage ?? "Unable to determine target state."

--- a/Dashboard/Services/Remediation/ClearPlanHandler.cs
+++ b/Dashboard/Services/Remediation/ClearPlanHandler.cs
@@ -207,7 +207,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             action.ClearPlanTargets ?? Array.Empty<ClearPlanTarget>();
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/Dashboard/Services/Remediation/DbConfigHandler.cs
+++ b/Dashboard/Services/Remediation/DbConfigHandler.cs
@@ -267,7 +267,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             action.DbConfigTargets ?? Array.Empty<DbConfigTarget>();
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/Dashboard/Services/Remediation/FileAutogrowthHandler.cs
+++ b/Dashboard/Services/Remediation/FileAutogrowthHandler.cs
@@ -255,7 +255,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             action.FileGrowthTargets ?? Array.Empty<FileGrowthTarget>();
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/Dashboard/Services/Remediation/ForcePlanHandler.cs
+++ b/Dashboard/Services/Remediation/ForcePlanHandler.cs
@@ -314,7 +314,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             $"connect with a login that already has it. No elevation prompt is offered.";
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/Dashboard/Services/Remediation/RcsiHandler.cs
+++ b/Dashboard/Services/Remediation/RcsiHandler.cs
@@ -262,7 +262,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             action.DbConfigTargets ?? Array.Empty<DbConfigTarget>();
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/Dashboard/Services/Remediation/RemediationApplyModels.cs
+++ b/Dashboard/Services/Remediation/RemediationApplyModels.cs
@@ -139,7 +139,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
 
         public IReadOnlyList<RemediationConfirmTarget> Targets { get; init; } = new List<RemediationConfirmTarget>();
 
-        /// <summary>False when the target server is pre-2.12.0 schema — apply will hard-block.</summary>
+        /// <summary>False when the target server is pre-3.0.0 schema — apply will hard-block.</summary>
         public bool AuditTableExists { get; init; }
 
         /// <summary>

--- a/Dashboard/Services/Remediation/RemediationResults.cs
+++ b/Dashboard/Services/Remediation/RemediationResults.cs
@@ -98,7 +98,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
         /// <summary>
         /// Whether <c>config.remediation_action_log</c> exists on the monitoring
         /// server. When false, every target is hard-blocked at apply time (no
-        /// mutation) — the server is on pre-2.12.0 schema.
+        /// mutation) — the server is on pre-3.0.0 schema.
         /// </summary>
         public bool AuditTableExists { get; init; }
     }

--- a/Dashboard/Services/Remediation/ServerConfigHandler.cs
+++ b/Dashboard/Services/Remediation/ServerConfigHandler.cs
@@ -301,7 +301,7 @@ namespace PerformanceMonitorDashboard.Services.Remediation
             action.ServerConfigTargets ?? Array.Empty<ServerConfigTarget>();
 
         private const string AuditAbsentMessage =
-            "This server is not on the 2.12.0 schema (config.remediation_action_log is absent). " +
-            "Upgrade this server to 2.12.0 to enable audited Apply Fix; no change was made.";
+            "This server is not on the 3.0.0 schema (config.remediation_action_log is absent). " +
+            "Upgrade this server to 3.0.0 to enable audited Apply Fix; no change was made.";
     }
 }

--- a/tools/Remove-OrphanedTraceFiles.ps1
+++ b/tools/Remove-OrphanedTraceFiles.ps1
@@ -14,7 +14,7 @@
         files at all (xp_delete_file only handles backups / maintenance-plan
         reports), and in fact failed the job outright.
 
-    Version 2.12.0 fixes the source: collect.trace_management_collector now
+    Version 3.0.0 fixes the source: collect.trace_management_collector now
     keeps a single long-running trace bounded with a rollover file-count cap
     (@filecount), so SQL Server deletes its own old files going forward. This
     script is the one-time sweep for the files already on disk.

--- a/upgrades/2.11.0-to-3.0.0/01_extend_blocked_process_report_columns.sql
+++ b/upgrades/2.11.0-to-3.0.0/01_extend_blocked_process_report_columns.sql
@@ -2,7 +2,7 @@
 Copyright 2026 Darling Data, LLC
 https://www.erikdarling.com/
 
-Upgrade from 2.11.0 to 2.12.0
+Upgrade from 2.11.0 to 3.0.0
 Adds typed blocker-side columns to collect.blocking_BlockedProcessReport so
 the Dashboard analysis path (BLOCKING_CHAIN fact + drill-down) can read
 structured columns instead of re-parsing blocked_process_report_xml on every

--- a/upgrades/2.11.0-to-3.0.0/02_make_other_process_cpu_nullable.sql
+++ b/upgrades/2.11.0-to-3.0.0/02_make_other_process_cpu_nullable.sql
@@ -2,7 +2,7 @@
 Copyright 2026 Darling Data, LLC
 https://www.erikdarling.com/
 
-Upgrade from 2.11.0 to 2.12.0
+Upgrade from 2.11.0 to 3.0.0
 Issue #1048: Linux host CPU pinned at 100%.
 
 On SQL Server on Linux the RING_BUFFER_SCHEDULER_MONITOR ring buffer reports

--- a/upgrades/2.11.0-to-3.0.0/03_add_transaction_mutex_ignored_wait.sql
+++ b/upgrades/2.11.0-to-3.0.0/03_add_transaction_mutex_ignored_wait.sql
@@ -2,7 +2,7 @@
 Copyright 2026 Darling Data, LLC
 https://www.erikdarling.com/
 
-Upgrade from 2.11.0 to 2.12.0
+Upgrade from 2.11.0 to 3.0.0
 Add TRANSACTION_MUTEX to config.ignored_wait_types. It is an internal synchronization
 wait (multiple requests sharing one transaction / MARS / app pattern), not a DBA-tunable
 condition -- it belongs with the other *_MUTEX waits already ignored

--- a/upgrades/2.11.0-to-3.0.0/04_add_server_health_columns.sql
+++ b/upgrades/2.11.0-to-3.0.0/04_add_server_health_columns.sql
@@ -2,7 +2,7 @@
 Copyright 2026 Darling Data, LLC
 https://www.erikdarling.com/
 
-Upgrade from 2.11.0 to 2.12.0
+Upgrade from 2.11.0 to 3.0.0
 WS5: surface Lock Pages in Memory (LPIM), Instant File Initialization (IFI),
 and SQL Server memory dumps as advise-only server-health recommendations.
 


### PR DESCRIPTION
## Problem
The release was developed as `2.12.0`, then rebumped to the `3.0.0` major — but embedded `2.12.0` strings were never updated. The user-facing ones are a real bug: the **Apply Fix** handlers + remediation confirm dialog tell users *"Upgrade this server to 2.12.0 to enable audited Apply Fix"* — a version that will never ship.

## Fix
Replaced `2.12.0` → `3.0.0` in 17 files (26 lines, no EOL churn): 6 Apply Fix handler messages + `RemediationConfirmWindow` dialog text, 2 code comments, the `Remove-OrphanedTraceFiles.ps1` doc comment, the 4 `upgrades/2.11.0-to-3.0.0/` script headers (still read "2.11.0 to 2.12.0"), and the 4 `Dashboard.Tests` asserts that pin the literal text (lockstep, or build breaks).

Found by the `release-auditor` pre-release gate. Dashboard builds clean; Dashboard.Tests 487/487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
