### PR TITLE
Lite: remove dead RefreshAllTabsAsync (full-refresh path)

### DIFF
--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -28,7 +28,7 @@ public partial class ServerTab : UserControl
     /// </summary>
     public async void RefreshData()
     {
-        await RefreshAllDataAsync(fullRefresh: false);
+        await RefreshAllDataAsync();
     }
 
     /* Deadlock-graph XML parsing (XElement.Parse + deep Descendants traversal per row) is heavy
@@ -37,7 +37,7 @@ public partial class ServerTab : UserControl
     private static Task<List<DeadlockProcessDetail>> ParseDeadlocksOffUiThreadAsync(List<DeadlockRow> rows)
         => Task.Run(() => DeadlockProcessDetail.ParseFromRows(rows));
 
-    private async System.Threading.Tasks.Task RefreshAllDataAsync(bool fullRefresh = false)
+    private async System.Threading.Tasks.Task RefreshAllDataAsync()
     {
         if (_isRefreshing) return;
         _isRefreshing = true;
@@ -62,27 +62,20 @@ public partial class ServerTab : UserControl
         {
             using var _profiler = Helpers.MethodProfiler.StartTiming($"ServerTab-{_server?.DisplayName}");
 
-            if (fullRefresh)
+            /* When this server tab isn't the selected one, its charts/grids aren't on screen —
+               skip the heavy sub-tab data refresh and just keep the alert badge current. Mark
+               dirty so the sub-tab is refreshed when the tab is selected again (IsVisibleChanged). */
+            if (IsVisible)
             {
-                await RefreshAllTabsAsync(hoursBack, fromDate, toDate);
+                await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
             }
             else
             {
-                /* When this server tab isn't the selected one, its charts/grids aren't on screen —
-                   skip the heavy sub-tab data refresh and just keep the alert badge current. Mark
-                   dirty so the sub-tab is refreshed when the tab is selected again (IsVisibleChanged). */
-                if (IsVisible)
-                {
-                    await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
-                }
-                else
-                {
-                    _refreshPendingWhileHidden = true;
-                }
-                /* Always keep alert badge current even when Blocking tab is not visible */
-                if (MainTabControl.SelectedIndex != 8)
-                    await RefreshAlertCountsAsync(hoursBack, fromDate, toDate);
+                _refreshPendingWhileHidden = true;
             }
+            /* Always keep alert badge current even when Blocking tab is not visible */
+            if (MainTabControl.SelectedIndex != 8)
+                await RefreshAlertCountsAsync(hoursBack, fromDate, toDate);
 
             var tz = ServerTimeHelper.GetTimezoneLabel(ServerTimeHelper.CurrentDisplayMode);
             ConnectionStatusText.Text = $"Last refresh: {DateTime.Now:HH:mm:ss} ({tz})";
@@ -134,169 +127,6 @@ public partial class ServerTab : UserControl
         {
             AppLogger.Info("ServerTab", $"[{_server.DisplayName}] RefreshAlertCountsAsync failed: {ex.Message}");
         }
-    }
-
-    /// <summary>
-    /// Full refresh of all tabs — used for first load, manual refresh, and time range changes.
-    /// </summary>
-    private async System.Threading.Tasks.Task RefreshAllTabsAsync(int hoursBack, DateTime? fromDate, DateTime? toDate)
-    {
-        var loadSw = Stopwatch.StartNew();
-
-        /* Load all tabs in parallel, off the UI thread.
-           DuckDB.NET is synchronous, so calling these directly on the dispatcher would run all
-           ~36 queries serially on the UI thread (the freeze). Task.Run pushes each onto a pool
-           thread — each query's read lock is acquired AND released inside that one synchronous run,
-           so the ReaderWriterLockSlim thread affinity is respected — and the fan-out below becomes
-           genuinely parallel. The UI-update code after the awaits is unchanged. */
-        var snapshotsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.Snapshots", () => Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate)));
-        var cpuTask = Helpers.MethodProfiler.TimeAsync("Cpu.Utilization", () => Task.Run(() => _dataService.GetCpuUtilizationAsync(_serverId, hoursBack, fromDate, toDate)));
-        var memoryTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryStats", () => Task.Run(() => _dataService.GetLatestMemoryStatsAsync(_serverId)));
-        var memoryTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryTrend", () => Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var queryStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStats", () => Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
-        var procStatsTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcStats", () => Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, hoursBack, 50, fromDate, toDate, UtcOffsetMinutes)));
-        var fileIoTrendTask = Helpers.MethodProfiler.TimeAsync("FileIo.LatencyTrend", () => Task.Run(() => _dataService.GetFileIoLatencyTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var fileIoThroughputTask = Helpers.MethodProfiler.TimeAsync("FileIo.ThroughputTrend", () => Task.Run(() => _dataService.GetFileIoThroughputTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var tempDbTask = Helpers.MethodProfiler.TimeAsync("TempDb.Trend", () => Task.Run(() => _dataService.GetTempDbTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var tempDbFileIoTask = Helpers.MethodProfiler.TimeAsync("TempDb.FileIoTrend", () => Task.Run(() => _dataService.GetTempDbFileIoTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var deadlockTask = Helpers.MethodProfiler.TimeAsync("Locking.Deadlocks", () => Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, hoursBack, fromDate, toDate)));
-        var blockedProcessTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedProcessReports", () => Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, hoursBack, fromDate, toDate)));
-        var waitTypesTask = Helpers.MethodProfiler.TimeAsync("WaitStats.WaitTypes", () => Task.Run(() => _dataService.GetDistinctWaitTypesAsync(_serverId, hoursBack, fromDate, toDate)));
-        var memoryClerkTypesTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryClerks", () => Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate)));
-        var perfmonCountersTask = Helpers.MethodProfiler.TimeAsync("Perfmon.Counters", () => Task.Run(() => _dataService.GetDistinctPerfmonCountersAsync(_serverId, hoursBack, fromDate, toDate)));
-        var queryStoreTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryStore", () => Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, hoursBack, 50, fromDate, toDate)));
-        var memoryGrantTrendTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrantTrend", () => Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate)));
-        var memoryGrantChartTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryGrants", () => Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate)));
-        var memoryPressureEventsTask = Helpers.MethodProfiler.TimeAsync("Memory.MemoryPressureEvents", () => Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate)));
-        var serverConfigTask = Helpers.MethodProfiler.TimeAsync("Config.ServerConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestServerConfigAsync(_serverId))));
-        var databaseConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseConfigAsync(_serverId))));
-        var databaseScopedConfigTask = Helpers.MethodProfiler.TimeAsync("Config.DatabaseScopedConfig", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestDatabaseScopedConfigAsync(_serverId))));
-        var traceFlagsTask = Helpers.MethodProfiler.TimeAsync("Config.TraceFlags", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLatestTraceFlagsAsync(_serverId))));
-        var runningJobsTask = Helpers.MethodProfiler.TimeAsync("RunningJobs.Jobs", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRunningJobsAsync(_serverId))));
-        var collectionHealthTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Health", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId))));
-        var collectionLogTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Log", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack))));
-        var dailySummaryTask = Helpers.MethodProfiler.TimeAsync("DailySummary.Summary", () => Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate)));
-        /* Core data tasks */
-        await System.Threading.Tasks.Task.WhenAll(
-            snapshotsTask, cpuTask, memoryTask, memoryTrendTask,
-            queryStatsTask, procStatsTask, fileIoTrendTask, fileIoThroughputTask, tempDbTask, tempDbFileIoTask,
-            deadlockTask, blockedProcessTask, waitTypesTask, memoryClerkTypesTask, perfmonCountersTask,
-            queryStoreTask, memoryGrantTrendTask, memoryGrantChartTask, memoryPressureEventsTask,
-            serverConfigTask, databaseConfigTask, databaseScopedConfigTask, traceFlagsTask,
-            runningJobsTask, collectionHealthTask, collectionLogTask, dailySummaryTask);
-
-        /* Trend chart tasks - run separately so failures don't kill the whole refresh */
-        var lockWaitTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.LockWaitTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetLockWaitTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var blockingTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockingTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockingTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var deadlockTrendTask = Helpers.MethodProfiler.TimeAsync("Locking.DeadlockTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetDeadlockTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var queryDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QueryDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var procDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ProcDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetProcedureDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var queryStoreDurationTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var executionCountTrendTask = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var currentWaitsDurationTask = Helpers.MethodProfiler.TimeAsync("Locking.WaitingTaskTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetWaitingTaskTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-        var currentWaitsBlockedTask = Helpers.MethodProfiler.TimeAsync("Locking.BlockedSessionTrend", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetBlockedSessionTrendAsync(_serverId, hoursBack, fromDate, toDate))));
-
-        await System.Threading.Tasks.Task.WhenAll(
-            lockWaitTrendTask, blockingTrendTask, deadlockTrendTask,
-            queryDurationTrendTask, procDurationTrendTask, queryStoreDurationTrendTask, executionCountTrendTask,
-            currentWaitsDurationTask, currentWaitsBlockedTask);
-
-        loadSw.Stop();
-
-        /* Log data counts and timing for diagnostics */
-        AppLogger.DataDiag("ServerTab", $"[{_server.DisplayName}] serverId={_serverId} hoursBack={hoursBack} dataLoad={loadSw.ElapsedMilliseconds}ms");
-        AppLogger.DataDiag("ServerTab", $"  Snapshots: {snapshotsTask.Result.Count}, CPU: {cpuTask.Result.Count}");
-        AppLogger.DataDiag("ServerTab", $"  Memory: {(memoryTask.Result != null ? "1" : "null")}, MemoryTrend: {memoryTrendTask.Result.Count}");
-        AppLogger.DataDiag("ServerTab", $"  QueryStats: {queryStatsTask.Result.Count}, ProcStats: {procStatsTask.Result.Count}");
-        AppLogger.DataDiag("ServerTab", $"  FileIoTrend: {fileIoTrendTask.Result.Count}");
-        AppLogger.DataDiag("ServerTab", $"  TempDb: {tempDbTask.Result.Count}, BlockedProcessReports: {blockedProcessTask.Result.Count}, Deadlocks: {deadlockTask.Result.Count}");
-        AppLogger.DataDiag("ServerTab", $"  WaitTypes: {waitTypesTask.Result.Count}, PerfmonCounters: {perfmonCountersTask.Result.Count}, QueryStore: {queryStoreTask.Result.Count}");
-
-        /* Update grids (via filter managers to preserve active filters) */
-        _querySnapshotsFilterMgr!.UpdateData(snapshotsTask.Result);
-        LiveSnapshotIndicator.Text = "";
-        _queryStatsFilterMgr!.UpdateData(queryStatsTask.Result);
-        SetDefaultSortIfNone(QueryStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
-        {
-            var cEnd = toDate ?? DateTime.UtcNow;
-            var cStart = fromDate ?? cEnd.AddHours(-hoursBack);
-            await RefreshQueryStatsComparisonAsync(cStart, cEnd);
-        }
-        _procStatsFilterMgr!.UpdateData(procStatsTask.Result);
-        SetDefaultSortIfNone(ProcedureStatsGrid, "TotalElapsedMs", ListSortDirection.Descending);
-        {
-            var cEnd2 = toDate ?? DateTime.UtcNow;
-            var cStart2 = fromDate ?? cEnd2.AddHours(-hoursBack);
-            await RefreshProcStatsComparisonAsync(cStart2, cEnd2);
-        }
-        _blockedProcessFilterMgr!.UpdateData(blockedProcessTask.Result);
-        _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(deadlockTask.Result));
-        _queryStoreFilterMgr!.UpdateData(queryStoreTask.Result);
-        SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
-        {
-            var cEnd3 = toDate ?? DateTime.UtcNow;
-            var cStart3 = fromDate ?? cEnd3.AddHours(-hoursBack);
-            await RefreshQueryStoreComparisonAsync(cStart3, cEnd3);
-        }
-        _serverConfigFilterMgr!.UpdateData(serverConfigTask.Result);
-        _databaseConfigFilterMgr!.UpdateData(databaseConfigTask.Result);
-        _dbScopedConfigFilterMgr!.UpdateData(databaseScopedConfigTask.Result);
-        _traceFlagsFilterMgr!.UpdateData(traceFlagsTask.Result);
-        _runningJobsFilterMgr!.UpdateData(runningJobsTask.Result);
-        _collectionHealthFilterMgr!.UpdateData(collectionHealthTask.Result);
-        _collectionLogFilterMgr!.UpdateData(collectionLogTask.Result);
-        var dailySummary = await dailySummaryTask;
-        DailySummaryGrid.ItemsSource = dailySummary != null
-            ? new List<DailySummaryRow> { dailySummary } : null;
-        DailySummaryNoData.Visibility = dailySummary == null
-            ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
-        UpdateCollectorDurationChart(collectionLogTask.Result);
-
-        /* Update memory summary */
-        UpdateMemorySummary(memoryTask.Result);
-
-        /* Update charts */
-        UpdateCpuChart(cpuTask.Result);
-        UpdateMemoryChart(memoryTrendTask.Result, memoryGrantTrendTask.Result);
-        UpdateTempDbChart(tempDbTask.Result);
-        UpdateTempDbFileIoChart(tempDbFileIoTask.Result);
-        UpdateFileIoCharts(fileIoTrendTask.Result);
-        UpdateFileIoThroughputCharts(fileIoThroughputTask.Result);
-        UpdateLockWaitTrendChart(lockWaitTrendTask.Result, hoursBack, fromDate, toDate);
-        UpdateBlockingTrendChart(blockingTrendTask.Result, hoursBack, fromDate, toDate);
-        UpdateDeadlockTrendChart(deadlockTrendTask.Result, hoursBack, fromDate, toDate);
-        UpdateCurrentWaitsDurationChart(currentWaitsDurationTask.Result, hoursBack, fromDate, toDate);
-        UpdateCurrentWaitsBlockedChart(currentWaitsBlockedTask.Result, hoursBack, fromDate, toDate);
-        UpdateQueryDurationTrendChart(queryDurationTrendTask.Result);
-        UpdateProcDurationTrendChart(procDurationTrendTask.Result);
-        UpdateQueryStoreDurationTrendChart(queryStoreDurationTrendTask.Result);
-        UpdateExecutionCountTrendChart(executionCountTrendTask.Result);
-        UpdateMemoryGrantCharts(memoryGrantChartTask.Result);
-        UpdateMemoryPressureEventsChart(memoryPressureEventsTask.Result, hoursBack, fromDate, toDate);
-
-        /* Populate pickers (preserve selections) */
-        PopulateWaitTypePicker(waitTypesTask.Result);
-        PopulateMemoryClerkPicker(memoryClerkTypesTask.Result);
-        PopulatePerfmonPicker(perfmonCountersTask.Result);
-
-        /* Update picker-driven charts */
-        await UpdateWaitStatsChartFromPickerAsync();
-        await UpdateMemoryClerksChartFromPickerAsync();
-        await UpdatePerfmonChartFromPickerAsync();
-
-        /* Notify parent of alert counts for tab badge.
-           Include the latest event timestamp so acknowledgement is only
-           cleared when genuinely new events arrive, not when the time range changes. */
-        var blockingCount = blockedProcessTask.Result.Count;
-        var deadlockCount = deadlockTask.Result.Count;
-        DateTime? latestEventTime = null;
-        if (blockingCount > 0 || deadlockCount > 0)
-        {
-            var latestBlocking = blockedProcessTask.Result.Max(r => (DateTime?)r.EventTime);
-            var latestDeadlock = deadlockTask.Result.Max(r => (DateTime?)r.DeadlockTime);
-            latestEventTime = latestBlocking > latestDeadlock ? latestBlocking : latestDeadlock;
-        }
-        AlertCountsChanged?.Invoke(blockingCount, deadlockCount, latestEventTime);
     }
 
     /* ───────────────────────────── Per-tab refresh methods ───────────────────────────── */

--- a/Lite/Controls/ServerTab.TimeRange.cs
+++ b/Lite/Controls/ServerTab.TimeRange.cs
@@ -170,7 +170,7 @@ public partial class ServerTab : UserControl
                 await ManualRefreshRequested.Invoke();
             }
             /* Manual refresh loads all sub-tabs of the visible tab, not all 13 tabs */
-            await RefreshAllDataAsync(fullRefresh: false);
+            await RefreshAllDataAsync();
         }
         finally
         {
@@ -277,7 +277,7 @@ public partial class ServerTab : UserControl
 
         if (!isCustom)
         {
-            await RefreshAllDataAsync(fullRefresh: false);
+            await RefreshAllDataAsync();
         }
     }
 
@@ -286,7 +286,7 @@ public partial class ServerTab : UserControl
         if (!IsLoaded || _isRefreshing) return;
         if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
         {
-            await RefreshAllDataAsync(fullRefresh: false);
+            await RefreshAllDataAsync();
         }
     }
 
@@ -296,7 +296,7 @@ public partial class ServerTab : UserControl
         /* Only refresh if we have valid dates selected */
         if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
         {
-            await RefreshAllDataAsync(fullRefresh: false);
+            await RefreshAllDataAsync();
         }
     }
 

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -153,7 +153,7 @@ public partial class ServerTab : UserControl
         };
         _refreshTimer.Tick += async (s, e) =>
         {
-            await RefreshAllDataAsync(fullRefresh: false);
+            await RefreshAllDataAsync();
         };
         _refreshTimer.Start();
 
@@ -164,7 +164,7 @@ public partial class ServerTab : UserControl
             if (IsVisible && _refreshPendingWhileHidden)
             {
                 _refreshPendingWhileHidden = false;
-                _ = RefreshAllDataAsync(fullRefresh: false);
+                _ = RefreshAllDataAsync();
             }
         };
 


### PR DESCRIPTION
## What

Removes dead code in Lite: `RefreshAllTabsAsync` (the all-tabs "full refresh" path).

It was unreachable — every caller of `RefreshAllDataAsync` passes `fullRefresh:false`, which routes to the visible-only `RefreshVisibleTabAsync`. So the 163-line method, the `if (fullRefresh)` branch, and the `fullRefresh` parameter were all dead. The 7 callers now use the parameterless `RefreshAllDataAsync()`.

## Why

Flagged in #1193 — Lite was found to be already visible-only/lazy, leaving this as the orphaned legacy full-refresh path. Erik asked to kill it.

## Risk

Behavior-preserving (refresh was already visible-tab/sub-tab only). Build green (0 errors, 0 new warnings). Net -170 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
