### PR TITLE
Lite: deadlock parsing off UI thread + View Plan parity

### DIFF
--- a/Lite/Controls/ServerTab.DrillDown.cs
+++ b/Lite/Controls/ServerTab.DrillDown.cs
@@ -177,7 +177,7 @@ public partial class ServerTab : UserControl
         MainTabControl.SelectedIndex = 8; // Blocking
         BlockingSubTabControl.SelectedIndex = 3; // Deadlocks
         var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromDate, toDate);
-        _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(dlr));
+        _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(dlr));
     }
 
     private async void OnHeatmapDrillDown(DateTime bucketTimeUtc)

--- a/Lite/Controls/ServerTab.Plans.cs
+++ b/Lite/Controls/ServerTab.Plans.cs
@@ -546,10 +546,13 @@ public partial class ServerTab : UserControl
         try
         {
             var doc = System.Xml.Linq.XElement.Parse(bprXml);
-            var processContainer = blockingSide
-                ? doc.Element("blocking-process")
-                : doc.Element("blocked-process");
-            var stack = processContainer?.Element("process")?.Element("executionStack");
+            // The collector stores the <blocked-process-report> element as the root, so the
+            // {blocking|blocked}-process nodes are direct children today — but search by descendant
+            // (matching Dashboard) so this keeps working regardless of how deep the node sits.
+            var processContainer = doc
+                .Descendants(blockingSide ? "blocking-process" : "blocked-process")
+                .FirstOrDefault();
+            var stack = processContainer?.Descendants("executionStack").FirstOrDefault();
             if (stack == null) return empty;
 
             var frames = new List<(string, int, int)>();

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -31,6 +31,12 @@ public partial class ServerTab : UserControl
         await RefreshAllDataAsync(fullRefresh: false);
     }
 
+    /* Deadlock-graph XML parsing (XElement.Parse + deep Descendants traversal per row) is heavy
+       enough to hitch the dispatcher on the Blocking tab; run it on the thread pool so only the
+       grid bind stays on the UI thread. */
+    private static Task<List<DeadlockProcessDetail>> ParseDeadlocksOffUiThreadAsync(List<DeadlockRow> rows)
+        => Task.Run(() => DeadlockProcessDetail.ParseFromRows(rows));
+
     private async System.Threading.Tasks.Task RefreshAllDataAsync(bool fullRefresh = false)
     {
         if (_isRefreshing) return;
@@ -224,7 +230,7 @@ public partial class ServerTab : UserControl
             await RefreshProcStatsComparisonAsync(cStart2, cEnd2);
         }
         _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
-        _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(deadlockTask.Result));
+        _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(deadlockTask.Result));
         _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
         SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
         {
@@ -595,12 +601,15 @@ public partial class ServerTab : UserControl
                         break;
                     case 2: // Blocked Process Reports
                         var bpr = await Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate));
-                        _blockedProcessFilterMgr!.UpdateData(bpr);
+                        using (Helpers.MethodProfiler.StartTiming("Locking.BindBlockedGrid"))
+                            _blockedProcessFilterMgr!.UpdateData(bpr);
                         await LoadBlockingSlicerAsync();
                         break;
                     case 3: // Deadlocks
                         var dlr = await Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate));
-                        _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(dlr));
+                        var dlrDetails = await ParseDeadlocksOffUiThreadAsync(dlr);
+                        using (Helpers.MethodProfiler.StartTiming("Locking.BindDeadlockGrid"))
+                            _deadlockFilterMgr!.UpdateData(dlrDetails);
                         await LoadDeadlockSlicerAsync();
                         break;
                 }
@@ -623,14 +632,22 @@ public partial class ServerTab : UserControl
                 lockWaitTrendTask, blockingTrendTask, deadlockTrendTask,
                 currentWaitsDurationTask, currentWaitsBlockedTask);
 
-            _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
-            _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(deadlockTask.Result));
+            /* Parse deadlock graphs off the UI thread (this was the Blocking-tab hitch). Time the
+               remaining UI-thread render steps so any new hot spot is pinpointed (bind vs charts). */
+            var deadlockDetails = await ParseDeadlocksOffUiThreadAsync(deadlockTask.Result);
+            using (Helpers.MethodProfiler.StartTiming("Locking.BindBlockedGrid"))
+                _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
+            using (Helpers.MethodProfiler.StartTiming("Locking.BindDeadlockGrid"))
+                _deadlockFilterMgr!.UpdateData(deadlockDetails);
 
-            UpdateLockWaitTrendChart(lockWaitTrendTask.Result, hoursBack, fromDate, toDate);
-            UpdateBlockingTrendChart(blockingTrendTask.Result, hoursBack, fromDate, toDate);
-            UpdateDeadlockTrendChart(deadlockTrendTask.Result, hoursBack, fromDate, toDate);
-            UpdateCurrentWaitsDurationChart(currentWaitsDurationTask.Result, hoursBack, fromDate, toDate);
-            UpdateCurrentWaitsBlockedChart(currentWaitsBlockedTask.Result, hoursBack, fromDate, toDate);
+            using (Helpers.MethodProfiler.StartTiming("Locking.RenderTrendCharts"))
+            {
+                UpdateLockWaitTrendChart(lockWaitTrendTask.Result, hoursBack, fromDate, toDate);
+                UpdateBlockingTrendChart(blockingTrendTask.Result, hoursBack, fromDate, toDate);
+                UpdateDeadlockTrendChart(deadlockTrendTask.Result, hoursBack, fromDate, toDate);
+                UpdateCurrentWaitsDurationChart(currentWaitsDurationTask.Result, hoursBack, fromDate, toDate);
+                UpdateCurrentWaitsBlockedChart(currentWaitsBlockedTask.Result, hoursBack, fromDate, toDate);
+            }
 
             await LoadBlockingSlicerAsync();
             await LoadDeadlockSlicerAsync();

--- a/Lite/Controls/ServerTab.Slicers.cs
+++ b/Lite/Controls/ServerTab.Slicers.cs
@@ -59,7 +59,7 @@ public partial class ServerTab : UserControl
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
 
             var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromServer, toServer);
-            _deadlockFilterMgr!.UpdateData(DeadlockProcessDetail.ParseFromRows(dlr));
+            _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(dlr));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## What

Lite UI-responsiveness pass (companion to the Dashboard work in #1190).

- **Perf:** the Blocking tab's ~930ms render hitch was `DeadlockProcessDetail.ParseFromRows` (XElement.Parse + deep Descendants traversal over up to 50 graphs) running on the **UI thread** at all 5 call sites. Routed through a shared `ParseDeadlocksOffUiThreadAsync` (thread pool); only the grid bind stays on the dispatcher.
- **Parity:** Lite's blocked-process View Plan now uses Dashboard's robust `Descendants(...)` XML nav instead of fragile direct-child `Element` nav.
- **Instrumentation:** permanent `MethodProfiler` timing around the Blocking render steps (`BindBlockedGrid` / `BindDeadlockGrid` / `RenderTrendCharts`), >500ms threshold, so any remaining UI-thread cost is pinpointed.

## Why Lite needed little else

Lite is already visible-only/lazy (the all-tabs flood path is dead code), the slicer refreshes in the grid path, and right-click select already shipped — so the Dashboard flood/slicer/range fixes had no equivalent.

## Notes / follow-ups
- `RefreshAllTabsAsync` is verified-unreachable dead code (nothing passes `fullRefresh:true`) — left in place pending a decision.
- Blocked-process XML still loaded inline (200 rows); not mirrored from Dashboard's defer because in DuckDB it's cheap text + a background cost, not a UI hitch. The `BindBlockedGrid` timer tests whether it matters.

## Testing
Build green (0 errors, 0 new warnings). Runtime validation under HammerDB pending from the integrated dev build — Blocking-tab smoothness + View Plan smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
