### PR TITLE
Share FactCollector pure helpers across Lite/Dashboard

### DIFF
--- a/Dashboard/Analysis/SqlServerFactCollector.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.cs
@@ -28,8 +28,8 @@ public class SqlServerFactCollector : IFactCollector
         var facts = new List<Fact>();
 
         await CollectWaitStatsFactsAsync(context, facts);
-        GroupGeneralLockWaits(facts, context);
-        GroupParallelismWaits(facts, context);
+        FactCollectorHelpers.GroupGeneralLockWaits(facts, context);
+        FactCollectorHelpers.GroupParallelismWaits(facts, context);
         await CollectBlockingFactsAsync(context, facts);
         await CollectDeadlockFactsAsync(context, facts);
         await CollectServerConfigFactsAsync(context, facts);
@@ -2094,76 +2094,11 @@ SELECT
             // WS5 server-health advisories (advise-only). Gating lives here so a fact that would
             // score 0 is simply never emitted (noise control); the scorer then scores the emitted
             // fact's Value. Shared with Lite — keep the rules identical (see DuckDbFactCollector).
-            EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
+            FactCollectorHelpers.EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
         }
         catch (Exception ex)
         {
             Logger.Error("SqlServerFactCollector.CollectServerPropertiesFactsAsync failed", ex);
-        }
-    }
-
-    // RAM floor below which LPIM-off is not worth flagging — on a small buffer pool the OS paging
-    // SQL out is not the practical risk it is on a large dedicated host. Shared rule with Lite.
-    private const long LpimAdvisoryMinPhysicalMemoryMb = 32 * 1024;
-
-    /// <summary>
-    /// Emits the WS5 advise-only server-health facts (IFI off / LPIM off / memory dumps) from the
-    /// latest server_properties values, applying the noise-control gating both apps share:
-    ///   • IFI: emit whenever the value is known (Value = enabled bit) — universally good advice.
-    ///   • LPIM: emit only on non-Express editions with meaningful RAM (Value = enabled bit) — so a
-    ///     tiny instance never flags. When LPIM is ON the emitted Value scores 0 (harmless).
-    ///   • Dumps: emit whenever the count is known (Value = count) — the scorer flags count > 0.
-    /// </summary>
-    private static void EmitServerHealthFacts(
-        AnalysisContext context, List<Fact> facts, string edition, long physicalMemMb,
-        bool? lockPagesInMemory, bool? instantFileInit, int? memoryDumpCount)
-    {
-        var isExpress = edition.Contains("Express", StringComparison.OrdinalIgnoreCase);
-
-        if (instantFileInit.HasValue)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "CONFIG_IFI_DISABLED",
-                Value = instantFileInit.Value ? 1 : 0,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["instant_file_initialization_enabled"] = instantFileInit.Value ? 1 : 0
-                }
-            });
-        }
-
-        if (lockPagesInMemory.HasValue && !isExpress && physicalMemMb >= LpimAdvisoryMinPhysicalMemoryMb)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "CONFIG_LPIM_DISABLED",
-                Value = lockPagesInMemory.Value ? 1 : 0,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["lock_pages_in_memory"] = lockPagesInMemory.Value ? 1 : 0,
-                    ["physical_memory_mb"] = physicalMemMb
-                }
-            });
-        }
-
-        if (memoryDumpCount.HasValue)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "SERVER_MEMORY_DUMPS",
-                Value = memoryDumpCount.Value,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["memory_dump_count"] = memoryDumpCount.Value
-                }
-            });
         }
     }
 
@@ -2317,114 +2252,4 @@ FROM latest WHERE rn = 1";
         }
     }
 
-    /// <summary>
-    /// Groups general lock waits (X, U, IX, SIX, BU, IU, UIX, etc.) into a single "LCK" fact.
-    /// Keeps individual facts for:
-    ///   - LCK_M_S, LCK_M_IS (reader/writer blocking -- RCSI signal)
-    ///   - LCK_M_RS_*, LCK_M_RIn_*, LCK_M_RX_* (serializable/repeatable read signal)
-    ///   - SCH_M, SCH_S (schema locks -- DDL/index operations)
-    /// Individual constituent wait times are preserved in metadata as "{type}_ms" keys.
-    /// </summary>
-    private static void GroupGeneralLockWaits(List<Fact> facts, AnalysisContext context)
-    {
-        var generalLocks = facts.Where(f => f.Source == "waits" && IsGeneralLockWait(f.Key)).ToList();
-        if (generalLocks.Count == 0) return;
-
-        var totalWaitTimeMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
-        var totalWaitingTasks = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
-        var totalSignalMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
-        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
-        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
-
-        var metadata = new Dictionary<string, double>
-        {
-            ["wait_time_ms"] = totalWaitTimeMs,
-            ["waiting_tasks_count"] = totalWaitingTasks,
-            ["signal_wait_time_ms"] = totalSignalMs,
-            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
-            ["avg_ms_per_wait"] = avgMsPerWait,
-            ["period_duration_ms"] = context.PeriodDurationMs,
-            ["lock_type_count"] = generalLocks.Count
-        };
-
-        // Preserve individual constituent wait times for detailed analysis
-        foreach (var lck in generalLocks)
-            metadata[$"{lck.Key}_ms"] = lck.Metadata.GetValueOrDefault("wait_time_ms");
-
-        // Remove individual facts, add grouped fact
-        foreach (var lck in generalLocks)
-            facts.Remove(lck);
-
-        facts.Add(new Fact
-        {
-            Source = "waits",
-            Key = "LCK",
-            Value = fractionOfPeriod,
-            ServerId = context.ServerId,
-            Metadata = metadata
-        });
-    }
-
-    /// <summary>
-    /// Groups all CX* parallelism waits (CXPACKET, CXCONSUMER, CXSYNC_PORT, CXSYNC_CONSUMER, etc.)
-    /// into a single "CXPACKET" fact. They all indicate the same thing: parallel queries are running.
-    /// Individual wait times are preserved in metadata for detailed analysis.
-    /// </summary>
-    private static void GroupParallelismWaits(List<Fact> facts, AnalysisContext context)
-    {
-        var cxWaits = facts.Where(f => f.Source == "waits" && f.Key.StartsWith("CX", StringComparison.Ordinal)).ToList();
-        if (cxWaits.Count <= 1) return;
-
-        var totalWaitTimeMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
-        var totalWaitingTasks = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
-        var totalSignalMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
-        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
-        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
-
-        var metadata = new Dictionary<string, double>
-        {
-            ["wait_time_ms"] = totalWaitTimeMs,
-            ["waiting_tasks_count"] = totalWaitingTasks,
-            ["signal_wait_time_ms"] = totalSignalMs,
-            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
-            ["avg_ms_per_wait"] = avgMsPerWait,
-            ["period_duration_ms"] = context.PeriodDurationMs
-        };
-
-        // Preserve individual constituent wait times for detailed analysis
-        foreach (var cx in cxWaits)
-            metadata[$"{cx.Key}_ms"] = cx.Metadata.GetValueOrDefault("wait_time_ms");
-
-        foreach (var cx in cxWaits)
-            facts.Remove(cx);
-
-        facts.Add(new Fact
-        {
-            Source = "waits",
-            Key = "CXPACKET",
-            Value = fractionOfPeriod,
-            ServerId = cxWaits[0].ServerId,
-            Metadata = metadata
-        });
-    }
-
-    /// <summary>
-    /// Returns true for general lock waits that should be grouped into "LCK".
-    /// Excludes reader locks (S, IS), range locks (RS_*, RIn_*, RX_*), and schema locks.
-    /// </summary>
-    private static bool IsGeneralLockWait(string waitType)
-    {
-        if (!waitType.StartsWith("LCK_M_", StringComparison.OrdinalIgnoreCase)) return false;
-
-        // Keep individual: reader/writer locks
-        if (waitType is "LCK_M_S" or "LCK_M_IS") return false;
-
-        // Keep individual: range locks (serializable/repeatable read)
-        if (waitType.StartsWith("LCK_M_RS_", StringComparison.OrdinalIgnoreCase) ||
-            waitType.StartsWith("LCK_M_RIn_", StringComparison.OrdinalIgnoreCase) ||
-            waitType.StartsWith("LCK_M_RX_", StringComparison.OrdinalIgnoreCase)) return false;
-
-        // Everything else (X, U, IX, SIX, BU, IU, UIX, etc.) -> group
-        return true;
-    }
 }

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -28,8 +28,8 @@ public class DuckDbFactCollector : IFactCollector
         var facts = new List<Fact>();
 
         await CollectWaitStatsFactsAsync(context, facts);
-        GroupGeneralLockWaits(facts, context);
-        GroupParallelismWaits(facts, context);
+        FactCollectorHelpers.GroupGeneralLockWaits(facts, context);
+        FactCollectorHelpers.GroupParallelismWaits(facts, context);
         await CollectBlockingFactsAsync(context, facts);
         await CollectBlockingChainFactsAsync(context, facts);
         await CollectDeadlockFactsAsync(context, facts);
@@ -1891,73 +1891,9 @@ LIMIT 1";
             // WS5 server-health advisories (advise-only). Gating mirrors the Dashboard collector so
             // both apps agree on what is worth flagging; a fact that would score 0 is simply never
             // emitted (noise control).
-            EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
+            FactCollectorHelpers.EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
         }
         catch { /* Table may not exist or have no data */ }
-    }
-
-    // RAM floor below which LPIM-off is not worth flagging — shared rule with the Dashboard
-    // SqlServerFactCollector (small buffer pools do not suffer from OS paging the way large ones do).
-    private const long LpimAdvisoryMinPhysicalMemoryMb = 32 * 1024;
-
-    /// <summary>
-    /// Emits the WS5 advise-only server-health facts (IFI off / LPIM off / memory dumps) from the
-    /// latest server_properties values, applying the same noise-control gating as the Dashboard:
-    ///   • IFI: emit whenever the value is known (Value = enabled bit) — universally good advice.
-    ///   • LPIM: emit only on non-Express editions with meaningful RAM (Value = enabled bit).
-    ///   • Dumps: emit whenever the count is known (Value = count) — the scorer flags count > 0.
-    /// </summary>
-    private static void EmitServerHealthFacts(
-        AnalysisContext context, List<Fact> facts, string edition, long physicalMemMb,
-        bool? lockPagesInMemory, bool? instantFileInit, int? memoryDumpCount)
-    {
-        var isExpress = edition.Contains("Express", StringComparison.OrdinalIgnoreCase);
-
-        if (instantFileInit.HasValue)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "CONFIG_IFI_DISABLED",
-                Value = instantFileInit.Value ? 1 : 0,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["instant_file_initialization_enabled"] = instantFileInit.Value ? 1 : 0
-                }
-            });
-        }
-
-        if (lockPagesInMemory.HasValue && !isExpress && physicalMemMb >= LpimAdvisoryMinPhysicalMemoryMb)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "CONFIG_LPIM_DISABLED",
-                Value = lockPagesInMemory.Value ? 1 : 0,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["lock_pages_in_memory"] = lockPagesInMemory.Value ? 1 : 0,
-                    ["physical_memory_mb"] = physicalMemMb
-                }
-            });
-        }
-
-        if (memoryDumpCount.HasValue)
-        {
-            facts.Add(new Fact
-            {
-                Source = "config",
-                Key = "SERVER_MEMORY_DUMPS",
-                Value = memoryDumpCount.Value,
-                ServerId = context.ServerId,
-                Metadata = new Dictionary<string, double>
-                {
-                    ["memory_dump_count"] = memoryDumpCount.Value
-                }
-            });
-        }
     }
 
     /// <summary>
@@ -2104,117 +2040,6 @@ FROM latest WHERE rn = 1";
             });
         }
         catch { /* Table may not exist or have no data */ }
-    }
-
-    /// <summary>
-    /// Groups general lock waits (X, U, IX, SIX, BU, IU, UIX, etc.) into a single "LCK" fact.
-    /// Keeps individual facts for:
-    ///   - LCK_M_S, LCK_M_IS (reader/writer blocking — RCSI signal)
-    ///   - LCK_M_RS_*, LCK_M_RIn_*, LCK_M_RX_* (serializable/repeatable read signal)
-    ///   - SCH_M, SCH_S (schema locks — DDL/index operations)
-    /// Individual constituent wait times are preserved in metadata as "{type}_ms" keys.
-    /// </summary>
-    private static void GroupGeneralLockWaits(List<Fact> facts, AnalysisContext context)
-    {
-        var generalLocks = facts.Where(f => f.Source == "waits" && IsGeneralLockWait(f.Key)).ToList();
-        if (generalLocks.Count == 0) return;
-
-        var totalWaitTimeMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
-        var totalWaitingTasks = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
-        var totalSignalMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
-        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
-        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
-
-        var metadata = new Dictionary<string, double>
-        {
-            ["wait_time_ms"] = totalWaitTimeMs,
-            ["waiting_tasks_count"] = totalWaitingTasks,
-            ["signal_wait_time_ms"] = totalSignalMs,
-            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
-            ["avg_ms_per_wait"] = avgMsPerWait,
-            ["period_duration_ms"] = context.PeriodDurationMs,
-            ["lock_type_count"] = generalLocks.Count
-        };
-
-        // Preserve individual constituent wait times for detailed analysis
-        foreach (var lck in generalLocks)
-            metadata[$"{lck.Key}_ms"] = lck.Metadata.GetValueOrDefault("wait_time_ms");
-
-        // Remove individual facts, add grouped fact
-        foreach (var lck in generalLocks)
-            facts.Remove(lck);
-
-        facts.Add(new Fact
-        {
-            Source = "waits",
-            Key = "LCK",
-            Value = fractionOfPeriod,
-            ServerId = context.ServerId,
-            Metadata = metadata
-        });
-    }
-
-    /// <summary>
-    /// Groups all CX* parallelism waits (CXPACKET, CXCONSUMER, CXSYNC_PORT, CXSYNC_CONSUMER, etc.)
-    /// into a single "CXPACKET" fact. They all indicate the same thing: parallel queries are running.
-    /// Individual wait times are preserved in metadata for detailed analysis.
-    /// </summary>
-    private static void GroupParallelismWaits(List<Fact> facts, AnalysisContext context)
-    {
-        var cxWaits = facts.Where(f => f.Source == "waits" && f.Key.StartsWith("CX", StringComparison.Ordinal)).ToList();
-        if (cxWaits.Count <= 1) return;
-
-        var totalWaitTimeMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
-        var totalWaitingTasks = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
-        var totalSignalMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
-        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
-        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
-
-        var metadata = new Dictionary<string, double>
-        {
-            ["wait_time_ms"] = totalWaitTimeMs,
-            ["waiting_tasks_count"] = totalWaitingTasks,
-            ["signal_wait_time_ms"] = totalSignalMs,
-            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
-            ["avg_ms_per_wait"] = avgMsPerWait,
-            ["period_duration_ms"] = context.PeriodDurationMs
-        };
-
-        // Preserve individual constituent wait times for detailed analysis
-        foreach (var cx in cxWaits)
-            metadata[$"{cx.Key}_ms"] = cx.Metadata.GetValueOrDefault("wait_time_ms");
-
-        foreach (var cx in cxWaits)
-            facts.Remove(cx);
-
-        facts.Add(new Fact
-        {
-            Source = "waits",
-            Key = "CXPACKET",
-            Value = fractionOfPeriod,
-            ServerId = cxWaits[0].ServerId,
-            Metadata = metadata
-        });
-    }
-
-    /// <summary>
-    /// Returns true for general lock waits that should be grouped into "LCK".
-    /// Excludes reader locks (S, IS), range locks (RS_*, RIn_*, RX_*), and schema locks.
-    /// </summary>
-    private static bool IsGeneralLockWait(string waitType)
-    {
-        if (!waitType.StartsWith("LCK_M_", StringComparison.OrdinalIgnoreCase)) return false;
-
-        // Keep individual: reader/writer locks
-        if (waitType is "LCK_M_S" or "LCK_M_IS") return false;
-
-        // Keep individual: range locks (serializable/repeatable read)
-        if (waitType.StartsWith("LCK_M_RS_", StringComparison.OrdinalIgnoreCase) ||
-            waitType.StartsWith("LCK_M_RIn_", StringComparison.OrdinalIgnoreCase) ||
-            waitType.StartsWith("LCK_M_RX_", StringComparison.OrdinalIgnoreCase)) return false;
-
-        // Everything else (X, U, IX, SIX, BU, IU, UIX, etc.) → group
-        return true;
     }
 
     private static long ToInt64(object value)

--- a/PerformanceMonitor.Analysis/FactCollectorHelpers.cs
+++ b/PerformanceMonitor.Analysis/FactCollectorHelpers.cs
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Pure, data-source-agnostic fact-shaping helpers shared by the per-app fact collectors
+/// (Dashboard's SqlServerFactCollector and Lite's DuckDbFactCollector). These operate only on the
+/// already-collected <see cref="Fact"/> list plus <see cref="AnalysisContext"/>, so both apps emit
+/// and group facts identically regardless of where the underlying data was read from. Keeping one
+/// copy here prevents the two collectors from drifting apart.
+/// </summary>
+public static class FactCollectorHelpers
+{
+    /// <summary>
+    /// RAM floor below which LPIM-off is not worth flagging — on a small buffer pool the OS paging
+    /// SQL out is not the practical risk it is on a large dedicated host.
+    /// </summary>
+    public const long LpimAdvisoryMinPhysicalMemoryMb = 32 * 1024;
+
+    /// <summary>
+    /// Emits the WS5 advise-only server-health facts (IFI off / LPIM off / memory dumps) from the
+    /// latest server_properties values, applying the noise-control gating both apps share:
+    ///   • IFI: emit whenever the value is known (Value = enabled bit) — universally good advice.
+    ///   • LPIM: emit only on non-Express editions with meaningful RAM (Value = enabled bit) — so a
+    ///     tiny instance never flags. When LPIM is ON the emitted Value scores 0 (harmless).
+    ///   • Dumps: emit whenever the count is known (Value = count) — the scorer flags count > 0.
+    /// </summary>
+    public static void EmitServerHealthFacts(
+        AnalysisContext context, List<Fact> facts, string edition, long physicalMemMb,
+        bool? lockPagesInMemory, bool? instantFileInit, int? memoryDumpCount)
+    {
+        var isExpress = edition.Contains("Express", StringComparison.OrdinalIgnoreCase);
+
+        if (instantFileInit.HasValue)
+        {
+            facts.Add(new Fact
+            {
+                Source = "config",
+                Key = "CONFIG_IFI_DISABLED",
+                Value = instantFileInit.Value ? 1 : 0,
+                ServerId = context.ServerId,
+                Metadata = new Dictionary<string, double>
+                {
+                    ["instant_file_initialization_enabled"] = instantFileInit.Value ? 1 : 0
+                }
+            });
+        }
+
+        if (lockPagesInMemory.HasValue && !isExpress && physicalMemMb >= LpimAdvisoryMinPhysicalMemoryMb)
+        {
+            facts.Add(new Fact
+            {
+                Source = "config",
+                Key = "CONFIG_LPIM_DISABLED",
+                Value = lockPagesInMemory.Value ? 1 : 0,
+                ServerId = context.ServerId,
+                Metadata = new Dictionary<string, double>
+                {
+                    ["lock_pages_in_memory"] = lockPagesInMemory.Value ? 1 : 0,
+                    ["physical_memory_mb"] = physicalMemMb
+                }
+            });
+        }
+
+        if (memoryDumpCount.HasValue)
+        {
+            facts.Add(new Fact
+            {
+                Source = "config",
+                Key = "SERVER_MEMORY_DUMPS",
+                Value = memoryDumpCount.Value,
+                ServerId = context.ServerId,
+                Metadata = new Dictionary<string, double>
+                {
+                    ["memory_dump_count"] = memoryDumpCount.Value
+                }
+            });
+        }
+    }
+
+    /// <summary>
+    /// Groups general lock waits (X, U, IX, SIX, BU, IU, UIX, etc.) into a single "LCK" fact.
+    /// Keeps individual facts for:
+    ///   - LCK_M_S, LCK_M_IS (reader/writer blocking — RCSI signal)
+    ///   - LCK_M_RS_*, LCK_M_RIn_*, LCK_M_RX_* (serializable/repeatable read signal)
+    ///   - SCH_M, SCH_S (schema locks — DDL/index operations)
+    /// Individual constituent wait times are preserved in metadata as "{type}_ms" keys.
+    /// </summary>
+    public static void GroupGeneralLockWaits(List<Fact> facts, AnalysisContext context)
+    {
+        var generalLocks = facts.Where(f => f.Source == "waits" && IsGeneralLockWait(f.Key)).ToList();
+        if (generalLocks.Count == 0) return;
+
+        var totalWaitTimeMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
+        var totalWaitingTasks = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
+        var totalSignalMs = generalLocks.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
+        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
+        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
+
+        var metadata = new Dictionary<string, double>
+        {
+            ["wait_time_ms"] = totalWaitTimeMs,
+            ["waiting_tasks_count"] = totalWaitingTasks,
+            ["signal_wait_time_ms"] = totalSignalMs,
+            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
+            ["avg_ms_per_wait"] = avgMsPerWait,
+            ["period_duration_ms"] = context.PeriodDurationMs,
+            ["lock_type_count"] = generalLocks.Count
+        };
+
+        // Preserve individual constituent wait times for detailed analysis
+        foreach (var lck in generalLocks)
+            metadata[$"{lck.Key}_ms"] = lck.Metadata.GetValueOrDefault("wait_time_ms");
+
+        // Remove individual facts, add grouped fact
+        foreach (var lck in generalLocks)
+            facts.Remove(lck);
+
+        facts.Add(new Fact
+        {
+            Source = "waits",
+            Key = "LCK",
+            Value = fractionOfPeriod,
+            ServerId = context.ServerId,
+            Metadata = metadata
+        });
+    }
+
+    /// <summary>
+    /// Groups all CX* parallelism waits (CXPACKET, CXCONSUMER, CXSYNC_PORT, CXSYNC_CONSUMER, etc.)
+    /// into a single "CXPACKET" fact. They all indicate the same thing: parallel queries are running.
+    /// Individual wait times are preserved in metadata for detailed analysis.
+    /// </summary>
+    public static void GroupParallelismWaits(List<Fact> facts, AnalysisContext context)
+    {
+        var cxWaits = facts.Where(f => f.Source == "waits" && f.Key.StartsWith("CX", StringComparison.Ordinal)).ToList();
+        if (cxWaits.Count <= 1) return;
+
+        var totalWaitTimeMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("wait_time_ms"));
+        var totalWaitingTasks = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("waiting_tasks_count"));
+        var totalSignalMs = cxWaits.Sum(f => f.Metadata.GetValueOrDefault("signal_wait_time_ms"));
+        var avgMsPerWait = totalWaitingTasks > 0 ? totalWaitTimeMs / totalWaitingTasks : 0;
+        var fractionOfPeriod = totalWaitTimeMs / context.PeriodDurationMs;
+
+        var metadata = new Dictionary<string, double>
+        {
+            ["wait_time_ms"] = totalWaitTimeMs,
+            ["waiting_tasks_count"] = totalWaitingTasks,
+            ["signal_wait_time_ms"] = totalSignalMs,
+            ["resource_wait_time_ms"] = totalWaitTimeMs - totalSignalMs,
+            ["avg_ms_per_wait"] = avgMsPerWait,
+            ["period_duration_ms"] = context.PeriodDurationMs
+        };
+
+        // Preserve individual constituent wait times for detailed analysis
+        foreach (var cx in cxWaits)
+            metadata[$"{cx.Key}_ms"] = cx.Metadata.GetValueOrDefault("wait_time_ms");
+
+        foreach (var cx in cxWaits)
+            facts.Remove(cx);
+
+        facts.Add(new Fact
+        {
+            Source = "waits",
+            Key = "CXPACKET",
+            Value = fractionOfPeriod,
+            ServerId = cxWaits[0].ServerId,
+            Metadata = metadata
+        });
+    }
+
+    /// <summary>
+    /// Returns true for general lock waits that should be grouped into "LCK".
+    /// Excludes reader locks (S, IS), range locks (RS_*, RIn_*, RX_*), and schema locks.
+    /// </summary>
+    private static bool IsGeneralLockWait(string waitType)
+    {
+        if (!waitType.StartsWith("LCK_M_", StringComparison.OrdinalIgnoreCase)) return false;
+
+        // Keep individual: reader/writer locks
+        if (waitType is "LCK_M_S" or "LCK_M_IS") return false;
+
+        // Keep individual: range locks (serializable/repeatable read)
+        if (waitType.StartsWith("LCK_M_RS_", StringComparison.OrdinalIgnoreCase) ||
+            waitType.StartsWith("LCK_M_RIn_", StringComparison.OrdinalIgnoreCase) ||
+            waitType.StartsWith("LCK_M_RX_", StringComparison.OrdinalIgnoreCase)) return false;
+
+        // Everything else (X, U, IX, SIX, BU, IU, UIX, etc.) -> group
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Second wave of the Lite↔Dashboard code-sharing follow-up. The Dashboard `SqlServerFactCollector` and Lite `DuckDbFactCollector` each carried **byte-identical, data-source-agnostic** fact-shaping helpers (verified by reading both). Moved them to a single `PerformanceMonitor.Analysis.FactCollectorHelpers` so the two collectors can't drift:

- `EmitServerHealthFacts` (WS5 IFI / LPIM / memory-dump advisories) + the `LpimAdvisoryMinPhysicalMemoryMb` RAM-floor const
- `GroupGeneralLockWaits` / `IsGeneralLockWait` (LCK grouping)
- `GroupParallelismWaits` (CX* grouping)

These operate only on the already-collected `Fact` list + `AnalysisContext`, so **no new project dependencies** are needed — the helper lives in `Analysis`, where `Fact`/`AnalysisContext` already are. Both collectors now call `FactCollectorHelpers.*`.

## Test plan
- [x] `dotnet build PerformanceMonitor.sln` — succeeds, no errors/warnings
- [x] `Dashboard.Tests` — **488 passed**
- [x] `Lite.Tests` — **544 passed** (exercises the collectors via FactCollectorMisery/Scenario tests)
- [x] `Installer.Tests` — **80 passed**
- [x] Pure refactor — moved identical code, no behavior change

## Follow-ups
McpPlanTools `BuildAnalysisResult`/`CollectNodes` is also byte-identical but its natural home (`PlanAnalysis`) has **no project references** and the method needs `McpHelpers` (in Common) — so sharing it requires adding a PlanAnalysis→Common dependency (a structural decision), deferred to a separate PR. Remaining: ServerConnectionStatus, DataGridFilterService/Manager, and the decision-carrying items (ActualPlanExecutor, PlanIconMapper, ReproScriptBuilder, CredentialService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)