### PR TITLE
Bump Velopack 0.0.1298 → 1.2.0 and pin the vpk CLI to match

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          dotnet tool install -g vpk
+          # Pin vpk to the Velopack library version (keep in sync with the Velopack
+          # PackageReference in Dashboard.csproj / PerformanceMonitorLite.csproj).
+          dotnet tool install -g vpk --version 1.2.0
           New-Item -ItemType Directory -Force -Path releases/velopack-dashboard
           New-Item -ItemType Directory -Force -Path releases/velopack-lite
 

--- a/Dashboard/Dashboard.csproj
+++ b/Dashboard/Dashboard.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Velopack" Version="0.0.1298" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dashboard/packages.lock.json
+++ b/Dashboard/packages.lock.json
@@ -130,12 +130,9 @@
       },
       "Velopack": {
         "type": "Direct",
-        "requested": "[0.0.1298, )",
-        "resolved": "0.0.1298",
-        "contentHash": "PJ6Nm28qJ4ChsHYzgHUJ8g+DGyyHes2+bwxY709+znMhgi8fMp8M1FTF8x6pZMjnsPCWVwoMlxVEyq0NLeRZtA==",
-        "dependencies": {
-          "NuGet.Versioning": "6.14.0"
-        }
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -541,11 +538,6 @@
           "Microsoft.Extensions.AI.Abstractions": "10.5.2",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
-      },
-      "NuGet.Versioning": {
-        "type": "Transitive",
-        "resolved": "6.14.0",
-        "contentHash": "4v4blkhCv8mpKtfx+z0G/X0daVCzdIaHSC51GkUspugi5JIMn2Bo8xm5PdZYF0U68gOBfz/+aPWMnpRd85Jbow=="
       },
       "OpenTK": {
         "type": "Transitive",

--- a/Lite.Tests/packages.lock.json
+++ b/Lite.Tests/packages.lock.json
@@ -619,11 +619,6 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
-      "NuGet.Versioning": {
-        "type": "Transitive",
-        "resolved": "6.14.0",
-        "contentHash": "4v4blkhCv8mpKtfx+z0G/X0daVCzdIaHSC51GkUspugi5JIMn2Bo8xm5PdZYF0U68gOBfz/+aPWMnpRd85Jbow=="
-      },
       "OpenTK": {
         "type": "Transitive",
         "resolved": "4.9.4",
@@ -821,11 +816,8 @@
       },
       "Velopack": {
         "type": "Transitive",
-        "resolved": "0.0.1298",
-        "contentHash": "PJ6Nm28qJ4ChsHYzgHUJ8g+DGyyHes2+bwxY709+znMhgi8fMp8M1FTF8x6pZMjnsPCWVwoMlxVEyq0NLeRZtA==",
-        "dependencies": {
-          "NuGet.Versioning": "6.14.0"
-        }
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -938,7 +930,7 @@
           "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",
           "PerformanceMonitor.Ui": "[1.0.0, )",
           "ScottPlot.WPF": "[5.1.58, )",
-          "Velopack": "[0.0.1298, )"
+          "Velopack": "[1.2.0, )"
         }
       }
     }

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -73,7 +73,7 @@
     <!-- MCP server for LLM tool access -->
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
-    <PackageReference Include="Velopack" Version="0.0.1298" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lite/packages.lock.json
+++ b/Lite/packages.lock.json
@@ -134,12 +134,9 @@
       },
       "Velopack": {
         "type": "Direct",
-        "requested": "[0.0.1298, )",
-        "resolved": "0.0.1298",
-        "contentHash": "PJ6Nm28qJ4ChsHYzgHUJ8g+DGyyHes2+bwxY709+znMhgi8fMp8M1FTF8x6pZMjnsPCWVwoMlxVEyq0NLeRZtA==",
-        "dependencies": {
-          "NuGet.Versioning": "6.14.0"
-        }
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -560,11 +557,6 @@
           "Microsoft.Extensions.AI.Abstractions": "10.5.2",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
-      },
-      "NuGet.Versioning": {
-        "type": "Transitive",
-        "resolved": "6.14.0",
-        "contentHash": "4v4blkhCv8mpKtfx+z0G/X0daVCzdIaHSC51GkUspugi5JIMn2Bo8xm5PdZYF0U68gOBfz/+aPWMnpRd85Jbow=="
       },
       "OpenTK": {
         "type": "Transitive",


### PR DESCRIPTION
Moves the auto-update framework to the Velopack 1.x stable line, and **corrects a latent mismatch**: `build.yml` ran `dotnet tool install -g vpk` unpinned, so releases were already packed with vpk 1.x while the app library trailed at 0.0.1298. This aligns the reader library with the packer (now pinned `vpk --version 1.2.0`) **without changing the feed format**.

## Changes
- Dashboard + Lite: `Velopack` `0.0.1298 → 1.2.0`
- `build.yml`: `dotnet tool install -g vpk --version 1.2.0` (was unpinned)
- Lock files regenerated (`--force-evaluate`); they shrink — Velopack 1.x dropped the `NuGet.Versioning` transitive dep (custom `SemanticVersion`, since 1.0.1).

## No source changes needed
`VelopackApp.Build().Run()`, `UpdateManager`, `GithubSource`, `CheckForUpdatesAsync` / `DownloadUpdatesAsync` / `ApplyUpdatesAndRestart` all unchanged at the API level.

## Verification
Build clean (0 new warnings); **Lite 524 + Dashboard 487** green.

## Follow-up
The live cross-release auto-update path can only be fully validated at an actual tagged release — covered by the new **§8b** release-checklist step (Help → About → download → restart). Since the feed was already vpk-1.x-generated, this bump reduces rather than adds update-path risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)