### PR TITLE
Fix FinOps Database Sizes empty until manual refresh (init-order race)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -42,6 +42,12 @@ namespace PerformanceMonitorDashboard.Controls
         public FinOpsContent()
         {
             InitializeComponent();
+            // Create the Database Sizes filter manager here, NOT in OnLoaded: Initialize() sets
+            // ServerSelector.SelectedIndex = 0, which fires RefreshDataAsync -> LoadDatabaseSizesAsync,
+            // and that can run before the Loaded event. If the manager isn't set yet, the loader
+            // fetches the data then silently discards it at its null-guard (Database Sizes stays
+            // empty until a manual refresh). Creating it here removes that init-order race.
+            _dbSizesFilterMgr = new DataGridFilterManager<FinOpsDatabaseSizeStats>(DatabaseSizesDataGrid);
             Loaded += OnLoaded;
         }
 
@@ -76,8 +82,6 @@ namespace PerformanceMonitorDashboard.Controls
             TabHelpers.FreezeColumns(ExpensiveQueriesDataGrid, 1);
             TabHelpers.FreezeColumns(IndexAnalysisDetailGrid, 1);
             TabHelpers.FreezeColumns(HighImpactDataGrid, 1);
-
-            _dbSizesFilterMgr = new DataGridFilterManager<FinOpsDatabaseSizeStats>(DatabaseSizesDataGrid);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
The FinOps **Database Sizes** tab showed no data on first load (every other FinOps tab populated); a manual refresh fixed it. Root cause is an init-order race:

`Initialize()` sets `ServerSelector.SelectedIndex = 0` → `SelectionChanged` → `RefreshDataAsync` → `LoadDatabaseSizesAsync`. That loader fetches the rows then bails at `if (_dbSizesFilterMgr == null) return;`. But `_dbSizesFilterMgr` was created in **`OnLoaded`**, which can fire *after* `Initialize()` — so on first load the data was fetched and silently discarded. A later manual refresh ran after `OnLoaded`, so it worked. It's the only FinOps sub-tab whose `DataGridFilterManager` was created in `OnLoaded`, which is why only it was affected.

**Fix:** create `_dbSizesFilterMgr` in the **constructor** (the grid exists right after `InitializeComponent`), so it's always ready before any load — removing the race. One-line move.

Pre-existing race; unrelated to the recent FinOpsContent partial-class split (that only relocated `LoadDatabaseSizesAsync`).

## Test plan
- [x] `dotnet build PerformanceMonitor.sln` — succeeds
- [x] `Dashboard.Tests` — **491 passed**
- [ ] Manual: open FinOps → Database Sizes on a fresh launch → data present without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)