### PR TITLE
Harden .gitattributes: force LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 * text=auto eol=crlf
 
+# Shell scripts must stay LF (this repo uses Git Bash) — CRLF breaks them.
+*.sh text eol=lf
+
 # Explicit binary markers (prevent text mis-detection / corruption):
 *.png binary
 *.jpg binary


### PR DESCRIPTION
Maintenance follow-up to the EOL-hygiene item. Finding: the repo **already has** a `.gitattributes` (`* text=auto eol=crlf` + binary markers) and the tree is **already normalized** (`git add --renormalize .` is a no-op) — so the CRLF/LF mix is resolved.

One gap closed here: the global `eol=crlf` rule would check out a future `*.sh` as CRLF, which fails under Git Bash (this repo uses it heavily). Added `*.sh text eol=lf`. No tracked `.sh` files today, so this changes nothing now — it's a latent-footgun guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)