### PR TITLE
Fix #1145: Webhook (Teams/Slack) alerts re-fire after an app restart

### DIFF
--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -169,8 +169,11 @@ namespace PerformanceMonitorDashboard
             _alertHistoryStore = new JsonAlertHistoryStore(_preferencesService);
             /* Webhook service is constructed first and injected into the email service
                (Plan E E3c): the shared lib service carries no Current static, so Dashboard
-               keeps this handle for the email fan-out and any MCP/health consumers. */
-            _webhookAlertService = new WebhookAlertService(alertSettings, EmailAlertService.Branding, new LoggerAdapter<WebhookAlertService>());
+               keeps this handle for the email fan-out and any MCP/health consumers. The
+               history store (built at line above) is passed so the webhook cooldown is seeded
+               across restart (#1145) — without it a restart inside the cooldown window
+               re-posts a Teams/Slack alert delivered just before the restart. */
+            _webhookAlertService = new WebhookAlertService(alertSettings, EmailAlertService.Branding, new LoggerAdapter<WebhookAlertService>(), _alertHistoryStore);
             _emailAlertService = new EmailAlertService(alertSettings, _alertHistoryStore, _webhookAlertService, new LoggerAdapter<EmailAlertService>());
 
             _alertCheckTimer = new DispatcherTimer();

--- a/Dashboard/Services/JsonAlertHistoryStore.cs
+++ b/Dashboard/Services/JsonAlertHistoryStore.cs
@@ -125,6 +125,35 @@ namespace PerformanceMonitorDashboard.Services
         }
 
         /// <summary>
+        /// Returns the UTC time the most recent alert webhook was successfully
+        /// sent for this server/metric, scanned from the in-memory alert log
+        /// (loaded from alert_history.json on startup) — or null if none. Seeds
+        /// the webhook cooldown after restart so a Teams/Slack alert posted
+        /// shortly before a restart is not re-posted afterward (#1145, mirroring
+        /// the email seed #981).
+        /// </summary>
+        /// <remarks>
+        /// Dashboard records webhook deliveries as their own alert-log rows with
+        /// NotificationType == "webhook" (written only on a successful post), so
+        /// the type alone implies success — no SendError filter is needed.
+        /// </remarks>
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+        {
+            lock (_alertLogLock)
+            {
+                DateTime? max = null;
+                foreach (var entry in _alertLog)
+                {
+                    if (entry.ServerId != serverId) continue;
+                    if (entry.MetricName != metricName) continue;
+                    if (entry.NotificationType != "webhook") continue;
+                    if (max == null || entry.AlertTime > max.Value) max = entry.AlertTime;
+                }
+                return Task.FromResult(max);
+            }
+        }
+
+        /// <summary>
         /// Returns the AlertTime of the most recent log entry for the given
         /// (serverId, metricName), regardless of notification channel or send
         /// result. Used by <see cref="AnalysisNotificationService"/> to seed

--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -138,8 +138,9 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 31 tables from Schema (schema_version is created separately by DuckDbInitializer) */
-        Assert.Equal(31, tableCount);
+        /* 32 tables from Schema (schema_version is created separately by DuckDbInitializer).
+           Includes config_edge_trigger_watermarks added for #1145. */
+        Assert.Equal(32, tableCount);
     }
 
     [Fact]

--- a/Lite.Tests/StoreRoundTripTests.cs
+++ b/Lite.Tests/StoreRoundTripTests.cs
@@ -125,6 +125,70 @@ public class StoreRoundTripTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLastWebhookSentUtc_FiltersToWebhookRows_IncludingEmailWebhook()
+    {
+        await _duckDb.InitializeAsync();
+        var store = new DuckDbAlertHistoryStore(_duckDb);
+
+        /* #1145: only rows whose notification_type implies a webhook delivered seed the webhook
+           cooldown. email-only / tray rows must NOT; an 'email+webhook' row counts even though its
+           send_error is the EMAIL failure (the webhook still delivered), because send_error tracks
+           the email channel, not the webhook. */
+        await RecordAsync(store, "5", "Blocking Detected", "email", null);          // email only
+        await RecordAsync(store, "5", "Blocking Detected", "tray", null);           // tray only
+        await RecordAsync(store, "5", "Blocking Detected", "webhook", null);        // webhook
+        await RecordAsync(store, "5", "Blocking Detected", "email+webhook", "smtp boom"); // webhook sent, email failed (latest)
+
+        var lastWebhook = await store.GetLastWebhookSentUtcAsync("5", "Blocking Detected");
+        var lastAny = await store.GetLastAlertTimeAsync("5", "Blocking Detected");
+
+        Assert.NotNull(lastWebhook);
+        /* The email+webhook row is the last written, so it is both the unfiltered max and the
+           webhook-filtered max. */
+        Assert.Equal(lastAny!.Value, lastWebhook!.Value);
+
+        /* A metric with only email/tray rows → no webhook seed. */
+        await RecordAsync(store, "5", "EmailOnly", "email", null);
+        await RecordAsync(store, "5", "EmailOnly", "tray", null);
+        Assert.Null(await store.GetLastWebhookSentUtcAsync("5", "EmailOnly"));
+
+        /* Unknown metric → null. */
+        Assert.Null(await store.GetLastWebhookSentUtcAsync("5", "Missing"));
+    }
+
+    [Fact]
+    public async Task EdgeTriggerWatermark_SaveLoad_RoundTripsAndUpserts()
+    {
+        await _duckDb.InitializeAsync();
+        var store = new DuckDbAlertHistoryStore(_duckDb);
+
+        /* #1145: empty table → empty load. */
+        Assert.Empty(await store.LoadEdgeTriggerWatermarksAsync());
+
+        await store.SaveEdgeTriggerWatermarkAsync(1, "Blocking Detected", 4);
+        await store.SaveEdgeTriggerWatermarkAsync(1, "Deadlocks Detected", 2);
+        await store.SaveEdgeTriggerWatermarkAsync(2, "Blocking Detected", 7);
+
+        var loaded = await store.LoadEdgeTriggerWatermarksAsync();
+        Assert.Equal(3, loaded.Count);
+        Assert.Contains(loaded, r => r.ServerId == 1 && r.MetricName == "Blocking Detected" && r.Watermark == 4);
+        Assert.Contains(loaded, r => r.ServerId == 1 && r.MetricName == "Deadlocks Detected" && r.Watermark == 2);
+        Assert.Contains(loaded, r => r.ServerId == 2 && r.MetricName == "Blocking Detected" && r.Watermark == 7);
+
+        /* Upsert on the (server_id, metric_name) primary key: same key overwrites, no dup row. */
+        await store.SaveEdgeTriggerWatermarkAsync(1, "Blocking Detected", 9);
+        loaded = await store.LoadEdgeTriggerWatermarksAsync();
+        Assert.Equal(3, loaded.Count);
+        Assert.Contains(loaded, r => r.ServerId == 1 && r.MetricName == "Blocking Detected" && r.Watermark == 9);
+
+        /* A reset to 0 (the window drained) persists too — so a restart restores 0, not a stale count. */
+        await store.SaveEdgeTriggerWatermarkAsync(1, "Blocking Detected", 0);
+        loaded = await store.LoadEdgeTriggerWatermarksAsync();
+        Assert.Equal(3, loaded.Count);
+        Assert.Contains(loaded, r => r.ServerId == 1 && r.MetricName == "Blocking Detected" && r.Watermark == 0);
+    }
+
+    [Fact]
     public async Task MuteRuleStore_InsertUpdateSetEnabledDeleteExpire_RoundTrips()
     {
         await _duckDb.InitializeAsync();

--- a/Lite.Tests/WebhookCooldownSeedTests.cs
+++ b/Lite.Tests/WebhookCooldownSeedTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorLite;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1145: the shared <see cref="WebhookAlertService"/> must seed its per-(serverId, metricName)
+/// cooldown from alert history on first use, so a Teams/Slack alert posted shortly before an app
+/// restart is not re-posted on the first post-restart sweep — the guarantee #981 gave the email
+/// channel. The cooldown is time-bounded (EmailCooldownMinutes), so it only covers a restart
+/// inside the cooldown window; the time-independent edge-trigger watermark persistence (Lite)
+/// covers the rest. These tests use a dead webhook URL: a SUPPRESSED post never touches the
+/// network (the cooldown short-circuits first), while an ATTEMPTED post fails against the dead
+/// URL and increments the Teams failure counter — the observable proxy for "did it try to post".
+/// </summary>
+public class WebhookCooldownSeedTests
+{
+    private static WebhookAlertService MakeService(IAlertHistoryStore? history, FakeWebhookSettings settings)
+        => new(settings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>(), history);
+
+    private static FakeWebhookSettings EnabledTeamsSettings() => new()
+    {
+        TeamsWebhookEnabled = true,
+        TeamsWebhookUrl = "http://localhost:1/never", // closed port -> connection refused, fast deterministic failure
+        EmailCooldownMinutes = 15
+    };
+
+    [Fact]
+    public async Task SeedsCooldownFromHistory_WithinWindow_SuppressesRepostAfterRestart()
+    {
+        // A webhook delivered "just now", then a restart (fresh service = empty in-memory cooldown).
+        var history = new FakeHistoryStore { LastWebhookSent = DateTime.UtcNow };
+        var svc = MakeService(history, EnabledTeamsSettings());
+
+        var sent = await svc.TrySendWebhookAlertsAsync("Deadlocks Detected", "Srv", "4", "1", "1");
+
+        Assert.False(sent);                                        // suppressed
+        Assert.Equal(1, history.GetLastWebhookSentCallCount);      // the seed was consulted
+        Assert.Equal(0, svc.GetTeamsHealth().ConsecutiveFailures); // and NO post was attempted
+    }
+
+    [Fact]
+    public async Task SeedFromHistory_OlderThanCooldown_DoesNotSuppress()
+    {
+        // gotqn's repro: the restart is 17 min after the send, beyond the 15-min cooldown. The
+        // cooldown seed must NOT suppress here — that's exactly why the Lite watermark persistence
+        // is also needed. The post is attempted (and fails against the dead URL).
+        var history = new FakeHistoryStore { LastWebhookSent = DateTime.UtcNow.AddMinutes(-17) };
+        var svc = MakeService(history, EnabledTeamsSettings());
+
+        var sent = await svc.TrySendWebhookAlertsAsync("Deadlocks Detected", "Srv", "4", "1", "1");
+
+        Assert.False(sent);                                        // dead URL -> post failed
+        Assert.Equal(1, history.GetLastWebhookSentCallCount);      // seed consulted
+        Assert.Equal(1, svc.GetTeamsHealth().ConsecutiveFailures); // but it WAS attempted (not suppressed)
+    }
+
+    [Fact]
+    public async Task NullHistoryStore_NoSeed_AttemptsPost()
+    {
+        // The legacy/test path passes no history store: pre-#1145 in-memory-only cooldown, so a
+        // fresh service attempts the post.
+        var svc = MakeService(history: null, EnabledTeamsSettings());
+
+        var sent = await svc.TrySendWebhookAlertsAsync("Deadlocks Detected", "Srv", "4", "1", "1");
+
+        Assert.False(sent);
+        Assert.Equal(1, svc.GetTeamsHealth().ConsecutiveFailures);
+    }
+
+    private sealed class FakeWebhookSettings : IAlertSettings
+    {
+        public bool SmtpEnabled => false;
+        public string SmtpServer => "";
+        public int SmtpPort => 25;
+        public bool SmtpUseSsl => false;
+        public string SmtpUsername => "";
+        public string SmtpFromAddress => "";
+        public string SmtpRecipients => "";
+        public string? GetSmtpPassword() => null;
+        public int EmailCooldownMinutes { get; set; } = 15;
+        public bool TeamsWebhookEnabled { get; set; }
+        public string TeamsWebhookUrl { get; set; } = "";
+        public string TeamsProxyAddress => "";
+        public bool SlackWebhookEnabled { get; set; }
+        public string SlackWebhookUrl { get; set; } = "";
+        public string SlackProxyAddress => "";
+        public double AnalysisNotifySeverity => 1.5;
+        public int AnalysisNotifyCooldownMinutes => 360;
+    }
+
+    private sealed class FakeHistoryStore : IAlertHistoryStore
+    {
+        public DateTime? LastWebhookSent { get; set; }
+        public int GetLastWebhookSentCallCount { get; private set; }
+
+        public Task RecordAlertAsync(AlertHistoryRecord record) => Task.CompletedTask;
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName) => Task.FromResult<DateTime?>(null);
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+        {
+            GetLastWebhookSentCallCount++;
+            return Task.FromResult(LastWebhookSent);
+        }
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName) => Task.FromResult<DateTime?>(null);
+    }
+}

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -768,6 +768,20 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
     context_json VARCHAR
 )";
 
+    /* Edge-trigger watermarks for the rolling-count blocking/deadlock alert gate (#1091).
+       Persisted so the watermark survives an app restart (#1145): without it the in-memory
+       watermark resets to 0 and the first post-restart sweep re-fires the same alert (and
+       re-posts the same webhook) for events still lingering in the 1-hour lookback window.
+       Keyed (server_id, metric_name); one short row per server/metric, upserted on change. */
+    public const string CreateEdgeTriggerWatermarksTable = @"
+CREATE TABLE IF NOT EXISTS config_edge_trigger_watermarks (
+    server_id INTEGER NOT NULL,
+    metric_name VARCHAR NOT NULL,
+    watermark INTEGER NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (server_id, metric_name)
+)";
+
     public const string CreateMuteRulesTable = @"
 CREATE TABLE IF NOT EXISTS config_mute_rules (
     id VARCHAR NOT NULL PRIMARY KEY,
@@ -829,6 +843,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateServerPropertiesTable;
         yield return CreateSessionStatsTable;
         yield return CreateAlertLogTable;
+        yield return CreateEdgeTriggerWatermarksTable;
         yield return CreateMuteRulesTable;
         yield return CreateDismissedArchiveAlertsTable;
     }

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -68,6 +68,8 @@ public partial class MainWindow : Window
     private readonly IAlertSettings _alertSettings = new AppAlertSettings();
     private readonly MuteRuleService _muteRuleService;
     private EmailAlertService _emailAlertService;
+    /* Held so the edge-trigger watermark seed/persist (#1145) can reach the store directly. */
+    private readonly DuckDbAlertHistoryStore _alertHistoryStore;
 
     /* Track active alert states for resolved notifications */
     private readonly Dictionary<string, bool> _activeCpuAlert = new();
@@ -98,6 +100,14 @@ public partial class MainWindow : Window
     private readonly Dictionary<string, int> _lastAlertedBlockingCount = new();
     private readonly Dictionary<string, int> _lastAlertedDeadlockCount = new();
 
+    /* Persistence for the two watermarks above (#1145): seeded from the alert store at
+       startup (SeedEdgeTriggerWatermarksAsync) and upserted on change, so a restart does
+       not reset the watermark to 0 and re-fire / re-post a webhook for events still
+       lingering in the rolling 1-hour lookback window. The metric_name values are the
+       persisted-row keys; they need not match the alert "Detected" metric names. */
+    private const string BlockingWatermarkMetric = "Blocking Detected";
+    private const string DeadlockWatermarkMetric = "Deadlocks Detected";
+
     public MainWindow()
     {
         InitializeComponent();
@@ -105,12 +115,14 @@ public partial class MainWindow : Window
         // Initialize services (with loggers wired to AppLogger)
         _databaseInitializer = new DuckDbInitializer(App.DatabasePath, new AppLoggerAdapter<DuckDbInitializer>());
         /* Webhook service is constructed first and injected into the email service
-           (Plan E E3c): the shared send core fans out to it. */
+           (Plan E E3c): the shared send core fans out to it. The history store is shared
+           by both so the webhook service can seed its cooldown across restart (#1145). */
+        _alertHistoryStore = new DuckDbAlertHistoryStore(_databaseInitializer);
         var webhookAlertService = new WebhookAlertService(
-            _alertSettings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>());
+            _alertSettings, EmailAlertService.Branding, new AppLoggerAdapter<WebhookAlertService>(), _alertHistoryStore);
         _emailAlertService = new EmailAlertService(
             _alertSettings,
-            new DuckDbAlertHistoryStore(_databaseInitializer),
+            _alertHistoryStore,
             webhookAlertService,
             new AppLoggerAdapter<EmailAlertService>());
         _muteRuleService = new MuteRuleService(
@@ -168,6 +180,14 @@ public partial class MainWindow : Window
 
             // Initialize the DuckDB database
             await _databaseInitializer.InitializeAsync();
+
+            /* Restore edge-trigger watermarks now — after the DB (and the watermark table)
+               exist, but before ANY alert sweep can read the watermark dicts. RefreshServerList()
+               below ends in a fire-and-forget RefreshOverviewAsync() → CheckPerformanceAlerts, so
+               seeding here (not just before the explicit RefreshOverviewAsync later) keeps a
+               restart from re-firing / re-posting alerts for events still in the lookback
+               window (#1145), independent of whether the DuckDB reads ever yield. */
+            await SeedEdgeTriggerWatermarksAsync();
 
             // Initialize the collection engine (with loggers wired to AppLogger)
             _collectorService = new RemoteCollectorService(
@@ -1536,6 +1556,36 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// Seeds the in-memory edge-trigger watermarks from the persisted store (#1145) so a
+    /// restart does not reset them to 0 and re-fire / re-post a webhook for blocking/deadlock
+    /// events still lingering in the rolling 1-hour lookback window. Runs once at startup,
+    /// after the DB is initialized and before the first alert sweep.
+    /// </summary>
+    private async Task SeedEdgeTriggerWatermarksAsync()
+    {
+        try
+        {
+            var rows = await _alertHistoryStore.LoadEdgeTriggerWatermarksAsync();
+            foreach (var (serverId, metricName, watermark) in rows)
+            {
+                var key = serverId.ToString();
+                if (metricName == BlockingWatermarkMetric)
+                {
+                    _lastAlertedBlockingCount[key] = watermark;
+                }
+                else if (metricName == DeadlockWatermarkMetric)
+                {
+                    _lastAlertedDeadlockCount[key] = watermark;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Alerts", $"Failed to seed edge-trigger watermarks: {ex.Message}");
+        }
+    }
+
     private async void CheckPerformanceAlerts(ServerSummaryItem summary)
     {
         if (!App.AlertsEnabled || _trayService == null) return;
@@ -1644,6 +1694,13 @@ public partial class MainWindow : Window
             ? RollingCountAlertGate.Evaluate(effectiveBlockingCount, App.AlertBlockingThreshold, blockingWatermark, blockingCooldownElapsed, suppressPopups)
             : new RollingCountAlertGate.Decision(false, false, 0);
         _lastAlertedBlockingCount[key] = blockingDecision.Watermark;
+        /* Persist the watermark across restart so the same blocked-process reports aren't
+           re-alerted (and re-posted to Teams/Slack) on the first post-restart sweep (#1145).
+           On-change only — the gate returns the same watermark on most sweeps. */
+        if (blockingDecision.Watermark != blockingWatermark)
+        {
+            await _alertHistoryStore.SaveEdgeTriggerWatermarkAsync(summary.ServerId, BlockingWatermarkMetric, blockingDecision.Watermark);
+        }
 
         bool wasBlockingActive = _activeBlockingAlert.TryGetValue(key, out var wasBlocking) && wasBlocking;
         _activeBlockingAlert[key] = blockingDecision.Active;
@@ -1715,6 +1772,12 @@ public partial class MainWindow : Window
             ? RollingCountAlertGate.Evaluate(effectiveDeadlockCount, App.AlertDeadlockThreshold, deadlockWatermark, deadlockCooldownElapsed, suppressPopups)
             : new RollingCountAlertGate.Decision(false, false, 0);
         _lastAlertedDeadlockCount[key] = deadlockDecision.Watermark;
+        /* Persist the watermark across restart so the same deadlocks aren't re-alerted (and
+           re-posted to Teams/Slack) on the first post-restart sweep (#1145). On-change only. */
+        if (deadlockDecision.Watermark != deadlockWatermark)
+        {
+            await _alertHistoryStore.SaveEdgeTriggerWatermarkAsync(summary.ServerId, DeadlockWatermarkMetric, deadlockDecision.Watermark);
+        }
 
         bool wasDeadlockActive = _activeDeadlockAlert.TryGetValue(key, out var wasDeadlock) && wasDeadlock;
         _activeDeadlockAlert[key] = deadlockDecision.Active;

--- a/Lite/Services/DuckDbAlertHistoryStore.cs
+++ b/Lite/Services/DuckDbAlertHistoryStore.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Database;
@@ -156,6 +157,60 @@ AND   send_error IS NULL";
     }
 
     /// <summary>
+    /// Returns the UTC time the most recent alert webhook was successfully sent
+    /// for this server/metric, read from config_alert_log — or null if none.
+    /// Seeds the webhook cooldown after restart so a Teams/Slack alert posted
+    /// shortly before a restart is not re-posted afterward (#1145, mirroring the
+    /// email seed #981).
+    /// </summary>
+    public async Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+    {
+        var sid = int.TryParse(serverId, out var s) ? s : 0;
+        try
+        {
+            /* Use injected initializer, fall back to creating one from App.DatabasePath */
+            var duckDb = _duckDb;
+            if (duckDb == null)
+            {
+                var dbPath = App.DatabasePath;
+                if (string.IsNullOrEmpty(dbPath)) return null;
+                duckDb = new DuckDbInitializer(dbPath);
+            }
+
+            using var readLock = duckDb.AcquireReadLock();
+            using var connection = duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            /* A successful webhook send is logged with a notification_type of
+               'webhook' / 'email+webhook' — those types are only ever written
+               when WebhookSent is true, so the type alone implies success.
+               send_error tracks the EMAIL channel, so it is NOT filtered on:
+               an email-failed-but-webhook-sent row must still seed the cooldown. */
+            command.CommandText = @"
+SELECT MAX(alert_time)
+FROM config_alert_log
+WHERE server_id = $1
+AND   metric_name = $2
+AND   notification_type IN ('webhook', 'email+webhook')";
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = sid });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = metricName });
+
+            var result = await command.ExecuteScalarAsync();
+            if (result == null || result == DBNull.Value) return null;
+
+            /* alert_time is written as DateTime.UtcNow; tag it UTC so the kind
+               is explicit (the cooldown subtraction is tick math regardless). */
+            return DateTime.SpecifyKind(Convert.ToDateTime(result), DateTimeKind.Utc);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("WebhookAlert", $"Could not read persisted webhook cooldown: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Returns the UTC time of the most recent alert_log row for this
     /// (serverId, metricName), regardless of notification channel or
     /// delivery result. Used by <see cref="AnalysisNotificationService"/>
@@ -205,6 +260,88 @@ AND   metric_name = $2";
         {
             AppLogger.Error("AnalysisNotify", $"Could not read persisted analysis cooldown: {ex.Message}");
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Loads all persisted edge-trigger watermarks (#1145), one entry per
+    /// (server_id, metric_name). The caller seeds its in-memory watermark dicts
+    /// from these at startup, before the first alert sweep, so a restart does not
+    /// reset the watermark to 0 and re-fire (and re-post a webhook for) events
+    /// still lingering in the rolling lookback window.
+    /// </summary>
+    public async Task<List<(int ServerId, string MetricName, int Watermark)>> LoadEdgeTriggerWatermarksAsync()
+    {
+        var result = new List<(int, string, int)>();
+        try
+        {
+            var duckDb = _duckDb;
+            if (duckDb == null)
+            {
+                var dbPath = App.DatabasePath;
+                if (string.IsNullOrEmpty(dbPath)) return result;
+                duckDb = new DuckDbInitializer(dbPath);
+            }
+
+            using var readLock = duckDb.AcquireReadLock();
+            using var connection = duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT server_id, metric_name, watermark
+FROM config_edge_trigger_watermarks";
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.Add((Convert.ToInt32(reader.GetValue(0)), reader.GetString(1), Convert.ToInt32(reader.GetValue(2))));
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Alerts", $"Could not load edge-trigger watermarks: {ex.Message}");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Upserts one edge-trigger watermark (#1145). Called on-change only — the gate
+    /// returns the same watermark on the vast majority of sweeps — so this is a
+    /// low-frequency write that piggybacks on the existing alert-store write lock.
+    /// </summary>
+    public async Task SaveEdgeTriggerWatermarkAsync(int serverId, string metricName, int watermark)
+    {
+        try
+        {
+            var duckDb = _duckDb;
+            if (duckDb == null)
+            {
+                var dbPath = App.DatabasePath;
+                if (string.IsNullOrEmpty(dbPath)) return;
+                duckDb = new DuckDbInitializer(dbPath);
+            }
+
+            using var writeLock = duckDb.AcquireWriteLock();
+            using var connection = duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            /* INSERT OR REPLACE upserts on the (server_id, metric_name) primary key —
+               one stable row per server/metric, overwritten each time the watermark moves. */
+            command.CommandText = @"
+INSERT OR REPLACE INTO config_edge_trigger_watermarks (server_id, metric_name, watermark, updated_at)
+VALUES ($1, $2, $3, $4)";
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = serverId });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = metricName });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = watermark });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = DateTime.UtcNow });
+
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Alerts", $"Could not persist edge-trigger watermark ({metricName}): {ex.Message}");
         }
     }
 }

--- a/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
+++ b/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
@@ -42,6 +42,16 @@ public interface IAlertHistoryStore
     Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName);
 
     /// <summary>
+    /// MAX(alert_time) filtered to a *successful webhook send* — seeds the webhook
+    /// cooldown across restart so a Teams/Slack alert delivered shortly before a restart
+    /// is not re-posted afterward (#1145, mirroring the email seed #981). The
+    /// notification_type already implies the webhook delivered (it's only written on a
+    /// successful post), and send_error tracks the EMAIL channel, so it is NOT filtered on.
+    /// Lite: notification_type IN ('webhook','email+webhook'). Dash: NotificationType == "webhook".
+    /// </summary>
+    Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName);
+
+    /// <summary>
     /// MAX(alert_time) UNFILTERED (any channel/result) — seeds the analysis
     /// per-finding cooldown across restart. Stamped unconditionally upstream.
     /// </summary>

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -41,17 +41,28 @@ public class WebhookAlertService
     private readonly IAlertSettings _settings;
     private readonly AlertBranding _branding;
     private readonly ILogger<WebhookAlertService> _logger;
+    private readonly IAlertHistoryStore? _historyStore;
 
     private int _consecutiveTeamsFailures;
     private string? _lastTeamsError;
     private int _consecutiveSlackFailures;
     private string? _lastSlackError;
 
-    public WebhookAlertService(IAlertSettings settings, AlertBranding branding, ILogger<WebhookAlertService> logger)
+    /// <param name="historyStore">
+    /// Optional alert-history store used to seed the per-(serverId, metricName) webhook
+    /// cooldown across an app restart (#1145, mirroring the email seed #981). When null the
+    /// cooldown is purely in-memory (the pre-#1145 behavior) — the test call sites pass null.
+    /// </param>
+    public WebhookAlertService(
+        IAlertSettings settings,
+        AlertBranding branding,
+        ILogger<WebhookAlertService> logger,
+        IAlertHistoryStore? historyStore = null)
     {
         _settings = settings;
         _branding = branding;
         _logger = logger;
+        _historyStore = historyStore;
     }
 
     /// <summary>
@@ -69,6 +80,20 @@ public class WebhookAlertService
         try
         {
             var cooldownKey = $"webhook:{serverId}:{metricName}";
+
+            /* Seed the in-memory cooldown from the alert log the first time this key is
+               seen, so a Teams/Slack alert posted shortly before an app restart is not
+               immediately re-posted afterward (#1145, mirroring the email seed #981). The
+               in-memory dictionary is authoritative once seeded. */
+            if (_historyStore is not null && !_cooldowns.ContainsKey(cooldownKey))
+            {
+                var lastPersistedSend = await _historyStore.GetLastWebhookSentUtcAsync(serverId, metricName);
+                if (lastPersistedSend.HasValue)
+                {
+                    _cooldowns.TryAdd(cooldownKey, lastPersistedSend.Value);
+                }
+            }
+
             if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
                 DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(_settings.EmailCooldownMinutes))
             {


### PR DESCRIPTION
Closes #1145.

## Problem
#981 added restart-dedup for the **email** channel only. A restart cleared the two guards that suppress a webhook re-send, so reopening Lite re-posted a Teams/Slack alert already delivered before the restart — identical Dedup Key and Occurrences. For a webhook-only deployment there was zero restart protection.

Two independent guards must fail together: the in-memory edge-trigger watermark (#1091) resets to 0 on restart, making the gate fire; the in-memory webhook cooldown is empty, letting the post through.

## Fix

**1. Webhook cooldown seed — shared, BOTH apps.**
`WebhookAlertService` now seeds its per-`(serverId, metricName)` cooldown from alert history on first use, mirroring the email seed (#981), via a new `IAlertHistoryStore.GetLastWebhookSentUtcAsync`. Lite filters `notification_type IN ('webhook','email+webhook')`; Dashboard filters `NotificationType == "webhook"`. `send_error` is **not** filtered on — it tracks the email channel, so an email-failed-but-webhook-sent row must still seed. Wired into the `WebhookAlertService` DI in both `MainWindow`s.

**2. Edge-trigger watermark persistence — Lite.**
The rolling-count gate's in-memory watermark (`_lastAlertedBlockingCount` / `_lastAlertedDeadlockCount`) reset to 0 on restart, so the first post-restart sweep re-fired for events still in the 1-hour lookback. Because that gap can exceed the cooldown (gotqn's repro was 17 min > 15-min cooldown), the time-bounded seed alone does **not** cover it — only persisting the watermark does. The watermark now persists to a new `config_edge_trigger_watermarks` DuckDB table (upsert on change), seeded **before the first sweep** at startup.

## Why Dashboard needs no watermark persistence (parity rationale)
Dashboard's deadlock gate re-baselines on restart (raw delta) or is 5-minute-windowed (`FilteredDeadlockCount`, always within the cooldown the seed now covers); blocking is level + cooldown (re-fires on its normal cadence, now bounded by the seeded cooldown). None produces the **byte-identical duplicate** the Lite edge-trigger gate does. The webhook cooldown seed (part 1) is the shared half and applies to both apps.

## Tests
- Lite **505** + Dashboard **487** green; 0 warnings.
- New: webhook-row history filter (`GetLastWebhookSentUtc_FiltersToWebhookRows_IncludingEmailWebhook`); watermark save/load/upsert round-trip (`EdgeTriggerWatermark_SaveLoad_RoundTripsAndUpserts`); `WebhookAlertService` seed-suppresses-within-window / seed-older-than-cooldown-does-not-suppress / null-store-attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)