### PR TITLE
Workload-aware THREADPOOL advice: attribute parallel vs blocking

### DIFF
--- a/Dashboard.Tests/FactAdviceComposeTests.cs
+++ b/Dashboard.Tests/FactAdviceComposeTests.cs
@@ -1,0 +1,183 @@
+using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests the value-stated advice substrate (FactAdvice.Compose / PopulateStoryText /
+/// GetComposedForFinding / Serialize-round-trip). The composer reads the server's ACTUAL settings
+/// from the full fact set and states them — current MAXDOP, CTFP, cores — instead of generic
+/// folklore, and the result is frozen into StoryText so read-back cards show the same numbers.
+/// </summary>
+public class FactAdviceComposeTests
+{
+    private static Dictionary<string, Fact> Facts(params Fact[] facts)
+    {
+        var d = new Dictionary<string, Fact>();
+        foreach (var f in facts)
+            d[f.Key] = f;
+        return d;
+    }
+
+    private static Fact F(string key, double value) =>
+        new() { Key = key, Source = "config", Value = value, Severity = 0.0 };
+
+    private static Fact Hardware(int coresPerSocket) =>
+        new()
+        {
+            Key = "SERVER_HARDWARE",
+            Source = "config",
+            Value = 1,
+            Severity = 0,
+            Metadata = new Dictionary<string, double> { ["cores_per_socket"] = coresPerSocket }
+        };
+
+    // ── THREADPOOL_PARALLEL: states the actual MAXDOP/CTFP, recommends the topology cap ──
+
+    [Fact]
+    public void ThreadpoolParallel_StatesCurrentMaxdopAndCtfp_AndRecommendsTopologyCap()
+    {
+        var advice = FactAdvice.Compose(
+            "THREADPOOL_PARALLEL", Facts(F("CONFIG_MAXDOP", 16), F("CONFIG_CTFP", 5), Hardware(8)));
+
+        Assert.NotNull(advice);
+        var r = advice!.Remediation;
+        Assert.Contains("MAXDOP is 16", r);
+        Assert.Contains("cost threshold for parallelism is 5", r);
+        Assert.Contains("raise cost threshold for parallelism to 50", r);
+        Assert.Contains("lower MAXDOP from 16 to 8", r);
+        // The whole point: no hedging about settings the engine collected.
+        Assert.DoesNotContain("if those are already set", r);
+    }
+
+    [Fact]
+    public void ThreadpoolParallel_AlreadyWithinGuidance_GuardsHarder()
+    {
+        // MAXDOP 8 / CTFP 50 are within topology guidance yet the pool still exhausted, so the
+        // driver is concurrency volume — the workload-aware override guards harder.
+        var advice = FactAdvice.Compose(
+            "THREADPOOL_PARALLEL", Facts(F("CONFIG_MAXDOP", 8), F("CONFIG_CTFP", 50), Hardware(8)));
+
+        var r = advice!.Remediation;
+        Assert.Contains("MAXDOP is 8", r);
+        Assert.Contains("already within topology guidance", r);
+        Assert.Contains("MAXDOP from 8 to 4", r); // harder = rec/2
+    }
+
+    [Fact]
+    public void ThreadpoolParallel_NoConfigFacts_FallsBackToStaticBlock()
+    {
+        var advice = FactAdvice.Compose("THREADPOOL_PARALLEL", Facts());
+        Assert.Equal(FactAdvice.GetForFactKey("THREADPOOL_PARALLEL"), advice);
+    }
+
+    // ── CONFIG_MAXDOP: headline states the real value (the static block hard-coded "0") ──
+
+    [Theory]
+    [InlineData(0, "MAXDOP is 0")]
+    [InlineData(1, "MAXDOP is 1")]
+    [InlineData(16, "MAXDOP is 16")]
+    public void ConfigMaxdop_HeadlineStatesActualValue(int maxdop, string expected)
+    {
+        var advice = FactAdvice.Compose("CONFIG_MAXDOP", Facts(F("CONFIG_MAXDOP", maxdop), Hardware(8)));
+        Assert.Contains(expected, advice!.Headline);
+    }
+
+    [Fact]
+    public void ConfigMaxdop_AboveGuidance_RecommendsLoweringToCores()
+    {
+        var advice = FactAdvice.Compose("CONFIG_MAXDOP", Facts(F("CONFIG_MAXDOP", 32), Hardware(8)));
+        Assert.Contains("Lower MAXDOP from 32 to 8", advice!.Remediation);
+    }
+
+    // ── CONFIG_CTFP: states the real value ──
+
+    [Fact]
+    public void ConfigCtfp_StatesActualValue()
+    {
+        var advice = FactAdvice.Compose("CONFIG_CTFP", Facts(F("CONFIG_CTFP", 5)));
+        Assert.Contains("Cost Threshold for Parallelism is 5", advice!.Headline);
+        Assert.Contains("Raise it to 50", advice.Remediation);
+    }
+
+    // ── non-value keys pass through to the static block ──
+
+    [Fact]
+    public void Compose_NonValueKey_ReturnsStaticBlock()
+    {
+        Assert.Equal(FactAdvice.GetForFactKey("DEADLOCKS"), FactAdvice.Compose("DEADLOCKS", Facts()));
+    }
+
+    // ── serialize / read-back round-trip ──
+
+    [Fact]
+    public void SerializeForStoryText_RoundTrips()
+    {
+        var composed = FactAdvice.Compose(
+            "THREADPOOL_PARALLEL", Facts(F("CONFIG_MAXDOP", 16), F("CONFIG_CTFP", 5), Hardware(8)));
+        var json = FactAdvice.SerializeForStoryText(composed);
+
+        Assert.StartsWith("{", json);
+        var back = FactAdvice.TryReadStoryText(json);
+        Assert.NotNull(back);
+        Assert.Equal(composed!.Headline, back!.Headline);
+        Assert.Equal(composed.Investigation, back.Investigation);
+        Assert.Equal(composed.Remediation, back.Remediation);
+    }
+
+    [Fact]
+    public void TryReadStoryText_LegacyOrEmpty_ReturnsNull()
+    {
+        Assert.Null(FactAdvice.TryReadStoryText(""));
+        Assert.Null(FactAdvice.TryReadStoryText(null));
+        Assert.Null(FactAdvice.TryReadStoryText("plain legacy text"));
+    }
+
+    // ── render entry point: prefer frozen StoryText, fall back to static ──
+
+    [Fact]
+    public void GetComposedForFinding_PrefersFrozenStoryText()
+    {
+        var custom = new AdviceBlock("Frozen headline", "Frozen investigation", "Frozen remediation");
+        var finding = new AnalysisFinding
+        {
+            RootFactKey = "THREADPOOL_PARALLEL",
+            StoryText = FactAdvice.SerializeForStoryText(custom)
+        };
+
+        var advice = FactAdvice.GetComposedForFinding(finding);
+        Assert.Equal("Frozen headline", advice!.Headline);
+        Assert.Equal("Frozen remediation", advice.Remediation);
+    }
+
+    [Fact]
+    public void GetComposedForFinding_EmptyStoryText_FallsBackToStatic()
+    {
+        var finding = new AnalysisFinding { RootFactKey = "CONFIG_CTFP", StoryText = "" };
+        Assert.Equal(FactAdvice.GetForFactKey("CONFIG_CTFP"), FactAdvice.GetComposedForFinding(finding));
+    }
+
+    // ── PopulateStoryText: freezes value-stated advice, skips absolution ──
+
+    [Fact]
+    public void PopulateStoryText_FreezesValueStatedAdvice_OnValueBearingStory()
+    {
+        var story = new AnalysisStory { RootFactKey = "THREADPOOL_PARALLEL", IsAbsolution = false };
+        var facts = new List<Fact> { F("CONFIG_MAXDOP", 16), F("CONFIG_CTFP", 5), Hardware(8) };
+
+        FactAdvice.PopulateStoryText(new[] { story }, facts);
+
+        Assert.StartsWith("{", story.StoryText);
+        var back = FactAdvice.TryReadStoryText(story.StoryText);
+        Assert.Contains("MAXDOP is 16", back!.Remediation);
+    }
+
+    [Fact]
+    public void PopulateStoryText_SkipsAbsolution()
+    {
+        var story = new AnalysisStory { RootFactKey = "server_health", IsAbsolution = true, StoryText = "" };
+        FactAdvice.PopulateStoryText(new[] { story }, new List<Fact>());
+        Assert.Equal("", story.StoryText);
+    }
+}

--- a/Dashboard.Tests/FactScorerTests.cs
+++ b/Dashboard.Tests/FactScorerTests.cs
@@ -360,4 +360,22 @@ public class FactScorerTests
         Assert.False(string.IsNullOrWhiteSpace(advice.Remediation));
         Assert.Null(advice.RemediationTsql);
     }
+
+    // C (workload-aware MAXDOP/CTFP): every THREADPOOL attribution variant InferenceEngine can root
+    // on (parallel/blocking/mixed) plus the generic fallback has an advice block — a relabeled root
+    // with no advice would render an empty card (the dead-fact bug class).
+    [Theory]
+    [InlineData("THREADPOOL")]
+    [InlineData("THREADPOOL_PARALLEL")]
+    [InlineData("THREADPOOL_BLOCKING")]
+    [InlineData("THREADPOOL_MIXED")]
+    public void ThreadpoolVariants_HaveAdviceBlocks(string key)
+    {
+        var advice = FactAdvice.GetForFactKey(key);
+
+        Assert.NotNull(advice);
+        Assert.False(string.IsNullOrWhiteSpace(advice!.Headline));
+        Assert.False(string.IsNullOrWhiteSpace(advice.Investigation));
+        Assert.False(string.IsNullOrWhiteSpace(advice.Remediation));
+    }
 }

--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using PerformanceMonitor.Analysis;
 using Xunit;
 
@@ -217,5 +218,31 @@ public class InferenceEngineTests
         var ex = Record.Exception(() => engine.BuildStories(facts));
 
         Assert.Null(ex);
+    }
+
+    // C (workload-aware MAXDOP/CTFP): a THREADPOOL root is relabeled by its co-elevated cause so the
+    // persisted root key carries parallel-vs-blocking — only the parallel flavor is a MAXDOP/CTFP
+    // problem. CXPACKET/high-DOP co-fired -> _PARALLEL; blocking co-fired -> _BLOCKING; both ->
+    // _MIXED; neither -> generic THREADPOOL. Co-causes are seeded below 0.5 so only THREADPOOL roots.
+    [Fact]
+    public void Threadpool_RootIsAttributedByCoElevatedCause()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+
+        string ThreadpoolRoot(params Fact[] facts) =>
+            engine.BuildStories(facts.ToList())
+                  .First(s => s.RootFactKey.StartsWith("THREADPOOL"))
+                  .RootFactKey;
+
+        Fact Tp() => new() { Key = "THREADPOOL", Source = "waits", Value = 0.5, Severity = 0.9 };
+        Fact Cx() => new() { Key = "CXPACKET", Source = "waits", Value = 0.3, Severity = 0.3 };
+        Fact Dop() => new() { Key = "QUERY_HIGH_DOP", Source = "queries", Value = 6, Severity = 0.3 };
+        Fact Blk() => new() { Key = "BLOCKING_EVENTS", Source = "blocking", Value = 20, Severity = 0.3 };
+
+        Assert.Equal("THREADPOOL_PARALLEL", ThreadpoolRoot(Tp(), Cx()));
+        Assert.Equal("THREADPOOL_PARALLEL", ThreadpoolRoot(Tp(), Dop()));
+        Assert.Equal("THREADPOOL_BLOCKING", ThreadpoolRoot(Tp(), Blk()));
+        Assert.Equal("THREADPOOL_MIXED", ThreadpoolRoot(Tp(), Cx(), Blk()));
+        Assert.Equal("THREADPOOL", ThreadpoolRoot(Tp()));
     }
 }

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -184,6 +184,12 @@ public class AnalysisService
             // 3. Build stories via graph traversal
             var stories = _engine.BuildStories(facts);
 
+            // 3.5. Freeze value-stated advice (current MAXDOP/CTFP/etc.) into each story's StoryText
+            // from the FULL fact set, BEFORE the store copies StoryText onto the finding. This is the
+            // only place the raw fact VALUES are in scope; read-back cards then state the numbers
+            // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
+            FactAdvice.PopulateStoryText(stories, facts);
+
             // 4. Mute-filter the stories into the surviving findings (P2 reorder) — WITHOUT
             //    inserting yet, so enrichment + action-build happen on the survivors first
             //    and the BUILT RemediationAction is persisted on each row (D2). Muted/

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -369,10 +369,13 @@ public sealed class McpAnalysisTools
                 {
                     // Persisted findings carry no drill-down (it is ephemeral —
                     // see AnalysisModels.cs), so generate advice prose only.
+                    // The prose IS value-stated: GetComposedForFinding reads the
+                    // value-bearing advice (current MAXDOP/CTFP/etc.) frozen into
+                    // StoryText at analysis time, falling back to the static block.
                     // suggested_remediation_sql is intentionally omitted: it
                     // would always be null here. The operator re-runs
                     // analyze_server when they need the copy-paste T-SQL.
-                    var advice = FactAdvice.GetForFactKey(f.RootFactKey);
+                    var advice = FactAdvice.GetComposedForFinding(f);
                     return new
                     {
                         severity = Math.Round(f.Severity, 2),

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -145,7 +145,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 string.Equals(serverAction.FactKey, "SERVER_CONFIG", StringComparison.Ordinal))
             {
                 var band = RecommendationDeduper.FromEngineSeverity(finding.Severity);
-                var adviceText = ComposeEngineAdvice(FactAdvice.GetForFactKey(finding.RootFactKey));
+                var adviceText = ComposeEngineAdvice(FactAdvice.GetComposedForFinding(finding));
                 var items = new List<RecommendationItem>(serverTargets.Count);
 
                 foreach (var target in serverTargets)
@@ -185,7 +185,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 ((remediation.DbConfigTargets is { Count: > 0 }) || (remediation.RcsiTargets is { Count: > 0 })))
             {
                 var band = RecommendationDeduper.FromEngineSeverity(finding.Severity);
-                var adviceText = ComposeEngineAdvice(FactAdvice.GetForFactKey(finding.RootFactKey));
+                var adviceText = ComposeEngineAdvice(FactAdvice.GetComposedForFinding(finding));
                 var safeTargets = remediation.DbConfigTargets ?? Array.Empty<DbConfigTarget>();
                 var rcsiTargets = remediation.RcsiTargets ?? Array.Empty<RcsiTarget>();
                 var items = new List<RecommendationItem>(safeTargets.Count + rcsiTargets.Count);
@@ -336,7 +336,8 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         internal static RecommendationItem MapEngineFinding(AnalysisFinding finding)
         {
             var band = RecommendationDeduper.FromEngineSeverity(finding.Severity);
-            var advice = FactAdvice.GetForFactKey(finding.RootFactKey);
+            // Value-stated advice frozen into StoryText at analysis time, static block as fallback.
+            var advice = FactAdvice.GetComposedForFinding(finding);
 
             // WS4: a MISSING_INDEX action is COPY-PASTE ONLY. Render its CREATE statements as the
             // card's copy-paste SQL (via BuildCopyPasteFromAction below), but DON'T carry it as the
@@ -352,7 +353,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 CanonicalSeverity = band,
                 RawSeverity = finding.Severity,
                 Database = finding.DatabaseName,
-                Title = !string.IsNullOrEmpty(advice?.Headline) ? advice!.Headline : finding.StoryText,
+                Title = !string.IsNullOrEmpty(advice?.Headline) ? advice!.Headline : finding.RootFactKey,
                 ProblemArea = finding.Category,
                 AdviceText = ComposeEngineAdvice(advice),
                 CopyPasteSql = BuildCopyPasteFromAction(finding.Remediation),

--- a/Lite.Tests/LiteRecommendationsReaderTests.cs
+++ b/Lite.Tests/LiteRecommendationsReaderTests.cs
@@ -98,14 +98,16 @@ public class LiteRecommendationsReaderTests
     }
 
     [Fact]
-    public void MapFinding_UnknownFactKey_FallsBackToStoryTextForTitleAndAdvice()
+    public void MapFinding_UnknownFactKey_FallsBackToRootFactKeyTitle_NoAdvice()
     {
+        // StoryText now carries value-stated advice JSON (or empty), never human prose — so an
+        // unknown key with no static advice block falls the title back to the fact key, with no
+        // advice text, rather than echoing StoryText (which would dump JSON).
         var item = LiteRecommendationsReader.MapFinding(
-            Finding("TOTALLY_UNKNOWN_KEY", 0.5, storyText: "A bespoke story."), ServerName);
+            Finding("TOTALLY_UNKNOWN_KEY", 0.5, storyText: ""), ServerName);
 
-        // No advice block matches -> title and advice both fall back to the story text.
-        Assert.Equal("A bespoke story.", item.Title);
-        Assert.Equal("A bespoke story.", item.AdviceText);
+        Assert.Equal("TOTALLY_UNKNOWN_KEY", item.Title);
+        Assert.Null(item.AdviceText);
         Assert.Equal(LiteRecommendationSeverity.Info, item.Severity);
     }
 

--- a/Lite.Tests/ScenarioTests.cs
+++ b/Lite.Tests/ScenarioTests.cs
@@ -47,8 +47,10 @@ public class ScenarioTests : IDisposable
         var (stories, facts) = await RunFullPipelineAsync(s => s.SeedThreadExhaustionServerAsync());
         PrintStories("THREAD EXHAUSTION", stories);
 
-        // THREADPOOL should be in the stories (very high severity due to low threshold)
-        Assert.Contains(stories, s => s.Path.Contains("THREADPOOL"));
+        // THREADPOOL should be in the stories (very high severity due to low threshold). When it roots
+        // its own story the key is relabeled by attribution (THREADPOOL_PARALLEL/_BLOCKING/_MIXED), so
+        // match the prefix rather than the exact key.
+        Assert.Contains(stories, s => s.Path.Any(p => p.StartsWith("THREADPOOL")));
     }
 
     [Fact]
@@ -56,8 +58,9 @@ public class ScenarioTests : IDisposable
     {
         var (stories, _) = await RunFullPipelineAsync(s => s.SeedThreadExhaustionServerAsync());
 
-        // THREADPOOL should connect to CXPACKET (parallel queries consuming thread pool)
-        var threadpoolStory = stories.FirstOrDefault(s => s.RootFactKey == "THREADPOOL");
+        // THREADPOOL should connect to CXPACKET (parallel queries consuming thread pool). When it
+        // roots, the key is relabeled by attribution (THREADPOOL_PARALLEL here), so match the prefix.
+        var threadpoolStory = stories.FirstOrDefault(s => s.RootFactKey.StartsWith("THREADPOOL"));
         if (threadpoolStory != null)
         {
             Assert.Contains("CXPACKET", threadpoolStory.Path);
@@ -78,8 +81,9 @@ public class ScenarioTests : IDisposable
         Assert.NotNull(blockingStory);
         Assert.Contains("LCK", blockingStory.Path);
 
-        // THREADPOOL still appears as a separate story
-        Assert.Contains(stories, s => s.Path.Contains("THREADPOOL"));
+        // THREADPOOL still appears as a separate story, now attribution-keyed: blocking co-fired here,
+        // so the engine roots it as THREADPOOL_BLOCKING (or _MIXED if parallelism also fired).
+        Assert.Contains(stories, s => s.RootFactKey is "THREADPOOL_BLOCKING" or "THREADPOOL_MIXED");
     }
 
     [Fact]

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -141,6 +141,12 @@ public class AnalysisService
             // 3. Build stories via graph traversal
             var stories = _engine.BuildStories(facts);
 
+            // 3.5. Freeze value-stated advice (current MAXDOP/CTFP/etc.) into each story's StoryText
+            // from the FULL fact set, BEFORE the store copies StoryText onto the finding. This is the
+            // only place the raw fact VALUES are in scope; read-back cards then state the numbers
+            // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
+            FactAdvice.PopulateStoryText(stories, facts);
+
             // 4. Persist findings (filtering out muted)
             var findings = await _findingStore.SaveFindingsAsync(stories, context);
 

--- a/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
@@ -113,16 +113,19 @@ public sealed class LiteRecommendationsReader
     /// </summary>
     internal static LiteRecommendationItem MapFinding(AnalysisFinding finding, string serverName)
     {
-        var advice = FactAdvice.GetForFactKey(finding.RootFactKey);
+        // Value-stated advice frozen into StoryText at analysis time (current MAXDOP/CTFP/etc.),
+        // with the static block as the fallback for legacy findings. StoryText now holds advice
+        // JSON, never the old (always-empty) story prose, so it is no longer a Title/text fallback.
+        var advice = FactAdvice.GetComposedForFinding(finding);
 
         return new LiteRecommendationItem
         {
             Severity = SeverityBand(finding.Severity),
             RawSeverity = finding.Severity,
             Database = string.IsNullOrEmpty(finding.DatabaseName) ? null : finding.DatabaseName,
-            Title = !string.IsNullOrEmpty(advice?.Headline) ? advice!.Headline : finding.StoryText,
+            Title = !string.IsNullOrEmpty(advice?.Headline) ? advice!.Headline : finding.RootFactKey,
             ProblemArea = finding.Category,
-            AdviceText = ComposeAdvice(advice) ?? NullIfEmpty(finding.StoryText),
+            AdviceText = ComposeAdvice(advice),
             CopyPasteSql = NullIfEmpty(FactRemediation.GenerateForFinding(finding)),
             RootFactKey = finding.RootFactKey,
             ServerName = serverName ?? string.Empty,

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -537,10 +537,13 @@ public sealed class McpAnalysisTools
                 {
                     // Persisted findings carry no drill-down (it is ephemeral —
                     // see AnalysisModels.cs), so generate advice prose only.
+                    // The prose IS value-stated: GetComposedForFinding reads the
+                    // value-bearing advice (current MAXDOP/CTFP/etc.) frozen into
+                    // StoryText at analysis time, falling back to the static block.
                     // suggested_remediation_sql is intentionally omitted: it
                     // would always be null here. The operator re-runs
                     // analyze_server when they need the copy-paste T-SQL.
-                    var advice = FactAdvice.GetForFactKey(f.RootFactKey);
+                    var advice = FactAdvice.GetComposedForFinding(f);
                     return new
                     {
                         finding_id = f.FindingId,

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
 
 namespace PerformanceMonitor.Analysis;
 
@@ -70,7 +72,9 @@ public static class FactAdvice
         if (finding is null)
             return null;
 
-        var advice = GetForFactKey(finding.RootFactKey);
+        // Value-stated prose first (frozen StoryText), static fallback for legacy findings; then
+        // overlay the generated copy-paste T-SQL and the two-sided risk disclosure as before.
+        var advice = GetComposedForFinding(finding);
         if (advice is null)
             return null;
 
@@ -95,6 +99,305 @@ public static class FactAdvice
         }
 
         return advice;
+    }
+
+    /// <summary>
+    /// Render-time entry point for a persisted or live finding. Prefers the value-stated advice
+    /// FROZEN into <see cref="AnalysisFinding.StoryText"/> at analysis time (see
+    /// <see cref="PopulateStoryText"/>), and falls back to the static <see cref="GetForFactKey"/>
+    /// block for findings persisted before this field carried advice. Every read surface (Lite and
+    /// Dashboard recommendation cards, MCP get_analysis_findings, analyze_server) calls this so the
+    /// operator reads the SAME numbers the engine observed — current MAXDOP, CTFP, cores — instead
+    /// of generic folklore. The composer ran where the facts live; the card just displays the result.
+    /// </summary>
+    public static AdviceBlock? GetComposedForFinding(AnalysisFinding finding)
+    {
+        if (finding is null)
+            return null;
+        return TryReadStoryText(finding.StoryText) ?? GetForFactKey(finding.RootFactKey);
+    }
+
+    /// <summary>
+    /// Composes value-stated advice for a story's root fact key from the FULL scored fact set.
+    /// The full set matters: a healthy setting (e.g. MAXDOP already at 8) scores 0 and is therefore
+    /// ABSENT from the engine's >0 working set, so the composer must see every fact to state the
+    /// current value. Value-bearing keys (THREADPOOL_PARALLEL / _MIXED, CONFIG_MAXDOP, CONFIG_CTFP)
+    /// interpolate the server's actual settings and tailor the recommendation to how far they are
+    /// from guidance — including the "already within guidance and still exhausting" override. Every
+    /// other key returns its static block unchanged.
+    /// </summary>
+    public static AdviceBlock? Compose(string? rootFactKey, IReadOnlyDictionary<string, Fact> factsByKey)
+    {
+        if (string.IsNullOrEmpty(rootFactKey))
+            return null;
+        return rootFactKey switch
+        {
+            "THREADPOOL_PARALLEL" => ComposeThreadpoolParallel(factsByKey),
+            "THREADPOOL_MIXED" => ComposeThreadpoolMixed(factsByKey),
+            "CONFIG_MAXDOP" => ComposeConfigMaxdop(factsByKey),
+            "CONFIG_CTFP" => ComposeConfigCtfp(factsByKey),
+            _ => GetForFactKey(rootFactKey)
+        };
+    }
+
+    /// <summary>
+    /// Freezes each story's value-stated advice into <see cref="AnalysisStory.StoryText"/> as a
+    /// compact JSON {h,i,r} blob, BEFORE the finding stores copy StoryText onto the persisted
+    /// finding. The full <paramref name="facts"/> list (every severity) backs the value reads.
+    /// Read-back surfaces deserialize it via <see cref="GetComposedForFinding"/>; the static blocks
+    /// remain the fallback. No schema change — StoryText already round-trips in both stores and was
+    /// previously written empty.
+    /// </summary>
+    public static void PopulateStoryText(IEnumerable<AnalysisStory> stories, IReadOnlyList<Fact> facts)
+    {
+        if (stories is null)
+            return;
+        var byKey = (facts ?? Array.Empty<Fact>()).ToFactLookup();
+        foreach (var story in stories)
+        {
+            if (story is null || story.IsAbsolution)
+                continue;
+            var advice = Compose(story.RootFactKey, byKey);
+            if (advice is not null)
+                story.StoryText = SerializeForStoryText(advice);
+        }
+    }
+
+    /// <summary>Serializes an advice block's prose to the compact {h,i,r} JSON stored in StoryText.</summary>
+    public static string SerializeForStoryText(AdviceBlock? advice) =>
+        advice is null
+            ? string.Empty
+            : JsonSerializer.Serialize(new StoryAdvice(advice.Headline, advice.Investigation, advice.Remediation));
+
+    /// <summary>
+    /// Reads back the frozen advice from a finding's StoryText. Returns null for empty or legacy
+    /// (non-JSON) StoryText so the caller falls back to the static block, and is defensive against
+    /// malformed JSON.
+    /// </summary>
+    public static AdviceBlock? TryReadStoryText(string? storyText)
+    {
+        if (string.IsNullOrEmpty(storyText) || storyText[0] != '{')
+            return null;
+        try
+        {
+            var s = JsonSerializer.Deserialize<StoryAdvice>(storyText);
+            if (s is null || (string.IsNullOrEmpty(s.h) && string.IsNullOrEmpty(s.i) && string.IsNullOrEmpty(s.r)))
+                return null;
+            return new AdviceBlock(s.h ?? string.Empty, s.i ?? string.Empty, s.r ?? string.Empty);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record StoryAdvice(string? h, string? i, string? r);
+
+    // ── Value readers: the fact's RAW collected value (the setting/metric), not its severity ──
+
+    /// <summary>The fact's raw collected value rounded to a whole number, or null when the fact is absent.</summary>
+    private static long? FactValue(IReadOnlyDictionary<string, Fact> facts, string key) =>
+        facts.TryGetValue(key, out var f) ? (long)Math.Round(f.Value) : (long?)null;
+
+    /// <summary>
+    /// Cores-per-socket from SERVER_HARDWARE metadata — the per-NUMA-node proxy MAXDOP guidance keys
+    /// on (NUMA node count itself is not collected). 0 when absent.
+    /// </summary>
+    private static int CoresPerSocket(IReadOnlyDictionary<string, Fact> facts) =>
+        facts.TryGetValue("SERVER_HARDWARE", out var hw)
+            && hw.Metadata.TryGetValue("cores_per_socket", out var c) ? (int)c : 0;
+
+    /// <summary>
+    /// The collection-gap caveat appended to every THREADPOOL-family block: under live thread
+    /// exhaustion the collector is itself a query waiting for a worker, so a gap in Collection Health
+    /// around the window corroborates the event rather than being a separate problem.
+    /// </summary>
+    private const string CollectionGapNote =
+        " Note on the data: under live thread exhaustion the collector is itself a query waiting for " +
+        "a worker, so expect a gap in collection during the worst of it — a missing interval in " +
+        "Collection Health around this window corroborates the event, it is not a separate problem.";
+
+    /// <summary>
+    /// THREADPOOL_PARALLEL composed with the server's ACTUAL MAXDOP, CTFP, and cores-per-socket, so
+    /// the card states the numbers and tailors the guard to how far they are from guidance —
+    /// including the workload-aware override when both are already within guidance and the pool still
+    /// exhausted (the cause is the volume of concurrent parallel queries, so guard harder). Falls
+    /// back to the static block when neither config fact was collected this window.
+    /// </summary>
+    private static AdviceBlock ComposeThreadpoolParallel(IReadOnlyDictionary<string, Fact> facts)
+    {
+        var fallback = _byKey["THREADPOOL_PARALLEL"];
+        var maxdop = FactValue(facts, "CONFIG_MAXDOP");
+        var ctfp = FactValue(facts, "CONFIG_CTFP");
+        if (maxdop is null && ctfp is null)
+            return fallback;
+
+        var cores = CoresPerSocket(facts);
+        var rec = FactRemediation.RecommendedMaxdop(cores);
+        return fallback with { Remediation = ParallelGuardCore(maxdop, ctfp, cores, rec) + CollectionGapNote };
+    }
+
+    /// <summary>
+    /// THREADPOOL_MIXED composed: collapse the blocking first (workers parked on locks are not
+    /// running, so it is the faster win), THEN the value-stated parallelism guard. Falls back to the
+    /// static block when neither config fact was collected this window.
+    /// </summary>
+    private static AdviceBlock ComposeThreadpoolMixed(IReadOnlyDictionary<string, Fact> facts)
+    {
+        var fallback = _byKey["THREADPOOL_MIXED"];
+        var maxdop = FactValue(facts, "CONFIG_MAXDOP");
+        var ctfp = FactValue(facts, "CONFIG_CTFP");
+        if (maxdop is null && ctfp is null)
+            return fallback;
+
+        var cores = CoresPerSocket(facts);
+        var rec = FactRemediation.RecommendedMaxdop(cores);
+        var remediation =
+            "Collapse the blocking first — workers parked on locks are not running, so it is the " +
+            "faster win: if the chain was headed by a sleeping/abandoned transaction, fix the code " +
+            "path that leaves a BEGIN TRAN open (and SET XACT_ABORT ON so an aborted batch rolls " +
+            "back); otherwise fix the slow operation under the held lock (usually a missing index " +
+            "turning a seek into a scan). Then guard parallelism. " +
+            ParallelGuardCore(maxdop, ctfp, cores, rec) + CollectionGapNote;
+        return fallback with { Remediation = remediation };
+    }
+
+    /// <summary>
+    /// The value-stated parallelism-guard recommendation shared by THREADPOOL_PARALLEL and
+    /// THREADPOOL_MIXED. States the server's current MAXDOP and CTFP (no "if") and recommends the
+    /// specific change: raise CTFP toward 50 and bring MAXDOP to the per-NUMA-node proxy (≤ 8) when
+    /// either is loose; or, when both are already within guidance and the pool still exhausted,
+    /// guard harder for the concurrency level. Does NOT include the collection-gap note (the caller
+    /// appends it once).
+    /// </summary>
+    private static string ParallelGuardCore(long? maxdop, long? ctfp, int cores, long rec)
+    {
+        var sb = new StringBuilder();
+
+        // 1. State what was observed — no conditional about settings the engine collected.
+        sb.Append("This server's MAXDOP is ")
+          .Append(maxdop?.ToString() ?? "not readable this window")
+          .Append(" and cost threshold for parallelism is ")
+          .Append(ctfp?.ToString() ?? "not readable this window")
+          .Append(cores > 0 ? $" (cores per socket {cores})." : ".");
+
+        var ctfpGuarded = ctfp is >= 50;
+        var maxdopGuarded = maxdop is > 0 && maxdop <= rec;
+
+        if (ctfpGuarded && maxdopGuarded)
+        {
+            // Workload-aware override: settings are sane, so the driver is the VOLUME of concurrent
+            // parallel queries — guard harder and go after the specific offenders.
+            var harder = Math.Max(2, rec / 2);
+            sb.Append(" Both are already within topology guidance, so the exhaustion is the volume of ")
+              .Append("concurrent parallel queries, not loose settings: guard harder for this concurrency ")
+              .Append($"level by lowering MAXDOP from {maxdop} to {harder} and/or raising cost threshold ")
+              .Append($"for parallelism above {ctfp}, and go after the specific high-DOP offenders");
+        }
+        else
+        {
+            sb.Append(" Guard parallelism:");
+            if (ctfp is null || ctfp <= 5)
+                sb.Append(" raise cost threshold for parallelism to 50 so trivial queries stop going parallel");
+            else if (ctfp < 50)
+                sb.Append($" raise cost threshold for parallelism from {ctfp} toward 50");
+            else
+                sb.Append(" cost threshold for parallelism is already past the trivial-query cutoff");
+
+            if (maxdop is 0)
+                sb.Append($", and cap MAXDOP at {rec} (this server's per-NUMA-node processor count, capped at 8) instead of unlimited");
+            else if (maxdop > rec)
+                sb.Append($", and lower MAXDOP from {maxdop} to {rec} (the per-NUMA-node processor count, capped at 8)");
+            else
+                sb.Append($"; MAXDOP at {maxdop} is already within the ≤ {rec} guidance");
+            sb.Append(". Then go after the specific high-DOP offenders");
+        }
+
+        sb.Append(" — `get_top_queries_by_cpu` with `parallel_only=true` ranks them; the usual shapes ")
+          .Append("are a parallel scan of a large table or a skewed plan where one branch does all the work.");
+
+        // 2. The one factor not collected (workload type) + the don't-mask rule.
+        sb.Append(" Thread exhaustion means concurrency is already high enough to drain the pool, so ")
+          .Append("guarding is warranted here; if these are deliberately large reporting/DW queries ")
+          .Append("rather than OLTP, prefer limiting how many run at once over clamping MAXDOP (which ")
+          .Append("slows each one). Do NOT raise `max worker threads` to mask it — that trades thread ")
+          .Append("exhaustion for memory pressure without fixing the cause.");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// CONFIG_MAXDOP composed with the ACTUAL value, so the headline states the real number (the
+    /// static block hard-coded "MAXDOP is 0", wrong whenever the finding fired for 1 or an
+    /// above-guidance value) and the remediation is tailored to 0 / 1 / above-guidance. Falls back
+    /// to the static block when the fact was not collected this window.
+    /// </summary>
+    private static AdviceBlock ComposeConfigMaxdop(IReadOnlyDictionary<string, Fact> facts)
+    {
+        var fallback = _byKey["CONFIG_MAXDOP"];
+        var maxdop = FactValue(facts, "CONFIG_MAXDOP");
+        if (maxdop is null)
+            return fallback;
+
+        var cores = CoresPerSocket(facts);
+        var rec = FactRemediation.RecommendedMaxdop(cores);
+        var coresNote = cores > 0 ? $" (cores per socket {cores})" : string.Empty;
+
+        string headline, remediation;
+        if (maxdop == 0)
+        {
+            headline = "MAXDOP is 0 — a single query can fan out across every scheduler (up to 64)";
+            remediation =
+                $"Set MAXDOP to {rec} — this server's cores-per-socket capped at 8{coresNote}, the per-NUMA-node " +
+                "proxy; the SKU is irrelevant to the right value. The Apply button runs sp_configure + " +
+                "RECONFIGURE, an online metadata change. On hardware with more than 16 logical processors " +
+                "per NUMA node you can raise it by hand. Raise Cost Threshold for Parallelism in the same pass " +
+                "if its companion finding fired.";
+        }
+        else if (maxdop == 1)
+        {
+            headline = "MAXDOP is 1 — every query is forced to run single-threaded";
+            remediation =
+                $"MAXDOP 1 forces every query serial: large analytical queries, index rebuilds, and DBCC run " +
+                $"far slower. Unless this was set deliberately to fix a specific parallelism problem, set MAXDOP " +
+                $"to {rec} (cores-per-socket capped at 8{coresNote}) via sp_configure + RECONFIGURE, an online change.";
+        }
+        else
+        {
+            headline = $"MAXDOP is {maxdop} — above this server's topology-based guidance of {rec}";
+            remediation =
+                $"Lower MAXDOP from {maxdop} to {rec} (cores-per-socket capped at 8{coresNote}, the per-NUMA-node " +
+                "proxy; the SKU is irrelevant). The Apply button runs sp_configure + RECONFIGURE, an online " +
+                "metadata change. On hardware with more than 16 logical processors per NUMA node a higher value " +
+                "can be justified by hand. Pair it with a sane Cost Threshold for Parallelism if that finding fired.";
+        }
+
+        return fallback with { Headline = headline, Remediation = remediation };
+    }
+
+    /// <summary>
+    /// CONFIG_CTFP composed with the ACTUAL value so the headline and remediation state the current
+    /// number. Falls back to the static block when the fact was not collected this window.
+    /// </summary>
+    private static AdviceBlock ComposeConfigCtfp(IReadOnlyDictionary<string, Fact> facts)
+    {
+        var fallback = _byKey["CONFIG_CTFP"];
+        var ctfp = FactValue(facts, "CONFIG_CTFP");
+        if (ctfp is null)
+            return fallback;
+
+        string headline = ctfp <= 5
+            ? $"Cost Threshold for Parallelism is {ctfp} — at (or below) the 1990s default"
+            : $"Cost Threshold for Parallelism is {ctfp}";
+        string remediation = ctfp <= 5
+            ? $"CTFP is {ctfp}, the shipped default — on modern hardware it sends trivial queries parallel, paying " +
+              "thread-coordination overhead (CXPACKET) for no gain. Raise it to 50 as a starting point, then tune " +
+              "up if CXPACKET persists on genuinely large queries. The Apply button runs sp_configure + RECONFIGURE, " +
+              "an online metadata change. Pair it with a sane MAXDOP if that companion finding fired."
+            : $"CTFP is {ctfp}. Raise it toward 50 so only genuinely expensive queries go parallel, then tune up if " +
+              "CXPACKET persists on large queries. The Apply button runs sp_configure + RECONFIGURE, an online change.";
+
+        return fallback with { Headline = headline, Remediation = remediation };
     }
 
     /// <summary>
@@ -162,7 +465,7 @@ public static class FactAdvice
             Investigation:
                 "Sustained THREADPOOL (it cleared the wait-time + per-wait-average gate, so this isn't pool grow/shrink noise) means new sessions cannot start until a worker frees up. Neither CXPACKET/high-DOP (parallelism) nor blocking co-fired above their own thresholds this window, so the engine could not attribute it — which happens when a co-cause stayed just under threshold or, commonly, the collector could not sample the peak. Decide it by hand: if CXPACKET / high-DOP are present treat it as parallelism (below); if a blocking chain is present treat it as blocking. `get_waiting_tasks` (Lite) / `get_cpu_scheduler_pressure` (Dashboard) show what is queued.",
             Remediation:
-                "Resolve the dominant cause — parallelism (raise `cost threshold for parallelism` to 50, cap `MAXDOP` at the logical processors in a single NUMA node, ≤ 8) or blocking (collapse the chain; kill a sleeping apex if present). Do NOT raise `max worker threads` to mask it — that trades thread exhaustion for memory pressure (each worker reserves a thread stack outside max server memory) without fixing the cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+                "Resolve the dominant cause — parallelism (raise `cost threshold for parallelism` to 50, cap `MAXDOP` at the logical processors in a single NUMA node, ≤ 8) or blocking. This is a report on a window that has already passed, so the worker pool has long since recovered: aim at stopping the recurrence, not a one-off `KILL`. For the blocking case that means fixing the abandoned-transaction code path (a BEGIN TRAN left open on an error/timeout path; SET XACT_ABORT ON) or the slow operation under the held lock (usually a missing index turning a seek into a scan). Do NOT raise `max worker threads` to mask it — that trades thread exhaustion for memory pressure (each worker reserves a thread stack outside max server memory) without fixing the cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
 
         t["THREADPOOL_PARALLEL"] = new AdviceBlock(
             Headline:
@@ -170,7 +473,7 @@ public static class FactAdvice
             Investigation:
                 "THREADPOOL fired alongside CXPACKET and/or high-DOP queries: a parallel query reserves up to DOP workers per parallel branch, so a moderate-concurrency workload at high DOP can drain the pool with zero blocking. This is the MAXDOP/CTFP flavor of thread exhaustion. `get_top_queries_by_cpu` with `parallel_only=true` ranks the parallel offenders; check whether they genuinely benefit from the degree of parallelism they are getting.",
             Remediation:
-                "Guard parallelism: raise `cost threshold for parallelism` to 50 so trivial queries stop going parallel, and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). If those are already set and the pool still exhausts, guard harder — lower MAXDOP further and/or raise CTFP — and tune the specific high-DOP queries (a parallel scan of a large table, or a skewed plan where one branch does all the work). Do NOT raise `max worker threads` to mask it (trades thread exhaustion for memory pressure). Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+                "Guard parallelism: raise `cost threshold for parallelism` to 50 so trivial queries stop going parallel, and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). When both are already at guidance and the pool still exhausts, the driver is the volume of concurrent parallel queries — lower MAXDOP further and/or raise CTFP for that concurrency level, and tune the specific high-DOP queries (a parallel scan of a large table, or a skewed plan where one branch does all the work). Do NOT raise `max worker threads` to mask it (trades thread exhaustion for memory pressure). Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
 
         t["THREADPOOL_BLOCKING"] = new AdviceBlock(
             Headline:
@@ -178,7 +481,7 @@ public static class FactAdvice
             Investigation:
                 "THREADPOOL fired alongside blocking: every session waiting on a lock keeps its worker thread assigned, so a wide or deep blocking chain ties up one worker per blocked session and can exhaust the pool. Lowering MAXDOP frees nothing here — the workers are not running parallel work, they are parked on locks. The BLOCKING_CHAIN drill-down `reconstructed_blocking_chains` shows `apex_spid`, `apex_sleeping`, `depth`, and `victim_count`; `get_blocked_process_reports` (Lite) / `get_blocking` (Dashboard) show the live chain.",
             Remediation:
-                "Clear the blocking — that is what frees the workers. If `apex_sleeping` is true on the top chain, KILL the apex (one kill collapses the pile-up because every downstream victim was waiting on that one transaction). Otherwise fix the one slow operation everyone is queued behind (a missing index turning a seek into a scan under a held lock is the usual shape), and enable RCSI where the contention is readers blocked by writers. MAXDOP/CTFP are not the levers for this. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+                "Clearing the blocking is what frees the workers — but this is a report on a window that has already passed, so the pile-up is gone and a `KILL` now buys nothing. Aim at the recurrence. If the chain was headed by a sleeping apex (`apex_sleeping = true`), that is the abandoned-transaction signature: fix the code path that opens a BEGIN TRAN and never reaches COMMIT/ROLLBACK on the error or client-timeout path, and SET XACT_ABORT ON so an aborted batch rolls back automatically. If the apex was active, there is one slow operation everyone queued behind — fix it (a missing index turning a seek into a scan under a held lock is the usual shape), and enable RCSI where the contention is readers blocked by writers. MAXDOP/CTFP are not the levers for this. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
 
         t["THREADPOOL_MIXED"] = new AdviceBlock(
             Headline:
@@ -186,7 +489,7 @@ public static class FactAdvice
             Investigation:
                 "THREADPOOL fired with BOTH CXPACKET/high-DOP and blocking co-elevated, so workers are being consumed from two directions: parallel queries reserving DOP workers, and blocked sessions parking workers on locks. Look at the BLOCKING_CHAIN drill-down `reconstructed_blocking_chains` (apex, depth, victim_count) and the parallel offenders (`get_top_queries_by_cpu` with `parallel_only=true`) together.",
             Remediation:
-                "Collapse the blocking first — it pins workers on sessions that are not even running, so it is the faster win (kill a sleeping apex if present; fix the slow operation under the held lock). Then guard parallelism: raise `cost threshold for parallelism` to 50 and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). Do NOT raise `max worker threads` to mask either cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+                "Collapse the blocking first — it pins workers on sessions that are not even running, so it is the bigger win. This is a report on a past window, so go after the recurrence rather than a one-off kill: fix the abandoned-transaction code path (BEGIN TRAN left open on an error/timeout path; SET XACT_ABORT ON) or the slow operation under the held lock. Then guard parallelism: raise `cost threshold for parallelism` to 50 and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). Do NOT raise `max worker threads` to mask either cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
 
         t["CXPACKET"] = new AdviceBlock(
             Headline:
@@ -282,7 +585,7 @@ public static class FactAdvice
             Investigation:
                 "The drill-down `reconstructed_blocking_chains` is already attached: up to three chains, each carrying `apex_spid`, `apex_sleeping`, `depth`, `victim_count`, `max_wait_ms`, and a per-level breakdown with `blocking_spid`, `blocked_spid`, `lock_mode`, `wait_time_ms`, and the SQL on both sides. `apex_sleeping = true` is the abandoned-transaction signature — an application started a BEGIN TRAN and never reached COMMIT/ROLLBACK on the error path. THREADPOOL co-elevation means every blocked victim is also holding a worker thread, and the server is at risk of thread exhaustion. Open Blocking → Blocked Process Reports to walk the same chain in the UI; `get_blocked_process_reports` (Lite) or `get_blocked_process_xml` (Dashboard) returns the parsed event stream.",
             Remediation:
-                "If `apex_sleeping = true` on the top chain, kill the apex session — that single `KILL` collapses the entire pile-up because all victims downstream were waiting on that one transaction. For non-sleeping apex chains, look at the level-0 entry: there's one slow operation everyone else is queued behind. Common shapes: a missing index forcing a scan under a held lock, an UPDATE without a useful WHERE-clause index, or an unindexed foreign key forcing Sch-S during a parent-row update. Fix that one query and the chain dissolves.");
+                "This is a report on a window that has already passed — the pile-up has cleared and a `KILL` now buys nothing, so aim at the recurrence. If `apex_sleeping = true` on the top chain, that is the abandoned-transaction signature: an application opened a BEGIN TRAN and never reached COMMIT/ROLLBACK on its error or client-timeout path. Fix that code path, and SET XACT_ABORT ON so an aborted batch rolls back automatically — killing the session only clears one occurrence. For an active apex, look at the level-0 entry: there is one slow operation everyone else is queued behind. Common shapes: a missing index forcing a scan under a held lock, an UPDATE whose WHERE clause has no supporting index so it locks rows while it scans, or an unindexed foreign key that makes a parent-side UPDATE/DELETE scan the child table to enforce referential integrity. Fix that one operation and the chain dissolves.");
 
         t["LCK"] = new AdviceBlock(
             Headline:

--- a/PerformanceMonitor.Analysis/FactAdvice.cs
+++ b/PerformanceMonitor.Analysis/FactAdvice.cs
@@ -152,13 +152,41 @@ public static class FactAdvice
             Remediation:
                 "Tune the queries in `top_cpu_queries` before sizing more hardware — scheduler yield means CPU demand exceeds supply, and demand is almost always the cheaper variable. Fix the missing indexes, scans, and parameter sniffing the plan analysis surfaces. If CXPACKET is co-elevated, run `audit_config`: a default `cost threshold for parallelism` of 5 with `MAXDOP` 0 is the usual cause, and the recommendation engine will tell you what to set them to.");
 
+        // THREADPOOL (thread exhaustion) is attribution-keyed by InferenceEngine.ClassifyThreadpool:
+        // the finding roots on THREADPOOL_PARALLEL / THREADPOOL_BLOCKING / THREADPOOL_MIXED when the
+        // co-cause is clear, else the generic THREADPOOL below. Only the parallel flavor is a
+        // MAXDOP/CTFP problem; blocking-driven exhaustion is fixed by clearing the blocking.
         t["THREADPOOL"] = new AdviceBlock(
             Headline:
-                "THREADPOOL waits — SQL Server has run out of worker threads and new sessions are queuing for one",
+                "THREADPOOL waits — SQL Server has run out of worker threads, with no clear parallel or blocking cause this window",
             Investigation:
-                "Any time on THREADPOOL means sessions cannot start until a worker frees up — treat this as severe by default. The engine's THREADPOOL amplifiers (in `FactScorer.ThreadpoolAmplifiers`) score BLOCKING and CXPACKET co-elevation as peer causes, not blocking-first. Look at the BLOCKING_CHAIN drill-down `reconstructed_blocking_chains` for the `apex_spid`, `apex_sleeping`, `depth`, and `victim_count` — every blocked victim is also holding a worker. In parallel, check the CXPACKET line on the Wait Stats tab for the same window: each parallel query consumes one worker per scheduler it touches, so a moderate-concurrency workload at high DOP can exhaust the pool with zero blocking. Call `get_waiting_tasks` (Lite) or `get_cpu_scheduler_pressure` (Dashboard) to see what's queued or under scheduler pressure right now, and `get_top_queries_by_cpu` with `parallel_only=true` to find the parallel offenders.",
+                "Sustained THREADPOOL (it cleared the wait-time + per-wait-average gate, so this isn't pool grow/shrink noise) means new sessions cannot start until a worker frees up. Neither CXPACKET/high-DOP (parallelism) nor blocking co-fired above their own thresholds this window, so the engine could not attribute it — which happens when a co-cause stayed just under threshold or, commonly, the collector could not sample the peak. Decide it by hand: if CXPACKET / high-DOP are present treat it as parallelism (below); if a blocking chain is present treat it as blocking. `get_waiting_tasks` (Lite) / `get_cpu_scheduler_pressure` (Dashboard) show what is queued.",
             Remediation:
-                "Two independent levers: collapse the blocking chain and lower parallelism. If `apex_sleeping` is true on the top reconstructed chain, kill that session — the entire chain unblocks and the workers free. For the parallelism half, `audit_config` will tell you whether `cost threshold for parallelism` and `MAXDOP` are at the defaults that drive this; raising CTFP to 50 and capping MAXDOP at the logical processors in a single NUMA node (≤ 8) is the typical starting point. Do not raise `max worker threads` to mask either cause — it trades thread exhaustion for memory pressure without fixing the underlying contention.");
+                "Resolve the dominant cause — parallelism (raise `cost threshold for parallelism` to 50, cap `MAXDOP` at the logical processors in a single NUMA node, ≤ 8) or blocking (collapse the chain; kill a sleeping apex if present). Do NOT raise `max worker threads` to mask it — that trades thread exhaustion for memory pressure (each worker reserves a thread stack outside max server memory) without fixing the cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+
+        t["THREADPOOL_PARALLEL"] = new AdviceBlock(
+            Headline:
+                "Thread exhaustion driven by parallelism — too many parallel queries each reserving worker threads",
+            Investigation:
+                "THREADPOOL fired alongside CXPACKET and/or high-DOP queries: a parallel query reserves up to DOP workers per parallel branch, so a moderate-concurrency workload at high DOP can drain the pool with zero blocking. This is the MAXDOP/CTFP flavor of thread exhaustion. `get_top_queries_by_cpu` with `parallel_only=true` ranks the parallel offenders; check whether they genuinely benefit from the degree of parallelism they are getting.",
+            Remediation:
+                "Guard parallelism: raise `cost threshold for parallelism` to 50 so trivial queries stop going parallel, and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). If those are already set and the pool still exhausts, guard harder — lower MAXDOP further and/or raise CTFP — and tune the specific high-DOP queries (a parallel scan of a large table, or a skewed plan where one branch does all the work). Do NOT raise `max worker threads` to mask it (trades thread exhaustion for memory pressure). Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+
+        t["THREADPOOL_BLOCKING"] = new AdviceBlock(
+            Headline:
+                "Thread exhaustion driven by blocking — workers are pinned on blocked (not running) sessions",
+            Investigation:
+                "THREADPOOL fired alongside blocking: every session waiting on a lock keeps its worker thread assigned, so a wide or deep blocking chain ties up one worker per blocked session and can exhaust the pool. Lowering MAXDOP frees nothing here — the workers are not running parallel work, they are parked on locks. The BLOCKING_CHAIN drill-down `reconstructed_blocking_chains` shows `apex_spid`, `apex_sleeping`, `depth`, and `victim_count`; `get_blocked_process_reports` (Lite) / `get_blocking` (Dashboard) show the live chain.",
+            Remediation:
+                "Clear the blocking — that is what frees the workers. If `apex_sleeping` is true on the top chain, KILL the apex (one kill collapses the pile-up because every downstream victim was waiting on that one transaction). Otherwise fix the one slow operation everyone is queued behind (a missing index turning a seek into a scan under a held lock is the usual shape), and enable RCSI where the contention is readers blocked by writers. MAXDOP/CTFP are not the levers for this. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
+
+        t["THREADPOOL_MIXED"] = new AdviceBlock(
+            Headline:
+                "Thread exhaustion with both parallelism and blocking elevated",
+            Investigation:
+                "THREADPOOL fired with BOTH CXPACKET/high-DOP and blocking co-elevated, so workers are being consumed from two directions: parallel queries reserving DOP workers, and blocked sessions parking workers on locks. Look at the BLOCKING_CHAIN drill-down `reconstructed_blocking_chains` (apex, depth, victim_count) and the parallel offenders (`get_top_queries_by_cpu` with `parallel_only=true`) together.",
+            Remediation:
+                "Collapse the blocking first — it pins workers on sessions that are not even running, so it is the faster win (kill a sleeping apex if present; fix the slow operation under the held lock). Then guard parallelism: raise `cost threshold for parallelism` to 50 and cap `MAXDOP` at the logical processors in a single NUMA node (≤ 8). Do NOT raise `max worker threads` to mask either cause. Note on the data: under live thread exhaustion the collector is itself a query waiting for a worker, so expect a gap in collection during the worst of it — a missing interval in Collection Health around this window corroborates the event, it is not a separate problem.");
 
         t["CXPACKET"] = new AdviceBlock(
             Headline:

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -167,7 +167,18 @@ public class InferenceEngine
         var leafKey = path.Count > 1 ? path[^1] : null;
         var leafFact = leafKey != null ? factsByKey.GetValueOrDefault(leafKey) : null;
 
-        var storyPath = string.Join(" → ", path);
+        // Attribute THREADPOOL (thread exhaustion) by its co-elevated cause, so the finding's ROOT
+        // KEY — the thing that persists and that FactAdvice is keyed on — carries parallel-vs-blocking.
+        // Only parallel-driven exhaustion is a MAXDOP/CTFP problem; blocking-driven exhaustion pins
+        // workers on blocked (not running) sessions and is fixed by clearing the blocking. The fact
+        // object keeps its "THREADPOOL" key (relationship graph + amplifiers untouched); only the
+        // finding's root key and story path are relabeled to the attribution variant.
+        var rootKey = path[0] == "THREADPOOL" ? ClassifyThreadpool(factsByKey) : path[0];
+        var effectivePath = rootKey == path[0]
+            ? path
+            : path.Select((k, i) => i == 0 ? rootKey : k).ToList();
+
+        var storyPath = string.Join(" → ", effectivePath);
         var category = rootFact?.Source ?? "unknown";
 
         // Confidence = what fraction of edge destinations had matching facts
@@ -176,12 +187,12 @@ public class InferenceEngine
 
         return new AnalysisStory
         {
-            RootFactKey = path[0],
+            RootFactKey = rootKey,
             RootFactValue = rootFact?.Severity ?? 0,
             Severity = rootFact?.Severity ?? 0,
             Confidence = confidence,
             Category = category,
-            Path = path,
+            Path = effectivePath,
             StoryPath = storyPath,
             StoryPathHash = ComputeHash(storyPath),
             StoryText = string.Empty,
@@ -192,6 +203,31 @@ public class InferenceEngine
             RootFactMetadata = rootFact?.Metadata,
             // Carry the root fact's database through so findings/recommendation cards can show it.
             DatabaseName = rootFact?.DatabaseName
+        };
+    }
+
+    /// <summary>
+    /// Classifies a THREADPOOL (thread-exhaustion) root by its co-elevated cause so the persisted,
+    /// read-back root key carries the attribution that FactAdvice routes on. Parallel-driven
+    /// (CXPACKET / high-DOP co-fired) is the only flavor MAXDOP/CTFP fixes; blocking-driven
+    /// (blocked sessions pinning workers) is fixed by clearing the blocking. Mirrors the THREADPOOL
+    /// amplifier peers (CXPACKET, blocking/LCK). Returns the generic "THREADPOOL" when neither
+    /// co-fired (unattributed — the advice then tells the operator how to tell which it is).
+    /// factsByKey here contains only facts that scored above zero, so presence == fired.
+    /// </summary>
+    private static string ClassifyThreadpool(Dictionary<string, Fact> factsByKey)
+    {
+        var parallel = factsByKey.ContainsKey("CXPACKET")
+                    || factsByKey.ContainsKey("QUERY_HIGH_DOP");
+        var blocking = factsByKey.ContainsKey("BLOCKING_EVENTS")
+                    || factsByKey.ContainsKey("BLOCKING_CHAIN")
+                    || factsByKey.ContainsKey("LCK");
+        return (parallel, blocking) switch
+        {
+            (true, true) => "THREADPOOL_MIXED",
+            (true, false) => "THREADPOOL_PARALLEL",
+            (false, true) => "THREADPOOL_BLOCKING",
+            _ => "THREADPOOL"
         };
     }
 


### PR DESCRIPTION
## What & why

You called it: THREADPOOL (thread exhaustion) has two causes that need **opposite** fixes —
- **parallel-driven** (too many parallel queries each reserving DOP workers) → lower MAXDOP / raise CTFP;
- **blocking-driven** (workers pinned on *blocked*, not running, sessions) → clear the blocking; MAXDOP does nothing.

The advice treated them as one flat "two levers" list, so it would tell you to touch MAXDOP for a blocking problem.

## How (option C — no schema change)

The attribution exists at analysis time (`THREADPOOL`'s amplifier peers: CXPACKET vs LCK) but didn't survive to the read-back card (Lite renders from `FactAdvice[rootKey]` off DuckDB; no fact values / drill-down persist). So `InferenceEngine.BuildStory` relabels the THREADPOOL story's **root key** by its co-elevated cause — `THREADPOOL_PARALLEL` / `THREADPOOL_BLOCKING` / `THREADPOOL_MIXED` (generic `THREADPOOL` when neither co-fired). The root key **is** persisted and is what `FactAdvice` keys on → attribution survives read-back identically in both apps. The **fact object keeps its `THREADPOOL` key**, so the relationship graph + amplifiers are untouched.

- `InferenceEngine.ClassifyThreadpool(factsByKey)` — CXPACKET / QUERY_HIGH_DOP (parallel) vs BLOCKING_EVENTS / BLOCKING_CHAIN / LCK (blocking).
- `FactAdvice` — 4 blocks: generic (teaches how to tell which), `_PARALLEL` (MAXDOP/CTFP guard, with the "already capped and still exhausting → guard harder" override), `_BLOCKING` (clear the blocking; MAXDOP won't help), `_MIXED` (collapse blocking first, then guard). Each carries the **collection-gap note** (in, per your call): under live THREADPOOL the collector is itself a query waiting for a worker, so a gap in Collection Health around the window corroborates the event.
- Tests: classification (`InferenceEngineTests`) + variant advice coverage (`FactScorerTests`); updated the THREADPOOL scenario tests for the attribution-keyed roots.

Settled-decision trail in `plans/maxdop-ctfp-workload-aware.md`.

## Verify
- Build: 0 errors (one pre-existing, unrelated `CS8602`).
- Dashboard.Tests **495/495**, Lite.Tests **543/543** (one credential test flaked on the first run — real Windows Credential Manager, parallel-sensitive — and passed on re-run; unrelated to this change).

Reviewer note: the four `THREADPOOL*` blocks in `FactAdvice.cs` are the new prose to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
