### PR TITLE
#1140/#1141: stable dedup fingerprint + involved-objects on alert payloads

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -1582,7 +1582,7 @@ namespace PerformanceMonitorDashboard
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastBlockingAlert[serverId] = now;
 
-                    var blockingContext = await BuildBlockingContextAsync(databaseService, prefs.AlertExcludedDatabases);
+                    var blockingContext = await BuildBlockingContextAsync(serverName, databaseService, prefs.AlertExcludedDatabases);
                     var detailText = ContextToDetailText(blockingContext)
                         ?? $"Blocked Sessions: {(int)health.TotalBlocked}\nLongest Wait: {(int)health.LongestBlockedSeconds}s";
 
@@ -1648,7 +1648,7 @@ namespace PerformanceMonitorDashboard
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastDeadlockAlert[serverId] = now;
 
-                    var deadlockContext = await BuildDeadlockContextAsync(databaseService, prefs.AlertExcludedDatabases);
+                    var deadlockContext = await BuildDeadlockContextAsync(serverName, databaseService, prefs.AlertExcludedDatabases);
                     var detailText = ContextToDetailText(deadlockContext)
                         ?? $"New Deadlocks: {effectiveDeadlockDelta}";
 
@@ -1897,7 +1897,7 @@ namespace PerformanceMonitorDashboard
                     };
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastLongRunningQueryAlert[serverId] = now;
-                    var lrqContext = BuildLongRunningQueryContext(lrqList);
+                    var lrqContext = BuildLongRunningQueryContext(serverName, lrqList);
                     var detailText = ContextToDetailText(lrqContext);
 
                     if (!isMuted)
@@ -2009,7 +2009,7 @@ namespace PerformanceMonitorDashboard
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastLowDiskAlert[serverId] = now;
                     _lastAlertedLowDiskPercent[serverId] = worst.FreePercent;
-                    var lowDiskContext = BuildVolumeFreeSpaceContext(breachedVolumes);
+                    var lowDiskContext = BuildVolumeFreeSpaceContext(serverName, breachedVolumes);
                     /* #1136: grade the alert — WARNING normally, CRITICAL when the worst volume is
                        critically low — so the email/webhook badge reflects how dire the breach is.
                        (lowDiskContext is non-null here — breachedVolumes.Count > 0 — but typed nullable.) */
@@ -2082,7 +2082,7 @@ namespace PerformanceMonitorDashboard
                     var muteCtx = new AlertMuteContext { ServerName = serverName, MetricName = "Long-Running Job", JobName = worst.JobName };
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastLongRunningJobAlert[jobKey] = now;
-                    var jobContext = BuildAnomalousJobContext(health.AnomalousJobs);
+                    var jobContext = BuildAnomalousJobContext(serverName, health.AnomalousJobs);
                     var detailText = ContextToDetailText(jobContext);
 
                     if (!isMuted)
@@ -2195,7 +2195,7 @@ namespace PerformanceMonitorDashboard
             return sb.ToString().TrimEnd();
         }
 
-        private static async Task<AlertContext?> BuildBlockingContextAsync(DatabaseService databaseService, List<string>? excludedDatabases = null)
+        private static async Task<AlertContext?> BuildBlockingContextAsync(string serverName, DatabaseService databaseService, List<string>? excludedDatabases = null)
         {
             try
             {
@@ -2244,6 +2244,15 @@ namespace PerformanceMonitorDashboard
                     context.AttachmentFileName = "blocked_process_report.xml";
                 }
 
+                /* #1140: dedup by the resolved contentious object across the blocked-process rows
+                   (already populated by sp_HumanEventsBlockViewer); falls back to db+query-pair only
+                   when an object did not resolve. Computed over ALL events, not just the 3 displayed. */
+                AlertIncidentRenderer.Apply(context, BlockingIncidentGrouper.Group(
+                    serverName,
+                    events.Select(e => new BlockingIncidentGrouper.BlockedEvent(
+                        e.DatabaseName, e.ContentiousObject, e.QueryText, null, e.WaitTimeMs ?? 0)))
+                    .Select(g => g.Incident).ToList());
+
                 return context;
             }
             catch (Exception ex)
@@ -2253,7 +2262,7 @@ namespace PerformanceMonitorDashboard
             }
         }
 
-        private static async Task<AlertContext?> BuildDeadlockContextAsync(DatabaseService databaseService, List<string>? excludedDatabases = null)
+        private static async Task<AlertContext?> BuildDeadlockContextAsync(string serverName, DatabaseService databaseService, List<string>? excludedDatabases = null)
         {
             try
             {
@@ -2312,6 +2321,16 @@ namespace PerformanceMonitorDashboard
                     context.AttachmentFileName = "deadlock_graph.xml";
                 }
 
+                /* #1140: fingerprint each deadlock by its sorted involved-object set, parsed from the
+                   deadlock graph (same DeadlockObjectExtractor Lite uses, for parity), grouped per
+                   deadlock event across ALL events in the window. */
+                AlertIncidentRenderer.Apply(context, DeadlockIncidentGrouper.Group(
+                    serverName,
+                    deadlocks.GroupBy(d => d.EventDate).Select(g => new DeadlockIncidentGrouper.DeadlockEvent(
+                        DeadlockObjectExtractor.FromGraphXml(
+                            g.Select(x => x.DeadlockGraph).FirstOrDefault(x => !string.IsNullOrEmpty(x))))))
+                    .Select(g => g.Incident).ToList());
+
                 return context;
             }
             catch (Exception ex)
@@ -2365,12 +2384,13 @@ namespace PerformanceMonitorDashboard
             return context;
         }
 
-        private static AlertContext? BuildLongRunningQueryContext(List<LongRunningQueryInfo> queries)
+        private static AlertContext? BuildLongRunningQueryContext(string serverName, List<LongRunningQueryInfo> queries)
         {
             if (queries.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var q in queries.GetRange(0, Math.Min(3, queries.Count)))
+            var shown = queries.GetRange(0, Math.Min(3, queries.Count));
+            foreach (var q in shown)
             {
                 var item = new AlertDetailItem
                 {
@@ -2394,15 +2414,22 @@ namespace PerformanceMonitorDashboard
 
                 context.Details.Add(item);
             }
+
+            /* #1140: dedup key = query_hash (stable across literals/plans). Null hash -> no incident. */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(q => AlertFingerprint.ForKey(serverName, AlertFingerprint.Query, q.QueryHash ?? "",
+                    string.IsNullOrEmpty(q.DatabaseName) ? System.Array.Empty<string>() : new[] { q.DatabaseName }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 
-        private static AlertContext? BuildAnomalousJobContext(List<AnomalousJobInfo> jobs)
+        private static AlertContext? BuildAnomalousJobContext(string serverName, List<AnomalousJobInfo> jobs)
         {
             if (jobs.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var j in jobs.GetRange(0, Math.Min(3, jobs.Count)))
+            var shown = jobs.GetRange(0, Math.Min(3, jobs.Count));
+            foreach (var j in shown)
             {
                 context.Details.Add(new AlertDetailItem
                 {
@@ -2417,6 +2444,11 @@ namespace PerformanceMonitorDashboard
                     }
                 });
             }
+
+            /* #1140: dedup key per job (job name, scoped to the instance via serverName). */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(j => AlertFingerprint.ForKey(serverName, AlertFingerprint.Job, j.JobName, new[] { j.JobName }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 
@@ -2464,12 +2496,13 @@ namespace PerformanceMonitorDashboard
             return parts.Count > 0 ? string.Join(" / ", parts) : "—";
         }
 
-        private static AlertContext? BuildVolumeFreeSpaceContext(List<VolumeFreeSpaceInfo> volumes)
+        private static AlertContext? BuildVolumeFreeSpaceContext(string serverName, List<VolumeFreeSpaceInfo> volumes)
         {
             if (volumes.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var v in volumes.GetRange(0, Math.Min(5, volumes.Count)))
+            var shown = volumes.GetRange(0, Math.Min(5, volumes.Count));
+            foreach (var v in shown)
             {
                 context.Details.Add(new AlertDetailItem
                 {
@@ -2482,6 +2515,11 @@ namespace PerformanceMonitorDashboard
                     }
                 });
             }
+
+            /* #1140: dedup key per volume (the drive/mount point). */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(v => AlertFingerprint.ForKey(serverName, AlertFingerprint.Disk, v.MountPoint, new[] { v.MountPoint }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 

--- a/Dashboard/Models/LongRunningQueryInfo.cs
+++ b/Dashboard/Models/LongRunningQueryInfo.cs
@@ -18,5 +18,6 @@ namespace PerformanceMonitorDashboard.Models
         public long Writes { get; set; }
         public string? WaitType { get; set; }
         public int? BlockingSessionId { get; set; }
+        public string? QueryHash { get; set; }
     }
 }

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -824,7 +824,8 @@ namespace PerformanceMonitorDashboard.Services
                     r.reads,
                     r.writes,
                     r.wait_type,
-                    r.blocking_session_id
+                    r.blocking_session_id,
+                    CONVERT(varchar(18), r.query_hash, 1) AS query_hash
                 FROM sys.dm_exec_requests AS r
                 CROSS APPLY sys.dm_exec_sql_text(r.sql_handle) AS t
                 JOIN sys.dm_exec_sessions AS s ON s.session_id = r.session_id
@@ -862,7 +863,8 @@ namespace PerformanceMonitorDashboard.Services
                         Reads = Convert.ToInt64(reader.GetValue(6), System.Globalization.CultureInfo.InvariantCulture),
                         Writes = Convert.ToInt64(reader.GetValue(7), System.Globalization.CultureInfo.InvariantCulture),
                         WaitType = reader.IsDBNull(8) ? null : reader.GetString(8),
-                        BlockingSessionId = reader.IsDBNull(9) ? null : (int?)Convert.ToInt32(reader.GetValue(9), System.Globalization.CultureInfo.InvariantCulture)
+                        BlockingSessionId = reader.IsDBNull(9) ? null : (int?)Convert.ToInt32(reader.GetValue(9), System.Globalization.CultureInfo.InvariantCulture),
+                        QueryHash = reader.IsDBNull(10) ? null : reader.GetString(10)
                     });
                 }
             }

--- a/Lite.Tests/AlertFingerprintTests.cs
+++ b/Lite.Tests/AlertFingerprintTests.cs
@@ -1,0 +1,116 @@
+using System;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Guards <see cref="AlertFingerprint"/> (#1140): the stable dedup key must be deterministic,
+/// order- and case-insensitive over the involved objects, scoped by server + incident type, and
+/// must NOT move when volatile per-sample fields (occurrence count, wait range) change. The shared
+/// helper covers both apps, so this one suite is the canonical fingerprint coverage.
+/// </summary>
+public class AlertFingerprintTests
+{
+    private const string Server = "SQL2022";
+
+    [Fact]
+    public void ForObjects_IsDeterministic()
+    {
+        var a = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "SalesDB.dbo.Orders" });
+        var b = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "SalesDB.dbo.Orders" });
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+    }
+
+    [Fact]
+    public void ForObjects_IsOrderIndependent()
+    {
+        var a = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "db.dbo.A", "db.dbo.B" });
+        var b = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "db.dbo.B", "db.dbo.A" });
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+    }
+
+    [Fact]
+    public void ForObjects_CollapsesDuplicatesCasingAndWhitespace()
+    {
+        var a = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "db.dbo.A" });
+        var b = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "  DB.DBO.A  ", "db.dbo.a", "db.dbo.A" });
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+    }
+
+    [Fact]
+    public void ForObjects_PreservesOriginalCasingForDisplay()
+    {
+        var a = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "SalesDB.dbo.Orders" });
+        Assert.Equal(new[] { "SalesDB.dbo.Orders" }, a!.InvolvedObjects);
+    }
+
+    [Fact]
+    public void ForObjects_DistinctIncidentType_DiffersKey()
+    {
+        var deadlock = AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "db.dbo.A" });
+        var blocking = AlertFingerprint.ForObjects(Server, AlertFingerprint.Blocking, new[] { "db.dbo.A" });
+        Assert.NotEqual(deadlock!.DedupKey, blocking!.DedupKey);
+    }
+
+    [Fact]
+    public void ForObjects_DistinctServer_DiffersKey()
+    {
+        var a = AlertFingerprint.ForObjects("SQL2019", AlertFingerprint.Deadlock, new[] { "db.dbo.A" });
+        var b = AlertFingerprint.ForObjects("SQL2022", AlertFingerprint.Deadlock, new[] { "db.dbo.A" });
+        Assert.NotEqual(a!.DedupKey, b!.DedupKey);
+    }
+
+    [Fact]
+    public void ForObjects_VolatileFields_DoNotAffectKey()
+    {
+        var a = AlertFingerprint.ForObjects(Server, AlertFingerprint.Blocking, new[] { "db.dbo.A" }, occurrenceCount: 3, waitRange: "80.8-90.8 s");
+        var b = AlertFingerprint.ForObjects(Server, AlertFingerprint.Blocking, new[] { "db.dbo.A" }, occurrenceCount: 8, waitRange: "10-20 s");
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+        Assert.Equal(3, a.OccurrenceCount);
+        Assert.Equal("80.8-90.8 s", a.WaitRange);
+    }
+
+    [Fact]
+    public void ForObjects_NoUsableObjects_ReturnsNull()
+    {
+        Assert.Null(AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, new[] { "", "   " }));
+        Assert.Null(AlertFingerprint.ForObjects(Server, AlertFingerprint.Deadlock, Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ForKey_IsDeterministicAndScoped()
+    {
+        var a = AlertFingerprint.ForKey(Server, AlertFingerprint.Query, "0xABCD");
+        var b = AlertFingerprint.ForKey(Server, AlertFingerprint.Query, "0xabcd"); // case-normalized to the same key
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+
+        var differentType = AlertFingerprint.ForKey(Server, AlertFingerprint.Job, "0xABCD");
+        Assert.NotEqual(a.DedupKey, differentType!.DedupKey);
+    }
+
+    [Fact]
+    public void ForKey_BlankKey_ReturnsNull()
+    {
+        Assert.Null(AlertFingerprint.ForKey(Server, AlertFingerprint.Disk, "   "));
+    }
+
+    [Fact]
+    public void ForKey_DisplayObjects_DoNotAffectKey()
+    {
+        var a = AlertFingerprint.ForKey(Server, AlertFingerprint.Job, "Nightly ETL", new[] { "shown A" });
+        var b = AlertFingerprint.ForKey(Server, AlertFingerprint.Job, "Nightly ETL", new[] { "shown B" });
+        Assert.Equal(a!.DedupKey, b!.DedupKey);
+        Assert.Equal(new[] { "shown A" }, a.InvolvedObjects);
+    }
+
+    [Fact]
+    public void Hash_IsLowercaseHex64()
+    {
+        var h = AlertFingerprint.Hash("anything");
+        Assert.Equal(64, h.Length);
+        Assert.Matches("^[0-9a-f]{64}$", h);
+    }
+}

--- a/Lite.Tests/AlertIncidentRenderTests.cs
+++ b/Lite.Tests/AlertIncidentRenderTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Guards <see cref="AlertIncidentRenderer"/> (#1140): incidents project into <see cref="AlertContext.Details"/>
+/// so the dedup fingerprint renders on every surface (Teams / Slack / email HTML + plaintext) via the
+/// shared detail-item path, without touching any individual renderer.
+/// </summary>
+public class AlertIncidentRenderTests
+{
+    private static readonly AlertBranding Branding = new("Test Edition", null);
+
+    [Fact]
+    public void Apply_SetsIncidentsAndAppendsDetailWithoutDisturbingExistingOrder()
+    {
+        var ctx = new AlertContext();
+        ctx.Details.Add(new AlertDetailItem { Heading = "Diagnosis" });
+
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("key1", new[] { "SalesDB.dbo.Orders" }) });
+
+        Assert.NotNull(ctx.Incidents);
+        Assert.Single(ctx.Incidents!);
+        Assert.Equal("Diagnosis", ctx.Details[0].Heading); // existing item untouched
+        var incident = ctx.Details.Single(d => d.Heading == "Incident");
+        Assert.Contains(incident.Fields, f => f.Label == "Dedup Key" && f.Value == "key1");
+        Assert.Contains(incident.Fields, f => f.Label == "Involved Objects" && f.Value == "SalesDB.dbo.Orders");
+    }
+
+    [Fact]
+    public void Apply_NoIncidents_IsNoOp()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, null);
+        AlertIncidentRenderer.Apply(ctx, Array.Empty<AlertIncident>());
+        Assert.Null(ctx.Incidents);
+        Assert.Empty(ctx.Details);
+    }
+
+    [Fact]
+    public void Apply_MultipleIncidents_NumbersHeadingsShowsOccurrencesAndWaitRange()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[]
+        {
+            new AlertIncident("k1", new[] { "db.dbo.A" }, OccurrenceCount: 8, WaitRange: "80-90 s"),
+            new AlertIncident("k2", new[] { "db.dbo.B" })
+        });
+
+        var first = ctx.Details.Single(d => d.Heading == "Incident 1 of 2");
+        var second = ctx.Details.Single(d => d.Heading == "Incident 2 of 2");
+        Assert.Contains(first.Fields, f => f.Label == "Occurrences" && f.Value == "8");
+        Assert.Contains(first.Fields, f => f.Label == "Wait Range" && f.Value == "80-90 s");
+        Assert.DoesNotContain(second.Fields, f => f.Label == "Occurrences"); // count 1 is omitted
+    }
+
+    [Fact]
+    public void Apply_UnresolvedObjects_RendersPlaceholder()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("k", Array.Empty<string>()) });
+        var incident = ctx.Details.Single(d => d.Heading == "Incident");
+        Assert.Contains(incident.Fields, f => f.Label == "Involved Objects" && f.Value == "(unresolved)");
+    }
+
+    [Fact]
+    public void DedupKey_RendersOnTeamsSlackAndBothEmailBodies()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("fingerprint-abc", new[] { "SalesDB.dbo.Orders" }) });
+
+        var teams = WebhookAlertService.BuildTeamsPayload("Blocking Detected", "S1", "8", "n/a", Branding, context: ctx);
+        var slack = WebhookAlertService.BuildSlackPayload("Blocking Detected", "S1", "8", "n/a", Branding, context: ctx);
+        var (html, plain) = EmailTemplateBuilder.BuildAlertEmail("Blocking Detected", "S1", "8", "n/a", 15, Branding, ctx);
+
+        Assert.Contains("fingerprint-abc", teams);
+        Assert.Contains("fingerprint-abc", slack);
+        Assert.Contains("fingerprint-abc", html);
+        Assert.Contains("fingerprint-abc", plain);
+    }
+}

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -306,6 +306,38 @@ public class AnalysisNotificationTests : IDisposable
         Assert.Contains("sp_query_store_force_plan", tsql.Body);
     }
 
+    [Fact]
+    public void AlertContext_RoundTripsIncidents_AndLegacyJsonHasNullIncidents()
+    {
+        // #1140: the dedup incidents must survive the context_json round-trip (so the alert-history
+        // UI / MCP can show the key), and legacy contextJson written before the field existed must
+        // still deserialize with Incidents == null.
+        var context = new AlertContext
+        {
+            Incidents = new List<AlertIncident>
+            {
+                new("abc123", new[] { "SalesDB.dbo.Orders", "SalesDB.dbo.LineItems" }, OccurrenceCount: 8, WaitRange: "80.8-90.8 s"),
+                new("def456", new[] { "SalesDB.dbo.Inventory" })
+            }
+        };
+
+        var json = AlertContextSerializer.Serialize(context);
+        Assert.True(AlertContextSerializer.TryDeserialize(json, out var restored));
+
+        Assert.NotNull(restored.Incidents);
+        Assert.Equal(2, restored.Incidents!.Count);
+        Assert.Equal("abc123", restored.Incidents[0].DedupKey);
+        Assert.Equal(new[] { "SalesDB.dbo.Orders", "SalesDB.dbo.LineItems" }, restored.Incidents[0].InvolvedObjects);
+        Assert.Equal(8, restored.Incidents[0].OccurrenceCount);
+        Assert.Equal("80.8-90.8 s", restored.Incidents[0].WaitRange);
+        Assert.Equal("def456", restored.Incidents[1].DedupKey);
+        Assert.Equal(1, restored.Incidents[1].OccurrenceCount);
+
+        // Backward-compat: legacy contextJson written before #1140 has no "Incidents" property.
+        Assert.True(AlertContextSerializer.TryDeserialize("{\"Details\":[]}", out var legacy));
+        Assert.Null(legacy.Incidents);
+    }
+
     /* ── AnalysisNotificationService: severity filter + cooldown ── */
     /* TrySendAlertEmailAsync writes one config_alert_log row per call (regardless of
        whether a channel is configured), so the row count is an observable proxy for

--- a/Lite.Tests/IncidentGroupingTests.cs
+++ b/Lite.Tests/IncidentGroupingTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Guards the shared incident groupers (#1140 / #1141): blocking rows that are one chain collapse to a
+/// single incident with the true count + wait range (gotqn's "shown 3x" report), and deadlocks group by
+/// involved-object set. Both apps' live builders call these, so this is the canonical grouping coverage.
+/// </summary>
+public class IncidentGroupingTests
+{
+    private const string Server = "SQL2022";
+
+    private static BlockingIncidentGrouper.BlockedEvent Blocked(
+        string? db, string? obj, string? blocked, string? blocking, long waitMs) =>
+        new(db, obj, blocked, blocking, waitMs);
+
+    [Fact]
+    public void Blocking_SameChainAcrossSamples_CollapsesToOneIncidentWithCountAndWaitRange()
+    {
+        // gotqn: one card showed the same chain 3x differing only by wait time (90.8 / 85.8 / 80.8 s).
+        var events = new[]
+        {
+            Blocked("SalesDB", null, "UPDATE SurveyInstances SET x = 1", "SELECT * FROM A CROSS JOIN B", 90800),
+            Blocked("SalesDB", null, "UPDATE SurveyInstances SET x = 1", "SELECT * FROM A CROSS JOIN B", 85800),
+            Blocked("SalesDB", null, "UPDATE SurveyInstances SET x = 1", "SELECT * FROM A CROSS JOIN B", 80800),
+        };
+
+        var groups = BlockingIncidentGrouper.Group(Server, events);
+
+        Assert.Single(groups);
+        Assert.Equal(3, groups[0].OccurrenceCount);
+        Assert.Equal(80800, groups[0].MinWaitMs);
+        Assert.Equal(90800, groups[0].MaxWaitMs);
+        Assert.Equal("80.8s-90.8s", groups[0].Incident.WaitRange);
+        Assert.Equal(3, groups[0].Incident.OccurrenceCount);
+        Assert.False(string.IsNullOrEmpty(groups[0].Incident.DedupKey));
+    }
+
+    [Fact]
+    public void Blocking_LiteralVaryingQueries_StillGroupTogether()
+    {
+        var events = new[]
+        {
+            Blocked("DB", null, "UPDATE T SET c = 1 WHERE id = 5", "SELECT * FROM T WHERE id = 5", 1000),
+            Blocked("DB", null, "UPDATE T SET c = 1 WHERE id = 99", "SELECT * FROM T WHERE id = 99", 2000),
+        };
+
+        var groups = BlockingIncidentGrouper.Group(Server, events);
+        Assert.Single(groups);
+        Assert.Equal(2, groups[0].OccurrenceCount);
+    }
+
+    [Fact]
+    public void Blocking_DistinctChains_ProduceDistinctIncidents()
+    {
+        var events = new[]
+        {
+            Blocked("DB", null, "UPDATE A SET c = 1", "SELECT * FROM A", 1000),
+            Blocked("DB", null, "UPDATE B SET c = 1", "SELECT * FROM B", 1000),
+        };
+
+        var groups = BlockingIncidentGrouper.Group(Server, events);
+        Assert.Equal(2, groups.Count);
+        Assert.NotEqual(groups[0].Incident.DedupKey, groups[1].Incident.DedupKey);
+    }
+
+    [Fact]
+    public void Blocking_ContentiousObject_DrivesIdentityAndInvolvedObjects()
+    {
+        // When the object is resolved, two different query pairs on the SAME object are one incident.
+        var events = new[]
+        {
+            Blocked("DB", "DB.dbo.Orders", "UPDATE Orders SET a = 1", "SELECT * FROM Orders WHERE x = 1", 1000),
+            Blocked("DB", "DB.dbo.Orders", "DELETE Orders WHERE z = 2", "SELECT TOP 1 * FROM Orders", 3000),
+        };
+
+        var groups = BlockingIncidentGrouper.Group(Server, events);
+        Assert.Single(groups);
+        Assert.Equal(2, groups[0].OccurrenceCount);
+        Assert.Equal(new[] { "DB.dbo.Orders" }, groups[0].Incident.InvolvedObjects);
+    }
+
+    [Fact]
+    public void Blocking_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(BlockingIncidentGrouper.Group(Server, Array.Empty<BlockingIncidentGrouper.BlockedEvent>()));
+    }
+
+    [Fact]
+    public void Deadlock_SameObjectSet_CollapsesAndCounts()
+    {
+        var events = new[]
+        {
+            new DeadlockIncidentGrouper.DeadlockEvent(new[] { "SalesDB.dbo.Orders", "SalesDB.dbo.LineItems" }),
+            new DeadlockIncidentGrouper.DeadlockEvent(new[] { "SalesDB.dbo.LineItems", "SalesDB.dbo.Orders" }), // order swapped
+        };
+
+        var groups = DeadlockIncidentGrouper.Group(Server, events);
+        Assert.Single(groups);
+        Assert.Equal(2, groups[0].OccurrenceCount);
+        Assert.Equal(2, groups[0].Incident.OccurrenceCount);
+        Assert.Equal(new[] { "SalesDB.dbo.LineItems", "SalesDB.dbo.Orders" }, groups[0].Incident.InvolvedObjects);
+    }
+
+    [Fact]
+    public void Deadlock_DistinctObjectSets_ProduceDistinctIncidents()
+    {
+        var events = new[]
+        {
+            new DeadlockIncidentGrouper.DeadlockEvent(new[] { "DB.dbo.A" }),
+            new DeadlockIncidentGrouper.DeadlockEvent(new[] { "DB.dbo.B" }),
+        };
+
+        var groups = DeadlockIncidentGrouper.Group(Server, events);
+        Assert.Equal(2, groups.Count);
+        Assert.NotEqual(groups[0].Incident.DedupKey, groups[1].Incident.DedupKey);
+    }
+
+    [Fact]
+    public void Deadlock_NoParseableObjects_AreSkipped()
+    {
+        var events = new[] { new DeadlockIncidentGrouper.DeadlockEvent(Array.Empty<string>()) };
+        Assert.Empty(DeadlockIncidentGrouper.Group(Server, events));
+    }
+
+    [Fact]
+    public void DeadlockObjectExtractor_PullsObjectNamesFromResourceList()
+    {
+        const string xml = @"<deadlock>
+  <resource-list>
+    <keylock dbid='5' objectname='SalesDB.dbo.Orders'><owner-list/><waiter-list/></keylock>
+    <keylock dbid='5' objectname='SalesDB.dbo.LineItems'><owner-list/><waiter-list/></keylock>
+    <pagelock dbid='5' objectname='SalesDB.dbo.Orders'><owner-list/></pagelock>
+  </resource-list>
+</deadlock>";
+
+        var objects = DeadlockObjectExtractor.FromGraphXml(xml);
+        Assert.Equal(new[] { "SalesDB.dbo.LineItems", "SalesDB.dbo.Orders" }, objects); // distinct + sorted
+    }
+
+    [Fact]
+    public void DeadlockObjectExtractor_MalformedOrEmpty_ReturnsEmpty()
+    {
+        Assert.Empty(DeadlockObjectExtractor.FromGraphXml(null));
+        Assert.Empty(DeadlockObjectExtractor.FromGraphXml("not xml <<<"));
+        Assert.Empty(DeadlockObjectExtractor.FromGraphXml("<deadlock><process-list/></deadlock>"));
+    }
+}

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 29;
+    internal const int CurrentSchemaVersion = 30;
 
     private readonly string _archivePath;
 
@@ -747,6 +747,27 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v28 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 30)
+        {
+            /* v30 (#1140): dedup-fingerprint support. blocked_process_reports gains the contentious
+               object the blocked_process_report event already carries (object_id/database_id) plus the
+               resolved name; query_snapshots gains query_hash for the long-running-query dedup key.
+               Appended at the end to keep the positional appender aligned; the v_ views union BY NAME
+               so old parquet reads back NULL for these. */
+            _logger?.LogInformation("Running migration to v30: dedup fingerprint columns (#1140)");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE blocked_process_reports ADD COLUMN IF NOT EXISTS object_id INTEGER");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE blocked_process_reports ADD COLUMN IF NOT EXISTS database_id INTEGER");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE blocked_process_reports ADD COLUMN IF NOT EXISTS contentious_object VARCHAR");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS query_hash VARCHAR");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v30 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -347,7 +347,8 @@ CREATE TABLE IF NOT EXISTS query_snapshots (
     program_name VARCHAR,
     open_transaction_count INTEGER,
     percent_complete DECIMAL(5,2),
-    is_cdc_capture BOOLEAN DEFAULT false
+    is_cdc_capture BOOLEAN DEFAULT false,
+    query_hash VARCHAR
 )";
 
     public const string CreateTempdbStatsTable = @"
@@ -468,7 +469,10 @@ CREATE TABLE IF NOT EXISTS blocked_process_reports (
     blocking_last_batch_completed TIMESTAMP,
     blocked_priority INTEGER,
     blocking_priority INTEGER,
-    blocked_process_report_xml VARCHAR
+    blocked_process_report_xml VARCHAR,
+    object_id INTEGER,
+    database_id INTEGER,
+    contentious_object VARCHAR
 )";
 
     public const string CreateDatabaseConfigTable = @"

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1665,7 +1665,7 @@ public partial class MainWindow : Window
                     _muteRuleService);
             }
 
-            var blockingContext = await BuildBlockingContextAsync(summary.ServerId);
+            var blockingContext = await BuildBlockingContextAsync(summary.ServerId, summary.DisplayName);
             var detailText = ContextToDetailText(blockingContext);
 
             await _emailAlertService.TrySendAlertEmailAsync(
@@ -1736,7 +1736,7 @@ public partial class MainWindow : Window
                     _muteRuleService);
             }
 
-            var deadlockContext = await BuildDeadlockContextAsync(summary.ServerId);
+            var deadlockContext = await BuildDeadlockContextAsync(summary.ServerId, summary.DisplayName);
             var detailText = ContextToDetailText(deadlockContext);
 
             await _emailAlertService.TrySendAlertEmailAsync(
@@ -2012,7 +2012,7 @@ public partial class MainWindow : Window
                                 _muteRuleService);
                         }
 
-                        var lowDiskContext = BuildVolumeFreeSpaceContext(breached);
+                        var lowDiskContext = BuildVolumeFreeSpaceContext(summary.DisplayName, breached);
                         /* #1136: grade the alert — WARNING normally, CRITICAL when the worst volume is
                            critically low — so the email/webhook badge reflects how dire the breach is.
                            (lowDiskContext is non-null here — breached.Count > 0 — but typed nullable.) */
@@ -2097,7 +2097,7 @@ public partial class MainWindow : Window
                                 _muteRuleService);
                         }
 
-                        var jobContext = BuildAnomalousJobContext(anomalousJobs);
+                        var jobContext = BuildAnomalousJobContext(summary.DisplayName, anomalousJobs);
                         var detailText = ContextToDetailText(jobContext);
 
                         await _emailAlertService.TrySendAlertEmailAsync(
@@ -2249,7 +2249,7 @@ public partial class MainWindow : Window
             return sb.ToString().TrimEnd();
         }
 
-        private async Task<AlertContext?> BuildBlockingContextAsync(int serverId)
+        private async Task<AlertContext?> BuildBlockingContextAsync(int serverId, string serverName)
         {
             try
             {
@@ -2268,39 +2268,56 @@ public partial class MainWindow : Window
                     if (events.Count == 0) return null;
                 }
 
-                var context = new AlertContext();
-                var firstXml = (string?)null;
+                /* #1140/#1141: collapse samples of the same chain into one group (true occurrence count
+                   + wait range) instead of listing it once per sample, and attach the dedup fingerprint.
+                   ContentiousObject is null until Lite's blocked-process collector resolves it (plan
+                   §5.3), so identity currently falls back to database + literal-stripped query pair. */
+                var groups = BlockingIncidentGrouper.Group(
+                    serverName,
+                    events.Select(e => new BlockingIncidentGrouper.BlockedEvent(
+                        e.DatabaseName, null, e.BlockedSqlText, e.BlockingSqlText, e.WaitTimeMs)));
 
-                foreach (var e in events.Take(3))
+                const int maxGroups = 10;
+                var shown = groups.Take(maxGroups).ToList();
+
+                var context = new AlertContext();
+                foreach (var g in shown)
                 {
                     var item = new AlertDetailItem
                     {
-                        Heading = $"Blocked #{e.BlockedSpid} by #{e.BlockingSpid}",
+                        Heading = g.OccurrenceCount > 1 ? $"Blocking chain (x{g.OccurrenceCount})" : "Blocking chain",
                         Fields = new()
                     };
-
-                    if (!string.IsNullOrEmpty(e.DatabaseName))
-                        item.Fields.Add(("Database", e.DatabaseName));
-                    if (!string.IsNullOrEmpty(e.BlockedSqlText))
-                        item.Fields.Add(("Blocked Query", TruncateText(e.BlockedSqlText)));
-                    if (!string.IsNullOrEmpty(e.BlockingSqlText))
-                        item.Fields.Add(("Blocking Query", TruncateText(e.BlockingSqlText)));
-                    item.Fields.Add(("Wait Time", e.WaitTimeFormatted));
-                    if (!string.IsNullOrEmpty(e.LockMode))
-                        item.Fields.Add(("Lock Mode", e.LockMode));
-
+                    if (!string.IsNullOrEmpty(g.Database))
+                        item.Fields.Add(("Database", g.Database));
+                    if (!string.IsNullOrEmpty(g.BlockedQuery))
+                        item.Fields.Add(("Blocked Query", TruncateText(g.BlockedQuery)));
+                    if (!string.IsNullOrEmpty(g.BlockingQuery))
+                        item.Fields.Add(("Blocking Query", TruncateText(g.BlockingQuery)));
+                    item.Fields.Add(("Wait Range", g.Incident.WaitRange ?? g.MaxWaitMs.ToString()));
                     context.Details.Add(item);
-                    if (firstXml == null && e.HasReportXml)
-                        firstXml = e.BlockedProcessReportXml;
                 }
 
+                /* Surface the true total instead of silently dropping (gotqn's report). */
+                if (groups.Count > maxGroups)
+                {
+                    context.Details.Add(new AlertDetailItem
+                    {
+                        Heading = $"+{groups.Count - maxGroups} more distinct blocking incident(s)",
+                        Fields = new()
+                    });
+                }
+
+                var firstXml = events.FirstOrDefault(e => e.HasReportXml)?.BlockedProcessReportXml;
                 if (!string.IsNullOrEmpty(firstXml))
                 {
                     context.AttachmentXml = firstXml;
                     context.AttachmentFileName = "blocked_process_report.xml";
                 }
 
-                return context;
+                AlertIncidentRenderer.Apply(context, shown.Select(g => g.Incident).ToList());
+
+                return context.Details.Count == 0 ? null : context;
             }
             catch (Exception ex)
             {
@@ -2309,7 +2326,7 @@ public partial class MainWindow : Window
             }
         }
 
-        private async Task<AlertContext?> BuildDeadlockContextAsync(int serverId)
+        private async Task<AlertContext?> BuildDeadlockContextAsync(int serverId, string serverName)
         {
             try
             {
@@ -2352,6 +2369,15 @@ public partial class MainWindow : Window
                     context.AttachmentXml = firstGraph;
                     context.AttachmentFileName = "deadlock_graph.xml";
                 }
+
+                /* #1140: fingerprint each deadlock by its sorted involved-object set (parsed from the
+                   graph), across ALL deadlocks in the window — not just the 3 displayed — grouped so
+                   recurrences over the same objects collapse to one incident with a count. */
+                var groups = DeadlockIncidentGrouper.Group(
+                    serverName,
+                    deadlocks.Select(d => new DeadlockIncidentGrouper.DeadlockEvent(
+                        DeadlockObjectExtractor.FromGraphXml(d.DeadlockGraphXml))));
+                AlertIncidentRenderer.Apply(context, groups.Select(g => g.Incident).ToList());
 
                 return context;
             }
@@ -2451,12 +2477,13 @@ public partial class MainWindow : Window
             return parts.Count > 0 ? string.Join(" / ", parts) : "—";
         }
 
-        private static AlertContext? BuildVolumeFreeSpaceContext(List<VolumeFreeSpaceInfo> volumes)
+        private static AlertContext? BuildVolumeFreeSpaceContext(string serverName, List<VolumeFreeSpaceInfo> volumes)
         {
             if (volumes.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var v in volumes.GetRange(0, Math.Min(5, volumes.Count)))
+            var shown = volumes.GetRange(0, Math.Min(5, volumes.Count));
+            foreach (var v in shown)
             {
                 context.Details.Add(new AlertDetailItem
                 {
@@ -2469,6 +2496,11 @@ public partial class MainWindow : Window
                     }
                 });
             }
+
+            /* #1140: dedup key per volume (the drive/mount point). */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(v => AlertFingerprint.ForKey(serverName, AlertFingerprint.Disk, v.MountPoint, new[] { v.MountPoint }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 
@@ -2493,12 +2525,13 @@ public partial class MainWindow : Window
             return context;
         }
 
-        private static AlertContext? BuildAnomalousJobContext(List<AnomalousJobInfo> jobs)
+        private static AlertContext? BuildAnomalousJobContext(string serverName, List<AnomalousJobInfo> jobs)
         {
             if (jobs.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var j in jobs.GetRange(0, Math.Min(3, jobs.Count)))
+            var shown = jobs.GetRange(0, Math.Min(3, jobs.Count));
+            foreach (var j in shown)
             {
                 context.Details.Add(new AlertDetailItem
                 {
@@ -2513,6 +2546,11 @@ public partial class MainWindow : Window
                     }
                 });
             }
+
+            /* #1140: dedup key per job (job name, scoped to the instance via serverName). */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(j => AlertFingerprint.ForKey(serverName, AlertFingerprint.Job, j.JobName, new[] { j.JobName }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1876,7 +1876,7 @@ public partial class MainWindow : Window
                                 _muteRuleService);
                         }
 
-                        var lrqContext = BuildLongRunningQueryContext(longRunning);
+                        var lrqContext = BuildLongRunningQueryContext(summary.DisplayName, longRunning);
                         var detailText = ContextToDetailText(lrqContext);
 
                         await _emailAlertService.TrySendAlertEmailAsync(
@@ -2270,12 +2270,12 @@ public partial class MainWindow : Window
 
                 /* #1140/#1141: collapse samples of the same chain into one group (true occurrence count
                    + wait range) instead of listing it once per sample, and attach the dedup fingerprint.
-                   ContentiousObject is null until Lite's blocked-process collector resolves it (plan
-                   §5.3), so identity currently falls back to database + literal-stripped query pair. */
+                   Identity is the resolved contentious object (collected server-side, §5.3), falling back
+                   to database + literal-stripped query pair only when the object did not resolve. */
                 var groups = BlockingIncidentGrouper.Group(
                     serverName,
                     events.Select(e => new BlockingIncidentGrouper.BlockedEvent(
-                        e.DatabaseName, null, e.BlockedSqlText, e.BlockingSqlText, e.WaitTimeMs)));
+                        e.DatabaseName, e.ContentiousObject, e.BlockedSqlText, e.BlockingSqlText, e.WaitTimeMs)));
 
                 const int maxGroups = 10;
                 var shown = groups.Take(maxGroups).ToList();
@@ -2427,12 +2427,13 @@ public partial class MainWindow : Window
             return context;
         }
 
-        private static AlertContext? BuildLongRunningQueryContext(List<LongRunningQueryInfo> queries)
+        private static AlertContext? BuildLongRunningQueryContext(string serverName, List<LongRunningQueryInfo> queries)
         {
             if (queries.Count == 0) return null;
 
             var context = new AlertContext();
-            foreach (var q in queries.GetRange(0, Math.Min(3, queries.Count)))
+            var shown = queries.GetRange(0, Math.Min(3, queries.Count));
+            foreach (var q in shown)
             {
                 var item = new AlertDetailItem
                 {
@@ -2454,6 +2455,12 @@ public partial class MainWindow : Window
 
                 context.Details.Add(item);
             }
+
+            /* #1140: dedup key = query_hash (stable across literals/plans). Null hash -> no incident. */
+            AlertIncidentRenderer.Apply(context, shown
+                .Select(q => AlertFingerprint.ForKey(serverName, AlertFingerprint.Query, q.QueryHash ?? "",
+                    string.IsNullOrEmpty(q.DatabaseName) ? System.Array.Empty<string>() : new[] { q.DatabaseName }))
+                .Where(i => i is not null).Select(i => i!).ToList());
             return context;
         }
 

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -369,7 +369,8 @@ SELECT
     blocked_last_batch_completed,
     blocking_last_batch_completed,
     blocked_priority,
-    blocking_priority
+    blocking_priority,
+    contentious_object
 FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -421,7 +422,8 @@ LIMIT 200";
                 BlockedLastBatchCompleted = reader.IsDBNull(31) ? null : reader.GetDateTime(31),
                 BlockingLastBatchCompleted = reader.IsDBNull(32) ? null : reader.GetDateTime(32),
                 BlockedPriority = reader.IsDBNull(33) ? 0 : reader.GetInt32(33),
-                BlockingPriority = reader.IsDBNull(34) ? 0 : reader.GetInt32(34)
+                BlockingPriority = reader.IsDBNull(34) ? 0 : reader.GetInt32(34),
+                ContentiousObject = reader.IsDBNull(35) ? "" : reader.GetString(35)
             });
         }
 
@@ -932,6 +934,7 @@ public class BlockedProcessReportRow
     public string BlockingLoginName { get; set; } = "";
     public string BlockingSqlText { get; set; } = "";
     public string BlockedProcessReportXml { get; set; } = "";
+    public string ContentiousObject { get; set; } = "";
     public string BlockedTransactionName { get; set; } = "";
     public string BlockingTransactionName { get; set; } = "";
     public DateTime? BlockedLastTranStarted { get; set; }

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -468,7 +468,8 @@ LIMIT 2000";
                     r.reads,
                     r.writes,
                     r.wait_type,
-                    r.blocking_session_id
+                    r.blocking_session_id,
+                    r.query_hash
                 FROM v_query_snapshots AS r
                 WHERE r.server_id = $1
                     AND r.collection_time = (SELECT MAX(vqs.collection_time) FROM v_query_snapshots AS vqs WHERE vqs.server_id = $1)
@@ -501,7 +502,8 @@ LIMIT 2000";
                 Reads = reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
                 Writes = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
                 WaitType = reader.IsDBNull(7) ? null : reader.GetString(7),
-                BlockingSessionId = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8)
+                BlockingSessionId = reader.IsDBNull(8) ? null : (int?)reader.GetInt32(8),
+                QueryHash = reader.IsDBNull(9) ? null : reader.GetString(9)
             });
         }
 
@@ -521,6 +523,7 @@ public class LongRunningQueryInfo
     public long Writes { get; set; }
     public string? WaitType { get; set; }
     public int? BlockingSessionId { get; set; }
+    public string? QueryHash { get; set; }
 }
 
 public class PoisonWaitDelta

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -302,16 +302,38 @@ AND   xet.target_name = N'ring_buffer'
 OPTION(RECOMPILE);
 
 SELECT
-    event_time = evt.value('(@timestamp)[1]', 'datetime2'),
-    blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report'))
+    x.event_time,
+    x.blocked_process_report_xml,
+    x.object_id,
+    x.database_id,
+    /* #1140: resolve the contentious object the blocked_process_report event already carries
+       (object_id/database_id). Mirrors sp_HumanEventsBlockViewer's contentious_object EXACTLY
+       (2-part schema.object + the same 'Unresolved: ...' fallback) so the dedup fingerprint
+       matches the Dashboard for the same object. OBJECT_NAME with the database_id arg resolves
+       cross-DB with no USE; NULL (cross-db perms / dropped object) -> the stable id fallback. */
+    contentious_object =
+        ISNULL
+        (
+            OBJECT_SCHEMA_NAME(x.object_id, x.database_id) + N'.' + OBJECT_NAME(x.object_id, x.database_id),
+            N'Unresolved: database: ' + ISNULL(DB_NAME(x.database_id), N'unknown') +
+            N' object_id: ' + ISNULL(CONVERT(nvarchar(20), x.object_id), N'unknown')
+        )
 FROM
 (
     SELECT
-        pmd.ring_buffer
-    FROM @PerformanceMonitor_BlockedProcess AS pmd
-) AS rb
-CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
-WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
+        event_time = evt.value('(@timestamp)[1]', 'datetime2'),
+        blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report')),
+        object_id = evt.value('(data[@name=""object_id""]/value/text())[1]', 'integer'),
+        database_id = evt.value('(data[@name=""database_id""]/value/text())[1]', 'integer')
+    FROM
+    (
+        SELECT
+            pmd.ring_buffer
+        FROM @PerformanceMonitor_BlockedProcess AS pmd
+    ) AS rb
+    CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
+    WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
+) AS x
 OPTION(RECOMPILE);";
         }
         else
@@ -342,16 +364,38 @@ AND   xet.target_name = N'ring_buffer'
 OPTION(RECOMPILE);
 
 SELECT
-    event_time = evt.value('(@timestamp)[1]', 'datetime2'),
-    blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report'))
+    x.event_time,
+    x.blocked_process_report_xml,
+    x.object_id,
+    x.database_id,
+    /* #1140: resolve the contentious object the blocked_process_report event already carries
+       (object_id/database_id). Mirrors sp_HumanEventsBlockViewer's contentious_object EXACTLY
+       (2-part schema.object + the same 'Unresolved: ...' fallback) so the dedup fingerprint
+       matches the Dashboard for the same object. OBJECT_NAME with the database_id arg resolves
+       cross-DB with no USE; NULL (cross-db perms / dropped object) -> the stable id fallback. */
+    contentious_object =
+        ISNULL
+        (
+            OBJECT_SCHEMA_NAME(x.object_id, x.database_id) + N'.' + OBJECT_NAME(x.object_id, x.database_id),
+            N'Unresolved: database: ' + ISNULL(DB_NAME(x.database_id), N'unknown') +
+            N' object_id: ' + ISNULL(CONVERT(nvarchar(20), x.object_id), N'unknown')
+        )
 FROM
 (
     SELECT
-        pmd.ring_buffer
-    FROM @PerformanceMonitor_BlockedProcess AS pmd
-) AS rb
-CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
-WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
+        event_time = evt.value('(@timestamp)[1]', 'datetime2'),
+        blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report')),
+        object_id = evt.value('(data[@name=""object_id""]/value/text())[1]', 'integer'),
+        database_id = evt.value('(data[@name=""database_id""]/value/text())[1]', 'integer')
+    FROM
+    (
+        SELECT
+            pmd.ring_buffer
+        FROM @PerformanceMonitor_BlockedProcess AS pmd
+    ) AS rb
+    CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
+    WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
+) AS x
 OPTION(RECOMPILE);";
         }
 
@@ -408,6 +452,11 @@ OPTION(RECOMPILE);";
                     {
                         var eventTime = reader.IsDBNull(0) ? (DateTime?)null : reader.GetDateTime(0);
                         var reportXml = reader.IsDBNull(1) ? null : reader.GetString(1);
+                        /* #1140: object_id/database_id are the event's own data fields and contentious_object
+                           is resolved server-side in the collection query (cols 2-4), not parsed from the XML. */
+                        var objectId = reader.IsDBNull(2) ? (int?)null : reader.GetInt32(2);
+                        var databaseId = reader.IsDBNull(3) ? (int?)null : reader.GetInt32(3);
+                        var contentiousObject = reader.IsDBNull(4) ? null : reader.GetString(4);
 
                         if (string.IsNullOrEmpty(reportXml))
                         {
@@ -460,6 +509,9 @@ OPTION(RECOMPILE);";
                            .AppendValue(parsed.BlockedPriority)
                            .AppendValue(parsed.BlockingPriority)
                            .AppendValue(reportXml)
+                           .AppendValue(objectId)
+                           .AppendValue(databaseId)
+                           .AppendValue(contentiousObject)
                            .EndRow();
 
                         rowsCollected++;

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -93,7 +93,8 @@ SELECT /* PerformanceMonitorLite */
                      AND (dest.text LIKE N'%sp_MScdc_capture_job%' OR dest.text LIKE N'%sp_cdc_scan%')
                 THEN 1
                 ELSE 0
-            END)
+            END),
+    query_hash = CONVERT(varchar(18), der.query_hash, 1) /* #1140 long-running-query dedup key */
 FROM sys.dm_exec_requests AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -148,7 +149,8 @@ SELECT
     der.transaction_isolation_level,
     der.dop,
     der.parallel_worker_count,
-    der.percent_complete
+    der.percent_complete,
+    der.query_hash
 INTO #req
 FROM sys.dm_exec_requests AS der
 WHERE der.session_id <> @@SPID
@@ -201,7 +203,8 @@ SELECT /* PerformanceMonitorLite */
     des.open_transaction_count,
     der.percent_complete,
     /* Azure SQL Database has no SQL Agent / msdb.dbo.cdc_jobs (CDC there is scheduler-based), so no capture job to exclude. */
-    is_cdc_capture = CONVERT(bit, 0)
+    is_cdc_capture = CONVERT(bit, 0),
+    query_hash = CONVERT(varchar(18), der.query_hash, 1) /* #1140 long-running-query dedup key */
 FROM #req AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -328,6 +331,7 @@ DROP TABLE #req;
                    .AppendValue(reader.IsDBNull(23) ? 0 : Convert.ToInt32(reader.GetValue(23)))            /* open_transaction_count */
                    .AppendValue(reader.IsDBNull(24) ? 0m : Convert.ToDecimal(reader.GetValue(24)))        /* percent_complete */
                    .AppendValue(!reader.IsDBNull(25) && Convert.ToBoolean(reader.GetValue(25)))           /* is_cdc_capture */
+                   .AppendValue(reader.IsDBNull(26) ? (string?)null : reader.GetString(26))                /* query_hash (#1140) */
                    .EndRow();
 
                 rowsCollected++;

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -31,7 +31,28 @@ public class AlertContext
     /// JSON projection (<see cref="AlertContextSerializer"/>) need not carry it.
     /// </summary>
     public AlertSeverityLevel? SeverityOverride { get; set; }
+
+    /// <summary>
+    /// One entry per distinct grouped incident this alert covers (#1140). Carries the stable
+    /// dedup fingerprint + human-readable involved objects that downstream automation uses to
+    /// collapse recurrences of the same incident. <c>null</c>/empty = no fingerprintable incident
+    /// (alert type not wired, or no objects resolvable). Persisted in the alert-history context JSON.
+    /// </summary>
+    public List<AlertIncident>? Incidents { get; set; }
 }
+
+/// <summary>
+/// A single dedup-able incident within an alert (#1140): a stable fingerprint, the fully-qualified
+/// objects it involves (human-readable, for the ticket body), the grouped occurrence count, and an
+/// optional display-only wait range. Volatile per-sample fields (wait time, durations, SPIDs) are
+/// never part of <see cref="DedupKey"/> — only the identity members hashed by
+/// <see cref="AlertFingerprint"/>.
+/// </summary>
+public sealed record AlertIncident(
+    string DedupKey,
+    IReadOnlyList<string> InvolvedObjects,
+    int OccurrenceCount = 1,
+    string? WaitRange = null);
 
 /// <summary>
 /// A single detail item (e.g., one blocking chain or one deadlock participant).
@@ -75,9 +96,16 @@ public class AlertDetailItem
 /// <see cref="AlertContext.AttachmentXml"/>/<see cref="AlertContext.AttachmentFileName"/>
 /// are deliberately not persisted (the dialog has no attachment surface).
 /// </summary>
-public record AlertContextDto(List<AlertDetailItemDto> Details);
+public record AlertContextDto(List<AlertDetailItemDto> Details, List<AlertIncidentDto>? Incidents = null);
 public record AlertDetailItemDto(string Heading, List<FieldDto> Fields, string? Body, bool IsCodeBlock, RemediationActionDto? Remediation = null);
 public record FieldDto(string Label, string Value);
+
+/// <summary>
+/// JSON mirror of <see cref="AlertIncident"/> (#1140). The trailing optional <c>Incidents</c>
+/// member on <see cref="AlertContextDto"/> keeps the round-trip backward-compatible: legacy
+/// contextJson written before this field existed deserializes <c>Incidents</c> to null.
+/// </summary>
+public record AlertIncidentDto(string DedupKey, List<string> InvolvedObjects, int OccurrenceCount = 1, string? WaitRange = null);
 
 /// <summary>
 /// JSON mirror of <see cref="RemediationAction"/> / <see cref="ForcePlanTarget"/>
@@ -228,7 +256,12 @@ public static class AlertContextSerializer
                 d.Fields.ConvertAll(f => new FieldDto(f.Label, f.Value)),
                 d.Body,
                 d.IsCodeBlock,
-                ToDto(d.Remediation))));
+                ToDto(d.Remediation))),
+            context.Incidents?.ConvertAll(i => new AlertIncidentDto(
+                i.DedupKey,
+                new List<string>(i.InvolvedObjects),
+                i.OccurrenceCount,
+                i.WaitRange)));
         return JsonSerializer.Serialize(dto);
     }
 
@@ -295,6 +328,21 @@ public static class AlertContextSerializer
                         item.Fields.Add((f.Label, f.Value));
                 }
                 context.Details.Add(item);
+            }
+
+            /* #1140: rehydrate the dedup incidents. Legacy contextJson without the field leaves
+               dto.Incidents null -> context.Incidents stays null (backward-compatible). */
+            if (dto.Incidents is { Count: > 0 })
+            {
+                context.Incidents = new List<AlertIncident>(dto.Incidents.Count);
+                foreach (var i in dto.Incidents)
+                {
+                    context.Incidents.Add(new AlertIncident(
+                        i.DedupKey ?? string.Empty,
+                        i.InvolvedObjects ?? new List<string>(),
+                        i.OccurrenceCount,
+                        i.WaitRange));
+                }
             }
             return true;
         }

--- a/PerformanceMonitor.Notifications/AlertFingerprint.cs
+++ b/PerformanceMonitor.Notifications/AlertFingerprint.cs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Computes the stable, machine-readable dedup fingerprint and the human-readable involved-objects
+/// list that ride on an <see cref="AlertIncident"/> (#1140). Downstream automation (e.g. a Logic App
+/// creating Azure DevOps tickets) matches on the fingerprint to collapse recurrences of the same
+/// incident instead of opening a new ticket each time.
+///
+/// <para>
+/// The fingerprint hashes only STABLE identity members — the involved objects (or a natural key like
+/// a query_hash / job name / mount point), scoped by server and incident type. Volatile per-sample
+/// values (wait time, durations, SPIDs, counts) are deliberately excluded so the same incident hashes
+/// identically across collection cycles. Reuses the SHA-256 idiom from
+/// <c>PerformanceMonitor.Analysis.InferenceEngine</c>.
+/// </para>
+/// </summary>
+public static class AlertFingerprint
+{
+    /// <summary>Incident-type tags hashed into the key so the same objects under different incident
+    /// kinds (a deadlock vs a blocking chain on the same table) never collide.</summary>
+    public const string Deadlock = "deadlock";
+    public const string Blocking = "blocking";
+    public const string Query = "query";
+    public const string Job = "job";
+    public const string Disk = "disk";
+
+    private static readonly Regex s_whitespace = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Builds an incident from the set of fully-qualified objects it involves. The fingerprint is a
+    /// hash over (serverName, incidentType, sorted-distinct-normalized objects); the returned
+    /// <see cref="AlertIncident.InvolvedObjects"/> preserves the original casing (deduped, ordered)
+    /// for display. Returns <c>null</c> when no usable object remains (caller emits no incident).
+    /// </summary>
+    public static AlertIncident? ForObjects(
+        string serverName,
+        string incidentType,
+        IEnumerable<string> objects,
+        int occurrenceCount = 1,
+        string? waitRange = null)
+    {
+        // Dedup case-insensitively by normalized form, keep the first original casing for display,
+        // order by normalized form so both the hash input and the display list are stable.
+        var byNormalized = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        if (objects is not null)
+        {
+            foreach (var o in objects)
+            {
+                var normalized = Normalize(o);
+                if (normalized.Length == 0)
+                    continue;
+                if (!byNormalized.ContainsKey(normalized))
+                    byNormalized[normalized] = (o ?? string.Empty).Trim();
+            }
+        }
+
+        if (byNormalized.Count == 0)
+            return null;
+
+        var key = Hash(BuildInput(serverName, incidentType, byNormalized.Keys));
+        return new AlertIncident(key, byNormalized.Values.ToList(), occurrenceCount, waitRange);
+    }
+
+    /// <summary>
+    /// Builds an incident from a single natural key (a query_hash, job name, mount point, or a
+    /// "database:object_id" fallback) rather than an object set. The fingerprint hashes
+    /// (serverName, incidentType, normalized naturalKey); <paramref name="displayObjects"/> are
+    /// shown to the user but do NOT affect the key. Returns <c>null</c> when the key is blank.
+    /// </summary>
+    public static AlertIncident? ForKey(
+        string serverName,
+        string incidentType,
+        string naturalKey,
+        IReadOnlyList<string>? displayObjects = null,
+        int occurrenceCount = 1,
+        string? waitRange = null)
+    {
+        var normalized = Normalize(naturalKey);
+        if (normalized.Length == 0)
+            return null;
+
+        var key = Hash(BuildInput(serverName, incidentType, new[] { normalized }));
+        return new AlertIncident(key, displayObjects ?? Array.Empty<string>(), occurrenceCount, waitRange);
+    }
+
+    /// <summary>SHA-256 of <paramref name="input"/> as lowercase hex (64 chars). Public for tests.</summary>
+    public static string Hash(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input ?? string.Empty));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    // serverName | incidentType | identity members. serverName/incidentType are normalized here;
+    // members arrive already normalized. The server scope makes the same object name on two
+    // instances two distinct incidents; the type tag separates deadlock from blocking.
+    private static string BuildInput(string serverName, string incidentType, IEnumerable<string> normalizedMembers)
+    {
+        var sb = new StringBuilder();
+        sb.Append(Normalize(serverName)).Append('|').Append(Normalize(incidentType));
+        foreach (var member in normalizedMembers)
+            sb.Append('|').Append(member);
+        return sb.ToString();
+    }
+
+    // Trim, collapse internal whitespace runs to a single space, lower-invariant. Stable identity
+    // at the cost of merging names that differ only by case (accepted; see plan SS9 Q3).
+    private static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+        return s_whitespace.Replace(value.Trim(), " ").ToLowerInvariant();
+    }
+}

--- a/PerformanceMonitor.Notifications/AlertIncidentRenderer.cs
+++ b/PerformanceMonitor.Notifications/AlertIncidentRenderer.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Projects the structured <see cref="AlertContext.Incidents"/> (#1140) into renderable
+/// <see cref="AlertDetailItem"/>s so the dedup fingerprint + involved objects appear on every
+/// surface (Teams facts, Slack fields, email HTML/plaintext, in-app dialog) WITHOUT touching any
+/// renderer — they all iterate <see cref="AlertContext.Details"/>.
+/// <para>
+/// Items are appended (not prepended) so the existing detail order — e.g. the finding path's
+/// Diagnosis → Advice → T-SQL → drill-down — is preserved. Downstream automation keys on the fact
+/// <b>name</b> ("Dedup Key"), and incidents are the only producer of that fact, so the first
+/// "Dedup Key" fact is always the primary incident regardless of absolute position.
+/// </para>
+/// </summary>
+public static class AlertIncidentRenderer
+{
+    /// <summary>
+    /// Sets <paramref name="context"/>.Incidents and appends one detail item per incident. No-op when
+    /// there are no incidents. Call once from each alert builder after computing the incidents.
+    /// </summary>
+    public static void Apply(AlertContext context, IReadOnlyList<AlertIncident>? incidents)
+    {
+        if (incidents is not { Count: > 0 })
+            return;
+
+        context.Incidents = new List<AlertIncident>(incidents);
+
+        for (int n = 0; n < incidents.Count; n++)
+        {
+            var incident = incidents[n];
+            var item = new AlertDetailItem
+            {
+                Heading = incidents.Count == 1 ? "Incident" : $"Incident {n + 1} of {incidents.Count}"
+            };
+            item.Fields.Add(("Dedup Key", incident.DedupKey));
+            item.Fields.Add(("Involved Objects",
+                incident.InvolvedObjects.Count > 0
+                    ? string.Join(", ", incident.InvolvedObjects)
+                    : "(unresolved)"));
+            if (incident.OccurrenceCount > 1)
+                item.Fields.Add(("Occurrences", incident.OccurrenceCount.ToString()));
+            if (!string.IsNullOrEmpty(incident.WaitRange))
+                item.Fields.Add(("Wait Range", incident.WaitRange));
+
+            context.Details.Add(item);
+        }
+    }
+}

--- a/PerformanceMonitor.Notifications/DeadlockObjectExtractor.cs
+++ b/PerformanceMonitor.Notifications/DeadlockObjectExtractor.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Extracts the distinct fully-qualified object names (<c>database.schema.object</c>) from a deadlock
+/// graph's <c>&lt;resource-list&gt;</c> for the #1140 fingerprint. Mirrors the object extraction the
+/// Lite deadlock detail UI already does (LocalDataService deadlock parse) so Lite's live "Deadlocks
+/// Detected" builder can feed <see cref="DeadlockIncidentGrouper"/> without re-querying. Dashboard
+/// already carries the equivalent on <c>DeadlockItem.ObjectNames</c> and need not parse XML.
+/// </summary>
+public static class DeadlockObjectExtractor
+{
+    // Lock resource elements that carry an objectname attribute (matches the Lite UI parser).
+    private static readonly string[] s_lockTypes =
+        { "objectlock", "pagelock", "keylock", "ridlock", "rowgrouplock" };
+
+    /// <summary>
+    /// Returns the distinct object names across all lock resources in the graph, or an empty list when
+    /// the XML is blank, unparseable, or carries no named objects. Never throws.
+    /// </summary>
+    public static IReadOnlyList<string> FromGraphXml(string? graphXml)
+    {
+        if (string.IsNullOrWhiteSpace(graphXml))
+            return Array.Empty<string>();
+
+        try
+        {
+            var doc = XElement.Parse(graphXml);
+            var resourceList = doc.Descendants("resource-list").FirstOrDefault();
+            if (resourceList is null)
+                return Array.Empty<string>();
+
+            var names = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var lockType in s_lockTypes)
+            {
+                foreach (var node in resourceList.Elements(lockType))
+                {
+                    var objectName = node.Attribute("objectname")?.Value;
+                    if (!string.IsNullOrWhiteSpace(objectName))
+                        names.Add(objectName.Trim());
+                }
+            }
+
+            return names.Count == 0 ? Array.Empty<string>() : names.ToList();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/PerformanceMonitor.Notifications/IncidentGrouping.cs
+++ b/PerformanceMonitor.Notifications/IncidentGrouping.cs
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Groups raw blocked-process rows into distinct incidents (#1140 / #1141). Today's alert lists the
+/// same blocking chain several times (one row per sample, differing only by wait time) and caps the
+/// list at a few rows while the count says more — gotqn's report. This collapses rows that share an
+/// incident identity into one group carrying the true occurrence count and wait range, and attaches
+/// the stable dedup fingerprint. Both apps' live "Blocking Detected" builders call this, so the
+/// grouping + fingerprint are identical across Lite and Dashboard.
+/// <para>
+/// Incident identity (volatile fields excluded): the resolved contentious object when available
+/// (Dashboard's <c>contentious_object</c> / Lite's event-resolved object — stable across index
+/// rebuilds), else database + literal-stripped blocked/blocking query pair, matching plan §4.2.
+/// </para>
+/// </summary>
+public static class BlockingIncidentGrouper
+{
+    /// <summary>One blocked-process sample projected from each app's row model into a shared shape.</summary>
+    public readonly record struct BlockedEvent(
+        string? Database,
+        string? ContentiousObject,
+        string? BlockedQuery,
+        string? BlockingQuery,
+        long WaitTimeMs);
+
+    /// <summary>One distinct blocking incident: a representative chain, its true occurrence count and
+    /// wait range, and the dedup <see cref="AlertIncident"/>.</summary>
+    public sealed record BlockingGroup(
+        string? Database,
+        string? ContentiousObject,
+        string? BlockedQuery,
+        string? BlockingQuery,
+        int OccurrenceCount,
+        long MinWaitMs,
+        long MaxWaitMs,
+        AlertIncident Incident);
+
+    private static readonly Regex s_stringLiteral = new("'(?:[^']|'')*'", RegexOptions.Compiled);
+    private static readonly Regex s_numericLiteral = new(@"\b\d+(\.\d+)?\b", RegexOptions.Compiled);
+    private static readonly Regex s_whitespace = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Collapses the events into one group per distinct incident, preserving input order of first
+    /// appearance, with the highest occurrence count first. Empty input returns an empty list.
+    /// </summary>
+    public static List<BlockingGroup> Group(string serverName, IEnumerable<BlockedEvent> events)
+    {
+        var order = new List<string>();
+        var buckets = new Dictionary<string, List<BlockedEvent>>(StringComparer.Ordinal);
+
+        foreach (var e in events ?? Enumerable.Empty<BlockedEvent>())
+        {
+            var identity = IdentityKey(e);
+            if (!buckets.TryGetValue(identity, out var list))
+            {
+                list = new List<BlockedEvent>();
+                buckets[identity] = list;
+                order.Add(identity);
+            }
+            list.Add(e);
+        }
+
+        var groups = new List<BlockingGroup>(order.Count);
+        foreach (var identity in order)
+        {
+            var rows = buckets[identity];
+            var representative = rows[0];
+            var minWait = rows.Min(r => r.WaitTimeMs);
+            var maxWait = rows.Max(r => r.WaitTimeMs);
+            var waitRange = FormatWaitRange(minWait, maxWait);
+
+            var hasObject = !string.IsNullOrWhiteSpace(representative.ContentiousObject);
+            var incident = hasObject
+                ? AlertFingerprint.ForObjects(
+                    serverName, AlertFingerprint.Blocking,
+                    new[] { representative.ContentiousObject! }, rows.Count, waitRange)
+                : AlertFingerprint.ForKey(
+                    serverName, AlertFingerprint.Blocking,
+                    QueryPairKey(representative),
+                    DatabaseDisplay(representative.Database), rows.Count, waitRange);
+
+            // ForObjects/ForKey only return null on empty identity, which IdentityKey already excludes,
+            // so incident is non-null here; guard defensively rather than assert.
+            if (incident is null)
+                continue;
+
+            groups.Add(new BlockingGroup(
+                representative.Database, representative.ContentiousObject,
+                representative.BlockedQuery, representative.BlockingQuery,
+                rows.Count, minWait, maxWait, incident));
+        }
+
+        groups.Sort((a, b) => b.OccurrenceCount.CompareTo(a.OccurrenceCount));
+        return groups;
+    }
+
+    private static string IdentityKey(BlockedEvent e) =>
+        !string.IsNullOrWhiteSpace(e.ContentiousObject)
+            ? "obj|" + Norm(e.Database) + "|" + Norm(e.ContentiousObject)
+            : "qp|" + QueryPairKey(e);
+
+    private static string QueryPairKey(BlockedEvent e) =>
+        Norm(e.Database) + "|" + NormalizeQuery(e.BlockedQuery) + "|" + NormalizeQuery(e.BlockingQuery);
+
+    private static string[] DatabaseDisplay(string? database) =>
+        string.IsNullOrWhiteSpace(database) ? Array.Empty<string>() : new[] { database! };
+
+    private static string Norm(string? s) =>
+        string.IsNullOrWhiteSpace(s) ? string.Empty : s_whitespace.Replace(s.Trim(), " ").ToLowerInvariant();
+
+    // Strip string + numeric literals so chains differing only by parameter values group together
+    // ("WHERE id = 5" and "WHERE id = 9" -> the same key), then collapse whitespace + lower.
+    private static string NormalizeQuery(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return string.Empty;
+        var s = s_stringLiteral.Replace(query, "'?'");
+        s = s_numericLiteral.Replace(s, "?");
+        return s_whitespace.Replace(s.Trim(), " ").ToLowerInvariant();
+    }
+
+    private static string FormatWaitRange(long minMs, long maxMs)
+    {
+        string Sec(long ms) => (ms / 1000.0).ToString("F1", CultureInfo.InvariantCulture) + "s";
+        return minMs == maxMs ? Sec(maxMs) : Sec(minMs) + "-" + Sec(maxMs);
+    }
+}
+
+/// <summary>
+/// Groups deadlock events by the sorted set of fully-qualified objects involved (#1140). One
+/// deadlock spanning multiple databases/objects is a single incident listing them all; recurrences
+/// over the same object set collapse to one fingerprint with the occurrence count. Both apps feed
+/// the per-event object lists (Dashboard from <c>DeadlockItem.ObjectNames</c>, Lite via
+/// <see cref="DeadlockObjectExtractor"/>) so the fingerprint is identical across them.
+/// </summary>
+public static class DeadlockIncidentGrouper
+{
+    /// <summary>One deadlock event projected to the distinct fully-qualified objects it involved.</summary>
+    public readonly record struct DeadlockEvent(IReadOnlyList<string> Objects);
+
+    /// <summary>One distinct deadlock incident: the involved object set, occurrence count, and fingerprint.</summary>
+    public sealed record DeadlockGroup(IReadOnlyList<string> Objects, int OccurrenceCount, AlertIncident Incident);
+
+    /// <summary>
+    /// Collapses events sharing an involved-object set into one group (highest occurrence count first).
+    /// Events with no parseable objects are skipped (no fingerprintable identity); the builder still
+    /// displays them. Empty input returns an empty list.
+    /// </summary>
+    public static List<DeadlockGroup> Group(string serverName, IEnumerable<DeadlockEvent> events)
+    {
+        var order = new List<string>();
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var incidents = new Dictionary<string, AlertIncident>(StringComparer.Ordinal);
+
+        foreach (var e in events ?? Enumerable.Empty<DeadlockEvent>())
+        {
+            // Probe identity first so we group by the SAME normalized set the fingerprint hashes.
+            var probe = AlertFingerprint.ForObjects(serverName, AlertFingerprint.Deadlock, e.Objects ?? Array.Empty<string>());
+            if (probe is null)
+                continue; // no parseable objects -> not fingerprintable
+
+            var key = probe.DedupKey;
+            if (!counts.TryGetValue(key, out var current))
+            {
+                order.Add(key);
+                incidents[key] = probe;
+                current = 0;
+            }
+            counts[key] = current + 1;
+        }
+
+        var groups = new List<DeadlockGroup>(order.Count);
+        foreach (var key in order)
+        {
+            var count = counts[key];
+            var baseIncident = incidents[key];
+            // Re-stamp the occurrence count onto the incident (the probe used count 1).
+            var incident = baseIncident with { OccurrenceCount = count };
+            groups.Add(new DeadlockGroup(incident.InvolvedObjects, count, incident));
+        }
+
+        groups.Sort((a, b) => b.OccurrenceCount.CompareTo(a.OccurrenceCount));
+        return groups;
+    }
+}


### PR DESCRIPTION
Implements [#1140](https://github.com/erikdarlingdata/PerformanceMonitor/issues/1140) (stable machine-readable dedup fingerprint + involved-objects on alert payloads) and the grouping foundation of [#1141](https://github.com/erikdarlingdata/PerformanceMonitor/issues/1141), across **both apps**.

## What downstream automation gets
Every alert now carries, on every surface (Teams `facts[]`, Slack `fields`, email HTML + plaintext, in-app dialog) and persisted in alert history:
- **`Dedup Key`** — a stable SHA-256 fingerprint computed server-side, scoped by server + incident type, excluding volatile per-sample fields (wait time etc.) so recurrences of the same incident hash identically.
- **`Involved Objects`** — the human-readable object list for the ticket body.
- **`Occurrences` + `Wait Range`** — from grouping (see below).

Identity per type: deadlock = sorted involved-object set; blocking = resolved contentious object (else db + literal-stripped query pair); long-running query = `query_hash`; job = job name; volume = mount point.

## Highlights
- **Shared, unit-tested core** (`PerformanceMonitor.Notifications`): `AlertFingerprint`, `AlertIncident`, `AlertIncidentRenderer`, `BlockingIncidentGrouper`, `DeadlockIncidentGrouper`, `DeadlockObjectExtractor` + serializer persistence (backward-compatible).
- **Live "Detected"/threshold builders wired in BOTH apps** for deadlock, blocking, long-running query, volume free space, long-running job — this is the path consumers actually receive.
- **Grouping (#1141 foundation / #1140 comment):** blocking samples of the same chain collapse into one entry with the true occurrence count + wait range (fixes "same chain shown 3×, count says 8"), and the silent `Take(3)` truncation now surfaces "+N more".
- **Lite collector changes:** capture the `blocked_process_report` event's `object_id`/`database_id` and resolve `contentious_object` server-side, **mirroring `sp_HumanEventsBlockViewer` exactly** so fingerprints match the Dashboard; capture `query_hash` into `query_snapshots`. DuckDB schema v29→v30 (additive `ALTER ADD COLUMN`; views union BY NAME).
- **Dashboard** needed no schema change (`object_names` + `contentious_object` already collected; `query_hash` added from `sys.dm_exec_requests`).

## Verification
- **975 unit tests green** (488 Lite + 487 Dashboard); both apps build with 0 warnings.
- The new collector SQL (BPR object resolution + `query_hash` conversion) was **validated against SQL Server 2022** via sqlcmd.

## Scope note (one deliberate follow-up)
The **secondary anomaly/finding path** (`ANOMALY_*_SPIKE` via `AnalysisNotificationService`) is **not** wired for incidents in this PR. Its deadlock/blocking drill-downs don't carry object identity, so it needs a separate `DrillDownCollector` change in both apps. It's shared code, so wiring it later is automatic parity (no drift). The consumer-facing live path is complete.

## Test plan (on dev)
1. Trigger blocking + deadlocks on a monitored server; confirm the Teams/Slack/email alert shows a `Dedup Key` + `Involved Objects`, that a repeated chain shows once with the right count/wait range, and that the key is stable across repeats.
2. Confirm Lite and Dashboard produce the **same** `Dedup Key` for the same contended object.
3. Long-running query / job / volume alerts carry their keys.
4. **Cloud:** verify the Lite blocked-process `contentious_object` resolution on Azure SQL DB + AWS RDS (the monitoring login needs object-name visibility; falls back to `Unresolved: database:… object_id:…` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)