### PR TITLE
Chart UI style port - Track A (color foundation, line polish, slicer, in-grid bars, per-DB cards)

### DIFF
--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -297,7 +297,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 Position = d.Time,
                 Value = d.Value,
                 Size = barWidth,
-                FillColor = ScottPlot.Color.FromHex("#E57373"),
+                FillColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking")),
                 LineWidth = 0
             }).ToArray();
             BlockingChart.Plot.Add.Bars(bars);
@@ -311,7 +311,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 Position = d.Time,
                 Value = d.Value,
                 Size = barWidth * 0.6,
-                FillColor = ScottPlot.Color.FromHex("#FFD54F"),
+                FillColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks")),
                 LineWidth = 0
             }).ToArray();
             BlockingChart.Plot.Add.Bars(bars);
@@ -569,7 +569,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         var values = data.Select(d => d.Value).ToArray();
 
         var scatter = chart.Plot.Add.Scatter(times, values);
-        scatter.Color = ScottPlot.Colors.White.WithAlpha(140);
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("GhostLine")).WithAlpha(140);
         scatter.MarkerSize = 0;
         scatter.LineWidth = 1.5f;
         scatter.LinePattern = ScottPlot.LinePattern.Dashed;
@@ -595,7 +595,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     {
         TabHelpers.ReapplyAxisColors(chart);
         var text = chart.Plot.Add.Text($"{title}\nNo Data", 0, 0);
-        text.LabelFontColor = ScottPlot.Color.FromHex("#888888");
+        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
         text.LabelFontSize = 12;
         text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
         chart.Plot.HideGrid();

--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -20,6 +20,7 @@ using PerformanceMonitor.Analysis;
 using PerformanceMonitorDashboard.Analysis;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls;
@@ -332,11 +333,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             if (baseline.EffectiveStdDev > 0)
             {
                 var band = BlockingChart.Plot.Add.HorizontalSpan(lower, upper);
-                band.FillStyle.Color = ScottPlot.Color.FromHex("#E57373").WithAlpha(25);
+                band.FillStyle.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineBlocking")).WithAlpha(25);
                 band.LineStyle.Width = 0;
 
                 var meanLine = BlockingChart.Plot.Add.HorizontalLine(baseline.Mean);
-                meanLine.Color = ScottPlot.Color.FromHex("#E57373").WithAlpha(60);
+                meanLine.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineBlocking")).WithAlpha(60);
                 meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
                 meanLine.LineWidth = 1;
             }
@@ -389,11 +390,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             _crosshairManager?.SetLaneBaseline(CpuChart, lower, upper, 10);
 
             var band = CpuChart.Plot.Add.HorizontalSpan(lower, upper);
-            band.FillStyle.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(25);
+            band.FillStyle.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineCpu")).WithAlpha(25);
             band.LineStyle.Width = 0;
 
             var meanLine = CpuChart.Plot.Add.HorizontalLine(baseline.Mean);
-            meanLine.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(60);
+            meanLine.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineCpu")).WithAlpha(60);
             meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
             meanLine.LineWidth = 1;
 
@@ -409,7 +410,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 var anomalyTimes = anomalyIndices.Select(i => sqlTimes[i]).ToArray();
                 var anomalyVals = anomalyIndices.Select(i => sqlValues[i]).ToArray();
                 var anomalyScatter = CpuChart.Plot.Add.Scatter(anomalyTimes, anomalyVals);
-                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Anomaly"));
                 anomalyScatter.MarkerSize = 6;
                 anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
                 anomalyScatter.LineWidth = 0;
@@ -419,7 +420,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         if (totalValues.Length > 0)
         {
             var totalScatter = CpuChart.Plot.Add.Scatter(totalTimes, totalValues);
-            totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+            totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalCpu"));
             totalScatter.MarkerSize = 0;
             totalScatter.LineWidth = 1.5f;
             totalScatter.LegendText = "Total";
@@ -429,7 +430,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         if (sqlValues.Length > 0)
         {
             var sqlScatter = CpuChart.Plot.Add.Scatter(sqlTimes, sqlValues);
-            sqlScatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
             sqlScatter.MarkerSize = 0;
             sqlScatter.LineWidth = 1.5f;
             sqlScatter.LegendText = "SQL";
@@ -496,7 +497,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 var anomalyTimes = anomalyIndices.Select(i => times[i]).ToArray();
                 var anomalyValues = anomalyIndices.Select(i => values[i]).ToArray();
                 var anomalyScatter = chart.Plot.Add.Scatter(anomalyTimes, anomalyValues);
-                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Anomaly"));
                 anomalyScatter.MarkerSize = 6;
                 anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
                 anomalyScatter.LineWidth = 0;

--- a/Dashboard/Controls/MemoryContent.MemoryClerks.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryClerks.cs
@@ -173,9 +173,8 @@ namespace PerformanceMonitorDashboard.Controls
                                 var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                                 var scatter = MemoryClerksChart.Plot.Add.Scatter(xs, ys);
-                                scatter.LineWidth = 2;
-                                scatter.MarkerSize = 5;
                                 scatter.Color = colors[colorIndex % colors.Length];
+                                ChartStyle.StyleScatter(scatter);
                                 var label = clerkType.Length > 20 ? clerkType.Substring(0, 20) + "..." : clerkType;
                                 scatter.LegendText = label;
                                 _memoryClerksHover?.Add(scatter, label);

--- a/Dashboard/Controls/MemoryContent.MemoryGrants.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryGrants.cs
@@ -138,9 +138,8 @@ namespace PerformanceMonitorDashboard.Controls
                     if (xs.Length > 0)
                     {
                         var scatter = MemoryGrantSizingChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         var label = $"Pool {poolId}: {metricName}";
                         scatter.LegendText = label;
                         _memoryGrantSizingHover?.Add(scatter, label);
@@ -208,9 +207,8 @@ namespace PerformanceMonitorDashboard.Controls
                     if (xs.Length > 0)
                     {
                         var scatter = MemoryGrantActivityChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         var label = $"Pool {poolId}: {metricName}";
                         scatter.LegendText = label;
                         _memoryGrantActivityHover?.Add(scatter, label);

--- a/Dashboard/Controls/MemoryContent.MemoryPressure.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryPressure.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -87,10 +88,10 @@ namespace PerformanceMonitorDashboard.Controls
                 var osMediumBars = new List<ScottPlot.Bar>();
                 var osSevereBars = new List<ScottPlot.Bar>();
 
-                var sqlMediumColor = ScottPlot.Color.FromHex("#FFB74D");  // orange 300
-                var sqlSevereColor = ScottPlot.Color.FromHex("#E65100");  // orange 900
-                var osMediumColor = ScottPlot.Color.FromHex("#E57373");   // red 300
-                var osSevereColor = ScottPlot.Color.FromHex("#B71C1C");   // red 900
+                var sqlMediumColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlPressureMedium"));
+                var sqlSevereColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlPressureSevere"));
+                var osMediumColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OsPressureMedium"));
+                var osSevereColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OsPressureSevere"));
 
                 foreach (var g in grouped)
                 {
@@ -197,7 +198,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryPressureEventsChart.Plot.Add.Text("No memory pressure events in selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/MemoryContent.MemoryStats.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryStats.cs
@@ -89,30 +89,26 @@ namespace PerformanceMonitorDashboard.Controls
                 AddPressureWarningSpans(dataList);
 
                 var totalScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(totalXs, totalYs);
-                totalScatter.LineWidth = 2;
-                totalScatter.MarkerSize = 5;
                 totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalMemory"));
+                ChartStyle.StyleScatter(totalScatter);
                 totalScatter.LegendText = "Total Memory";
                 _memoryStatsOverviewHover?.Add(totalScatter, "Total Memory");
 
                 var bufferScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(bufferXs, bufferYs);
-                bufferScatter.LineWidth = 2;
-                bufferScatter.MarkerSize = 5;
                 bufferScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
+                ChartStyle.StyleScatter(bufferScatter);
                 bufferScatter.LegendText = "Buffer Pool";
                 _memoryStatsOverviewHover?.Add(bufferScatter, "Buffer Pool");
 
                 var cacheScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(cacheXs, cacheYs);
-                cacheScatter.LineWidth = 2;
-                cacheScatter.MarkerSize = 5;
                 cacheScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("CacheMemory"));
+                ChartStyle.StyleScatter(cacheScatter);
                 cacheScatter.LegendText = "Plan Cache";
                 _memoryStatsOverviewHover?.Add(cacheScatter, "Plan Cache");
 
                 var availScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(availXs, availYs);
-                availScatter.LineWidth = 2;
-                availScatter.MarkerSize = 5;
                 availScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("AvailableMemory"));
+                ChartStyle.StyleScatter(availScatter);
                 availScatter.LegendText = "Available Physical";
                 _memoryStatsOverviewHover?.Add(availScatter, "Available Physical");
 

--- a/Dashboard/Controls/MemoryContent.MemoryStats.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryStats.cs
@@ -91,7 +91,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var totalScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(totalXs, totalYs);
                 totalScatter.LineWidth = 2;
                 totalScatter.MarkerSize = 5;
-                totalScatter.Color = TabHelpers.ChartColors[9];
+                totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalMemory"));
                 totalScatter.LegendText = "Total Memory";
                 _memoryStatsOverviewHover?.Add(totalScatter, "Total Memory");
 
@@ -105,14 +105,14 @@ namespace PerformanceMonitorDashboard.Controls
                 var cacheScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(cacheXs, cacheYs);
                 cacheScatter.LineWidth = 2;
                 cacheScatter.MarkerSize = 5;
-                cacheScatter.Color = TabHelpers.ChartColors[1];
+                cacheScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("CacheMemory"));
                 cacheScatter.LegendText = "Plan Cache";
                 _memoryStatsOverviewHover?.Add(cacheScatter, "Plan Cache");
 
                 var availScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(availXs, availYs);
                 availScatter.LineWidth = 2;
                 availScatter.MarkerSize = 5;
-                availScatter.Color = TabHelpers.ChartColors[2];
+                availScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("AvailableMemory"));
                 availScatter.LegendText = "Available Physical";
                 _memoryStatsOverviewHover?.Add(availScatter, "Available Physical");
 

--- a/Dashboard/Controls/MemoryContent.MemoryStats.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryStats.cs
@@ -124,7 +124,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryStatsOverviewChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/MemoryContent.MemoryStats.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryStats.cs
@@ -162,7 +162,7 @@ namespace PerformanceMonitorDashboard.Controls
 
                     if (item.BufferPoolPressureWarning && item.PlanCachePressureWarning)
                     {
-                        vline.Color = TabHelpers.ChartColors[3].WithAlpha(0.5);
+                        vline.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("PressureSevere")).WithAlpha(0.5);
                         // Add legend entry for BP pressure (covers "both" case too)
                         if (!bpLegendAdded)
                         {
@@ -172,7 +172,7 @@ namespace PerformanceMonitorDashboard.Controls
                     }
                     else if (item.BufferPoolPressureWarning)
                     {
-                        vline.Color = TabHelpers.ChartColors[3].WithAlpha(0.3);
+                        vline.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("PressureSevere")).WithAlpha(0.3);
                         if (!bpLegendAdded)
                         {
                             vline.LegendText = "BP Pressure";
@@ -181,7 +181,7 @@ namespace PerformanceMonitorDashboard.Controls
                     }
                     else
                     {
-                        vline.Color = TabHelpers.ChartColors[2].WithAlpha(0.3);
+                        vline.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("PressureMedium")).WithAlpha(0.3);
                         if (!pcLegendAdded)
                         {
                             vline.LegendText = "PC Pressure";

--- a/Dashboard/Controls/MemoryContent.MemoryStats.cs
+++ b/Dashboard/Controls/MemoryContent.MemoryStats.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -97,7 +98,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var bufferScatter = MemoryStatsOverviewChart.Plot.Add.Scatter(bufferXs, bufferYs);
                 bufferScatter.LineWidth = 2;
                 bufferScatter.MarkerSize = 5;
-                bufferScatter.Color = TabHelpers.ChartColors[0];
+                bufferScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
                 bufferScatter.LegendText = "Buffer Pool";
                 _memoryStatsOverviewHover?.Add(bufferScatter, "Buffer Pool");
 

--- a/Dashboard/Controls/MemoryContent.PlanCache.cs
+++ b/Dashboard/Controls/MemoryContent.PlanCache.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -83,7 +84,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var singleScatter = PlanCacheChart.Plot.Add.Scatter(singleXs, singleYs);
                     singleScatter.LineWidth = 2;
                     singleScatter.MarkerSize = 5;
-                    singleScatter.Color = TabHelpers.ChartColors[3];
+                    singleScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SinglePagePlans"));
                     singleScatter.LegendText = "Single-Use";
                     _planCacheHover?.Add(singleScatter, "Single-Use");
 
@@ -95,7 +96,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var multiScatter = PlanCacheChart.Plot.Add.Scatter(multiXs, multiYs);
                     multiScatter.LineWidth = 2;
                     multiScatter.MarkerSize = 5;
-                    multiScatter.Color = TabHelpers.ChartColors[1];
+                    multiScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MultiPagePlans"));
                     multiScatter.LegendText = "Multi-Use";
                     _planCacheHover?.Add(multiScatter, "Multi-Use");
 

--- a/Dashboard/Controls/MemoryContent.PlanCache.cs
+++ b/Dashboard/Controls/MemoryContent.PlanCache.cs
@@ -119,7 +119,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = PlanCacheChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/MemoryContent.PlanCache.cs
+++ b/Dashboard/Controls/MemoryContent.PlanCache.cs
@@ -82,9 +82,8 @@ namespace PerformanceMonitorDashboard.Controls
                         grouped.Select(d => (double)d.SingleUseSizeMb));
 
                     var singleScatter = PlanCacheChart.Plot.Add.Scatter(singleXs, singleYs);
-                    singleScatter.LineWidth = 2;
-                    singleScatter.MarkerSize = 5;
                     singleScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SinglePagePlans"));
+                    ChartStyle.StyleScatter(singleScatter);
                     singleScatter.LegendText = "Single-Use";
                     _planCacheHover?.Add(singleScatter, "Single-Use");
 
@@ -94,9 +93,8 @@ namespace PerformanceMonitorDashboard.Controls
                         grouped.Select(d => (double)d.MultiUseSizeMb));
 
                     var multiScatter = PlanCacheChart.Plot.Add.Scatter(multiXs, multiYs);
-                    multiScatter.LineWidth = 2;
-                    multiScatter.MarkerSize = 5;
                     multiScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MultiPagePlans"));
+                    ChartStyle.StyleScatter(multiScatter);
                     multiScatter.LegendText = "Multi-Use";
                     _planCacheHover?.Add(multiScatter, "Multi-Use");
 

--- a/Dashboard/Controls/PlanViewerControl.Properties.cs
+++ b/Dashboard/Controls/PlanViewerControl.Properties.cs
@@ -12,7 +12,9 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.PlanAnalysis;
+using PerformanceMonitor.Ui;
 using PerformanceMonitorDashboard.Models;
 
 namespace PerformanceMonitorDashboard.Controls;
@@ -1115,45 +1117,12 @@ public partial class PlanViewerControl
         WaitStatsContent.Children.Add(grid);
     }
 
-    private static string GetWaitCategory(string waitType)
-    {
-        if (waitType.StartsWith("SOS_SCHEDULER_YIELD", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXPACKET", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXCONSUMER", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXSYNC_PORT", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXSYNC_CONSUMER", StringComparison.Ordinal))
-            return "CPU";
-
-        if (waitType.StartsWith("PAGEIOLATCH", StringComparison.Ordinal) ||
-            waitType.StartsWith("WRITELOG", StringComparison.Ordinal) ||
-            waitType.StartsWith("IO_COMPLETION", StringComparison.Ordinal) ||
-            waitType.StartsWith("ASYNC_IO_COMPLETION", StringComparison.Ordinal))
-            return "I/O";
-
-        if (waitType.StartsWith("LCK_M_", StringComparison.Ordinal))
-            return "Lock";
-
-        if (waitType == "RESOURCE_SEMAPHORE" || waitType == "CMEMTHREAD")
-            return "Memory";
-
-        if (waitType == "ASYNC_NETWORK_IO")
-            return "Network";
-
-        return "Other";
-    }
+    // Wait category + color come from the shared ChartPalette (PerformanceStudio's ~21-category
+    // taxonomy + palette), with a light-theme override for the near-invisible pale colors (D3).
+    private static string GetWaitCategory(string waitType) => ChartPalette.WaitCategory(waitType);
 
     private static string GetWaitCategoryColor(string category)
-    {
-        return category switch
-        {
-            "CPU" => "#4FA3FF",
-            "I/O" => "#FFB347",
-            "Lock" => "#E57373",
-            "Memory" => "#9B59B6",
-            "Network" => "#2ECC71",
-            _ => "#6BB5FF"
-        };
-    }
+        => ChartPalette.WaitColor(category, ThemeManager.HasLightBackground);
 
     private void ShowRuntimeSummary(PlanStatement statement)
     {

--- a/Dashboard/Controls/QueryPerformanceContent.BarCells.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.BarCells.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitorDashboard.Models;
+
+namespace PerformanceMonitorDashboard.Controls
+{
+    /// <summary>
+    /// Column maxima for the in-grid <see cref="PerformanceMonitor.Ui.BarChartCell"/>s on the query-
+    /// stats grid. Each bar fills to <c>value / max</c> for its column, so the cells need that column's
+    /// max. Recomputed whenever the grid's ItemsSource changes (initial load + every filter), via a
+    /// DependencyPropertyDescriptor so we don't have to hook every individual setter. The cells bind
+    /// these by RelativeSource to the host control.
+    /// </summary>
+    public partial class QueryPerformanceContent : UserControl
+    {
+        public static readonly DependencyProperty BarMaxExecutionsProperty = DependencyProperty.Register(
+            nameof(BarMaxExecutions), typeof(double), typeof(QueryPerformanceContent), new PropertyMetadata(1.0));
+        public double BarMaxExecutions
+        {
+            get => (double)GetValue(BarMaxExecutionsProperty);
+            set => SetValue(BarMaxExecutionsProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalCpuProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalCpu), typeof(double), typeof(QueryPerformanceContent), new PropertyMetadata(1.0));
+        public double BarMaxTotalCpu
+        {
+            get => (double)GetValue(BarMaxTotalCpuProperty);
+            set => SetValue(BarMaxTotalCpuProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalElapsedProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalElapsed), typeof(double), typeof(QueryPerformanceContent), new PropertyMetadata(1.0));
+        public double BarMaxTotalElapsed
+        {
+            get => (double)GetValue(BarMaxTotalElapsedProperty);
+            set => SetValue(BarMaxTotalElapsedProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalReadsProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalReads), typeof(double), typeof(QueryPerformanceContent), new PropertyMetadata(1.0));
+        public double BarMaxTotalReads
+        {
+            get => (double)GetValue(BarMaxTotalReadsProperty);
+            set => SetValue(BarMaxTotalReadsProperty, value);
+        }
+
+        private void SetupBarCellMaxes()
+        {
+            var dpd = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, typeof(DataGrid));
+            dpd?.AddValueChanged(QueryStatsDataGrid, (_, _) => RecomputeBarCellMaxes());
+        }
+
+        private void RecomputeBarCellMaxes()
+        {
+            var items = (QueryStatsDataGrid.ItemsSource as IEnumerable)?.OfType<QueryStatsItem>().ToList();
+            if (items == null || items.Count == 0)
+            {
+                BarMaxExecutions = BarMaxTotalCpu = BarMaxTotalElapsed = BarMaxTotalReads = 1.0;
+                return;
+            }
+
+            // Max(1,...) keeps the bar denominator positive even for an all-zero column.
+            BarMaxExecutions = Math.Max(1.0, items.Max(i => (double)i.ExecutionCount));
+            BarMaxTotalCpu = Math.Max(1.0, items.Max(i => i.TotalCpuTimeMs));
+            BarMaxTotalElapsed = Math.Max(1.0, items.Max(i => i.TotalElapsedTimeMs));
+            BarMaxTotalReads = Math.Max(1.0, items.Max(i => (double)i.TotalLogicalReads));
+        }
+    }
+}

--- a/Dashboard/Controls/QueryPerformanceContent.BarCells.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.BarCells.cs
@@ -8,10 +8,14 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
 using PerformanceMonitorDashboard.Models;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -69,6 +73,7 @@ namespace PerformanceMonitorDashboard.Controls
             if (items == null || items.Count == 0)
             {
                 BarMaxExecutions = BarMaxTotalCpu = BarMaxTotalElapsed = BarMaxTotalReads = 1.0;
+                if (QueryStatsByDbCards != null) QueryStatsByDbCards.Items = null;
                 return;
             }
 
@@ -77,6 +82,55 @@ namespace PerformanceMonitorDashboard.Controls
             BarMaxTotalCpu = Math.Max(1.0, items.Max(i => i.TotalCpuTimeMs));
             BarMaxTotalElapsed = Math.Max(1.0, items.Max(i => i.TotalElapsedTimeMs));
             BarMaxTotalReads = Math.Max(1.0, items.Max(i => (double)i.TotalLogicalReads));
+
+            RefreshByDbCards(items);
+        }
+
+        /// <summary>
+        /// Builds the per-database CPU bar-cards (A.6) from the currently displayed query rows — no
+        /// new query, just an aggregation of what the grid already holds. A database's color is a
+        /// STABLE alphabetical index (D4), so it keeps its color no matter how the bars are ranked;
+        /// the bars themselves are ordered by value (largest first).
+        /// </summary>
+        private void RefreshByDbCards(List<QueryStatsItem> items)
+        {
+            if (QueryStatsByDbCards == null) return;
+
+            var byDb = items
+                .GroupBy(i => i.DatabaseName ?? string.Empty)
+                .Select(g => new { Db = g.Key, Cpu = g.Sum(x => x.TotalCpuTimeMs) })
+                .Where(x => x.Cpu > 0)
+                .ToList();
+
+            if (byDb.Count == 0)
+            {
+                QueryStatsByDbCards.Items = null;
+                return;
+            }
+
+            var sortedNames = byDb.Select(x => x.Db)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            double max = byDb.Max(x => x.Cpu);
+
+            QueryStatsByDbCards.Items = byDb
+                .OrderByDescending(x => x.Cpu)
+                .Select(x => new MetricBarItem
+                {
+                    Label = string.IsNullOrEmpty(x.Db) ? "(unknown)" : x.Db,
+                    Value = x.Cpu,
+                    Maximum = max,
+                    ValueText = x.Cpu.ToString("N0"),
+                    BarBrush = BrushFromHex(ChartPalette.CyclingColor(sortedNames.IndexOf(x.Db))),
+                })
+                .ToList();
+        }
+
+        private static Brush BrushFromHex(string hex)
+        {
+            var b = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+            b.Freeze();
+            return b;
         }
     }
 }

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
              xmlns:local="clr-namespace:PerformanceMonitorDashboard.Controls"
+             xmlns:ui="clr-namespace:PerformanceMonitor.Ui;assembly=PerformanceMonitor.Ui"
              xmlns:converters="clr-namespace:PerformanceMonitorDashboard.Converters"
              mc:Ignorable="d">
     <UserControl.Resources>
@@ -644,22 +645,36 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn SortMemberPath="ExecutionCount" Width="100">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                        <DataGridTextColumn.Header>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ui:BarChartCell Value="{Binding ExecutionCount}"
+                                                 Maximum="{Binding BarMaxExecutions, RelativeSource={RelativeSource AncestorType={x:Type local:QueryPerformanceContent}}}"
+                                                 Text="{Binding ExecutionCount, StringFormat='{}{0:N0}'}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn SortMemberPath="TotalCpuTimeMs" Width="110">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ui:BarChartCell Value="{Binding TotalCpuTimeMs}"
+                                                 Maximum="{Binding BarMaxTotalCpu, RelativeSource={RelativeSource AncestorType={x:Type local:QueryPerformanceContent}}}"
+                                                 Text="{Binding TotalCpuTimeMs, StringFormat='{}{0:N2}'}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -684,14 +699,21 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn SortMemberPath="TotalElapsedTimeMs" Width="120">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Total Elapsed (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ui:BarChartCell Value="{Binding TotalElapsedTimeMs}"
+                                                 Maximum="{Binding BarMaxTotalElapsed, RelativeSource={RelativeSource AncestorType={x:Type local:QueryPerformanceContent}}}"
+                                                 Text="{Binding TotalElapsedTimeMs, StringFormat='{}{0:N2}'}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -716,14 +738,21 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                        <DataGridTextColumn.Header>
+                    <DataGridTemplateColumn SortMemberPath="TotalLogicalReads" Width="100">
+                        <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Total Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </DataGridTextColumn.Header>
-                    </DataGridTextColumn>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ui:BarChartCell Value="{Binding TotalLogicalReads}"
+                                                 Maximum="{Binding BarMaxTotalReads, RelativeSource={RelativeSource AncestorType={x:Type local:QueryPerformanceContent}}}"
+                                                 Text="{Binding TotalLogicalReads, StringFormat='{}{0:N0}'}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                     <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">

--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -577,10 +577,17 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <local:TimeRangeSlicerControl x:Name="QueryStatsSlicer" Grid.Row="0"/>
-                <TextBlock x:Name="QueryStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
-                           Padding="8,4" FontWeight="Bold"
-                           Foreground="{DynamicResource ForegroundBrush}"
-                           Background="#2244AAFF"/>
+                <StackPanel Grid.Row="1">
+                    <TextBlock x:Name="QueryStatsComparisonBanner" Visibility="Collapsed"
+                               Padding="8,4" FontWeight="Bold"
+                               Foreground="{DynamicResource ForegroundBrush}"
+                               Background="#2244AAFF"/>
+                    <Expander x:Name="QueryStatsByDbExpander" Header="CPU by database" IsExpanded="False" Margin="4,2,4,0">
+                        <ScrollViewer MaxHeight="220" VerticalScrollBarVisibility="Auto">
+                            <ui:MetricBarCards x:Name="QueryStatsByDbCards" Margin="4,4,4,8"/>
+                        </ScrollViewer>
+                    </Expander>
+                </StackPanel>
             <DataGrid Grid.Row="2" x:Name="QueryStatsDataGrid" AutoGenerateColumns="False" IsReadOnly="True"
                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -135,6 +135,7 @@ namespace PerformanceMonitorDashboard.Controls
         {
             InitializeComponent();
             SetupChartSaveMenus();
+            SetupBarCellMaxes();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
             SubTabControl.SelectionChanged += async (s, e) =>

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -21,6 +21,7 @@ using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Controls
@@ -1275,7 +1276,7 @@ namespace PerformanceMonitorDashboard.Controls
             var scatter = QueryPerfTrendsExecChart.Plot.Add.Scatter(xs, ys);
             scatter.LineWidth = 2;
             scatter.MarkerSize = 5;
-            scatter.Color = TabHelpers.ChartColors[0];
+            scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             scatter.LegendText = "Executions/sec";
             _execTrendsHover?.Add(scatter, "Executions/sec");
 

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1219,9 +1219,8 @@ namespace PerformanceMonitorDashboard.Controls
                     dataList.Select(d => d.AvgDurationMs));
 
                 var scatter = chart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = color;
+                ChartStyle.StyleScatter(scatter);
                 scatter.LegendText = legendText;
                 hover?.Add(scatter, legendText);
 
@@ -1274,9 +1273,8 @@ namespace PerformanceMonitorDashboard.Controls
                 dataList.Select(d => (double)d.ExecutionsPerSecond));
 
             var scatter = QueryPerfTrendsExecChart.Plot.Add.Scatter(xs, ys);
-            scatter.LineWidth = 2;
-            scatter.MarkerSize = 5;
             scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+            ChartStyle.StyleScatter(scatter);
             scatter.LegendText = "Executions/sec";
             _execTrendsHover?.Add(scatter, "Executions/sec");
 

--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -1230,7 +1230,7 @@ namespace PerformanceMonitorDashboard.Controls
                     double xCenter = xMin + (xMax - xMin) / 2;
                     var noDataText = chart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                     noDataText.LabelFontSize = 14;
-                    noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                    noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                     noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
                 }
 
@@ -1285,7 +1285,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = QueryPerfTrendsExecChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.FileIoLatency.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.FileIoLatency.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -131,7 +132,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = chart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.FileIoLatency.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.FileIoLatency.cs
@@ -89,10 +89,9 @@ namespace PerformanceMonitorDashboard.Controls
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                         var scatter = chart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         var color = colors[colorIndex % colors.Length];
                         scatter.Color = color;
+                        ChartStyle.StyleScatter(scatter);
 
                         // Use just the filename for legend (not database.filename which is redundant)
                         var fileName = fileData.First().FileName;

--- a/Dashboard/Controls/ResourceMetricsContent.LatchStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.LatchStats.cs
@@ -91,9 +91,8 @@ namespace PerformanceMonitorDashboard.Controls
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                         var scatter = LatchStatsChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = latchClass?.Length > 20 ? latchClass.Substring(0, 20) + "..." : latchClass ?? "";
                         _latchStatsHover?.Add(scatter, latchClass ?? "");
                         colorIndex++;

--- a/Dashboard/Controls/ResourceMetricsContent.LatchStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.LatchStats.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -107,7 +108,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = LatchStatsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.PerfmonCounters.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.PerfmonCounters.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -322,7 +323,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = PerfmonCountersChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.PerfmonCounters.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.PerfmonCounters.cs
@@ -303,9 +303,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                     var scatter = PerfmonCountersChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5; // Show small markers to ensure visibility
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = counter.CounterName;
                     _perfmonHover?.Add(scatter, counter.CounterName);
 

--- a/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
@@ -166,7 +166,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var noDataText = SessionStatsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 UpdateSessionStatsSummary(null);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
@@ -76,9 +76,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, totalCounts.Select(c => c));
                     var totalScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    totalScatter.LineWidth = 2;
-                    totalScatter.MarkerSize = 5;
                     totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionTotal"));
+                    ChartStyle.StyleScatter(totalScatter);
                     totalScatter.LegendText = "Total";
                     _sessionStatsHover?.Add(totalScatter, "Total");
                 }
@@ -87,9 +86,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, runningCounts.Select(c => c));
                     var runningScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    runningScatter.LineWidth = 2;
-                    runningScatter.MarkerSize = 5;
                     runningScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionRunning"));
+                    ChartStyle.StyleScatter(runningScatter);
                     runningScatter.LegendText = "Running";
                     _sessionStatsHover?.Add(runningScatter, "Running");
                 }
@@ -98,9 +96,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, sleepingCounts.Select(c => c));
                     var sleepingScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    sleepingScatter.LineWidth = 2;
-                    sleepingScatter.MarkerSize = 5;
                     sleepingScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionSleeping"));
+                    ChartStyle.StyleScatter(sleepingScatter);
                     sleepingScatter.LegendText = "Sleeping";
                     _sessionStatsHover?.Add(sleepingScatter, "Sleeping");
                 }
@@ -110,9 +107,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, backgroundCounts.Select(c => c));
                     var backgroundScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    backgroundScatter.LineWidth = 2;
-                    backgroundScatter.MarkerSize = 5;
                     backgroundScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionBackground"));
+                    ChartStyle.StyleScatter(backgroundScatter);
                     backgroundScatter.LegendText = "Background";
                     _sessionStatsHover?.Add(backgroundScatter, "Background");
                 }
@@ -122,9 +118,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, dormantCounts.Select(c => c));
                     var dormantScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    dormantScatter.LineWidth = 2;
-                    dormantScatter.MarkerSize = 5;
                     dormantScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionDormant"));
+                    ChartStyle.StyleScatter(dormantScatter);
                     dormantScatter.LegendText = "Dormant";
                     _sessionStatsHover?.Add(dormantScatter, "Dormant");
                 }
@@ -134,9 +129,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, idleOver30MinCounts.Select(c => c));
                     var idleScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    idleScatter.LineWidth = 2;
-                    idleScatter.MarkerSize = 5;
                     idleScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionIdle"));
+                    ChartStyle.StyleScatter(idleScatter);
                     idleScatter.LegendText = "Idle >30m";
                     _sessionStatsHover?.Add(idleScatter, "Idle >30m");
                 }
@@ -146,9 +140,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, waitingForMemoryCounts.Select(c => c));
                     var waitingScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
-                    waitingScatter.LineWidth = 2;
-                    waitingScatter.MarkerSize = 5;
                     waitingScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionWaiting"));
+                    ChartStyle.StyleScatter(waitingScatter);
                     waitingScatter.LegendText = "Waiting for Memory";
                     _sessionStatsHover?.Add(waitingScatter, "Waiting for Memory");
                 }

--- a/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.SessionStats.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -77,7 +78,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var totalScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     totalScatter.LineWidth = 2;
                     totalScatter.MarkerSize = 5;
-                    totalScatter.Color = TabHelpers.ChartColors[0];
+                    totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionTotal"));
                     totalScatter.LegendText = "Total";
                     _sessionStatsHover?.Add(totalScatter, "Total");
                 }
@@ -88,7 +89,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var runningScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     runningScatter.LineWidth = 2;
                     runningScatter.MarkerSize = 5;
-                    runningScatter.Color = TabHelpers.ChartColors[1];
+                    runningScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionRunning"));
                     runningScatter.LegendText = "Running";
                     _sessionStatsHover?.Add(runningScatter, "Running");
                 }
@@ -99,7 +100,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var sleepingScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     sleepingScatter.LineWidth = 2;
                     sleepingScatter.MarkerSize = 5;
-                    sleepingScatter.Color = TabHelpers.ChartColors[2];
+                    sleepingScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionSleeping"));
                     sleepingScatter.LegendText = "Sleeping";
                     _sessionStatsHover?.Add(sleepingScatter, "Sleeping");
                 }
@@ -111,7 +112,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var backgroundScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     backgroundScatter.LineWidth = 2;
                     backgroundScatter.MarkerSize = 5;
-                    backgroundScatter.Color = TabHelpers.ChartColors[4];
+                    backgroundScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionBackground"));
                     backgroundScatter.LegendText = "Background";
                     _sessionStatsHover?.Add(backgroundScatter, "Background");
                 }
@@ -123,7 +124,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var dormantScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     dormantScatter.LineWidth = 2;
                     dormantScatter.MarkerSize = 5;
-                    dormantScatter.Color = TabHelpers.ChartColors[5];
+                    dormantScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionDormant"));
                     dormantScatter.LegendText = "Dormant";
                     _sessionStatsHover?.Add(dormantScatter, "Dormant");
                 }
@@ -135,7 +136,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var idleScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     idleScatter.LineWidth = 2;
                     idleScatter.MarkerSize = 5;
-                    idleScatter.Color = TabHelpers.ChartColors[9];
+                    idleScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionIdle"));
                     idleScatter.LegendText = "Idle >30m";
                     _sessionStatsHover?.Add(idleScatter, "Idle >30m");
                 }
@@ -147,7 +148,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var waitingScatter = SessionStatsChart.Plot.Add.Scatter(xs, ys);
                     waitingScatter.LineWidth = 2;
                     waitingScatter.MarkerSize = 5;
-                    waitingScatter.Color = TabHelpers.ChartColors[3];
+                    waitingScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SessionWaiting"));
                     waitingScatter.LegendText = "Waiting for Memory";
                     _sessionStatsHover?.Add(waitingScatter, "Waiting for Memory");
                 }

--- a/Dashboard/Controls/ResourceMetricsContent.SpinlockStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.SpinlockStats.cs
@@ -91,9 +91,8 @@ namespace PerformanceMonitorDashboard.Controls
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                         var scatter = SpinlockStatsChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = spinlock?.Length > 20 ? spinlock.Substring(0, 20) + "..." : spinlock ?? "";
                         _spinlockStatsHover?.Add(scatter, spinlock ?? "");
                         colorIndex++;

--- a/Dashboard/Controls/ResourceMetricsContent.SpinlockStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.SpinlockStats.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -107,7 +108,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = SpinlockStatsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
@@ -163,7 +163,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var userScatter = TempdbStatsChart.Plot.Add.Scatter(userXs, userYs);
                 userScatter.LineWidth = 2;
                 userScatter.MarkerSize = 5;
-                userScatter.Color = TabHelpers.ChartColors[0];
+                userScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UserObjects"));
                 userScatter.LegendText = "User Objects";
                 _tempdbStatsHover?.Add(userScatter, "User Objects");
 
@@ -174,7 +174,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var versionScatter = TempdbStatsChart.Plot.Add.Scatter(versionXs, versionYs);
                 versionScatter.LineWidth = 2;
                 versionScatter.MarkerSize = 5;
-                versionScatter.Color = TabHelpers.ChartColors[1];
+                versionScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("VersionStore"));
                 versionScatter.LegendText = "Version Store";
                 _tempdbStatsHover?.Add(versionScatter, "Version Store");
 
@@ -185,7 +185,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var internalScatter = TempdbStatsChart.Plot.Add.Scatter(internalXs, internalYs);
                 internalScatter.LineWidth = 2;
                 internalScatter.MarkerSize = 5;
-                internalScatter.Color = TabHelpers.ChartColors[2];
+                internalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("InternalObjects"));
                 internalScatter.LegendText = "Internal Objects";
                 _tempdbStatsHover?.Add(internalScatter, "Internal Objects");
 
@@ -198,7 +198,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var unallocScatter = TempdbStatsChart.Plot.Add.Scatter(unallocXs, unallocYs);
                     unallocScatter.LineWidth = 2;
                     unallocScatter.MarkerSize = 5;
-                    unallocScatter.Color = TabHelpers.ChartColors[9];
+                    unallocScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UnallocatedTempdb"));
                     unallocScatter.LegendText = "Unallocated";
                     _tempdbStatsHover?.Add(unallocScatter, "Unallocated");
                 }
@@ -213,7 +213,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var topTaskScatter = TempdbStatsChart.Plot.Add.Scatter(topTaskXs, topTaskYs);
                     topTaskScatter.LineWidth = 2;
                     topTaskScatter.MarkerSize = 5;
-                    topTaskScatter.Color = TabHelpers.ChartColors[3];
+                    topTaskScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TopTempdbTask"));
                     topTaskScatter.LegendText = "Top Task";
                 }
 

--- a/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -100,7 +101,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var readScatter = TempDbLatencyChart.Plot.Add.Scatter(readXs, readYs);
                 readScatter.LineWidth = 2;
                 readScatter.MarkerSize = 5;
-                readScatter.Color = TabHelpers.ChartColors[0];
+                readScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ReadLatency"));
                 readScatter.LegendText = "Read Latency";
                 _tempDbLatencyHover?.Add(readScatter, "Read Latency");
 
@@ -111,7 +112,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var writeScatter = TempDbLatencyChart.Plot.Add.Scatter(writeXs, writeYs);
                 writeScatter.LineWidth = 2;
                 writeScatter.MarkerSize = 5;
-                writeScatter.Color = TabHelpers.ChartColors[2];
+                writeScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("WriteLatency"));
                 writeScatter.LegendText = "Write Latency";
                 _tempDbLatencyHover?.Add(writeScatter, "Write Latency");
 

--- a/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
@@ -99,9 +99,8 @@ namespace PerformanceMonitorDashboard.Controls
                     aggregated.Select(d => d.Time),
                     aggregated.Select(d => d.AvgReadLatency));
                 var readScatter = TempDbLatencyChart.Plot.Add.Scatter(readXs, readYs);
-                readScatter.LineWidth = 2;
-                readScatter.MarkerSize = 5;
                 readScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ReadLatency"));
+                ChartStyle.StyleScatter(readScatter);
                 readScatter.LegendText = "Read Latency";
                 _tempDbLatencyHover?.Add(readScatter, "Read Latency");
 
@@ -110,9 +109,8 @@ namespace PerformanceMonitorDashboard.Controls
                     aggregated.Select(d => d.Time),
                     aggregated.Select(d => d.AvgWriteLatency));
                 var writeScatter = TempDbLatencyChart.Plot.Add.Scatter(writeXs, writeYs);
-                writeScatter.LineWidth = 2;
-                writeScatter.MarkerSize = 5;
                 writeScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("WriteLatency"));
+                ChartStyle.StyleScatter(writeScatter);
                 writeScatter.LegendText = "Write Latency";
                 _tempDbLatencyHover?.Add(writeScatter, "Write Latency");
 
@@ -161,9 +159,8 @@ namespace PerformanceMonitorDashboard.Controls
                     dataList.Select(d => d.CollectionTime),
                     dataList.Select(d => (double)d.UserObjectReservedMb));
                 var userScatter = TempdbStatsChart.Plot.Add.Scatter(userXs, userYs);
-                userScatter.LineWidth = 2;
-                userScatter.MarkerSize = 5;
                 userScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UserObjects"));
+                ChartStyle.StyleScatter(userScatter);
                 userScatter.LegendText = "User Objects";
                 _tempdbStatsHover?.Add(userScatter, "User Objects");
 
@@ -172,9 +169,8 @@ namespace PerformanceMonitorDashboard.Controls
                     dataList.Select(d => d.CollectionTime),
                     dataList.Select(d => (double)d.VersionStoreReservedMb));
                 var versionScatter = TempdbStatsChart.Plot.Add.Scatter(versionXs, versionYs);
-                versionScatter.LineWidth = 2;
-                versionScatter.MarkerSize = 5;
                 versionScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("VersionStore"));
+                ChartStyle.StyleScatter(versionScatter);
                 versionScatter.LegendText = "Version Store";
                 _tempdbStatsHover?.Add(versionScatter, "Version Store");
 
@@ -183,9 +179,8 @@ namespace PerformanceMonitorDashboard.Controls
                     dataList.Select(d => d.CollectionTime),
                     dataList.Select(d => (double)d.InternalObjectReservedMb));
                 var internalScatter = TempdbStatsChart.Plot.Add.Scatter(internalXs, internalYs);
-                internalScatter.LineWidth = 2;
-                internalScatter.MarkerSize = 5;
                 internalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("InternalObjects"));
+                ChartStyle.StyleScatter(internalScatter);
                 internalScatter.LegendText = "Internal Objects";
                 _tempdbStatsHover?.Add(internalScatter, "Internal Objects");
 
@@ -196,9 +191,8 @@ namespace PerformanceMonitorDashboard.Controls
                 if (unallocYs.Any(y => y > 0))
                 {
                     var unallocScatter = TempdbStatsChart.Plot.Add.Scatter(unallocXs, unallocYs);
-                    unallocScatter.LineWidth = 2;
-                    unallocScatter.MarkerSize = 5;
                     unallocScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UnallocatedTempdb"));
+                    ChartStyle.StyleScatter(unallocScatter);
                     unallocScatter.LegendText = "Unallocated";
                     _tempdbStatsHover?.Add(unallocScatter, "Unallocated");
                 }
@@ -211,9 +205,8 @@ namespace PerformanceMonitorDashboard.Controls
                         dataList.Select(d => d.CollectionTime),
                         topTaskValues);
                     var topTaskScatter = TempdbStatsChart.Plot.Add.Scatter(topTaskXs, topTaskYs);
-                    topTaskScatter.LineWidth = 2;
-                    topTaskScatter.MarkerSize = 5;
                     topTaskScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TopTempdbTask"));
+                    ChartStyle.StyleScatter(topTaskScatter);
                     topTaskScatter.LegendText = "Top Task";
                 }
 

--- a/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
@@ -125,7 +125,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = TempDbLatencyChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -230,7 +230,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = TempdbStatsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/ResourceMetricsContent.WaitStatsDetail.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.WaitStatsDetail.cs
@@ -323,9 +323,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                     var scatter = WaitStatsDetailChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
 
                     // Truncate legend text if too long
                     string legendText = waitType.WaitType;

--- a/Dashboard/Controls/ResourceMetricsContent.WaitStatsDetail.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.WaitStatsDetail.cs
@@ -23,6 +23,7 @@ using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitorDashboard.Helpers;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -347,7 +348,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = WaitStatsDetailChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
+++ b/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
@@ -83,9 +83,8 @@ namespace PerformanceMonitorDashboard.Controls
                     double[] workersCreated = grouped.Select(g => (double)g.Max(i => i.WorkersCreated ?? 0)).ToArray();
                     var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, workersCreated.Select(c => c));
                     var scatter = CPUTasksChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Workers Created";
                     _cpuTasksHover?.Add(scatter, "Workers Created");
 

--- a/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
+++ b/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -93,7 +94,7 @@ namespace PerformanceMonitorDashboard.Controls
                     if (maxWorkersValue > 0)
                     {
                         var hLine = CPUTasksChart.Plot.Add.HorizontalLine(maxWorkersValue);
-                        hLine.Color = TabHelpers.ChartColors[2];
+                        hLine.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Threshold"));
                         hLine.LineWidth = 2;
                         hLine.LinePattern = ScottPlot.LinePattern.Dashed;
                         hLine.LegendText = $"Max Workers ({maxWorkersValue})";

--- a/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
+++ b/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
@@ -85,7 +85,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = CPUTasksChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[0];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
                     scatter.LegendText = "Workers Created";
                     _cpuTasksHover?.Add(scatter, "Workers Created");
 
@@ -114,7 +114,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var dlYs = unresolvableDLByHour.Select(b => 0.0).ToArray();
                         var dlScatter = CPUTasksChart.Plot.Add.Scatter(dlXs, dlYs);
                         dlScatter.LineWidth = 0;
-                        dlScatter.Color = TabHelpers.ChartColors[3];
+                        dlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                         dlScatter.LegendText = "Unresolvable DL";
                         dlScatter.MarkerSize = 10;
                         dlScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
@@ -133,7 +133,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var schedYs = schedDLByHour.Select(b => 0.0).ToArray();
                         var schedScatter = CPUTasksChart.Plot.Add.Scatter(schedXs, schedYs);
                         schedScatter.LineWidth = 0;
-                        schedScatter.Color = TabHelpers.ChartColors[2];
+                        schedScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                         schedScatter.LegendText = "Sched Deadlock";
                         schedScatter.MarkerSize = 10;
                         schedScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
@@ -153,7 +153,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var blockingYs = blockingByHour.Select(b => 0.0).ToArray(); // At bottom
                         var blockingScatter = CPUTasksChart.Plot.Add.Scatter(blockingXs, blockingYs);
                         blockingScatter.LineWidth = 0; // No connecting line
-                        blockingScatter.Color = TabHelpers.ChartColors[6];
+                        blockingScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(6));
                         blockingScatter.LegendText = "Blocking";
                         // Size points based on count - min 8, max 20, scaled by count
                         var maxCount = blockingByHour.Max(b => b.Count);

--- a/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
+++ b/Dashboard/Controls/SystemEventsContent.CPUTasks.cs
@@ -174,7 +174,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = CPUTasksChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.IOIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.IOIssues.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -87,7 +88,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var scatter = IOIssuesChart.Plot.Add.Scatter(xs, ys);
                         scatter.LineWidth = 2;
                         scatter.MarkerSize = 5;
-                        scatter.Color = TabHelpers.ChartColors[3];
+                        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                         scatter.LegendText = "Latch Timeouts";
                         _ioIssuesHover?.Add(scatter, "Latch Timeouts");
                     }
@@ -98,7 +99,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var scatter = IOIssuesChart.Plot.Add.Scatter(xs, ys);
                         scatter.LineWidth = 2;
                         scatter.MarkerSize = 5;
-                        scatter.Color = TabHelpers.ChartColors[2];
+                        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                         scatter.LegendText = "Long IOs";
                         _ioIssuesHover?.Add(scatter, "Long IOs");
                     }

--- a/Dashboard/Controls/SystemEventsContent.IOIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.IOIssues.cs
@@ -86,9 +86,8 @@ namespace PerformanceMonitorDashboard.Controls
                     {
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, latchTimeouts.Select(c => c));
                         var scatter = IOIssuesChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = "Latch Timeouts";
                         _ioIssuesHover?.Add(scatter, "Latch Timeouts");
                     }
@@ -97,9 +96,8 @@ namespace PerformanceMonitorDashboard.Controls
                     {
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, longIos.Select(c => c));
                         var scatter = IOIssuesChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = "Long IOs";
                         _ioIssuesHover?.Add(scatter, "Long IOs");
                     }
@@ -189,9 +187,8 @@ namespace PerformanceMonitorDashboard.Controls
                                 durations.Select(d => d));
 
                             var scatter = LongestPendingIOChart.Plot.Add.Scatter(xs, ys);
-                            scatter.LineWidth = 2;
-                            scatter.MarkerSize = 5;
                             scatter.Color = colors[colorIndex % colors.Length];
+                            ChartStyle.StyleScatter(scatter);
                             scatter.LegendText = fileName;
                             _longestPendingIoHover?.Add(scatter, fileName);
                             colorIndex++;

--- a/Dashboard/Controls/SystemEventsContent.IOIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.IOIssues.cs
@@ -114,7 +114,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = IOIssuesChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -208,7 +208,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = LongestPendingIOChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -125,7 +126,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryBrokerRatioChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[0];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
                     scatter.LegendText = "Memory Ratio";
                     _memoryBrokerRatioHover?.Add(scatter, "Memory Ratio");
                 }
@@ -140,7 +141,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryBrokerRatioChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[2];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                     scatter.LegendText = "Overall";
                     _memoryBrokerRatioHover?.Add(scatter, "Overall");
                 }

--- a/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
@@ -158,7 +158,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryBrokerChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -167,7 +167,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryBrokerRatioChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
@@ -96,9 +96,8 @@ namespace PerformanceMonitorDashboard.Controls
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, values);
 
                         var scatter = MemoryBrokerChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         var brokerLabel = brokerGroup.Key.Length > 25 ? brokerGroup.Key.Substring(0, 25) + "..." : brokerGroup.Key;
                         scatter.LegendText = brokerLabel;
                         _memoryBrokerHover?.Add(scatter, brokerLabel);
@@ -124,9 +123,8 @@ namespace PerformanceMonitorDashboard.Controls
                         ratioData.Select(d => (double)(d.MemoryRatio ?? 0)));
 
                     var scatter = MemoryBrokerRatioChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Memory Ratio";
                     _memoryBrokerRatioHover?.Add(scatter, "Memory Ratio");
                 }
@@ -139,9 +137,8 @@ namespace PerformanceMonitorDashboard.Controls
                         overallData.Select(d => (double)(d.Overall ?? 0)));
 
                     var scatter = MemoryBrokerRatioChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Overall";
                     _memoryBrokerRatioHover?.Add(scatter, "Overall");
                 }

--- a/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
@@ -101,7 +101,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryConditionsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -84,7 +85,7 @@ namespace PerformanceMonitorDashboard.Controls
                         var scatter = MemoryConditionsChart.Plot.Add.Scatter(xs, ys);
                         scatter.LineWidth = 2;
                         scatter.MarkerSize = 5;
-                        scatter.Color = TabHelpers.ChartColors[3];
+                        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                         scatter.LegendText = "OOM Exceptions";
                         _memoryConditionsHover?.Add(scatter, "OOM Exceptions");
                         hasData = true;

--- a/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryConditions.cs
@@ -83,9 +83,8 @@ namespace PerformanceMonitorDashboard.Controls
                     {
                         var (xs, ys) = TabHelpers.FillTimeSeriesGaps(timePoints, oomCounts.Select(c => c));
                         var scatter = MemoryConditionsChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = "OOM Exceptions";
                         _memoryConditionsHover?.Add(scatter, "OOM Exceptions");
                         hasData = true;

--- a/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
@@ -104,7 +104,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryNodeOOMChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -154,7 +154,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryNodeOOMUtilChart.Plot.Add.Text("No data", xCenter, 50);
                 noDataText.LabelFontSize = 12;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -257,7 +257,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = MemoryNodeOOMMemoryChart.Plot.Add.Text("No data", xCenter, 0.5);
                 noDataText.LabelFontSize = 12;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
@@ -88,9 +88,8 @@ namespace PerformanceMonitorDashboard.Controls
                         grouped.Select(g => (double)g.Count()));
 
                     var scatter = MemoryNodeOOMChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "OOM Event Count";
                     _memoryNodeOomHover?.Add(scatter, "OOM Event Count");
 
@@ -142,9 +141,8 @@ namespace PerformanceMonitorDashboard.Controls
                 {
                     hasData = true;
                     var scatter = MemoryNodeOOMUtilChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+                    ChartStyle.StyleScatter(scatter);
                     _memoryNodeOomUtilHover?.Add(scatter, "Memory Utilization %");
                 }
             }
@@ -193,9 +191,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var xs = targetData.Select(d => d.EventTime!.Value.ToOADate()).ToArray();
                     var ys = targetData.Select(d => (double)d.TargetKb!.Value / 1024.0).ToArray();
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(1));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Target";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Target");
                 }
@@ -208,9 +205,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var xs = committedData.Select(d => d.EventTime!.Value.ToOADate()).ToArray();
                     var ys = committedData.Select(d => (double)d.CommittedKb!.Value / 1024.0).ToArray();
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Committed";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Committed");
                 }
@@ -223,9 +219,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var xs = totalPFData.Select(d => d.EventTime!.Value.ToOADate()).ToArray();
                     var ys = totalPFData.Select(d => (double)d.TotalPageFileKb!.Value / 1024.0).ToArray();
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(4));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Total Page File";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Total Page File");
                 }
@@ -238,9 +233,8 @@ namespace PerformanceMonitorDashboard.Controls
                     var xs = availPFData.Select(d => d.EventTime!.Value.ToOADate()).ToArray();
                     var ys = availPFData.Select(d => (double)d.AvailablePageFileKb!.Value / 1024.0).ToArray();
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(5));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Avail Page File";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Avail Page File");
                 }

--- a/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryNodeOOM.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -89,7 +90,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[3];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                     scatter.LegendText = "OOM Event Count";
                     _memoryNodeOomHover?.Add(scatter, "OOM Event Count");
 
@@ -143,7 +144,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMUtilChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[0];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
                     _memoryNodeOomUtilHover?.Add(scatter, "Memory Utilization %");
                 }
             }
@@ -194,7 +195,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[1];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(1));
                     scatter.LegendText = "Target";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Target");
                 }
@@ -209,7 +210,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[2];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                     scatter.LegendText = "Committed";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Committed");
                 }
@@ -224,7 +225,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[4];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(4));
                     scatter.LegendText = "Total Page File";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Total Page File");
                 }
@@ -239,7 +240,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = MemoryNodeOOMMemoryChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[5];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(5));
                     scatter.LegendText = "Avail Page File";
                     _memoryNodeOomMemoryHover?.Add(scatter, "Avail Page File");
                 }

--- a/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
@@ -106,7 +106,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = SchedulerIssuesChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -91,7 +92,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = SchedulerIssuesChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[2];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                     scatter.LegendText = "Total Non-Yield Time";
                     _schedulerIssuesHover?.Add(scatter, "Total Non-Yield Time");
 

--- a/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
+++ b/Dashboard/Controls/SystemEventsContent.SchedulerIssues.cs
@@ -90,9 +90,8 @@ namespace PerformanceMonitorDashboard.Controls
                         grouped.Select(g => (double)g.Sum(i => ParseNonYield(i.NonYieldingTimeMs))));
 
                     var scatter = SchedulerIssuesChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Total Non-Yield Time";
                     _schedulerIssuesHover?.Add(scatter, "Total Non-Yield Time");
 

--- a/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
+++ b/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -85,7 +86,7 @@ namespace PerformanceMonitorDashboard.Controls
                     var scatter = SevereErrorsChart.Plot.Add.Scatter(xs, ys);
                     scatter.LineWidth = 2;
                     scatter.MarkerSize = 5;
-                    scatter.Color = TabHelpers.ChartColors[3];
+                    scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                     scatter.LegendText = "Error Count";
                     _severeErrorsHover?.Add(scatter, "Error Count");
 

--- a/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
+++ b/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
@@ -84,9 +84,8 @@ namespace PerformanceMonitorDashboard.Controls
                         grouped.Select(g => (double)g.Count()));
 
                     var scatter = SevereErrorsChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = "Error Count";
                     _severeErrorsHover?.Add(scatter, "Error Count");
 

--- a/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
+++ b/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
@@ -100,7 +100,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = SevereErrorsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
+++ b/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
@@ -71,7 +71,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = BadPagesChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[3];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                 _badPagesHover?.Add(scatter, "Bad Pages");
             }
             else
@@ -100,7 +100,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = DumpRequestsChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[2];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                 _dumpRequestsHover?.Add(scatter, "Dump Requests");
             }
             else
@@ -129,7 +129,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = AccessViolationsChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[4];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(4));
                 _accessViolationsHover?.Add(scatter, "Access Violations");
             }
             else
@@ -158,7 +158,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = WriteAccessViolationsChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[0];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
                 _writeAccessViolationsHover?.Add(scatter, "Write Access Violations");
             }
             else
@@ -199,7 +199,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = NonYieldingTasksChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[3];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
                 _nonYieldingTasksHover?.Add(scatter, "Non-Yielding Tasks");
             }
             else
@@ -228,7 +228,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var scatter = LatchWarningsChart.Plot.Add.Scatter(xs, ys);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[2];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
                 _latchWarningsHover?.Add(scatter, "Latch Warnings");
             }
             else
@@ -326,7 +326,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var sysScatter = CpuComparisonChart.Plot.Add.Scatter(sysXs, sysYs);
                 sysScatter.LineWidth = 2;
                 sysScatter.MarkerSize = 5;
-                sysScatter.Color = TabHelpers.ChartColors[0];
+                sysScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
                 sysScatter.LegendText = "System CPU %";
                 _cpuComparisonHover?.Add(sysScatter, "System CPU %");
 

--- a/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
+++ b/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
@@ -69,9 +69,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.BadPagesDetected ?? 0)));
                 var scatter = BadPagesChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                ChartStyle.StyleScatter(scatter);
                 _badPagesHover?.Add(scatter, "Bad Pages");
             }
             else
@@ -98,9 +97,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.IntervalDumpRequests ?? 0)));
                 var scatter = DumpRequestsChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                ChartStyle.StyleScatter(scatter);
                 _dumpRequestsHover?.Add(scatter, "Dump Requests");
             }
             else
@@ -127,9 +125,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.IsAccessViolationOccurred ?? 0)));
                 var scatter = AccessViolationsChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(4));
+                ChartStyle.StyleScatter(scatter);
                 _accessViolationsHover?.Add(scatter, "Access Violations");
             }
             else
@@ -156,9 +153,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.WriteAccessViolationCount ?? 0)));
                 var scatter = WriteAccessViolationsChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+                ChartStyle.StyleScatter(scatter);
                 _writeAccessViolationsHover?.Add(scatter, "Write Access Violations");
             }
             else
@@ -197,9 +193,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.NonYieldingTasksReported ?? 0)));
                 var scatter = NonYieldingTasksChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(3));
+                ChartStyle.StyleScatter(scatter);
                 _nonYieldingTasksHover?.Add(scatter, "Non-Yielding Tasks");
             }
             else
@@ -226,9 +221,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.LatchWarnings ?? 0)));
                 var scatter = LatchWarningsChart.Plot.Add.Scatter(xs, ys);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(2));
+                ChartStyle.StyleScatter(scatter);
                 _latchWarningsHover?.Add(scatter, "Latch Warnings");
             }
             else
@@ -279,9 +273,8 @@ namespace PerformanceMonitorDashboard.Controls
                             typeData.Select(d => d.CollectionTime),
                             typeData.Select(d => (double)(d.SpinlockBackoffs ?? 1))); // Use backoffs count or 1 if null
                         var scatter = SickSpinlocksChart.Plot.Add.Scatter(xs, ys);
-                        scatter.LineWidth = 2;
-                        scatter.MarkerSize = 5;
                         scatter.Color = colors[colorIndex % colors.Length];
+                        ChartStyle.StyleScatter(scatter);
                         scatter.LegendText = spinlockType ?? "Unknown";
                         _sickSpinlocksHover?.Add(scatter, spinlockType ?? "Unknown");
                         colorIndex++;
@@ -324,9 +317,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.SystemCpuUtilization ?? 0)));
                 var sysScatter = CpuComparisonChart.Plot.Add.Scatter(sysXs, sysYs);
-                sysScatter.LineWidth = 2;
-                sysScatter.MarkerSize = 5;
                 sysScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+                ChartStyle.StyleScatter(sysScatter);
                 sysScatter.LegendText = "System CPU %";
                 _cpuComparisonHover?.Add(sysScatter, "System CPU %");
 
@@ -335,9 +327,8 @@ namespace PerformanceMonitorDashboard.Controls
                     orderedData.Select(d => d.CollectionTime),
                     orderedData.Select(d => (double)(d.SqlCpuUtilization ?? 0)));
                 var sqlScatter = CpuComparisonChart.Plot.Add.Scatter(sqlXs, sqlYs);
-                sqlScatter.LineWidth = 2;
-                sqlScatter.MarkerSize = 5;
                 sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
+                ChartStyle.StyleScatter(sqlScatter);
                 sqlScatter.LegendText = "SQL CPU %";
                 _cpuComparisonHover?.Add(sqlScatter, "SQL CPU %");
 

--- a/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
+++ b/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
@@ -21,6 +21,7 @@ using Microsoft.Win32;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 
@@ -336,7 +337,7 @@ namespace PerformanceMonitorDashboard.Controls
                 var sqlScatter = CpuComparisonChart.Plot.Add.Scatter(sqlXs, sqlYs);
                 sqlScatter.LineWidth = 2;
                 sqlScatter.MarkerSize = 5;
-                sqlScatter.Color = TabHelpers.ChartColors[1];
+                sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
                 sqlScatter.LegendText = "SQL CPU %";
                 _cpuComparisonHover?.Add(sqlScatter, "SQL CPU %");
 

--- a/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
+++ b/Dashboard/Controls/SystemEventsContent.SystemHealth.cs
@@ -79,7 +79,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = BadPagesChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             BadPagesChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -108,7 +108,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = DumpRequestsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             DumpRequestsChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -137,7 +137,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = AccessViolationsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             AccessViolationsChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -166,7 +166,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = WriteAccessViolationsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             WriteAccessViolationsChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -207,7 +207,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = NonYieldingTasksChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             NonYieldingTasksChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -236,7 +236,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = LatchWarningsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             LatchWarningsChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -299,7 +299,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = SickSpinlocksChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             SickSpinlocksChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -349,7 +349,7 @@ namespace PerformanceMonitorDashboard.Controls
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = CpuComparisonChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             CpuComparisonChart.Plot.Axes.DateTimeTicksBottomDateChange();

--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml
@@ -28,7 +28,7 @@
                                VerticalAlignment="Center" Margin="12,0,0,0"/>
                 </StackPanel>
             </Button>
-            <Border x:Name="SlicerBorder" Grid.Row="1" Height="150" Margin="8,0,8,6"
+            <Border x:Name="SlicerBorder" Grid.Row="1" Height="130" Margin="8,0,8,6"
                     Background="{DynamicResource SlicerBackgroundBrush}"
                     CornerRadius="4" ClipToBounds="True">
                 <Canvas x:Name="SlicerCanvas"
@@ -36,6 +36,7 @@
                         MouseLeftButtonDown="Canvas_MouseLeftButtonDown"
                         MouseMove="Canvas_MouseMove"
                         MouseLeftButtonUp="Canvas_MouseLeftButtonUp"
+                        MouseLeave="Canvas_MouseLeave"
                         MouseWheel="Canvas_MouseWheel"/>
             </Border>
         </Grid>

--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
@@ -38,6 +38,9 @@ public partial class TimeRangeSlicerControl : UserControl
 
     private enum DragMode { None, MoveRange, DragStart, DragEnd }
     private DragMode _dragMode = DragMode.None;
+
+    private enum HandleHover { None, Start, End }
+    private HandleHover _hoveredHandle = HandleHover.None;
     private double _dragOriginX;
     private double _dragOriginRangeStart;
     private double _dragOriginRangeEnd;
@@ -242,6 +245,7 @@ public partial class TimeRangeSlicerControl : UserControl
         var overlayBrush = FindBrush("SlicerOverlayBrush", "#99000000");
         var selectedBrush = FindBrush("SlicerSelectedBrush", "#22FFFFFF");
         var handleBrush = FindBrush("SlicerHandleBrush", "#E4E6EB");
+        var handleHoverBrush = FindBrush("SlicerHandleHoverBrush", "#2EAEF1");
 
         var selLeft = _rangeStart * w;
         var selRight = _rangeEnd * w;
@@ -250,8 +254,8 @@ public partial class TimeRangeSlicerControl : UserControl
         if (selRight < w) AddRect(selRight, 0, w - selRight, h, overlayBrush);
         AddRect(selLeft, 0, Math.Max(0, selRight - selLeft), h, selectedBrush);
 
-        DrawHandle(selLeft, h, handleBrush);
-        DrawHandle(selRight - HandleWidthPx, h, handleBrush);
+        DrawHandle(selLeft, h, _hoveredHandle == HandleHover.Start ? handleHoverBrush : handleBrush);
+        DrawHandle(selRight - HandleWidthPx, h, _hoveredHandle == HandleHover.End ? handleHoverBrush : handleBrush);
         AddLine(selLeft, 0, selRight, 0, handleBrush, 0.5);
         AddLine(selLeft, h, selRight, h, handleBrush, 0.5);
 
@@ -378,12 +382,16 @@ public partial class TimeRangeSlicerControl : UserControl
         {
             var selLeft = _rangeStart * w;
             var selRight = _rangeEnd * w;
-            if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx || Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
-                SlicerCanvas.Cursor = Cursors.SizeWE;
+            HandleHover newHover = HandleHover.None;
+            if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx)
+            { SlicerCanvas.Cursor = Cursors.SizeWE; newHover = HandleHover.Start; }
+            else if (Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
+            { SlicerCanvas.Cursor = Cursors.SizeWE; newHover = HandleHover.End; }
             else if (pos.X >= selLeft && pos.X <= selRight)
                 SlicerCanvas.Cursor = Cursors.SizeAll;
             else
                 SlicerCanvas.Cursor = Cursors.Arrow;
+            if (newHover != _hoveredHandle) { _hoveredHandle = newHover; Redraw(); }
             return;
         }
 
@@ -408,6 +416,15 @@ public partial class TimeRangeSlicerControl : UserControl
         UpdateRangeLabel();
         Redraw();
         e.Handled = true;
+    }
+
+    private void Canvas_MouseLeave(object sender, MouseEventArgs e)
+    {
+        if (_dragMode == DragMode.None && _hoveredHandle != HandleHover.None)
+        {
+            _hoveredHandle = HandleHover.None;
+            Redraw();
+        }
     }
 
     private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -176,53 +176,18 @@ namespace PerformanceMonitorDashboard.Helpers
         }
 
         /// <summary>
-        /// Locks the vertical axis of a chart so mouse wheel zooming only affects the time (X) axis.
-        /// Also reapplies dark mode axis colors after DateTimeTicksBottom() modifications.
+        /// Locks the vertical axis so mouse-wheel zoom only affects the time (X) axis.
+        /// Delegates to the shared <see cref="ChartStyle"/>.
         /// </summary>
-        public static void LockChartVerticalAxis(WpfPlot chart)
-        {
-            var limits = chart.Plot.Axes.GetLimits();
-            var rule = new ScottPlot.AxisRules.LockedVertical(
-                chart.Plot.Axes.Left,
-                limits.Bottom,
-                limits.Top);
-            chart.Plot.Axes.Rules.Clear();
-            chart.Plot.Axes.Rules.Add(rule);
-
-            // Reapply axis colors after DateTimeTicksBottom() may have reset them
-            ReapplyAxisColors(chart);
-        }
+        public static void LockChartVerticalAxis(WpfPlot chart) => ChartStyle.LockChartVerticalAxis(chart);
 
         /// <summary>
-        /// Sets Y-axis limits with appropriate padding for charts with horizontal legends at bottom.
-        /// Call this BEFORE LockChartVerticalAxis.
+        /// Sets Y-axis limits with padding for a bottom legend. Delegates to the shared
+        /// <see cref="ChartStyle"/> (canonical behavior keeps a small margin below a zero baseline
+        /// so flat-at-zero lines stay visible).
         /// </summary>
         public static void SetChartYLimitsWithLegendPadding(WpfPlot chart, double dataYMin = 0, double dataYMax = 0)
-        {
-            // If no explicit values provided, use auto-calculated limits
-            if (dataYMin == 0 && dataYMax == 0)
-            {
-                var limits = chart.Plot.Axes.GetLimits();
-                dataYMin = limits.Bottom;
-                dataYMax = limits.Top;
-            }
-
-            // Handle edge cases
-            if (dataYMax <= dataYMin)
-            {
-                dataYMax = dataYMin + 100;
-            }
-
-            // Calculate padding: 5% above for breathing room
-            double range = dataYMax - dataYMin;
-            double topPadding = range * 0.05;
-
-            /* Only add bottom padding if dataYMin is above zero - don't go negative */
-            double yMin = dataYMin >= 0 ? 0 : dataYMin - (range * 0.10);
-            double yMax = dataYMax + topPadding;
-
-            chart.Plot.Axes.SetLimitsY(yMin, yMax);
-        }
+            => ChartStyle.SetChartYLimitsWithLegendPadding(chart, dataYMin, dataYMax);
 
         /// <summary>
         /// Applies theme-appropriate styling to a WPF Calendar control (used by DatePicker popup).

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -19,6 +19,7 @@ using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.Win32;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard.Helpers
@@ -53,33 +54,13 @@ namespace PerformanceMonitorDashboard.Helpers
         }
 
         /// <summary>
-        /// Material Design 300-level color palette for chart data series.
-        /// Soft pastels optimized for dark backgrounds, ordered to map 1:1
-        /// with common ScottPlot stock colors (Blue→[0], Green→[1], etc.).
+        /// Material Design 300/200 cycling palette for arbitrary/data-driven chart series (per-DB,
+        /// per-wait-type lists, etc.), indexed by encounter order. Sourced from the shared
+        /// <see cref="ChartPalette"/> so Dashboard and Lite cycle through the SAME colors in the
+        /// same order (named fixed-meaning series use ChartPalette.SeriesColor instead).
         /// </summary>
-        public static readonly ScottPlot.Color[] ChartColors = new[]
-        {
-            ScottPlot.Color.FromHex("#4FC3F7"), // [0]  Light Blue 300
-            ScottPlot.Color.FromHex("#81C784"), // [1]  Green 300
-            ScottPlot.Color.FromHex("#FFB74D"), // [2]  Orange 300
-            ScottPlot.Color.FromHex("#E57373"), // [3]  Red 300
-            ScottPlot.Color.FromHex("#BA68C8"), // [4]  Purple 300
-            ScottPlot.Color.FromHex("#4DD0E1"), // [5]  Cyan 300
-            ScottPlot.Color.FromHex("#FFF176"), // [6]  Yellow 300
-            ScottPlot.Color.FromHex("#F06292"), // [7]  Pink 300
-            ScottPlot.Color.FromHex("#AED581"), // [8]  Light Green 300
-            ScottPlot.Color.FromHex("#90A4AE"), // [9]  Blue Grey 300
-            ScottPlot.Color.FromHex("#A1887F"), // [10] Brown 300
-            ScottPlot.Color.FromHex("#7986CB"), // [11] Indigo 300
-            ScottPlot.Color.FromHex("#FF7043"), // [12] Deep Orange 300
-            ScottPlot.Color.FromHex("#80DEEA"), // [13] Cyan 200
-            ScottPlot.Color.FromHex("#FFE082"), // [14] Amber 200
-            ScottPlot.Color.FromHex("#CE93D8"), // [15] Purple 200
-            ScottPlot.Color.FromHex("#EF9A9A"), // [16] Red 200
-            ScottPlot.Color.FromHex("#C5E1A5"), // [17] Light Green 200
-            ScottPlot.Color.FromHex("#FFCC80"), // [18] Orange 200
-            ScottPlot.Color.FromHex("#B0BEC5"), // [19] Blue Grey 200
-        };
+        public static readonly ScottPlot.Color[] ChartColors =
+            ChartPalette.CyclingPalette.Select(ScottPlot.Color.FromHex).ToArray();
 
         /// <summary>
         /// Poison waits — always selected by default. These indicate critical resource exhaustion.

--- a/Dashboard/Helpers/TabHelpers.cs
+++ b/Dashboard/Helpers/TabHelpers.cs
@@ -148,98 +148,16 @@ namespace PerformanceMonitorDashboard.Helpers
         }
 
         /// <summary>
-        /// Applies the current color theme to a ScottPlot chart.
+        /// Applies the current color theme (chrome) to a ScottPlot chart.
+        /// Delegates to the shared <see cref="ChartStyle"/> — single source of truth across apps.
         /// </summary>
-        public static void ApplyThemeToChart(WpfPlot chart)
-        {
-            ScottPlot.Color figureBackground, dataBackground, textColor, gridColor, legendBg, legendFg, legendOutline;
-
-            if (ThemeManager.CurrentTheme == "CoolBreeze")
-            {
-                figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-                dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-                textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-                gridColor        = ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120);
-                legendBg         = ScottPlot.Color.FromHex("#EEF4FA");
-                legendFg         = ScottPlot.Color.FromHex("#1A2A3A");
-                legendOutline    = ScottPlot.Color.FromHex("#A8BDD0");
-            }
-            else if (ThemeManager.HasLightBackground)
-            {
-                figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-                dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-                textColor        = ScottPlot.Color.FromHex("#1A1D23");
-                gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-                legendBg         = ScottPlot.Color.FromHex("#FFFFFF");
-                legendFg         = ScottPlot.Color.FromHex("#1A1D23");
-                legendOutline    = ScottPlot.Color.FromHex("#DEE2E6");
-            }
-            else
-            {
-                figureBackground = ScottPlot.Color.FromHex("#22252b");
-                dataBackground   = ScottPlot.Color.FromHex("#111217");
-                textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-                gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-                legendBg         = ScottPlot.Color.FromHex("#22252b");
-                legendFg         = ScottPlot.Color.FromHex("#E4E6EB");
-                legendOutline    = ScottPlot.Color.FromHex("#2a2d35");
-            }
-
-            chart.Plot.FigureBackground.Color = figureBackground;
-            chart.Plot.DataBackground.Color = dataBackground;
-            chart.Plot.Axes.Color(textColor);
-            chart.Plot.Grid.MajorLineColor = gridColor;
-            chart.Plot.Legend.BackgroundColor = legendBg;
-            chart.Plot.Legend.FontColor = legendFg;
-            chart.Plot.Legend.OutlineColor = legendOutline;
-            chart.Plot.Legend.Alignment = ScottPlot.Alignment.LowerCenter;
-            chart.Plot.Legend.Orientation = ScottPlot.Orientation.Horizontal;
-            chart.Plot.Axes.Margins(bottom: 0); // No bottom margin - SetChartYLimitsWithLegendPadding handles Y-axis
-
-            // Explicitly set axis tick label colors (needed after DateTimeTicksBottom() is called)
-            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-            chart.Plot.Axes.Left.Label.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
-            chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
-
-            // Set the WPF control Background to match so no white flash appears before ScottPlot's render loop fires
-            chart.Background = new SolidColorBrush(Color.FromRgb(figureBackground.R, figureBackground.G, figureBackground.B));
-
-            // Ensure ScottPlot renders with the correct colors the very first time it gets pixel dimensions.
-            // Without this, ScottPlot's first auto-render (triggered by SizeChanged) would show a white canvas
-            // before our FigureBackground color takes visual effect.
-            chart.Loaded -= HandleChartFirstLoaded;
-            if (!chart.IsLoaded)
-                chart.Loaded += HandleChartFirstLoaded;
-        }
-
-        private static void HandleChartFirstLoaded(object sender, RoutedEventArgs e)
-        {
-            var chart = (WpfPlot)sender;
-            chart.Loaded -= HandleChartFirstLoaded;
-            chart.Refresh();
-        }
+        public static void ApplyThemeToChart(WpfPlot chart) => ChartStyle.ApplyThemeToChart(chart);
 
         /// <summary>
-        /// Reapplies theme-appropriate text colors to chart axes.
-        /// Call this AFTER DateTimeTicksBottom() or other axis modifications.
+        /// Reapplies theme-appropriate text colors to chart axes (after DateTimeTicksBottom() etc.).
+        /// Delegates to the shared <see cref="ChartStyle"/>.
         /// </summary>
-        public static void ReapplyAxisColors(WpfPlot chart)
-        {
-            var textColor = ThemeManager.CurrentTheme == "CoolBreeze"
-                ? ScottPlot.Color.FromHex("#1A2A3A")
-                : ThemeManager.HasLightBackground
-                    ? ScottPlot.Color.FromHex("#1A1D23")
-                    : ScottPlot.Color.FromHex("#E4E6EB");
-            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-            chart.Plot.Axes.Left.Label.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
-            chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
-        }
+        public static void ReapplyAxisColors(WpfPlot chart) => ChartStyle.ReapplyAxisColors(chart);
 
         /// <summary>
         /// Recursively finds all WpfPlot chart controls in a visual tree.

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -207,18 +207,7 @@ namespace PerformanceMonitorDashboard
             var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
-
-            // Sparse data: show only markers to avoid misleading interpolated lines
-            if (dates.Length <= 1)
-            {
-                scatter.LineWidth = 0;
-                scatter.MarkerSize = 8;
-            }
-            else
-            {
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 4;
-            }
+            ChartStyle.StyleScatter(scatter);
 
             HistoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
             Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -204,7 +204,7 @@ namespace PerformanceMonitorDashboard
             var dates = orderedData.Select(h => h.CollectionTime.ToOADate()).ToArray();
             var values = orderedData.Select(h => GetMetricValue(h, metricTag)).ToArray();
 
-            var color = ScottPlot.Color.FromHex("#4FC3F7");
+            var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
 

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -190,18 +190,8 @@ namespace PerformanceMonitorDashboard
                 .OrderBy(g => g.Key)
                 .ToList();
 
-            // Color palette for different plans
-            var colors = new[]
-            {
-                ScottPlot.Color.FromHex("#4FC3F7"),
-                ScottPlot.Color.FromHex("#81C784"),
-                ScottPlot.Color.FromHex("#FFB74D"),
-                ScottPlot.Color.FromHex("#F06292"),
-                ScottPlot.Color.FromHex("#BA68C8"),
-                ScottPlot.Color.FromHex("#4DB6AC"),
-                ScottPlot.Color.FromHex("#FF8A65"),
-                ScottPlot.Color.FromHex("#A1887F")
-            };
+            // Color palette for different plans — shared cross-app cycling palette
+            var colors = ChartPalette.CyclingPalette.Select(ScottPlot.Color.FromHex).ToArray();
 
             int colorIndex = 0;
             var scatterSeries = new List<(ScottPlot.Plottables.Scatter Scatter, string Label)>();

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -209,21 +209,9 @@ namespace PerformanceMonitorDashboard
                 var color = colors[colorIndex % colors.Length];
                 var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
                 scatter.Color = color;
+                ChartStyle.StyleScatter(scatter);
                 var label = $"Plan {planGroup.Key}";
                 scatter.LegendText = label;
-
-                // Sparse data: use total dataset size, not per-plan size, since
-                // data is split across plan groups
-                if (_historyData.Count <= 1)
-                {
-                    scatter.LineWidth = 0;
-                    scatter.MarkerSize = 8;
-                }
-                else
-                {
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 4;
-                }
 
                 scatterSeries.Add((scatter, label));
                 colorIndex++;

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -199,7 +199,7 @@ namespace PerformanceMonitorDashboard
             var dates = orderedData.Select(h => h.CollectionTime.ToOADate()).ToArray();
             var values = orderedData.Select(h => GetMetricValue(h, metricTag)).ToArray();
 
-            var color = ScottPlot.Color.FromHex("#4FC3F7");
+            var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
 

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -202,18 +202,7 @@ namespace PerformanceMonitorDashboard
             var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
-
-            // Sparse data: show only markers to avoid misleading interpolated lines
-            if (dates.Length <= 1)
-            {
-                scatter.LineWidth = 0;
-                scatter.MarkerSize = 8;
-            }
-            else
-            {
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 4;
-            }
+            ChartStyle.StyleScatter(scatter);
 
             HistoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
             Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);

--- a/Dashboard/ServerTab.Charts.cs
+++ b/Dashboard/ServerTab.Charts.cs
@@ -13,6 +13,7 @@ using System.Windows.Controls;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using ScottPlot.WPF;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorDashboard
@@ -484,14 +485,14 @@ namespace PerformanceMonitorDashboard
                 var totalScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsTotal, ysTotal);
                 totalScatter.LineWidth = 2;
                 totalScatter.MarkerSize = 5;
-                totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+                totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalCpu"));
                 totalScatter.LegendText = "Total CPU %";
                 _resourceOverviewCpuHover?.Add(totalScatter, "Total CPU %");
 
                 var sqlScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsSql, ysSql);
                 sqlScatter.LineWidth = 2;
                 sqlScatter.MarkerSize = 5;
-                sqlScatter.Color = TabHelpers.ChartColors[0];
+                sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
                 sqlScatter.LegendText = "SQL CPU %";
                 _resourceOverviewCpuHover?.Add(sqlScatter, "SQL CPU %");
 
@@ -547,14 +548,14 @@ namespace PerformanceMonitorDashboard
                 var bufferScatter = ResourceOverviewMemoryChart.Plot.Add.Scatter(bufferXs, bufferYs);
                 bufferScatter.LineWidth = 2;
                 bufferScatter.MarkerSize = 5;
-                bufferScatter.Color = TabHelpers.ChartColors[4];
+                bufferScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
                 bufferScatter.LegendText = "Buffer Pool";
                 _resourceOverviewMemoryHover?.Add(bufferScatter, "Buffer Pool");
 
                 var grantsScatter = ResourceOverviewMemoryChart.Plot.Add.Scatter(grantsXs, grantsYs);
                 grantsScatter.LineWidth = 2;
                 grantsScatter.MarkerSize = 5;
-                grantsScatter.Color = TabHelpers.ChartColors[2];
+                grantsScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MemoryGrants"));
                 grantsScatter.LegendText = "Memory Grants";
                 _resourceOverviewMemoryHover?.Add(grantsScatter, "Memory Grants");
 
@@ -624,14 +625,14 @@ namespace PerformanceMonitorDashboard
                 var readScatter = ResourceOverviewIoChart.Plot.Add.Scatter(readXs, readYs);
                 readScatter.LineWidth = 2;
                 readScatter.MarkerSize = 5;
-                readScatter.Color = TabHelpers.ChartColors[1];
+                readScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ReadLatency"));
                 readScatter.LegendText = "Read ms";
                 _resourceOverviewIoHover?.Add(readScatter, "Read ms");
 
                 var writeScatter = ResourceOverviewIoChart.Plot.Add.Scatter(writeXs, writeYs);
                 writeScatter.LineWidth = 2;
                 writeScatter.MarkerSize = 5;
-                writeScatter.Color = TabHelpers.ChartColors[2];
+                writeScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("WriteLatency"));
                 writeScatter.LegendText = "Write ms";
                 _resourceOverviewIoHover?.Add(writeScatter, "Write ms");
 

--- a/Dashboard/ServerTab.Charts.cs
+++ b/Dashboard/ServerTab.Charts.cs
@@ -131,7 +131,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = BlockingStatsBlockingEventsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             BlockingStatsBlockingEventsChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -160,7 +160,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = BlockingStatsDurationChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             BlockingStatsDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -189,7 +189,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = BlockingStatsDeadlocksChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             BlockingStatsDeadlocksChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -218,7 +218,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = BlockingStatsDeadlockWaitTimeChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
             BlockingStatsDeadlockWaitTimeChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -326,7 +326,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = LockWaitStatsChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -383,7 +383,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = CurrentWaitsDurationChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -440,7 +440,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = CurrentWaitsBlockedChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -504,7 +504,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = ResourceOverviewCpuChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -567,7 +567,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = ResourceOverviewMemoryChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -644,7 +644,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = ResourceOverviewIoChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 
@@ -716,7 +716,7 @@ namespace PerformanceMonitorDashboard
                 double xCenter = xMin + (xMax - xMin) / 2;
                 var noDataText = ResourceOverviewWaitChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
                 noDataText.LabelFontSize = 14;
-                noDataText.LabelFontColor = ScottPlot.Colors.Gray;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
                 noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
             }
 

--- a/Dashboard/ServerTab.Charts.cs
+++ b/Dashboard/ServerTab.Charts.cs
@@ -121,9 +121,8 @@ namespace PerformanceMonitorDashboard
             if (blockingXs.Length > 0)
             {
                 var scatter = BlockingStatsBlockingEventsChart.Plot.Add.Scatter(blockingXs, blockingYs);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
+                ChartStyle.StyleScatter(scatter);
                 _blockingEventsHover?.Add(scatter, "Blocking Events");
             }
             else
@@ -150,9 +149,8 @@ namespace PerformanceMonitorDashboard
             if (durationXs.Length > 0)
             {
                 var scatter = BlockingStatsDurationChart.Plot.Add.Scatter(durationXs, durationYs);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BlockingDuration"));
+                ChartStyle.StyleScatter(scatter);
                 _blockingDurationHover?.Add(scatter, "Blocking Duration");
             }
             else
@@ -179,9 +177,8 @@ namespace PerformanceMonitorDashboard
             if (deadlockXs.Length > 0)
             {
                 var scatter = BlockingStatsDeadlocksChart.Plot.Add.Scatter(deadlockXs, deadlockYs);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
+                ChartStyle.StyleScatter(scatter);
                 _deadlocksHover?.Add(scatter, "Deadlocks");
             }
             else
@@ -208,9 +205,8 @@ namespace PerformanceMonitorDashboard
             if (deadlockWaitXs.Length > 0)
             {
                 var scatter = BlockingStatsDeadlockWaitTimeChart.Plot.Add.Scatter(deadlockWaitXs, deadlockWaitYs);
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 5;
                 scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("DeadlockWaitTime"));
+                ChartStyle.StyleScatter(scatter);
                 _deadlockWaitTimeHover?.Add(scatter, "Deadlock Wait Time");
             }
             else
@@ -311,9 +307,8 @@ namespace PerformanceMonitorDashboard
                         waitTypeData.Select(d => (double)d.WaitTimeMsPerSecond));
 
                     var scatter = LockWaitStatsChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
                     var lockLabel = waitType.Replace("LCK_M_", "").Replace("LCK_", "");
                     scatter.LegendText = lockLabel;
                     _lockWaitStatsHover?.Add(scatter, lockLabel);
@@ -369,9 +364,8 @@ namespace PerformanceMonitorDashboard
                         waitTypeData.Select(d => (double)d.TotalWaitMs));
 
                     var scatter = CurrentWaitsDurationChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = waitType;
                     _currentWaitsDurationHover?.Add(scatter, waitType);
                     colorIndex++;
@@ -426,9 +420,8 @@ namespace PerformanceMonitorDashboard
                         dbData.Select(d => (double)d.BlockedCount));
 
                     var scatter = CurrentWaitsBlockedChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
                     scatter.LegendText = db;
                     _currentWaitsBlockedHover?.Add(scatter, db);
                     colorIndex++;
@@ -483,16 +476,14 @@ namespace PerformanceMonitorDashboard
             if (xsTotal.Length > 0)
             {
                 var totalScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsTotal, ysTotal);
-                totalScatter.LineWidth = 2;
-                totalScatter.MarkerSize = 5;
                 totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalCpu"));
+                ChartStyle.StyleScatter(totalScatter);
                 totalScatter.LegendText = "Total CPU %";
                 _resourceOverviewCpuHover?.Add(totalScatter, "Total CPU %");
 
                 var sqlScatter = ResourceOverviewCpuChart.Plot.Add.Scatter(xsSql, ysSql);
-                sqlScatter.LineWidth = 2;
-                sqlScatter.MarkerSize = 5;
                 sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
+                ChartStyle.StyleScatter(sqlScatter);
                 sqlScatter.LegendText = "SQL CPU %";
                 _resourceOverviewCpuHover?.Add(sqlScatter, "SQL CPU %");
 
@@ -546,16 +537,14 @@ namespace PerformanceMonitorDashboard
             if (bufferXs.Length > 0)
             {
                 var bufferScatter = ResourceOverviewMemoryChart.Plot.Add.Scatter(bufferXs, bufferYs);
-                bufferScatter.LineWidth = 2;
-                bufferScatter.MarkerSize = 5;
                 bufferScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
+                ChartStyle.StyleScatter(bufferScatter);
                 bufferScatter.LegendText = "Buffer Pool";
                 _resourceOverviewMemoryHover?.Add(bufferScatter, "Buffer Pool");
 
                 var grantsScatter = ResourceOverviewMemoryChart.Plot.Add.Scatter(grantsXs, grantsYs);
-                grantsScatter.LineWidth = 2;
-                grantsScatter.MarkerSize = 5;
                 grantsScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MemoryGrants"));
+                ChartStyle.StyleScatter(grantsScatter);
                 grantsScatter.LegendText = "Memory Grants";
                 _resourceOverviewMemoryHover?.Add(grantsScatter, "Memory Grants");
 
@@ -623,16 +612,14 @@ namespace PerformanceMonitorDashboard
             if (readXs.Length > 0)
             {
                 var readScatter = ResourceOverviewIoChart.Plot.Add.Scatter(readXs, readYs);
-                readScatter.LineWidth = 2;
-                readScatter.MarkerSize = 5;
                 readScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ReadLatency"));
+                ChartStyle.StyleScatter(readScatter);
                 readScatter.LegendText = "Read ms";
                 _resourceOverviewIoHover?.Add(readScatter, "Read ms");
 
                 var writeScatter = ResourceOverviewIoChart.Plot.Add.Scatter(writeXs, writeYs);
-                writeScatter.LineWidth = 2;
-                writeScatter.MarkerSize = 5;
                 writeScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("WriteLatency"));
+                ChartStyle.StyleScatter(writeScatter);
                 writeScatter.LegendText = "Write ms";
                 _resourceOverviewIoHover?.Add(writeScatter, "Write ms");
 
@@ -699,9 +686,8 @@ namespace PerformanceMonitorDashboard
                         waitTypeData.Select(d => (double)d.WaitTimeMsPerSecond));
 
                     var scatter = ResourceOverviewWaitChart.Plot.Add.Scatter(xs, ys);
-                    scatter.LineWidth = 2;
-                    scatter.MarkerSize = 5;
                     scatter.Color = colors[colorIndex % colors.Length];
+                    ChartStyle.StyleScatter(scatter);
                     var waitLabel = waitType.Length > 15 ? waitType.Substring(0, 15) + "..." : waitType;
                     scatter.LegendText = waitLabel;
                     _resourceOverviewWaitHover?.Add(scatter, waitLabel);

--- a/Dashboard/ServerTab.Charts.cs
+++ b/Dashboard/ServerTab.Charts.cs
@@ -123,7 +123,7 @@ namespace PerformanceMonitorDashboard
                 var scatter = BlockingStatsBlockingEventsChart.Plot.Add.Scatter(blockingXs, blockingYs);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[0];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
                 _blockingEventsHover?.Add(scatter, "Blocking Events");
             }
             else
@@ -152,7 +152,7 @@ namespace PerformanceMonitorDashboard
                 var scatter = BlockingStatsDurationChart.Plot.Add.Scatter(durationXs, durationYs);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[2];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BlockingDuration"));
                 _blockingDurationHover?.Add(scatter, "Blocking Duration");
             }
             else
@@ -181,7 +181,7 @@ namespace PerformanceMonitorDashboard
                 var scatter = BlockingStatsDeadlocksChart.Plot.Add.Scatter(deadlockXs, deadlockYs);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[3];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
                 _deadlocksHover?.Add(scatter, "Deadlocks");
             }
             else
@@ -210,7 +210,7 @@ namespace PerformanceMonitorDashboard
                 var scatter = BlockingStatsDeadlockWaitTimeChart.Plot.Add.Scatter(deadlockWaitXs, deadlockWaitYs);
                 scatter.LineWidth = 2;
                 scatter.MarkerSize = 5;
-                scatter.Color = TabHelpers.ChartColors[4];
+                scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("DeadlockWaitTime"));
                 _deadlockWaitTimeHover?.Add(scatter, "Deadlock Wait Time");
             }
             else

--- a/Dashboard/Themes/CoolBreezeTheme.xaml
+++ b/Dashboard/Themes/CoolBreezeTheme.xaml
@@ -1327,6 +1327,7 @@
     <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#55FFFFFF"/>
     <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#11000000"/>
     <SolidColorBrush x:Key="SlicerHandleBrush" Color="#364D61"/>
+    <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="#1E6FA8"/>
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="#B0C4D8"/>
     <SolidColorBrush x:Key="SlicerLabelBrush" Color="#5A7A94"/>
     <SolidColorBrush x:Key="SlicerToggleBrush" Color="#364D61"/>

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -1326,6 +1326,7 @@
     <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#99000000"/>
     <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#22FFFFFF"/>
     <SolidColorBrush x:Key="SlicerHandleBrush" Color="#E4E6EB"/>
+    <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="#2EAEF1"/>
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="SlicerLabelBrush" Color="#E4E6EB"/>
     <SolidColorBrush x:Key="SlicerToggleBrush" Color="#E4E6EB"/>

--- a/Dashboard/Themes/LightTheme.xaml
+++ b/Dashboard/Themes/LightTheme.xaml
@@ -1327,6 +1327,7 @@
     <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#55FFFFFF"/>
     <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#11000000"/>
     <SolidColorBrush x:Key="SlicerHandleBrush" Color="#4A5568"/>
+    <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="#2196F3"/>
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="#CBD5E0"/>
     <SolidColorBrush x:Key="SlicerLabelBrush" Color="#718096"/>
     <SolidColorBrush x:Key="SlicerToggleBrush" Color="#4A5568"/>

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -180,18 +180,7 @@ namespace PerformanceMonitorDashboard
             var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
-
-            // Sparse data: show only markers to avoid misleading interpolated lines
-            if (dates.Length <= 1)
-            {
-                scatter.LineWidth = 0;
-                scatter.MarkerSize = 8;
-            }
-            else
-            {
-                scatter.LineWidth = 2;
-                scatter.MarkerSize = 4;
-            }
+            ChartStyle.StyleScatter(scatter);
 
             HistoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
             Helpers.TabHelpers.ReapplyAxisColors(HistoryChart);

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -177,7 +177,7 @@ namespace PerformanceMonitorDashboard
             var dates = orderedData.Select(h => h.EndTime!.Value.ToOADate()).ToArray();
             var values = orderedData.Select(h => GetMetricValue(h, metricTag)).ToArray();
 
-            var color = ScottPlot.Color.FromHex("#4FC3F7");
+            var color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
             var scatter = HistoryChart.Plot.Add.Scatter(dates, values);
             scatter.Color = color;
 

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -263,14 +263,14 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 Position = d.Time,
                 Value = d.Value,
                 Size = barWidth,
-                FillColor = ScottPlot.Color.FromHex("#E57373"),
+                FillColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking")),
                 LineWidth = 0
             }).ToArray();
             BlockingChart.Plot.Add.Bars(bars);
             maxCount = Math.Max(maxCount, blockingData.Max(d => d.Value));
         }
 
-        // Deadlock bars — yellow/amber, slightly narrower so both are visible
+        // Deadlock bars — slightly narrower so both are visible over the blocking bars
         if (deadlockData.Count > 0)
         {
             var bars = deadlockData.Select(d => new ScottPlot.Bar
@@ -278,7 +278,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 Position = d.Time,
                 Value = d.Value,
                 Size = barWidth * 0.6,
-                FillColor = ScottPlot.Color.FromHex("#FFD54F"),
+                FillColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks")),
                 LineWidth = 0
             }).ToArray();
             BlockingChart.Plot.Add.Bars(bars);
@@ -546,7 +546,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
         var scatter = chart.Plot.Add.Scatter(times, values);
         // White-ish ghost line — distinct from the primary colored line
-        scatter.Color = ScottPlot.Colors.White.WithAlpha(140);
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("GhostLine")).WithAlpha(140);
         scatter.MarkerSize = 0;
         scatter.LineWidth = 1.5f;
         scatter.LinePattern = ScottPlot.LinePattern.Dashed;
@@ -575,7 +575,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     {
         ReapplyAxisColors(chart);
         var text = chart.Plot.Add.Text($"{title}\nNo Data", 0, 0);
-        text.LabelFontColor = ScottPlot.Color.FromHex("#888888");
+        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
         text.LabelFontSize = 12;
         text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
         chart.Plot.HideGrid();

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -601,55 +601,30 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
     private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart)
     {
-        ScottPlot.Color figureBackground, dataBackground, textColor, gridColor;
-
-        if (ThemeManager.CurrentTheme == "CoolBreeze")
-        {
-            figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-            dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-            textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-            gridColor        = ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120);
-        }
-        else if (ThemeManager.HasLightBackground)
-        {
-            figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-            dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-            textColor        = ScottPlot.Color.FromHex("#1A1D23");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else
-        {
-            figureBackground = ScottPlot.Color.FromHex("#22252b");
-            dataBackground   = ScottPlot.Color.FromHex("#111217");
-            textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-            gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-        }
-
-        chart.Plot.FigureBackground.Color = figureBackground;
-        chart.Plot.DataBackground.Color = dataBackground;
-        chart.Plot.Axes.Color(textColor);
-        chart.Plot.Grid.MajorLineColor = gridColor;
+        // Lanes are a deliberately stripped chrome variant (legend hidden, no font-size / first-render
+        // hook). Colors come from the shared ChartStyle so the per-theme hexes can't drift.
+        var c = ChartStyle.GetThemeColors();
+        chart.Plot.FigureBackground.Color = c.FigureBackground;
+        chart.Plot.DataBackground.Color = c.DataBackground;
+        chart.Plot.Axes.Color(c.Text);
+        chart.Plot.Grid.MajorLineColor = c.Grid;
         chart.Plot.Legend.IsVisible = false;
         chart.Plot.Axes.Margins(bottom: 0);
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-        chart.Plot.Axes.Left.Label.ForeColor = textColor;
+        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = c.Text;
+        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = c.Text;
+        chart.Plot.Axes.Bottom.Label.ForeColor = c.Text;
+        chart.Plot.Axes.Left.Label.ForeColor = c.Text;
 
         chart.Background = new System.Windows.Media.SolidColorBrush(
-            System.Windows.Media.Color.FromRgb(figureBackground.R, figureBackground.G, figureBackground.B));
+            System.Windows.Media.Color.FromRgb(c.FigureBackground.R, c.FigureBackground.G, c.FigureBackground.B));
     }
 
     private static void ReapplyAxisColors(ScottPlot.WPF.WpfPlot chart)
     {
-        var textColor = ThemeManager.CurrentTheme == "CoolBreeze"
-            ? ScottPlot.Color.FromHex("#1A2A3A")
-            : ThemeManager.HasLightBackground
-                ? ScottPlot.Color.FromHex("#1A1D23")
-                : ScottPlot.Color.FromHex("#E4E6EB");
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-        chart.Plot.Axes.Left.Label.ForeColor = textColor;
+        var text = ChartStyle.GetThemeColors().Text;
+        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = text;
+        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = text;
+        chart.Plot.Axes.Bottom.Label.ForeColor = text;
+        chart.Plot.Axes.Left.Label.ForeColor = text;
     }
 }

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -19,6 +19,7 @@ using PerformanceMonitor.Analysis;
 using PerformanceMonitorLite.Analysis;
 using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Controls;
@@ -293,11 +294,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             _crosshairManager?.SetLaneBaseline(BlockingChart, lower, upper, isEventBased: true);
 
             var band = BlockingChart.Plot.Add.HorizontalSpan(lower, upper);
-            band.FillStyle.Color = ScottPlot.Color.FromHex("#E57373").WithAlpha(25);
+            band.FillStyle.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineBlocking")).WithAlpha(25);
             band.LineStyle.Width = 0;
 
             var meanLine = BlockingChart.Plot.Add.HorizontalLine(baseline.Mean);
-            meanLine.Color = ScottPlot.Color.FromHex("#E57373").WithAlpha(60);
+            meanLine.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineBlocking")).WithAlpha(60);
             meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
             meanLine.LineWidth = 1;
         }
@@ -352,11 +353,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             _crosshairManager?.SetLaneBaseline(CpuChart, lower, upper, 10);
 
             var band = CpuChart.Plot.Add.HorizontalSpan(lower, upper);
-            band.FillStyle.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(25);
+            band.FillStyle.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineCpu")).WithAlpha(25);
             band.LineStyle.Width = 0;
 
             var meanLine = CpuChart.Plot.Add.HorizontalLine(baseline.Mean);
-            meanLine.Color = ScottPlot.Color.FromHex("#4FC3F7").WithAlpha(60);
+            meanLine.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("BaselineCpu")).WithAlpha(60);
             meanLine.LinePattern = ScottPlot.LinePattern.Dashed;
             meanLine.LineWidth = 1;
 
@@ -373,7 +374,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 var anomalyTimes = anomalyIndices.Select(i => sqlTimes[i]).ToArray();
                 var anomalyVals = anomalyIndices.Select(i => sqlValues[i]).ToArray();
                 var anomalyScatter = CpuChart.Plot.Add.Scatter(anomalyTimes, anomalyVals);
-                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Anomaly"));
                 anomalyScatter.MarkerSize = 6;
                 anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
                 anomalyScatter.LineWidth = 0;
@@ -383,7 +384,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         if (totalValues.Length > 0)
         {
             var totalScatter = CpuChart.Plot.Add.Scatter(totalTimes, totalValues);
-            totalScatter.Color = ScottPlot.Color.FromHex("#FF7043");
+            totalScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalCpu"));
             totalScatter.MarkerSize = 0;
             totalScatter.LineWidth = 1.5f;
             totalScatter.LegendText = "Total";
@@ -393,7 +394,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         if (sqlValues.Length > 0)
         {
             var sqlScatter = CpuChart.Plot.Add.Scatter(sqlTimes, sqlValues);
-            sqlScatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
             sqlScatter.MarkerSize = 0;
             sqlScatter.LineWidth = 1.5f;
             sqlScatter.LegendText = "SQL";
@@ -462,7 +463,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 var anomalyTimes = anomalyIndices.Select(i => times[i]).ToArray();
                 var anomalyValues = anomalyIndices.Select(i => values[i]).ToArray();
                 var anomalyScatter = chart.Plot.Add.Scatter(anomalyTimes, anomalyValues);
-                anomalyScatter.Color = ScottPlot.Color.FromHex("#FF5252");
+                anomalyScatter.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Anomaly"));
                 anomalyScatter.MarkerSize = 6;
                 anomalyScatter.MarkerShape = ScottPlot.MarkerShape.FilledCircle;
                 anomalyScatter.LineWidth = 0;

--- a/Lite/Controls/PlanViewerControl.Properties.cs
+++ b/Lite/Controls/PlanViewerControl.Properties.cs
@@ -11,7 +11,9 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.PlanAnalysis;
+using PerformanceMonitor.Ui;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
 
@@ -1104,45 +1106,12 @@ public partial class PlanViewerControl : UserControl
         WaitStatsContent.Children.Add(grid);
     }
 
-    private static string GetWaitCategory(string waitType)
-    {
-        if (waitType.StartsWith("SOS_SCHEDULER_YIELD", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXPACKET", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXCONSUMER", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXSYNC_PORT", StringComparison.Ordinal) ||
-            waitType.StartsWith("CXSYNC_CONSUMER", StringComparison.Ordinal))
-            return "CPU";
-
-        if (waitType.StartsWith("PAGEIOLATCH", StringComparison.Ordinal) ||
-            waitType.StartsWith("WRITELOG", StringComparison.Ordinal) ||
-            waitType.StartsWith("IO_COMPLETION", StringComparison.Ordinal) ||
-            waitType.StartsWith("ASYNC_IO_COMPLETION", StringComparison.Ordinal))
-            return "I/O";
-
-        if (waitType.StartsWith("LCK_M_", StringComparison.Ordinal))
-            return "Lock";
-
-        if (waitType == "RESOURCE_SEMAPHORE" || waitType == "CMEMTHREAD")
-            return "Memory";
-
-        if (waitType == "ASYNC_NETWORK_IO")
-            return "Network";
-
-        return "Other";
-    }
+    // Wait category + color come from the shared ChartPalette (PerformanceStudio's ~21-category
+    // taxonomy + palette), with a light-theme override for the near-invisible pale colors (D3).
+    private static string GetWaitCategory(string waitType) => ChartPalette.WaitCategory(waitType);
 
     private static string GetWaitCategoryColor(string category)
-    {
-        return category switch
-        {
-            "CPU" => "#4FA3FF",
-            "I/O" => "#FFB347",
-            "Lock" => "#E57373",
-            "Memory" => "#9B59B6",
-            "Network" => "#2ECC71",
-            _ => "#6BB5FF"
-        };
-    }
+        => ChartPalette.WaitColor(category, ThemeManager.HasLightBackground);
 
     private void ShowRuntimeSummary(PlanStatement statement)
     {

--- a/Lite/Controls/ServerTab.BarCells.cs
+++ b/Lite/Controls/ServerTab.BarCells.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Controls
+{
+    /// <summary>
+    /// Column maxima for the in-grid <see cref="PerformanceMonitor.Ui.BarChartCell"/>s on the
+    /// top-queries grid (mirror of Dashboard's QueryPerformanceContent.BarCells). Each bar fills to
+    /// <c>value / max</c> for its column; recomputed whenever the grid's ItemsSource changes (initial
+    /// load + every filter) via a DependencyPropertyDescriptor so we don't hook each setter. The
+    /// cells bind these by RelativeSource to the host ServerTab.
+    /// </summary>
+    public partial class ServerTab
+    {
+        public static readonly DependencyProperty BarMaxExecutionsProperty = DependencyProperty.Register(
+            nameof(BarMaxExecutions), typeof(double), typeof(ServerTab), new PropertyMetadata(1.0));
+        public double BarMaxExecutions
+        {
+            get => (double)GetValue(BarMaxExecutionsProperty);
+            set => SetValue(BarMaxExecutionsProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalCpuProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalCpu), typeof(double), typeof(ServerTab), new PropertyMetadata(1.0));
+        public double BarMaxTotalCpu
+        {
+            get => (double)GetValue(BarMaxTotalCpuProperty);
+            set => SetValue(BarMaxTotalCpuProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalElapsedProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalElapsed), typeof(double), typeof(ServerTab), new PropertyMetadata(1.0));
+        public double BarMaxTotalElapsed
+        {
+            get => (double)GetValue(BarMaxTotalElapsedProperty);
+            set => SetValue(BarMaxTotalElapsedProperty, value);
+        }
+
+        public static readonly DependencyProperty BarMaxTotalReadsProperty = DependencyProperty.Register(
+            nameof(BarMaxTotalReads), typeof(double), typeof(ServerTab), new PropertyMetadata(1.0));
+        public double BarMaxTotalReads
+        {
+            get => (double)GetValue(BarMaxTotalReadsProperty);
+            set => SetValue(BarMaxTotalReadsProperty, value);
+        }
+
+        private void SetupBarCellMaxes()
+        {
+            var dpd = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, typeof(DataGrid));
+            dpd?.AddValueChanged(QueryStatsGrid, (_, _) => RecomputeBarCellMaxes());
+        }
+
+        private void RecomputeBarCellMaxes()
+        {
+            var items = (QueryStatsGrid.ItemsSource as IEnumerable)?.OfType<QueryStatsRow>().ToList();
+            if (items == null || items.Count == 0)
+            {
+                BarMaxExecutions = BarMaxTotalCpu = BarMaxTotalElapsed = BarMaxTotalReads = 1.0;
+                return;
+            }
+
+            // Max(1,...) keeps the bar denominator positive even for an all-zero column.
+            BarMaxExecutions = Math.Max(1.0, items.Max(i => (double)i.TotalExecutions));
+            BarMaxTotalCpu = Math.Max(1.0, items.Max(i => i.TotalCpuMs));
+            BarMaxTotalElapsed = Math.Max(1.0, items.Max(i => i.TotalElapsedMs));
+            BarMaxTotalReads = Math.Max(1.0, items.Max(i => (double)i.TotalLogicalReads));
+        }
+    }
+}

--- a/Lite/Controls/ServerTab.BarCells.cs
+++ b/Lite/Controls/ServerTab.BarCells.cs
@@ -8,10 +8,14 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Controls
@@ -69,6 +73,7 @@ namespace PerformanceMonitorLite.Controls
             if (items == null || items.Count == 0)
             {
                 BarMaxExecutions = BarMaxTotalCpu = BarMaxTotalElapsed = BarMaxTotalReads = 1.0;
+                if (QueryStatsByDbCards != null) QueryStatsByDbCards.Items = null;
                 return;
             }
 
@@ -77,6 +82,55 @@ namespace PerformanceMonitorLite.Controls
             BarMaxTotalCpu = Math.Max(1.0, items.Max(i => i.TotalCpuMs));
             BarMaxTotalElapsed = Math.Max(1.0, items.Max(i => i.TotalElapsedMs));
             BarMaxTotalReads = Math.Max(1.0, items.Max(i => (double)i.TotalLogicalReads));
+
+            RefreshByDbCards(items);
+        }
+
+        /// <summary>
+        /// Builds the per-database CPU bar-cards (A.6) from the currently displayed query rows — no
+        /// new query, just an aggregation of what the grid already holds. A database's color is a
+        /// STABLE alphabetical index (D4), so it keeps its color no matter how the bars are ranked;
+        /// the bars themselves are ordered by value (largest first). Mirror of Dashboard's.
+        /// </summary>
+        private void RefreshByDbCards(List<QueryStatsRow> items)
+        {
+            if (QueryStatsByDbCards == null) return;
+
+            var byDb = items
+                .GroupBy(i => i.DatabaseName ?? string.Empty)
+                .Select(g => new { Db = g.Key, Cpu = g.Sum(x => x.TotalCpuMs) })
+                .Where(x => x.Cpu > 0)
+                .ToList();
+
+            if (byDb.Count == 0)
+            {
+                QueryStatsByDbCards.Items = null;
+                return;
+            }
+
+            var sortedNames = byDb.Select(x => x.Db)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            double max = byDb.Max(x => x.Cpu);
+
+            QueryStatsByDbCards.Items = byDb
+                .OrderByDescending(x => x.Cpu)
+                .Select(x => new MetricBarItem
+                {
+                    Label = string.IsNullOrEmpty(x.Db) ? "(unknown)" : x.Db,
+                    Value = x.Cpu,
+                    Maximum = max,
+                    ValueText = x.Cpu.ToString("N0"),
+                    BarBrush = BrushFromHex(ChartPalette.CyclingColor(sortedNames.IndexOf(x.Db))),
+                })
+                .ToList();
+        }
+
+        private static Brush BrushFromHex(string hex)
+        {
+            var b = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+            b.Freeze();
+            return b;
         }
     }
 }

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -77,11 +77,13 @@ public partial class ServerTab : UserControl
         var sqlPlot = CpuChart.Plot.Add.Scatter(times, sqlCpu);
         sqlPlot.LegendText = "SQL Server";
         sqlPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
+        ChartStyle.StyleScatter(sqlPlot);
         _cpuHover?.Add(sqlPlot, "SQL Server");
 
         var otherPlot = CpuChart.Plot.Add.Scatter(times, otherCpu);
         otherPlot.LegendText = "Other";
         otherPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OtherCpu"));
+        ChartStyle.StyleScatter(otherPlot);
         _cpuHover?.Add(otherPlot, "Other");
 
         CpuChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -109,17 +111,20 @@ public partial class ServerTab : UserControl
         var totalPlot = MemoryChart.Plot.Add.Scatter(times, totalMem);
         totalPlot.LegendText = "Total Server Memory";
         totalPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalServerMemory"));
+        ChartStyle.StyleScatter(totalPlot);
         _memoryHover?.Add(totalPlot, "Total Server Memory");
 
         var targetPlot = MemoryChart.Plot.Add.Scatter(times, targetMem);
         targetPlot.LegendText = "Target Memory";
         targetPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TargetMemory"));
+        ChartStyle.StyleScatter(targetPlot);
         targetPlot.LineStyle.Pattern = LinePattern.Dashed;
         _memoryHover?.Add(targetPlot, "Target Memory");
 
         var bpPlot = MemoryChart.Plot.Add.Scatter(times, bufferPool);
         bpPlot.LegendText = "Buffer Pool";
         bpPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
+        ChartStyle.StyleScatter(bpPlot);
         _memoryHover?.Add(bpPlot, "Buffer Pool");
 
         /* Memory grants trend line — show zero line when no grant data */
@@ -138,6 +143,7 @@ public partial class ServerTab : UserControl
         var grantPlot = MemoryChart.Plot.Add.Scatter(grantTimes, grantMb);
         grantPlot.LegendText = "Memory Grants";
         grantPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MemoryGrants"));
+        ChartStyle.StyleScatter(grantPlot);
         _memoryHover?.Add(grantPlot, "Memory Grants");
 
         MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -191,6 +197,7 @@ public partial class ServerTab : UserControl
                 var label = $"Pool {poolId}: {metric.Name}";
                 plot.LegendText = label;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIndex % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
                 _memoryGrantSizingHover?.Add(plot, label);
                 if (values.Length > 0) sizingMax = Math.Max(sizingMax, values.Max());
                 colorIndex++;
@@ -227,6 +234,7 @@ public partial class ServerTab : UserControl
                 var label = $"Pool {poolId}: {metric.Name}";
                 plot.LegendText = label;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIndex % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
                 _memoryGrantActivityHover?.Add(plot, label);
                 if (values.Length > 0) activityMax = Math.Max(activityMax, values.Max());
                 colorIndex++;
@@ -370,16 +378,19 @@ public partial class ServerTab : UserControl
         var userPlot = TempDbChart.Plot.Add.Scatter(times, userObj);
         userPlot.LegendText = "User Objects";
         userPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UserObjects"));
+        ChartStyle.StyleScatter(userPlot);
         _tempDbHover?.Add(userPlot, "User Objects");
 
         var internalPlot = TempDbChart.Plot.Add.Scatter(times, internalObj);
         internalPlot.LegendText = "Internal Objects";
         internalPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("InternalObjects"));
+        ChartStyle.StyleScatter(internalPlot);
         _tempDbHover?.Add(internalPlot, "Internal Objects");
 
         var vsPlot = TempDbChart.Plot.Add.Scatter(times, versionStore);
         vsPlot.LegendText = "Version Store";
         vsPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("VersionStore"));
+        ChartStyle.StyleScatter(vsPlot);
         _tempDbHover?.Add(vsPlot, "Version Store");
 
         TempDbChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -423,6 +434,7 @@ public partial class ServerTab : UserControl
                 var plot = TempDbFileIoChart.Plot.Add.Scatter(times, latency);
                 plot.LegendText = fileGroup.Key;
                 plot.Color = color;
+                ChartStyle.StyleScatter(plot);
                 _tempDbFileIoHover?.Add(plot, fileGroup.Key);
                 maxLatency = Math.Max(maxLatency, latency.Max());
             }
@@ -473,6 +485,7 @@ public partial class ServerTab : UserControl
                 var readPlot = FileIoReadChart.Plot.Add.Scatter(times, readLatency);
                 readPlot.LegendText = dbGroup.Key;
                 readPlot.Color = color;
+                ChartStyle.StyleScatter(readPlot);
                 _fileIoReadHover?.Add(readPlot, dbGroup.Key);
                 readMax = Math.Max(readMax, readLatency.Max());
             }
@@ -482,6 +495,7 @@ public partial class ServerTab : UserControl
                 var writePlot = FileIoWriteChart.Plot.Add.Scatter(times, writeLatency);
                 writePlot.LegendText = dbGroup.Key;
                 writePlot.Color = color;
+                ChartStyle.StyleScatter(writePlot);
                 _fileIoWriteHover?.Add(writePlot, dbGroup.Key);
                 writeMax = Math.Max(writeMax, writeLatency.Max());
             }
@@ -497,6 +511,7 @@ public partial class ServerTab : UserControl
                     var qReadPlot = FileIoReadChart.Plot.Add.Scatter(times, queuedReadLatency);
                     qReadPlot.LegendText = $"{dbGroup.Key} (queued)";
                     qReadPlot.Color = color;
+                    ChartStyle.StyleScatter(qReadPlot);
                     qReadPlot.LinePattern = ScottPlot.LinePattern.Dashed;
                     _fileIoReadHover?.Add(qReadPlot, $"{dbGroup.Key} (queued)");
                 }
@@ -506,6 +521,7 @@ public partial class ServerTab : UserControl
                     var qWritePlot = FileIoWriteChart.Plot.Add.Scatter(times, queuedWriteLatency);
                     qWritePlot.LegendText = $"{dbGroup.Key} (queued)";
                     qWritePlot.Color = color;
+                    ChartStyle.StyleScatter(qWritePlot);
                     qWritePlot.LinePattern = ScottPlot.LinePattern.Dashed;
                     _fileIoWriteHover?.Add(qWritePlot, $"{dbGroup.Key} (queued)");
                 }
@@ -562,6 +578,7 @@ public partial class ServerTab : UserControl
                 var readPlot = FileIoReadThroughputChart.Plot.Add.Scatter(times, readThroughput);
                 readPlot.LegendText = fileGroup.Key;
                 readPlot.Color = color;
+                ChartStyle.StyleScatter(readPlot);
                 _fileIoReadThroughputHover?.Add(readPlot, fileGroup.Key);
                 readMax = Math.Max(readMax, readThroughput.Max());
             }
@@ -571,6 +588,7 @@ public partial class ServerTab : UserControl
                 var writePlot = FileIoWriteThroughputChart.Plot.Add.Scatter(times, writeThroughput);
                 writePlot.LegendText = fileGroup.Key;
                 writePlot.Color = color;
+                ChartStyle.StyleScatter(writePlot);
                 _fileIoWriteThroughputHover?.Add(writePlot, fileGroup.Key);
                 writeMax = Math.Max(writeMax, writeThroughput.Max());
             }
@@ -641,6 +659,7 @@ public partial class ServerTab : UserControl
             var plot = LockWaitTrendChart.Plot.Add.Scatter(times, values);
             plot.LegendText = group.Key;
             plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+            ChartStyle.StyleScatter(plot);
             _lockWaitTrendHover?.Add(plot, group.Key);
 
             if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
@@ -863,9 +882,8 @@ public partial class ServerTab : UserControl
 
             var plot = CurrentWaitsDurationChart.Plot.Add.Scatter(times, values);
             plot.LegendText = group.Key;
-            plot.LineWidth = 2;
-            plot.MarkerSize = 5;
             plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+            ChartStyle.StyleScatter(plot);
             _currentWaitsDurationHover?.Add(plot, group.Key);
 
             if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
@@ -928,9 +946,8 @@ public partial class ServerTab : UserControl
 
             var plot = CurrentWaitsBlockedChart.Plot.Add.Scatter(times, values);
             plot.LegendText = group.Key;
-            plot.LineWidth = 2;
-            plot.MarkerSize = 5;
             plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+            ChartStyle.StyleScatter(plot);
             _currentWaitsBlockedHover?.Add(plot, group.Key);
 
             if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
@@ -961,6 +978,7 @@ public partial class ServerTab : UserControl
         var plot = QueryDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Query Duration";
         plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("QueryDuration"));
+        ChartStyle.StyleScatter(plot);
         _queryDurationTrendHover?.Add(plot, "Query Duration");
 
         QueryDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -985,6 +1003,7 @@ public partial class ServerTab : UserControl
         var plot = ProcDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Procedure Duration";
         plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ProcedureDuration"));
+        ChartStyle.StyleScatter(plot);
         _procDurationTrendHover?.Add(plot, "Procedure Duration");
 
         ProcDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -1009,6 +1028,7 @@ public partial class ServerTab : UserControl
         var plot = QueryStoreDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Query Store Duration";
         plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("QueryStoreDuration"));
+        ChartStyle.StyleScatter(plot);
         _queryStoreDurationTrendHover?.Add(plot, "Query Store Duration");
 
         QueryStoreDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -1033,6 +1053,7 @@ public partial class ServerTab : UserControl
         var plot = ExecutionCountTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Executions";
         plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Executions"));
+        ChartStyle.StyleScatter(plot);
         _executionCountTrendHover?.Add(plot, "Executions");
 
         ExecutionCountTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -1296,77 +1296,10 @@ public partial class ServerTab : UserControl
     }
 
     /// <summary>
-    /// Applies the Darling Data dark theme to a ScottPlot chart.
-    /// Matches Dashboard TabHelpers.ApplyThemeToChart exactly.
+    /// Applies the chrome theme to a ScottPlot chart.
+    /// Delegates to the shared <see cref="ChartStyle"/> — single source of truth across apps.
     /// </summary>
-    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart)
-    {
-        ScottPlot.Color figureBackground, dataBackground, textColor, gridColor, legendBg, legendFg, legendOutline;
-
-        if (ThemeManager.CurrentTheme == "CoolBreeze")
-        {
-            figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-            dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-            textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-            gridColor        = ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120);
-            legendBg         = ScottPlot.Color.FromHex("#EEF4FA");
-            legendFg         = ScottPlot.Color.FromHex("#1A2A3A");
-            legendOutline    = ScottPlot.Color.FromHex("#A8BDD0");
-        }
-        else if (ThemeManager.HasLightBackground)
-        {
-            figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-            dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-            textColor        = ScottPlot.Color.FromHex("#1A1D23");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-            legendBg         = ScottPlot.Color.FromHex("#FFFFFF");
-            legendFg         = ScottPlot.Color.FromHex("#1A1D23");
-            legendOutline    = ScottPlot.Color.FromHex("#DEE2E6");
-        }
-        else
-        {
-            figureBackground = ScottPlot.Color.FromHex("#22252b");
-            dataBackground   = ScottPlot.Color.FromHex("#111217");
-            textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-            gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-            legendBg         = ScottPlot.Color.FromHex("#22252b");
-            legendFg         = ScottPlot.Color.FromHex("#E4E6EB");
-            legendOutline    = ScottPlot.Color.FromHex("#2a2d35");
-        }
-
-        chart.Plot.FigureBackground.Color = figureBackground;
-        chart.Plot.DataBackground.Color = dataBackground;
-        chart.Plot.Axes.Color(textColor);
-        chart.Plot.Grid.MajorLineColor = gridColor;
-        chart.Plot.Legend.BackgroundColor = legendBg;
-        chart.Plot.Legend.FontColor = legendFg;
-        chart.Plot.Legend.OutlineColor = legendOutline;
-        chart.Plot.Legend.Alignment = ScottPlot.Alignment.LowerCenter;
-        chart.Plot.Legend.Orientation = ScottPlot.Orientation.Horizontal;
-        chart.Plot.Axes.Margins(bottom: 0); /* No bottom margin - SetChartYLimitsWithLegendPadding handles Y-axis */
-
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-        chart.Plot.Axes.Left.Label.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
-        chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
-
-        // Set the WPF control Background to match so no white flash appears before ScottPlot's render loop fires
-        chart.Background = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(figureBackground.R, figureBackground.G, figureBackground.B));
-
-        // Ensure ScottPlot renders with the correct colors the very first time it gets pixel dimensions.
-        chart.Loaded -= HandleChartFirstLoaded;
-        if (!chart.IsLoaded)
-            chart.Loaded += HandleChartFirstLoaded;
-    }
-
-    private static void HandleChartFirstLoaded(object sender, RoutedEventArgs e)
-    {
-        var chart = (ScottPlot.WPF.WpfPlot)sender;
-        chart.Loaded -= HandleChartFirstLoaded;
-        chart.Refresh();
-    }
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyThemeToChart(chart);
 
     private void OnThemeChanged(string _)
     {
@@ -1395,22 +1328,10 @@ public partial class ServerTab : UserControl
     }
 
     /// <summary>
-    /// Reapplies theme-appropriate text colors and font sizes after DateTimeTicksBottom() resets them.
+    /// Reapplies theme-appropriate axis text colors/sizes after DateTimeTicksBottom() resets them.
+    /// Delegates to the shared <see cref="ChartStyle"/>.
     /// </summary>
-    private static void ReapplyAxisColors(ScottPlot.WPF.WpfPlot chart)
-    {
-        var textColor = ThemeManager.CurrentTheme == "CoolBreeze"
-            ? ScottPlot.Color.FromHex("#1A2A3A")
-            : ThemeManager.HasLightBackground
-                ? ScottPlot.Color.FromHex("#1A1D23")
-                : ScottPlot.Color.FromHex("#E4E6EB");
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-        chart.Plot.Axes.Left.Label.ForeColor = textColor;
-        chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
-        chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
-    }
+    private static void ReapplyAxisColors(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ReapplyAxisColors(chart);
 
     /// <summary>
     /// Sets Y-axis limits with padding for bottom legend and top breathing room.

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -721,7 +721,7 @@ public partial class ServerTab : UserControl
 
         var plot = BlockingTrendChart.Plot.Add.Scatter(expandedTimes.ToArray(), expandedCounts.ToArray());
         plot.LegendText = "Blocking Incidents";
-        plot.Color = ScottPlot.Color.FromHex("#E57373");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
         plot.MarkerSize = 0; /* No markers, just lines */
         _blockingTrendHover?.Add(plot, "Blocking Incidents");
 
@@ -800,7 +800,7 @@ public partial class ServerTab : UserControl
 
         var plot = DeadlockTrendChart.Plot.Add.Scatter(expandedTimes.ToArray(), expandedCounts.ToArray());
         plot.LegendText = "Deadlocks";
-        plot.Color = ScottPlot.Color.FromHex("#FFB74D");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
         plot.MarkerSize = 0; /* No markers, just lines */
         _deadlockTrendHover?.Add(plot, "Deadlocks");
 
@@ -904,7 +904,7 @@ public partial class ServerTab : UserControl
                 new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
                 new[] { 0.0, 0.0 });
             zeroLine.LegendText = "Blocked Sessions";
-            zeroLine.Color = ScottPlot.Color.FromHex("#E57373");
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BlockedSessions"));
             zeroLine.MarkerSize = 0;
             CurrentWaitsBlockedChart.Plot.Axes.DateTimeTicksBottomDateChange();
             CurrentWaitsBlockedChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -23,13 +23,9 @@ namespace PerformanceMonitorLite.Controls;
 
 public partial class ServerTab : UserControl
 {
-    private static readonly string[] SeriesColors = new[]
-    {
-        "#4FC3F7", "#E57373", "#81C784", "#FFD54F", "#BA68C8",
-        "#FFB74D", "#4DD0E1", "#F06292", "#AED581", "#7986CB",
-        "#FFF176", "#A1887F", "#FF7043", "#80DEEA", "#FFE082",
-        "#CE93D8", "#EF9A9A", "#C5E1A5", "#FFCC80", "#B0BEC5"
-    };
+    // Cycling palette sourced from the shared ChartPalette so Lite and Dashboard cycle through the
+    // SAME colors in the same order (Lite's old array was reordered, breaking cross-app parity).
+    private static readonly string[] SeriesColors = ChartPalette.CyclingPalette.ToArray();
 
     private void UpdateMemorySummary(MemoryStatsRow? stats)
     {

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -1335,26 +1335,10 @@ public partial class ServerTab : UserControl
 
     /// <summary>
     /// Sets Y-axis limits with padding for bottom legend and top breathing room.
+    /// Delegates to the shared <see cref="ChartStyle"/>.
     /// </summary>
     private static void SetChartYLimitsWithLegendPadding(ScottPlot.WPF.WpfPlot chart, double dataYMin = 0, double dataYMax = 0)
-    {
-        if (dataYMin == 0 && dataYMax == 0)
-        {
-            var limits = chart.Plot.Axes.GetLimits();
-            dataYMin = limits.Bottom;
-            dataYMax = limits.Top;
-        }
-        if (dataYMax <= dataYMin) dataYMax = dataYMin + 1;
-
-        double range = dataYMax - dataYMin;
-        double topPadding = range * 0.05;
-
-        /* Add small bottom margin when dataYMin is zero so flat lines at Y=0 are visible above the axis */
-        double yMin = dataYMin > 0 ? 0 : dataYMin == 0 ? -(range * 0.05) : dataYMin - (range * 0.10);
-        double yMax = dataYMax + topPadding;
-
-        chart.Plot.Axes.SetLimitsY(yMin, yMax);
-    }
+        => ChartStyle.SetChartYLimitsWithLegendPadding(chart, dataYMin, dataYMax);
 
     /* ========== Collection Health ========== */
 

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -369,17 +369,17 @@ public partial class ServerTab : UserControl
 
         var userPlot = TempDbChart.Plot.Add.Scatter(times, userObj);
         userPlot.LegendText = "User Objects";
-        userPlot.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        userPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UserObjects"));
         _tempDbHover?.Add(userPlot, "User Objects");
 
         var internalPlot = TempDbChart.Plot.Add.Scatter(times, internalObj);
         internalPlot.LegendText = "Internal Objects";
-        internalPlot.Color = ScottPlot.Color.FromHex("#FFD54F");
+        internalPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("InternalObjects"));
         _tempDbHover?.Add(internalPlot, "Internal Objects");
 
         var vsPlot = TempDbChart.Plot.Add.Scatter(times, versionStore);
         vsPlot.LegendText = "Version Store";
-        vsPlot.Color = ScottPlot.Color.FromHex("#81C784");
+        vsPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("VersionStore"));
         _tempDbHover?.Add(vsPlot, "Version Store");
 
         TempDbChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -617,7 +617,7 @@ public partial class ServerTab : UserControl
                 new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
                 new[] { 0.0, 0.0 });
             zeroLine.LegendText = "Lock Waits";
-            zeroLine.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("LockWaits"));
             zeroLine.MarkerSize = 0;
             LockWaitTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
             LockWaitTrendChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
@@ -681,7 +681,7 @@ public partial class ServerTab : UserControl
                 new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
                 new[] { 0.0, 0.0 });
             zeroLine.LegendText = "Blocking Incidents";
-            zeroLine.Color = ScottPlot.Color.FromHex("#E57373");
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
             zeroLine.MarkerSize = 0;
             BlockingTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
             BlockingTrendChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
@@ -760,7 +760,7 @@ public partial class ServerTab : UserControl
                 new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
                 new[] { 0.0, 0.0 });
             zeroLine.LegendText = "Deadlocks";
-            zeroLine.Color = ScottPlot.Color.FromHex("#FFB74D");
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
             zeroLine.MarkerSize = 0;
             DeadlockTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
             DeadlockTrendChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
@@ -839,7 +839,7 @@ public partial class ServerTab : UserControl
                 new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
                 new[] { 0.0, 0.0 });
             zeroLine.LegendText = "Current Waits";
-            zeroLine.Color = ScottPlot.Color.FromHex("#4FC3F7");
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("CurrentWaits"));
             zeroLine.MarkerSize = 0;
             CurrentWaitsDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
             CurrentWaitsDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
@@ -960,7 +960,7 @@ public partial class ServerTab : UserControl
         _queryDurationTrendHover?.Clear();
         var plot = QueryDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Query Duration";
-        plot.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("QueryDuration"));
         _queryDurationTrendHover?.Add(plot, "Query Duration");
 
         QueryDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -984,7 +984,7 @@ public partial class ServerTab : UserControl
         _procDurationTrendHover?.Clear();
         var plot = ProcDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Procedure Duration";
-        plot.Color = ScottPlot.Color.FromHex("#81C784");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("ProcedureDuration"));
         _procDurationTrendHover?.Add(plot, "Procedure Duration");
 
         ProcDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -1008,7 +1008,7 @@ public partial class ServerTab : UserControl
         _queryStoreDurationTrendHover?.Clear();
         var plot = QueryStoreDurationTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Query Store Duration";
-        plot.Color = ScottPlot.Color.FromHex("#FFB74D");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("QueryStoreDuration"));
         _queryStoreDurationTrendHover?.Add(plot, "Query Store Duration");
 
         QueryStoreDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -1032,7 +1032,7 @@ public partial class ServerTab : UserControl
         _executionCountTrendHover?.Clear();
         var plot = ExecutionCountTrendChart.Plot.Add.Scatter(times, values);
         plot.LegendText = "Executions";
-        plot.Color = ScottPlot.Color.FromHex("#BA68C8");
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Executions"));
         _executionCountTrendHover?.Add(plot, "Executions");
 
         ExecutionCountTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -1260,7 +1260,7 @@ public partial class ServerTab : UserControl
         /* Add invisible scatter to create legend entry (matches data chart layout) */
         var placeholder = chart.Plot.Add.Scatter(new double[] { 0 }, new double[] { 0 });
         placeholder.LegendText = legendText;
-        placeholder.Color = ScottPlot.Color.FromHex("#888888");
+        placeholder.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
         placeholder.MarkerSize = 0;
         placeholder.LineWidth = 0;
 

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -16,6 +16,7 @@ using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Controls;
@@ -79,12 +80,12 @@ public partial class ServerTab : UserControl
 
         var sqlPlot = CpuChart.Plot.Add.Scatter(times, sqlCpu);
         sqlPlot.LegendText = "SQL Server";
-        sqlPlot.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        sqlPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
         _cpuHover?.Add(sqlPlot, "SQL Server");
 
         var otherPlot = CpuChart.Plot.Add.Scatter(times, otherCpu);
         otherPlot.LegendText = "Other";
-        otherPlot.Color = ScottPlot.Color.FromHex("#E57373");
+        otherPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OtherCpu"));
         _cpuHover?.Add(otherPlot, "Other");
 
         CpuChart.Plot.Axes.DateTimeTicksBottomDateChange();
@@ -111,7 +112,7 @@ public partial class ServerTab : UserControl
 
         var totalPlot = MemoryChart.Plot.Add.Scatter(times, totalMem);
         totalPlot.LegendText = "Total Server Memory";
-        totalPlot.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        totalPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TotalServerMemory"));
         _memoryHover?.Add(totalPlot, "Total Server Memory");
 
         var targetPlot = MemoryChart.Plot.Add.Scatter(times, targetMem);
@@ -122,7 +123,7 @@ public partial class ServerTab : UserControl
 
         var bpPlot = MemoryChart.Plot.Add.Scatter(times, bufferPool);
         bpPlot.LegendText = "Buffer Pool";
-        bpPlot.Color = ScottPlot.Color.FromHex("#81C784");
+        bpPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("BufferPool"));
         _memoryHover?.Add(bpPlot, "Buffer Pool");
 
         /* Memory grants trend line — show zero line when no grant data */
@@ -140,7 +141,7 @@ public partial class ServerTab : UserControl
 
         var grantPlot = MemoryChart.Plot.Add.Scatter(grantTimes, grantMb);
         grantPlot.LegendText = "Memory Grants";
-        grantPlot.Color = ScottPlot.Color.FromHex("#FFB74D");
+        grantPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MemoryGrants"));
         _memoryHover?.Add(grantPlot, "Memory Grants");
 
         MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -113,7 +113,7 @@ public partial class ServerTab : UserControl
 
         var targetPlot = MemoryChart.Plot.Add.Scatter(times, targetMem);
         targetPlot.LegendText = "Target Memory";
-        targetPlot.Color = ScottPlot.Colors.Gray;
+        targetPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("TargetMemory"));
         targetPlot.LineStyle.Pattern = LinePattern.Dashed;
         _memoryHover?.Add(targetPlot, "Target Memory");
 
@@ -276,10 +276,10 @@ public partial class ServerTab : UserControl
             double barSize = hourWidth * 0.4;
             double barOffset = hourWidth * 0.22;
 
-            var sqlMediumColor = ScottPlot.Color.FromHex("#FFB74D"); // orange 300
-            var sqlSevereColor = ScottPlot.Color.FromHex("#E65100"); // orange 900
-            var osMediumColor = ScottPlot.Color.FromHex("#E57373");  // red 300
-            var osSevereColor = ScottPlot.Color.FromHex("#B71C1C");  // red 900
+            var sqlMediumColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlPressureMedium"));
+            var sqlSevereColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlPressureSevere"));
+            var osMediumColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OsPressureMedium"));
+            var osSevereColor = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("OsPressureSevere"));
 
             var sqlMediumBars = new List<ScottPlot.Bar>();
             var sqlSevereBars = new List<ScottPlot.Bar>();
@@ -1266,7 +1266,7 @@ public partial class ServerTab : UserControl
 
         /* Add centered "No Data" text */
         var text = chart.Plot.Add.Text($"{legendText}\nNo Data", 0, 0);
-        text.LabelFontColor = ScottPlot.Color.FromHex("#888888");
+        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
         text.LabelFontSize = 14;
         text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
 

--- a/Lite/Controls/ServerTab.Pickers.cs
+++ b/Lite/Controls/ServerTab.Pickers.cs
@@ -187,6 +187,7 @@ public partial class ServerTab : UserControl
                 var plot = WaitStatsChart.Plot.Add.Scatter(times, values);
                 plot.LegendText = selected[i].DisplayName;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
                 _waitStatsHover?.Add(plot, selected[i].DisplayName);
 
                 if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
@@ -343,6 +344,7 @@ public partial class ServerTab : UserControl
                 var plot = MemoryClerksChart.Plot.Add.Scatter(times, values);
                 plot.LegendText = selected[i].DisplayName;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
                 _memoryClerksHover?.Add(plot, selected[i].DisplayName);
 
                 if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
@@ -553,6 +555,7 @@ public partial class ServerTab : UserControl
                 var plot = PerfmonChart.Plot.Add.Scatter(times, values);
                 plot.LegendText = selected[i].DisplayName;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[i % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
                 _perfmonHover?.Add(plot, selected[i].DisplayName);
 
                 if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ScottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+             xmlns:ui="clr-namespace:PerformanceMonitor.Ui;assembly=PerformanceMonitor.Ui"
              xmlns:controls="clr-namespace:PerformanceMonitorLite.Controls">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -430,24 +431,36 @@
                                     <DataGridTextColumn Binding="{Binding CreationTimeLocal}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Creation Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn SortMemberPath="TotalExecutions" Width="90">
+                                        <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalExecutions" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate><DataTemplate>
+                                            <ui:BarChartCell Value="{Binding TotalExecutions}" Maximum="{Binding BarMaxExecutions, RelativeSource={RelativeSource AncestorType={x:Type controls:ServerTab}}}" Text="{Binding TotalExecutions, StringFormat=N0}"/>
+                                        </DataTemplate></DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn SortMemberPath="TotalCpuMs" Width="110">
+                                        <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate><DataTemplate>
+                                            <ui:BarChartCell Value="{Binding TotalCpuMs}" Maximum="{Binding BarMaxTotalCpu, RelativeSource={RelativeSource AncestorType={x:Type controls:ServerTab}}}" Text="{Binding TotalCpuMs, StringFormat=N1}"/>
+                                        </DataTemplate></DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn SortMemberPath="TotalElapsedMs" Width="130">
+                                        <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate><DataTemplate>
+                                            <ui:BarChartCell Value="{Binding TotalElapsedMs}" Maximum="{Binding BarMaxTotalElapsed, RelativeSource={RelativeSource AncestorType={x:Type controls:ServerTab}}}" Text="{Binding TotalElapsedMs, StringFormat=N1}"/>
+                                        </DataTemplate></DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
-                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn SortMemberPath="TotalLogicalReads" Width="100">
+                                        <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
+                                        <DataGridTemplateColumn.CellTemplate><DataTemplate>
+                                            <ui:BarChartCell Value="{Binding TotalLogicalReads}" Maximum="{Binding BarMaxTotalReads, RelativeSource={RelativeSource AncestorType={x:Type controls:ServerTab}}}" Text="{Binding TotalLogicalReads, StringFormat=N0}"/>
+                                        </DataTemplate></DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Binding="{Binding AvgReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -409,10 +409,17 @@
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
                                 <controls:TimeRangeSlicerControl x:Name="QueryStatsSlicer" Grid.Row="0"/>
-                                <TextBlock x:Name="QueryStatsComparisonBanner" Grid.Row="1" Visibility="Collapsed"
-                                           Padding="8,4" FontWeight="Bold"
-                                           Foreground="{DynamicResource ForegroundBrush}"
-                                           Background="#2244AAFF"/>
+                                <StackPanel Grid.Row="1">
+                                    <TextBlock x:Name="QueryStatsComparisonBanner" Visibility="Collapsed"
+                                               Padding="8,4" FontWeight="Bold"
+                                               Foreground="{DynamicResource ForegroundBrush}"
+                                               Background="#2244AAFF"/>
+                                    <Expander x:Name="QueryStatsByDbExpander" Header="CPU by database" IsExpanded="False" Margin="4,2,4,0">
+                                        <ScrollViewer MaxHeight="220" VerticalScrollBarVisibility="Auto">
+                                            <ui:MetricBarCards x:Name="QueryStatsByDbCards" Margin="4,4,4,8"/>
+                                        </ScrollViewer>
+                                    </Expander>
+                                </StackPanel>
                             <DataGrid Grid.Row="2" x:Name="QueryStatsGrid"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource GridRowStyle}"

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -121,6 +121,7 @@ public partial class ServerTab : UserControl
     public ServerTab(ServerConnection server, DuckDbInitializer duckDb, CredentialResolver credentialResolver, int utcOffsetMinutes = 0, bool hasMsdbAccess = true, bool isAzureSqlDatabase = false)
     {
         InitializeComponent();
+        SetupBarCellMaxes();
 
         _server = server;
         _dataService = new LocalDataService(duckDb);

--- a/Lite/Controls/TimeRangeSlicerControl.xaml
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml
@@ -36,6 +36,7 @@
                         MouseLeftButtonDown="Canvas_MouseLeftButtonDown"
                         MouseMove="Canvas_MouseMove"
                         MouseLeftButtonUp="Canvas_MouseLeftButtonUp"
+                        MouseLeave="Canvas_MouseLeave"
                         MouseWheel="Canvas_MouseWheel"/>
             </Border>
         </Grid>

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -36,6 +36,9 @@ public partial class TimeRangeSlicerControl : UserControl
 
     private enum DragMode { None, MoveRange, DragStart, DragEnd }
     private DragMode _dragMode = DragMode.None;
+
+    private enum HandleHover { None, Start, End }
+    private HandleHover _hoveredHandle = HandleHover.None;
     private double _dragOriginX;
     private double _dragOriginRangeStart;
     private double _dragOriginRangeEnd;
@@ -260,6 +263,7 @@ public partial class TimeRangeSlicerControl : UserControl
         var overlayBrush = FindBrush("SlicerOverlayBrush", "#99000000");
         var selectedBrush = FindBrush("SlicerSelectedBrush", "#22FFFFFF");
         var handleBrush = FindBrush("SlicerHandleBrush", "#E4E6EB");
+        var handleHoverBrush = FindBrush("SlicerHandleHoverBrush", "#2EAEF1");
 
         var selLeft = _rangeStart * w;
         var selRight = _rangeEnd * w;
@@ -268,8 +272,8 @@ public partial class TimeRangeSlicerControl : UserControl
         if (selRight < w) AddRect(selRight, 0, w - selRight, h, overlayBrush);
         AddRect(selLeft, 0, Math.Max(0, selRight - selLeft), h, selectedBrush);
 
-        DrawHandle(selLeft, h, handleBrush);
-        DrawHandle(selRight - HandleWidthPx, h, handleBrush);
+        DrawHandle(selLeft, h, _hoveredHandle == HandleHover.Start ? handleHoverBrush : handleBrush);
+        DrawHandle(selRight - HandleWidthPx, h, _hoveredHandle == HandleHover.End ? handleHoverBrush : handleBrush);
 
         AddLine(selLeft, 0, selRight, 0, handleBrush, 0.5);
         AddLine(selLeft, h, selRight, h, handleBrush, 0.5);
@@ -397,12 +401,16 @@ public partial class TimeRangeSlicerControl : UserControl
         {
             var selLeft = _rangeStart * w;
             var selRight = _rangeEnd * w;
-            if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx || Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
-                SlicerCanvas.Cursor = Cursors.SizeWE;
+            HandleHover newHover = HandleHover.None;
+            if (Math.Abs(pos.X - selLeft) <= HandleGripWidthPx)
+            { SlicerCanvas.Cursor = Cursors.SizeWE; newHover = HandleHover.Start; }
+            else if (Math.Abs(pos.X - selRight) <= HandleGripWidthPx)
+            { SlicerCanvas.Cursor = Cursors.SizeWE; newHover = HandleHover.End; }
             else if (pos.X >= selLeft && pos.X <= selRight)
                 SlicerCanvas.Cursor = Cursors.SizeAll;
             else
                 SlicerCanvas.Cursor = Cursors.Arrow;
+            if (newHover != _hoveredHandle) { _hoveredHandle = newHover; Redraw(); }
             return;
         }
 
@@ -429,6 +437,15 @@ public partial class TimeRangeSlicerControl : UserControl
         UpdateRangeLabel();
         Redraw();
         e.Handled = true;
+    }
+
+    private void Canvas_MouseLeave(object sender, MouseEventArgs e)
+    {
+        if (_dragMode == DragMode.None && _hoveredHandle != HandleHover.None)
+        {
+            _hoveredHandle = HandleHover.None;
+            Redraw();
+        }
     }
 
     private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -1271,6 +1271,7 @@
     <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#99000000"/>
     <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#22FFFFFF"/>
     <SolidColorBrush x:Key="SlicerHandleBrush" Color="#E4E6EB"/>
+    <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="#2EAEF1"/>
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="SlicerLabelBrush" Color="#E4E6EB"/>
     <SolidColorBrush x:Key="SlicerToggleBrush" Color="#E4E6EB"/>

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -106,9 +106,8 @@ public partial class ProcedureHistoryWindow : Window
         var ys = _historyData.Select(r => GetMetricValue(r, tag)).ToArray();
 
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
-        scatter.LineWidth = 2;
-        scatter.MarkerSize = 5;
         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+        ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Windows;
@@ -107,7 +108,7 @@ public partial class ProcedureHistoryWindow : Window
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
         scatter.LineWidth = 2;
         scatter.MarkerSize = 5;
-        scatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -129,37 +129,7 @@ public partial class ProcedureHistoryWindow : Window
 
     private void MetricSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) { if (IsLoaded) UpdateChart(); }
 
-    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart)
-    {
-        ScottPlot.Color figureBackground, dataBackground, textColor, gridColor;
-        if (ThemeManager.CurrentTheme == "CoolBreeze")
-        {
-            figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-            dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-            textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else if (ThemeManager.HasLightBackground)
-        {
-            figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-            dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-            textColor        = ScottPlot.Color.FromHex("#1A1D23");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else
-        {
-            figureBackground = ScottPlot.Color.FromHex("#22252b");
-            dataBackground   = ScottPlot.Color.FromHex("#111217");
-            textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-            gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-        }
-        chart.Plot.FigureBackground.Color = figureBackground;
-        chart.Plot.DataBackground.Color = dataBackground;
-        chart.Plot.Axes.Color(textColor);
-        chart.Plot.Grid.MajorLineColor = gridColor;
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-    }
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
 
     private void OnThemeChanged(string _)
     {

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -188,37 +188,7 @@ public partial class QueryStatsHistoryWindow : Window
         }
     }
 
-    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart)
-    {
-        ScottPlot.Color figureBackground, dataBackground, textColor, gridColor;
-        if (ThemeManager.CurrentTheme == "CoolBreeze")
-        {
-            figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-            dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-            textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else if (ThemeManager.HasLightBackground)
-        {
-            figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-            dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-            textColor        = ScottPlot.Color.FromHex("#1A1D23");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else
-        {
-            figureBackground = ScottPlot.Color.FromHex("#22252b");
-            dataBackground   = ScottPlot.Color.FromHex("#111217");
-            textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-            gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-        }
-        chart.Plot.FigureBackground.Color = figureBackground;
-        chart.Plot.DataBackground.Color = dataBackground;
-        chart.Plot.Axes.Color(textColor);
-        chart.Plot.Grid.MajorLineColor = gridColor;
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-    }
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
 
     private void OnThemeChanged(string _)
     {

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Windows;
@@ -106,7 +107,7 @@ public partial class QueryStatsHistoryWindow : Window
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
         scatter.LineWidth = 2;
         scatter.MarkerSize = 5;
-        scatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -105,9 +105,8 @@ public partial class QueryStatsHistoryWindow : Window
         var ys = _historyData.Select(r => GetMetricValue(r, tag)).ToArray();
 
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
-        scatter.LineWidth = 2;
-        scatter.MarkerSize = 5;
         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+        ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -108,9 +108,8 @@ public partial class QueryStoreHistoryWindow : Window
         var ys = _historyData.Select(r => GetMetricValue(r, tag)).ToArray();
 
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
-        scatter.LineWidth = 2;
-        scatter.MarkerSize = 5;
         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+        ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -169,37 +169,7 @@ public partial class QueryStoreHistoryWindow : Window
         }
     }
 
-    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart)
-    {
-        ScottPlot.Color figureBackground, dataBackground, textColor, gridColor;
-        if (ThemeManager.CurrentTheme == "CoolBreeze")
-        {
-            figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-            dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-            textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else if (ThemeManager.HasLightBackground)
-        {
-            figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-            dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-            textColor        = ScottPlot.Color.FromHex("#1A1D23");
-            gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-        }
-        else
-        {
-            figureBackground = ScottPlot.Color.FromHex("#22252b");
-            dataBackground   = ScottPlot.Color.FromHex("#111217");
-            textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-            gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-        }
-        chart.Plot.FigureBackground.Color = figureBackground;
-        chart.Plot.DataBackground.Color = dataBackground;
-        chart.Plot.Axes.Color(textColor);
-        chart.Plot.Grid.MajorLineColor = gridColor;
-        chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-        chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-    }
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
 
     private void OnThemeChanged(string _)
     {

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using Microsoft.Win32;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Windows;
@@ -109,7 +110,7 @@ public partial class QueryStoreHistoryWindow : Window
         var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
         scatter.LineWidth = 2;
         scatter.MarkerSize = 5;
-        scatter.Color = ScottPlot.Color.FromHex("#4FC3F7");
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
         scatter.LegendText = label;
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -61,6 +61,11 @@ namespace PerformanceMonitor.Common
                 ["MemoryGrants"]  = "#FFB74D", // Granted memory MB
                 ["OtherCpu"]          = "#E57373", // Other (non-SQL) process CPU %
                 ["TotalServerMemory"] = "#4FC3F7", // Total server memory GB
+                ["Blocking"]          = "#FFB74D", // blocking count / incidents
+                ["BlockingDuration"]  = "#FF7043", // total blocking duration
+                ["Deadlocks"]         = "#E57373", // deadlock count
+                ["DeadlockWaitTime"]  = "#BA68C8", // total deadlock wait time
+                ["BlockedSessions"]   = "#EF9A9A", // blocked session count
                 ["ReadLatency"]   = "#4DD0E1", // Avg read latency ms
                 ["WriteLatency"]  = "#F06292", // Avg write latency ms
                 ["Reads"]         = "#4DD0E1", // Logical/physical reads

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -105,6 +105,7 @@ namespace PerformanceMonitor.Common
                 ["Tran Log IO"]      = "#0984E3",
                 ["Network IO"]       = "#75BBF8",
                 ["Parallelism"]      = "#7B4FFF",
+                ["Batch Mode"]       = "#00CEC9",
                 ["Memory"]           = "#FDCB6E",
                 ["Tracing"]          = "#B2BEC3",
                 ["Full Text Search"] = "#DFE6E9",
@@ -149,13 +150,20 @@ namespace PerformanceMonitor.Common
 
             bool Starts(string p) => w.StartsWith(p, StringComparison.Ordinal);
 
-            // Parallelism (exchange / bitmap / hash-build), incl. the CX* family
-            if (Starts("CXPACKET") || Starts("CXCONSUMER") || Starts("CXSYNC_") || Starts("EXCHANGE") ||
-                Starts("HTBUILD") || Starts("HTREPARTITION") || Starts("HTDELETE") || Starts("HTMEMO") ||
-                Starts("BMPBUILD") || Starts("BMPREPARTITION") || Starts("BMPALLOCATION") || Starts("BPSORT"))
+            // Parallelism — exchange-iterator / CX* family (genuine parallel-plan exchange waits).
+            if (Starts("CXPACKET") || Starts("CXCONSUMER") || Starts("CXSYNC_") || Starts("EXCHANGE"))
                 return "Parallelism";
 
-            if (w == "SOS_SCHEDULER_YIELD" || w == "SOS_WORK_DISPATCHER")
+            // Batch mode — hash-table / bitmap-filter / batch-sort operator waits (verified vs SQLskills
+            // + sys.dm_os_wait_stats docs). BMPALLOCATION IS documented (MS docs: batch-mode bitmap
+            // allocation) even though SQLskills' page is a stub, so it belongs here with its siblings.
+            if (Starts("HTBUILD") || Starts("HTREPARTITION") || Starts("HTDELETE") || Starts("HTMEMO") ||
+                Starts("BMPBUILD") || Starts("BMPREPARTITION") || Starts("BMPALLOCATION") || Starts("BPSORT"))
+                return "Batch Mode";
+
+            // SOS_WORK_DISPATCHER is deliberately NOT classified as CPU: it is an idle/benign
+            // "waiting for something to do" wait (per SQLskills), not CPU pressure -> falls to Unknown.
+            if (w == "SOS_SCHEDULER_YIELD")
                 return "CPU";
 
             if (w == "THREADPOOL")
@@ -189,7 +197,7 @@ namespace PerformanceMonitor.Common
                 return "Memory";
 
             if (w == "ASYNC_NETWORK_IO" || w == "NET_WAITFOR_PACKET" || w == "PROXY_NETWORK_IO" ||
-                w == "EXTERNAL_SCRIPT_NETWORK_IOF")
+                w == "EXTERNAL_SCRIPT_NETWORK_IO")
                 return "Network IO";
 
             if (Starts("SQLCLR") || Starts("CLR_"))
@@ -207,7 +215,9 @@ namespace PerformanceMonitor.Common
             if (Starts("FT_") || Starts("FULLTEXT") || Starts("MSSEARCH"))
                 return "Full Text Search";
 
-            if (Starts("DTC") || Starts("XACT") || Starts("TRANSACTION_") || w == "MSQL_XP")
+            // MSQL_XP is NOT here: it's an extended-stored-procedure wait (per SQLskills), unrelated
+            // to transactions -> falls through to Unknown.
+            if (Starts("DTC") || Starts("XACT") || Starts("TRANSACTION_"))
                 return "Transaction";
 
             if (Starts("TRACE") || Starts("SQLTRACE") || w == "QUERY_TRACEOUT")

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// The single, app-agnostic source of truth for chart COLOR IDENTITY — which color means what
+    /// across Dashboard and Lite. Lives in Common (no ScottPlot / WPF dependency) and therefore
+    /// returns plain hex strings; callers wrap with <c>ScottPlot.Color.FromHex(...)</c> or WPF
+    /// <c>ColorConverter.ConvertFromString(...)</c> as needed (both already used throughout).
+    ///
+    /// Four resolvers, by the rule that keeps both apps consistent:
+    ///   - <see cref="SeriesColor"/>  : a fixed, enumerable-meaning data series (Buffer Pool, SQL CPU, …).
+    ///   - <see cref="AccentColor"/>  : thresholds / pressure-zones / anomaly accents.
+    ///   - <see cref="WaitColor"/>    : a value in the wait taxonomy (use with <see cref="WaitCategory"/>).
+    ///   - <see cref="CyclingColor"/> : an unbounded / data-driven member set (per-DB, per-plan, wait-type
+    ///                                  lists) — assign by a STABLE index (e.g. sorted-key position).
+    ///
+    /// Series/category colors are intentionally CONSTANT across themes; the only per-theme variation is
+    /// a light/CoolBreeze override for the few wait colors that are near-invisible on a light background
+    /// (see <see cref="WaitColor"/>'s <c>lightBackground</c> parameter).
+    /// </summary>
+    public static class ChartPalette
+    {
+        // ── Cycling palette (Material Design 300/200) — for arbitrary, data-driven series ──
+        // Ported from Dashboard's ChartColors so both apps share one ordering (Lite's old
+        // SeriesColors was reordered + swapped #FFD54F<->#90A4AE, which broke cross-app parity).
+        private static readonly string[] Cycling =
+        {
+            "#4FC3F7", "#81C784", "#FFB74D", "#E57373", "#BA68C8",
+            "#4DD0E1", "#FFF176", "#F06292", "#AED581", "#90A4AE",
+            "#A1887F", "#7986CB", "#FF7043", "#80DEEA", "#FFE082",
+            "#CE93D8", "#EF9A9A", "#C5E1A5", "#FFCC80", "#B0BEC5",
+        };
+
+        /// <summary>Stable cycling color for index <paramref name="index"/> (wraps the palette).</summary>
+        public static string CyclingColor(int index)
+            => Cycling[((index % Cycling.Length) + Cycling.Length) % Cycling.Length];
+
+        // ── Fixed-meaning data series ──────────────────────────────────────────────────────
+        // Defines ONE color per named series, applied identically in both apps. This is the fix
+        // for "Buffer Pool is three different colors today" (green in Lite, blue and purple in two
+        // Dashboard charts). Unknown names fall back to stable cycling.
+        private static readonly Dictionary<string, string> Series =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SqlCpu"]        = "#4FC3F7", // SQL Server CPU %
+                ["TotalCpu"]      = "#FF7043", // Total (non-idle) CPU %
+                ["BufferPool"]    = "#81C784", // Buffer pool MB
+                ["MemoryGrants"]  = "#FFB74D", // Granted memory MB
+                ["ReadLatency"]   = "#4DD0E1", // Avg read latency ms
+                ["WriteLatency"]  = "#F06292", // Avg write latency ms
+                ["Reads"]         = "#4DD0E1", // Logical/physical reads
+                ["Writes"]        = "#F06292", // Logical/physical writes
+                ["Duration"]      = "#4FC3F7", // Elapsed/duration
+                ["Executions"]    = "#AED581", // Execution count
+            };
+
+        /// <summary>Color for a fixed-meaning series (e.g. "BufferPool"); falls back to cycling.</summary>
+        public static string SeriesColor(string name)
+            => Series.TryGetValue(name, out var hex) ? hex : CyclingColor(StableIndex(name));
+
+        // ── Accents: thresholds, pressure zones, anomaly markers ───────────────────────────
+        private static readonly Dictionary<string, string> Accents =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Threshold"]      = "#FFD54F", // generic threshold / target line (yellow)
+                ["PressureMedium"] = "#FFB74D", // medium pressure zone (orange)
+                ["PressureSevere"] = "#E57373", // severe pressure zone (red)
+                ["Anomaly"]        = "#FF7043", // anomaly dot
+                ["Average"]        = "#FFD54F", // mean / average line
+            };
+
+        /// <summary>Color for a threshold / pressure-zone / anomaly accent.</summary>
+        public static string AccentColor(string name)
+            => Accents.TryGetValue(name, out var hex) ? hex : "#B0BEC5";
+
+        // ── Wait categories ────────────────────────────────────────────────────────────────
+        // PerformanceStudio's ~21 semantic wait-category colors (Themes/DarkTheme.axaml). Constant
+        // across themes EXCEPT the handful flagged near-invisible on a light background, which get a
+        // darker variant when lightBackground = true (D3).
+        private static readonly Dictionary<string, string> WaitCategoryColors =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["CPU"]              = "#00BD23",
+                ["Worker Thread"]    = "#52E3B5",
+                ["Lock"]             = "#EE5A24",
+                ["Latch"]            = "#F368E0",
+                ["Buffer Latch"]     = "#F5069E",
+                ["Buffer IO"]        = "#2D13F2",
+                ["Compilation"]      = "#A29BFE",
+                ["SQL CLR"]          = "#B8DCDC",
+                ["Mirroring"]        = "#54625F",
+                ["Transaction"]      = "#C77416",
+                ["Preemptive"]       = "#FD79A8",
+                ["Service Broker"]   = "#E17055",
+                ["Tran Log IO"]      = "#0984E3",
+                ["Network IO"]       = "#75BBF8",
+                ["Parallelism"]      = "#7B4FFF",
+                ["Memory"]           = "#FDCB6E",
+                ["Tracing"]          = "#B2BEC3",
+                ["Full Text Search"] = "#DFE6E9",
+                ["Other Disk IO"]    = "#636E72",
+                ["Replication"]      = "#81ECEC",
+                ["Log Rate Governor"]= "#FAB1A0",
+                ["Unknown"]          = "#8E8E93",
+                ["Others"]           = "#555D66",
+            };
+
+        // Darker variants for the three categories that are near-invisible on light/CoolBreeze
+        // backgrounds (D3). Only consulted when lightBackground = true.
+        private static readonly Dictionary<string, string> WaitCategoryColorsLight =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SQL CLR"]          = "#5BA3A3", // was #B8DCDC
+                ["Full Text Search"] = "#8FA3AB", // was #DFE6E9
+                ["Replication"]      = "#1FA8A8", // was #81ECEC
+            };
+
+        /// <summary>Color for a wait category. Pass lightBackground=true on Light/CoolBreeze themes.</summary>
+        public static string WaitColor(string category, bool lightBackground = false)
+        {
+            if (lightBackground && WaitCategoryColorsLight.TryGetValue(category, out var light))
+                return light;
+            return WaitCategoryColors.TryGetValue(category, out var hex) ? hex : WaitCategoryColors["Others"];
+        }
+
+        /// <summary>
+        /// Classifies a raw wait_type into one of the wait categories above. A CURATED mapping of
+        /// the wait types that actually surface in query / DMV wait stats — NOT the full SQL Server
+        /// internal table — following SQL Server's own categorization (so CXPACKET is Parallelism,
+        /// not CPU, etc.). Anything unrecognized returns "Unknown".
+        /// REVIEW NOTE: wait categorization is opinionated; tune to taste.
+        /// </summary>
+        public static string WaitCategory(string? waitType)
+        {
+            if (string.IsNullOrEmpty(waitType))
+                return "Unknown";
+
+            var w = waitType.ToUpperInvariant();
+
+            bool Starts(string p) => w.StartsWith(p, StringComparison.Ordinal);
+
+            // Parallelism (exchange / bitmap / hash-build), incl. the CX* family
+            if (Starts("CXPACKET") || Starts("CXCONSUMER") || Starts("CXSYNC_") || Starts("EXCHANGE") ||
+                Starts("HTBUILD") || Starts("HTREPARTITION") || Starts("HTDELETE") || Starts("HTMEMO") ||
+                Starts("BMPBUILD") || Starts("BMPREPARTITION") || Starts("BMPALLOCATION") || Starts("BPSORT"))
+                return "Parallelism";
+
+            if (w == "SOS_SCHEDULER_YIELD" || w == "SOS_WORK_DISPATCHER")
+                return "CPU";
+
+            if (w == "THREADPOOL")
+                return "Worker Thread";
+
+            if (Starts("LCK_M_"))
+                return "Lock";
+
+            if (Starts("PAGEIOLATCH_"))
+                return "Buffer IO";
+
+            if (Starts("PAGELATCH_"))
+                return "Buffer Latch";
+
+            if (Starts("LATCH_"))
+                return "Latch";
+
+            if (w == "WRITELOG" || Starts("LOGBUFFER") || Starts("LOGMGR") || Starts("LOG_RATE"))
+                return w.Contains("RATE", StringComparison.Ordinal) ? "Log Rate Governor" : "Tran Log IO";
+
+            if (Starts("POOL_LOG_RATE_GOVERNOR") || Starts("INSTANCE_LOG_RATE_GOVERNOR") || Starts("LOG_RATE_GOVERNOR"))
+                return "Log Rate Governor";
+
+            if (w == "IO_COMPLETION" || w == "ASYNC_IO_COMPLETION" || Starts("BACKUPIO") ||
+                w == "IO_QUEUE_LIMIT" || w == "IO_RETRY" || Starts("DISKIO"))
+                return "Other Disk IO";
+
+            if (w == "RESOURCE_SEMAPHORE" || w == "RESOURCE_SEMAPHORE_QUERY_COMPILE" ||
+                w == "CMEMTHREAD" || Starts("MEMORY_ALLOCATION") || Starts("RESERVED_MEMORY") ||
+                w == "RESOURCE_SEMAPHORE_SMALL_QUERY")
+                return "Memory";
+
+            if (w == "ASYNC_NETWORK_IO" || w == "NET_WAITFOR_PACKET" || w == "PROXY_NETWORK_IO" ||
+                w == "EXTERNAL_SCRIPT_NETWORK_IOF")
+                return "Network IO";
+
+            if (Starts("SQLCLR") || Starts("CLR_"))
+                return "SQL CLR";
+
+            if (Starts("DBMIRROR") || Starts("MIRROR_"))
+                return "Mirroring";
+
+            if (Starts("REPL_") || Starts("REPLICA_") || Starts("PUB_"))
+                return "Replication";
+
+            if (Starts("BROKER_") || Starts("SERVICE_BROKER") || Starts("SSB"))
+                return "Service Broker";
+
+            if (Starts("FT_") || Starts("FULLTEXT") || Starts("MSSEARCH"))
+                return "Full Text Search";
+
+            if (Starts("DTC") || Starts("XACT") || Starts("TRANSACTION_") || w == "MSQL_XP")
+                return "Transaction";
+
+            if (Starts("TRACE") || Starts("SQLTRACE") || w == "QUERY_TRACEOUT")
+                return "Tracing";
+
+            if (Starts("PREEMPTIVE_"))
+                return "Preemptive";
+
+            return "Unknown";
+        }
+
+        private static int StableIndex(string key)
+        {
+            // Deterministic non-negative hash so an unmapped name keeps the same cycling color.
+            unchecked
+            {
+                int h = 17;
+                foreach (var ch in key) h = h * 31 + ch;
+                return h & 0x7FFFFFFF;
+            }
+        }
+    }
+}

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -61,6 +61,7 @@ namespace PerformanceMonitor.Common
                 ["MemoryGrants"]  = "#FFB74D", // Granted memory MB
                 ["OtherCpu"]          = "#E57373", // Other (non-SQL) process CPU %
                 ["TotalServerMemory"] = "#4FC3F7", // Total server memory GB
+                ["TargetMemory"]      = "#808080", // Target server memory (dashed grey reference line)
                 ["Blocking"]          = "#FFB74D", // blocking count / incidents
                 ["BlockingDuration"]  = "#FF7043", // total blocking duration
                 ["Deadlocks"]         = "#E57373", // deadlock count
@@ -84,6 +85,11 @@ namespace PerformanceMonitor.Common
                 ["TotalMemory"]       = "#90A4AE",
                 ["CacheMemory"]       = "#81C784",
                 ["AvailableMemory"]   = "#FFB74D",
+                // Memory pressure event severity (stacked event-count bars; SQL = orange family, OS = red family)
+                ["SqlPressureMedium"] = "#FFB74D",
+                ["SqlPressureSevere"] = "#E65100",
+                ["OsPressureMedium"]  = "#E57373",
+                ["OsPressureSevere"]  = "#B71C1C",
                 // Plan cache size buckets
                 ["SinglePagePlans"]   = "#E57373",
                 ["MultiPagePlans"]    = "#81C784",
@@ -118,6 +124,7 @@ namespace PerformanceMonitor.Common
                 ["BaselineCpu"]      = "#4FC3F7", // CPU-lane baseline band / mean tint
                 ["BaselineBlocking"] = "#E57373", // blocking-lane baseline band / mean tint
                 ["Crosshair"]        = "#FFFFFF", // correlated-charts crosshair vline
+                ["GhostLine"]        = "#FFFFFF", // comparison-overlay ghost line (rendered semi-transparent)
                 ["Placeholder"]      = "#888888", // no-data placeholder line
             };
 

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -56,6 +56,8 @@ namespace PerformanceMonitor.Common
                 ["TotalCpu"]      = "#FF7043", // Total (non-idle) CPU %
                 ["BufferPool"]    = "#81C784", // Buffer pool MB
                 ["MemoryGrants"]  = "#FFB74D", // Granted memory MB
+                ["OtherCpu"]          = "#E57373", // Other (non-SQL) process CPU %
+                ["TotalServerMemory"] = "#4FC3F7", // Total server memory GB
                 ["ReadLatency"]   = "#4DD0E1", // Avg read latency ms
                 ["WriteLatency"]  = "#F06292", // Avg write latency ms
                 ["Reads"]         = "#4DD0E1", // Logical/physical reads

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -71,7 +71,35 @@ namespace PerformanceMonitor.Common
                 ["Reads"]         = "#4DD0E1", // Logical/physical reads
                 ["Writes"]        = "#F06292", // Logical/physical writes
                 ["Duration"]      = "#4FC3F7", // Elapsed/duration
-                ["Executions"]    = "#AED581", // Execution count
+                ["Executions"]    = "#BA68C8", // Execution count
+                // Session states (co-occur in the Sessions chart)
+                ["SessionTotal"]      = "#4FC3F7",
+                ["SessionRunning"]    = "#81C784",
+                ["SessionSleeping"]   = "#FFB74D",
+                ["SessionBackground"] = "#BA68C8",
+                ["SessionDormant"]    = "#4DD0E1",
+                ["SessionIdle"]       = "#90A4AE",
+                ["SessionWaiting"]    = "#E57373",
+                // Memory overview (total / plan cache / available)
+                ["TotalMemory"]       = "#90A4AE",
+                ["CacheMemory"]       = "#81C784",
+                ["AvailableMemory"]   = "#FFB74D",
+                // Plan cache size buckets
+                ["SinglePagePlans"]   = "#E57373",
+                ["MultiPagePlans"]    = "#81C784",
+                // Tempdb object types
+                ["UserObjects"]       = "#4FC3F7",
+                ["VersionStore"]      = "#81C784",
+                ["InternalObjects"]   = "#FFB74D",
+                ["UnallocatedTempdb"] = "#90A4AE",
+                ["TopTempdbTask"]     = "#E57373",
+                // Duration trend charts (history windows / per-type)
+                ["QueryDuration"]     = "#4FC3F7",
+                ["ProcedureDuration"] = "#81C784",
+                ["QueryStoreDuration"]= "#FFB74D",
+                ["MetricTrend"]       = "#4FC3F7", // generic single-metric history trend
+                ["LockWaits"]         = "#4FC3F7",
+                ["CurrentWaits"]      = "#4FC3F7",
             };
 
         /// <summary>Color for a fixed-meaning series (e.g. "BufferPool"); falls back to cycling.</summary>
@@ -85,8 +113,12 @@ namespace PerformanceMonitor.Common
                 ["Threshold"]      = "#FFD54F", // generic threshold / target line (yellow)
                 ["PressureMedium"] = "#FFB74D", // medium pressure zone (orange)
                 ["PressureSevere"] = "#E57373", // severe pressure zone (red)
-                ["Anomaly"]        = "#FF7043", // anomaly dot
+                ["Anomaly"]        = "#FF5252", // anomaly dot
                 ["Average"]        = "#FFD54F", // mean / average line
+                ["BaselineCpu"]      = "#4FC3F7", // CPU-lane baseline band / mean tint
+                ["BaselineBlocking"] = "#E57373", // blocking-lane baseline band / mean tint
+                ["Crosshair"]        = "#FFFFFF", // correlated-charts crosshair vline
+                ["Placeholder"]      = "#888888", // no-data placeholder line
             };
 
         /// <summary>Color for a threshold / pressure-zone / anomaly accent.</summary>

--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -45,6 +45,9 @@ namespace PerformanceMonitor.Common
         public static string CyclingColor(int index)
             => Cycling[((index % Cycling.Length) + Cycling.Length) % Cycling.Length];
 
+        /// <summary>The raw cycling palette (hex), for callers that build their own color arrays.</summary>
+        public static IReadOnlyList<string> CyclingPalette => Cycling;
+
         // ── Fixed-meaning data series ──────────────────────────────────────────────────────
         // Defines ONE color per named series, applied identically in both apps. This is the fix
         // for "Buffer Pool is three different colors today" (green in Lite, blue and purple in two

--- a/PerformanceMonitor.Ui/BarChartCell.xaml
+++ b/PerformanceMonitor.Ui/BarChartCell.xaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="PerformanceMonitor.Ui.BarChartCell"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <!--
+      In-grid sparkline cell: a right-aligned value over a thin proportional fill bar
+      (bar length = Value / Maximum, where Maximum is the column max supplied by the host).
+      The fill uses star-sized grid columns so it scales with the cell width and needs no
+      width math or OS ProgressBar chrome. Accent color switches when this column is the
+      active sort. Ported from PerformanceStudio's BarChartCell.
+    -->
+    <Grid Margin="6,2,6,3">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="4"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="{Binding Text, ElementName=Root}"
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Center"/>
+
+        <Border Grid.Row="1"
+                Background="{Binding TrackBrush, ElementName=Root}"
+                CornerRadius="2">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="{Binding FillWidth, ElementName=Root}"/>
+                    <ColumnDefinition Width="{Binding RestWidth, ElementName=Root}"/>
+                </Grid.ColumnDefinitions>
+                <Rectangle Grid.Column="0"
+                           Fill="{Binding EffectiveBarBrush, ElementName=Root}"
+                           RadiusX="2" RadiusY="2"/>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/PerformanceMonitor.Ui/BarChartCell.xaml.cs
+++ b/PerformanceMonitor.Ui/BarChartCell.xaml.cs
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// In-grid sparkline cell: a right-aligned value over a thin proportional fill bar.
+    /// The bar length is <c>Value / Maximum</c>, where <see cref="Maximum"/> is the column max
+    /// supplied by the host (so every bar in a column is relative to that column's largest value).
+    /// The fill is rendered with star-sized grid columns, so it scales with the cell width with no
+    /// width math or OS ProgressBar chrome. When <see cref="IsActiveSort"/> is true the bar uses
+    /// <see cref="AccentBrush"/> instead of <see cref="BarBrush"/>. Shared by both apps (lives in
+    /// .Ui) so the in-grid bars can't drift. Ported from PerformanceStudio's BarChartCell.
+    /// </summary>
+    public partial class BarChartCell : UserControl, INotifyPropertyChanged
+    {
+        public BarChartCell()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>The numeric value this cell represents (drives the bar length and, by default, the text).</summary>
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value), typeof(double), typeof(BarChartCell),
+            new PropertyMetadata(0.0, OnFillChanged));
+        public double Value
+        {
+            get => (double)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+
+        /// <summary>The column maximum: the bar fills to <c>Value / Maximum</c>. Supplied by the host.</summary>
+        public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register(
+            nameof(Maximum), typeof(double), typeof(BarChartCell),
+            new PropertyMetadata(1.0, OnFillChanged));
+        public double Maximum
+        {
+            get => (double)GetValue(MaximumProperty);
+            set => SetValue(MaximumProperty, value);
+        }
+
+        /// <summary>The text shown above the bar (host-formatted so units/precision stay the host's call).</summary>
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+            nameof(Text), typeof(string), typeof(BarChartCell),
+            new PropertyMetadata(string.Empty));
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        /// <summary>When true, the bar uses <see cref="AccentBrush"/> (this column is the active sort).</summary>
+        public static readonly DependencyProperty IsActiveSortProperty = DependencyProperty.Register(
+            nameof(IsActiveSort), typeof(bool), typeof(BarChartCell),
+            new PropertyMetadata(false, OnBrushChanged));
+        public bool IsActiveSort
+        {
+            get => (bool)GetValue(IsActiveSortProperty);
+            set => SetValue(IsActiveSortProperty, value);
+        }
+
+        /// <summary>The normal bar color.</summary>
+        public static readonly DependencyProperty BarBrushProperty = DependencyProperty.Register(
+            nameof(BarBrush), typeof(Brush), typeof(BarChartCell),
+            new PropertyMetadata(MakeFrozen("#5B8DB8"), OnBrushChanged));
+        public Brush BarBrush
+        {
+            get => (Brush)GetValue(BarBrushProperty);
+            set => SetValue(BarBrushProperty, value);
+        }
+
+        /// <summary>The bar color used when this column is the active sort.</summary>
+        public static readonly DependencyProperty AccentBrushProperty = DependencyProperty.Register(
+            nameof(AccentBrush), typeof(Brush), typeof(BarChartCell),
+            new PropertyMetadata(MakeFrozen("#4FC3F7"), OnBrushChanged));
+        public Brush AccentBrush
+        {
+            get => (Brush)GetValue(AccentBrushProperty);
+            set => SetValue(AccentBrushProperty, value);
+        }
+
+        /// <summary>The unfilled-track color behind the bar (default transparent).</summary>
+        public static readonly DependencyProperty TrackBrushProperty = DependencyProperty.Register(
+            nameof(TrackBrush), typeof(Brush), typeof(BarChartCell),
+            new PropertyMetadata(Brushes.Transparent));
+        public Brush TrackBrush
+        {
+            get => (Brush)GetValue(TrackBrushProperty);
+            set => SetValue(TrackBrushProperty, value);
+        }
+
+        // ── Computed, INPC-bound layout/color ──────────────────────────────────────────────
+        public GridLength FillWidth { get; private set; } = new GridLength(0, GridUnitType.Star);
+        public GridLength RestWidth { get; private set; } = new GridLength(1, GridUnitType.Star);
+        public Brush EffectiveBarBrush => IsActiveSort ? AccentBrush : BarBrush;
+
+        private static void OnFillChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            => ((BarChartCell)d).RecomputeFill();
+
+        private static void OnBrushChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            => ((BarChartCell)d).OnPropertyChanged(nameof(EffectiveBarBrush));
+
+        private void RecomputeFill()
+        {
+            double ratio = Maximum > 0 ? Math.Clamp(Value / Maximum, 0.0, 1.0) : 0.0;
+            FillWidth = new GridLength(ratio, GridUnitType.Star);
+            // Keep a sliver of "rest" even at full so the star math never collapses to 0/0.
+            RestWidth = new GridLength(Math.Max(1.0 - ratio, 0.0001), GridUnitType.Star);
+            OnPropertyChanged(nameof(FillWidth));
+            OnPropertyChanged(nameof(RestWidth));
+        }
+
+        private static Brush MakeFrozen(string hex)
+        {
+            var b = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+            b.Freeze();
+            return b;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string name)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/PerformanceMonitor.Ui/ChartStyle.cs
+++ b/PerformanceMonitor.Ui/ChartStyle.cs
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Media;
+using ScottPlot.WPF;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// Shared CHROME styling for ScottPlot charts — the single source of truth for chart
+    /// theming across Dashboard and Lite. "Chrome" = figure/data backgrounds, axis + grid +
+    /// legend colors, tick label colors/sizes, and axis-mechanics helpers. It deliberately does
+    /// NOT own series/category COLOR IDENTITY (that is a separate concern; see ChartPalette).
+    ///
+    /// Theme colors read <see cref="ThemeManager.CurrentTheme"/> (Dark / Light / CoolBreeze).
+    /// </summary>
+    public static class ChartStyle
+    {
+        /// <summary>
+        /// Applies the current color theme (chrome only) to a ScottPlot chart.
+        /// </summary>
+        public static void ApplyThemeToChart(WpfPlot chart)
+        {
+            ScottPlot.Color figureBackground, dataBackground, textColor, gridColor, legendBg, legendFg, legendOutline;
+
+            if (ThemeManager.CurrentTheme == "CoolBreeze")
+            {
+                figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
+                dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
+                textColor        = ScottPlot.Color.FromHex("#1A2A3A");
+                gridColor        = ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120);
+                legendBg         = ScottPlot.Color.FromHex("#EEF4FA");
+                legendFg         = ScottPlot.Color.FromHex("#1A2A3A");
+                legendOutline    = ScottPlot.Color.FromHex("#A8BDD0");
+            }
+            else if (ThemeManager.HasLightBackground)
+            {
+                figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
+                dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
+                textColor        = ScottPlot.Color.FromHex("#1A1D23");
+                gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
+                legendBg         = ScottPlot.Color.FromHex("#FFFFFF");
+                legendFg         = ScottPlot.Color.FromHex("#1A1D23");
+                legendOutline    = ScottPlot.Color.FromHex("#DEE2E6");
+            }
+            else
+            {
+                figureBackground = ScottPlot.Color.FromHex("#22252b");
+                dataBackground   = ScottPlot.Color.FromHex("#111217");
+                textColor        = ScottPlot.Color.FromHex("#E4E6EB");
+                gridColor        = ScottPlot.Colors.White.WithAlpha(40);
+                legendBg         = ScottPlot.Color.FromHex("#22252b");
+                legendFg         = ScottPlot.Color.FromHex("#E4E6EB");
+                legendOutline    = ScottPlot.Color.FromHex("#2a2d35");
+            }
+
+            chart.Plot.FigureBackground.Color = figureBackground;
+            chart.Plot.DataBackground.Color = dataBackground;
+            chart.Plot.Axes.Color(textColor);
+            chart.Plot.Grid.MajorLineColor = gridColor;
+            chart.Plot.Legend.BackgroundColor = legendBg;
+            chart.Plot.Legend.FontColor = legendFg;
+            chart.Plot.Legend.OutlineColor = legendOutline;
+            chart.Plot.Legend.Alignment = ScottPlot.Alignment.LowerCenter;
+            chart.Plot.Legend.Orientation = ScottPlot.Orientation.Horizontal;
+            chart.Plot.Axes.Margins(bottom: 0); // No bottom margin - SetChartYLimitsWithLegendPadding handles Y-axis
+
+            // Explicitly set axis tick label colors (needed after DateTimeTicksBottom() is called)
+            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
+            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
+            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
+            chart.Plot.Axes.Left.Label.ForeColor = textColor;
+            chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
+            chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
+
+            // Set the WPF control Background to match so no white flash appears before ScottPlot's render loop fires
+            chart.Background = new SolidColorBrush(Color.FromRgb(figureBackground.R, figureBackground.G, figureBackground.B));
+
+            // Ensure ScottPlot renders with the correct colors the very first time it gets pixel dimensions.
+            // Without this, ScottPlot's first auto-render (triggered by SizeChanged) would show a white canvas
+            // before our FigureBackground color takes visual effect.
+            chart.Loaded -= HandleChartFirstLoaded;
+            if (!chart.IsLoaded)
+                chart.Loaded += HandleChartFirstLoaded;
+        }
+
+        private static void HandleChartFirstLoaded(object sender, RoutedEventArgs e)
+        {
+            var chart = (WpfPlot)sender;
+            chart.Loaded -= HandleChartFirstLoaded;
+            chart.Refresh();
+        }
+
+        /// <summary>
+        /// Reapplies theme-appropriate text colors (and font sizes) to chart axes.
+        /// Call this AFTER DateTimeTicksBottom() or other axis modifications that reset them.
+        /// </summary>
+        public static void ReapplyAxisColors(WpfPlot chart)
+        {
+            var textColor = ThemeManager.CurrentTheme == "CoolBreeze"
+                ? ScottPlot.Color.FromHex("#1A2A3A")
+                : ThemeManager.HasLightBackground
+                    ? ScottPlot.Color.FromHex("#1A1D23")
+                    : ScottPlot.Color.FromHex("#E4E6EB");
+            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
+            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
+            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
+            chart.Plot.Axes.Left.Label.ForeColor = textColor;
+            chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
+            chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
+        }
+    }
+}

--- a/PerformanceMonitor.Ui/ChartStyle.cs
+++ b/PerformanceMonitor.Ui/ChartStyle.cs
@@ -189,5 +189,36 @@ namespace PerformanceMonitor.Ui
 
             chart.Plot.Axes.SetLimitsY(yMin, yMax);
         }
+
+        /// <summary>
+        /// Applies the shared line-series polish to a <see cref="ScottPlot.Plottables.Scatter"/>:
+        /// a consistent line width, a slight line transparency so overlapping series read clearly
+        /// (markers stay fully opaque so peaks stay crisp), and a marker size scaled to point
+        /// density — dense series collapse to a clean line, sparse series keep visible markers.
+        /// Call this AFTER setting the scatter's <c>Color</c>. Deliberately typed to Scatter so
+        /// Bars / lines / heatmaps can't be mis-fed. Sites that intentionally use MarkerSize 0
+        /// (line-only reference lines) or a fixed anomaly marker (6) set their own and must NOT
+        /// call this (the density rule would override their intent).
+        /// </summary>
+        public static void StyleScatter(ScottPlot.Plottables.Scatter scatter)
+        {
+            int pointCount = scatter.Data.GetScatterPoints().Count;
+            scatter.LineWidth = 2;
+            scatter.MarkerSize = MarkerSizeForDensity(pointCount);
+            // Soften only the connecting line; keep markers fully opaque so peaks stay legible.
+            scatter.LineColor = scatter.LineColor.WithAlpha(210);
+        }
+
+        /// <summary>
+        /// Marker size chosen by point density (see <see cref="StyleScatter"/>). Public so callers
+        /// that build scatters in a non-standard way can reuse the same density curve.
+        /// </summary>
+        public static float MarkerSizeForDensity(int pointCount) => pointCount switch
+        {
+            <= 1   => 7f,   // a lone sample has no line to anchor it — needs a visible dot
+            <= 50  => 5f,   // sparse: full markers
+            <= 120 => 3f,   // medium: small markers
+            _      => 0f,   // dense: line only — markers would be a wall of dots
+        };
     }
 }

--- a/PerformanceMonitor.Ui/ChartStyle.cs
+++ b/PerformanceMonitor.Ui/ChartStyle.cs
@@ -14,74 +14,92 @@ using ScottPlot.WPF;
 namespace PerformanceMonitor.Ui
 {
     /// <summary>
-    /// Shared CHROME styling for ScottPlot charts — the single source of truth for chart
-    /// theming across Dashboard and Lite. "Chrome" = figure/data backgrounds, axis + grid +
-    /// legend colors, tick label colors/sizes, and axis-mechanics helpers. It deliberately does
-    /// NOT own series/category COLOR IDENTITY (that is a separate concern; see ChartPalette).
+    /// The per-theme chart CHROME colors (Dark / Light / CoolBreeze). The single source of truth
+    /// for these hex values — every chart, in both apps, resolves them through
+    /// <see cref="ChartStyle.GetThemeColors"/> so they can never drift between copies again.
+    /// </summary>
+    public readonly record struct ChartThemeColors(
+        ScottPlot.Color FigureBackground,
+        ScottPlot.Color DataBackground,
+        ScottPlot.Color Text,
+        ScottPlot.Color Grid,
+        ScottPlot.Color LegendBackground,
+        ScottPlot.Color LegendForeground,
+        ScottPlot.Color LegendOutline);
+
+    /// <summary>
+    /// Shared CHROME styling for ScottPlot charts — the single source of truth for chart theming
+    /// across Dashboard and Lite. "Chrome" = figure/data backgrounds, axis + grid + legend colors,
+    /// tick label colors/sizes, and axis-mechanics helpers. It deliberately does NOT own series /
+    /// category COLOR IDENTITY (that is a separate concern; see the ChartPalette work in A.3).
     ///
     /// Theme colors read <see cref="ThemeManager.CurrentTheme"/> (Dark / Light / CoolBreeze).
     /// </summary>
     public static class ChartStyle
     {
+        /// <summary>Resolves the chrome colors for the currently active theme.</summary>
+        public static ChartThemeColors GetThemeColors()
+        {
+            if (ThemeManager.CurrentTheme == "CoolBreeze")
+                return new ChartThemeColors(
+                    ScottPlot.Color.FromHex("#EEF4FA"),
+                    ScottPlot.Color.FromHex("#DAE6F0"),
+                    ScottPlot.Color.FromHex("#1A2A3A"),
+                    ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120),
+                    ScottPlot.Color.FromHex("#EEF4FA"),
+                    ScottPlot.Color.FromHex("#1A2A3A"),
+                    ScottPlot.Color.FromHex("#A8BDD0"));
+
+            if (ThemeManager.HasLightBackground)
+                return new ChartThemeColors(
+                    ScottPlot.Color.FromHex("#FFFFFF"),
+                    ScottPlot.Color.FromHex("#F5F7FA"),
+                    ScottPlot.Color.FromHex("#1A1D23"),
+                    ScottPlot.Colors.Black.WithAlpha(20),
+                    ScottPlot.Color.FromHex("#FFFFFF"),
+                    ScottPlot.Color.FromHex("#1A1D23"),
+                    ScottPlot.Color.FromHex("#DEE2E6"));
+
+            return new ChartThemeColors(
+                ScottPlot.Color.FromHex("#22252b"),
+                ScottPlot.Color.FromHex("#111217"),
+                ScottPlot.Color.FromHex("#E4E6EB"),
+                ScottPlot.Colors.White.WithAlpha(40),
+                ScottPlot.Color.FromHex("#22252b"),
+                ScottPlot.Color.FromHex("#E4E6EB"),
+                ScottPlot.Color.FromHex("#2a2d35"));
+        }
+
         /// <summary>
-        /// Applies the current color theme (chrome only) to a ScottPlot chart.
+        /// Applies the full chrome theme to a ScottPlot chart (backgrounds, axis/grid/legend
+        /// colors, bottom-horizontal legend, tick label colors + 13px font, and a first-render
+        /// hook to avoid a white flash). Use for the standard multi-series trend charts.
         /// </summary>
         public static void ApplyThemeToChart(WpfPlot chart)
         {
-            ScottPlot.Color figureBackground, dataBackground, textColor, gridColor, legendBg, legendFg, legendOutline;
+            var c = GetThemeColors();
 
-            if (ThemeManager.CurrentTheme == "CoolBreeze")
-            {
-                figureBackground = ScottPlot.Color.FromHex("#EEF4FA");
-                dataBackground   = ScottPlot.Color.FromHex("#DAE6F0");
-                textColor        = ScottPlot.Color.FromHex("#1A2A3A");
-                gridColor        = ScottPlot.Color.FromHex("#A8BDD0").WithAlpha(120);
-                legendBg         = ScottPlot.Color.FromHex("#EEF4FA");
-                legendFg         = ScottPlot.Color.FromHex("#1A2A3A");
-                legendOutline    = ScottPlot.Color.FromHex("#A8BDD0");
-            }
-            else if (ThemeManager.HasLightBackground)
-            {
-                figureBackground = ScottPlot.Color.FromHex("#FFFFFF");
-                dataBackground   = ScottPlot.Color.FromHex("#F5F7FA");
-                textColor        = ScottPlot.Color.FromHex("#1A1D23");
-                gridColor        = ScottPlot.Colors.Black.WithAlpha(20);
-                legendBg         = ScottPlot.Color.FromHex("#FFFFFF");
-                legendFg         = ScottPlot.Color.FromHex("#1A1D23");
-                legendOutline    = ScottPlot.Color.FromHex("#DEE2E6");
-            }
-            else
-            {
-                figureBackground = ScottPlot.Color.FromHex("#22252b");
-                dataBackground   = ScottPlot.Color.FromHex("#111217");
-                textColor        = ScottPlot.Color.FromHex("#E4E6EB");
-                gridColor        = ScottPlot.Colors.White.WithAlpha(40);
-                legendBg         = ScottPlot.Color.FromHex("#22252b");
-                legendFg         = ScottPlot.Color.FromHex("#E4E6EB");
-                legendOutline    = ScottPlot.Color.FromHex("#2a2d35");
-            }
-
-            chart.Plot.FigureBackground.Color = figureBackground;
-            chart.Plot.DataBackground.Color = dataBackground;
-            chart.Plot.Axes.Color(textColor);
-            chart.Plot.Grid.MajorLineColor = gridColor;
-            chart.Plot.Legend.BackgroundColor = legendBg;
-            chart.Plot.Legend.FontColor = legendFg;
-            chart.Plot.Legend.OutlineColor = legendOutline;
+            chart.Plot.FigureBackground.Color = c.FigureBackground;
+            chart.Plot.DataBackground.Color = c.DataBackground;
+            chart.Plot.Axes.Color(c.Text);
+            chart.Plot.Grid.MajorLineColor = c.Grid;
+            chart.Plot.Legend.BackgroundColor = c.LegendBackground;
+            chart.Plot.Legend.FontColor = c.LegendForeground;
+            chart.Plot.Legend.OutlineColor = c.LegendOutline;
             chart.Plot.Legend.Alignment = ScottPlot.Alignment.LowerCenter;
             chart.Plot.Legend.Orientation = ScottPlot.Orientation.Horizontal;
             chart.Plot.Axes.Margins(bottom: 0); // No bottom margin - SetChartYLimitsWithLegendPadding handles Y-axis
 
             // Explicitly set axis tick label colors (needed after DateTimeTicksBottom() is called)
-            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-            chart.Plot.Axes.Left.Label.ForeColor = textColor;
+            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = c.Text;
+            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = c.Text;
+            chart.Plot.Axes.Bottom.Label.ForeColor = c.Text;
+            chart.Plot.Axes.Left.Label.ForeColor = c.Text;
             chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
             chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
 
             // Set the WPF control Background to match so no white flash appears before ScottPlot's render loop fires
-            chart.Background = new SolidColorBrush(Color.FromRgb(figureBackground.R, figureBackground.G, figureBackground.B));
+            chart.Background = new SolidColorBrush(Color.FromRgb(c.FigureBackground.R, c.FigureBackground.G, c.FigureBackground.B));
 
             // Ensure ScottPlot renders with the correct colors the very first time it gets pixel dimensions.
             // Without this, ScottPlot's first auto-render (triggered by SizeChanged) would show a white canvas
@@ -89,6 +107,23 @@ namespace PerformanceMonitor.Ui
             chart.Loaded -= HandleChartFirstLoaded;
             if (!chart.IsLoaded)
                 chart.Loaded += HandleChartFirstLoaded;
+        }
+
+        /// <summary>
+        /// Minimal chrome for simple single-series charts (e.g. the history dialogs): backgrounds,
+        /// axis, grid, and tick label colors only — no legend handling, axis-margin override,
+        /// font-size override, background brush, or first-render hook. Sources colors from
+        /// <see cref="GetThemeColors"/> so the per-theme hexes can't drift from the full theme.
+        /// </summary>
+        public static void ApplyMinimalChartTheme(WpfPlot chart)
+        {
+            var c = GetThemeColors();
+            chart.Plot.FigureBackground.Color = c.FigureBackground;
+            chart.Plot.DataBackground.Color = c.DataBackground;
+            chart.Plot.Axes.Color(c.Text);
+            chart.Plot.Grid.MajorLineColor = c.Grid;
+            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = c.Text;
+            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = c.Text;
         }
 
         private static void HandleChartFirstLoaded(object sender, RoutedEventArgs e)
@@ -99,22 +134,60 @@ namespace PerformanceMonitor.Ui
         }
 
         /// <summary>
-        /// Reapplies theme-appropriate text colors (and font sizes) to chart axes.
+        /// Reapplies theme-appropriate text colors (and 13px font) to chart axes.
         /// Call this AFTER DateTimeTicksBottom() or other axis modifications that reset them.
         /// </summary>
         public static void ReapplyAxisColors(WpfPlot chart)
         {
-            var textColor = ThemeManager.CurrentTheme == "CoolBreeze"
-                ? ScottPlot.Color.FromHex("#1A2A3A")
-                : ThemeManager.HasLightBackground
-                    ? ScottPlot.Color.FromHex("#1A1D23")
-                    : ScottPlot.Color.FromHex("#E4E6EB");
-            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = textColor;
-            chart.Plot.Axes.Bottom.Label.ForeColor = textColor;
-            chart.Plot.Axes.Left.Label.ForeColor = textColor;
+            var text = GetThemeColors().Text;
+            chart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = text;
+            chart.Plot.Axes.Left.TickLabelStyle.ForeColor = text;
+            chart.Plot.Axes.Bottom.Label.ForeColor = text;
+            chart.Plot.Axes.Left.Label.ForeColor = text;
             chart.Plot.Axes.Bottom.TickLabelStyle.FontSize = 13;
             chart.Plot.Axes.Left.TickLabelStyle.FontSize = 13;
+        }
+
+        /// <summary>
+        /// Locks the vertical axis so mouse-wheel zoom only affects the time (X) axis.
+        /// Also reapplies axis colors (DateTimeTicksBottom() may have reset them).
+        /// </summary>
+        public static void LockChartVerticalAxis(WpfPlot chart)
+        {
+            var limits = chart.Plot.Axes.GetLimits();
+            var rule = new ScottPlot.AxisRules.LockedVertical(
+                chart.Plot.Axes.Left,
+                limits.Bottom,
+                limits.Top);
+            chart.Plot.Axes.Rules.Clear();
+            chart.Plot.Axes.Rules.Add(rule);
+
+            ReapplyAxisColors(chart);
+        }
+
+        /// <summary>
+        /// Sets Y-axis limits with padding for a bottom legend and top breathing room.
+        /// Adds a small margin below a zero baseline so flat-at-zero lines stay visible above the
+        /// axis. Call this BEFORE LockChartVerticalAxis.
+        /// </summary>
+        public static void SetChartYLimitsWithLegendPadding(WpfPlot chart, double dataYMin = 0, double dataYMax = 0)
+        {
+            if (dataYMin == 0 && dataYMax == 0)
+            {
+                var limits = chart.Plot.Axes.GetLimits();
+                dataYMin = limits.Bottom;
+                dataYMax = limits.Top;
+            }
+            if (dataYMax <= dataYMin) dataYMax = dataYMin + 1;
+
+            double range = dataYMax - dataYMin;
+            double topPadding = range * 0.05;
+
+            /* Add a small bottom margin when dataYMin is zero so flat lines at Y=0 are visible above the axis */
+            double yMin = dataYMin > 0 ? 0 : dataYMin == 0 ? -(range * 0.05) : dataYMin - (range * 0.10);
+            double yMax = dataYMax + topPadding;
+
+            chart.Plot.Axes.SetLimitsY(yMin, yMax);
         }
     }
 }

--- a/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
+++ b/PerformanceMonitor.Ui/CorrelatedCrosshairManager.cs
@@ -15,6 +15,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Ui;
 
@@ -219,7 +220,7 @@ internal sealed class CorrelatedCrosshairManager : IDisposable
         try
         {
             var vline = chart.Plot.Add.VerticalLine(0);
-            vline.Color = ScottPlot.Color.FromHex("#FFFFFF").WithAlpha(100);
+            vline.Color = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Crosshair")).WithAlpha(100);
             vline.LineWidth = 1;
             vline.LinePattern = ScottPlot.LinePattern.Dashed;
             vline.IsVisible = false;

--- a/PerformanceMonitor.Ui/MetricBarCards.xaml
+++ b/PerformanceMonitor.Ui/MetricBarCards.xaml
@@ -1,0 +1,49 @@
+<UserControl x:Class="PerformanceMonitor.Ui.MetricBarCards"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <!--
+      A compact "per-entity bar cards" list (ported from PerformanceStudio's per-DB bar cards):
+      one row per item = label | horizontal proportional bar (entity-colored) | formatted value.
+      The bar fills to Value / Maximum using star-sized grid columns (scales with width, no math).
+      Bind Items to a list of MetricBarItem. All text uses the inherited theme foreground so it
+      stays readable on every theme; the bar itself carries the entity identity color.
+    -->
+    <ItemsControl ItemsSource="{Binding Items, ElementName=Root}">
+        <ItemsControl.ItemTemplate>
+            <DataTemplate>
+                <Grid Height="22" Margin="0,1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="170"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="90"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding Label}"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               Margin="2,0,6,0"
+                               ToolTip="{Binding Label}"/>
+
+                    <Border Grid.Column="1" CornerRadius="2" ClipToBounds="True" VerticalAlignment="Center" Height="14">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="{Binding FillWidth}"/>
+                                <ColumnDefinition Width="{Binding RestWidth}"/>
+                            </Grid.ColumnDefinitions>
+                            <Rectangle Grid.Column="0" Fill="{Binding BarBrush}" RadiusX="2" RadiusY="2"/>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Grid.Column="2"
+                               Text="{Binding ValueText}"
+                               HorizontalAlignment="Right"
+                               VerticalAlignment="Center"
+                               Margin="6,0,2,0"
+                               FontSize="11"/>
+                </Grid>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+</UserControl>

--- a/PerformanceMonitor.Ui/MetricBarCards.xaml.cs
+++ b/PerformanceMonitor.Ui/MetricBarCards.xaml.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// Renders a list of <see cref="MetricBarItem"/> as per-entity horizontal bar cards
+    /// (label | proportional entity-colored bar | value). Shared by both apps (lives in .Ui) so
+    /// the per-DB overview can't drift. Ported from PerformanceStudio's per-DB bar cards.
+    /// </summary>
+    public partial class MetricBarCards : UserControl
+    {
+        public MetricBarCards()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>The bar rows to render (a list of <see cref="MetricBarItem"/>).</summary>
+        public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register(
+            nameof(Items), typeof(IEnumerable), typeof(MetricBarCards), new PropertyMetadata(null));
+        public IEnumerable? Items
+        {
+            get => (IEnumerable?)GetValue(ItemsProperty);
+            set => SetValue(ItemsProperty, value);
+        }
+    }
+}

--- a/PerformanceMonitor.Ui/MetricBarItem.cs
+++ b/PerformanceMonitor.Ui/MetricBarItem.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// One row of a <see cref="MetricBarCards"/> list: a label (e.g. a database name), a value
+    /// rendered as a horizontal bar proportional to <see cref="Maximum"/>, the formatted value
+    /// text, and the bar color (the entity's identity color via ChartPalette.CyclingColor).
+    /// Items are rebuilt on each refresh, so the fill widths are simple computed getters with no
+    /// change notification.
+    /// </summary>
+    public sealed class MetricBarItem
+    {
+        public string Label { get; set; } = string.Empty;
+        public double Value { get; set; }
+        public double Maximum { get; set; } = 1.0;
+        public string ValueText { get; set; } = string.Empty;
+        public Brush BarBrush { get; set; } = Brushes.SteelBlue;
+
+        private double Ratio => Maximum > 0 ? Math.Clamp(Value / Maximum, 0.0, 1.0) : 0.0;
+
+        /// <summary>Star width of the filled portion (proportional to Value/Maximum).</summary>
+        public GridLength FillWidth => new GridLength(Ratio, GridUnitType.Star);
+
+        /// <summary>Star width of the remaining track (kept &gt; 0 so the star math never divides by zero).</summary>
+        public GridLength RestWidth => new GridLength(Math.Max(1.0 - Ratio, 0.0001), GridUnitType.Star);
+    }
+}


### PR DESCRIPTION
Track A of the PerformanceStudio chart-style port (everything except A.2 overlay legend). Both apps build clean. Rebased onto current dev, including the slicer/range fixes from #1190 (those live in ServerTab.Slicers/TimeRange; my A.4 work is in the slicer control + themes, so they reconciled with no conflicts).

## Shipped phases
- **A.0 / A.3 - Foundation**: shared `ChartStyle` (chrome) in .Ui + `ChartPalette` (color identity) in Common. Every series/accent/category/placeholder/ghost color in both apps now routes through ChartPalette; only per-theme chrome stays hardcoded (ChartStyle.GetThemeColors). Wait categories audited vs sqlskills.
- **A.1 - Line polish**: `ChartStyle.StyleScatter` (line width + slight line alpha + density-based marker size) on ~104 scatter sites; intentional line-only / anomaly / event markers left alone.
- **A.4 - Slicer parity**: Dashboard slicer height 150 -> 130 (matched Lite); added `SlicerHandleHoverBrush` to all four themes + wired the handle hover.
- **A.5 - In-grid bars**: shared `BarChartCell`; proportional bars on the four magnitude columns (Executions/CPU/Duration/Reads) of the top-queries grid, both apps.
- **A.6 - Per-DB cards**: shared `MetricBarCards`; collapsed "CPU by database" panel in the Query Stats sub-tab, both apps, data-free (aggregates the already-loaded rows).

## NOT in this PR
- A.2 overlay legend (largest/most-coupled; app-wide legend replacement, wants visual validation).
- Data-blocked (need collectors, not UI): per-row wait-profile bar, donut, wait-ribbons.
- Flagged follow-ons: A.5 active-sort accent + proc/QS/history grids; A.4 quick-filter row.

Pending visual review across the three themes (Dark / Light / CoolBreeze).

Generated with [Claude Code](https://claude.com/claude-code)