### PR TITLE
Refresh Active Queries sub-tab on view; guard the drill-down race

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -70,6 +70,10 @@ namespace PerformanceMonitorDashboard.Controls
         private DateTime? _activeQueriesFromDate;
         private DateTime? _activeQueriesToDate;
         private bool _isDrillDownActive;
+        // Guards the Active Queries auto-refresh: SelectActiveQueriesForDrillDown() sets this before
+        // a drill-down flips the sub-tab to Active Queries, so the SelectionChanged handler skips its
+        // refresh and doesn't clobber the filtered snapshot the drill-down loads next (async race).
+        private bool _suppressActiveQueriesAutoRefresh;
 
         // Query Stats state
         private int _queryStatsHoursBack = 24;
@@ -126,12 +130,20 @@ namespace PerformanceMonitorDashboard.Controls
             SetupChartSaveMenus();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-            SubTabControl.SelectionChanged += (s, e) =>
+            SubTabControl.SelectionChanged += async (s, e) =>
             {
-                if (e.Source == SubTabControl)
+                if (e.Source != SubTabControl) return;
+
+                _isDrillDownActive = false;
+                SubTabChanged?.Invoke();
+
+                // Re-run Active Queries whenever it becomes the active sub-tab so the live snapshot
+                // grid is fresh on view. Drill-downs route through SelectActiveQueriesForDrillDown(),
+                // which sets _suppressActiveQueriesAutoRefresh first so this doesn't clobber the
+                // filtered snapshot they load via an async race.
+                if (SubTabControl.SelectedIndex == 1 && !_suppressActiveQueriesAutoRefresh)
                 {
-                    _isDrillDownActive = false;
-                    SubTabChanged?.Invoke();
+                    await RefreshActiveQueriesAsync();
                 }
             };
             ThemeManager.ThemeChanged += OnThemeChanged;
@@ -206,7 +218,7 @@ namespace PerformanceMonitorDashboard.Controls
                     // Query also uses server time (same as collection_time in SQL Server)
                     var queryFrom = serverFrom;
                     var queryTo = serverTo;
-                    SubTabControl.SelectedIndex = 1; // Active Queries
+                    SelectActiveQueriesForDrillDown();
                     await RefreshActiveQueriesWithRangeAsync(queryFrom, queryTo);
                 }
             };
@@ -571,9 +583,21 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         /// <summary>
-        /// Sets the time range for all sub-tabs.
+        /// Switches to the Active Queries sub-tab for a drill-down, suppressing the SelectionChanged
+        /// auto-refresh so it doesn't clobber the filtered snapshot the caller loads next (async race).
         /// </summary>
-        public void SelectSubTab(int index) => SubTabControl.SelectedIndex = index;
+        public void SelectActiveQueriesForDrillDown()
+        {
+            _suppressActiveQueriesAutoRefresh = true;
+            try
+            {
+                SubTabControl.SelectedIndex = 1; // Active Queries
+            }
+            finally
+            {
+                _suppressActiveQueriesAutoRefresh = false;
+            }
+        }
 
         public void SetTimeRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null)
         {
@@ -1271,7 +1295,7 @@ namespace PerformanceMonitorDashboard.Controls
         /// </summary>
         public async Task ShowActiveQueriesForRange(DateTime from, DateTime to)
         {
-            SubTabControl.SelectedIndex = 1; // Active Queries
+            SelectActiveQueriesForDrillDown();
             await RefreshActiveQueriesWithRangeAsync(from, to);
         }
 

--- a/Dashboard/ServerTab.DrillDown.cs
+++ b/Dashboard/ServerTab.DrillDown.cs
@@ -260,7 +260,7 @@ namespace PerformanceMonitorDashboard
             SetDrillDownGlobalRange(from, to);
 
             QueriesTabItem.IsSelected = true;
-            PerformanceTab.SelectSubTab(1); // Active Queries
+            PerformanceTab.SelectActiveQueriesForDrillDown();
             PerformanceTab.SetTimeRange(0, from, to);
             PerformanceTab.IsRefreshing = true;
             try { await RefreshQueriesTabAsync(); }
@@ -274,7 +274,7 @@ namespace PerformanceMonitorDashboard
             SetDrillDownGlobalRange(from, to);
 
             QueriesTabItem.IsSelected = true;
-            PerformanceTab.SelectSubTab(1); // Active Queries
+            PerformanceTab.SelectActiveQueriesForDrillDown();
             PerformanceTab.SetTimeRange(0, from, to);
             PerformanceTab.IsRefreshing = true;
             try { await RefreshQueriesTabAsync(); }

--- a/Lite/Controls/ServerTab.DrillDown.cs
+++ b/Lite/Controls/ServerTab.DrillDown.cs
@@ -93,6 +93,25 @@ public partial class ServerTab : UserControl
         };
     }
 
+    /// <summary>
+    /// Navigates to Queries → Active Queries for a drill-down without triggering the
+    /// MainTabControl_SelectionChanged auto-refresh (the caller loads its own filtered snapshot
+    /// next; the auto-refresh would clobber it via an async race).
+    /// </summary>
+    private void SelectActiveQueriesForDrillDown()
+    {
+        _suppressActiveQueriesAutoRefresh = true;
+        try
+        {
+            MainTabControl.SelectedIndex = 2; // Queries
+            QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+        }
+        finally
+        {
+            _suppressActiveQueriesAutoRefresh = false;
+        }
+    }
+
     private async void OnCpuDrillDown(DateTime time)
     {
         var fromDate = time.AddMinutes(-30);
@@ -102,8 +121,7 @@ public partial class ServerTab : UserControl
         SetDrillDownTimeRange(fromDate, toDate);
 
         // Navigate to Queries > Active Queries with ±15 min window
-        MainTabControl.SelectedIndex = 2; // Queries
-        QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+        SelectActiveQueriesForDrillDown();
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
@@ -116,8 +134,7 @@ public partial class ServerTab : UserControl
         var toDate = time.AddMinutes(30);
         SetDrillDownTimeRange(fromDate, toDate);
 
-        MainTabControl.SelectedIndex = 2; // Queries
-        QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+        SelectActiveQueriesForDrillDown();
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
@@ -131,8 +148,7 @@ public partial class ServerTab : UserControl
         SetDrillDownTimeRange(fromDate, toDate);
 
         // Navigate to Active Queries — TempDB spills are visible there
-        MainTabControl.SelectedIndex = 2; // Queries
-        QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+        SelectActiveQueriesForDrillDown();
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
@@ -173,8 +189,7 @@ public partial class ServerTab : UserControl
 
         SetDrillDownTimeRange(fromDate, toDate);
 
-        MainTabControl.SelectedIndex = 2; // Queries
-        QueriesSubTabControl.SelectedIndex = 1; // Active Queries
+        SelectActiveQueriesForDrillDown();
 
         AppLogger.Info("DrillDown", $"Calling GetLatestQuerySnapshotsAsync with fromDate={fromDate:O}, toDate={toDate:O}");
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -44,6 +44,11 @@ public partial class ServerTab : UserControl
     private readonly DispatcherTimer _refreshTimer;
     private bool _refreshPendingWhileHidden;
     private bool _isRefreshing;
+    // Guards the visible-tab auto-refresh during an Active Queries drill-down:
+    // SelectActiveQueriesForDrillDown() sets this before flipping to Queries → Active Queries so
+    // MainTabControl_SelectionChanged skips its refresh and doesn't clobber the filtered snapshot
+    // the drill-down loads next (async race).
+    private bool _suppressActiveQueriesAutoRefresh;
     private readonly Dictionary<ScottPlot.WPF.WpfPlot, ScottPlot.IPanel?> _legendPanels = new();
     private List<SelectableItem> _waitTypeItems = new();
     private List<SelectableItem> _perfmonCounterItems = new();
@@ -393,6 +398,11 @@ public partial class ServerTab : UserControl
             && e.Source != MemorySubTabControl && e.Source != BlockingSubTabControl) return;
 
         UpdateCompareDropdownState();
+
+        // A drill-down navigates here programmatically and loads its own filtered snapshot;
+        // skip the auto-refresh so it doesn't clobber that data via an async race. The flag is
+        // set/cleared around the tab switch in SelectActiveQueriesForDrillDown().
+        if (_suppressActiveQueriesAutoRefresh) return;
 
         var hoursBack = GetHoursBack();
         DateTime? fromDate = null, toDate = null;


### PR DESCRIPTION
## What

Make the **Active Queries** sub-tab re-run its live snapshot fetch each time it becomes the active sub-tab, so the grid is fresh on view instead of showing stale data until the next timer tick. Both apps.

## Why

- **Dashboard** had no auto-refresh on the Active Queries sub-tab — `SubTabControl.SelectionChanged` only reset the drill-down flag and updated the Compare dropdown. Switching to the tab showed whatever was last loaded.
- **Lite** already auto-refreshes the visible sub-tab via `MainTabControl_SelectionChanged`, but its Active-Queries drill-downs raced that auto-refresh (double-load + the "Drill-down: …" indicator could get overwritten with "" depending on async ordering).

## The race

The wait/chart/heatmap drill-downs select Active Queries **programmatically** and then load **filtered** snapshot data. WPF raises `SelectionChanged` *synchronously* inside the `SelectedIndex` setter, so a refresh fired from that handler would run concurrently with (and clobber) the filtered load.

## The fix

A `_suppressActiveQueriesAutoRefresh` flag, set inside a new `SelectActiveQueriesForDrillDown()` helper (try/finally around the tab switch) and honored by the SelectionChanged auto-refresh. Because the suppressed handler returns before its first `await`, the set → (synchronous handler) → finally-clear sequence is airtight; the flag can't leak across an await or get stuck when the target tab is already selected.

**Dashboard** (`QueryPerformanceContent.xaml.cs`, `ServerTab.DrillDown.cs`)
- `SelectionChanged` now runs `RefreshActiveQueriesAsync()` when Active Queries (index 1) becomes selected and the flag is clear.
- Heatmap drill-down, `ShowActiveQueriesForRange`, and the parent `OnQueryDrillDown`/`OnChildChartDrillDown` route through the helper. The now-unused `SelectSubTab(int)` is removed.

**Lite** (`ServerTab.xaml.cs`, `ServerTab.DrillDown.cs`)
- The Cpu/Memory/TempDb/Heatmap drill-downs route through the helper (it spans both `MainTabControl` and `QueriesSubTabControl` index assignments, so both handler firings on a cross-main-tab drill are suppressed).
- `MainTabControl_SelectionChanged` returns early when the flag is set — *after* `UpdateCompareDropdownState()` so the Compare dropdown still updates.

## Out of scope

Lite's blocking/deadlock drill-downs navigate to a different main tab (Blocking) and were left unchanged — see PR comment.

## Test plan (manual)

Both apps, against a server with recent query-snapshot data:
1. **Fresh on view** — switch to another sub-tab, run some queries on the monitored server, then click **Active Queries**: the grid reloads with the latest snapshots (no need to wait for the timer / hit Refresh).
2. **Drill-down not clobbered** — on the Query Heatmap (or a CPU/wait chart in Lite), drill into a point: Active Queries shows the **filtered** set for that window (Dashboard keeps drill-down mode; Lite shows the "Drill-down: …" indicator), *not* a full refresh.
3. Drill in, switch away, click back to Active Queries: it refreshes normally (no stuck-suppression).

Builds clean (both apps, net10.0-windows). Independent code review confirmed the race handling and that no other site programmatically selects Active Queries + loads filtered data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)