### PR TITLE
Stop integration tests from leaking orphaned Agent jobs on real instances

### DIFF
--- a/Installer.Tests/AdversarialTests.cs
+++ b/Installer.Tests/AdversarialTests.cs
@@ -510,9 +510,17 @@ IF DB_ID(N'PerformanceMonitor_RestrictedTest') IS NULL
             {
                 var name = Path.GetFileName(f);
                 if (!pattern.IsMatch(name)) return false;
+                // Server-scoped scripts create instance-wide objects (SQL Agent jobs,
+                // server-level XE sessions, sp_configure) that can't be namespaced to the
+                // test database. Run against a real instance they leak orphaned jobs/XE
+                // sessions and clobber a production install's identically-named jobs. Their
+                // errors are already swallowed by IsExpectedTestFailure, so excluding them
+                // loses no real coverage.
                 if (name.StartsWith("00_", StringComparison.Ordinal) ||
                     name.StartsWith("97_", StringComparison.Ordinal) ||
-                    name.StartsWith("99_", StringComparison.Ordinal))
+                    name.StartsWith("99_", StringComparison.Ordinal) ||
+                    name.Equals("21_setup_blocked_process_xe.sql", StringComparison.Ordinal) ||
+                    name.Equals("45_create_agent_jobs.sql", StringComparison.Ordinal))
                     return false;
                 return true;
             })

--- a/Installer.Tests/IdempotencyTests.cs
+++ b/Installer.Tests/IdempotencyTests.cs
@@ -71,9 +71,17 @@ public class IdempotencyTests : IAsyncLifetime
             {
                 var name = Path.GetFileName(f);
                 if (!pattern.IsMatch(name)) return false;
+                // Server-scoped scripts create instance-wide objects (SQL Agent jobs,
+                // server-level XE sessions, sp_configure) that can't be namespaced to the
+                // test database. Run against a real instance they leak orphaned jobs/XE
+                // sessions and clobber a production install's identically-named jobs. Their
+                // errors are already swallowed by IsExpectedTestFailure, so excluding them
+                // loses no real coverage.
                 if (name.StartsWith("00_", StringComparison.Ordinal) ||
                     name.StartsWith("97_", StringComparison.Ordinal) ||
-                    name.StartsWith("99_", StringComparison.Ordinal))
+                    name.StartsWith("99_", StringComparison.Ordinal) ||
+                    name.Equals("21_setup_blocked_process_xe.sql", StringComparison.Ordinal) ||
+                    name.Equals("45_create_agent_jobs.sql", StringComparison.Ordinal))
                     return false;
                 return true;
             })


### PR DESCRIPTION
## Problem

After every release, the three `PerformanceMonitor - *` SQL Agent jobs on sql2022 start failing every minute with `Unable to connect to SQL Server '(local)'` (plus a one-time `Error 596 — session is in kill state`). This has happened three times.

**Root cause — the release test harness, not the product:**

- `release-checklist` §4b runs `dotnet test -c Debug` on `Installer.Tests` locally.
- `IdempotencyTests` and `AdversarialTests` (both `[Trait("Category","Integration")]`) are hardcoded to the **real** `Server=SQL2022;sa` (`TestDatabaseHelper.cs`). They create a `PerformanceMonitor_Test` DB and run the real `install/*.sql` against it after `RewriteForTestDatabase()`.
- That rewrite turns `@database_name = N'PerformanceMonitor'` → `N'PerformanceMonitor_Test'` but **misses the job names** `N'PerformanceMonitor - Collection'` (no closing quote right after the word). So `45_create_agent_jobs.sql` creates jobs with **production names** whose step points at `_Test`, and its drop-by-name logic **clobbers the real install's jobs**.
- Teardown (`DropTestDatabaseAsync`) drops **only** the `_Test` database — leaving the 3 jobs (and the server-level XE sessions + `sp_configure` from `21_setup_blocked_process_xe.sql`) orphaned, pointing at a database that no longer exists.
- The author assumed these creations would fail and be swallowed by `IsExpectedTestFailure` — true on a CI runner, but on a full instance with Agent + sysadmin they **succeed and persist**. CI excludes these tests (`build.yml` `--filter !~IdempotencyTests&!~AdversarialTests`), so it only ever happens locally during the release checklist.

## Fix

Exclude the two **instance-scoped** scripts — `21_setup_blocked_process_xe.sql` and `45_create_agent_jobs.sql` — from `GetFilteredInstallFiles` in both test classes, mirroring the existing `00_/97_/99_` exclusion. Their errors were already swallowed by `IsExpectedTestFailure`, so this **loses no real coverage** while removing the destructive server-scoped side effect and the production-job collision. `44_hung_job_monitor.sql` is DB-scoped (just the proc) and stays.

## Test plan

- [x] `dotnet build Installer.Tests -c Debug` — clean (0 warnings, 0 errors)
- [x] `dotnet test Installer.Tests -c Debug` (IdempotencyTests + AdversarialTests + VersionDetectionTests) — **19/19 pass** against SQL2022
- [x] After a full test run, the real `PerformanceMonitor` Agent jobs **still point at `PerformanceMonitor`** (previously clobbered to `_Test`); `PerformanceMonitor_Test` cleanly gone
- [x] Live cleanup on sql2022: re-ran `install/45_create_agent_jobs.sql` to restore the 3 jobs to the real DB; collectors logging `SUCCESS`, 0 steady-state errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)