### PR TITLE
Persist failed-job tray watermark across restart (both apps)

### DIFF
--- a/Dashboard.Tests/FailedJobWatermarkPreferenceTests.cs
+++ b/Dashboard.Tests/FailedJobWatermarkPreferenceTests.cs
@@ -1,0 +1,77 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using PerformanceMonitorDashboard.Models;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Failed-job tray watermark persistence (the Dashboard half of the #1145 parity fix): a reopen
+/// must not re-fire tray toasts for failures still inside the lookback window that the user already
+/// saw and dismissed. The watermark is the newest already-alerted failure's server-local run time,
+/// stored as <see cref="DateTime.Ticks"/> in <see cref="UserPreferences.FailedJobAlertWatermarkTicks"/>.
+/// These pin the JSON persistence contract UserPreferencesService relies on (it serializes/
+/// deserializes the whole UserPreferences object with the same options).
+/// </summary>
+public class FailedJobWatermarkPreferenceTests
+{
+    /// <summary>Serializer options matching UserPreferencesService (WriteIndented = true).</summary>
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    [Fact]
+    public void FailedJobAlertWatermarkTicks_DefaultsToEmpty()
+    {
+        var prefs = new UserPreferences();
+        Assert.NotNull(prefs.FailedJobAlertWatermarkTicks);
+        Assert.Empty(prefs.FailedJobAlertWatermarkTicks);
+    }
+
+    [Fact]
+    public void FailedJobAlertWatermarkTicks_RoundTripsExactValue_ThroughJson()
+    {
+        /* Ticks keep the server-local run time basis-exact across the JSON round-trip — the value is
+           compared directly against FailedJobInfo.RunDateTime, so DateTimeKind drift would corrupt it. */
+        var serverLocal = new DateTime(2026, 6, 19, 14, 30, 15);
+        var prefs = new UserPreferences
+        {
+            FailedJobAlertWatermarkTicks = new Dictionary<string, long>
+            {
+                ["server-a"] = serverLocal.Ticks,
+                ["server-b"] = new DateTime(2026, 6, 19, 9, 5, 0).Ticks
+            }
+        };
+
+        var json = JsonSerializer.Serialize(prefs, s_jsonOptions);
+        var loaded = JsonSerializer.Deserialize<UserPreferences>(json);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(2, loaded!.FailedJobAlertWatermarkTicks.Count);
+        Assert.Equal(serverLocal, new DateTime(loaded.FailedJobAlertWatermarkTicks["server-a"]));
+        Assert.Equal(new DateTime(2026, 6, 19, 9, 5, 0), new DateTime(loaded.FailedJobAlertWatermarkTicks["server-b"]));
+    }
+
+    [Fact]
+    public void FailedJobAlertWatermarkTicks_AbsentFromExistingJson_DeserializesToEmpty()
+    {
+        // A preferences.json written before this PR has no "FailedJobAlertWatermarkTicks" key;
+        // the default initializer (= empty dict) must apply so upgraded installs don't NRE on seed.
+        const string legacyJson = """
+        {
+            "AnalysisIntervalMinutes": 30
+        }
+        """;
+
+        var loaded = JsonSerializer.Deserialize<UserPreferences>(legacyJson);
+
+        Assert.NotNull(loaded);
+        Assert.NotNull(loaded!.FailedJobAlertWatermarkTicks);
+        Assert.Empty(loaded.FailedJobAlertWatermarkTicks);
+    }
+}

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -2137,6 +2137,15 @@ namespace PerformanceMonitorDashboard
             if (prefs.NotifyOnFailedJobs && health.RecentlyFailedJobs.Count > 0)
             {
                 var newestFailure = health.RecentlyFailedJobs.Max(j => j.RunDateTime);
+                /* Lazy restart-seed: the in-memory watermark is empty after a reopen, so failures
+                   still in the lookback window would re-fire toasts the user already saw and
+                   dismissed. Seed once per server from the persisted watermark (server-local basis,
+                   stored as Ticks) — the failed-job equivalent of the #1145 blocking/deadlock seed. */
+                if (!_lastAlertedFailedJobTime.ContainsKey(serverId)
+                    && prefs.FailedJobAlertWatermarkTicks.TryGetValue(serverId, out var seededTicks))
+                {
+                    _lastAlertedFailedJobTime[serverId] = new DateTime(seededTicks);
+                }
                 bool hasWatermark = _lastAlertedFailedJobTime.TryGetValue(serverId, out var lastFailure);
                 bool hasNewFailure = !hasWatermark || newestFailure > lastFailure;
 
@@ -2150,6 +2159,11 @@ namespace PerformanceMonitorDashboard
                     bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                     _lastFailedJobAlert[serverId] = now;
                     _lastAlertedFailedJobTime[serverId] = newestFailure;
+                    /* Persist so the watermark survives a reopen (#1145 parity): a restart must not
+                       re-fire toasts for these failures while they linger in the lookback window.
+                       On-change only — only when a failed-job toast actually fires. */
+                    prefs.FailedJobAlertWatermarkTicks[serverId] = newestFailure.Ticks;
+                    _preferencesService.SavePreferences(prefs);
                     var jobContext = BuildFailedJobContext(serverName, health.RecentlyFailedJobs);
                     var detailText = ContextToDetailText(jobContext);
 

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -210,6 +210,13 @@ namespace PerformanceMonitorDashboard.Models
 
         // Acknowledged alert baselines (persisted, keyed by "serverId:tabName")
         public Dictionary<string, AlertBaseline> AcknowledgedBaselines { get; set; } = new();
+
+        /* Failed-Agent-job tray watermark (persisted, keyed by serverId): the newest already-alerted
+           failure's server-local run time, stored as DateTime.Ticks. Seeds the in-memory watermark
+           on restart so a reopen does not re-fire toasts for failures still inside the lookback window
+           that the user already saw and dismissed (the failed-job equivalent of #1145). Ticks keep the
+           value basis-exact across JSON round-trips, free of DateTimeKind ambiguity. */
+        public Dictionary<string, long> FailedJobAlertWatermarkTicks { get; set; } = new();
     }
 
     /// <summary>

--- a/Lite.Tests/StoreRoundTripTests.cs
+++ b/Lite.Tests/StoreRoundTripTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Database;
@@ -219,6 +220,42 @@ public class StoreRoundTripTests : IDisposable
         loaded = await store.LoadEdgeTriggerWatermarksAsync();
         Assert.Equal(3, loaded.Count);
         Assert.Contains(loaded, r => r.ServerId == 1 && r.MetricName == "Blocking Detected" && r.Watermark == 0);
+    }
+
+    [Fact]
+    public async Task FailedJobWatermark_SaveLoad_RoundTripsExactValue_AndUpserts()
+    {
+        await _duckDb.InitializeAsync();
+        var store = new DuckDbAlertHistoryStore(_duckDb);
+
+        /* Empty table → empty load. */
+        Assert.Empty(await store.LoadFailedJobWatermarksAsync());
+
+        /* Server-local run times (Kind=Unspecified) must round-trip byte-for-byte: the watermark is
+           compared directly against FailedJobInfo.RunDateTime, so any UTC coercion would corrupt it. */
+        var server1 = new DateTime(2026, 6, 19, 14, 30, 15);
+        var server2 = new DateTime(2026, 6, 19, 9, 5, 0);
+        await store.SaveFailedJobWatermarkAsync(1, server1);
+        await store.SaveFailedJobWatermarkAsync(2, server2);
+
+        var loaded = await store.LoadFailedJobWatermarksAsync();
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal(server1, loaded.Single(r => r.ServerId == 1).Watermark);
+        Assert.Equal(server2, loaded.Single(r => r.ServerId == 2).Watermark);
+
+        /* Upsert on the (server_id, metric_name) primary key: a newer failure overwrites, no dup row. */
+        var server1Newer = new DateTime(2026, 6, 19, 16, 45, 0);
+        await store.SaveFailedJobWatermarkAsync(1, server1Newer);
+        loaded = await store.LoadFailedJobWatermarksAsync();
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal(server1Newer, loaded.Single(r => r.ServerId == 1).Watermark);
+
+        /* The time-based failed-job rows and the count-based blocking/deadlock rows share the table
+           but never bleed into each other's load. */
+        await store.SaveEdgeTriggerWatermarkAsync(1, "Blocking Detected", 5);
+        Assert.Equal(2, (await store.LoadFailedJobWatermarksAsync()).Count);          // unchanged by the count row
+        Assert.DoesNotContain(await store.LoadEdgeTriggerWatermarksAsync(),
+            r => r.MetricName == "Failed Agent Job");                                 // failed-job row absent from count load
     }
 
     [Fact]

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 30;
+    internal const int CurrentSchemaVersion = 31;
 
     private readonly string _archivePath;
 
@@ -768,6 +768,26 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v30 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 31)
+        {
+            /* v31: failed-Agent-job watermark persistence. The blocking/deadlock edge-trigger
+               watermarks already survive restart (#1145); the failed-job watermark did not, so a
+               reopen re-fired tray toasts for failures still inside the lookback window that the
+               user had already seen and dismissed. Adds a nullable watermark_time column to the
+               existing watermark table to hold the newest already-alerted failure's server-local
+               run time. Only ALTER if the table exists — fresh installs get the column from
+               GetAllTableStatements(). */
+            _logger?.LogInformation("Running migration to v31: failed-job watermark column");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE config_edge_trigger_watermarks ADD COLUMN IF NOT EXISTS watermark_time TIMESTAMP");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v31 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -768,16 +768,20 @@ CREATE TABLE IF NOT EXISTS config_alert_log (
     context_json VARCHAR
 )";
 
-    /* Edge-trigger watermarks for the rolling-count blocking/deadlock alert gate (#1091).
-       Persisted so the watermark survives an app restart (#1145): without it the in-memory
-       watermark resets to 0 and the first post-restart sweep re-fires the same alert (and
-       re-posts the same webhook) for events still lingering in the 1-hour lookback window.
-       Keyed (server_id, metric_name); one short row per server/metric, upserted on change. */
+    /* Edge-trigger watermarks for the rolling-count blocking/deadlock alert gate (#1091) and the
+       time-based failed-Agent-job watermark. Persisted so the watermark survives an app restart
+       (#1145): without it the in-memory watermark resets and the first post-restart sweep re-fires
+       the same alert (and re-posts the same webhook) for events still lingering in the lookback
+       window — including failed-job toasts the user already saw and dismissed before the restart.
+       Keyed (server_id, metric_name); one short row per server/metric, upserted on change.
+       Count metrics (blocking/deadlock) use the INTEGER watermark column; the failed-job metric
+       uses watermark_time (the newest already-alerted failure's server-local run time). */
     public const string CreateEdgeTriggerWatermarksTable = @"
 CREATE TABLE IF NOT EXISTS config_edge_trigger_watermarks (
     server_id INTEGER NOT NULL,
     metric_name VARCHAR NOT NULL,
     watermark INTEGER NOT NULL,
+    watermark_time TIMESTAMP,
     updated_at TIMESTAMP NOT NULL,
     PRIMARY KEY (server_id, metric_name)
 )";

--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1583,6 +1583,15 @@ public partial class MainWindow : Window
                     _lastAlertedDeadlockCount[key] = watermark;
                 }
             }
+
+            /* Failed-job watermark (time-based): seed so a restart does not re-fire tray toasts
+               for failures still inside the lookback window that the user already saw and dismissed
+               before the restart — the failed-job equivalent of the blocking/deadlock seed above. */
+            var failedJobRows = await _alertHistoryStore.LoadFailedJobWatermarksAsync();
+            foreach (var (serverId, watermark) in failedJobRows)
+            {
+                _lastAlertedFailedJobTime[serverId.ToString()] = watermark;
+            }
         }
         catch (Exception ex)
         {
@@ -2243,6 +2252,10 @@ public partial class MainWindow : Window
                             bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
                             _lastFailedJobAlert[key] = now;
                             _lastAlertedFailedJobTime[key] = newestFailure;
+                            /* Persist the watermark so the same failures don't re-fire on the first
+                               post-restart sweep while they linger in the lookback window (#1145
+                               parity). On-change only — only when a failed-job toast actually fires. */
+                            await _alertHistoryStore.SaveFailedJobWatermarkAsync(summary.ServerId, newestFailure);
 
                             if (!isMuted)
                             {

--- a/Lite/Services/DuckDbAlertHistoryStore.cs
+++ b/Lite/Services/DuckDbAlertHistoryStore.cs
@@ -303,9 +303,13 @@ AND   metric_name = $2";
             await connection.OpenAsync();
 
             using var command = connection.CreateCommand();
+            /* Count-based rows only (blocking/deadlock). The time-based failed-job rows live in the
+               same table but set watermark_time (NULL here) and are loaded by
+               LoadFailedJobWatermarksAsync, so they never bleed into the count seed. */
             command.CommandText = @"
 SELECT server_id, metric_name, watermark
-FROM config_edge_trigger_watermarks";
+FROM config_edge_trigger_watermarks
+WHERE watermark_time IS NULL";
 
             using var reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
@@ -357,6 +361,96 @@ VALUES ($1, $2, $3, $4)";
         catch (Exception ex)
         {
             AppLogger.Error("Alerts", $"Could not persist edge-trigger watermark ({metricName}): {ex.Message}");
+        }
+    }
+
+    /* The failed-Agent-job watermark shares the edge-trigger table but is time-based, not a count:
+       it holds the newest already-alerted failure's server-local run time (stored in watermark_time,
+       not the INTEGER watermark column). One reserved metric_name row per server. */
+    private const string FailedJobWatermarkMetric = "Failed Agent Job";
+
+    /// <summary>
+    /// Loads the persisted failed-job watermarks (#1145 parity for the failed-job toast). The caller
+    /// seeds <c>_lastAlertedFailedJobTime</c> from these at startup so a restart does not re-fire tray
+    /// toasts for failures still inside the lookback window that the user already saw and dismissed.
+    /// The value is the server-local run time of the newest already-alerted failure, returned in its
+    /// native basis (NOT coerced to UTC) so it compares directly against <c>FailedJobInfo.RunDateTime</c>.
+    /// </summary>
+    public async Task<List<(int ServerId, DateTime Watermark)>> LoadFailedJobWatermarksAsync()
+    {
+        var result = new List<(int, DateTime)>();
+        try
+        {
+            var duckDb = _duckDb;
+            if (duckDb == null)
+            {
+                var dbPath = App.DatabasePath;
+                if (string.IsNullOrEmpty(dbPath)) return result;
+                duckDb = new DuckDbInitializer(dbPath);
+            }
+
+            using var readLock = duckDb.AcquireReadLock();
+            using var connection = duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT server_id, watermark_time
+FROM config_edge_trigger_watermarks
+WHERE metric_name = $1
+AND   watermark_time IS NOT NULL";
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = FailedJobWatermarkMetric });
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.Add((Convert.ToInt32(reader.GetValue(0)), Convert.ToDateTime(reader.GetValue(1))));
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Alerts", $"Could not load failed-job watermarks: {ex.Message}");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Upserts one failed-job watermark — the newest already-alerted failure's server-local run time.
+    /// Called on-change only (when a failed-job toast fires), so it is a low-frequency write that
+    /// piggybacks on the existing alert-store write lock, mirroring <see cref="SaveEdgeTriggerWatermarkAsync"/>.
+    /// </summary>
+    public async Task SaveFailedJobWatermarkAsync(int serverId, DateTime watermark)
+    {
+        try
+        {
+            var duckDb = _duckDb;
+            if (duckDb == null)
+            {
+                var dbPath = App.DatabasePath;
+                if (string.IsNullOrEmpty(dbPath)) return;
+                duckDb = new DuckDbInitializer(dbPath);
+            }
+
+            using var writeLock = duckDb.AcquireWriteLock();
+            using var connection = duckDb.CreateConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            /* watermark (the INTEGER count column) is unused for the time-based failed-job row;
+               it is non-nullable, so write 0. The meaningful value lives in watermark_time. */
+            command.CommandText = @"
+INSERT OR REPLACE INTO config_edge_trigger_watermarks (server_id, metric_name, watermark, watermark_time, updated_at)
+VALUES ($1, $2, 0, $3, $4)";
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = serverId });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = FailedJobWatermarkMetric });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = watermark });
+            command.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = DateTime.UtcNow });
+
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Alerts", $"Could not persist failed-job watermark: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
## Problem

The failed-Agent-job tray watermark (`_lastAlertedFailedJobTime`) was an **in-memory dictionary in both apps and never persisted**. Blocking/deadlock watermarks got restart persistence in #1145; the failed-job path never did. So on reopen the watermark was empty, every failure still inside the lookback window looked "new," and the toast **re-fired for alerts the user had already seen and dismissed** before the restart.

## Fix (both apps, parity)

Persist the exact **server-local** `newestFailure` value and re-seed it on startup, mirroring #1145. The persisted value and the in-session compared value (`FailedJobInfo.RunDateTime`) always share a basis by construction — the UTC `alert_time` is never mixed in (the trap: `RunDateTime` is server-local, `alert_time` is host-UTC).

**Lite (DuckDB):** nullable `watermark_time` column on the existing `config_edge_trigger_watermarks` table (schema v30→v31 migration + fresh `CREATE`); `Save/LoadFailedJobWatermarksAsync`; seed in `SeedEdgeTriggerWatermarksAsync`, persist on fire. Count-watermark load filtered by `watermark_time IS NULL` so count and time rows stay cleanly separated.

**Dashboard (JSON prefs):** `FailedJobAlertWatermarkTicks` on `UserPreferences` (server-local time as `DateTime.Ticks` — basis-exact across JSON, no `DateTimeKind` drift); lazy-seed on first sweep, persist on fire via the existing `SavePreferences` pattern.

Result: after a reopen, already-alerted failures stay suppressed; only a genuinely new failure (including one that happened while the app was closed) alerts.

## Tests

- Lite store round-trip: exact-value preservation, upsert, no bleed between count and time rows.
- Dashboard prefs round-trip + legacy-JSON-without-the-key.
- **Lite 545/545, Dashboard 491/491**, both apps build clean.

## Live verification (recommended post-merge)

The persistence layer is unit-tested; the seed→suppress path lives in `MainWindow`. Behavioral check: fire a failed-job toast → dismiss → close + reopen → confirm it does not re-fire for that failure, while a new failure still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)