### PR TITLE
Fix #1154: key the alert delivery cooldown on the #1140 incident fingerprint

### DIFF
--- a/Dashboard.Tests/JsonAlertHistoryStoreDedupKeyTests.cs
+++ b/Dashboard.Tests/JsonAlertHistoryStoreDedupKeyTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// #1154: the Dashboard JSON store's per-fingerprint cooldown seed. Proves the in-memory scan
+/// restricts to rows whose ContextJson carries the #1140 dedup key, isolates per-fingerprint, and
+/// — critically — does NOT NRE on the many null-ContextJson rows (tray/muted) the scan also visits
+/// (the round-1 MAJOR). A unique serverId keeps the test isolated from any on-disk alert_history.json
+/// the store loads in its constructor.
+/// </summary>
+public class JsonAlertHistoryStoreDedupKeyTests
+{
+    /// <summary>Minimal IUserPreferencesService over one UserPreferences instance (mirrors the other Dashboard tests).</summary>
+    private sealed class FakePreferencesService : IUserPreferencesService
+    {
+        public UserPreferences Preferences { get; } = new();
+        public UserPreferences GetPreferences() => Preferences;
+        public void SavePreferences(UserPreferences preferences) { }
+        public void UpdateWaitStatsRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCpuRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateMemoryRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateFileIoRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateExpensiveQueriesRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateBlockingRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCollectionHealthRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+    }
+
+    private static string JsonWith(string dedupKey)
+    {
+        var ctx = new AlertContext
+        {
+            Incidents = new List<AlertIncident> { new(dedupKey, new[] { "db.dbo.T" }) }
+        };
+        return AlertContextSerializer.Serialize(ctx);
+    }
+
+    private static Task RecordAsync(JsonAlertHistoryStore store, string serverId, string metric, string type, string? contextJson)
+        => store.RecordAlertAsync(new AlertHistoryRecord(
+            serverId, "Srv", metric, "4", "1", null, null,
+            AlertSent: true, NotificationType: type, SendError: null,
+            Muted: false, DetailText: null, ContextJson: contextJson));
+
+    [Fact]
+    public async Task GetLastSentUtc_WithDedupKey_FiltersToFingerprint_AndIgnoresNullContextRows()
+    {
+        var store = new JsonAlertHistoryStore(new FakePreferencesService());
+        var srv = "test-" + Guid.NewGuid().ToString("N"); // unique -> isolated from on-disk history
+
+        // Email rows: AAA earlier, BBB later, then a null-context "email" row (must not NRE, must be
+        // excluded by a dedupKey filter, but still counts for the metric-level seed).
+        await RecordAsync(store, srv, "Deadlocks Detected", "email", JsonWith("aaaa1111"));
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        await RecordAsync(store, srv, "Deadlocks Detected", "email", JsonWith("bbbb2222"));
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        await RecordAsync(store, srv, "Deadlocks Detected", "email", null);
+
+        var lastAaa = await store.GetLastEmailSentUtcAsync(srv, "Deadlocks Detected", "aaaa1111");
+        var lastBbb = await store.GetLastEmailSentUtcAsync(srv, "Deadlocks Detected", "bbbb2222");
+        var lastCcc = await store.GetLastEmailSentUtcAsync(srv, "Deadlocks Detected", "cccc3333");
+        var lastMetric = await store.GetLastEmailSentUtcAsync(srv, "Deadlocks Detected"); // metric-level (null key)
+
+        Assert.NotNull(lastAaa);
+        Assert.NotNull(lastBbb);
+        Assert.Null(lastCcc);                            // no such fingerprint
+        Assert.True(lastAaa!.Value < lastBbb!.Value);    // the filter isolates per-fingerprint
+        Assert.NotNull(lastMetric);
+        Assert.True(lastMetric!.Value >= lastBbb.Value); // metric-level still sees the later null-context row
+
+        // Webhook channel parity.
+        await RecordAsync(store, srv, "Blocking Detected", "webhook", JsonWith("dddd4444"));
+        Assert.NotNull(await store.GetLastWebhookSentUtcAsync(srv, "Blocking Detected", "dddd4444"));
+        Assert.Null(await store.GetLastWebhookSentUtcAsync(srv, "Blocking Detected", "eeee5555"));
+    }
+}

--- a/Dashboard/Services/JsonAlertHistoryStore.cs
+++ b/Dashboard/Services/JsonAlertHistoryStore.cs
@@ -106,8 +106,11 @@ namespace PerformanceMonitorDashboard.Services
         /// Dashboard records email and webhook deliveries as separate alert-log
         /// rows, so the filter is just NotificationType == "email" — Lite's
         /// combined "email+webhook" notification_type never appears here.
+        /// When <paramref name="dedupKey"/> is non-null (#1154), the scan is additionally
+        /// restricted to rows whose ContextJson carries that #1140 fingerprint (the helper
+        /// null-guards the many tray/muted rows whose ContextJson is null).
         /// </remarks>
-        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName)
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null)
         {
             lock (_alertLogLock)
             {
@@ -118,6 +121,7 @@ namespace PerformanceMonitorDashboard.Services
                     if (entry.MetricName != metricName) continue;
                     if (entry.NotificationType != "email") continue;
                     if (!string.IsNullOrEmpty(entry.SendError)) continue;
+                    if (dedupKey is not null && !AlertContextSerializer.ContextJsonContainsDedupKey(entry.ContextJson, dedupKey)) continue;
                     if (max == null || entry.AlertTime > max.Value) max = entry.AlertTime;
                 }
                 return Task.FromResult(max);
@@ -136,8 +140,10 @@ namespace PerformanceMonitorDashboard.Services
         /// Dashboard records webhook deliveries as their own alert-log rows with
         /// NotificationType == "webhook" (written only on a successful post), so
         /// the type alone implies success — no SendError filter is needed.
+        /// When <paramref name="dedupKey"/> is non-null (#1154), the scan is additionally
+        /// restricted to rows whose ContextJson carries that #1140 fingerprint.
         /// </remarks>
-        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null)
         {
             lock (_alertLogLock)
             {
@@ -147,6 +153,7 @@ namespace PerformanceMonitorDashboard.Services
                     if (entry.ServerId != serverId) continue;
                     if (entry.MetricName != metricName) continue;
                     if (entry.NotificationType != "webhook") continue;
+                    if (dedupKey is not null && !AlertContextSerializer.ContextJsonContainsDedupKey(entry.ContextJson, dedupKey)) continue;
                     if (max == null || entry.AlertTime > max.Value) max = entry.AlertTime;
                 }
                 return Task.FromResult(max);

--- a/Lite.Tests/ContextJsonContainsDedupKeyTests.cs
+++ b/Lite.Tests/ContextJsonContainsDedupKeyTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1154: the per-fingerprint cooldown seed matches rows by the serialized #1140 dedup key.
+/// These tests pin the match against the REAL serializer output (so a future naming-policy
+/// change breaks here, not silently in production), and the null/blank guards that keep the
+/// Dashboard scan from NRE-ing on its many null-ContextJson rows.
+/// </summary>
+public class ContextJsonContainsDedupKeyTests
+{
+    private static string SerializeWith(params string[] dedupKeys)
+    {
+        var ctx = new AlertContext
+        {
+            Incidents = new List<AlertIncident>()
+        };
+        foreach (var k in dedupKeys)
+            ctx.Incidents.Add(new AlertIncident(k, new[] { "db.dbo.T" }));
+        return AlertContextSerializer.Serialize(ctx);
+    }
+
+    [Fact]
+    public void Finds_EachDedupKey_InRealSerializedContext()
+    {
+        var json = SerializeWith("aaaa1111", "bbbb2222");
+
+        Assert.True(AlertContextSerializer.ContextJsonContainsDedupKey(json, "aaaa1111"));
+        Assert.True(AlertContextSerializer.ContextJsonContainsDedupKey(json, "bbbb2222"));
+    }
+
+    [Fact]
+    public void Misses_AbsentDedupKey()
+    {
+        var json = SerializeWith("aaaa1111");
+        Assert.False(AlertContextSerializer.ContextJsonContainsDedupKey(json, "cccc3333"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ReturnsFalse_OnNullOrBlankContextJson(string? contextJson)
+    {
+        // The Dashboard scan visits many rows whose ContextJson is null (tray/muted/server rows);
+        // an un-guarded match would NRE and unwind every fingerprinted send.
+        Assert.False(AlertContextSerializer.ContextJsonContainsDedupKey(contextJson, "aaaa1111"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ReturnsFalse_OnNullOrBlankDedupKey(string? dedupKey)
+    {
+        var json = SerializeWith("aaaa1111");
+        Assert.False(AlertContextSerializer.ContextJsonContainsDedupKey(json, dedupKey));
+    }
+
+    [Fact]
+    public void IsAnchored_DoesNotMatchSameValueUnderADifferentProperty()
+    {
+        // The same string under a non-DedupKey property must NOT match — the anchor is "DedupKey":"…".
+        const string notADedupKey = "{\"QueryHash\":\"deadbeef\",\"Other\":\"deadbeef\"}";
+        Assert.False(AlertContextSerializer.ContextJsonContainsDedupKey(notADedupKey, "deadbeef"));
+    }
+}

--- a/Lite.Tests/IncidentCooldownTests.cs
+++ b/Lite.Tests/IncidentCooldownTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1154: the shared per-incident-fingerprint cooldown. Replaces the old per-(serverId, metricName)
+/// throttle that silently dropped a genuinely distinct incident arriving inside the window. These
+/// tests pin the send decision (send if ANY candidate key is fresh; stamp ALL on success), the
+/// metric-level fallback for non-fingerprinted alerts, the per-fingerprint restart seed, and the
+/// 2×-window eviction bound. Windows are large (minutes) so the real-clock math is deterministic
+/// within a sub-second test run; the one eviction test uses a tiny window with a generous delay.
+/// </summary>
+public class IncidentCooldownTests
+{
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(15);
+
+    private static AlertIncident Incident(string dedupKey) =>
+        new(dedupKey, new[] { "db.dbo." + dedupKey });
+
+    private static IReadOnlyList<AlertIncident> Incidents(params string[] keys) =>
+        keys.Select(Incident).ToList();
+
+    /// <summary>A cooldown with no restart seed (history returns null for every key).</summary>
+    private static IncidentCooldown NoSeed() =>
+        new(keyPrefix: "", seedLastSentUtc: (_, _, _) => Task.FromResult<DateTime?>(null));
+
+    [Fact]
+    public async Task DistinctFingerprints_BothFresh_SendsWithOneKeyPerFingerprint()
+    {
+        var cd = NoSeed();
+        var d = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A", "B"), Window);
+
+        Assert.True(d.ShouldSend);
+        Assert.Equal(2, d.Keys.Count);
+        Assert.Equal(2, d.Keys.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task SameFingerprintRepeat_WithinWindow_Suppressed()
+    {
+        var cd = NoSeed();
+
+        var first = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        Assert.True(first.ShouldSend);
+        cd.Stamp(first);
+
+        var second = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        Assert.False(second.ShouldSend);   // #1091: a re-fire of the same fingerprint stays suppressed
+    }
+
+    [Fact]
+    public async Task DistinctFingerprint_WithinWindowOfAnother_StillSends()
+    {
+        // gotqn's #1154 repro: A delivered, then a DIFFERENT incident B arrives in the window.
+        var cd = NoSeed();
+
+        var a = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        cd.Stamp(a);
+
+        var b = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("B"), Window);
+        Assert.True(b.ShouldSend);         // B is not throttled by A's unrelated cooldown
+    }
+
+    [Fact]
+    public async Task SummaryWithMixedFreshness_SendsThenStampAllSuppressesEither()
+    {
+        var cd = NoSeed();
+
+        var a = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        cd.Stamp(a);
+
+        // Summary {A (in cooldown), B (fresh)} -> send because B is fresh; stamp BOTH.
+        var summary = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A", "B"), Window);
+        Assert.True(summary.ShouldSend);
+        cd.Stamp(summary);
+
+        // Now A and B are both freshly stamped -> either one alone is suppressed.
+        Assert.False((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window)).ShouldSend);
+        Assert.False((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("B"), Window)).ShouldSend);
+    }
+
+    [Fact]
+    public async Task AllIncidentsInCooldown_Suppressed()
+    {
+        var cd = NoSeed();
+        var first = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A", "B"), Window);
+        cd.Stamp(first);
+
+        var again = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A", "B"), Window);
+        Assert.False(again.ShouldSend);
+    }
+
+    [Fact]
+    public async Task NonFingerprinted_FallsBackToMetricKey_LikePre1154()
+    {
+        var cd = NoSeed();
+
+        // No incidents -> single metric-level key.
+        var cpu = await cd.EvaluateAsync("1", "High CPU", null, Window);
+        Assert.True(cpu.ShouldSend);
+        Assert.Single(cpu.Keys);
+        cd.Stamp(cpu);
+
+        // Same metric within window -> suppressed (today's behavior).
+        Assert.False((await cd.EvaluateAsync("1", "High CPU", null, Window)).ShouldSend);
+        // A different metric is its own key -> fresh.
+        Assert.True((await cd.EvaluateAsync("1", "TempDB Space", new List<AlertIncident>(), Window)).ShouldSend);
+        // A different server is its own key -> fresh.
+        Assert.True((await cd.EvaluateAsync("2", "High CPU", null, Window)).ShouldSend);
+    }
+
+    [Fact]
+    public async Task Seed_WithinWindow_Suppresses_OlderThanWindow_Sends()
+    {
+        // Seed returns "just now" for A and an old time for B.
+        var cd = new IncidentCooldown("", (_, _, dedupKey) => Task.FromResult<DateTime?>(
+            dedupKey == "A" ? DateTime.UtcNow
+            : dedupKey == "B" ? DateTime.UtcNow - TimeSpan.FromMinutes(17)
+            : null));
+
+        Assert.False((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window)).ShouldSend); // seeded in-window
+        Assert.True((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("B"), Window)).ShouldSend);  // seeded but stale
+        Assert.True((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("C"), Window)).ShouldSend);  // never sent
+    }
+
+    [Fact]
+    public async Task NullSeedDelegate_NeverSeeds_FirstTouchAlwaysFresh()
+    {
+        // Mirrors the webhook null-store path: no seeding, pure in-memory.
+        var cd = new IncidentCooldown("webhook:", seedLastSentUtc: null);
+
+        var d = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        Assert.True(d.ShouldSend);
+    }
+
+    [Fact]
+    public async Task FailedSend_NotStamped_DoesNotStartCooldown()
+    {
+        var cd = NoSeed();
+
+        // Evaluate but do NOT stamp (simulating a failed send).
+        var d = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window);
+        Assert.True(d.ShouldSend);
+
+        // Next evaluation still sends — a failed send must not consume the cooldown.
+        Assert.True((await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), Window)).ShouldSend);
+    }
+
+    [Fact]
+    public async Task Eviction_DropsKeysPastTwiceWindow_KeepsDictBounded()
+    {
+        var window = TimeSpan.FromMilliseconds(50);
+        var cd = NoSeed();
+
+        var a = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("A"), window);
+        cd.Stamp(a);
+        Assert.Equal(1, cd.TrackedKeyCount);
+
+        await Task.Delay(250, TestContext.Current.CancellationToken); // > 2x window: A is now evictable
+
+        var b = await cd.EvaluateAsync("1", "Deadlocks Detected", Incidents("B"), window);
+        cd.Stamp(b);
+
+        // A was pruned at the top of the second Evaluate, so only B remains (not 2).
+        Assert.Equal(1, cd.TrackedKeyCount);
+    }
+}

--- a/Lite.Tests/StoreRoundTripTests.cs
+++ b/Lite.Tests/StoreRoundTripTests.cs
@@ -157,6 +157,39 @@ public class StoreRoundTripTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLastSentUtc_WithDedupKey_FiltersToContextJsonFingerprint()
+    {
+        await _duckDb.InitializeAsync();
+        var store = new DuckDbAlertHistoryStore(_duckDb);
+
+        /* #1154: two distinct deadlock incidents recorded as successful email rows (AAA earlier,
+           BBB later) carrying real serialized #1140 context, plus a later null-context row that
+           any dedupKey filter must exclude (it would NRE/over-match a naive scan). */
+        await RecordWithContextAsync(store, "9", "Deadlocks Detected", "email", JsonWith("aaaa1111"));
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        await RecordWithContextAsync(store, "9", "Deadlocks Detected", "email", JsonWith("bbbb2222"));
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        await RecordAsync(store, "9", "Deadlocks Detected", "email", null); // null context, latest row
+
+        var lastAaa = await store.GetLastEmailSentUtcAsync("9", "Deadlocks Detected", "aaaa1111");
+        var lastBbb = await store.GetLastEmailSentUtcAsync("9", "Deadlocks Detected", "bbbb2222");
+        var lastCcc = await store.GetLastEmailSentUtcAsync("9", "Deadlocks Detected", "cccc3333");
+        var lastMetric = await store.GetLastEmailSentUtcAsync("9", "Deadlocks Detected"); // metric-level (null key)
+
+        Assert.NotNull(lastAaa);
+        Assert.NotNull(lastBbb);
+        Assert.Null(lastCcc);                            // no such fingerprint
+        Assert.True(lastAaa!.Value < lastBbb!.Value);    // the filter isolates per-fingerprint (AAA is earlier)
+        Assert.NotNull(lastMetric);
+        Assert.True(lastMetric!.Value >= lastBbb.Value); // metric-level still sees the later null-context row
+
+        /* Webhook channel uses the identical filter — prove it too. */
+        await RecordWithContextAsync(store, "9", "Blocking Detected", "webhook", JsonWith("dddd4444"));
+        Assert.NotNull(await store.GetLastWebhookSentUtcAsync("9", "Blocking Detected", "dddd4444"));
+        Assert.Null(await store.GetLastWebhookSentUtcAsync("9", "Blocking Detected", "eeee5555"));
+    }
+
+    [Fact]
     public async Task EdgeTriggerWatermark_SaveLoad_RoundTripsAndUpserts()
     {
         await _duckDb.InitializeAsync();
@@ -249,6 +282,21 @@ public class StoreRoundTripTests : IDisposable
         => store.RecordAlertAsync(new AlertHistoryRecord(
             serverId, "Srv", metric, "90", "80", 90, 80,
             true, type, error, false, null, null));
+
+    private static Task RecordWithContextAsync(IAlertHistoryStore store, string serverId, string metric, string type, string? contextJson)
+        => store.RecordAlertAsync(new AlertHistoryRecord(
+            serverId, "Srv", metric, "90", "80", 90, 80,
+            true, type, null, false, null, contextJson));
+
+    /// <summary>Real serialized #1140 context carrying a single incident with the given dedup key.</summary>
+    private static string JsonWith(string dedupKey)
+    {
+        var ctx = new AlertContext
+        {
+            Incidents = new List<AlertIncident> { new(dedupKey, new[] { "db.dbo.T" }) }
+        };
+        return AlertContextSerializer.Serialize(ctx);
+    }
 
     private sealed record AlertRow(
         DateTime AlertTime, int ServerId, string ServerName, string MetricName,

--- a/Lite.Tests/WebhookCooldownSeedTests.cs
+++ b/Lite.Tests/WebhookCooldownSeedTests.cs
@@ -98,13 +98,56 @@ public class WebhookCooldownSeedTests
         public DateTime? LastWebhookSent { get; set; }
         public int GetLastWebhookSentCallCount { get; private set; }
 
+        /// <summary>When set (#1154), the seed applies ONLY to this dedup key; other keys seed null.
+        /// Null (default) returns <see cref="LastWebhookSent"/> for any call — the pre-#1154 shape.</summary>
+        public string? SeededDedupKey { get; set; }
+
         public Task RecordAlertAsync(AlertHistoryRecord record) => Task.CompletedTask;
-        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName) => Task.FromResult<DateTime?>(null);
-        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) => Task.FromResult<DateTime?>(null);
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null)
         {
             GetLastWebhookSentCallCount++;
+            if (SeededDedupKey is not null && dedupKey != SeededDedupKey)
+                return Task.FromResult<DateTime?>(null);
             return Task.FromResult(LastWebhookSent);
         }
         public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName) => Task.FromResult<DateTime?>(null);
+    }
+
+    private static AlertContext ContextWith(string dedupKey) => new()
+    {
+        Incidents = new System.Collections.Generic.List<AlertIncident>
+        {
+            new(dedupKey, new[] { "db.dbo.T" })
+        }
+    };
+
+    [Fact]
+    public async Task DistinctFingerprint_NotSuppressedByAnotherIncidentsCooldown()
+    {
+        // #1154: incident X was delivered "just now"; a DISTINCT incident Y arrives within the window.
+        // Y must be attempted (it fails against the dead URL) — not throttled by X's cooldown.
+        var history = new FakeHistoryStore { LastWebhookSent = DateTime.UtcNow, SeededDedupKey = "X" };
+        var svc = MakeService(history, EnabledTeamsSettings());
+
+        var sent = await svc.TrySendWebhookAlertsAsync(
+            "Deadlocks Detected", "Srv", "4", "1", "1", ContextWith("Y"));
+
+        Assert.False(sent);                                        // dead URL -> attempted, failed
+        Assert.Equal(1, svc.GetTeamsHealth().ConsecutiveFailures); // ATTEMPTED, not suppressed
+    }
+
+    [Fact]
+    public async Task SameFingerprint_SuppressedByItsOwnSeededCooldown()
+    {
+        // The same incident X, seeded "just now" -> suppressed (no network touch).
+        var history = new FakeHistoryStore { LastWebhookSent = DateTime.UtcNow, SeededDedupKey = "X" };
+        var svc = MakeService(history, EnabledTeamsSettings());
+
+        var sent = await svc.TrySendWebhookAlertsAsync(
+            "Deadlocks Detected", "Srv", "4", "1", "1", ContextWith("X"));
+
+        Assert.False(sent);                                        // suppressed
+        Assert.Equal(0, svc.GetTeamsHealth().ConsecutiveFailures); // NOT attempted
     }
 }

--- a/Lite/Services/DuckDbAlertHistoryStore.cs
+++ b/Lite/Services/DuckDbAlertHistoryStore.cs
@@ -108,9 +108,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
     /// <summary>
     /// Returns the UTC time the most recent alert email was successfully sent
     /// for this server/metric, read from config_alert_log — or null if none.
-    /// Used to seed the in-memory cooldown after an app restart (#981).
+    /// Used to seed the in-memory cooldown after an app restart (#981). When
+    /// <paramref name="dedupKey"/> is non-null (#1154), the result is additionally
+    /// restricted to rows whose context_json carries that #1140 fingerprint.
     /// </summary>
-    public async Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName)
+    public async Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null)
     {
         var sid = int.TryParse(serverId, out var s) ? s : 0;
         try
@@ -131,16 +133,22 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
             using var command = connection.CreateCommand();
             /* A successful email send is logged with a notification_type of
                'email' / 'email+webhook' and a null send_error — that mirrors
-               exactly when _cooldowns is updated after SendEmailAsync. */
+               exactly when the cooldown is stamped after SendEmailAsync.
+               #1154: when a dedupKey is supplied, push the per-fingerprint filter into
+               DuckDB via an anchored LIKE on the serialized "DedupKey":"<hex>" property
+               (the hex key has no LIKE wildcards; NULL context_json rows fail the match). */
             command.CommandText = @"
 SELECT MAX(alert_time)
 FROM config_alert_log
 WHERE server_id = $1
 AND   metric_name = $2
 AND   notification_type IN ('email', 'email+webhook')
-AND   send_error IS NULL";
+AND   send_error IS NULL"
+            + (dedupKey is null ? "" : "\nAND   context_json LIKE $3");
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = sid });
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = metricName });
+            if (dedupKey is not null)
+                command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = "%\"DedupKey\":\"" + dedupKey + "\"%" });
 
             var result = await command.ExecuteScalarAsync();
             if (result == null || result == DBNull.Value) return null;
@@ -161,9 +169,11 @@ AND   send_error IS NULL";
     /// for this server/metric, read from config_alert_log — or null if none.
     /// Seeds the webhook cooldown after restart so a Teams/Slack alert posted
     /// shortly before a restart is not re-posted afterward (#1145, mirroring the
-    /// email seed #981).
+    /// email seed #981). When <paramref name="dedupKey"/> is non-null (#1154), the
+    /// result is additionally restricted to rows whose context_json carries that
+    /// #1140 fingerprint.
     /// </summary>
-    public async Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName)
+    public async Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null)
     {
         var sid = int.TryParse(serverId, out var s) ? s : 0;
         try
@@ -186,15 +196,20 @@ AND   send_error IS NULL";
                'webhook' / 'email+webhook' — those types are only ever written
                when WebhookSent is true, so the type alone implies success.
                send_error tracks the EMAIL channel, so it is NOT filtered on:
-               an email-failed-but-webhook-sent row must still seed the cooldown. */
+               an email-failed-but-webhook-sent row must still seed the cooldown.
+               #1154: when a dedupKey is supplied, push the per-fingerprint filter into
+               DuckDB via an anchored LIKE on the serialized "DedupKey":"<hex>" property. */
             command.CommandText = @"
 SELECT MAX(alert_time)
 FROM config_alert_log
 WHERE server_id = $1
 AND   metric_name = $2
-AND   notification_type IN ('webhook', 'email+webhook')";
+AND   notification_type IN ('webhook', 'email+webhook')"
+            + (dedupKey is null ? "" : "\nAND   context_json LIKE $3");
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = sid });
             command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = metricName });
+            if (dedupKey is not null)
+                command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = "%\"DedupKey\":\"" + dedupKey + "\"%" });
 
             var result = await command.ExecuteScalarAsync();
             if (result == null || result == DBNull.Value) return null;

--- a/PerformanceMonitor.Notifications/AlertContext.cs
+++ b/PerformanceMonitor.Notifications/AlertContext.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using PerformanceMonitor.Analysis;
@@ -259,6 +260,23 @@ public record MissingIndexTargetDto(
 /// </summary>
 public static class AlertContextSerializer
 {
+    /// <summary>
+    /// True when the persisted <paramref name="contextJson"/> carries the given #1140 dedup fingerprint
+    /// (#1154 per-fingerprint cooldown seed). Anchored substring match on the serialized
+    /// <c>"DedupKey":"&lt;hex&gt;"</c> property — safe because the key is lowercase SHA-256 hex (no JSON
+    /// escaping, no collision with any other serialized field) and <see cref="Serialize"/> emits PascalCase
+    /// with default options. Returns false on null/blank input — the Dashboard scan visits many rows whose
+    /// <c>ContextJson</c> is null (tray/muted/server-reachability rows), and an un-guarded match would NRE.
+    /// Centralizes the JSON shape so the Dashboard store cannot drift; the Lite store re-states the same
+    /// anchor in its SQL <c>LIKE</c> for push-down and is guarded by a store round-trip test.
+    /// </summary>
+    public static bool ContextJsonContainsDedupKey(string? contextJson, string? dedupKey)
+    {
+        if (string.IsNullOrEmpty(contextJson) || string.IsNullOrEmpty(dedupKey))
+            return false;
+        return contextJson.Contains("\"DedupKey\":\"" + dedupKey + "\"", StringComparison.Ordinal);
+    }
+
     public static string Serialize(AlertContext context)
     {
         var dto = new AlertContextDto(

--- a/PerformanceMonitor.Notifications/EmailSendCore.cs
+++ b/PerformanceMonitor.Notifications/EmailSendCore.cs
@@ -7,7 +7,6 @@
  */
 
 using System;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Net;
 using System.Net.Mail;
@@ -30,11 +29,15 @@ namespace PerformanceMonitor.Notifications;
 public sealed class EmailSendCore
 {
     private readonly IAlertSettings _settings;
-    private readonly IAlertHistoryStore _historyStore;
     private readonly WebhookAlertService _webhookAlertService;
     private readonly AlertBranding _branding;
     private readonly ILogger _logger;
-    private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+
+    /* #1154: per-incident-fingerprint cooldown (was a per-(serverId, metricName)
+       ConcurrentDictionary). Keyed per #1140 dedup fingerprint so a distinct incident in
+       the window is delivered; falls back to the metric-level key when an alert carries no
+       fingerprintable incident. Seeds the email last-sent time from the alert log (#981). */
+    private readonly IncidentCooldown _cooldown;
 
     /* Failure tracking for louder logging + the health getter (MIN-4: counters stay
        co-located with GetEmailHealth on the shared core). */
@@ -49,10 +52,13 @@ public sealed class EmailSendCore
         ILogger logger)
     {
         _settings = settings;
-        _historyStore = historyStore;
         _webhookAlertService = webhookAlertService;
         _branding = branding;
         _logger = logger;
+        _cooldown = new IncidentCooldown(
+            keyPrefix: "",
+            seedLastSentUtc: (serverId, metricName, dedupKey) =>
+                historyStore.GetLastEmailSentUtcAsync(serverId, metricName, dedupKey));
     }
 
     /// <summary>
@@ -84,24 +90,15 @@ public sealed class EmailSendCore
             !string.IsNullOrWhiteSpace(_settings.SmtpFromAddress) &&
             !string.IsNullOrWhiteSpace(_settings.SmtpRecipients))
         {
-            var cooldownKey = $"{serverId}:{metricName}";
+            /* #1154: per-fingerprint cooldown. Send if any incident in this alert is outside its
+               window (a distinct fingerprint is not throttled by an unrelated prior incident);
+               stamp every candidate key only after a successful send. Seeds from the alert log on
+               first touch per key (#981). No incidents -> the metric-level fallback key (today's behavior). */
+            var decision = await _cooldown.EvaluateAsync(
+                serverId, metricName, context?.Incidents,
+                TimeSpan.FromMinutes(_settings.EmailCooldownMinutes));
 
-            /* Seed the in-memory cooldown from the alert log the first time this key is
-               seen, so an alert email sent shortly before an app restart is not immediately
-               re-sent afterward (#981). The in-memory dictionary is authoritative once seeded. */
-            if (!_cooldowns.ContainsKey(cooldownKey))
-            {
-                var lastPersistedSend = await _historyStore.GetLastEmailSentUtcAsync(serverId, metricName);
-                if (lastPersistedSend.HasValue)
-                {
-                    _cooldowns.TryAdd(cooldownKey, lastPersistedSend.Value);
-                }
-            }
-
-            var withinCooldown = _cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
-                DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(_settings.EmailCooldownMinutes);
-
-            if (!withinCooldown)
+            if (decision.ShouldSend)
             {
                 emailAttempted = true;
 
@@ -113,7 +110,7 @@ public sealed class EmailSendCore
                 {
                     await SendEmailAsync(_settings, subject, htmlBody, plainTextBody, context);
                     emailSent = true;
-                    _cooldowns[cooldownKey] = DateTime.UtcNow;
+                    _cooldown.Stamp(decision);
 
                     if (_consecutiveFailures > 0)
                     {

--- a/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
+++ b/PerformanceMonitor.Notifications/IAlertHistoryStore.cs
@@ -38,8 +38,14 @@ public interface IAlertHistoryStore
     /// cooldown across restart (#981). Lite: notification_type IN
     /// ('email','email+webhook') AND send_error IS NULL. Dash: NotificationType
     /// == "email" AND SendError empty.
+    /// <para>
+    /// When <paramref name="dedupKey"/> is non-null (#1154 per-fingerprint cooldown), the result is
+    /// additionally restricted to rows whose persisted <c>ContextJson</c> carries that #1140 dedup
+    /// fingerprint, so the seed reconstructs the per-incident last-sent time. Null = the metric-level
+    /// seed (the pre-#1154 behavior, used by the non-fingerprinted fallback).
+    /// </para>
     /// </summary>
-    Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName);
+    Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null);
 
     /// <summary>
     /// MAX(alert_time) filtered to a *successful webhook send* — seeds the webhook
@@ -48,8 +54,13 @@ public interface IAlertHistoryStore
     /// notification_type already implies the webhook delivered (it's only written on a
     /// successful post), and send_error tracks the EMAIL channel, so it is NOT filtered on.
     /// Lite: notification_type IN ('webhook','email+webhook'). Dash: NotificationType == "webhook".
+    /// <para>
+    /// When <paramref name="dedupKey"/> is non-null (#1154 per-fingerprint cooldown), the result is
+    /// additionally restricted to rows whose persisted <c>ContextJson</c> carries that #1140 dedup
+    /// fingerprint. Null = the metric-level seed (the pre-#1154 behavior).
+    /// </para>
     /// </summary>
-    Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName);
+    Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null);
 
     /// <summary>
     /// MAX(alert_time) UNFILTERED (any channel/result) — seeds the analysis

--- a/PerformanceMonitor.Notifications/IncidentCooldown.cs
+++ b/PerformanceMonitor.Notifications/IncidentCooldown.cs
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Per-incident-fingerprint delivery cooldown shared by the email (<see cref="EmailSendCore"/>) and
+/// webhook (<see cref="WebhookAlertService"/>) send paths (#1154). Replaces the old per-
+/// (serverId, metricName) cooldown that silently dropped a genuinely distinct incident arriving inside
+/// the window: the cooldown is now keyed per #1140 dedup fingerprint, so a DISTINCT fingerprint is
+/// delivered while a REPEAT of the same fingerprint stays suppressed (#1091). Alerts with no
+/// fingerprintable incidents (Incidents null/empty — CPU/memory/poison-wait/tempdb/failed-job) fall back
+/// to the metric-level key, byte-identical to the pre-#1154 behavior.
+/// </summary>
+public sealed class IncidentCooldown
+{
+    private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+    private readonly string _keyPrefix;
+    private readonly Func<string, string, string?, Task<DateTime?>>? _seedLastSentUtc;
+
+    /// <param name="keyPrefix">
+    /// Per-channel prefix so the two channels' keys never collide in shape: <c>""</c> for email,
+    /// <c>"webhook:"</c> for the webhook path (matching the pre-#1154 key strings).
+    /// </param>
+    /// <param name="seedLastSentUtc">
+    /// Lazy restart seed: <c>(serverId, metricName, dedupKey) =&gt;</c> the last successful send time for
+    /// that key, or <c>null</c> if none. <c>dedupKey</c> is <c>null</c> for the metric-level fallback. A
+    /// <c>null</c> delegate disables seeding entirely (the webhook no-store path — preserves
+    /// <c>WebhookCooldownSeedTests.NullHistoryStore_NoSeed_AttemptsPost</c>).
+    /// </param>
+    public IncidentCooldown(string keyPrefix, Func<string, string, string?, Task<DateTime?>>? seedLastSentUtc)
+    {
+        _keyPrefix = keyPrefix;
+        _seedLastSentUtc = seedLastSentUtc;
+    }
+
+    /// <summary>
+    /// Decides whether to send, seeding unseen keys from history and evicting stale keys first. Does NOT
+    /// stamp — the caller stamps via <see cref="Stamp"/> only after a successful send, so a failed send
+    /// never starts the cooldown. Sends when AT LEAST ONE candidate key is fresh (outside the window); a
+    /// successful send then stamps EVERY candidate key, so an in-cooldown incident that rode along on a
+    /// fresh sibling has its timer refreshed and never re-alerts standalone next cycle.
+    /// </summary>
+    public async Task<Decision> EvaluateAsync(
+        string serverId, string metricName, IReadOnlyList<AlertIncident>? incidents, TimeSpan window)
+    {
+        var now = DateTime.UtcNow;
+        Evict(now, window);
+
+        var keys = BuildKeys(serverId, metricName, incidents);
+
+        bool anyFresh = false;
+        foreach (var (key, dedupKey) in keys)
+        {
+            if (_seedLastSentUtc is not null && !_cooldowns.ContainsKey(key))
+            {
+                var lastSent = await _seedLastSentUtc(serverId, metricName, dedupKey);
+                if (lastSent.HasValue)
+                    _cooldowns.TryAdd(key, lastSent.Value);
+            }
+
+            if (!_cooldowns.TryGetValue(key, out var last) || now - last >= window)
+                anyFresh = true;
+        }
+
+        return new Decision(anyFresh, keys.Select(k => k.Key).ToList(), now);
+    }
+
+    /// <summary>
+    /// Stamps every candidate key from a <see cref="Decision"/> to its evaluation time. Call ONLY after a
+    /// successful send (a failed send must not start the cooldown).
+    /// </summary>
+    public void Stamp(Decision decision)
+    {
+        foreach (var key in decision.Keys)
+            _cooldowns[key] = decision.EvaluatedAtUtc;
+    }
+
+    // Distinct non-blank fingerprints -> one "{prefix}{server}:{metric}:{dedupKey}" key each; no
+    // fingerprint -> the single "{prefix}{server}:{metric}" fallback key (pre-#1154 behavior). A blank
+    // DedupKey can't occur (AlertFingerprint returns null incidents, filtered upstream) but is excluded
+    // defensively so it never produces a "…::" key.
+    private List<(string Key, string? DedupKey)> BuildKeys(
+        string serverId, string metricName, IReadOnlyList<AlertIncident>? incidents)
+    {
+        var dedupKeys = incidents?
+            .Select(i => i.DedupKey)
+            .Where(k => !string.IsNullOrEmpty(k))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (dedupKeys is { Count: > 0 })
+            return dedupKeys
+                .Select(d => ($"{_keyPrefix}{serverId}:{metricName}:{d}", (string?)d))
+                .ToList();
+
+        return new List<(string, string?)> { ($"{_keyPrefix}{serverId}:{metricName}", (string?)null) };
+    }
+
+    /* Drop entries past 2x the window so the per-fingerprint dict stays bounded — any entry past 1x is
+       already re-fire-eligible, so doubling only adds clock-skew margin and can never evict a key that
+       could still suppress. A key dropped here that later recurs is re-seeded from history on next touch;
+       that's a wash, not a bug. Mirrors AnalysisNotificationService's prune idiom. */
+    private void Evict(DateTime now, TimeSpan window)
+    {
+        var pruneBefore = now - TimeSpan.FromTicks(window.Ticks * 2);
+        foreach (var entry in _cooldowns)
+        {
+            if (entry.Value < pruneBefore)
+                _cooldowns.TryRemove(entry.Key, out _);
+        }
+    }
+
+    /// <summary>Live key count, for tests asserting eviction keeps the dict bounded.</summary>
+    internal int TrackedKeyCount => _cooldowns.Count;
+
+    /// <summary>The send decision plus the candidate keys to stamp on a successful send.</summary>
+    public sealed record Decision(bool ShouldSend, IReadOnlyList<string> Keys, DateTime EvaluatedAtUtc);
+}

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -37,11 +37,14 @@ public class WebhookAlertService
     private const string TsqlWebhookHint = "See email or in-app Alert Details for the copy-paste T-SQL.";
     private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = null };
 
-    private readonly ConcurrentDictionary<string, DateTime> _cooldowns = new();
+    /* #1154: per-incident-fingerprint cooldown (was a per-(serverId, metricName)
+       ConcurrentDictionary). Keyed per #1140 dedup fingerprint so a distinct incident in the
+       window is delivered; falls back to the metric-level key when an alert carries no
+       fingerprintable incident. */
+    private readonly IncidentCooldown _cooldown;
     private readonly IAlertSettings _settings;
     private readonly AlertBranding _branding;
     private readonly ILogger<WebhookAlertService> _logger;
-    private readonly IAlertHistoryStore? _historyStore;
 
     private int _consecutiveTeamsFailures;
     private string? _lastTeamsError;
@@ -49,9 +52,9 @@ public class WebhookAlertService
     private string? _lastSlackError;
 
     /// <param name="historyStore">
-    /// Optional alert-history store used to seed the per-(serverId, metricName) webhook
-    /// cooldown across an app restart (#1145, mirroring the email seed #981). When null the
-    /// cooldown is purely in-memory (the pre-#1145 behavior) — the test call sites pass null.
+    /// Optional alert-history store used to seed the per-fingerprint webhook cooldown across an app
+    /// restart (#1145, mirroring the email seed #981). When null the cooldown is purely in-memory
+    /// (the pre-#1145 behavior, seeding disabled) — the test call sites pass null.
     /// </param>
     public WebhookAlertService(
         IAlertSettings settings,
@@ -62,7 +65,13 @@ public class WebhookAlertService
         _settings = settings;
         _branding = branding;
         _logger = logger;
-        _historyStore = historyStore;
+        _cooldown = new IncidentCooldown(
+            keyPrefix: "webhook:",
+            // Null store -> null seed delegate -> no restart seeding (preserves the pre-#1145 in-memory path).
+            seedLastSentUtc: historyStore is null
+                ? null
+                : (serverId, metricName, dedupKey) =>
+                    historyStore.GetLastWebhookSentUtcAsync(serverId, metricName, dedupKey));
     }
 
     /// <summary>
@@ -79,23 +88,16 @@ public class WebhookAlertService
     {
         try
         {
-            var cooldownKey = $"webhook:{serverId}:{metricName}";
+            /* #1154: per-fingerprint cooldown. Post if any incident in this alert is outside its
+               window (a distinct fingerprint is not throttled by an unrelated prior incident); stamp
+               every candidate key only after a successful post. Seeds the webhook last-sent time from
+               the alert log on first touch per key (#1145), unless the store is null (no seeding). No
+               incidents -> the metric-level fallback key (today's behavior). */
+            var decision = await _cooldown.EvaluateAsync(
+                serverId, metricName, context?.Incidents,
+                TimeSpan.FromMinutes(_settings.EmailCooldownMinutes));
 
-            /* Seed the in-memory cooldown from the alert log the first time this key is
-               seen, so a Teams/Slack alert posted shortly before an app restart is not
-               immediately re-posted afterward (#1145, mirroring the email seed #981). The
-               in-memory dictionary is authoritative once seeded. */
-            if (_historyStore is not null && !_cooldowns.ContainsKey(cooldownKey))
-            {
-                var lastPersistedSend = await _historyStore.GetLastWebhookSentUtcAsync(serverId, metricName);
-                if (lastPersistedSend.HasValue)
-                {
-                    _cooldowns.TryAdd(cooldownKey, lastPersistedSend.Value);
-                }
-            }
-
-            if (_cooldowns.TryGetValue(cooldownKey, out var lastSent) &&
-                DateTime.UtcNow - lastSent < TimeSpan.FromMinutes(_settings.EmailCooldownMinutes))
+            if (!decision.ShouldSend)
             {
                 return false;
             }
@@ -114,7 +116,7 @@ public class WebhookAlertService
 
             if (sent)
             {
-                _cooldowns[cooldownKey] = DateTime.UtcNow;
+                _cooldown.Stamp(decision);
             }
 
             return sent;


### PR DESCRIPTION
Fixes #1154.

## Problem
The email/webhook delivery cooldown was keyed on `(serverId, metricName)`, ignoring the #1140 per-incident dedup fingerprint. A genuinely **distinct** deadlock/blocking/long-running-query/anomalous-job/low-disk incident arriving inside the `EmailCooldownMinutes` window (default 15) was silently dropped from email/Teams/Slack — the tray still fired, so it looked delivered. Per-event mode was worse: each per-incident send shared the one metric key, so the first stamped it and the rest of the cycle was suppressed, collapsing per-event delivery to ~one notification per cycle.

Verified blast radius: five live builders attach `AlertContext.Incidents` in **both** apps (deadlock, blocking, long-running query, anomalous job, low disk) — all five were throttled.

## Fix
New shared `IncidentCooldown` (in `PerformanceMonitor.Notifications`) keyed per fingerprint:
- **Send** if *any* incident in the alert is outside its window (a distinct fingerprint is never throttled by an unrelated prior incident); **stamp every** candidate key on a successful send.
- **Fall back** to the metric-level key when an alert carries no fingerprintable incident (CPU / memory / poison-wait / tempdb / failed-job) — byte-identical to today.
- **Restart seed** (#981 email, #1145 webhook) is now per-fingerprint, reconstructed from the persisted `ContextJson` via an anchored `"DedupKey"` match (null-guarded for the Dashboard scan's many null-context rows). The webhook null-store no-seed path is preserved.
- The per-fingerprint dict is bounded by the **2×-window eviction** idiom reused from `AnalysisNotificationService`.

Both apps and both channels run the **identical** shared decision; only the seed query differs (Lite DuckDB `LIKE` push-down vs Dashboard in-memory scan via the shared helper), both pinned to the real serializer output by tests.

## Out of scope
Failed-job is still non-fingerprinted (it stays on the metric-key fallback). Giving it a `Job` fingerprint by job name — mirroring `BuildAnomalousJobContext` — is a separate small follow-up; this change is forward-compatible with it.

## Testing
- Both apps + both test projects build warning-free (0/0).
- Full suites: **Lite 544/544, Dashboard 488/488**, 0 skipped.
- New/extended coverage: `IncidentCooldownTests` (distinct-delivers, same-suppresses, any-fresh-summary, all-in-cooldown, metric fallback, per-fingerprint seed, null-store no-seed, eviction), `ContextJsonContainsDedupKeyTests` (anchoring + null guards), Lite `StoreRoundTripTests` and Dashboard `JsonAlertHistoryStoreDedupKeyTests` (per-fingerprint seed filter, both channels, null-context rows excluded).
- **Not** live-smoke-tested (no email/Teams infra locally) — the decisive end-to-end check is two distinct deadlocks within the window both reaching Teams/email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
