### PR TITLE
Fix two Dashboard analysis bugs that drifted from Lite

### DIFF
--- a/Dashboard/Analysis/SqlServerAnomalyDetector.cs
+++ b/Dashboard/Analysis/SqlServerAnomalyDetector.cs
@@ -572,17 +572,27 @@ SELECT
             var currentBlocking = Convert.ToInt64(reader.GetValue(0));
             var currentDeadlocks = Convert.ToInt64(reader.GetValue(1));
 
+            /* Baseline mean is events per hour-of-day/dow bucket (≈ events per hour at this time of
+               day). current_* are raw counts over the whole analysis window (hoursBack, default 4),
+               so normalize them to per-hour before the ratio — otherwise the ratio scales with the
+               window length, not the workload, and a steady event rate trips the spike threshold. */
+            var windowHours = (context.TimeRangeEnd - context.TimeRangeStart).TotalHours;
+            if (windowHours <= 0) windowHours = 1;
+            var currentBlockingPerHour = currentBlocking / windowHours;
+            var currentDeadlocksPerHour = currentDeadlocks / windowHours;
+
+            // Baseline mean = events per hour for this hour+dow bucket
             var baselineBlockingRate = blockingBaseline.SampleCount > 0 ? blockingBaseline.Mean : 0;
             var baselineDeadlockRate = deadlockBaseline.SampleCount > 0 ? deadlockBaseline.Mean : 0;
 
-            // Blocking spike: at least 5 events AND 3x baseline rate (or no baseline)
-            if (currentBlocking >= 5 && (baselineBlockingRate <= 0 || currentBlocking / Math.Max(baselineBlockingRate, 1) >= DefaultEventRatioThreshold))
+            // Blocking spike: at least 5 events in the window AND per-hour rate >= 3x baseline (or no baseline)
+            if (currentBlocking >= 5 && (baselineBlockingRate <= 0 || currentBlockingPerHour / Math.Max(baselineBlockingRate, 1) >= DefaultEventRatioThreshold))
             {
                 var metadata = new Dictionary<string, double>
                 {
                     ["current_count"] = currentBlocking,
                     ["baseline_rate"] = baselineBlockingRate,
-                    ["ratio"] = baselineBlockingRate > 0 ? currentBlocking / baselineBlockingRate : 100.0
+                    ["ratio"] = baselineBlockingRate > 0 ? currentBlockingPerHour / baselineBlockingRate : 100.0
                 };
                 AddBaselineContext(metadata, blockingBaseline);
 
@@ -596,14 +606,14 @@ SELECT
                 });
             }
 
-            // Deadlock spike: at least 3 events AND 3x baseline rate (or no baseline)
-            if (currentDeadlocks >= 3 && (baselineDeadlockRate <= 0 || currentDeadlocks / Math.Max(baselineDeadlockRate, 1) >= DefaultEventRatioThreshold))
+            // Deadlock spike: at least 3 events in the window AND per-hour rate >= 3x baseline (or no baseline)
+            if (currentDeadlocks >= 3 && (baselineDeadlockRate <= 0 || currentDeadlocksPerHour / Math.Max(baselineDeadlockRate, 1) >= DefaultEventRatioThreshold))
             {
                 var metadata = new Dictionary<string, double>
                 {
                     ["current_count"] = currentDeadlocks,
                     ["baseline_rate"] = baselineDeadlockRate,
-                    ["ratio"] = baselineDeadlockRate > 0 ? currentDeadlocks / baselineDeadlockRate : 100.0
+                    ["ratio"] = baselineDeadlockRate > 0 ? currentDeadlocksPerHour / baselineDeadlockRate : 100.0
                 };
                 AddBaselineContext(metadata, deadlockBaseline);
 

--- a/Dashboard/Analysis/SqlServerBaselineProvider.cs
+++ b/Dashboard/Analysis/SqlServerBaselineProvider.cs
@@ -169,9 +169,11 @@ public class SqlServerBaselineProvider
                     Mean = mean,
                     StdDev = stddev,
                     SampleCount = count,
-                    Tier = count >= RestoreThreshold ? BaselineTier.Full
-                         : count >= CollapseThreshold ? BaselineTier.Full
-                         : BaselineTier.HourOnly
+                    // Every bucket here is a full (hour, day-of-week) bucket; the HourOnly/Flat
+                    // tiers are assigned only on the collapse/flat paths below. A sparse full
+                    // bucket is still Full, just low-sample. (Was a copy-paste of two identical
+                    // Full branches that mislabeled sparse buckets HourOnly in baseline_tier.)
+                    Tier = BaselineTier.Full
                 };
             }
 


### PR DESCRIPTION
## Summary

A Lite↔Dashboard code-sharing drift audit found two cases where a fix landed in **Lite** but the duplicated **Dashboard** copy still carried the bug. Both fixes here bring Dashboard in line with the already-correct Lite behavior.

### 1. `SqlServerBaselineProvider` — tier mislabeled for sparse buckets
The full `(hour, day-of-week)` bucket `Tier` was assigned by a copy-paste ternary whose **two arms both returned `BaselineTier.Full`**:
```csharp
Tier = count >= RestoreThreshold ? BaselineTier.Full
     : count >= CollapseThreshold ? BaselineTier.Full
     : BaselineTier.HourOnly
```
So any bucket with `count < CollapseThreshold` (<10 samples) was written to `baseline_tier` as `HourOnly`. Every bucket on this path is a full bucket; `HourOnly`/`Flat` are only assigned on the collapse/flat paths. Now `Tier = BaselineTier.Full`, matching `Lite/Analysis/BaselineProvider.cs`.

### 2. `SqlServerAnomalyDetector.DetectBlockingAnomalies` — ratio scaled with window length
Blocking/deadlock spike detection compared a **raw count over the whole analysis window** (default 4h) against a **per-hour** baseline mean, so the ratio scaled with window length and a steady event rate could trip the spike threshold. Now the current counts are normalized to per-hour before the ratio, mirroring Lite.

## Why this happened
Dashboard has **no** `SqlServerBaselineProvider`/`SqlServerAnomalyDetector` unit tests, while Lite has `BaselineProviderTests` + `AnomalyDetectorTests` (which is where the Lite fixes were validated). The Dashboard classes are wired directly to `SqlConnection`, so there's no in-memory test seam today. Durable fix for the drift class is the shared-base extraction recommended by the audit (follow-up) — that would give both apps one tested code path.

## Test plan
- [x] `dotnet build Dashboard` (+ all shared projects) succeeds
- [x] `dotnet test Dashboard.Tests` — **487 passed, 0 failed**
- [x] No Lite changes (Lite copies were already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
