### PR TITLE
Add in-app query-plan navigation to every query-identifying surface (both apps)

### DIFF
--- a/Dashboard/Controls/FinOpsContent.xaml
+++ b/Dashboard/Controls/FinOpsContent.xaml
@@ -27,6 +27,37 @@
             <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
                 <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
             </Style>
+
+            <!-- Plan-navigation menus for the query-identifying FinOps grids (a dedicated menu so the
+                 plan items don't leak onto the non-query FinOps grids that share DataGridContextMenu). -->
+            <ContextMenu x:Key="HighImpactPlanContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"><MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"><MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="FinOpsViewPlan_Click"><MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="FinOpsGetActualPlan_Click"><MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon></MenuItem>
+            </ContextMenu>
+            <Style x:Key="HighImpactRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource HighImpactPlanContextMenu}"/>
+            </Style>
+
+            <!-- Expensive Queries carry only the full query text (no query_hash / plan_id), so they get
+                 Get Actual Plan only — there is no stored plan key to fetch a collected plan with. -->
+            <ContextMenu x:Key="ExpensiveQueryPlanContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"><MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"><MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Get Actual Plan" Click="FinOpsGetActualPlan_Click"><MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon></MenuItem>
+            </ContextMenu>
+            <Style x:Key="ExpensiveQueryRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource ExpensiveQueryPlanContextMenu}"/>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -2059,7 +2090,7 @@
                                       HeadersVisibility="Column"
                                       SelectionMode="Extended"
                                       MaxHeight="350"
-                                      RowStyle="{StaticResource DefaultRowStyle}">
+                                      RowStyle="{StaticResource ExpensiveQueryRowStyle}">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
                                         <DataGridTextColumn.Header>
@@ -2320,7 +2351,7 @@
                           AutoGenerateColumns="False" IsReadOnly="True"
                           CanUserSortColumns="True" CanUserResizeColumns="True"
                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                          RowStyle="{StaticResource DefaultRowStyle}"
+                          RowStyle="{StaticResource HighImpactRowStyle}"
                           Background="Transparent" BorderThickness="0"
                           RowBackground="Transparent"
                           AlternatingRowBackground="{DynamicResource DataGridAlternatingRowBrush}">

--- a/Dashboard/Controls/FinOpsContent.xaml.cs
+++ b/Dashboard/Controls/FinOpsContent.xaml.cs
@@ -51,6 +51,50 @@ namespace PerformanceMonitorDashboard.Controls
             Loaded += OnLoaded;
         }
 
+        // ── Plan navigation for the query-identifying FinOps grids ──
+        // Lazy: the controller's executeActual reads the current _databaseService (set on server-select),
+        // and Window.GetWindow(this) is only valid once the control is in the visual tree.
+        private PlanNavigationController? _planActions;
+        private PlanNavigationController PlanActions => _planActions ??= new PlanNavigationController(
+            Window.GetWindow(this)!,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(Window.GetWindow(this)!, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _databaseService!.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
+
+        private async void FinOpsViewPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (_databaseService == null) return;
+            if (GetFinOpsRow(sender) is FinOpsHighImpactQuery row)
+                await PlanActions.ViewPlanAsync(
+                    () => _databaseService.GetQueryStatsPlanXmlAsync(row.DatabaseName, row.QueryHashDisplay),
+                    $"Est Plan - {row.QueryHashDisplay}", row.FullQueryText);
+        }
+
+        private async void FinOpsGetActualPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (_databaseService == null) return;
+            switch (GetFinOpsRow(sender))
+            {
+                case FinOpsHighImpactQuery hi:
+                    await PlanActions.GetActualPlanAsync(hi.FullQueryText, hi.DatabaseName, $"Actual Plan - {hi.QueryHashDisplay}");
+                    break;
+                case FinOpsExpensiveQuery ex:
+                    await PlanActions.GetActualPlanAsync(ex.FullQueryText, ex.DatabaseName, "Actual Plan - Expensive Query");
+                    break;
+            }
+        }
+
+        private static object? GetFinOpsRow(object sender)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                if (contextMenu.PlacementTarget is DataGridRow row) return row.DataContext;
+                if (contextMenu.PlacementTarget is DataGrid grid) return grid.CurrentCell.Item ?? grid.SelectedItem;
+            }
+            return null;
+        }
+
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             TabHelpers.AutoSizeColumnMinWidths(RecommendationsDataGrid);

--- a/Dashboard/Controls/QueryPerformanceContent.Plans.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.Plans.cs
@@ -16,6 +16,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls
 {
@@ -190,6 +191,18 @@ namespace PerformanceMonitorDashboard.Controls
                     queryText = reg.QueryTextSample;
                     label = $"Est Plan - QS {reg.QueryId}";
                     break;
+                case QueryStatsComparisonItem comp:
+                    queryText = comp.QueryText;
+                    label = $"Est Plan - {comp.QueryHash}";
+                    if (_databaseService != null && !string.IsNullOrEmpty(comp.QueryHash))
+                        planXml = await _databaseService.GetQueryStatsPlanXmlAsync(comp.DatabaseName, comp.QueryHash);
+                    break;
+                case ProcedureStatsComparisonItem procComp:
+                    queryText = procComp.FullName;
+                    label = $"Est Plan - {procComp.FullName}";
+                    if (_databaseService != null && !string.IsNullOrEmpty(procComp.ObjectName))
+                        planXml = await _databaseService.GetProcedureStatsPlanXmlByNameAsync(procComp.DatabaseName, procComp.SchemaName, procComp.ObjectName);
+                    break;
             }
 
             if (planXml == null && item is LongRunningQueryPatternItem)
@@ -273,6 +286,11 @@ namespace PerformanceMonitorDashboard.Controls
                     queryText = lrq.SampleQueryText;
                     databaseName = lrq.DatabaseName;
                     label = $"Actual Plan - Pattern";
+                    break;
+                case QueryStatsComparisonItem comp:
+                    queryText = comp.QueryText;
+                    databaseName = comp.DatabaseName;
+                    label = $"Actual Plan - {comp.QueryHash}";
                     break;
             }
 

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -968,7 +968,8 @@ namespace PerformanceMonitorDashboard.Controls
                     "Query Store",
                     _queryStoreHoursBack,
                     _queryStoreFromDate,
-                    _queryStoreToDate
+                    _queryStoreToDate,
+                    item.QueryText
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();
@@ -1000,7 +1001,8 @@ namespace PerformanceMonitorDashboard.Controls
                     "Query Store",
                     _queryStoreHoursBack,
                     _queryStoreFromDate,
-                    _queryStoreToDate
+                    _queryStoreToDate,
+                    item.QueryTextSample
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();
@@ -1067,7 +1069,8 @@ namespace PerformanceMonitorDashboard.Controls
                     item.QueryHash,
                     _queryStatsHoursBack,
                     _queryStatsFromDate,
-                    _queryStatsToDate
+                    _queryStatsToDate,
+                    item.QueryText
                 );
                 historyWindow.Owner = Window.GetWindow(this);
                 historyWindow.ShowDialog();

--- a/Dashboard/PlanViewerWindow.xaml
+++ b/Dashboard/PlanViewerWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="PerformanceMonitorDashboard.PlanViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:PerformanceMonitorDashboard.Controls"
+        Title="Query Plan" Width="1200" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid>
+        <controls:PlanViewerControl x:Name="Viewer"/>
+    </Grid>
+</Window>

--- a/Dashboard/PlanViewerWindow.xaml.cs
+++ b/Dashboard/PlanViewerWindow.xaml.cs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace PerformanceMonitorDashboard
+{
+    /// <summary>
+    /// Standalone window that hosts a <see cref="Controls.PlanViewerControl"/> so any drill-down /
+    /// history window can open a collected or actual plan in-app. Shown owned + non-modal so it stays
+    /// interactive above a modal drill-down and closes with its host.
+    /// </summary>
+    public partial class PlanViewerWindow : Window
+    {
+        public PlanViewerWindow()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>Loads a plan into this window's viewer. Throws <see cref="System.Xml.XmlException"/> for invalid XML.</summary>
+        public async Task LoadPlanAsync(string planXml, string label, string? queryText)
+        {
+            if (!string.IsNullOrWhiteSpace(label))
+                Title = label.Length > 80 ? label[..80] : label;
+            await Viewer.LoadPlan(planXml, label, queryText);
+        }
+
+        /// <summary>
+        /// Opens a new, owned, non-modal plan window and loads the plan. A new window per call lets the
+        /// user compare plans side by side; owned so it stays usable above a modal host window.
+        /// </summary>
+        public static async Task ShowPlanAsync(Window owner, string planXml, string label, string? queryText)
+        {
+            var window = new PlanViewerWindow { Owner = owner };
+            window.Show();
+            try
+            {
+                await window.LoadPlanAsync(planXml, label, queryText);
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                window.Close();
+                MessageBox.Show(owner, $"The plan XML is not valid:\n\n{ex.Message}", "Invalid Plan XML",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+            catch (Exception ex)
+            {
+                window.Close();
+                MessageBox.Show(owner, $"Failed to load the execution plan:\n\n{ex.Message}", "Plan Load Error",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+    }
+}

--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -26,6 +26,10 @@
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
+            <Separator/>
+            <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid>

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace PerformanceMonitorDashboard
         private readonly int _hoursBack;
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
+        private readonly PlanNavigationController _planActions;
         private List<ProcedureExecutionHistoryItem> _historyData = new();
         private ChartHoverHelper? _chartHover;
 
@@ -68,6 +69,13 @@ namespace PerformanceMonitorDashboard
             _hoursBack = hoursBack;
             _fromDate = fromDate;
             _toDate = toDate;
+
+            _planActions = new PlanNavigationController(
+                this,
+                (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+                (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                    _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+                "the monitored server");
 
             ProcedureIdentifierText.Text = $"Procedure Execution History: {objectName} in [{databaseName}]";
 
@@ -481,6 +489,30 @@ namespace PerformanceMonitorDashboard
                     }
                 }
             }
+        }
+
+        #endregion
+
+        #region Plan Actions
+
+        // Procedures are View Plan only — re-executing a proc without parameter values is unsafe,
+        // matching the main Procedure grid (no Get Actual case in its switch).
+        private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (GetHistoryItem(sender) is not { } item) return;
+            await _planActions.ViewPlanAsync(
+                () => _databaseService.GetProcedureStatsPlanXmlByCollectionIdAsync(item.CollectionId),
+                $"Est Plan - {_objectName}", queryText: null);
+        }
+
+        private static ProcedureExecutionHistoryItem? GetHistoryItem(object sender)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                return (dataGrid?.CurrentCell.Item ?? dataGrid?.SelectedItem) as ProcedureExecutionHistoryItem;
+            }
+            return null;
         }
 
         #endregion

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -26,6 +26,13 @@
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
+            <Separator/>
+            <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid>

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -35,6 +35,8 @@ namespace PerformanceMonitorDashboard
         private readonly int _hoursBack;
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
+        private readonly string? _queryText;
+        private readonly PlanNavigationController _planActions;
         private List<QueryExecutionHistoryItem> _historyData = new();
         private ScottPlot.IPanel? _legendPanel;
         private ChartHoverHelper? _chartHover;
@@ -52,7 +54,8 @@ namespace PerformanceMonitorDashboard
             string sourceType = "Query Store",
             int hoursBack = 24,
             DateTime? fromDate = null,
-            DateTime? toDate = null)
+            DateTime? toDate = null,
+            string? queryText = null)
         {
             InitializeComponent();
 
@@ -63,6 +66,14 @@ namespace PerformanceMonitorDashboard
             _hoursBack = hoursBack;
             _fromDate = fromDate;
             _toDate = toDate;
+            _queryText = queryText;
+
+            _planActions = new PlanNavigationController(
+                this,
+                (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+                (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                    _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+                "the monitored server");
 
             QueryIdentifierText.Text = $"Query Execution History: Query {queryId} in [{databaseName}]";
 
@@ -505,6 +516,33 @@ namespace PerformanceMonitorDashboard
                     }
                 }
             }
+        }
+
+        #endregion
+
+        #region Plan Actions
+
+        private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (GetHistoryItem(sender) is not { } item) return;
+            await _planActions.ViewPlanAsync(
+                () => _databaseService.GetQueryStorePlanXmlByCollectionIdAsync(item.CollectionId),
+                $"Est Plan - QS {_queryId}", _queryText);
+        }
+
+        private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+        {
+            await _planActions.GetActualPlanAsync(_queryText, _databaseName, $"Actual Plan - QS {_queryId}");
+        }
+
+        private static QueryExecutionHistoryItem? GetHistoryItem(object sender)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                return (dataGrid?.CurrentCell.Item ?? dataGrid?.SelectedItem) as QueryExecutionHistoryItem;
+            }
+            return null;
         }
 
         #endregion

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -26,6 +26,13 @@
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
+            <Separator/>
+            <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid>

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -34,6 +34,8 @@ namespace PerformanceMonitorDashboard
         private readonly int _hoursBack;
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
+        private readonly string? _queryText;
+        private readonly PlanNavigationController _planActions;
         private List<QueryStatsHistoryItem> _historyData = new();
         private ChartHoverHelper? _chartHover;
 
@@ -49,7 +51,8 @@ namespace PerformanceMonitorDashboard
             string queryHash,
             int hoursBack = 24,
             DateTime? fromDate = null,
-            DateTime? toDate = null)
+            DateTime? toDate = null,
+            string? queryText = null)
         {
             InitializeComponent();
 
@@ -59,6 +62,14 @@ namespace PerformanceMonitorDashboard
             _hoursBack = hoursBack;
             _fromDate = fromDate;
             _toDate = toDate;
+            _queryText = queryText;
+
+            _planActions = new PlanNavigationController(
+                this,
+                (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+                (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                    _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+                "the monitored server");
 
             QueryIdentifierText.Text = $"Query Stats History: {queryHash} in [{databaseName}]";
 
@@ -473,6 +484,33 @@ namespace PerformanceMonitorDashboard
                     }
                 }
             }
+        }
+
+        #endregion
+
+        #region Plan Actions
+
+        private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (GetHistoryItem(sender) is not { } item) return;
+            await _planActions.ViewPlanAsync(
+                () => _databaseService.GetQueryStatsPlanXmlByCollectionIdAsync(item.CollectionId),
+                $"Est Plan - {_queryHash}", _queryText);
+        }
+
+        private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+        {
+            await _planActions.GetActualPlanAsync(_queryText, _databaseName, $"Actual Plan - {_queryHash}");
+        }
+
+        private static QueryStatsHistoryItem? GetHistoryItem(object sender)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                return (dataGrid?.CurrentCell.Item ?? dataGrid?.SelectedItem) as QueryStatsHistoryItem;
+            }
+            return null;
         }
 
         #endregion

--- a/Dashboard/Services/DatabaseService.QueryPerformance.PlanXml.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.PlanXml.cs
@@ -144,5 +144,36 @@ namespace PerformanceMonitorDashboard.Services
             var result = await command.ExecuteScalarAsync();
             return result == DBNull.Value || result == null ? null : (string)result;
         }
+
+        /// <summary>
+        /// Fetches the collected plan XML for a procedure identified by database + schema + object name.
+        /// Used by the Procedure Stats comparison grid, whose rows carry only the name (no plan_handle
+        /// or collection_id). Reads the already-materialized plan from report.procedure_stats_summary.
+        /// </summary>
+        public async Task<string?> GetProcedureStatsPlanXmlByNameAsync(string databaseName, string schemaName, string objectName)
+        {
+            await using var tc = await OpenThrottledConnectionAsync();
+            var connection = tc.Connection;
+
+            string query = @"
+        SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+        SELECT TOP (1)
+            query_plan_xml = CONVERT(nvarchar(max), ps.query_plan_xml)
+        FROM report.procedure_stats_summary AS ps
+        WHERE ps.database_name = @databaseName
+        AND   ps.schema_name = @schemaName
+        AND   ps.procedure_name = @objectName  /* bare name; the view's object_name is bracketed [schema].[object] */
+        AND   ps.query_plan_xml IS NOT NULL;";
+
+            using var command = new SqlCommand(query, connection);
+            command.CommandTimeout = 120;
+            command.Parameters.Add(new SqlParameter("@databaseName", SqlDbType.NVarChar, 128) { Value = databaseName });
+            command.Parameters.Add(new SqlParameter("@schemaName", SqlDbType.NVarChar, 128) { Value = schemaName });
+            command.Parameters.Add(new SqlParameter("@objectName", SqlDbType.NVarChar, 128) { Value = objectName });
+
+            var result = await command.ExecuteScalarAsync();
+            return result == DBNull.Value || result == null ? null : (string)result;
+        }
     }
 }

--- a/Dashboard/TracePatternHistoryWindow.xaml
+++ b/Dashboard/TracePatternHistoryWindow.xaml
@@ -23,6 +23,10 @@
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
+            <Separator/>
+            <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+            </MenuItem>
         </ContextMenu>
     </Window.Resources>
     <Grid>

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace PerformanceMonitorDashboard
         private readonly int _hoursBack;
         private readonly DateTime? _fromDate;
         private readonly DateTime? _toDate;
+        private readonly PlanNavigationController _planActions;
         private List<TracePatternDetailItem> _historyData = new();
         private ChartHoverHelper? _chartHover;
 
@@ -59,6 +60,13 @@ namespace PerformanceMonitorDashboard
             _hoursBack = hoursBack;
             _fromDate = fromDate;
             _toDate = toDate;
+
+            _planActions = new PlanNavigationController(
+                this,
+                (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+                (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                    _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+                "the monitored server");
 
             // Collapse newlines/tabs to spaces and truncate for a clean single-line header
             var displayPattern = MultipleSpacesRegExp().Replace(queryPattern, " ").Trim();
@@ -410,6 +418,29 @@ namespace PerformanceMonitorDashboard
 
         [System.Text.RegularExpressions.GeneratedRegex(@"\s+")]
         private static partial System.Text.RegularExpressions.Regex MultipleSpacesRegExp();
+
+        #endregion
+
+        #region Plan Actions
+
+        // Trace patterns are aggregated trace/RPC-completed events with no cached plan, so only
+        // "Get Actual Plan" is offered (re-execute the sampled statement) — mirroring how the main
+        // grid treats LongRunningQueryPatternItem.
+        private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+        {
+            if (GetHistoryItem(sender) is not { } item) return;
+            await _planActions.GetActualPlanAsync(item.SqlText, _databaseName, "Actual Plan - Trace Pattern");
+        }
+
+        private static TracePatternDetailItem? GetHistoryItem(object sender)
+        {
+            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+            {
+                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+                return (dataGrid?.CurrentCell.Item ?? dataGrid?.SelectedItem) as TracePatternDetailItem;
+            }
+            return null;
+        }
 
         #endregion
     }

--- a/Dashboard/WaitDrillDownWindow.xaml
+++ b/Dashboard/WaitDrillDownWindow.xaml
@@ -21,6 +21,13 @@
                 <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
 
             <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">

--- a/Dashboard/WaitDrillDownWindow.xaml.cs
+++ b/Dashboard/WaitDrillDownWindow.xaml.cs
@@ -37,6 +37,7 @@ public partial class WaitDrillDownWindow : Window
     private List<QuerySnapshotItem>? _unfilteredData;
     private Popup? _filterPopup;
     private ColumnFilterPopup? _filterPopupContent;
+    private readonly PlanNavigationController _planActions;
 
     public WaitDrillDownWindow(
         DatabaseService databaseService,
@@ -51,6 +52,13 @@ public partial class WaitDrillDownWindow : Window
         _hoursBack = hoursBack;
         _fromDate = fromDate;
         _toDate = toDate;
+
+        _planActions = new PlanNavigationController(
+            this,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
 
         Title = $"Wait Drill-Down: {waitType}";
 
@@ -515,6 +523,35 @@ public partial class WaitDrillDownWindow : Window
                 }
             }
         }
+    }
+
+    #endregion
+
+    #region Plan Actions
+
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (GetSnapshotItem(sender) is not { } item) return;
+        await _planActions.ViewPlanAsync(
+            () => _databaseService.GetQuerySnapshotPlanAsync(item.CollectionTime, item.SessionId),
+            $"Est Plan - SPID {item.SessionId}", item.QueryText);
+    }
+
+    private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (GetSnapshotItem(sender) is not { } item) return;
+        await _planActions.GetActualPlanAsync(item.QueryText, item.DatabaseName ?? "",
+            $"Actual Plan - SPID {item.SessionId}");
+    }
+
+    private static QuerySnapshotItem? GetSnapshotItem(object sender)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
+            return (dataGrid?.CurrentCell.Item ?? dataGrid?.SelectedItem) as QuerySnapshotItem;
+        }
+        return null;
     }
 
     #endregion

--- a/Lite/Controls/FinOpsTab.xaml
+++ b/Lite/Controls/FinOpsTab.xaml
@@ -26,6 +26,37 @@
             <Style x:Key="DefaultRowStyle" TargetType="DataGridRow">
                 <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
             </Style>
+
+            <!-- Plan-navigation menus for the query-identifying FinOps grids (a dedicated menu so the
+                 plan items don't leak onto the non-query FinOps grids that share DataGridContextMenu). -->
+            <ContextMenu x:Key="HighImpactPlanContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"><MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"><MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="FinOpsViewPlan_Click"><MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="FinOpsGetActualPlan_Click"><MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon></MenuItem>
+            </ContextMenu>
+            <Style x:Key="HighImpactRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource HighImpactPlanContextMenu}"/>
+            </Style>
+
+            <!-- Expensive Queries carry only the full query text (no query_hash / plan_id), so they get
+                 Get Actual Plan only — there is no stored plan key to fetch a collected plan with. -->
+            <ContextMenu x:Key="ExpensiveQueryPlanContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click"><MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon></MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click"><MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click"><MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon></MenuItem>
+                <Separator/>
+                <MenuItem Header="Get Actual Plan" Click="FinOpsGetActualPlan_Click"><MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon></MenuItem>
+            </ContextMenu>
+            <Style x:Key="ExpensiveQueryRowStyle" TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource ExpensiveQueryPlanContextMenu}"/>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -1944,7 +1975,7 @@
                                       HeadersVisibility="Column"
                                       SelectionMode="Extended"
                                       MaxHeight="350"
-                                      RowStyle="{StaticResource DefaultRowStyle}">
+                                      RowStyle="{StaticResource ExpensiveQueryRowStyle}">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
@@ -2098,7 +2129,7 @@
                           AutoGenerateColumns="False" IsReadOnly="True"
                           CanUserSortColumns="True" CanUserResizeColumns="True"
                           HeadersVisibility="Column" GridLinesVisibility="Horizontal"
-                          RowStyle="{StaticResource DefaultRowStyle}"
+                          RowStyle="{StaticResource HighImpactRowStyle}"
                           Background="Transparent" BorderThickness="0"
                           RowBackground="Transparent"
                           AlternatingRowBackground="{DynamicResource DataGridAlternatingRowBrush}">

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -117,6 +117,72 @@ public partial class FinOpsTab : UserControl
         return 0;
     }
 
+    // ── Plan navigation for the query-identifying FinOps grids ──
+    // Lazy: executeActual reads the current selected-server connection string, and Window.GetWindow(this)
+    // is only valid once the control is in the visual tree.
+    private PlanNavigationController? _planActions;
+    private PlanNavigationController PlanActions => _planActions ??= new PlanNavigationController(
+        Window.GetWindow(this)!,
+        (xml, label, qt) => Windows.PlanViewerWindow.ShowPlanAsync(Window.GetWindow(this)!, xml, label, qt),
+        (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+            GetSelectedConnectionString() ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+        "the monitored server");
+
+    private string? GetSelectedConnectionString()
+        => ServerSelector.SelectedItem is ServerConnection s && _credentialResolver != null
+            ? _credentialResolver.GetConnectionString(s)
+            : null;
+
+    private async System.Threading.Tasks.Task<string?> FetchFinOpsHighImpactPlanAsync(string queryHash)
+    {
+        if (string.IsNullOrEmpty(queryHash)) return null;
+        var serverId = GetSelectedServerId();
+        string? plan = null;
+        if (serverId != 0 && _dataService != null)
+        {
+            try { plan = await _dataService.GetCachedQueryPlanAsync(serverId, queryHash); }
+            catch { /* fall through to the live server */ }
+        }
+        if (string.IsNullOrEmpty(plan))
+        {
+            var connStr = GetSelectedConnectionString();
+            if (!string.IsNullOrEmpty(connStr))
+                plan = await LocalDataService.FetchQueryPlanOnDemandAsync(connStr, queryHash);
+        }
+        return plan;
+    }
+
+    private async void FinOpsViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (GetFinOpsRow(sender) is HighImpactQueryRow row)
+            await PlanActions.ViewPlanAsync(
+                () => FetchFinOpsHighImpactPlanAsync(row.QueryHash),
+                $"Est Plan - {row.QueryHash}", row.FullQueryText);
+    }
+
+    private async void FinOpsGetActualPlan_Click(object sender, RoutedEventArgs e)
+    {
+        switch (GetFinOpsRow(sender))
+        {
+            case HighImpactQueryRow hi:
+                await PlanActions.GetActualPlanAsync(hi.FullQueryText, hi.DatabaseName, $"Actual Plan - {hi.QueryHash}");
+                break;
+            case ExpensiveQueryRow ex:
+                await PlanActions.GetActualPlanAsync(ex.FullQueryText, ex.DatabaseName, "Actual Plan - Expensive Query");
+                break;
+        }
+    }
+
+    private static object? GetFinOpsRow(object sender)
+    {
+        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
+        {
+            if (contextMenu.PlacementTarget is DataGridRow row) return row.DataContext;
+            if (contextMenu.PlacementTarget is DataGrid grid) return grid.CurrentCell.Item ?? grid.SelectedItem;
+        }
+        return null;
+    }
+
     /// <summary>
     /// Refreshes all FinOps data.
     /// </summary>

--- a/Lite/Controls/ServerTab.DrillDown.cs
+++ b/Lite/Controls/ServerTab.DrillDown.cs
@@ -55,7 +55,8 @@ public partial class ServerTab : UserControl
         var toDate = time.AddMinutes(30);
 
         var window = new Windows.WaitDrillDownWindow(
-            _dataService, _serverId, waitType, 1, fromDate, toDate);
+            _dataService, _serverId, waitType, 1, fromDate, toDate,
+            _credentialResolver.GetConnectionString(_server));
         window.Owner = Window.GetWindow(this);
         window.ShowDialog();
     }

--- a/Lite/Controls/ServerTab.Grids.cs
+++ b/Lite/Controls/ServerTab.Grids.cs
@@ -219,7 +219,7 @@ public partial class ServerTab : UserControl
         if (string.IsNullOrEmpty(item.DatabaseName) || string.IsNullOrEmpty(item.QueryHash)) return;
 
         var connStr = _credentialResolver.GetConnectionString(_server);
-        var window = new Windows.QueryStatsHistoryWindow(_dataService, _serverId, item.DatabaseName, item.QueryHash, GetHoursBack(), connStr);
+        var window = new Windows.QueryStatsHistoryWindow(_dataService, _serverId, item.DatabaseName, item.QueryHash, GetHoursBack(), item.QueryText, connStr);
         window.Owner = Window.GetWindow(this);
         window.ShowDialog();
     }

--- a/Lite/Controls/ServerTab.Plans.cs
+++ b/Lite/Controls/ServerTab.Plans.cs
@@ -19,6 +19,7 @@ using Microsoft.Win32;
 using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Controls;
 
@@ -300,6 +301,22 @@ public partial class ServerTab : UserControl
                     catch { }
                 }
                 break;
+            case QueryStatsComparisonItem comp:
+                queryText = comp.QueryText;
+                label = $"Est Plan - {comp.QueryHash}";
+                if (!string.IsNullOrEmpty(comp.QueryHash))
+                    planXml = await FetchPlanByHash(comp.QueryHash);
+                break;
+            case ProcedureStatsComparisonItem procComp:
+                label = $"Est Plan - {procComp.FullName}";
+                queryText = procComp.FullName;
+                try
+                {
+                    var procConnStr = _credentialResolver.GetConnectionString(_server);
+                    planXml = await LocalDataService.FetchProcedurePlanOnDemandAsync(procConnStr, procComp.DatabaseName, procComp.SchemaName, procComp.ObjectName);
+                }
+                catch { }
+                break;
         }
 
         if (!string.IsNullOrEmpty(planXml))
@@ -359,6 +376,16 @@ public partial class ServerTab : UserControl
                         var connStr = _credentialResolver.GetConnectionString(_server);
                         planXml = await LocalDataService.FetchQueryStorePlanAsync(connStr, qs.DatabaseName, qs.PlanId);
                     }
+                    catch { }
+                }
+                break;
+            case QueryStatsComparisonItem comp:
+                queryText = comp.QueryText;
+                databaseName = comp.DatabaseName;
+                label = $"Actual Plan - {comp.QueryHash}";
+                if (!string.IsNullOrEmpty(comp.QueryHash))
+                {
+                    try { planXml = await FetchPlanByHash(comp.QueryHash); }
                     catch { }
                 }
                 break;

--- a/Lite/Windows/PlanViewerWindow.xaml
+++ b/Lite/Windows/PlanViewerWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="PerformanceMonitorLite.Windows.PlanViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:PerformanceMonitorLite.Controls"
+        Title="Query Plan" Width="1200" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid>
+        <controls:PlanViewerControl x:Name="Viewer"/>
+    </Grid>
+</Window>

--- a/Lite/Windows/PlanViewerWindow.xaml.cs
+++ b/Lite/Windows/PlanViewerWindow.xaml.cs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Xml.Linq;
+
+namespace PerformanceMonitorLite.Windows;
+
+/// <summary>
+/// Standalone window that hosts a <see cref="PerformanceMonitorLite.Controls.PlanViewerControl"/> so any
+/// drill-down / history window can open a collected or actual plan in-app. Shown owned + non-modal so it
+/// stays interactive above a modal drill-down and closes with its host.
+/// </summary>
+public partial class PlanViewerWindow : Window
+{
+    public PlanViewerWindow()
+    {
+        InitializeComponent();
+        // The Lite PlanViewerControl needs an explicit Cleanup() to unsubscribe ThemeManager.
+        Closed += (_, _) => Viewer.Cleanup();
+    }
+
+    /// <summary>Loads a plan into this window's viewer. Caller validates the XML first (see <see cref="ShowPlanAsync"/>).</summary>
+    public void LoadPlan(string planXml, string label, string? queryText)
+    {
+        if (!string.IsNullOrWhiteSpace(label))
+            Title = label.Length > 80 ? label[..80] : label;
+        Viewer.LoadPlan(planXml, label, queryText);
+    }
+
+    /// <summary>
+    /// Opens a new, owned, non-modal plan window and loads the plan. A new window per call lets the user
+    /// compare plans side by side; owned so it stays usable above a modal host window. Returns a completed
+    /// Task so it satisfies the shared controller's async <c>showPlan</c> delegate.
+    /// </summary>
+    public static Task ShowPlanAsync(Window owner, string planXml, string label, string? queryText)
+    {
+        // The Lite control does not validate XML — mirror OpenPlanTab and parse-check up front.
+        try
+        {
+            XDocument.Parse(planXml);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            MessageBox.Show(owner, $"The plan XML is not valid:\n\n{ex.Message}", "Invalid Plan XML",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return Task.CompletedTask;
+        }
+
+        var window = new PlanViewerWindow { Owner = owner };
+        window.Show();
+        try
+        {
+            window.LoadPlan(planXml, label, queryText);
+        }
+        catch (Exception ex)
+        {
+            window.Close();
+            MessageBox.Show(owner, $"Failed to load the execution plan:\n\n{ex.Message}", "Plan Load Error",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Lite/Windows/ProcedureHistoryWindow.xaml
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml
@@ -24,6 +24,10 @@
                 <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -29,6 +29,7 @@ public partial class ProcedureHistoryWindow : Window
     private readonly string _objectName;
     private readonly int _hoursBack;
     private readonly string? _connectionString;
+    private readonly PlanNavigationController _planActions;
     private List<ProcedureStatsHistoryRow> _historyData = new();
 
     public ProcedureHistoryWindow(LocalDataService dataService, int serverId, string databaseName, string schemaName, string objectName, int hoursBack, string? connectionString = null)
@@ -41,6 +42,13 @@ public partial class ProcedureHistoryWindow : Window
         _objectName = objectName;
         _hoursBack = hoursBack;
         _connectionString = connectionString;
+
+        _planActions = new PlanNavigationController(
+            this,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
 
         var fullName = string.IsNullOrEmpty(schemaName) ? objectName : $"{schemaName}.{objectName}";
         ProcIdentifierText.Text = $"Procedure History: {fullName} in [{databaseName}]";
@@ -200,6 +208,20 @@ public partial class ProcedureHistoryWindow : Window
     private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "procedure_history");
+
+    // Procedures are View Plan only — re-executing a proc without parameter values is unsafe,
+    // matching the main Procedure grid (no Get Actual case in its switch).
+    private async System.Threading.Tasks.Task<string?> FetchPlanAsync()
+    {
+        if (string.IsNullOrEmpty(_connectionString) || string.IsNullOrEmpty(_objectName)) return null;
+        return await LocalDataService.FetchProcedurePlanOnDemandAsync(_connectionString, _databaseName, _schemaName, _objectName);
+    }
+
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        var fullName = string.IsNullOrEmpty(_schemaName) ? _objectName : $"{_schemaName}.{_objectName}";
+        await _planActions.ViewPlanAsync(FetchPlanAsync, $"Est Plan - {fullName}", queryText: null);
+    }
 
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml
@@ -24,6 +24,13 @@
                 <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -28,9 +28,11 @@ public partial class QueryStatsHistoryWindow : Window
     private readonly string _queryHash;
     private readonly int _hoursBack;
     private readonly string? _connectionString;
+    private readonly string? _queryText;
+    private readonly PlanNavigationController _planActions;
     private List<QueryStatsHistoryRow> _historyData = new();
 
-    public QueryStatsHistoryWindow(LocalDataService dataService, int serverId, string databaseName, string queryHash, int hoursBack, string? connectionString = null)
+    public QueryStatsHistoryWindow(LocalDataService dataService, int serverId, string databaseName, string queryHash, int hoursBack, string? queryText = null, string? connectionString = null)
     {
         InitializeComponent();
         _dataService = dataService;
@@ -38,7 +40,15 @@ public partial class QueryStatsHistoryWindow : Window
         _databaseName = databaseName;
         _queryHash = queryHash;
         _hoursBack = hoursBack;
+        _queryText = queryText;
         _connectionString = connectionString;
+
+        _planActions = new PlanNavigationController(
+            this,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
 
         QueryIdentifierText.Text = $"Query Stats History: {queryHash} in [{databaseName}]";
         Loaded += async (_, _) => await LoadHistoryAsync();
@@ -220,6 +230,23 @@ public partial class QueryStatsHistoryWindow : Window
     private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_stats_history");
+
+    private async System.Threading.Tasks.Task<string?> FetchPlanAsync()
+    {
+        if (string.IsNullOrEmpty(_queryHash)) return null;
+        string? plan = null;
+        try { plan = await _dataService.GetCachedQueryPlanAsync(_serverId, _queryHash); }
+        catch { /* DuckDB lookup failed — fall through to the live server */ }
+        if (string.IsNullOrEmpty(plan) && !string.IsNullOrEmpty(_connectionString))
+            plan = await LocalDataService.FetchQueryPlanOnDemandAsync(_connectionString, _queryHash);
+        return plan;
+    }
+
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+        => await _planActions.ViewPlanAsync(FetchPlanAsync, $"Est Plan - {_queryHash}", _queryText);
+
+    private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+        => await _planActions.GetActualPlanAsync(_queryText, _databaseName, $"Actual Plan - {_queryHash}");
 
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml
@@ -24,6 +24,13 @@
                 <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -29,6 +29,8 @@ public partial class QueryStoreHistoryWindow : Window
     private readonly long _planId;
     private readonly int _hoursBack;
     private readonly string? _connectionString;
+    private readonly string _queryText;
+    private readonly PlanNavigationController _planActions;
     private List<QueryStoreHistoryRow> _historyData = new();
 
     public QueryStoreHistoryWindow(LocalDataService dataService, int serverId, string databaseName, long queryId, long planId, string queryText, int hoursBack, string? connectionString = null)
@@ -41,6 +43,14 @@ public partial class QueryStoreHistoryWindow : Window
         _planId = planId;
         _hoursBack = hoursBack;
         _connectionString = connectionString;
+        _queryText = queryText;
+
+        _planActions = new PlanNavigationController(
+            this,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
 
         var displayText = queryText.Length > 120 ? queryText[..120] + "..." : queryText;
         QueryIdentifierText.Text = $"Query Store History: Query {queryId}, Plan {planId} in [{databaseName}]";
@@ -201,6 +211,18 @@ public partial class QueryStoreHistoryWindow : Window
     private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_store_history");
+
+    private async System.Threading.Tasks.Task<string?> FetchPlanAsync()
+    {
+        if (string.IsNullOrEmpty(_connectionString) || _planId == 0) return null;
+        return await LocalDataService.FetchQueryStorePlanAsync(_connectionString, _databaseName, _planId);
+    }
+
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+        => await _planActions.ViewPlanAsync(FetchPlanAsync, $"Est Plan - QS {_queryId}/{_planId}", _queryText);
+
+    private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+        => await _planActions.GetActualPlanAsync(_queryText, _databaseName, $"Actual Plan - QS {_queryId}");
 
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/Lite/Windows/WaitDrillDownWindow.xaml
+++ b/Lite/Windows/WaitDrillDownWindow.xaml
@@ -21,6 +21,13 @@
                 <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Get Actual Plan" Click="GetActualPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x25B6;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Lite/Windows/WaitDrillDownWindow.xaml.cs
+++ b/Lite/Windows/WaitDrillDownWindow.xaml.cs
@@ -30,6 +30,8 @@ public partial class WaitDrillDownWindow : Window
     private readonly int _hoursBack;
     private readonly DateTime? _fromDate;
     private readonly DateTime? _toDate;
+    private readonly string? _connectionString;
+    private readonly PlanNavigationController _planActions;
 
     // Filter state
     private DataGridFilterManager<QuerySnapshotRow>? _filterManager;
@@ -42,7 +44,8 @@ public partial class WaitDrillDownWindow : Window
         string waitType,
         int hoursBack,
         DateTime? fromDate = null,
-        DateTime? toDate = null)
+        DateTime? toDate = null,
+        string? connectionString = null)
     {
         InitializeComponent();
         _dataService = dataService;
@@ -51,6 +54,14 @@ public partial class WaitDrillDownWindow : Window
         _hoursBack = hoursBack;
         _fromDate = fromDate;
         _toDate = toDate;
+        _connectionString = connectionString;
+
+        _planActions = new PlanNavigationController(
+            this,
+            (xml, label, qt) => PlanViewerWindow.ShowPlanAsync(this, xml, label, qt),
+            (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
+                _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
+            "the monitored server");
 
         _filterManager = new DataGridFilterManager<QuerySnapshotRow>(ResultsDataGrid);
 
@@ -412,5 +423,23 @@ public partial class WaitDrillDownWindow : Window
     private void CopyRow_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyRow(sender);
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyAllRows(sender);
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.ExportToCsv(sender, "wait_drill_down");
+
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if ((ResultsDataGrid.CurrentItem ?? ResultsDataGrid.SelectedItem) is not QuerySnapshotRow row) return;
+        await _planActions.ViewPlanAsync(
+            () => System.Threading.Tasks.Task.FromResult<string?>(row.LiveQueryPlan ?? row.QueryPlan),
+            $"Est Plan - SPID {row.SessionId}", row.QueryText);
+    }
+
+    private async void GetActualPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if ((ResultsDataGrid.CurrentItem ?? ResultsDataGrid.SelectedItem) is not QuerySnapshotRow row) return;
+        await _planActions.GetActualPlanAsync(row.QueryText, row.DatabaseName ?? "",
+            $"Actual Plan - SPID {row.SessionId}",
+            estimatedPlanXml: row.LiveQueryPlan ?? row.QueryPlan,
+            isolationLevel: row.TransactionIsolationLevel);
+    }
+
     private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/PerformanceMonitor.Ui/PlanNavigationController.cs
+++ b/PerformanceMonitor.Ui/PlanNavigationController.cs
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Shared "View Plan" / "Get Actual Plan" behavior for every query-identifying surface in both apps.
+/// The duplicated confirm-dialog / cancellation / error-handling logic that used to live in each app's
+/// QueryPerformanceContent.Plans.cs and ServerTab.Plans.cs lives here once. The host supplies two
+/// delegates so this class never references an app-specific type (PlanViewerControl, ActualPlanExecutor,
+/// or a connection-string source):
+///   <c>showPlan</c>      — open the app's PlanViewerWindow and load the plan XML.
+///   <c>executeActual</c> — run the app's ActualPlanExecutor against the right connection string.
+/// </summary>
+public sealed class PlanNavigationController
+{
+    private readonly Window _owner;
+    private readonly Func<string, string, string?, Task> _showPlan;
+    private readonly Func<string, string, string?, string?, CancellationToken, Task<string?>> _executeActual;
+    private readonly string _targetDescription;
+    private readonly Action<string>? _setStatus;
+    private CancellationTokenSource? _actualPlanCts;
+
+    /// <param name="owner">Host window — owns the dialogs and cancels a running capture when closed.</param>
+    /// <param name="showPlan">(planXml, label, queryText) =&gt; opens the plan in the app's viewer.</param>
+    /// <param name="executeActual">(databaseName, queryText, estimatedPlanXml, isolationLevel, ct) =&gt; captured actual-plan XML.</param>
+    /// <param name="targetDescription">How the confirm dialog names the server (e.g. "the monitored server" or a server name).</param>
+    /// <param name="setStatus">Optional status-text callback for hosts that have a status line.</param>
+    public PlanNavigationController(
+        Window owner,
+        Func<string, string, string?, Task> showPlan,
+        Func<string, string, string?, string?, CancellationToken, Task<string?>> executeActual,
+        string targetDescription,
+        Action<string>? setStatus = null)
+    {
+        _owner = owner;
+        _showPlan = showPlan;
+        _executeActual = executeActual;
+        _targetDescription = targetDescription;
+        _setStatus = setStatus;
+
+        // Closing the host cancels any in-flight actual-plan capture.
+        _owner.Closed += (_, _) => _actualPlanCts?.Cancel();
+    }
+
+    /// <summary>
+    /// Fetches a collected/cached plan via <paramref name="fetchPlanXml"/> and opens it in the viewer.
+    /// Shows a friendly message when no plan is available.
+    /// </summary>
+    public async Task ViewPlanAsync(Func<Task<string?>> fetchPlanXml, string label, string? queryText)
+    {
+        string? planXml;
+        try
+        {
+            _setStatus?.Invoke("Fetching query plan...");
+            using (SetBusy())
+                planXml = await fetchPlanXml();
+        }
+        catch (Exception ex)
+        {
+            _setStatus?.Invoke("Error fetching query plan.");
+            MessageBox.Show(_owner, $"Error fetching the query plan:\n\n{ex.Message}",
+                "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(planXml))
+        {
+            _setStatus?.Invoke("No plan available.");
+            MessageBox.Show(_owner,
+                "No query plan is available for this row. The plan may have been evicted from the plan cache since it was last collected.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        _setStatus?.Invoke("Ready");
+        await _showPlan(planXml, label, queryText);
+    }
+
+    /// <summary>
+    /// Re-executes <paramref name="queryText"/> against the monitored server (after confirmation) with
+    /// SET STATISTICS XML ON and opens the captured actual plan. No-ops gracefully when there is no
+    /// query text (e.g. procedure rows, which carry only a name).
+    /// </summary>
+    public async Task GetActualPlanAsync(string? queryText, string databaseName, string label,
+        string? estimatedPlanXml = null, string? isolationLevel = null)
+    {
+        if (string.IsNullOrWhiteSpace(queryText))
+        {
+            MessageBox.Show(_owner, "No query text is available for this row.", "No Query Text",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var confirm = MessageBox.Show(_owner,
+            $"You are about to execute this query against {_targetDescription} in database " +
+            $"[{(string.IsNullOrEmpty(databaseName) ? "default" : databaseName)}].\n\n" +
+            "Make sure you understand what the query does before proceeding.\n" +
+            "The query will execute with SET STATISTICS XML ON to capture the actual plan.\n" +
+            "All data results will be discarded.",
+            "Get Actual Plan", MessageBoxButton.OKCancel, MessageBoxImage.Warning);
+        if (confirm != MessageBoxResult.OK) return;
+
+        _actualPlanCts?.Dispose();
+        _actualPlanCts = new CancellationTokenSource();
+
+        string? actualPlanXml;
+        try
+        {
+            _setStatus?.Invoke("Executing query for actual plan...");
+            using (SetBusy())
+                actualPlanXml = await _executeActual(databaseName ?? "", queryText, estimatedPlanXml, isolationLevel, _actualPlanCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _setStatus?.Invoke("Actual plan capture cancelled.");
+            MessageBox.Show(_owner, "The query was cancelled or timed out.", "Cancelled",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        catch (Exception ex)
+        {
+            _setStatus?.Invoke("Actual plan capture failed.");
+            MessageBox.Show(_owner, $"Failed to get the actual plan:\n\n{ex.Message}", "Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(actualPlanXml))
+        {
+            _setStatus?.Invoke("No actual plan captured.");
+            MessageBox.Show(_owner, "The query executed but no execution plan was captured.",
+                "No Plan", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        _setStatus?.Invoke("Actual plan captured successfully.");
+        await _showPlan(actualPlanXml, label, queryText);
+    }
+
+    private static BusyScope SetBusy()
+    {
+        Mouse.OverrideCursor = Cursors.Wait;
+        return new BusyScope();
+    }
+
+    private sealed class BusyScope : IDisposable
+    {
+        public void Dispose() => Mouse.OverrideCursor = null;
+    }
+}


### PR DESCRIPTION
## What

Adds in-app **View Plan** (open the collected/cached plan) and **Get Actual Plan** (re-execute for a fresh actual plan) to **every view that uniquely identifies a single query**, in **both** Dashboard and Lite. Closes the gap where drill-down/history windows, comparison grids, and FinOps query grids could only Copy/Export or save-to-disk — never open the plan in-app.

## Design — built once, shared

- **`PerformanceMonitor.Ui.PlanNavigationController`** (new, shared): centralizes the confirm dialog, cancellation (CTS, cancel-on-close), busy cursor, and "no plan / no query text / error" handling. Stays free of app-specific types via two delegates (`showPlan`, `executeActual`).
- **`PlanViewerWindow`** (new, thin, per app): standalone window hosting the app's `PlanViewerControl`; owned + non-modal so it stays interactive above a modal drill-down. Lite calls `Cleanup()` on close.
- Each surface adds only menu items + a small handler supplying a row→fetch lambda.

No new fetch methods except one Dashboard `GetProcedureStatsPlanXmlByNameAsync` (proc-comparison View Plan); all others already existed.

## Surfaces (parity across both apps unless noted)

| Surface | View Plan | Get Actual | Notes |
|---|---|---|---|
| QueryStats history window | ✅ | ✅ | per-row plan by collection_id (Dashboard) / live-by-hash (Lite) |
| QueryStore history (Dashboard QueryExecution) | ✅ | ✅ | per-row by collection_id (Dashboard) / by plan_id (Lite) |
| Procedure history window | ✅ | — | View only (can't safely re-exec a proc) |
| Wait drill-down window | ✅ | ✅ | snapshot plan per row |
| Trace pattern window | — | ✅ | Dashboard-only; aggregated events, no cached plan |
| Comparison grids (QueryStats/QueryStore/Procedure) | ✅ | ✅* | menu was shown but the switch silently no-opped — now wired; proc = View only |
| FinOps High-Impact grid | ✅ | ✅ | by query_hash |
| FinOps Expensive-Queries grid | — | ✅ | full text only, no plan key |

Procedures and blocking/deadlock stay View-only (re-executing them is unsafe) — consistent with the existing main grids.

## Verification

- **Build**: green, both apps.
- **Tests**: `Dashboard.Tests` 491/491, `Lite.Tests` 545/545.
- **Plan fetches verified against the live `PerformanceMonitor` DB.** Caught + fixed a silent no-op: proc-comparison View Plan was filtering the summary view's `object_name` (bracketed `[dbo].[delivery]`) with a bare name — now keyed on `procedure_name` (bare), confirmed to return plans.
- **Independent code review**: no CRITICAL/SHOULD-FIX findings; hash formats, identifiers, parity, controller lifecycle, and call sites all verified.

## Remaining gate before merge

This is a UI feature — please do a quick **live click-through** (right-click a row → View Plan / Get Actual Plan on each surface category in each app) before merging. The fetch paths are verified to return data, but the in-app rendering wasn't driven by automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
