### PR TITLE
Fix RootFactValue/LeafFactValue carrying severity instead of the fact value

### DIFF
--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -245,4 +245,42 @@ public class InferenceEngineTests
         Assert.Equal("THREADPOOL_MIXED", ThreadpoolRoot(Tp(), Cx(), Blk()));
         Assert.Equal("THREADPOOL", ThreadpoolRoot(Tp()));
     }
+
+    // Regression: RootFactValue/LeafFactValue must carry the fact's RAW collected VALUE, not its
+    // severity. They were both set to .Severity, so a CONFIG_CTFP finding (value 5, severity 0.4)
+    // reported RootFactValue 0.4 — which the MCP root_fact.value contract and the notification
+    // headline surface as "the value", contradicting the value-stated advice ("CTFP is 5").
+    [Fact]
+    public void BuildStory_RootFactValue_IsFactValue_NotSeverity()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var facts = new List<Fact>
+        {
+            new() { Key = "CONFIG_CTFP", Source = "config", Value = 5, Severity = 0.4 }
+        };
+
+        var story = engine.BuildStories(facts).First(s => s.RootFactKey == "CONFIG_CTFP");
+
+        Assert.Equal(5, story.RootFactValue);   // the collected value, NOT 0.4
+        Assert.Equal(0.4, story.Severity);      // severity still on its own field
+    }
+
+    [Fact]
+    public void BuildStory_LeafFactValue_IsFactValue_NotSeverity()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        // CXPACKET roots (severity >= 0.5) and traverses to SOS_SCHEDULER_YIELD (edge fires when SOS
+        // severity is high), so the story has a leaf whose value must be SOS's value, not its severity.
+        var facts = new List<Fact>
+        {
+            new() { Key = "CXPACKET", Source = "waits", Value = 0.6, Severity = 0.9 },
+            new() { Key = "SOS_SCHEDULER_YIELD", Source = "waits", Value = 0.5, Severity = 0.67 }
+        };
+
+        var story = engine.BuildStories(facts).First(s => s.RootFactKey == "CXPACKET");
+
+        Assert.Equal(0.6, story.RootFactValue);              // CXPACKET value, not 0.9
+        Assert.Equal("SOS_SCHEDULER_YIELD", story.LeafFactKey);
+        Assert.Equal(0.5, story.LeafFactValue);              // SOS value, not 0.67
+    }
 }

--- a/PerformanceMonitor.Analysis/AnalysisModels.cs
+++ b/PerformanceMonitor.Analysis/AnalysisModels.cs
@@ -60,6 +60,9 @@ public class Edge
 public class AnalysisStory
 {
     public string RootFactKey { get; set; } = string.Empty;
+    /// <summary>The root fact's RAW collected value (the setting/metric — MAXDOP 0, a wait's
+    /// fraction-of-period, CPU%, etc.), NOT its severity. <see cref="Severity"/> is the separate
+    /// 0–~2 score. Surfaced as MCP root_fact.value and in the notification headline.</summary>
     public double RootFactValue { get; set; }
     public double Severity { get; set; }
     public double Confidence { get; set; }
@@ -69,6 +72,7 @@ public class AnalysisStory
     public string StoryPathHash { get; set; } = string.Empty;
     public string StoryText { get; set; } = string.Empty;
     public string? LeafFactKey { get; set; }
+    /// <summary>The leaf fact's RAW collected value (see <see cref="RootFactValue"/>), not severity.</summary>
     public double? LeafFactValue { get; set; }
     public int FactCount { get; set; }
     public bool IsAbsolution { get; set; }
@@ -106,8 +110,11 @@ public class AnalysisFinding
     public string StoryPathHash { get; set; } = string.Empty;
     public string StoryText { get; set; } = string.Empty;
     public string RootFactKey { get; set; } = string.Empty;
+    /// <summary>The root fact's RAW collected value (the setting/metric), NOT its severity — see
+    /// <see cref="AnalysisStory.RootFactValue"/>. Persisted to analysis_findings.root_fact_value.</summary>
     public double? RootFactValue { get; set; }
     public string? LeafFactKey { get; set; }
+    /// <summary>The leaf fact's RAW collected value (see <see cref="RootFactValue"/>), not severity.</summary>
     public double? LeafFactValue { get; set; }
     public int FactCount { get; set; }
 

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -188,7 +188,12 @@ public class InferenceEngine
         return new AnalysisStory
         {
             RootFactKey = rootKey,
-            RootFactValue = rootFact?.Severity ?? 0,
+            // RootFactValue/LeafFactValue carry the fact's RAW collected value (the setting/metric —
+            // MAXDOP 0, a wait's fraction-of-period, etc.), NOT its severity. Severity has its own
+            // field below. These feed the MCP root_fact.value / leaf_fact.value contract and the
+            // notification headline; conflating them with severity made an MCP payload report
+            // "MAXDOP is 0" next to value 0.4 (the severity).
+            RootFactValue = rootFact?.Value ?? 0,
             Severity = rootFact?.Severity ?? 0,
             Confidence = confidence,
             Category = category,
@@ -197,7 +202,7 @@ public class InferenceEngine
             StoryPathHash = ComputeHash(storyPath),
             StoryText = string.Empty,
             LeafFactKey = leafKey,
-            LeafFactValue = leafFact?.Severity,
+            LeafFactValue = leafFact?.Value,
             FactCount = path.Count,
             IsAbsolution = false,
             RootFactMetadata = rootFact?.Metadata,


### PR DESCRIPTION
## The bug (found in the post-merge broad review)

`InferenceEngine.BuildStory` set `RootFactValue` and `LeafFactValue` to the fact's **Severity**, not its **Value** — so they were duplicates of the `Severity` field instead of the raw collected setting/metric.

The MCP `root_fact.value` / `leaf_fact.value` contract (Lite + Dashboard `analyze_server` / `get_analysis_findings`) and the notification headline (`AnalysisNotificationService.CurrentValue`, doc'd "the root fact and its value") all consume these as the value. So a `CONFIG_CTFP` finding reported `root_fact.value: 0.4` (the severity). The value-stated advice work made it **self-contradicting**: a payload could read `headline: "MAXDOP is 0"` next to `root_fact.value: 0.4`.

## Fix

`BuildStory` now sets both to the fact's `Value`; `Severity` keeps its own field. No schema change — the `root_fact_value` column already exists and simply stores the value now (re-analysis overwrites old rows; readers band on `Severity`, not this field, so no card/logic impact). Documented the fields on `AnalysisStory` / `AnalysisFinding`.

## Verify
- Regression tests: `RootFactValue == fact value` (CONFIG_CTFP 5, not severity 0.4) and `LeafFactValue == leaf fact value` (CXPACKET→SOS path).
- Dashboard.Tests **512/512** (+2), Lite.Tests **543/543**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
