### PR TITLE
Grade Volume Free Space alert severity (WARNING/CRITICAL) (#1136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Lite and Dashboard: the low-disk (Volume Free Space) alert is now severity-graded instead of always INFO** ([#1136]) — the metric name was absent from the shared severity map, so every low-disk alert fell through to the default INFO tier (blue, lowest severity) regardless of how full the volume was. A volume nearing full stops data/log file growth — transactions fail and the database can go into recovery/suspect — so this under-prioritized a potentially critical condition, including for downstream severity-based webhook routing (Teams/Slack). The alert now renders **WARNING** for a normal breach and **CRITICAL** when the worst breached volume is critically low (≤ 3% free **or** ≤ 2 GB free — a second, lower tier beneath the user-configured fire threshold). The critical grading lives in the shared `LowDiskAlertGate.IsCriticallyLow`, and the tier rides through to the email badge/accent, Teams card, and Slack sidebar via an `AlertContext.SeverityOverride`, so the metric name (hence mute rules, cooldown, and Alert-History matching) is unchanged. The existing "notify only on a fresh or worsening breach" firing rule is untouched — this is purely the severity classification. Fixed identically in both apps. Covered by `AlertSeverityTests` and `LowDiskAlertGateTests`
+
 ### Fixed
 
 - **Lite: the `index_object_stats` collector no longer times out and returns zero index data on larger estates** ([#1135]) — the v3.0.0 collector ran its entire multi-database sweep as **one** `SqlCommand` under the global 30s `CommandTimeoutSeconds`, cursoring over every online database into a `#temp` and returning a single final `SELECT`. Because nothing streamed back until the end, the 30s was a *cumulative, all-or-nothing* budget across every database — on a server with sizable/many databases the sweep blew past 30s, failed with `Execution Timeout Expired` (SQL `#-2`), and discarded results from **every** database, not just the slow one. Enabled by default and "never-run = due immediately," it failed on first connect right after upgrade and kept retrying the timeout. Now the collector runs **one command per database** (mirroring the Query Store collector): on-prem enumerates databases then sends each through `[db].sys.sp_executesql`, Azure SQL DB connects to each database individually, and each database has its own command, timeout, and `try/catch` — so a slow or inaccessible database fails only itself and the rest still persist. Within each database the three DMVs (`sys.dm_db_partition_stats`, `sys.dm_db_index_usage_stats`, `sys.dm_db_index_operational_stats`) are staged into `#temp` tables with single scans and then joined, giving the optimizer real cardinality and avoiding the bad plans the old single monolithic multi-DMV join produced on large databases (the `sp_IndexCleanup` technique). The collector also gets a dedicated 300s timeout (matching the FinOps `sp_IndexCleanup` path) instead of the 30s meant for lightweight DMV reads. The Dashboard's equivalent SQL collector (`install/55`) — which was not subject to the bug (it runs under SQL Agent and persists per database) — was brought to parity with the same DMV-staging technique for plan quality on large databases
@@ -88,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1121]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1121
 [#1122]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1122
 [#1135]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1135
+[#1136]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1136
 
 ## [2.11.0] - 2026-05-19
 

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -2010,6 +2010,13 @@ namespace PerformanceMonitorDashboard
                     _lastLowDiskAlert[serverId] = now;
                     _lastAlertedLowDiskPercent[serverId] = worst.FreePercent;
                     var lowDiskContext = BuildVolumeFreeSpaceContext(breachedVolumes);
+                    /* #1136: grade the alert — WARNING normally, CRITICAL when the worst volume is
+                       critically low — so the email/webhook badge reflects how dire the breach is.
+                       (lowDiskContext is non-null here — breachedVolumes.Count > 0 — but typed nullable.) */
+                    if (lowDiskContext is not null && LowDiskAlertGate.IsCriticallyLow(worst.FreePercent, worst.FreeGb))
+                    {
+                        lowDiskContext.SeverityOverride = AlertSeverityLevel.Critical;
+                    }
                     var detailText = ContextToDetailText(lowDiskContext);
                     var currentValue = $"{worst.MountPoint} {worst.FreePercent:F0}% free ({worst.FreeGb:F1} GB)";
                     var thresholdValue = FormatLowDiskThreshold(prefs);

--- a/Lite.Tests/AlertSeverityTests.cs
+++ b/Lite.Tests/AlertSeverityTests.cs
@@ -1,0 +1,84 @@
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Guards the runtime-graded severity for "Volume Free Space" (#1136). The metric used to be absent
+/// from the <see cref="AlertSeverity"/> map and fell through to INFO-blue (the lowest tier) for every
+/// breach; it now renders WARNING by default and CRITICAL when the alert site sets
+/// <see cref="AlertContext.SeverityOverride"/> for a critically-low volume. The email body, Teams card,
+/// and Slack sidebar all key severity off the shared map, so this one suite covers both apps' output.
+/// </summary>
+public class AlertSeverityTests
+{
+    private static readonly AlertBranding Branding = new("Test Edition", null);
+
+    [Fact]
+    public void VolumeFreeSpace_NoOverride_IsWarningNotInfo()
+    {
+        var (hex, badge, _) = AlertSeverity.ForMetric("Volume Free Space");
+        Assert.Equal("WARNING", badge);
+        Assert.Equal("#D97706", hex);
+    }
+
+    [Fact]
+    public void VolumeFreeSpace_CriticalOverride_IsCritical()
+    {
+        var (hex, badge, _) = AlertSeverity.ForMetric("Volume Free Space", AlertSeverityLevel.Critical);
+        Assert.Equal("CRITICAL", badge);
+        Assert.Equal("#DC2626", hex);
+    }
+
+    [Fact]
+    public void Override_IsAuthoritativeOverMetricMap()
+    {
+        // The override wins regardless of the metric's own mapped tier.
+        var (_, badge, _) = AlertSeverity.ForMetric("High CPU", AlertSeverityLevel.Critical);
+        Assert.Equal("CRITICAL", badge);
+    }
+
+    [Fact]
+    public void EmailBody_CriticalOverride_RendersCriticalNotInfo()
+    {
+        var ctx = new AlertContext { SeverityOverride = AlertSeverityLevel.Critical };
+        var (html, _) = EmailTemplateBuilder.BuildAlertEmail(
+            "Volume Free Space", "S1", "E:\\ 2% free (1.0 GB)", "10% / 5 GB", 15, Branding, ctx);
+
+        Assert.Contains("CRITICAL", html);
+        Assert.Contains("#DC2626", html);
+        Assert.DoesNotContain("INFO", html);
+    }
+
+    [Fact]
+    public void EmailBody_NoOverride_RendersWarningNotInfo()
+    {
+        var (html, _) = EmailTemplateBuilder.BuildAlertEmail(
+            "Volume Free Space", "S1", "E:\\ 8% free (40.0 GB)", "10% / 5 GB", 15, Branding, context: null);
+
+        Assert.Contains("WARNING", html);
+        Assert.DoesNotContain("INFO", html);
+    }
+
+    [Fact]
+    public void TeamsPayload_CriticalOverride_UsesCriticalColorAndBadge()
+    {
+        var ctx = new AlertContext { SeverityOverride = AlertSeverityLevel.Critical };
+        var payload = WebhookAlertService.BuildTeamsPayload(
+            "Volume Free Space", "S1", "E:\\ 2% free (1.0 GB)", "10% / 5 GB", Branding, context: ctx);
+
+        Assert.Contains("CRITICAL", payload);
+        Assert.Contains("DC2626", payload); // themeColor renders without the leading '#'
+    }
+
+    [Fact]
+    public void SlackPayload_CriticalOverride_UsesCriticalColor()
+    {
+        var ctx = new AlertContext { SeverityOverride = AlertSeverityLevel.Critical };
+        var payload = WebhookAlertService.BuildSlackPayload(
+            "Volume Free Space", "S1", "E:\\ 2% free (1.0 GB)", "10% / 5 GB", Branding, context: ctx);
+
+        Assert.Contains("CRITICAL", payload);
+        Assert.Contains("#DC2626", payload);
+    }
+}

--- a/Lite.Tests/LowDiskAlertGateTests.cs
+++ b/Lite.Tests/LowDiskAlertGateTests.cs
@@ -58,4 +58,20 @@ public class LowDiskAlertGateTests
     {
         Assert.Equal(expected, LowDiskAlertGate.ShouldAlert(current, last, margin));
     }
+
+    /// <summary>
+    /// #1136: the critical tier is graded on EITHER dimension (OR semantics, matching the breach
+    /// test) — a low percentage on a huge volume OR a few GB free on any volume is CRITICAL.
+    /// </summary>
+    [Theory]
+    [InlineData(2.0, 100.0, true)]  // 2% <= 3% floor (huge volume, low %) -> critical
+    [InlineData(3.0, 100.0, true)]  // exactly at the percent floor
+    [InlineData(4.0, 100.0, false)] // 4% above floor, plenty of GB -> warning tier
+    [InlineData(8.0, 1.5, true)]    // healthy %, but 1.5 GB <= 2 GB floor -> critical
+    [InlineData(8.0, 2.0, true)]    // exactly at the GB floor
+    [InlineData(8.0, 5.0, false)]   // above both floors -> warning tier
+    public void IsCriticallyLow_GradesEitherDimension(double freePercent, double freeGb, bool expected)
+    {
+        Assert.Equal(expected, LowDiskAlertGate.IsCriticallyLow(freePercent, freeGb));
+    }
 }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -2013,6 +2013,13 @@ public partial class MainWindow : Window
                         }
 
                         var lowDiskContext = BuildVolumeFreeSpaceContext(breached);
+                        /* #1136: grade the alert — WARNING normally, CRITICAL when the worst volume is
+                           critically low — so the email/webhook badge reflects how dire the breach is.
+                           (lowDiskContext is non-null here — breached.Count > 0 — but typed nullable.) */
+                        if (lowDiskContext is not null && LowDiskAlertGate.IsCriticallyLow(worst.FreePercent, worst.FreeGb))
+                        {
+                            lowDiskContext.SeverityOverride = AlertSeverityLevel.Critical;
+                        }
                         var detailText = ContextToDetailText(lowDiskContext);
 
                         await _emailAlertService.TrySendAlertEmailAsync(

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -21,6 +21,16 @@ public class AlertContext
     public List<AlertDetailItem> Details { get; set; } = new();
     public string? AttachmentXml { get; set; }
     public string? AttachmentFileName { get; set; }
+
+    /// <summary>
+    /// Forces the rendered severity tier (email badge/color, Teams/Slack accent) regardless of
+    /// metric name, for metrics graded at runtime — low-disk fires WARNING normally and CRITICAL
+    /// when critically low (#1136). <c>null</c> = use the per-metric <see cref="AlertSeverity"/>
+    /// map. Deliberately not persisted (like <see cref="AttachmentXml"/>): it drives the live
+    /// email/webhook render only, and the alert-history UI does not re-derive severity, so the
+    /// JSON projection (<see cref="AlertContextSerializer"/>) need not carry it.
+    /// </summary>
+    public AlertSeverityLevel? SeverityOverride { get; set; }
 }
 
 /// <summary>

--- a/PerformanceMonitor.Notifications/AlertSeverity.cs
+++ b/PerformanceMonitor.Notifications/AlertSeverity.cs
@@ -9,6 +9,18 @@
 namespace PerformanceMonitor.Notifications;
 
 /// <summary>
+/// Severity tier an alert site can force, independent of the metric-name map, for metrics whose
+/// seriousness is graded at runtime rather than fixed (e.g. "Volume Free Space": WARNING below the
+/// configured threshold, CRITICAL when critically low — #1136). Carried on
+/// <see cref="AlertContext.SeverityOverride"/>; <c>null</c> falls back to the per-metric map.
+/// </summary>
+public enum AlertSeverityLevel
+{
+    Warning,
+    Critical
+}
+
+/// <summary>
 /// Single source of truth for per-metric alert severity styling: accent/hex color, badge text,
 /// and the webhook emoji. Both the email body (<see cref="EmailTemplateBuilder"/>) and the
 /// webhook payloads (<see cref="WebhookAlertService"/>) consume this so the two maps cannot
@@ -16,21 +28,33 @@ namespace PerformanceMonitor.Notifications;
 /// </summary>
 internal static class AlertSeverity
 {
+    /// <param name="overrideLevel">
+    /// When non-null, forces the tier regardless of <paramref name="metricName"/> — for metrics
+    /// graded at runtime (#1136). <c>null</c> uses the per-metric map below.
+    /// </param>
     /// <returns>
     /// (HexColor, BadgeText, Emoji) for the metric. Unknown metrics fall back to INFO-blue.
     /// Email ignores the emoji; webhooks use all three.
     /// </returns>
-    public static (string HexColor, string BadgeText, string Emoji) ForMetric(string metricName) => metricName switch
+    public static (string HexColor, string BadgeText, string Emoji) ForMetric(
+        string metricName,
+        AlertSeverityLevel? overrideLevel = null) => overrideLevel switch
     {
-        "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
-        "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
-        "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
-        "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
-        "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
-        "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
-        "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
-        _ => ("#2eaef1", "INFO", "\U0001F535")
+        AlertSeverityLevel.Critical => ("#DC2626", "CRITICAL", "\U0001F534"),
+        AlertSeverityLevel.Warning => ("#D97706", "WARNING", "\U0001F7E0"),
+        _ => metricName switch
+        {
+            "Blocking Detected" => ("#D97706", "ALERT", "\U0001F7E0"),
+            "Deadlocks Detected" => ("#DC2626", "ALERT", "\U0001F534"),
+            "High CPU" => ("#F59E0B", "WARNING", "\U0001F7E1"),
+            "Poison Wait" => ("#DC2626", "CRITICAL", "\U0001F534"),
+            "Long-Running Query" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "TempDB Space" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "Long-Running Job" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "Volume Free Space" => ("#D97706", "WARNING", "\U0001F7E0"),
+            "Server Unreachable" => ("#DC2626", "CRITICAL", "\U0001F534"),
+            "Server Restored" => ("#16A34A", "RESOLVED", "\U0001F7E2"),
+            _ => ("#2eaef1", "INFO", "\U0001F535")
+        }
     };
 }

--- a/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
+++ b/PerformanceMonitor.Notifications/EmailTemplateBuilder.cs
@@ -35,7 +35,7 @@ internal static class EmailTemplateBuilder
     {
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
-        var (accentColor, badgeText, _) = AlertSeverity.ForMetric(metricName);
+        var (accentColor, badgeText, _) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
 
         var html = BuildHtmlBody(metricName, serverName, currentValue,
             thresholdValue, utcNow, localNow, accentColor, badgeText, branding, context: context, emailCooldownMinutes: emailCooldownMinutes);

--- a/PerformanceMonitor.Notifications/LowDiskAlertGate.cs
+++ b/PerformanceMonitor.Notifications/LowDiskAlertGate.cs
@@ -32,6 +32,30 @@ public static class LowDiskAlertGate
     public const double DefaultWorseningMarginPercent = 1.0;
 
     /// <summary>
+    /// Free-space percentage at or below which a breach is "critically low" (#1136) — a second,
+    /// lower tier beneath the user-configured fire threshold. Below this the database can no longer
+    /// grow data/log files, so transactions fail and the database can go into recovery/suspect; that
+    /// warrants CRITICAL, not the WARNING the normal breach renders.
+    /// </summary>
+    public const double CriticalFreePercent = 3.0;
+
+    /// <summary>
+    /// Free-space GB at or below which a breach is "critically low" regardless of percentage — a
+    /// large volume sitting at a few GB free has no room for a single autogrow. See
+    /// <see cref="CriticalFreePercent"/>.
+    /// </summary>
+    public const double CriticalFreeGb = 2.0;
+
+    /// <summary>
+    /// True when the worst breached volume is critically low on EITHER dimension (mirrors the OR
+    /// semantics of the breach test itself): free space at/below <see cref="CriticalFreePercent"/>
+    /// or at/below <see cref="CriticalFreeGb"/>. Drives the CRITICAL severity tier (#1136). Shared
+    /// by Lite and Dashboard so the two apps grade low-disk identically.
+    /// </summary>
+    public static bool IsCriticallyLow(double freePercent, double freeGb) =>
+        freePercent <= CriticalFreePercent || freeGb <= CriticalFreeGb;
+
+    /// <summary>
     /// Returns true when a low-disk alert should fire this cycle.
     /// </summary>
     /// <param name="currentWorstFreePercent">

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -202,7 +202,7 @@ public class WebhookAlertService
         bool isTest = false,
         AlertContext? context = null)
     {
-        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName);
+        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var themeColor = hexColor.TrimStart('#');
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
@@ -349,7 +349,7 @@ public class WebhookAlertService
         bool isTest = false,
         AlertContext? context = null)
     {
-        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName);
+        var (hexColor, badgeText, emoji) = AlertSeverity.ForMetric(metricName, context?.SeverityOverride);
         var utcNow = DateTime.UtcNow;
         var localNow = DateTime.Now;
 


### PR DESCRIPTION
Closes #1136.

## Problem
The low-disk **Volume Free Space** alert was absent from `AlertSeverity.ForMetric`, so every breach fell through to the default **INFO** tier (blue, lowest) regardless of how full the volume was. A volume nearing full stops data/log growth — transactions fail and the database can go into recovery/suspect — and severity drives the email badge/color and severity-based webhook routing (Teams/Slack), so a critical disk-full looked and routed like a low-priority notice.

## Change
- **WARNING** for a normal breach; **CRITICAL** when the worst breached volume is critically low (`<= 3% free` **or** `<= 2 GB free` — a second, lower tier beneath the user-configured fire threshold).
- Critical rule lives in the shared `LowDiskAlertGate.IsCriticallyLow` (OR semantics, matching the breach test). The tier rides through to the email badge/accent, Teams card, and Slack sidebar via a new `AlertContext.SeverityOverride`.
- **Metric name is unchanged** (`"Volume Free Space"`), so mute rules, the email/webhook cooldown key, the worsening-breach gate, and Alert-History matching are untouched. The existing "notify only on a fresh or worsening breach" firing rule is untouched — this is purely severity classification.
- Fixed identically in **Lite** and **Dashboard** (shared `PerformanceMonitor.Notifications` lib covers both apps' email + webhook; each `MainWindow` sets the override at its alert site).

## Tests
- `AlertSeverityTests` (new) — asserts the rendered email HTML, Teams JSON, and Slack JSON carry the CRITICAL badge + `#DC2626` when overridden, and WARNING (never INFO) by default.
- `LowDiskAlertGateTests` — `IsCriticallyLow` on both dimensions incl. boundaries.
- Lite 460/460, Dashboard 487/487, clean build (0 errors, no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)