### PR TITLE
Build health: remove dead test seam (solution to 0 warnings)

### DIFF
--- a/Dashboard.Tests/RemediationTests.cs
+++ b/Dashboard.Tests/RemediationTests.cs
@@ -1943,7 +1943,6 @@ public class RemediationTests
         public bool AuditWriteResult = true;
         public Func<string, long, long, TargetPreflight>? PreflightFunc;
         public Func<string, long, long, ForcePlanOutcome>? ForceFunc;
-        public Func<string, long, long, ForcePlanOutcome>? UnforceFunc;
 
         public int ForceCalls;
         public int UnforceCalls;
@@ -1974,7 +1973,7 @@ public class RemediationTests
         public Task<ForcePlanOutcome> UnforcePlanAsync(string database, long queryId, long planId, RemediationIdentity identity, CancellationToken ct)
         {
             UnforceCalls++;
-            return Task.FromResult(UnforceFunc?.Invoke(database, queryId, planId) ?? new ForcePlanOutcome
+            return Task.FromResult(new ForcePlanOutcome
             {
                 Database = database, QueryId = queryId, PlanId = planId,
                 Status = RemediationStatus.Success, Forced = true, ExecutingLogin = "sa", GateSpid = 55, ExecSpid = 55


### PR DESCRIPTION
Quarterly build-health pass. The only warning across the whole solution was a `CS0649` in `Dashboard.Tests` — `FakeExecutor.UnforceFunc` was read but never assigned by any test (always null). Removed the dead field + its no-op invoke; `UnforcePlanAsync` returns the same default outcome. **Solution now builds at 0 warnings.**

Part of a dependency/build-health maintenance sweep:
- **Dependencies & security (clean):** 0 vulnerable, 0 deprecated packages (all 12 projects); outdated handled (#1149 minor bumps, #1150 Velopack); DuckDB parked for the 1.5.4 .NET binding. GitHub Actions on current majors; `vpk` pinned (#1150).
- **Code & build health:** 0 TODO/FIXME/HACK markers; this CS0649 fixed. (`.gitattributes` line-ending normalization recommended as a separate, dedicated change since it renormalizes the whole repo.)

Verification: Dashboard.Tests 487 green; 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)