### PR TITLE
Share MCP plan-analysis JSON formatter across Lite/Dashboard

### DIFF
--- a/Dashboard/Mcp/McpPlanTools.cs
+++ b/Dashboard/Mcp/McpPlanTools.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using ModelContextProtocol.Server;
 using PerformanceMonitor.PlanAnalysis;
@@ -37,7 +34,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
         }
         catch (Exception ex)
         {
@@ -65,7 +62,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for sql_handle '{sql_handle}'. The procedure may have been evicted from the plan cache since the last collection.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", sql_handle);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", sql_handle);
         }
         catch (Exception ex)
         {
@@ -94,7 +91,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for query_id {query_id} in database '{database_name}'. Query Store may not be enabled or the query may have been purged.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{query_id}");
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{query_id}");
         }
         catch (Exception ex)
         {
@@ -114,7 +111,7 @@ public sealed class McpPlanTools
 
         try
         {
-            return BuildAnalysisResult(plan_xml, null, "xml", null);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(plan_xml, null, "xml", null);
         }
         catch (Exception ex)
         {
@@ -150,128 +147,4 @@ public sealed class McpPlanTools
         }
     }
 
-    /// <summary>
-    /// Parses plan XML, runs the analyzer, and builds a structured JSON result.
-    /// </summary>
-    private static string BuildAnalysisResult(string xml, string? serverName, string source, string? identifier)
-    {
-        var plan = ShowPlanParser.Parse(xml);
-        PlanAnalyzer.Analyze(plan);
-
-        var statements = plan.Batches
-            .SelectMany(b => b.Statements)
-            .Where(s => s.RootNode != null)
-            .Select(s =>
-            {
-                var allNodes = new List<PlanNode>();
-                CollectNodes(s.RootNode!, allNodes);
-
-                var nodeWarnings = allNodes
-                    .SelectMany(n => n.Warnings)
-                    .ToList();
-                var stmtWarnings = s.PlanWarnings;
-                var allWarnings = stmtWarnings.Concat(nodeWarnings).ToList();
-
-                var hasActuals = allNodes.Any(n => n.HasActualStats);
-                var topOps = (hasActuals
-                        ? allNodes.OrderByDescending(n => n.ActualElapsedMs)
-                        : allNodes.OrderByDescending(n => n.CostPercent))
-                    .Take(10)
-                    .Select(n => new
-                    {
-                        node_id = n.NodeId,
-                        physical_op = n.PhysicalOp,
-                        logical_op = n.LogicalOp,
-                        cost_percent = n.CostPercent,
-                        estimated_rows = n.EstimateRows,
-                        actual_rows = n.HasActualStats ? n.ActualRows : (long?)null,
-                        actual_elapsed_ms = n.HasActualStats ? n.ActualElapsedMs : (long?)null,
-                        actual_cpu_ms = n.HasActualStats ? n.ActualCPUMs : (long?)null,
-                        logical_reads = n.HasActualStats ? n.ActualLogicalReads : (long?)null,
-                        object_name = n.ObjectName,
-                        index_name = n.IndexName,
-                        predicate = McpHelpers.Truncate(n.Predicate, 500),
-                        seek_predicates = McpHelpers.Truncate(n.SeekPredicates, 500),
-                        warning_count = n.Warnings.Count
-                    });
-
-                return new
-                {
-                    statement_text = McpHelpers.Truncate(s.StatementText, 2000),
-                    statement_type = s.StatementType,
-                    estimated_cost = Math.Round(s.StatementSubTreeCost, 4),
-                    dop = s.DegreeOfParallelism,
-                    serial_reason = s.NonParallelPlanReason,
-                    compile_cpu_ms = s.CompileCPUMs,
-                    compile_memory_kb = s.CompileMemoryKB,
-                    cardinality_model = s.CardinalityEstimationModelVersion,
-                    query_hash = s.QueryHash,
-                    query_plan_hash = s.QueryPlanHash,
-                    has_actual_stats = hasActuals,
-                    warnings = allWarnings.Select(w => new
-                    {
-                        severity = w.Severity.ToString(),
-                        type = w.WarningType,
-                        message = w.Message
-                    }),
-                    warning_count = allWarnings.Count,
-                    critical_count = allWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical),
-                    missing_indexes = s.MissingIndexes.Select(idx => new
-                    {
-                        table = $"{idx.Schema}.{idx.Table}",
-                        database = idx.Database,
-                        impact = idx.Impact,
-                        equality_columns = idx.EqualityColumns,
-                        inequality_columns = idx.InequalityColumns,
-                        include_columns = idx.IncludeColumns,
-                        create_statement = idx.CreateStatement
-                    }),
-                    parameters = s.Parameters.Select(p => new
-                    {
-                        name = p.Name,
-                        data_type = p.DataType,
-                        compiled_value = p.CompiledValue,
-                        runtime_value = p.RuntimeValue,
-                        sniffing_mismatch = p.CompiledValue != null && p.RuntimeValue != null
-                            && p.CompiledValue != p.RuntimeValue
-                    }),
-                    memory_grant = s.MemoryGrant == null ? null : new
-                    {
-                        requested_kb = s.MemoryGrant.RequestedMemoryKB,
-                        granted_kb = s.MemoryGrant.GrantedMemoryKB,
-                        max_used_kb = s.MemoryGrant.MaxUsedMemoryKB,
-                        desired_kb = s.MemoryGrant.DesiredMemoryKB,
-                        grant_wait_ms = s.MemoryGrant.GrantWaitTimeMs,
-                        feedback = s.MemoryGrant.IsMemoryGrantFeedbackAdjusted
-                    },
-                    top_operators = topOps
-                };
-            })
-            .ToList();
-
-        var totalWarnings = statements.Sum(s => s.warning_count);
-        var totalCritical = statements.Sum(s => s.critical_count);
-        var totalMissing = statements.Sum(s => s.missing_indexes.Count());
-
-        var result = new
-        {
-            server = serverName,
-            source,
-            identifier,
-            statement_count = statements.Count,
-            total_warnings = totalWarnings,
-            total_critical = totalCritical,
-            total_missing_indexes = totalMissing,
-            statements
-        };
-
-        return JsonSerializer.Serialize(result, McpHelpers.JsonOptions);
-    }
-
-    private static void CollectNodes(PlanNode node, List<PlanNode> nodes)
-    {
-        nodes.Add(node);
-        foreach (var child in node.Children)
-            CollectNodes(child, nodes);
-    }
 }

--- a/Dashboard/packages.lock.json
+++ b/Dashboard/packages.lock.json
@@ -747,7 +747,10 @@
         }
       },
       "performancemonitor.plananalysis": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "PerformanceMonitor.Common": "[1.0.0, )"
+        }
       },
       "performancemonitor.ui": {
         "type": "Project",

--- a/Lite.Tests/packages.lock.json
+++ b/Lite.Tests/packages.lock.json
@@ -903,7 +903,10 @@
         }
       },
       "performancemonitor.plananalysis": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "PerformanceMonitor.Common": "[1.0.0, )"
+        }
       },
       "performancemonitor.ui": {
         "type": "Project",

--- a/Lite/Mcp/McpPlanTools.cs
+++ b/Lite/Mcp/McpPlanTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 using PerformanceMonitor.PlanAnalysis;
 using PerformanceMonitorLite.Models;
@@ -33,7 +32,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
         }
         catch (Exception ex)
         {
@@ -61,7 +60,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for plan_handle '{plan_handle}'. The procedure may have been evicted from the plan cache since the last collection.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", plan_handle);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", plan_handle);
         }
         catch (Exception ex)
         {
@@ -101,7 +100,7 @@ public sealed class McpPlanTools
             if (string.IsNullOrEmpty(xml))
                 return $"No plan found for plan_id {plan_id} in database '{database_name}'. Query Store may not be enabled or the plan may have been purged.";
 
-            return BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{plan_id}");
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{plan_id}");
         }
         catch (Exception ex)
         {
@@ -121,7 +120,7 @@ public sealed class McpPlanTools
 
         try
         {
-            return BuildAnalysisResult(plan_xml, null, "xml", null);
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(plan_xml, null, "xml", null);
         }
         catch (Exception ex)
         {
@@ -157,128 +156,4 @@ public sealed class McpPlanTools
         }
     }
 
-    /// <summary>
-    /// Parses plan XML, runs the analyzer, and builds a structured JSON result.
-    /// </summary>
-    private static string BuildAnalysisResult(string xml, string? serverName, string source, string? identifier)
-    {
-        var plan = ShowPlanParser.Parse(xml);
-        PlanAnalyzer.Analyze(plan);
-
-        var statements = plan.Batches
-            .SelectMany(b => b.Statements)
-            .Where(s => s.RootNode != null)
-            .Select(s =>
-            {
-                var allNodes = new List<PlanNode>();
-                CollectNodes(s.RootNode!, allNodes);
-
-                var nodeWarnings = allNodes
-                    .SelectMany(n => n.Warnings)
-                    .ToList();
-                var stmtWarnings = s.PlanWarnings;
-                var allWarnings = stmtWarnings.Concat(nodeWarnings).ToList();
-
-                var hasActuals = allNodes.Any(n => n.HasActualStats);
-                var topOps = (hasActuals
-                        ? allNodes.OrderByDescending(n => n.ActualElapsedMs)
-                        : allNodes.OrderByDescending(n => n.CostPercent))
-                    .Take(10)
-                    .Select(n => new
-                    {
-                        node_id = n.NodeId,
-                        physical_op = n.PhysicalOp,
-                        logical_op = n.LogicalOp,
-                        cost_percent = n.CostPercent,
-                        estimated_rows = n.EstimateRows,
-                        actual_rows = n.HasActualStats ? n.ActualRows : (long?)null,
-                        actual_elapsed_ms = n.HasActualStats ? n.ActualElapsedMs : (long?)null,
-                        actual_cpu_ms = n.HasActualStats ? n.ActualCPUMs : (long?)null,
-                        logical_reads = n.HasActualStats ? n.ActualLogicalReads : (long?)null,
-                        object_name = n.ObjectName,
-                        index_name = n.IndexName,
-                        predicate = McpHelpers.Truncate(n.Predicate, 500),
-                        seek_predicates = McpHelpers.Truncate(n.SeekPredicates, 500),
-                        warning_count = n.Warnings.Count
-                    });
-
-                return new
-                {
-                    statement_text = McpHelpers.Truncate(s.StatementText, 2000),
-                    statement_type = s.StatementType,
-                    estimated_cost = Math.Round(s.StatementSubTreeCost, 4),
-                    dop = s.DegreeOfParallelism,
-                    serial_reason = s.NonParallelPlanReason,
-                    compile_cpu_ms = s.CompileCPUMs,
-                    compile_memory_kb = s.CompileMemoryKB,
-                    cardinality_model = s.CardinalityEstimationModelVersion,
-                    query_hash = s.QueryHash,
-                    query_plan_hash = s.QueryPlanHash,
-                    has_actual_stats = hasActuals,
-                    warnings = allWarnings.Select(w => new
-                    {
-                        severity = w.Severity.ToString(),
-                        type = w.WarningType,
-                        message = w.Message
-                    }),
-                    warning_count = allWarnings.Count,
-                    critical_count = allWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical),
-                    missing_indexes = s.MissingIndexes.Select(idx => new
-                    {
-                        table = $"{idx.Schema}.{idx.Table}",
-                        database = idx.Database,
-                        impact = idx.Impact,
-                        equality_columns = idx.EqualityColumns,
-                        inequality_columns = idx.InequalityColumns,
-                        include_columns = idx.IncludeColumns,
-                        create_statement = idx.CreateStatement
-                    }),
-                    parameters = s.Parameters.Select(p => new
-                    {
-                        name = p.Name,
-                        data_type = p.DataType,
-                        compiled_value = p.CompiledValue,
-                        runtime_value = p.RuntimeValue,
-                        sniffing_mismatch = p.CompiledValue != null && p.RuntimeValue != null
-                            && p.CompiledValue != p.RuntimeValue
-                    }),
-                    memory_grant = s.MemoryGrant == null ? null : new
-                    {
-                        requested_kb = s.MemoryGrant.RequestedMemoryKB,
-                        granted_kb = s.MemoryGrant.GrantedMemoryKB,
-                        max_used_kb = s.MemoryGrant.MaxUsedMemoryKB,
-                        desired_kb = s.MemoryGrant.DesiredMemoryKB,
-                        grant_wait_ms = s.MemoryGrant.GrantWaitTimeMs,
-                        feedback = s.MemoryGrant.IsMemoryGrantFeedbackAdjusted
-                    },
-                    top_operators = topOps
-                };
-            })
-            .ToList();
-
-        var totalWarnings = statements.Sum(s => s.warning_count);
-        var totalCritical = statements.Sum(s => s.critical_count);
-        var totalMissing = statements.Sum(s => s.missing_indexes.Count());
-
-        var result = new
-        {
-            server = serverName,
-            source,
-            identifier,
-            statement_count = statements.Count,
-            total_warnings = totalWarnings,
-            total_critical = totalCritical,
-            total_missing_indexes = totalMissing,
-            statements
-        };
-
-        return JsonSerializer.Serialize(result, McpHelpers.JsonOptions);
-    }
-
-    private static void CollectNodes(PlanNode node, List<PlanNode> nodes)
-    {
-        nodes.Add(node);
-        foreach (var child in node.Children)
-            CollectNodes(child, nodes);
-    }
 }

--- a/Lite/packages.lock.json
+++ b/Lite/packages.lock.json
@@ -759,7 +759,10 @@
         }
       },
       "performancemonitor.plananalysis": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "PerformanceMonitor.Common": "[1.0.0, )"
+        }
       },
       "performancemonitor.ui": {
         "type": "Project",

--- a/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
+++ b/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="PerformanceMonitor.PlanAnalysis" />
     <InternalsVisibleTo Include="PerformanceMonitorLite" />
     <InternalsVisibleTo Include="PerformanceMonitorDashboard" />
     <InternalsVisibleTo Include="Lite.Tests" />

--- a/PerformanceMonitor.PlanAnalysis/McpPlanAnalysisFormatter.cs
+++ b/PerformanceMonitor.PlanAnalysis/McpPlanAnalysisFormatter.cs
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.PlanAnalysis;
+
+/// <summary>
+/// Parses a query plan, runs the analyzer, and serializes a structured JSON result for the MCP
+/// plan-analysis tools. Shared by Lite and Dashboard — both apps' McpPlanTools call this so the
+/// (previously byte-identical) projection stays in one place. The per-app tool wrappers that fetch
+/// the plan XML (from SQL Server vs DuckDB) remain app-specific.
+/// </summary>
+public static class McpPlanAnalysisFormatter
+{
+    /// <summary>
+    /// Parses plan XML, runs the analyzer, and builds a structured JSON result.
+    /// </summary>
+    public static string BuildAnalysisResult(string xml, string? serverName, string source, string? identifier)
+    {
+        var plan = ShowPlanParser.Parse(xml);
+        PlanAnalyzer.Analyze(plan);
+
+        var statements = plan.Batches
+            .SelectMany(b => b.Statements)
+            .Where(s => s.RootNode != null)
+            .Select(s =>
+            {
+                var allNodes = new List<PlanNode>();
+                CollectNodes(s.RootNode!, allNodes);
+
+                var nodeWarnings = allNodes
+                    .SelectMany(n => n.Warnings)
+                    .ToList();
+                var stmtWarnings = s.PlanWarnings;
+                var allWarnings = stmtWarnings.Concat(nodeWarnings).ToList();
+
+                var hasActuals = allNodes.Any(n => n.HasActualStats);
+                var topOps = (hasActuals
+                        ? allNodes.OrderByDescending(n => n.ActualElapsedMs)
+                        : allNodes.OrderByDescending(n => n.CostPercent))
+                    .Take(10)
+                    .Select(n => new
+                    {
+                        node_id = n.NodeId,
+                        physical_op = n.PhysicalOp,
+                        logical_op = n.LogicalOp,
+                        cost_percent = n.CostPercent,
+                        estimated_rows = n.EstimateRows,
+                        actual_rows = n.HasActualStats ? n.ActualRows : (long?)null,
+                        actual_elapsed_ms = n.HasActualStats ? n.ActualElapsedMs : (long?)null,
+                        actual_cpu_ms = n.HasActualStats ? n.ActualCPUMs : (long?)null,
+                        logical_reads = n.HasActualStats ? n.ActualLogicalReads : (long?)null,
+                        object_name = n.ObjectName,
+                        index_name = n.IndexName,
+                        predicate = McpHelpers.Truncate(n.Predicate, 500),
+                        seek_predicates = McpHelpers.Truncate(n.SeekPredicates, 500),
+                        warning_count = n.Warnings.Count
+                    });
+
+                return new
+                {
+                    statement_text = McpHelpers.Truncate(s.StatementText, 2000),
+                    statement_type = s.StatementType,
+                    estimated_cost = Math.Round(s.StatementSubTreeCost, 4),
+                    dop = s.DegreeOfParallelism,
+                    serial_reason = s.NonParallelPlanReason,
+                    compile_cpu_ms = s.CompileCPUMs,
+                    compile_memory_kb = s.CompileMemoryKB,
+                    cardinality_model = s.CardinalityEstimationModelVersion,
+                    query_hash = s.QueryHash,
+                    query_plan_hash = s.QueryPlanHash,
+                    has_actual_stats = hasActuals,
+                    warnings = allWarnings.Select(w => new
+                    {
+                        severity = w.Severity.ToString(),
+                        type = w.WarningType,
+                        message = w.Message
+                    }),
+                    warning_count = allWarnings.Count,
+                    critical_count = allWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical),
+                    missing_indexes = s.MissingIndexes.Select(idx => new
+                    {
+                        table = $"{idx.Schema}.{idx.Table}",
+                        database = idx.Database,
+                        impact = idx.Impact,
+                        equality_columns = idx.EqualityColumns,
+                        inequality_columns = idx.InequalityColumns,
+                        include_columns = idx.IncludeColumns,
+                        create_statement = idx.CreateStatement
+                    }),
+                    parameters = s.Parameters.Select(p => new
+                    {
+                        name = p.Name,
+                        data_type = p.DataType,
+                        compiled_value = p.CompiledValue,
+                        runtime_value = p.RuntimeValue,
+                        sniffing_mismatch = p.CompiledValue != null && p.RuntimeValue != null
+                            && p.CompiledValue != p.RuntimeValue
+                    }),
+                    memory_grant = s.MemoryGrant == null ? null : new
+                    {
+                        requested_kb = s.MemoryGrant.RequestedMemoryKB,
+                        granted_kb = s.MemoryGrant.GrantedMemoryKB,
+                        max_used_kb = s.MemoryGrant.MaxUsedMemoryKB,
+                        desired_kb = s.MemoryGrant.DesiredMemoryKB,
+                        grant_wait_ms = s.MemoryGrant.GrantWaitTimeMs,
+                        feedback = s.MemoryGrant.IsMemoryGrantFeedbackAdjusted
+                    },
+                    top_operators = topOps
+                };
+            })
+            .ToList();
+
+        var totalWarnings = statements.Sum(s => s.warning_count);
+        var totalCritical = statements.Sum(s => s.critical_count);
+        var totalMissing = statements.Sum(s => s.missing_indexes.Count());
+
+        var result = new
+        {
+            server = serverName,
+            source,
+            identifier,
+            statement_count = statements.Count,
+            total_warnings = totalWarnings,
+            total_critical = totalCritical,
+            total_missing_indexes = totalMissing,
+            statements
+        };
+
+        return JsonSerializer.Serialize(result, McpHelpers.JsonOptions);
+    }
+
+    private static void CollectNodes(PlanNode node, List<PlanNode> nodes)
+    {
+        nodes.Add(node);
+        foreach (var child in node.Children)
+            CollectNodes(child, nodes);
+    }
+}

--- a/PerformanceMonitor.PlanAnalysis/PerformanceMonitor.PlanAnalysis.csproj
+++ b/PerformanceMonitor.PlanAnalysis/PerformanceMonitor.PlanAnalysis.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\PerformanceMonitor.Common\PerformanceMonitor.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="PerformanceMonitorLite" />
     <InternalsVisibleTo Include="PerformanceMonitorDashboard" />
     <InternalsVisibleTo Include="Lite.Tests" />


### PR DESCRIPTION
## Summary

The byte-identical `BuildAnalysisResult` + `CollectNodes` (parse plan XML → analyze → serialize structured JSON) lived privately in **both** apps' `McpPlanTools`. Moved to `PerformanceMonitor.PlanAnalysis.McpPlanAnalysisFormatter`; both apps' five MCP tool wrappers (which fetch plan XML from SQL Server vs DuckDB) now call the shared formatter.

## Structural change (the "decision" part)
The formatter uses `McpHelpers.Truncate`/`JsonOptions` (in Common), so this required:
- A new **`PlanAnalysis` → `Common`** project reference. No dependency cycle — `Common` references no other project (only the ModelContextProtocol package).
- Granting Common's `InternalsVisibleTo` to `PerformanceMonitor.PlanAnalysis` (same as the apps already have, since `McpHelpers` is internal).

Also dropped now-unused usings from both `McpPlanTools` files; `packages.lock.json` files updated (PlanAnalysis now pulls ModelContextProtocol transitively via Common).

## Test plan
- [x] `dotnet build PerformanceMonitor.sln` — succeeds, no errors/warnings
- [x] `Dashboard.Tests` — **488 passed**
- [x] `Lite.Tests` — **544 passed**
- [x] `Installer.Tests` — **80 passed**
- [x] Pure refactor — moved identical code, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)