### PR TITLE
Fix in-app plan viewing for query drill-downs; defer QueryStats plan hydration

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.Plans.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.Plans.cs
@@ -137,7 +137,13 @@ namespace PerformanceMonitorDashboard.Controls
 
             switch (item)
             {
-                case QuerySnapshotItem snap when !string.IsNullOrEmpty(snap.QueryPlan):
+                case QuerySnapshotItem snap:
+                    // Active-query plans are fetched on demand (not loaded with the grid), so pull it
+                    // here the same way the Download button does — otherwise View Plan silently no-ops.
+                    if (string.IsNullOrEmpty(snap.QueryPlan) && _databaseService != null)
+                    {
+                        snap.QueryPlan = await _databaseService.GetQuerySnapshotPlanAsync(snap.CollectionTime, snap.SessionId);
+                    }
                     planXml = snap.QueryPlan;
                     queryText = snap.QueryText;
                     label = $"Est Plan - SPID {snap.SessionId}";
@@ -152,7 +158,11 @@ namespace PerformanceMonitorDashboard.Controls
                     queryText = live.QueryText;
                     label = $"Est Plan - SPID {live.SessionId}";
                     break;
-                case QueryStatsItem stats when !string.IsNullOrEmpty(stats.QueryPlanXml):
+                case QueryStatsItem stats:
+                    if (string.IsNullOrEmpty(stats.QueryPlanXml) && _databaseService != null && !string.IsNullOrEmpty(stats.QueryHash))
+                    {
+                        stats.QueryPlanXml = await _databaseService.GetQueryStatsPlanXmlAsync(stats.DatabaseName, stats.QueryHash);
+                    }
                     planXml = stats.QueryPlanXml;
                     queryText = stats.QueryText;
                     label = $"Est Plan - {stats.QueryHash}";
@@ -236,6 +246,10 @@ namespace PerformanceMonitorDashboard.Controls
                 case QueryStatsItem stats:
                     queryText = stats.QueryText;
                     databaseName = stats.DatabaseName;
+                    if (string.IsNullOrEmpty(stats.QueryPlanXml) && _databaseService != null && !string.IsNullOrEmpty(stats.QueryHash))
+                    {
+                        stats.QueryPlanXml = await _databaseService.GetQueryStatsPlanXmlAsync(stats.DatabaseName, stats.QueryHash);
+                    }
                     planXml = stats.QueryPlanXml;
                     label = $"Actual Plan - {stats.QueryHash}";
                     break;

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Snapshots.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Snapshots.cs
@@ -201,7 +201,9 @@ namespace PerformanceMonitorDashboard.Services
                     using var command = new SqlCommand(query, connection);
                     command.CommandTimeout = 120;
 
-                    command.Parameters.Add(new SqlParameter("@collectionTime", SqlDbType.DateTime2) { Value = collectionTime });
+                    // collection_time is legacy datetime(3); a DateTime2 parameter fails the exact "="
+                    // match on precision and returns zero rows ("no plan found"). Match the column type.
+                    command.Parameters.Add(new SqlParameter("@collectionTime", SqlDbType.DateTime) { Value = collectionTime });
                     command.Parameters.Add(new SqlParameter("@sessionId", SqlDbType.SmallInt) { Value = sessionId });
 
                     var result = await command.ExecuteScalarAsync();

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
@@ -194,7 +194,10 @@ namespace PerformanceMonitorDashboard.Services
             tr.min_spills,
             tr.max_spills,
             qt.query_text,
-            qp.query_plan_xml,
+            /* query_plan_xml is hydrated on demand via GetQueryStatsPlanXmlAsync (when a plan is
+               opened) — DECOMPRESSing plan XML for all TOP (500) rows cost ~7s of CPU and the grid
+               never displays it. */
+            query_plan_xml = CONVERT(nvarchar(max), NULL),
             tr.query_plan_hash,
             tr.sql_handle,
             tr.plan_handle
@@ -208,16 +211,6 @@ namespace PerformanceMonitorDashboard.Services
             AND   qs2.database_name = tr.database_name
             ORDER BY qs2.collection_time DESC
         ) AS qt
-        OUTER APPLY
-        (
-            SELECT TOP (1)
-                query_plan_xml = CAST(DECOMPRESS(qs3.query_plan_text) AS nvarchar(max))
-            FROM collect.query_stats AS qs3
-            WHERE qs3.query_hash = tr.query_hash
-            AND   qs3.database_name = tr.database_name
-            AND   qs3.query_plan_text IS NOT NULL
-            ORDER BY qs3.collection_time DESC
-        ) AS qp
         ORDER BY
             tr.avg_worker_time_ms DESC;";
 

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -507,6 +507,37 @@ ORDER BY bucket_hour;";
                     return result == DBNull.Value ? null : result as string;
                 }
 
+                /// <summary>
+                /// Fetches (and DECOMPRESSes) the cached plan XML for a single query_stats row on demand.
+                /// GetQueryStatsAsync deliberately does NOT hydrate plan XML for its TOP (500) grid rows
+                /// (that DECOMPRESS cost ~7s of CPU); the plan is fetched here only when a plan is opened.
+                /// </summary>
+                public async Task<string?> GetQueryStatsPlanXmlAsync(string databaseName, string queryHash)
+                {
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    string query = @"
+        SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+        SELECT TOP (1)
+            query_plan_xml = CAST(DECOMPRESS(qs.query_plan_text) AS nvarchar(max))
+        FROM collect.query_stats AS qs
+        WHERE qs.query_hash = CONVERT(binary(8), @queryHash, 1)
+        AND   qs.database_name = @databaseName
+        AND   qs.query_plan_text IS NOT NULL
+        ORDER BY qs.collection_time DESC;";
+
+                    using var command = new SqlCommand(query, connection);
+                    command.CommandTimeout = 120;
+
+                    command.Parameters.Add(new SqlParameter("@databaseName", SqlDbType.NVarChar, 128) { Value = databaseName });
+                    command.Parameters.Add(new SqlParameter("@queryHash", SqlDbType.NVarChar, 20) { Value = queryHash });
+
+                    var result = await command.ExecuteScalarAsync();
+                    return result == DBNull.Value ? null : result as string;
+                }
+
                 public async Task<List<SessionStatsItem>> GetSessionStatsAsync(int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
                 {
                     var items = new List<SessionStatsItem>();


### PR DESCRIPTION
## Two query-plan fixes found while profiling the Queries tab

### 1. View Plan / Download silently broken in the Active Queries drill-downs
`report.query_snapshots.collection_time` is legacy **`datetime(3)`**, but `GetQuerySnapshotPlanAsync` bound `@collectionTime` as **`SqlDbType.DateTime2`**. The exact `collection_time = @collectionTime` match fails on precision and returns **zero rows** — so *every* row reported "no plan found", breaking both the Download button and the right-click **View Plan**. (Verified in SQL: `datetime` param matches, `datetime2` matches 0, on a row that has a plan.)

- Bind the parameter as `SqlDbType.DateTime` to match the column.
- Wire the `QuerySnapshotItem` **View Plan** case to fetch the plan on demand (snapshot plans aren't loaded with the grid) — it was guarded on a pre-loaded plan that's always null, so it never fired even though the menu was present.

**Result:** right-click → View Plan now opens captured plans in the in-app viewer for the ~60% of snapshots that have one (verified).

### 2. Defer QueryStats grid plan hydration
`GetQueryStatsAsync` `DECOMPRESS`ed `query_plan_xml` for all `TOP (500)` rows (~7s CPU under HammerDB) though the grid never displays it. Drop that `OUTER APPLY`; hydrate on demand via a new `GetQueryStatsPlanXmlAsync` when a plan is opened — mirroring the existing Query Store / Regression lazy-plan pattern. (~14s → ~9s for the Query Stats grid; the residual is `query_text` DECOMPRESS, addressed separately.)

## Verification
- Active-query View Plan verified opening plans in-app.
- `GetQueryStatsPlanXmlAsync` hash round-trip verified in SQL (returns the plan).
- Build ✓, `Dashboard.Tests` **491 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)