### PR TITLE
Style resolved/cleared tray toasts to match condition cards

### DIFF
--- a/Dashboard/Controls/StyledBalloon.xaml
+++ b/Dashboard/Controls/StyledBalloon.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="PerformanceMonitorDashboard.Controls.StyledBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="360"
+             FontFamily="Segoe UI">
+    <!-- Button-less themed card for resolved/cleared (and other informational) tray notifications.
+         Mirrors SnoozeBalloon's chrome so an "all clear" toast matches the snoozable condition cards
+         instead of rendering as a plain, unthemed Windows balloon. -->
+    <Border Background="{DynamicResource BackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            TextElement.FontFamily="Segoe UI">
+        <StackPanel Margin="14,12,14,12">
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock x:Name="SeverityIcon"
+                           Text="!"
+                           FontSize="16"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="TitleText"
+                           Text="Alert"
+                           FontWeight="SemiBold"
+                           FontSize="13"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+
+            <TextBlock x:Name="MessageText"
+                       Text=""
+                       TextWrapping="Wrap"
+                       FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       Margin="0"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Dashboard/Controls/StyledBalloon.xaml.cs
+++ b/Dashboard/Controls/StyledBalloon.xaml.cs
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    /// <summary>
+    /// A themed, button-less tray balloon for resolved/cleared (and other informational) notifications.
+    /// Shares <see cref="SnoozeBalloon"/>'s card chrome (background/border/severity icon) so a "Cleared"
+    /// or "Resolved" toast looks like the snoozable condition cards rather than a plain Windows balloon.
+    /// </summary>
+    public partial class StyledBalloon : UserControl
+    {
+        public StyledBalloon(string title, string message, ToastSeverity severity)
+        {
+            InitializeComponent();
+
+            TitleText.Text = title;
+            MessageText.Text = message;
+            ApplySeverity(severity);
+        }
+
+        /* Mirrors SnoozeBalloon.ApplySeverity (identical Warning/Error/Info glyphs + colors) and adds the
+           Success case — a green check (#16A34A), the same green the email/webhook "RESOLVED" badge uses —
+           for cleared/resolved conditions. */
+        private void ApplySeverity(ToastSeverity severity)
+        {
+            switch (severity)
+            {
+                case ToastSeverity.Error:
+                    SeverityIcon.Text = "⚠";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+                    break;
+                case ToastSeverity.Warning:
+                    SeverityIcon.Text = "⚠";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
+                    break;
+                case ToastSeverity.Success:
+                    SeverityIcon.Text = "✓";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x16, 0xA3, 0x4A));
+                    break;
+                default:
+                    SeverityIcon.Text = "ℹ";
+                    SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6));
+                    break;
+            }
+        }
+    }
+}

--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -209,8 +209,8 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activeBlockingAlert.TryRemove(serverId, out var wasBlocking) && wasBlocking)
             {
-                _notificationService?.ShowNotification("Blocking Cleared",
-                    $"{serverName}: No active blocking");
+                _notificationService?.ShowStyledNotification("Blocking Cleared",
+                    $"{serverName}: No active blocking", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Blocking Cleared",
                     "0", $"{prefs.BlockingThresholdSeconds}s", true, "tray");
             }
@@ -285,8 +285,8 @@ namespace PerformanceMonitorDashboard
                 {
                     _activeDeadlockAlert.TryRemove(serverId, out _);
                     _lastDeadlockActivity.TryRemove(serverId, out _);
-                    _notificationService?.ShowNotification("Deadlocks Cleared",
-                        $"{serverName}: No deadlocks in the last hour");
+                    _notificationService?.ShowStyledNotification("Deadlocks Cleared",
+                        $"{serverName}: No deadlocks in the last hour", ToastSeverity.Success);
                     _emailAlertService.RecordAlert(serverId, serverName, "Deadlocks Cleared",
                         "0", prefs.DeadlockThreshold.ToString(), true, "tray");
                 }
@@ -341,8 +341,8 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activeCaptureDownAlert.TryRemove(serverId, out var wasCaptureDown) && wasCaptureDown)
             {
-                _notificationService?.ShowNotification("Capture Restored",
-                    $"{serverName}: Blocking/deadlock capture is running again");
+                _notificationService?.ShowStyledNotification("Capture Restored",
+                    $"{serverName}: Blocking/deadlock capture is running again", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Capture Restored",
                     "running", "session running", true, "tray");
             }
@@ -397,8 +397,8 @@ namespace PerformanceMonitorDashboard
             else if (_activeHighCpuAlert.TryRemove(serverId, out var wasCpu) && wasCpu)
             {
                 var cpuText = alertCpuValue.HasValue ? $"{alertCpuValue.Value:F0}%" : "N/A";
-                _notificationService?.ShowNotification("CPU Resolved",
-                    $"{serverName}: {cpuMetricLabel} back to {cpuText}");
+                _notificationService?.ShowStyledNotification("CPU Resolved",
+                    $"{serverName}: {cpuMetricLabel} back to {cpuText}", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "CPU Resolved",
                     cpuText, $"{prefs.CpuThresholdPercent}%", true, "tray");
             }
@@ -455,8 +455,8 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activePoisonWaitAlert.TryRemove(serverId, out var wasPoisonWait) && wasPoisonWait)
             {
-                _notificationService?.ShowNotification("Poison Waits Cleared",
-                    $"{serverName}: Poison wait avg below threshold");
+                _notificationService?.ShowStyledNotification("Poison Waits Cleared",
+                    $"{serverName}: Poison wait avg below threshold", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Poison Waits Cleared",
                     "0", $"{prefs.PoisonWaitThresholdMs}ms avg", true, "tray");
             }
@@ -524,8 +524,8 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activeLongRunningQueryAlert.TryRemove(serverId, out var wasLongRunning) && wasLongRunning)
             {
-                _notificationService?.ShowNotification("Long-Running Queries Cleared",
-                    $"{serverName}: No queries over threshold");
+                _notificationService?.ShowStyledNotification("Long-Running Queries Cleared",
+                    $"{serverName}: No queries over threshold", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Queries Cleared",
                     "0", $"{prefs.LongRunningQueryThresholdMinutes}m", true, "tray");
             }
@@ -577,8 +577,8 @@ namespace PerformanceMonitorDashboard
             else if (_activeTempDbSpaceAlert.TryRemove(serverId, out var wasTempDb) && wasTempDb)
             {
                 var pct = health.TempDbSpace != null ? $"{health.TempDbSpace.UsedPercent:F0}%" : "N/A";
-                _notificationService?.ShowNotification("TempDB Space Resolved",
-                    $"{serverName}: TempDB usage back to {pct}");
+                _notificationService?.ShowStyledNotification("TempDB Space Resolved",
+                    $"{serverName}: TempDB usage back to {pct}", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "TempDB Space Resolved",
                     pct, $"{prefs.TempDbSpaceThresholdPercent}%", true, "tray");
             }
@@ -644,8 +644,8 @@ namespace PerformanceMonitorDashboard
             else if (_activeLowDiskAlert.TryRemove(serverId, out var wasLowDisk) && wasLowDisk)
             {
                 _lastAlertedLowDiskPercent.TryRemove(serverId, out _);
-                _notificationService?.ShowNotification("Volume Free Space Resolved",
-                    $"{serverName}: All volumes back above threshold");
+                _notificationService?.ShowStyledNotification("Volume Free Space Resolved",
+                    $"{serverName}: All volumes back above threshold", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Volume Free Space Resolved",
                     "OK", FormatLowDiskThreshold(prefs), true, "tray");
             }
@@ -708,8 +708,8 @@ namespace PerformanceMonitorDashboard
             }
             else if (_activeLongRunningJobAlert.TryRemove(serverId, out var wasJob) && wasJob)
             {
-                _notificationService?.ShowNotification("Long-Running Jobs Cleared",
-                    $"{serverName}: No jobs exceeding threshold");
+                _notificationService?.ShowStyledNotification("Long-Running Jobs Cleared",
+                    $"{serverName}: No jobs exceeding threshold", ToastSeverity.Success);
                 _emailAlertService.RecordAlert(serverId, serverName, "Long-Running Jobs Cleared",
                     "0", $"{prefs.LongRunningJobMultiplier}x avg", true, "tray");
             }

--- a/Dashboard/Services/NotificationService.cs
+++ b/Dashboard/Services/NotificationService.cs
@@ -145,6 +145,34 @@ namespace PerformanceMonitorDashboard.Services
         }
 
         /// <summary>
+        /// Shows a themed, button-less balloon (the same card chrome as the snoozable condition cards)
+        /// for resolved/cleared conditions, so an "all clear" toast no longer renders as a plain,
+        /// unthemed Windows balloon. Pass <see cref="ToastSeverity.Success"/> for a green-check "resolved"
+        /// accent. Honors the notifications-enabled pref and marshals to the UI thread, like
+        /// <see cref="ShowNotification"/>.
+        /// </summary>
+        public void ShowStyledNotification(string title, string message, ToastSeverity severity)
+        {
+            if (_trayIcon == null) return;
+
+            var prefs = _preferencesService.GetPreferences();
+            if (!prefs.NotificationsEnabled) return;
+
+            void Show()
+            {
+                var trayIcon = _trayIcon;
+                if (trayIcon == null) return;
+                var balloon = new Controls.StyledBalloon(title, message, severity);
+                trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 10000);
+            }
+
+            if (_mainWindow.Dispatcher.CheckAccess())
+                Show();
+            else
+                _mainWindow.Dispatcher.Invoke(Show);
+        }
+
+        /// <summary>
         /// Shows a custom interactive popup with Snooze 15m / 1h / 4h and Dismiss buttons.
         /// Snooze buttons create a temporary mute rule scoped to <paramref name="serverName"/> + <paramref name="metricName"/>.
         /// </summary>

--- a/Lite/Controls/StyledBalloon.xaml
+++ b/Lite/Controls/StyledBalloon.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="PerformanceMonitorLite.Controls.StyledBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="360"
+             FontFamily="Segoe UI">
+    <!-- Button-less themed card for resolved/cleared (and other informational) tray notifications.
+         Mirrors SnoozeBalloon's chrome so an "all clear" toast matches the snoozable condition cards
+         instead of rendering as a plain, unthemed Windows balloon. -->
+    <Border Background="{DynamicResource BackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            TextElement.FontFamily="Segoe UI">
+        <StackPanel Margin="14,12,14,12">
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock x:Name="SeverityIcon"
+                           Text="!"
+                           FontSize="16"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="TitleText"
+                           Text="Alert"
+                           FontWeight="SemiBold"
+                           FontSize="13"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+
+            <TextBlock x:Name="MessageText"
+                       Text=""
+                       TextWrapping="Wrap"
+                       FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       Margin="0"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Lite/Controls/StyledBalloon.xaml.cs
+++ b/Lite/Controls/StyledBalloon.xaml.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitorLite.Controls;
+
+/// <summary>
+/// A themed, button-less tray balloon for resolved/cleared (and other informational) notifications.
+/// Shares <see cref="SnoozeBalloon"/>'s card chrome (background/border/severity icon) so a "Cleared"
+/// or "Resolved" toast looks like the snoozable condition cards rather than a plain Windows balloon.
+/// </summary>
+public partial class StyledBalloon : UserControl
+{
+    public StyledBalloon(string title, string message, ToastSeverity severity)
+    {
+        InitializeComponent();
+
+        TitleText.Text = title;
+        MessageText.Text = message;
+        ApplySeverity(severity);
+    }
+
+    /* Mirrors SnoozeBalloon.ApplySeverity (identical Warning/Error/Info glyphs + colors) and adds the
+       Success case — a green check (#16A34A), the same green the email/webhook "RESOLVED" badge uses —
+       for cleared/resolved conditions. */
+    private void ApplySeverity(ToastSeverity severity)
+    {
+        switch (severity)
+        {
+            case ToastSeverity.Error:
+                SeverityIcon.Text = "⚠";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+                break;
+            case ToastSeverity.Warning:
+                SeverityIcon.Text = "⚠";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
+                break;
+            case ToastSeverity.Success:
+                SeverityIcon.Text = "✓";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x16, 0xA3, 0x4A));
+                break;
+            default:
+                SeverityIcon.Text = "ℹ";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6));
+                break;
+        }
+    }
+}

--- a/Lite/MainWindow.AlertEngine.cs
+++ b/Lite/MainWindow.AlertEngine.cs
@@ -104,10 +104,10 @@ public partial class MainWindow : Window
                flag) and silencing sets suppressPopups — neither means CPU actually recovered. */
             if (!suppressPopups && App.AlertCpuEnabled)
             {
-                _trayService.ShowNotification(
+                _trayService.ShowStyledNotification(
                     "CPU Resolved",
                     $"{summary.DisplayName}: {cpuMetricLabel} back to {alertCpuValue:F0}%",
-                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    ToastSeverity.Success);
             }
         }
 
@@ -184,10 +184,10 @@ public partial class MainWindow : Window
         {
             if (!suppressPopups && App.AlertBlockingEnabled)
             {
-                _trayService.ShowNotification(
+                _trayService.ShowStyledNotification(
                     "Blocking Cleared",
                     $"{summary.DisplayName}: No active blocking",
-                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    ToastSeverity.Success);
             }
         }
 
@@ -261,10 +261,10 @@ public partial class MainWindow : Window
         {
             if (!suppressPopups && App.AlertDeadlockEnabled)
             {
-                _trayService.ShowNotification(
+                _trayService.ShowStyledNotification(
                     "Deadlocks Cleared",
                     $"{summary.DisplayName}: No deadlocks in the last hour",
-                    Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                    ToastSeverity.Success);
             }
         }
 
@@ -324,10 +324,10 @@ public partial class MainWindow : Window
                     _activePoisonWaitAlert[key] = false;
                     if (!suppressPopups)
                     {
-                        _trayService.ShowNotification(
+                        _trayService.ShowStyledNotification(
                             "Poison Waits Cleared",
                             $"{summary.DisplayName}: Poison wait avg below threshold",
-                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                            ToastSeverity.Success);
                     }
                 }
             }
@@ -405,10 +405,10 @@ public partial class MainWindow : Window
                     _activeLongRunningQueryAlert[key] = false;
                     if (!suppressPopups)
                     {
-                        _trayService.ShowNotification(
+                        _trayService.ShowStyledNotification(
                             "Long-Running Queries Cleared",
                             $"{summary.DisplayName}: No queries over threshold",
-                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                            ToastSeverity.Success);
                     }
                 }
             }
@@ -467,10 +467,10 @@ public partial class MainWindow : Window
                     if (!suppressPopups)
                     {
                         var pct = tempDb != null ? $"{tempDb.UsedPercent:F0}%" : "N/A";
-                        _trayService.ShowNotification(
+                        _trayService.ShowStyledNotification(
                             "TempDB Space Resolved",
                             $"{summary.DisplayName}: TempDB usage back to {pct}",
-                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                            ToastSeverity.Success);
                     }
                 }
             }
@@ -549,10 +549,10 @@ public partial class MainWindow : Window
                     _lastAlertedLowDiskPercent.Remove(key);
                     if (!suppressPopups)
                     {
-                        _trayService.ShowNotification(
+                        _trayService.ShowStyledNotification(
                             "Volume Free Space Resolved",
                             $"{summary.DisplayName}: All volumes back above threshold",
-                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                            ToastSeverity.Success);
                     }
                 }
             }
@@ -626,10 +626,10 @@ public partial class MainWindow : Window
                     _activeLongRunningJobAlert[key] = false;
                     if (!suppressPopups)
                     {
-                        _trayService.ShowNotification(
+                        _trayService.ShowStyledNotification(
                             "Long-Running Jobs Cleared",
                             $"{summary.DisplayName}: No jobs exceeding threshold",
-                            Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Info);
+                            ToastSeverity.Success);
                     }
                 }
             }

--- a/Lite/Services/SystemTrayService.cs
+++ b/Lite/Services/SystemTrayService.cs
@@ -164,6 +164,21 @@ public class SystemTrayService : IDisposable
     }
 
     /// <summary>
+    /// Shows a themed, button-less balloon (the same card chrome as the snoozable condition cards)
+    /// for resolved/cleared conditions, so an "all clear" toast no longer renders as a plain, unthemed
+    /// Windows balloon. Pass <see cref="ToastSeverity.Success"/> for a green-check "resolved" accent.
+    /// No-op if the tray icon hasn't been initialized.
+    /// </summary>
+    public void ShowStyledNotification(string title, string message, ToastSeverity severity)
+    {
+        if (_trayIcon == null)
+            return;
+
+        var balloon = new StyledBalloon(title, message, severity);
+        _trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 10000);
+    }
+
+    /// <summary>
     /// Shows a custom interactive balloon with snooze buttons that create a temporary
     /// mute rule scoped to <paramref name="serverName"/> + <paramref name="metricName"/>.
     /// Falls back to a plain balloon if the tray icon hasn't been initialized.

--- a/PerformanceMonitor.Notifications/ToastSeverity.cs
+++ b/PerformanceMonitor.Notifications/ToastSeverity.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitor.Notifications;
+
+/// <summary>
+/// Visual severity for a styled tray balloon (<c>StyledBalloon</c>), mapped to an accent glyph + color.
+/// Shared by both apps so the resolved/cleared "all clear" cards (Success = green check) render the same
+/// themed chrome as the snoozable condition cards (Warning/Error) instead of a plain Windows balloon.
+/// <c>Success</c> uses the same green (#16A34A) the email/webhook "RESOLVED" badge uses (see
+/// <see cref="AlertSeverity"/>) so the resolved state reads the same across every surface.
+/// </summary>
+public enum ToastSeverity
+{
+    Info,
+    Success,
+    Warning,
+    Error
+}


### PR DESCRIPTION
## What
Resolved/cleared alert tray toasts ("Blocking Cleared", "CPU Resolved", …) rendered as plain, unthemed **Windows OS balloons** (`ShowNotification` → `ShowBalloonTip`), while the triggered condition alerts use the themed `SnoozeBalloon` card. The two looked nothing alike.

## Change
- New **`StyledBalloon`** control (both apps): button-less themed card mirroring `SnoozeBalloon`'s chrome, with a green-check **resolved** accent (`#16A34A` — the same green the email/webhook `RESOLVED` badge already uses).
- New shared **`ToastSeverity`** enum (`Info`/`Success`/`Warning`/`Error`) in `PerformanceMonitor.Notifications`, driving the icon glyph + color in both apps.
- New **`ShowStyledNotification(...)`** on Dashboard `NotificationService` and Lite `SystemTrayService` (custom-balloon path, same guards as the snoozable path).
- Routed **all 17 resolved/cleared sites** (9 Dashboard + 8 Lite) through it with `ToastSeverity.Success`.

## Deliberately unchanged
Server online/offline/connection-restored, update-available, and analysis-finding toasts stay as OS balloons so they persist in the Windows Action Center (they fire when you may be away). Converting them is a delivery-semantics tradeoff, not a styling fix.

## Test plan
- [x] `dotnet build` Dashboard — succeeded, 0 errors
- [x] `dotnet build` Lite — succeeded, 0 errors
- [ ] Full-cycle: trigger then clear a condition (blocking / high CPU) in each app; confirm the resolved toast is a themed dark card with a green check, matching the condition card chrome, across Dark / Light / CoolBreeze themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
