### PR TITLE
#1140: dedup fingerprints on the anomaly/finding alert path (both apps)

### DIFF
--- a/Dashboard/Analysis/SqlServerDrillDownCollector.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.cs
@@ -10,6 +10,7 @@ using PerformanceMonitorDashboard.Mcp;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorDashboard.Analysis;
 
@@ -163,7 +164,8 @@ SELECT TOP 3
     collection_time,
     event_date,
     spid,
-    LEFT(CAST(query AS NVARCHAR(MAX)), 500) AS victim_sql
+    LEFT(CAST(query AS NVARCHAR(MAX)), 500) AS victim_sql,
+    CAST(deadlock_graph AS NVARCHAR(MAX)) AS deadlock_graph
 FROM collect.deadlocks
 WHERE collection_time >= @startTime AND collection_time <= @endTime
 ORDER BY collection_time DESC;";
@@ -175,12 +177,16 @@ ORDER BY collection_time DESC;";
         using var reader = await cmd.ExecuteReaderAsync();
         while (await reader.ReadAsync())
         {
+            /* #1140: parse the involved objects from the graph for the dedup fingerprint + a readable
+               Objects field. The raw graph XML is NOT surfaced (it would bloat the alert detail). */
+            var objects = DeadlockObjectExtractor.FromGraphXml(reader.IsDBNull(4) ? null : reader.GetString(4));
             items.Add(new
             {
                 time = reader.IsDBNull(0) ? "" : reader.GetDateTime(0).ToString("o"),
                 deadlock_time = reader.IsDBNull(1) ? "" : reader.GetDateTime(1).ToString("o"),
                 victim = reader.IsDBNull(2) ? "" : reader.GetValue(2).ToString(),
-                victim_sql = reader.IsDBNull(3) ? "" : reader.GetString(3)
+                victim_sql = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                objects = string.Join(", ", objects)
             });
         }
 
@@ -205,7 +211,8 @@ SELECT TOP 5
     wait_time_ms,
     lock_mode,
     LEFT(CAST(query_text AS NVARCHAR(MAX)), 500) AS blocked_sql,
-    LEFT(blocking_tree, 500) AS blocking_sql
+    LEFT(blocking_tree, 500) AS blocking_sql,
+    contentious_object
 FROM collect.blocking_BlockedProcessReport
 WHERE collection_time >= @startTime AND collection_time <= @endTime
 ORDER BY wait_time_ms DESC;";
@@ -226,7 +233,8 @@ ORDER BY wait_time_ms DESC;";
                 wait_time_ms = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4)),
                 lock_mode = reader.IsDBNull(5) ? "" : reader.GetString(5),
                 blocked_sql = reader.IsDBNull(6) ? "" : reader.GetString(6),
-                blocking_sql = reader.IsDBNull(7) ? "" : reader.GetString(7)
+                blocking_sql = reader.IsDBNull(7) ? "" : reader.GetString(7),
+                contentious_object = reader.IsDBNull(8) ? "" : reader.GetString(8)
             });
         }
 

--- a/Lite.Tests/AnalysisNotificationTests.cs
+++ b/Lite.Tests/AnalysisNotificationTests.cs
@@ -84,6 +84,84 @@ public class AnalysisNotificationTests : IDisposable
         };
     }
 
+    /* ── #1140: finding-path dedup incidents (BuildContext derives them from the drill-down) ── */
+
+    [Fact]
+    public void BuildContext_DeadlockDrillDown_EmitsObjectSetIncident()
+    {
+        var finding = MakeFinding("dlfp000000000001", category: "deadlocks", rootFactKey: "DEADLOCKS",
+            drillDown: new Dictionary<string, object>
+            {
+                ["top_deadlocks"] = new List<object>
+                {
+                    new { time = "t1", victim_sql = "x", objects = "SalesDB.dbo.Orders, SalesDB.dbo.LineItems" },
+                    new { time = "t2", victim_sql = "y", objects = "SalesDB.dbo.LineItems, SalesDB.dbo.Orders" } // same set, swapped order
+                }
+            });
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        Assert.NotNull(context.Incidents);
+        var incident = Assert.Single(context.Incidents!);
+        Assert.Equal(new[] { "SalesDB.dbo.LineItems", "SalesDB.dbo.Orders" }, incident.InvolvedObjects);
+        Assert.Equal(2, incident.OccurrenceCount);
+        Assert.Contains(context.Details, d => d.Fields.Any(f => f.Label == "Dedup Key" && f.Value == incident.DedupKey));
+    }
+
+    [Fact]
+    public void BuildContext_BlockingDrillDown_EmitsContentiousObjectIncident()
+    {
+        var finding = MakeFinding("blfp000000000001", category: "blocking_events", rootFactKey: "BLOCKING_EVENTS",
+            drillDown: new Dictionary<string, object>
+            {
+                ["top_blocking_chains"] = new List<object>
+                {
+                    new { database = "DB", contentious_object = "DB.dbo.Orders", blocked_sql = "a", blocking_sql = "b", wait_time_ms = 5000L },
+                    new { database = "DB", contentious_object = "DB.dbo.Orders", blocked_sql = "c", blocking_sql = "d", wait_time_ms = 9000L }
+                }
+            });
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        var incident = Assert.Single(context.Incidents!);
+        Assert.Equal(new[] { "DB.dbo.Orders" }, incident.InvolvedObjects);
+        Assert.Equal(2, incident.OccurrenceCount);
+    }
+
+    [Fact]
+    public void BuildContext_CpuDrillDown_EmitsDistinctQueryHashIncidents()
+    {
+        var finding = MakeFinding("cpufp00000000001", rootFactKey: "CPU_SPIKE",
+            drillDown: new Dictionary<string, object>
+            {
+                ["top_cpu_queries"] = new List<object>
+                {
+                    new { database = "DB", query_hash = "0xAAA", total_cpu_ms = 1L },
+                    new { database = "DB", query_hash = "0xAAA", total_cpu_ms = 2L }, // duplicate hash -> one incident
+                    new { database = "DB", query_hash = "0xBBB", total_cpu_ms = 3L }
+                }
+            });
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        Assert.NotNull(context.Incidents);
+        Assert.Equal(2, context.Incidents!.Count); // one per distinct query_hash
+    }
+
+    [Fact]
+    public void BuildContext_NoFingerprintableDrillDown_LeavesIncidentsNull()
+    {
+        var finding = MakeFinding("nonefp0000000001",
+            drillDown: new Dictionary<string, object>
+            {
+                ["some_metric"] = new List<object> { new { foo = "bar", count = 3 } }
+            });
+
+        var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
+
+        Assert.Null(context.Incidents);
+    }
+
     /* ── FindingMessageFormatter ── */
 
     [Fact]
@@ -139,8 +217,9 @@ public class AnalysisNotificationTests : IDisposable
 
         var context = FindingMessageFormatter.BuildContext(finding, notifyThreshold: 1.5);
 
-        // Details[0] = Diagnosis, [1] = Advice (CPU_SPIKE has an advice block), then the two drill-downs.
-        Assert.Equal(4, context.Details.Count);
+        // Details[0] = Diagnosis, [1] = Advice (CPU_SPIKE has an advice block), then the two drill-downs,
+        // then (#1140) one appended incident detail per distinct query_hash in the drill-down.
+        Assert.Equal(6, context.Details.Count);
         Assert.Equal("Diagnosis", context.Details[0].Heading);
         Assert.NotNull(context.Details[1].Body);
         Assert.False(context.Details[1].IsCodeBlock);
@@ -150,6 +229,10 @@ public class AnalysisNotificationTests : IDisposable
 
         var peak = context.Details.Single(d => d.Heading == "Spike Peak");
         Assert.Contains(peak.Fields, f => f.Label == "Cpu Percent" && f.Value == "99");
+
+        // #1140: the two distinct query_hash values became dedup incidents on the finding path.
+        Assert.NotNull(context.Incidents);
+        Assert.Equal(2, context.Incidents!.Count);
     }
 
     [Fact]

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -10,6 +10,7 @@ using PerformanceMonitorLite.Mcp;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorLite.Analysis;
 
@@ -141,7 +142,8 @@ public class DrillDownCollector
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
 SELECT collection_time, deadlock_time, victim_process_id,
-       LEFT(victim_sql_text, 500) AS victim_sql
+       LEFT(victim_sql_text, 500) AS victim_sql,
+       deadlock_graph_xml
 FROM v_deadlocks
 WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
 ORDER BY collection_time DESC
@@ -155,12 +157,16 @@ LIMIT 3";
         using var reader = await cmd.ExecuteReaderAsync();
         while (await reader.ReadAsync())
         {
+            /* #1140: parse the involved objects from the graph for the dedup fingerprint + a readable
+               Objects field. The raw graph XML is NOT surfaced (it would bloat the alert detail). */
+            var objects = DeadlockObjectExtractor.FromGraphXml(reader.IsDBNull(4) ? null : reader.GetString(4));
             items.Add(new
             {
                 time = reader.IsDBNull(0) ? "" : reader.GetDateTime(0).ToString("o"),
                 deadlock_time = reader.IsDBNull(1) ? "" : reader.GetDateTime(1).ToString("o"),
                 victim = reader.IsDBNull(2) ? "" : reader.GetString(2),
-                victim_sql = reader.IsDBNull(3) ? "" : reader.GetString(3)
+                victim_sql = reader.IsDBNull(3) ? "" : reader.GetString(3),
+                objects = string.Join(", ", objects)
             });
         }
 
@@ -179,7 +185,8 @@ LIMIT 3";
 SELECT collection_time, database_name, blocked_spid, blocking_spid,
        wait_time_ms, lock_mode,
        LEFT(blocked_sql_text, 500) AS blocked_sql,
-       LEFT(blocking_sql_text, 500) AS blocking_sql
+       LEFT(blocking_sql_text, 500) AS blocking_sql,
+       contentious_object
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
 ORDER BY wait_time_ms DESC
@@ -202,7 +209,8 @@ LIMIT 5";
                 wait_time_ms = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4)),
                 lock_mode = reader.IsDBNull(5) ? "" : reader.GetString(5),
                 blocked_sql = reader.IsDBNull(6) ? "" : reader.GetString(6),
-                blocking_sql = reader.IsDBNull(7) ? "" : reader.GetString(7)
+                blocking_sql = reader.IsDBNull(7) ? "" : reader.GetString(7),
+                contentious_object = reader.IsDBNull(8) ? "" : reader.GetString(8)
             });
         }
 

--- a/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
+++ b/PerformanceMonitor.Notifications/AnalysisNotificationService.cs
@@ -430,8 +430,112 @@ internal static class FindingMessageFormatter
             }
         }
 
+        /* #1140: derive dedup incidents from the drill-down so this (secondary, anomaly) alert path
+           carries the SAME fingerprints as the live "Detected" path. Deadlock -> involved-object set,
+           blocking -> contentious object / query pair, query/CPU -> query_hash. Appended after the
+           detail items, so the existing Diagnosis->Advice->drill-down order is preserved. */
+        AlertIncidentRenderer.Apply(context, BuildIncidents(finding));
+
         return context;
     }
+
+    /// <summary>
+    /// #1140: derives the dedup incidents for the anomaly-finding alert path from the finding's
+    /// drill-down, reusing the same shared groupers/fingerprint as the live builders so a deadlock,
+    /// blocking chain, or long-running query produces an identical key on either path. Returns an
+    /// empty list when the drill-down carries no fingerprintable identity.
+    /// </summary>
+    private static List<AlertIncident> BuildIncidents(AnalysisFinding finding)
+    {
+        var result = new List<AlertIncident>();
+        if (finding.DrillDown is not { Count: > 0 })
+            return result;
+
+        var server = finding.ServerName ?? string.Empty;
+
+        if (TryGetRows(finding.DrillDown, "top_deadlocks", out var deadlockRows))
+        {
+            var events = deadlockRows.Select(r =>
+                new DeadlockIncidentGrouper.DeadlockEvent(SplitObjects(GetField(r, "objects"))));
+            result.AddRange(DeadlockIncidentGrouper.Group(server, events).Select(g => g.Incident));
+            return result;
+        }
+
+        if (TryGetRows(finding.DrillDown, "top_blocking_chains", out var blockingRows))
+        {
+            var events = blockingRows.Select(r => new BlockingIncidentGrouper.BlockedEvent(
+                GetField(r, "database"), GetField(r, "contentious_object"),
+                GetField(r, "blocked_sql"), GetField(r, "blocking_sql"), GetLongField(r, "wait_time_ms")));
+            result.AddRange(BlockingIncidentGrouper.Group(server, events).Select(g => g.Incident));
+            return result;
+        }
+
+        /* Query / CPU findings: one incident per distinct query_hash across any drill-down section. */
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (_, value) in finding.DrillDown)
+        {
+            if (value is null)
+                continue;
+            foreach (var row in AsRows(value))
+            {
+                var queryHash = GetField(row, "query_hash");
+                if (string.IsNullOrEmpty(queryHash) || !seen.Add(queryHash))
+                    continue;
+                var db = GetField(row, "database");
+                var incident = AlertFingerprint.ForKey(server, AlertFingerprint.Query, queryHash,
+                    string.IsNullOrEmpty(db) ? System.Array.Empty<string>() : new[] { db });
+                if (incident is not null)
+                    result.Add(incident);
+            }
+        }
+        return result;
+    }
+
+    private static bool TryGetRows(Dictionary<string, object> drillDown, string key, out List<JsonElement> rows)
+    {
+        rows = (drillDown.TryGetValue(key, out var value) && value is not null)
+            ? AsRows(value)
+            : new List<JsonElement>();
+        return rows.Count > 0;
+    }
+
+    /// <summary>Round-trips a drill-down value (anonymous object or List&lt;object&gt;) through JSON and
+    /// returns its object rows — the same robust shape-walk <see cref="FlattenInto"/> relies on.</summary>
+    private static List<JsonElement> AsRows(object value)
+    {
+        var rows = new List<JsonElement>();
+        try
+        {
+            var element = JsonSerializer.SerializeToElement(value);
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                    if (item.ValueKind == JsonValueKind.Object)
+                        rows.Add(item);
+            }
+            else if (element.ValueKind == JsonValueKind.Object)
+            {
+                rows.Add(element);
+            }
+        }
+        catch { /* unexpected shape -> no rows */ }
+        return rows;
+    }
+
+    private static string GetField(JsonElement row, string name) =>
+        row.ValueKind == JsonValueKind.Object && row.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static long GetLongField(JsonElement row, string name) =>
+        row.ValueKind == JsonValueKind.Object && row.TryGetProperty(name, out var p)
+            && p.ValueKind == JsonValueKind.Number && p.TryGetInt64(out var v)
+            ? v : 0L;
+
+    private static string[] SplitObjects(string joined) =>
+        string.IsNullOrWhiteSpace(joined)
+            ? System.Array.Empty<string>()
+            : joined.Split(", ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     /// <summary>
     /// Renders the two-sided <see cref="RiskDisclosure"/> as read-only prose for the


### PR DESCRIPTION
Completes #1140 by wiring the **secondary anomaly/finding alert path** (`ANOMALY_*_SPIKE` / CPU findings via `AnalysisNotificationService`) for dedup fingerprints — the one piece deferred from PR #1142. The consumer-facing live "Detected" path already shipped; this gives the anomaly alerts the same `Dedup Key` + `Involved Objects`.

## Changes
- **DrillDownCollector (Lite + Dashboard):** `top_deadlocks` now carries the involved objects (parsed from the deadlock graph via the shared `DeadlockObjectExtractor` — raw XML is **not** surfaced, to keep alert detail small), and `top_blocking_chains` now carries `contentious_object`. The source columns already existed.
- **`FindingMessageFormatter.BuildContext` (shared):** derives `context.Incidents` from the drill-down — deadlock → involved-object set, blocking → contentious object / query pair, query/CPU → distinct `query_hash` — reusing the **same** shared groupers/fingerprint as the live builders, so either path produces an identical key for the same incident. Incidents are appended after the detail items (existing order preserved). Shared code → Lite/Dashboard parity is automatic.

## Verification
- **Lite 492 + Dashboard 487 unit tests green**; both apps build 0-warnings.
- +4 finding-path tests (deadlock object-set, blocking contentious-object, distinct query_hash, no-op when no identity); 1 existing count-based test updated (its `top_cpu_queries` drill-down legitimately now yields 2 query incidents).

With this, #1140 is complete on both alert surfaces. (The remaining tracked follow-on is the separate #1141 per-event delivery mode.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)