### PR TITLE
Always-on per-section profiling on every server tab (both apps)

### DIFF
--- a/Dashboard/Controls/MemoryContent.xaml.cs
+++ b/Dashboard/Controls/MemoryContent.xaml.cs
@@ -228,11 +228,11 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     // Run all independent refreshes in parallel for initial load / manual refresh
                     await Task.WhenAll(
-                        RefreshMemoryStatsAsync(),
-                        RefreshMemoryGrantsAsync(),
-                        RefreshMemoryClerksAsync(),
-                        RefreshPlanCacheAsync(),
-                        RefreshMemoryPressureEventsAsync()
+                        Helpers.MethodProfiler.TimeAsync("Memory.MemoryStats", () => RefreshMemoryStatsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrants", () => RefreshMemoryGrantsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("Memory.MemoryClerks", () => RefreshMemoryClerksAsync()),
+                        Helpers.MethodProfiler.TimeAsync("Memory.PlanCache", () => RefreshPlanCacheAsync()),
+                        Helpers.MethodProfiler.TimeAsync("Memory.MemoryPressureEvents", () => RefreshMemoryPressureEventsAsync())
                     );
                 }
                 else

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -650,15 +650,15 @@ namespace PerformanceMonitorDashboard.Controls
                 }
 
                 // Fetch grid data (summary views aggregated per query/procedure)
-                var queryStatsTask = _databaseService.GetQueryStatsAsync(_queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate);
-                var procStatsTask = _databaseService.GetProcedureStatsAsync(_procStatsHoursBack, _procStatsFromDate, _procStatsToDate);
-                var queryStoreTask = _databaseService.GetQueryStoreDataAsync(_queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate);
+                var queryStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => _databaseService.GetQueryStatsAsync(_queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate));
+                var procStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => _databaseService.GetProcedureStatsAsync(_procStatsHoursBack, _procStatsFromDate, _procStatsToDate));
+                var queryStoreTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => _databaseService.GetQueryStoreDataAsync(_queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate));
 
                 // Fetch chart data (time-series aggregated per collection_time)
-                var queryDurationTrendsTask = _databaseService.GetQueryDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate);
-                var procDurationTrendsTask = _databaseService.GetProcedureDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate);
-                var qsDurationTrendsTask = _databaseService.GetQueryStoreDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate);
-                var execTrendsTask = _databaseService.GetExecutionTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate);
+                var queryDurationTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => _databaseService.GetQueryDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
+                var procDurationTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcDurationTrends", () => _databaseService.GetProcedureDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
+                var qsDurationTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => _databaseService.GetQueryStoreDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
+                var execTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => _databaseService.GetExecutionTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
 
                 // Fetch grid-only data in parallel
                 var activeTask = RefreshActiveQueriesAsync();

--- a/Dashboard/Controls/ResourceMetricsContent.xaml.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml.cs
@@ -291,15 +291,15 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     // Run all independent refreshes in parallel for initial load / manual refresh
                     await Task.WhenAll(
-                        RefreshLatchStatsAsync(),
-                        RefreshSpinlockStatsAsync(),
-                        RefreshTempdbStatsAsync(),
-                        RefreshSessionStatsAsync(),
-                        LoadFileIoLatencyChartsAsync(),
-                        LoadFileIoThroughputChartsAsync(),
-                        RefreshServerTrendsAsync(),
-                        RefreshPerfmonCountersTabAsync(),
-                        RefreshWaitStatsDetailTabAsync()
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.LatchStats", () => RefreshLatchStatsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.SpinlockStats", () => RefreshSpinlockStatsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.TempdbStats", () => RefreshTempdbStatsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.SessionStats", () => RefreshSessionStatsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.FileIoLatency", () => LoadFileIoLatencyChartsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.FileIoThroughput", () => LoadFileIoThroughputChartsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.ServerTrends", () => RefreshServerTrendsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.PerfmonCounters", () => RefreshPerfmonCountersTabAsync()),
+                        Helpers.MethodProfiler.TimeAsync("ResourceMetrics.WaitStatsDetail", () => RefreshWaitStatsDetailTabAsync())
                     );
                 }
                 else

--- a/Dashboard/Controls/SystemEventsContent.xaml.cs
+++ b/Dashboard/Controls/SystemEventsContent.xaml.cs
@@ -347,14 +347,14 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     // Run all independent refreshes in parallel for initial load / manual refresh
                     await Task.WhenAll(
-                        RefreshSystemHealthAsync(),
-                        RefreshSevereErrorsAsync(),
-                        RefreshIOIssuesAsync(),
-                        RefreshSchedulerIssuesAsync(),
-                        RefreshMemoryConditionsAsync(),
-                        RefreshCPUTasksAsync(),
-                        RefreshMemoryBrokerAsync(),
-                        RefreshMemoryNodeOOMAsync()
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.SystemHealth", () => RefreshSystemHealthAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.SevereErrors", () => RefreshSevereErrorsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.IOIssues", () => RefreshIOIssuesAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.SchedulerIssues", () => RefreshSchedulerIssuesAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.MemoryConditions", () => RefreshMemoryConditionsAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.CPUTasks", () => RefreshCPUTasksAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.MemoryBroker", () => RefreshMemoryBrokerAsync()),
+                        Helpers.MethodProfiler.TimeAsync("SystemEvents.MemoryNodeOOM", () => RefreshMemoryNodeOOMAsync())
                     );
                 }
                 else

--- a/Dashboard/Helpers/MethodProfiler.cs
+++ b/Dashboard/Helpers/MethodProfiler.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace PerformanceMonitorDashboard.Helpers
 {
@@ -99,6 +100,37 @@ namespace PerformanceMonitorDashboard.Helpers
             [CallerLineNumber] int lineNumber = 0)
         {
             return new MethodTimingContext(context, memberName, filePath, lineNumber);
+        }
+
+        /// <summary>
+        /// Times an async operation under <paramref name="context"/>, logging it if it exceeds the
+        /// slow-method threshold. Use for per-section profiling of parallel data loads, e.g.:
+        /// <code>var task = MethodProfiler.TimeAsync("Overview.DefaultTrace", () => LoadDefaultTraceAsync());</code>
+        /// The timing covers the full wall-clock of the operation (including any connection-throttle wait).
+        /// </summary>
+        public static async Task<T> TimeAsync<T>(
+            string context,
+            Func<Task<T>> operation,
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            using var _ = StartTiming(context, memberName, filePath, lineNumber);
+            return await operation();
+        }
+
+        /// <summary>
+        /// Void-returning overload of <see cref="TimeAsync{T}"/>.
+        /// </summary>
+        public static async Task TimeAsync(
+            string context,
+            Func<Task> operation,
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            using var _ = StartTiming(context, memberName, filePath, lineNumber);
+            await operation();
         }
 
         /// <summary>

--- a/Dashboard/ServerTab.Refresh.cs
+++ b/Dashboard/ServerTab.Refresh.cs
@@ -187,15 +187,15 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                var healthTask = Task.Run(() => _databaseService.GetCollectionHealthAsync());
-                var durationLogsTask = Task.Run(() => _databaseService.GetCollectionDurationLogsAsync());
-                var resourceOverviewTask = RefreshResourceOverviewAsync();
-                var runningJobsTask = RefreshRunningJobsAsync();
-                var dailySummaryTask = DailySummaryTab.RefreshDataAsync();
-                var recommendationsTask = RecommendationsTab.RefreshDataAsync();
-                var defaultTraceTask = DefaultTraceTab.RefreshAllDataAsync();
-                var currentConfigTask = CurrentConfigTab.RefreshAllDataAsync();
-                var configChangesTask = ConfigChangesTab.RefreshAllDataAsync();
+                var healthTask = Helpers.MethodProfiler.TimeAsync("Overview.Health", () => Task.Run(() => _databaseService.GetCollectionHealthAsync()));
+                var durationLogsTask = Helpers.MethodProfiler.TimeAsync("Overview.DurationLogs", () => Task.Run(() => _databaseService.GetCollectionDurationLogsAsync()));
+                var resourceOverviewTask = Helpers.MethodProfiler.TimeAsync("Overview.ResourceOverview", () => RefreshResourceOverviewAsync());
+                var runningJobsTask = Helpers.MethodProfiler.TimeAsync("Overview.RunningJobs", () => RefreshRunningJobsAsync());
+                var dailySummaryTask = Helpers.MethodProfiler.TimeAsync("Overview.DailySummary", () => DailySummaryTab.RefreshDataAsync());
+                var recommendationsTask = Helpers.MethodProfiler.TimeAsync("Overview.Recommendations", () => RecommendationsTab.RefreshDataAsync());
+                var defaultTraceTask = Helpers.MethodProfiler.TimeAsync("Overview.DefaultTrace", () => DefaultTraceTab.RefreshAllDataAsync());
+                var currentConfigTask = Helpers.MethodProfiler.TimeAsync("Overview.CurrentConfig", () => CurrentConfigTab.RefreshAllDataAsync());
+                var configChangesTask = Helpers.MethodProfiler.TimeAsync("Overview.ConfigChanges", () => ConfigChangesTab.RefreshAllDataAsync());
 
                 await Task.WhenAll(healthTask, durationLogsTask, resourceOverviewTask, runningJobsTask,
                     dailySummaryTask, recommendationsTask, defaultTraceTask, currentConfigTask, configChangesTask);
@@ -269,12 +269,12 @@ namespace PerformanceMonitorDashboard
         {
             try
             {
-                var blockingEventsTask = Task.Run(() => _databaseService.GetBlockingEventsAsync());
-                var deadlocksTask = Task.Run(() => _databaseService.GetDeadlocksAsync());
-                var blockingStatsTask = Task.Run(() => _databaseService.GetBlockingDeadlockStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
-                var lockWaitStatsTask = Task.Run(() => _databaseService.GetLockWaitStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
-                var currentWaitsDurationTask = Task.Run(() => _databaseService.GetWaitingTaskTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
-                var currentWaitsBlockedTask = Task.Run(() => _databaseService.GetBlockedSessionTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate));
+                var blockingEventsTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockingEvents", () => Task.Run(() => _databaseService.GetBlockingEventsAsync()));
+                var deadlocksTask = Helpers.MethodProfiler.TimeAsync("Locking.Deadlocks", () => Task.Run(() => _databaseService.GetDeadlocksAsync()));
+                var blockingStatsTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockingStats", () => Task.Run(() => _databaseService.GetBlockingDeadlockStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate)));
+                var lockWaitStatsTask = Helpers.MethodProfiler.TimeAsync("Locking.LockWaitStats", () => Task.Run(() => _databaseService.GetLockWaitStatsAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate)));
+                var currentWaitsDurationTask = Helpers.MethodProfiler.TimeAsync("Locking.WaitingTaskTrend", () => Task.Run(() => _databaseService.GetWaitingTaskTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate)));
+                var currentWaitsBlockedTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedSessionTrend", () => Task.Run(() => _databaseService.GetBlockedSessionTrendAsync(_blockingStatsHoursBack, _blockingStatsFromDate, _blockingStatsToDate)));
 
                 await Task.WhenAll(blockingEventsTask, deadlocksTask, blockingStatsTask, lockWaitStatsTask, currentWaitsDurationTask, currentWaitsBlockedTask);
 
@@ -349,10 +349,10 @@ namespace PerformanceMonitorDashboard
             try
             {
                 // Load all four charts in parallel
-                var cpuTask = Task.Run(() => _databaseService.GetCpuDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
-                var memoryTask = Task.Run(() => _databaseService.GetMemoryDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
-                var ioTask = Task.Run(() => _databaseService.GetFileIoDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate));
-                var waitTask = Task.Run(() => _databaseService.GetWaitStatsDataAsync(_resourceOverviewHoursBack, 5, _resourceOverviewFromDate, _resourceOverviewToDate));
+                var cpuTask = Helpers.MethodProfiler.TimeAsync("Overview.ResourceOverview.Cpu", () => Task.Run(() => _databaseService.GetCpuDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate)));
+                var memoryTask = Helpers.MethodProfiler.TimeAsync("Overview.ResourceOverview.Memory", () => Task.Run(() => _databaseService.GetMemoryDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate)));
+                var ioTask = Helpers.MethodProfiler.TimeAsync("Overview.ResourceOverview.FileIo", () => Task.Run(() => _databaseService.GetFileIoDataAsync(_resourceOverviewHoursBack, _resourceOverviewFromDate, _resourceOverviewToDate)));
+                var waitTask = Helpers.MethodProfiler.TimeAsync("Overview.ResourceOverview.Waits", () => Task.Run(() => _databaseService.GetWaitStatsDataAsync(_resourceOverviewHoursBack, 5, _resourceOverviewFromDate, _resourceOverviewToDate)));
 
                 await Task.WhenAll(cpuTask, memoryTask, ioTask, waitTask);
 

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -143,33 +143,33 @@ public partial class ServerTab : UserControl
            thread — each query's read lock is acquired AND released inside that one synchronous run,
            so the ReaderWriterLockSlim thread affinity is respected — and the fan-out below becomes
            genuinely parallel. The UI-update code after the awaits is unchanged. */
-        var snapshotsTask = Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate));
-        var cpuTask = Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate));
-        var memoryTask = Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId));
-        var memoryTrendTask = Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var queryStatsTask = Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
-        var procStatsTask = Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
-        var fileIoTrendTask = Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var fileIoThroughputTask = Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var tempDbTask = Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var tempDbFileIoTask = Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var deadlockTask = Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate));
-        var blockedProcessTask = Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate));
-        var waitTypesTask = Task.Run(() => _dataService.GetDistinctWaitTypesAsync(_serverId, hoursBack, fromDate, toDate));
-        var memoryClerkTypesTask = Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate));
-        var perfmonCountersTask = Task.Run(() => _dataService.GetDistinctPerfmonCountersAsync(_serverId, hoursBack, fromDate, toDate));
-        var queryStoreTask = Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate));
-        var memoryGrantTrendTask = Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate));
-        var memoryGrantChartTask = Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate));
-        var memoryPressureEventsTask = Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate));
-        var serverConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId)));
-        var databaseConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId)));
-        var databaseScopedConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId)));
-        var traceFlagsTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId)));
-        var runningJobsTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetRunningJobsAsync(_serverId)));
-        var collectionHealthTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId)));
-        var collectionLogTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack)));
-        var dailySummaryTask = Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate));
+        var snapshotsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.Snapshots", () => Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate)));
+        var cpuTask = Helpers.MethodProfiler.TimeAsync("Cpu.Utilization", () => Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate)));
+        var memoryTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryStats", () => Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId)));
+        var memoryTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryTrend", () => Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var queryStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
+        var procStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
+        var fileIoTrendTask = Helpers.MethodProfiler.TimeAsync("FileIo.LatencyTrend", () => Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var fileIoThroughputTask = Helpers.MethodProfiler.TimeAsync("FileIo.ThroughputTrend", () => Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var tempDbTask = Helpers.MethodProfiler.TimeAsync("TempDb.Trend", () => Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var tempDbFileIoTask = Helpers.MethodProfiler.TimeAsync("TempDb.FileIoTrend", () => Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var deadlockTask = Helpers.MethodProfiler.TimeAsync("Locking.Deadlocks", () => Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate)));
+        var blockedProcessTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedProcessReports", () => Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate)));
+        var waitTypesTask = Helpers.MethodProfiler.TimeAsync("WaitStats.WaitTypes", () => Task.Run(() => _dataService.GetDistinctWaitTypesAsync(_serverId, hoursBack, fromDate, toDate)));
+        var memoryClerkTypesTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryClerks", () => Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate)));
+        var perfmonCountersTask = Helpers.MethodProfiler.TimeAsync("Perfmon.Counters", () => Task.Run(() => _dataService.GetDistinctPerfmonCountersAsync(_serverId, hoursBack, fromDate, toDate)));
+        var queryStoreTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate)));
+        var memoryGrantTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrantTrend", () => Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var memoryGrantChartTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrants", () => Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate)));
+        var memoryPressureEventsTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryPressureEvents", () => Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate)));
+        var serverConfigTask = Helpers.MethodProfiler.TimeAsync("Config.ServerConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId))));
+        var databaseConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId))));
+        var databaseScopedConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseScopedConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId))));
+        var traceFlagsTask = Helpers.MethodProfiler.TimeAsync("Config.TraceFlags", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId))));
+        var runningJobsTask = Helpers.MethodProfiler.TimeAsync("RunningJobs.Jobs", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRunningJobsAsync(_serverId))));
+        var collectionHealthTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Health", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId))));
+        var collectionLogTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Log", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack))));
+        var dailySummaryTask = Helpers.MethodProfiler.TimeAsync("DailySummary.Summary", () => Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate)));
         /* Core data tasks */
         await System.Threading.Tasks.Task.WhenAll(
             snapshotsTask, cpuTask, memoryTask, memoryTrendTask,
@@ -180,15 +180,15 @@ public partial class ServerTab : UserControl
             runningJobsTask, collectionHealthTask, collectionLogTask, dailySummaryTask);
 
         /* Trend chart tasks - run separately so failures don't kill the whole refresh */
-        var lockWaitTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var blockingTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var deadlockTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var queryDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var procDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var queryStoreDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var executionCountTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var currentWaitsDurationTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var currentWaitsBlockedTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+        var lockWaitTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.LockWaitTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var blockingTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockingTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var deadlockTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.DeadlockTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var queryDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var procDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var queryStoreDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var executionCountTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var currentWaitsDurationTask = Helpers.MethodProfiler.TimeAsync("Locking.WaitingTaskTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+        var currentWaitsBlockedTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedSessionTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate))));
 
         await System.Threading.Tasks.Task.WhenAll(
             lockWaitTrendTask, blockingTrendTask, deadlockTrendTask,
@@ -322,10 +322,10 @@ public partial class ServerTab : UserControl
                 switch (QueriesSubTabControl.SelectedIndex)
                 {
                     case 0: // Performance Trends — 4 trend charts
-                        var qdt = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var pdt = Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var qsdt = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var ect = Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+                        var qdt = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var pdt = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var qsdt = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var ect = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate))));
                         await System.Threading.Tasks.Task.WhenAll(qdt, pdt, qsdt, ect);
                         UpdateQueryDurationTrendChart(qdt.Result);
                         UpdateProcDurationTrendChart(pdt.Result);
@@ -382,19 +382,19 @@ public partial class ServerTab : UserControl
             }
 
             /* Full refresh: load all sub-tabs */
-            var snapshotsTask = Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate));
-            var queryStatsTask = Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
-            var procStatsTask = Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes));
-            var queryStoreTask = Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate));
-            var queryDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var procDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var queryStoreDurationTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var executionCountTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var heatmapTask = Task.Run(async () =>
+            var snapshotsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.Snapshots", () => Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate)));
+            var queryStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
+            var procStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
+            var queryStoreTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate)));
+            var queryDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var procDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var queryStoreDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var executionCountTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var heatmapTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.Heatmap", () => Task.Run(async () =>
             {
                 try { return await _dataService.GetQueryHeatmapAsync(_serverId, (HeatmapMetric)Dispatcher.Invoke(() => HeatmapMetricCombo.SelectedIndex), hoursBack, fromDate, toDate); }
                 catch { return new HeatmapResult(); }
-            });
+            }));
 
             await System.Threading.Tasks.Task.WhenAll(
                 snapshotsTask, queryStatsTask, procStatsTask, queryStoreTask,
@@ -507,12 +507,12 @@ public partial class ServerTab : UserControl
             }
 
             /* Full refresh: load all sub-tabs */
-            var memoryTask = Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId));
-            var memoryTrendTask = Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate));
-            var memoryClerkTypesTask = Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate));
-            var memoryGrantTrendTask = Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate));
-            var memoryGrantChartTask = Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate));
-            var memoryPressureEventsTask = Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate));
+            var memoryTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryStats", () => Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId)));
+            var memoryTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryTrend", () => Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+            var memoryClerkTypesTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryClerks", () => Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate)));
+            var memoryGrantTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrantTrend", () => Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+            var memoryGrantChartTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrants", () => Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate)));
+            var memoryPressureEventsTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryPressureEvents", () => Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate)));
 
             await System.Threading.Tasks.Task.WhenAll(memoryTask, memoryTrendTask, memoryClerkTypesTask, memoryGrantTrendTask, memoryGrantChartTask, memoryPressureEventsTask);
 
@@ -534,8 +534,8 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var fileIoTrendTask = Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate));
-            var fileIoThroughputTask = Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var fileIoTrendTask = Helpers.MethodProfiler.TimeAsync("FileIo.LatencyTrend", () => Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+            var fileIoThroughputTask = Helpers.MethodProfiler.TimeAsync("FileIo.ThroughputTrend", () => Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate)));
 
             await System.Threading.Tasks.Task.WhenAll(fileIoTrendTask, fileIoThroughputTask);
 
@@ -553,8 +553,8 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var tempDbTask = Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate));
-            var tempDbFileIoTask = Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate));
+            var tempDbTask = Helpers.MethodProfiler.TimeAsync("TempDb.Trend", () => Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+            var tempDbFileIoTask = Helpers.MethodProfiler.TimeAsync("TempDb.FileIoTrend", () => Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate)));
 
             await System.Threading.Tasks.Task.WhenAll(tempDbTask, tempDbFileIoTask);
 
@@ -578,17 +578,17 @@ public partial class ServerTab : UserControl
                 switch (BlockingSubTabControl.SelectedIndex)
                 {
                     case 0: // Trends — 3 trend charts
-                        var lwt = Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var bt = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var dt = Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+                        var lwt = Helpers.MethodProfiler.TimeAsync("Locking.LockWaitTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var bt = Helpers.MethodProfiler.TimeAsync("Locking.BlockingTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var dt = Helpers.MethodProfiler.TimeAsync("Locking.DeadlockTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate))));
                         await System.Threading.Tasks.Task.WhenAll(lwt, bt, dt);
                         UpdateLockWaitTrendChart(lwt.Result, hoursBack, fromDate, toDate);
                         UpdateBlockingTrendChart(bt.Result, hoursBack, fromDate, toDate);
                         UpdateDeadlockTrendChart(dt.Result, hoursBack, fromDate, toDate);
                         break;
                     case 1: // Current Waits — 2 charts
-                        var cwd = Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-                        var cwb = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+                        var cwd = Helpers.MethodProfiler.TimeAsync("Locking.WaitingTaskTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+                        var cwb = Helpers.MethodProfiler.TimeAsync("Locking.BlockedSessionTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate))));
                         await System.Threading.Tasks.Task.WhenAll(cwd, cwb);
                         UpdateCurrentWaitsDurationChart(cwd.Result, hoursBack, fromDate, toDate);
                         UpdateCurrentWaitsBlockedChart(cwb.Result, hoursBack, fromDate, toDate);
@@ -610,13 +610,13 @@ public partial class ServerTab : UserControl
             }
 
             /* Full refresh: load all sub-tabs */
-            var blockedProcessTask = Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate));
-            var deadlockTask = Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate));
-            var lockWaitTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var blockingTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var deadlockTrendTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var currentWaitsDurationTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-            var currentWaitsBlockedTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate)));
+            var blockedProcessTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedProcessReports", () => Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate)));
+            var deadlockTask = Helpers.MethodProfiler.TimeAsync("Locking.Deadlocks", () => Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate)));
+            var lockWaitTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.LockWaitTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var blockingTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockingTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var deadlockTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.DeadlockTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var currentWaitsDurationTask = Helpers.MethodProfiler.TimeAsync("Locking.WaitingTaskTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate))));
+            var currentWaitsBlockedTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedSessionTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate))));
 
             await System.Threading.Tasks.Task.WhenAll(
                 blockedProcessTask, deadlockTask,
@@ -757,10 +757,10 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var serverConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId)));
-            var databaseConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId)));
-            var databaseScopedConfigTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId)));
-            var traceFlagsTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId)));
+            var serverConfigTask = Helpers.MethodProfiler.TimeAsync("Config.ServerConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId))));
+            var databaseConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId))));
+            var databaseScopedConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseScopedConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId))));
+            var traceFlagsTask = Helpers.MethodProfiler.TimeAsync("Config.TraceFlags", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId))));
 
             await System.Threading.Tasks.Task.WhenAll(serverConfigTask, databaseConfigTask, databaseScopedConfigTask, traceFlagsTask);
 
@@ -798,8 +798,8 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var collectionHealthTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId)));
-            var collectionLogTask = Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack)));
+            var collectionHealthTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Health", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId))));
+            var collectionLogTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Log", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack))));
 
             await System.Threading.Tasks.Task.WhenAll(collectionHealthTask, collectionLogTask);
 

--- a/Lite/Helpers/MethodProfiler.cs
+++ b/Lite/Helpers/MethodProfiler.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace PerformanceMonitorLite.Helpers;
 
@@ -54,6 +55,37 @@ public static class MethodProfiler
         [CallerLineNumber] int lineNumber = 0)
     {
         return new MethodTimingContext(context, memberName, filePath, lineNumber);
+    }
+
+    /// <summary>
+    /// Times an async operation under <paramref name="context"/>, logging it if it exceeds the
+    /// slow-method threshold. Use for per-section profiling of parallel data loads, e.g.:
+    /// <code>var task = MethodProfiler.TimeAsync("Overview.DefaultTrace", () => LoadDefaultTraceAsync());</code>
+    /// The timing covers the full wall-clock of the operation (including any connection-throttle wait).
+    /// </summary>
+    public static async Task<T> TimeAsync<T>(
+        string context,
+        Func<Task<T>> operation,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0)
+    {
+        using var _ = StartTiming(context, memberName, filePath, lineNumber);
+        return await operation();
+    }
+
+    /// <summary>
+    /// Void-returning overload of <see cref="TimeAsync{T}"/>.
+    /// </summary>
+    public static async Task TimeAsync(
+        string context,
+        Func<Task> operation,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0)
+    {
+        using var _ = StartTiming(context, memberName, filePath, lineNumber);
+        await operation();
     }
 
     internal static void LogSlowMethod(


### PR DESCRIPTION
## Why
Profiling the slow Dashboard server-tab loads under HammerDB exposed a blind spot: every tab eagerly loads all its sections in parallel and shows nothing until the slowest finishes, but only a handful of sections had any `MethodProfiler` timing — so the *actual* slow query was invisible. Two big offenders had **no timing at all**:
- Queries → `GetQueryStatsAsync`: **11–14s** (a `collect.query_stats` scan)
- Locking → `GetDeadlocksAsync`: **~4.8s** (deadlock-graph fetch — *not* the trend queries, as both the user and I had assumed)

## What
- **`MethodProfiler.TimeAsync(context, () => fetch)`** — a helper (added to both apps) that wraps any async fetch in a timing scope, preserving the real caller's file/line.
- Applied to **every section fetch on every server tab** in both apps:
  - **Dashboard** (48 sites): Overview (incl. Resource Overview's 4 charts), Queries, Locking, Resource Metrics, Memory, System Events.
  - **Lite** (77 sites): all 12 `Task.WhenAll` fan-outs in `ServerTab.Refresh.cs`; names match Dashboard where equivalent, Lite-only tabs named by their own tab.
- Logs at the existing **500ms** slow-method threshold, so it stays silent until a section is actually slow — then the MethodProfile log names exactly which fetch on which tab.

Pure observability — **no behavior change**. Each `var t = Task.Run(() => fetch)` becomes `var t = MethodProfiler.TimeAsync("Ctx", () => Task.Run(() => fetch))`.

## Verification
- Dashboard: build ✓, `Dashboard.Tests` **491 pass**, runtime-verified the log surfaces per-section timings with clean context names.
- Lite: build ✓, `Lite.Tests` **545 pass**, diff confirmed behavior-neutral.

## Follow-on (separate, not in this PR)
The *fixes* the instrumentation points to: lazy-load the Queries sub-tabs so the 14s `QueryStats` only runs when its sub-tab is opened; progressive rendering for the single-view Locking tab; and an index/query look at `GetQueryStatsAsync` / `GetDeadlocksAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)