### PR TITLE
Prettier charts: bolder area-filled lines + slicer quick-range chips

### DIFF
--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml
@@ -1,6 +1,39 @@
 <UserControl x:Class="PerformanceMonitorDashboard.Controls.TimeRangeSlicerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <!-- Quick-range pill/chip: rounded, theme-aware, lights up in the slicer accent on hover. -->
+        <Style x:Key="SlicerChipStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource SlicerLabelBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SlicerBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="7,1"/>
+            <Setter Property="Margin" Value="3,0,0,0"/>
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ChipBorder" CornerRadius="8"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ChipBorder" Property="Background" Value="{DynamicResource SlicerHandleHoverBrush}"/>
+                                <Setter TargetName="ChipBorder" Property="BorderBrush" Value="{DynamicResource SlicerHandleHoverBrush}"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
     <Border Background="{DynamicResource SlicerBackgroundBrush}"
             BorderBrush="{DynamicResource SlicerBorderBrush}"
             BorderThickness="0,0,0,1">
@@ -9,25 +42,39 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Button x:Name="ToggleButton" Grid.Row="0"
-                    Background="Transparent" BorderThickness="0"
-                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                    Padding="8,4" Cursor="Hand"
-                    Click="Toggle_Click">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock x:Name="ToggleIcon" Text="▾" FontSize="12"
-                               Foreground="{DynamicResource SlicerToggleBrush}"
-                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBlock x:Name="ToggleLabel" Text="Time Range"
-                               FontSize="11" FontWeight="SemiBold"
-                               Foreground="{DynamicResource SlicerToggleBrush}"
-                               VerticalAlignment="Center"/>
-                    <TextBlock x:Name="RangeLabel" Text=""
-                               FontSize="11"
-                               Foreground="{DynamicResource SlicerLabelBrush}"
-                               VerticalAlignment="Center" Margin="12,0,0,0"/>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button x:Name="ToggleButton" Grid.Column="0"
+                        Background="Transparent" BorderThickness="0"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                        Padding="8,4" Cursor="Hand"
+                        Click="Toggle_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="ToggleIcon" Text="▾" FontSize="12"
+                                   Foreground="{DynamicResource SlicerToggleBrush}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <TextBlock x:Name="ToggleLabel" Text="Time Range"
+                                   FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource SlicerToggleBrush}"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock x:Name="RangeLabel" Text=""
+                                   FontSize="11"
+                                   Foreground="{DynamicResource SlicerLabelBrush}"
+                                   VerticalAlignment="Center" Margin="12,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <StackPanel x:Name="QuickRangeChips" Grid.Column="1" Orientation="Horizontal"
+                            VerticalAlignment="Center" Margin="0,0,8,0">
+                    <Button Content="15m" Tag="15"   Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="1h"  Tag="60"   Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="6h"  Tag="360"  Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="24h" Tag="1440" Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="All" Tag="0"    Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
                 </StackPanel>
-            </Button>
+            </Grid>
             <Border x:Name="SlicerBorder" Grid.Row="1" Height="130" Margin="8,0,8,6"
                     Background="{DynamicResource SlicerBackgroundBrush}"
                     CornerRadius="4" ClipToBounds="True">

--- a/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Dashboard/Controls/TimeRangeSlicerControl.xaml.cs
@@ -350,6 +350,33 @@ public partial class TimeRangeSlicerControl : UserControl
 
     private void Toggle_Click(object sender, RoutedEventArgs e) => IsExpanded = !IsExpanded;
 
+    /// <summary>
+    /// Quick-range chip: selects the last N minutes of the loaded window (Tag = minutes), or the
+    /// full window when Tag is 0 ("All"). A duration longer than the window clamps to the start.
+    /// </summary>
+    private void QuickRange_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button b || _data.Count < 2) return;
+        if (b.Tag is not string tag || !int.TryParse(tag, out int minutes)) return;
+
+        if (minutes <= 0)
+        {
+            _rangeStart = 0;
+            _rangeEnd = 1.0;
+        }
+        else
+        {
+            var start = DataEnd.AddMinutes(-minutes);
+            if (start < DataStart) start = DataStart;
+            _rangeStart = NormAtTime(start);
+            _rangeEnd = 1.0;
+        }
+
+        UpdateRangeLabel();
+        Redraw();
+        FireRangeChanged();
+    }
+
     private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
         if (_data.Count < 2) return;

--- a/Lite/Controls/TimeRangeSlicerControl.xaml
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml
@@ -1,6 +1,39 @@
 <UserControl x:Class="PerformanceMonitorLite.Controls.TimeRangeSlicerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <!-- Quick-range pill/chip: rounded, theme-aware, lights up in the slicer accent on hover. -->
+        <Style x:Key="SlicerChipStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource SlicerLabelBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SlicerBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="7,1"/>
+            <Setter Property="Margin" Value="3,0,0,0"/>
+            <Setter Property="FontSize" Value="10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ChipBorder" CornerRadius="8"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ChipBorder" Property="Background" Value="{DynamicResource SlicerHandleHoverBrush}"/>
+                                <Setter TargetName="ChipBorder" Property="BorderBrush" Value="{DynamicResource SlicerHandleHoverBrush}"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
     <Border Background="{DynamicResource SlicerBackgroundBrush}"
             BorderBrush="{DynamicResource SlicerBorderBrush}"
             BorderThickness="0,0,0,1">
@@ -9,25 +42,39 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Button x:Name="ToggleButton" Grid.Row="0"
-                    Background="Transparent" BorderThickness="0"
-                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                    Padding="8,4" Cursor="Hand"
-                    Click="Toggle_Click">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock x:Name="ToggleIcon" Text="▾" FontSize="12"
-                               Foreground="{DynamicResource SlicerToggleBrush}"
-                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBlock x:Name="ToggleLabel" Text="Time Range"
-                               FontSize="11" FontWeight="SemiBold"
-                               Foreground="{DynamicResource SlicerToggleBrush}"
-                               VerticalAlignment="Center"/>
-                    <TextBlock x:Name="RangeLabel" Text=""
-                               FontSize="11"
-                               Foreground="{DynamicResource SlicerLabelBrush}"
-                               VerticalAlignment="Center" Margin="12,0,0,0"/>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button x:Name="ToggleButton" Grid.Column="0"
+                        Background="Transparent" BorderThickness="0"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                        Padding="8,4" Cursor="Hand"
+                        Click="Toggle_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="ToggleIcon" Text="▾" FontSize="12"
+                                   Foreground="{DynamicResource SlicerToggleBrush}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <TextBlock x:Name="ToggleLabel" Text="Time Range"
+                                   FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource SlicerToggleBrush}"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock x:Name="RangeLabel" Text=""
+                                   FontSize="11"
+                                   Foreground="{DynamicResource SlicerLabelBrush}"
+                                   VerticalAlignment="Center" Margin="12,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <StackPanel x:Name="QuickRangeChips" Grid.Column="1" Orientation="Horizontal"
+                            VerticalAlignment="Center" Margin="0,0,8,0">
+                    <Button Content="15m" Tag="15"   Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="1h"  Tag="60"   Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="6h"  Tag="360"  Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="24h" Tag="1440" Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
+                    <Button Content="All" Tag="0"    Click="QuickRange_Click" Style="{StaticResource SlicerChipStyle}"/>
                 </StackPanel>
-            </Button>
+            </Grid>
             <Border x:Name="SlicerBorder" Grid.Row="1" Height="130" Margin="8,0,8,6"
                     Background="{DynamicResource SlicerBackgroundBrush}"
                     CornerRadius="4" ClipToBounds="True">

--- a/Lite/Controls/TimeRangeSlicerControl.xaml.cs
+++ b/Lite/Controls/TimeRangeSlicerControl.xaml.cs
@@ -368,6 +368,33 @@ public partial class TimeRangeSlicerControl : UserControl
 
     private void Toggle_Click(object sender, RoutedEventArgs e) => IsExpanded = !IsExpanded;
 
+    /// <summary>
+    /// Quick-range chip: selects the last N minutes of the loaded window (Tag = minutes), or the
+    /// full window when Tag is 0 ("All"). A duration longer than the window clamps to the start.
+    /// </summary>
+    private void QuickRange_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button b || _data.Count < 2) return;
+        if (b.Tag is not string tag || !int.TryParse(tag, out int minutes)) return;
+
+        if (minutes <= 0)
+        {
+            _rangeStart = 0;
+            _rangeEnd = 1.0;
+        }
+        else
+        {
+            var start = DataEndUtc.AddMinutes(-minutes);
+            if (start < DataStartUtc) start = DataStartUtc;
+            _rangeStart = NormAtUtc(start);
+            _rangeEnd = 1.0;
+        }
+
+        UpdateRangeLabel();
+        Redraw();
+        FireRangeChanged();
+    }
+
     private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
         if (_data.Count < 2) return;

--- a/PerformanceMonitor.Ui/ChartStyle.cs
+++ b/PerformanceMonitor.Ui/ChartStyle.cs
@@ -203,10 +203,16 @@ namespace PerformanceMonitor.Ui
         public static void StyleScatter(ScottPlot.Plottables.Scatter scatter)
         {
             int pointCount = scatter.Data.GetScatterPoints().Count;
+            var seriesColor = scatter.LineColor;
             scatter.LineWidth = 2;
             scatter.MarkerSize = MarkerSizeForDensity(pointCount);
-            // Soften only the connecting line; keep markers fully opaque so peaks stay legible.
-            scatter.LineColor = scatter.LineColor.WithAlpha(210);
+            // Soften the connecting line; markers stay fully opaque so peaks read clearly.
+            scatter.LineColor = seriesColor.WithAlpha(215);
+            // Solid-ish area fill under the line — the main "easy on the eye" look ported from
+            // PerformanceStudio. Alpha 70 reads clearly without fully hiding overlapping series on
+            // the busy multi-line charts.
+            scatter.FillY = true;
+            scatter.FillYColor = seriesColor.WithAlpha(70);
         }
 
         /// <summary>


### PR DESCRIPTION
The two most-visible PerformanceStudio looks, on top of the foundation already merged in #1191. Rebased on current dev; both apps build clean.

- **Area fills**: `ChartStyle.StyleScatter` fills under every trend line (solid-ish alpha-70 series-colored fill) plus the softened stroke. Flows through the one shared helper, so all ~104 scatter sites in both apps get it at once.
- **Slicer quick-range chips**: rounded `15m / 1h / 6h / 24h / All` pills on the time-range slicer header (theme-aware, accent on hover) that select the last-N of the loaded window. Both apps.

Verified live: fills render on the CPU chart; chips render on the Query Stats slicer.

Generated with [Claude Code](https://claude.com/claude-code)