### PR TITLE
Share DataGrid column-filter matcher across Lite/Dashboard

### DIFF
--- a/Dashboard/Services/DataGridFilterService.cs
+++ b/Dashboard/Services/DataGridFilterService.cs
@@ -9,7 +9,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Controls;
@@ -99,123 +98,8 @@ namespace PerformanceMonitorDashboard.Services
         /// <param name="item">The data item to check</param>
         /// <param name="filter">The filter state containing operator and value</param>
         /// <returns>True if the value matches the filter, false otherwise</returns>
-        public static bool MatchesFilter(object item, ColumnFilterState filter)
-        {
-            if (item == null || filter == null || !filter.IsActive)
-                return true;
-
-            var property = item.GetType().GetProperty(filter.ColumnName);
-            if (property == null)
-                return true;
-
-            var rawValue = property.GetValue(item);
-
-            // Handle IsEmpty/IsNotEmpty operators first
-            if (filter.Operator == FilterOperator.IsEmpty)
-                return IsValueEmpty(rawValue);
-            if (filter.Operator == FilterOperator.IsNotEmpty)
-                return !IsValueEmpty(rawValue);
-
-            var stringValue = rawValue?.ToString() ?? string.Empty;
-            var filterValue = filter.Value ?? string.Empty;
-
-            // Split comma-separated values for text operators (e.g., "db1, db2")
-            var terms = filterValue.Split(',')
-                .Select(t => t.Trim())
-                .Where(t => !string.IsNullOrEmpty(t))
-                .ToArray();
-
-            if (terms.Length == 0)
-                return true;
-
-            // Text operators match ANY term, NotEquals excludes ALL terms
-            return filter.Operator switch
-            {
-                FilterOperator.Contains => terms.Any(t => stringValue.Contains(t, StringComparison.OrdinalIgnoreCase)),
-                FilterOperator.Equals => terms.Any(t => CompareValues(rawValue, t, (a, b) => a == b)),
-                FilterOperator.NotEquals => terms.All(t => CompareValues(rawValue, t, (a, b) => a != b)),
-                FilterOperator.GreaterThan => CompareNumeric(rawValue, filterValue, (a, b) => a > b),
-                FilterOperator.GreaterThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a >= b),
-                FilterOperator.LessThan => CompareNumeric(rawValue, filterValue, (a, b) => a < b),
-                FilterOperator.LessThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a <= b),
-                FilterOperator.StartsWith => terms.Any(t => stringValue.StartsWith(t, StringComparison.OrdinalIgnoreCase)),
-                FilterOperator.EndsWith => terms.Any(t => stringValue.EndsWith(t, StringComparison.OrdinalIgnoreCase)),
-                _ => true
-            };
-        }
-
-        /// <summary>
-        /// Checks if a value is considered empty (null, empty string, or whitespace).
-        /// </summary>
-        private static bool IsValueEmpty(object? value)
-        {
-            if (value == null)
-                return true;
-            if (value is string str)
-                return string.IsNullOrWhiteSpace(str);
-            return false;
-        }
-
-        /// <summary>
-        /// Compares values with case-insensitive string comparison for non-numeric types.
-        /// </summary>
-        private static bool CompareValues(object? rawValue, string filterValue, Func<int, int, bool> comparison)
-        {
-            if (rawValue == null)
-                return comparison(0, 1); // null is "less than" any value
-
-            var stringValue = rawValue.ToString() ?? string.Empty;
-
-            // Try numeric comparison first
-            if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
-            {
-                return comparison(numericValue.CompareTo(filterNumeric), 0);
-            }
-
-            // Fall back to string comparison
-            return comparison(string.Compare(stringValue, filterValue, StringComparison.OrdinalIgnoreCase), 0);
-        }
-
-        /// <summary>
-        /// Compares values numerically. Returns true if the value can't be parsed (non-numeric values pass through).
-        /// </summary>
-        private static bool CompareNumeric(object? rawValue, string filterValue, Func<decimal, decimal, bool> comparison)
-        {
-            if (rawValue == null)
-                return false;
-
-            var stringValue = rawValue.ToString() ?? string.Empty;
-
-            // Try to parse both values as decimals
-            if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
-            {
-                return comparison(numericValue, filterNumeric);
-            }
-
-            // If we can't parse both as numbers, the filter doesn't match
-            return false;
-        }
-
-        /// <summary>
-        /// Attempts to parse a string as a decimal, handling various formats.
-        /// </summary>
-        private static bool TryParseNumeric(string value, out decimal result)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                result = 0;
-                return false;
-            }
-
-            // Remove common formatting characters (commas, percent signs, currency symbols)
-            var cleanValue = value.Trim()
-                .Replace(",", "")
-                .Replace("%", "")
-                .Replace("$", "")
-                .Replace(" ", "");
-
-            return decimal.TryParse(cleanValue, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-        }
+        public static bool MatchesFilter(object item, ColumnFilterState filter) =>
+            ColumnFilterMatcher.MatchesFilter(item, filter);
 
         /// <summary>
         /// Applies a column-based filter to a DataGrid.

--- a/Lite/Services/DataGridFilterService.cs
+++ b/Lite/Services/DataGridFilterService.cs
@@ -6,120 +6,19 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System;
-using System.Globalization;
-using System.Linq;
-using PerformanceMonitorLite.Models;
 using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
 /// <summary>
-/// Provides operator-based filtering for DataGrid column filters.
+/// Provides operator-based filtering for DataGrid column filters. Forwards to the shared
+/// <see cref="ColumnFilterMatcher"/> so Lite and Dashboard share one matching implementation.
 /// </summary>
 public static class DataGridFilterService
 {
     /// <summary>
     /// Checks if an item matches a ColumnFilterState using operator-based filtering.
     /// </summary>
-    public static bool MatchesFilter(object item, ColumnFilterState filter)
-    {
-        if (item == null || filter == null || !filter.IsActive)
-            return true;
-
-        var property = item.GetType().GetProperty(filter.ColumnName);
-        if (property == null)
-            return true;
-
-        var rawValue = property.GetValue(item);
-
-        /* Handle IsEmpty/IsNotEmpty operators first */
-        if (filter.Operator == FilterOperator.IsEmpty)
-            return IsValueEmpty(rawValue);
-        if (filter.Operator == FilterOperator.IsNotEmpty)
-            return !IsValueEmpty(rawValue);
-
-        var stringValue = rawValue?.ToString() ?? string.Empty;
-        var filterValue = filter.Value ?? string.Empty;
-
-        /* Split comma-separated values for text operators (e.g., "db1, db2") */
-        var terms = filterValue.Split(',')
-            .Select(t => t.Trim())
-            .Where(t => !string.IsNullOrEmpty(t))
-            .ToArray();
-
-        if (terms.Length == 0)
-            return true;
-
-        /* Text operators match ANY term, NotEquals excludes ALL terms */
-        return filter.Operator switch
-        {
-            FilterOperator.Contains => terms.Any(t => stringValue.Contains(t, StringComparison.OrdinalIgnoreCase)),
-            FilterOperator.Equals => terms.Any(t => CompareValues(rawValue, t, (a, b) => a == b)),
-            FilterOperator.NotEquals => terms.All(t => CompareValues(rawValue, t, (a, b) => a != b)),
-            FilterOperator.GreaterThan => CompareNumeric(rawValue, filterValue, (a, b) => a > b),
-            FilterOperator.GreaterThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a >= b),
-            FilterOperator.LessThan => CompareNumeric(rawValue, filterValue, (a, b) => a < b),
-            FilterOperator.LessThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a <= b),
-            FilterOperator.StartsWith => terms.Any(t => stringValue.StartsWith(t, StringComparison.OrdinalIgnoreCase)),
-            FilterOperator.EndsWith => terms.Any(t => stringValue.EndsWith(t, StringComparison.OrdinalIgnoreCase)),
-            _ => true
-        };
-    }
-
-    private static bool IsValueEmpty(object? value)
-    {
-        if (value == null)
-            return true;
-        if (value is string str)
-            return string.IsNullOrWhiteSpace(str);
-        return false;
-    }
-
-    private static bool CompareValues(object? rawValue, string filterValue, Func<int, int, bool> comparison)
-    {
-        if (rawValue == null)
-            return comparison(0, 1);
-
-        var stringValue = rawValue.ToString() ?? string.Empty;
-
-        if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
-        {
-            return comparison(numericValue.CompareTo(filterNumeric), 0);
-        }
-
-        return comparison(string.Compare(stringValue, filterValue, StringComparison.OrdinalIgnoreCase), 0);
-    }
-
-    private static bool CompareNumeric(object? rawValue, string filterValue, Func<decimal, decimal, bool> comparison)
-    {
-        if (rawValue == null)
-            return false;
-
-        var stringValue = rawValue.ToString() ?? string.Empty;
-
-        if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
-        {
-            return comparison(numericValue, filterNumeric);
-        }
-
-        return false;
-    }
-
-    private static bool TryParseNumeric(string value, out decimal result)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            result = 0;
-            return false;
-        }
-
-        var cleanValue = value.Trim()
-            .Replace(",", "")
-            .Replace("%", "")
-            .Replace("$", "")
-            .Replace(" ", "");
-
-        return decimal.TryParse(cleanValue, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-    }
+    public static bool MatchesFilter(object item, ColumnFilterState filter) =>
+        ColumnFilterMatcher.MatchesFilter(item, filter);
 }

--- a/PerformanceMonitor.Common/Services/ColumnFilterMatcher.cs
+++ b/PerformanceMonitor.Common/Services/ColumnFilterMatcher.cs
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// Operator-based matching for popup column filters, shared by Lite and Dashboard.
+/// Pure reflection + value comparison over <see cref="ColumnFilterState"/> /
+/// <see cref="FilterOperator"/> — no WPF dependency — so both apps' DataGridFilterService
+/// forward here instead of each carrying their own (previously byte-identical) copy.
+/// </summary>
+public static class ColumnFilterMatcher
+{
+    /// <summary>
+    /// Checks if an item matches a ColumnFilterState using operator-based filtering.
+    /// </summary>
+    public static bool MatchesFilter(object item, ColumnFilterState filter)
+    {
+        if (item == null || filter == null || !filter.IsActive)
+            return true;
+
+        var property = item.GetType().GetProperty(filter.ColumnName);
+        if (property == null)
+            return true;
+
+        var rawValue = property.GetValue(item);
+
+        // Handle IsEmpty/IsNotEmpty operators first
+        if (filter.Operator == FilterOperator.IsEmpty)
+            return IsValueEmpty(rawValue);
+        if (filter.Operator == FilterOperator.IsNotEmpty)
+            return !IsValueEmpty(rawValue);
+
+        var stringValue = rawValue?.ToString() ?? string.Empty;
+        var filterValue = filter.Value ?? string.Empty;
+
+        // Split comma-separated values for text operators (e.g., "db1, db2")
+        var terms = filterValue.Split(',')
+            .Select(t => t.Trim())
+            .Where(t => !string.IsNullOrEmpty(t))
+            .ToArray();
+
+        if (terms.Length == 0)
+            return true;
+
+        // Text operators match ANY term, NotEquals excludes ALL terms
+        return filter.Operator switch
+        {
+            FilterOperator.Contains => terms.Any(t => stringValue.Contains(t, StringComparison.OrdinalIgnoreCase)),
+            FilterOperator.Equals => terms.Any(t => CompareValues(rawValue, t, (a, b) => a == b)),
+            FilterOperator.NotEquals => terms.All(t => CompareValues(rawValue, t, (a, b) => a != b)),
+            FilterOperator.GreaterThan => CompareNumeric(rawValue, filterValue, (a, b) => a > b),
+            FilterOperator.GreaterThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a >= b),
+            FilterOperator.LessThan => CompareNumeric(rawValue, filterValue, (a, b) => a < b),
+            FilterOperator.LessThanOrEqual => CompareNumeric(rawValue, filterValue, (a, b) => a <= b),
+            FilterOperator.StartsWith => terms.Any(t => stringValue.StartsWith(t, StringComparison.OrdinalIgnoreCase)),
+            FilterOperator.EndsWith => terms.Any(t => stringValue.EndsWith(t, StringComparison.OrdinalIgnoreCase)),
+            _ => true
+        };
+    }
+
+    private static bool IsValueEmpty(object? value)
+    {
+        if (value == null)
+            return true;
+        if (value is string str)
+            return string.IsNullOrWhiteSpace(str);
+        return false;
+    }
+
+    private static bool CompareValues(object? rawValue, string filterValue, Func<int, int, bool> comparison)
+    {
+        if (rawValue == null)
+            return comparison(0, 1); // null is "less than" any value
+
+        var stringValue = rawValue.ToString() ?? string.Empty;
+
+        // Try numeric comparison first
+        if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
+        {
+            return comparison(numericValue.CompareTo(filterNumeric), 0);
+        }
+
+        // Fall back to string comparison
+        return comparison(string.Compare(stringValue, filterValue, StringComparison.OrdinalIgnoreCase), 0);
+    }
+
+    private static bool CompareNumeric(object? rawValue, string filterValue, Func<decimal, decimal, bool> comparison)
+    {
+        if (rawValue == null)
+            return false;
+
+        var stringValue = rawValue.ToString() ?? string.Empty;
+
+        // Try to parse both values as decimals
+        if (TryParseNumeric(stringValue, out var numericValue) && TryParseNumeric(filterValue, out var filterNumeric))
+        {
+            return comparison(numericValue, filterNumeric);
+        }
+
+        // If we can't parse both as numbers, the filter doesn't match
+        return false;
+    }
+
+    private static bool TryParseNumeric(string value, out decimal result)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            result = 0;
+            return false;
+        }
+
+        // Remove common formatting characters (commas, percent signs, currency symbols)
+        var cleanValue = value.Trim()
+            .Replace(",", "")
+            .Replace("%", "")
+            .Replace("$", "")
+            .Replace(" ", "");
+
+        return decimal.TryParse(cleanValue, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
+    }
+}


### PR DESCRIPTION
## Summary

Fourth wave of the Lite↔Dashboard code-sharing follow-up. The operator-based `ColumnFilterState` matcher — `MatchesFilter(object, ColumnFilterState)` + `IsValueEmpty` / `CompareValues` / `CompareNumeric` / `TryParseNumeric` — was **byte-identical** in Lite's and Dashboard's `DataGridFilterService`. Extracted it to `PerformanceMonitor.Common.ColumnFilterMatcher` (pure reflection + value comparison, no WPF dependency).

Both apps' `DataGridFilterService.MatchesFilter(item, filter)` is now a **one-line forwarder** to the shared matcher, so the ~28 Dashboard + Lite call sites are untouched. Dashboard keeps its app-specific extras (the string-overload `MatchesFilter`, `ApplyFilter`, `NumericTypes`/`DateTypes`, property cache); Lite's service collapses to the single forwarder. Also dropped a now-unused `System.Globalization` import from Dashboard's file.

## Test plan
- [x] `dotnet build PerformanceMonitor.sln` — succeeds, no errors/warnings
- [x] `Dashboard.Tests` — **488 passed**
- [x] `Lite.Tests` — **544 passed**
- [x] `Installer.Tests` — **80 passed**
- [x] Pure refactor — moved identical code behind forwarders, no behavior change

## Not in this PR (deliberately)
`DataGridFilterManager<T>` carries a **behavioral diff** — Lite preserves sort on filter (`SetItemsSourcePreservingSort`), Dashboard reassigns `ItemsSource` directly. Unifying it means picking Lite's sort-preserving behavior for Dashboard too (a reconciliation decision), so it's deferred to a separate change rather than bundled into this pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)