### PR TITLE
Lite: offload sync DuckDB calls on interactive UI paths to Task.Run

### DIFF
--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -79,7 +79,7 @@ public partial class AlertsHistoryTab : UserControl
             var hoursBack = GetSelectedHoursBack();
             int? serverId = GetSelectedServerId();
 
-            var alerts = await _dataService.GetAlertHistoryAsync(hoursBack, 500, serverId);
+            var alerts = await System.Threading.Tasks.Task.Run(() => _dataService.GetAlertHistoryAsync(hoursBack, 500, serverId));
 
             if (_filterManager != null)
                 _filterManager.UpdateData(alerts);
@@ -312,7 +312,7 @@ public partial class AlertsHistoryTab : UserControl
 
         try
         {
-            var affected = await _dataService.DismissAlertsAsync(liveAlerts);
+            var affected = await System.Threading.Tasks.Task.Run(() => _dataService.DismissAlertsAsync(liveAlerts));
             if (affected < liveAlerts.Count && App.LogAlertDismissals)
             {
                 AppLogger.Warn("AlertsHistory", $"Dismiss selected: only {affected} of {liveAlerts.Count} live alert(s) were updated");
@@ -376,7 +376,7 @@ public partial class AlertsHistoryTab : UserControl
         {
             var hoursBack = GetSelectedHoursBack();
             int? serverId = GetSelectedServerId();
-            var affected = await _dataService.DismissAllVisibleAlertsAsync(hoursBack, serverId);
+            var affected = await System.Threading.Tasks.Task.Run(() => _dataService.DismissAllVisibleAlertsAsync(hoursBack, serverId));
             if (affected < liveCount && App.LogAlertDismissals)
             {
                 AppLogger.Warn("AlertsHistory", $"Dismiss all: only {affected} of {liveCount} live alert(s) were updated");

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -140,7 +140,7 @@ public partial class FinOpsTab : UserControl
         string? plan = null;
         if (serverId != 0 && _dataService != null)
         {
-            try { plan = await _dataService.GetCachedQueryPlanAsync(serverId, queryHash); }
+            try { plan = await System.Threading.Tasks.Task.Run(() => _dataService.GetCachedQueryPlanAsync(serverId, queryHash)); }
             catch { /* fall through to the live server */ }
         }
         if (string.IsNullOrEmpty(plan))

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -1243,7 +1243,7 @@ public partial class ServerTab : UserControl
                 }
             }
             var metric = (HeatmapMetric)HeatmapMetricCombo.SelectedIndex;
-            var result = await _dataService.GetQueryHeatmapAsync(_serverId, metric, hoursBack, fromDate, toDate);
+            var result = await System.Threading.Tasks.Task.Run(() => _dataService.GetQueryHeatmapAsync(_serverId, metric, hoursBack, fromDate, toDate));
             UpdateQueryHeatmapChart(result);
         }
         catch (Exception ex)

--- a/Lite/Controls/ServerTab.Comparison.cs
+++ b/Lite/Controls/ServerTab.Comparison.cs
@@ -112,9 +112,9 @@ public partial class ServerTab : UserControl
 
         SetQueryStatsComparisonMode(true, baselineRange);
 
-        var items = await _dataService.GetQueryStatsComparisonAsync(
+        var items = await Task.Run(() => _dataService.GetQueryStatsComparisonAsync(
             _serverId, currentStart, currentEnd,
-            baselineRange.Value.From, baselineRange.Value.To);
+            baselineRange.Value.From, baselineRange.Value.To));
 
         // Sort: NEW first, then by duration delta descending, GONE last
         var sorted = items
@@ -150,9 +150,9 @@ public partial class ServerTab : UserControl
 
         SetProcStatsComparisonMode(true, baselineRange);
 
-        var items = await _dataService.GetProcedureStatsComparisonAsync(
+        var items = await Task.Run(() => _dataService.GetProcedureStatsComparisonAsync(
             _serverId, currentStart, currentEnd,
-            baselineRange.Value.From, baselineRange.Value.To);
+            baselineRange.Value.From, baselineRange.Value.To));
 
         var sorted = items
             .OrderBy(x => x.SortGroup)
@@ -187,9 +187,9 @@ public partial class ServerTab : UserControl
 
         SetQueryStoreComparisonMode(true, baselineRange);
 
-        var items = await _dataService.GetQueryStoreComparisonAsync(
+        var items = await Task.Run(() => _dataService.GetQueryStoreComparisonAsync(
             _serverId, currentStart, currentEnd,
-            baselineRange.Value.From, baselineRange.Value.To);
+            baselineRange.Value.From, baselineRange.Value.To));
 
         var sorted = items
             .OrderBy(x => x.SortGroup)

--- a/Lite/Controls/ServerTab.DrillDown.cs
+++ b/Lite/Controls/ServerTab.DrillDown.cs
@@ -123,7 +123,7 @@ public partial class ServerTab : UserControl
 
         // Navigate to Queries > Active Queries with ±15 min window
         SelectActiveQueriesForDrillDown();
-        var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
+        var snapshots = await System.Threading.Tasks.Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate));
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
@@ -136,7 +136,7 @@ public partial class ServerTab : UserControl
         SetDrillDownTimeRange(fromDate, toDate);
 
         SelectActiveQueriesForDrillDown();
-        var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
+        var snapshots = await System.Threading.Tasks.Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate));
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
@@ -150,7 +150,7 @@ public partial class ServerTab : UserControl
 
         // Navigate to Active Queries — TempDB spills are visible there
         SelectActiveQueriesForDrillDown();
-        var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
+        var snapshots = await System.Threading.Tasks.Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate));
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LiveSnapshotIndicator.Text = $"Drill-down: {ServerTimeHelper.FormatServerTime(fromDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")} → {ServerTimeHelper.FormatServerTime(toDate.AddMinutes(-UtcOffsetMinutes), "HH:mm")}";
         _ = LoadActiveQueriesSlicerAsync();
@@ -164,7 +164,7 @@ public partial class ServerTab : UserControl
 
         MainTabControl.SelectedIndex = 8; // Blocking
         BlockingSubTabControl.SelectedIndex = 2; // Blocked Process Reports
-        var bpr = await _dataService.GetRecentBlockedProcessReportsAsync(_serverId, 0, fromDate, toDate);
+        var bpr = await System.Threading.Tasks.Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, 0, fromDate, toDate));
         _blockedProcessFilterMgr!.UpdateData(bpr);
     }
 
@@ -176,7 +176,7 @@ public partial class ServerTab : UserControl
 
         MainTabControl.SelectedIndex = 8; // Blocking
         BlockingSubTabControl.SelectedIndex = 3; // Deadlocks
-        var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromDate, toDate);
+        var dlr = await System.Threading.Tasks.Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromDate, toDate));
         _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(dlr));
     }
 
@@ -193,7 +193,7 @@ public partial class ServerTab : UserControl
         SelectActiveQueriesForDrillDown();
 
         AppLogger.Info("DrillDown", $"Calling GetLatestQuerySnapshotsAsync with fromDate={fromDate:O}, toDate={toDate:O}");
-        var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate);
+        var snapshots = await System.Threading.Tasks.Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromDate, toDate));
         AppLogger.Info("DrillDown", $"Got {snapshots.Count} snapshots");
 
         _querySnapshotsFilterMgr!.UpdateData(snapshots);

--- a/Lite/Controls/ServerTab.Grids.cs
+++ b/Lite/Controls/ServerTab.Grids.cs
@@ -149,7 +149,7 @@ public partial class ServerTab : UserControl
         {
             var hoursBack = GetHoursBack();
             var (fromDate, toDate) = GetCurrentViewDates();
-            var history = await _dataService.GetQueryStatsHistoryAsync(_serverId, row.DatabaseName, row.QueryHash, hoursBack, fromDate, toDate);
+            var history = await Task.Run(() => _dataService.GetQueryStatsHistoryAsync(_serverId, row.DatabaseName, row.QueryHash, hoursBack, fromDate, toDate));
 
             var points = ComputeQueryOverlayPoints(history, _queryStatsSlicerMetric);
             QueryStatsSlicer.SetOverlay(points, row.QueryHash);
@@ -169,7 +169,7 @@ public partial class ServerTab : UserControl
         {
             var hoursBack = GetHoursBack();
             var (fromDate, toDate) = GetCurrentViewDates();
-            var history = await _dataService.GetProcedureStatsHistoryAsync(_serverId, row.DatabaseName, row.SchemaName, row.ObjectName, hoursBack, fromDate, toDate);
+            var history = await Task.Run(() => _dataService.GetProcedureStatsHistoryAsync(_serverId, row.DatabaseName, row.SchemaName, row.ObjectName, hoursBack, fromDate, toDate));
 
             var points = ComputeProcOverlayPoints(history, _procStatsSlicerMetric);
             var label = row.ObjectName.Length > 30 ? row.ObjectName[..30] + "..." : row.ObjectName;
@@ -190,7 +190,7 @@ public partial class ServerTab : UserControl
         {
             var hoursBack = GetHoursBack();
             var (fromDate, toDate) = GetCurrentViewDates();
-            var history = await _dataService.GetQueryStoreHistoryAsync(_serverId, row.DatabaseName, row.QueryId, row.PlanId, hoursBack, fromDate, toDate);
+            var history = await Task.Run(() => _dataService.GetQueryStoreHistoryAsync(_serverId, row.DatabaseName, row.QueryId, row.PlanId, hoursBack, fromDate, toDate));
 
             // Query Store values are already per-interval averages, not cumulative
             Func<QueryStoreHistoryRow, double> selector = _queryStoreSlicerMetric switch

--- a/Lite/Controls/ServerTab.Plans.cs
+++ b/Lite/Controls/ServerTab.Plans.cs
@@ -40,7 +40,7 @@ public partial class ServerTab : UserControl
             // Try DuckDB first
             try
             {
-                plan = await _dataService.GetCachedQueryPlanAsync(_serverId, row.QueryHash);
+                plan = await Task.Run(() => _dataService.GetCachedQueryPlanAsync(_serverId, row.QueryHash));
             }
             catch
             {
@@ -94,7 +94,7 @@ public partial class ServerTab : UserControl
             {
                 try
                 {
-                    plan = await _dataService.GetCachedProcedurePlanAsync(_serverId, row.PlanHandle);
+                    plan = await Task.Run(() => _dataService.GetCachedProcedurePlanAsync(_serverId, row.PlanHandle));
                 }
                 catch
                 {
@@ -462,7 +462,7 @@ public partial class ServerTab : UserControl
         // Try DuckDB cache first
         try
         {
-            var plan = await _dataService.GetCachedQueryPlanAsync(_serverId, queryHash);
+            var plan = await Task.Run(() => _dataService.GetCachedQueryPlanAsync(_serverId, queryHash));
             if (!string.IsNullOrEmpty(plan)) return plan;
         }
         catch { }

--- a/Lite/Controls/ServerTab.Slicers.cs
+++ b/Lite/Controls/ServerTab.Slicers.cs
@@ -42,7 +42,7 @@ public partial class ServerTab : UserControl
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
 
-            var bpr = await _dataService.GetRecentBlockedProcessReportsAsync(_serverId, 0, fromServer, toServer);
+            var bpr = await Task.Run(() => _dataService.GetRecentBlockedProcessReportsAsync(_serverId, 0, fromServer, toServer));
             _blockedProcessFilterMgr!.UpdateData(bpr);
         }
         catch (Exception ex)
@@ -58,7 +58,7 @@ public partial class ServerTab : UserControl
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
 
-            var dlr = await _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromServer, toServer);
+            var dlr = await Task.Run(() => _dataService.GetRecentDeadlocksAsync(_serverId, 0, fromServer, toServer));
             _deadlockFilterMgr!.UpdateData(await ParseDeadlocksOffUiThreadAsync(dlr));
         }
         catch (Exception ex)
@@ -95,7 +95,7 @@ public partial class ServerTab : UserControl
                 queryTo = toDate.Value.AddHours(1);
             }
 
-            var data = await _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, queryFrom, queryTo);
+            var data = await Task.Run(() => _dataService.GetActiveQuerySlicerDataAsync(_serverId, hoursBack, queryFrom, queryTo));
             _activeQueriesSlicerData = data;
             _activeQueriesSlicerMetric = "Sessions";
             var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, queryFrom, queryTo);
@@ -119,7 +119,7 @@ public partial class ServerTab : UserControl
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
 
-            var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromServer, toServer);
+            var snapshots = await Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, 0, fromServer, toServer));
             _querySnapshotsFilterMgr!.UpdateData(snapshots);
             LiveSnapshotIndicator.Text = "";
         }
@@ -151,7 +151,7 @@ public partial class ServerTab : UserControl
                 }
             }
 
-            var data = await _dataService.GetQueryStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            var data = await Task.Run(() => _dataService.GetQueryStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate));
             _queryStatsSlicerData = data;
             _queryStatsSlicerMetric = "TotalCpu";
             var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
@@ -170,7 +170,7 @@ public partial class ServerTab : UserControl
         {
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
-            var queryStats = await _dataService.GetTopQueriesByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
+            var queryStats = await Task.Run(() => _dataService.GetTopQueriesByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes));
             _queryStatsFilterMgr!.UpdateData(queryStats);
             await RefreshQueryStatsComparisonAsync(fromServer, toServer);
         }
@@ -202,7 +202,7 @@ public partial class ServerTab : UserControl
                 }
             }
 
-            var data = await _dataService.GetQueryStoreSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            var data = await Task.Run(() => _dataService.GetQueryStoreSlicerDataAsync(_serverId, hoursBack, fromDate, toDate));
             _queryStoreSlicerData = data;
             _queryStoreSlicerMetric = "TotalCpu";
             var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
@@ -221,7 +221,7 @@ public partial class ServerTab : UserControl
         {
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
-            var qsData = await _dataService.GetQueryStoreTopQueriesAsync(_serverId, 0, 50, fromServer, toServer);
+            var qsData = await Task.Run(() => _dataService.GetQueryStoreTopQueriesAsync(_serverId, 0, 50, fromServer, toServer));
             _queryStoreFilterMgr!.UpdateData(qsData);
             await RefreshQueryStoreComparisonAsync(fromServer, toServer);
         }
@@ -253,7 +253,7 @@ public partial class ServerTab : UserControl
                 }
             }
 
-            var data = await _dataService.GetProcStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate);
+            var data = await Task.Run(() => _dataService.GetProcStatsSlicerDataAsync(_serverId, hoursBack, fromDate, toDate));
             _procStatsSlicerData = data;
             _procStatsSlicerMetric = "TotalCpu";
             var (slicerStart, slicerEnd) = GetSlicerTimeRange(hoursBack, fromDate, toDate);
@@ -272,7 +272,7 @@ public partial class ServerTab : UserControl
         {
             var fromServer = ServerTimeHelper.ToServerTime(e.StartUtc);
             var toServer = ServerTimeHelper.ToServerTime(e.EndUtc);
-            var procStats = await _dataService.GetTopProceduresByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes);
+            var procStats = await Task.Run(() => _dataService.GetTopProceduresByCpuAsync(_serverId, 0, 50, fromServer, toServer, UtcOffsetMinutes));
             _procStatsFilterMgr!.UpdateData(procStats);
             await RefreshProcStatsComparisonAsync(fromServer, toServer);
         }

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -443,7 +443,7 @@ public partial class ServerTab : UserControl
     {
         try
         {
-            var result = await _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate);
+            var result = await Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate));
             DailySummaryGrid.ItemsSource = result != null
                 ? new List<DailySummaryRow> { result } : null;
             DailySummaryNoData.Visibility = result == null


### PR DESCRIPTION
## What

Offloads **31** synchronous DuckDB calls on interactive UI paths to `Task.Run`, so interacting with Lite under load no longer freezes the dispatcher.

DuckDB.NET is synchronous, so an un-wrapped `await _dataService.X()` runs on the calling thread. On UI event handlers that blocks the dispatcher (a connection-open alone is ~766ms under load, the proven root cause of the ~930ms hitch that was already fixed for the 60s alert-check path). The auto-refresh path was swept; the interactive paths weren't.

## Sites wrapped (each verified genuinely UI-thread, not blind)
- `ServerTab.Slicers.cs` (10): slicer drags + slicer loads
- `ServerTab.DrillDown.cs` (6): chart drill-downs
- `ServerTab.Grids.cs` (3): grid row-history expands
- `ServerTab.Comparison.cs` (3): baseline comparisons
- `ServerTab.Plans.cs` (3): View/Download Plan (DuckDB cache lookup)
- `ServerTab.Charts.cs` (1): interactive heatmap metric change
- `ServerTab.xaml.cs` (1): daily summary
- `AlertsHistoryTab.xaml.cs` (3): alert history load + the two dismiss writes
- `FinOpsTab.xaml.cs` (1): FinOps View Plan

## Correctly left alone
- `Refresh.cs:231` heatmap: already inside a `Task.Run` lambda (false positive).
- `LocalDataService.Fetch*OnDemandAsync` live-server fallbacks: genuinely async SqlClient.

## Notes
- Completes #1193 (which moved the deadlock parse off-thread in slicer/drill-down but left the fetch on the UI thread).
- Same proven fix/pattern as the shipped alert-check offload. Build green (0 errors, 0 new warnings).
- Runtime confirmation pending via HammerDB from the integrated dev build (dispatcher p99 should stay single-digit ms when interacting under load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
