### PR TITLE
Queries tab responsiveness: lazy-load sub-tabs + TOP 500→50

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -71,6 +71,12 @@ namespace PerformanceMonitorDashboard.Controls
         private DateTime? _activeQueriesToDate;
         private bool _isDrillDownActive;
 
+        // Sub-tabs whose heavy summary grid has been lazily loaded in the current refresh cycle.
+        // Query Stats (3) / Proc Stats (4) / Query Store (5) are deferred out of the full refresh —
+        // their per-row plan/text DECOMPRESS dominated the Queries-tab open cost — and load only when
+        // their sub-tab is viewed. Cleared on each full refresh so manual refresh re-fetches.
+        private readonly HashSet<int> _lazyLoadedGridTabs = new();
+
         // Query Stats state
         private int _queryStatsHoursBack = 24;
         private DateTime? _queryStatsFromDate;
@@ -126,12 +132,14 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartSaveMenus();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-            SubTabControl.SelectionChanged += (s, e) =>
+            SubTabControl.SelectionChanged += async (s, e) =>
             {
                 if (e.Source == SubTabControl)
                 {
                     _isDrillDownActive = false;
                     SubTabChanged?.Invoke();
+                    // Lazily load the heavy summary grid the first time its sub-tab is viewed.
+                    await EnsureHeavyGridLoadedAsync(SubTabControl.SelectedIndex);
                 }
             };
             ThemeManager.ThemeChanged += OnThemeChanged;
@@ -640,19 +648,12 @@ namespace PerformanceMonitorDashboard.Controls
                     return;
                 }
 
-                // Full refresh — all sub-tabs in parallel
-
-                // Only show loading overlay on initial load (no existing data)
-                if (QueryStatsDataGrid.ItemsSource == null)
-                {
-                    QueryStatsLoading.IsLoading = true;
-                    QueryStatsNoDataMessage.Visibility = Visibility.Collapsed;
-                }
-
-                // Fetch grid data (summary views aggregated per query/procedure)
-                var queryStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => _databaseService.GetQueryStatsAsync(_queryStatsHoursBack, _queryStatsFromDate, _queryStatsToDate));
-                var procStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => _databaseService.GetProcedureStatsAsync(_procStatsHoursBack, _procStatsFromDate, _procStatsToDate));
-                var queryStoreTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => _databaseService.GetQueryStoreDataAsync(_queryStoreHoursBack, _queryStoreFromDate, _queryStoreToDate));
+                // Full refresh. The three heavy summary grids (Query Stats / Proc Stats / Query Store)
+                // are NOT loaded here — their per-row DECOMPRESS dominates the tab-open cost and each is
+                // only one sub-tab's data. They load lazily when their sub-tab is viewed
+                // (EnsureHeavyGridLoadedAsync), so opening the Queries tab only pays for the charts and
+                // the lighter grids. The currently-visible heavy grid (if any) is loaded at the end.
+                _lazyLoadedGridTabs.Clear();
 
                 // Fetch chart data (time-series aggregated per collection_time)
                 var queryDurationTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => _databaseService.GetQueryDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
@@ -660,50 +661,15 @@ namespace PerformanceMonitorDashboard.Controls
                 var qsDurationTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => _databaseService.GetQueryStoreDurationTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
                 var execTrendsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => _databaseService.GetExecutionTrendsAsync(_perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate));
 
-                // Fetch grid-only data in parallel
+                // Fetch grid-only data in parallel (these are light)
                 var activeTask = RefreshActiveQueriesAsync();
                 var regressionsTask = RefreshQueryStoreRegressionsAsync();
                 var patternsTask = RefreshLongRunningPatternsAsync();
 
-                // Wait for all fetches to complete
                 await Task.WhenAll(
-                    queryStatsTask, procStatsTask, queryStoreTask,
                     queryDurationTrendsTask, procDurationTrendsTask, qsDurationTrendsTask, execTrendsTask,
                     activeTask, regressionsTask, patternsTask
                 );
-
-                // Populate grids from summary data
-                // If slicer is narrowed, re-query with slicer dates instead of global range
-                if (QueryStatsSlicer.HasNarrowedSelection)
-                {
-                    var slicerData = await _databaseService.GetQueryStatsAsync(0, QueryStatsSlicer.SelectionStart, QueryStatsSlicer.SelectionEnd, fromSlicer: true);
-                    PopulateQueryStatsGrid(slicerData);
-                }
-                else
-                {
-                    PopulateQueryStatsGrid(await queryStatsTask);
-                }
-                _ = LoadQueryStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
-                if (ProcStatsSlicer.HasNarrowedSelection)
-                {
-                    var slicerProcData = await _databaseService.GetProcedureStatsAsync(0, ProcStatsSlicer.SelectionStart, ProcStatsSlicer.SelectionEnd, fromSlicer: true);
-                    PopulateProcStatsGrid(slicerProcData);
-                }
-                else
-                {
-                    PopulateProcStatsGrid(await procStatsTask);
-                }
-                _ = LoadProcStatsSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
-                if (QueryStoreSlicer.HasNarrowedSelection)
-                {
-                    var slicerQsData = await _databaseService.GetQueryStoreDataAsync(0, QueryStoreSlicer.SelectionStart, QueryStoreSlicer.SelectionEnd, fromSlicer: true);
-                    PopulateQueryStoreGrid(slicerQsData);
-                }
-                else
-                {
-                    PopulateQueryStoreGrid(await queryStoreTask);
-                }
-                _ = LoadQueryStoreSlicerAsync(); // fire-and-forget: detached slicer refresh, self-handles errors
 
                 // Populate charts from time-series data
                 LoadDurationChart(QueryPerfTrendsQueryChart, await queryDurationTrendsTask, _perfTrendsHoursBack, _perfTrendsFromDate, _perfTrendsToDate, "Duration (ms/sec)", TabHelpers.ChartColors[0], _queryDurationHover);
@@ -713,10 +679,50 @@ namespace PerformanceMonitorDashboard.Controls
 
                 // Heatmap
                 await RefreshQueryHeatmapAsync();
+
+                // Load the heavy summary grid only if its sub-tab is the one currently in view.
+                await EnsureHeavyGridLoadedAsync(SubTabControl.SelectedIndex);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error refreshing QueryPerformance data: {ex.Message}", ex);
+            }
+            finally
+            {
+                QueryStatsLoading.IsLoading = false;
+            }
+        }
+
+        /// <summary>
+        /// Loads one of the heavy summary grids (Query Stats / Proc Stats / Query Store) the first time
+        /// its sub-tab is viewed in the current refresh cycle. Deferred out of the full refresh because
+        /// their per-row plan/text DECOMPRESS dominated the Queries-tab open time.
+        /// </summary>
+        private async Task EnsureHeavyGridLoadedAsync(int subTabIndex)
+        {
+            if (subTabIndex is not (3 or 4 or 5)) return;        // only the three heavy grids are deferred
+            if (_databaseService == null) return;
+            if (!_lazyLoadedGridTabs.Add(subTabIndex)) return;   // already loaded this refresh cycle
+
+            try
+            {
+                if (subTabIndex == 3 && QueryStatsDataGrid.ItemsSource == null)
+                {
+                    QueryStatsLoading.IsLoading = true;
+                    QueryStatsNoDataMessage.Visibility = Visibility.Collapsed;
+                }
+
+                switch (subTabIndex)
+                {
+                    case 3: await Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => RefreshQueryStatsGridAsync()); break;
+                    case 4: await Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => RefreshProcStatsGridAsync()); break;
+                    case 5: await Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => RefreshQueryStoreGridAsync()); break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error loading Query Performance grid (sub-tab {subTabIndex}): {ex.Message}", ex);
+                _lazyLoadedGridTabs.Remove(subTabIndex);          // allow a retry next time the sub-tab is viewed
             }
             finally
             {

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
@@ -32,7 +32,7 @@ namespace PerformanceMonitorDashboard.Services
 
                     bool useCustomDates = fromDate.HasValue && toDate.HasValue;
 
-                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 500,
+                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 50,
                     // then hydrate text/plan for only the winners. This avoids decompressing
                     // query_text and query_plan_text for every row in the table.
                     string query = @"
@@ -98,10 +98,10 @@ namespace PerformanceMonitorDashboard.Services
             USE HINT('ENABLE_PARALLEL_PLAN_PREFERENCE')
         );
 
-        /*Phase 2: sum across lifetimes, rank, take TOP 500*/
+        /*Phase 2: sum across lifetimes, rank, take TOP 50*/
         DROP TABLE IF EXISTS #top_ranked;
 
-        SELECT TOP (500)
+        SELECT TOP (50)
             database_name = pl.database_name,
             query_hash = pl.query_hash,
             object_type = MAX(pl.object_type),
@@ -157,7 +157,7 @@ namespace PerformanceMonitorDashboard.Services
             HASH GROUP
         );
 
-        /*Phase 3: hydrate text and plan XML for the TOP 500 winners only*/
+        /*Phase 3: hydrate text and plan XML for the TOP 50 winners only*/
         SELECT
             tr.database_name,
             query_hash = CONVERT(nvarchar(20), tr.query_hash, 1),
@@ -195,7 +195,7 @@ namespace PerformanceMonitorDashboard.Services
             tr.max_spills,
             qt.query_text,
             /* query_plan_xml is hydrated on demand via GetQueryStatsPlanXmlAsync (when a plan is
-               opened) — DECOMPRESSing plan XML for all TOP (500) rows cost ~7s of CPU and the grid
+               opened) — DECOMPRESSing plan XML for all TOP (50) rows cost ~7s of CPU and the grid
                never displays it. */
             query_plan_xml = CONVERT(nvarchar(max), NULL),
             tr.query_plan_hash,
@@ -282,7 +282,7 @@ namespace PerformanceMonitorDashboard.Services
 
                     bool useCustomDates = fromDate.HasValue && toDate.HasValue;
 
-                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 500,
+                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 50,
                     // then hydrate plan XML for only the winners.
                     string query = @"
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -345,10 +345,10 @@ namespace PerformanceMonitorDashboard.Services
             USE HINT('ENABLE_PARALLEL_PLAN_PREFERENCE')
         );
 
-        /*Phase 2: sum across lifetimes, rank, take TOP 500*/
+        /*Phase 2: sum across lifetimes, rank, take TOP 50*/
         DROP TABLE IF EXISTS #proc_top_ranked;
 
-        SELECT TOP (500)
+        SELECT TOP (50)
             database_name = pl.database_name,
             object_id = MAX(pl.object_id),
             object_name = QUOTENAME(pl.schema_name) + N'.' + QUOTENAME(pl.object_name),
@@ -399,7 +399,7 @@ namespace PerformanceMonitorDashboard.Services
             HASH GROUP
         );
 
-        /*Phase 3: hydrate plan XML for the TOP 500 winners only*/
+        /*Phase 3: hydrate plan XML for the TOP 50 winners only*/
         SELECT
             tr.database_name,
             tr.object_id,
@@ -519,16 +519,16 @@ namespace PerformanceMonitorDashboard.Services
 
                     bool useCustomDates = fromDate.HasValue && toDate.HasValue;
 
-                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 500,
+                    // Phased approach: aggregate numerics first (no DECOMPRESS), rank TOP 50,
                     // then hydrate query text for only the winners.
                     // Note: query_plan_xml is NOT fetched here — use GetQueryStorePlanXmlAsync on demand.
                     string query = @"
         SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-        /*Phase 1: aggregate numerics, rank TOP 500 — no DECOMPRESS*/
+        /*Phase 1: aggregate numerics, rank TOP 50 — no DECOMPRESS*/
         DROP TABLE IF EXISTS #qs_top_ranked;
 
-        SELECT TOP (500)
+        SELECT TOP (50)
             database_name = qsd.database_name,
             query_id = qsd.query_id,
             execution_type_desc = MAX(qsd.execution_type_desc),
@@ -601,7 +601,7 @@ namespace PerformanceMonitorDashboard.Services
             USE HINT('ENABLE_PARALLEL_PLAN_PREFERENCE')
         );
 
-        /*Phase 2: hydrate query text for the TOP 500 winners only*/
+        /*Phase 2: hydrate query text for the TOP 50 winners only*/
         SELECT
             tr.*,
             qt.query_sql_text


### PR DESCRIPTION
Two changes that make the Dashboard Queries tab fast, in both idle and loaded states.

## 1. Lazy-load the heavy sub-tab grids
Opening the Queries tab eagerly loaded all 9 sub-tabs in parallel — including the three heavy summary grids (Query Stats / Proc Stats / Query Store) whose per-row text/plan `DECOMPRESS` dominates. The tab showed nothing for ~11s even though the default view is Performance Trends.

Defer those three grids: the full refresh loads only the charts + light grids and the currently-visible heavy grid; each heavy grid loads lazily the first time its sub-tab is viewed (`EnsureHeavyGridLoadedAsync`). Drill-down (Active Queries) untouched.

**Measured: opening the Queries tab ~11,000ms → ~850ms.**

## 2. Reduce metric grids TOP 500 → TOP 50
Query Stats / Proc Stats / Query Store pulled 500 rows; the Query Stats path DECOMPRESSes `query_text` per ranked row, so 500 was the bulk of the residual. Reduced to 50 (matching Lite, which already uses 50 for these exact grids) — ~10× less DECOMPRESS. Active Queries snapshots left at 500 (recent-snapshots grid, not top-N; Lite is uncapped there).

**Combined: opening Query Stats now loads in well under a second (was 3–9s).**

## Verification
- Build ✓, `Dashboard.Tests` **491 pass**
- Runtime: tab-open profiler entry ~850ms (confirmed); Query Stats no longer logs a >500ms entry; Trends / Active Queries / drill-down / sub-tab switching all functional.

## Follow-ups (separate)
- Lite Queries responsiveness — to be profiled separately (Lite's architecture pre-loads all tabs; needs its own data-driven fix, not a literal mirror).
- Auto-refresh Active Queries on sub-tab activation (needs drill-down suppress-flag coordination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)