### PR TITLE
TempDB Stats: drop Unallocated band, add allocated-size trend chart

### DIFF
--- a/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.TempdbStats.cs
@@ -42,6 +42,7 @@ namespace PerformanceMonitorDashboard.Controls
                 // Load TempDB usage stats
                 var data = await _databaseService.GetTempdbStatsAsync(_tempdbStatsHoursBack, _tempdbStatsFromDate, _tempdbStatsToDate);
                 LoadTempdbStatsChart(data, _tempdbStatsHoursBack, _tempdbStatsFromDate, _tempdbStatsToDate);
+                LoadTempdbSizeChart(data, _tempdbStatsHoursBack, _tempdbStatsFromDate, _tempdbStatsToDate);
 
                 // Load TempDB latency charts (moved from File I/O Latency tab)
                 await LoadTempdbLatencyChartsAsync();
@@ -184,18 +185,10 @@ namespace PerformanceMonitorDashboard.Controls
                 internalScatter.LegendText = "Internal Objects";
                 _tempdbStatsHover?.Add(internalScatter, "Internal Objects");
 
-                // Unallocated (free space) series
-                var (unallocXs, unallocYs) = TabHelpers.FillTimeSeriesGaps(
-                    dataList.Select(d => d.CollectionTime),
-                    dataList.Select(d => (double)d.UnallocatedMb));
-                if (unallocYs.Any(y => y > 0))
-                {
-                    var unallocScatter = TempdbStatsChart.Plot.Add.Scatter(unallocXs, unallocYs);
-                    unallocScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UnallocatedTempdb"));
-                    ChartStyle.StyleScatter(unallocScatter);
-                    unallocScatter.LegendText = "Unallocated";
-                    _tempdbStatsHover?.Add(unallocScatter, "Unallocated");
-                }
+                // Unallocated (free space) is intentionally NOT plotted here: it is almost always the
+                // largest value, so it set the Y-axis and flattened the actual usage series into an
+                // unreadable sliver. The tempdb total file size (used + unallocated) and its growth over
+                // the window are surfaced on the dedicated TempdbSizeChart below, on their own scale.
 
                 // Top Task Total MB series (worst session's usage)
                 var topTaskValues = dataList.Select(d => (double)(d.TopTaskTotalMb ?? 0)).ToArray();
@@ -233,6 +226,46 @@ namespace PerformanceMonitorDashboard.Controls
             TempdbStatsChart.Plot.YLabel("MB");
             TabHelpers.LockChartVerticalAxis(TempdbStatsChart);
             TempdbStatsChart.Refresh();
+        }
+
+        // Dedicated chart for tempdb TOTAL allocated size (used + unallocated free space) over time —
+        // the growth trend the Unallocated band used to carry, on its own scale so it doesn't flatten
+        // the usage breakdown above it.
+        private void LoadTempdbSizeChart(IEnumerable<TempdbStatsItem> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
+        {
+            DateTime rangeEnd = toDate ?? Helpers.ServerTimeHelper.ServerNow;
+            DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+            double xMin = rangeStart.ToOADate();
+            double xMax = rangeEnd.ToOADate();
+
+            TempdbSizeChart.Plot.Clear();
+            TabHelpers.ApplyThemeToChart(TempdbSizeChart);
+
+            var dataList = data?.OrderBy(d => d.CollectionTime).ToList() ?? new List<TempdbStatsItem>();
+            if (dataList.Count > 0)
+            {
+                var (xs, ys) = TabHelpers.FillTimeSeriesGaps(
+                    dataList.Select(d => d.CollectionTime),
+                    dataList.Select(d => (double)(d.TotalReservedMb + d.UnallocatedMb)));
+                var sizeScatter = TempdbSizeChart.Plot.Add.Scatter(xs, ys);
+                sizeScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UnallocatedTempdb"));
+                ChartStyle.StyleScatter(sizeScatter);
+            }
+            else
+            {
+                double xCenter = xMin + (xMax - xMin) / 2;
+                var noDataText = TempdbSizeChart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
+                noDataText.LabelFontSize = 14;
+                noDataText.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
+                noDataText.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
+            }
+
+            TempdbSizeChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            TempdbSizeChart.Plot.Axes.SetLimitsX(xMin, xMax);
+            TempdbSizeChart.Plot.Axes.AutoScaleY();
+            TempdbSizeChart.Plot.YLabel("MB");
+            TabHelpers.LockChartVerticalAxis(TempdbSizeChart);
+            TempdbSizeChart.Refresh();
         }
 
         private void UpdateTempdbStatsSummary(TempdbStatsItem? data)

--- a/Dashboard/Controls/ResourceMetricsContent.xaml
+++ b/Dashboard/Controls/ResourceMetricsContent.xaml
@@ -102,9 +102,10 @@
         </TabItem>
         <!-- TempDB Stats Sub-Tab -->
         <TabItem Header="TempDB Stats">
-            <!-- TempDB Stats - 2 charts vertical layout -->
+            <!-- TempDB Stats - usage / size / latency charts + summary -->
             <Grid Margin="5">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
@@ -122,8 +123,20 @@
                     </Grid>
                 </Border>
 
+                <!-- TempDB Allocated Size Chart (growth trend, own scale) -->
+                <Border Grid.Row="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="0,2,0,2">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Grid.Row="0" Text="TempDB Allocated Size Over Time (MB)" FontWeight="Bold" FontSize="11" Margin="5,3" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ScottPlot:WpfPlot Grid.Row="1" x:Name="TempdbSizeChart"/>
+                    </Grid>
+                </Border>
+
                 <!-- TempDB Latency Chart (Read + Write combined) -->
-                <Border Grid.Row="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="0,2,0,0">
+                <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="0,2,0,0">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -135,7 +148,7 @@
                 </Border>
 
                 <!-- Summary Panel -->
-                <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,8">
+                <Border Grid.Row="3" Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="10,8">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <TextBlock Text="Sessions Using TempDB:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                         <TextBlock x:Name="TempdbSessionsText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -404,6 +404,30 @@ public partial class ServerTab : UserControl
         TempDbChart.Refresh();
     }
 
+    // Dedicated chart for tempdb TOTAL allocated size (used + unallocated free space) over time — the
+    // growth trend, on its own scale so it doesn't flatten the usage series above. Mirror of Dashboard.
+    private void UpdateTempDbSizeChart(List<TempDbRow> data)
+    {
+        ClearChart(TempDbSizeChart);
+        ApplyTheme(TempDbSizeChart);
+
+        if (data.Count == 0) { TempDbSizeChart.Refresh(); return; }
+
+        var sorted = data.OrderBy(d => d.CollectionTime).ToList();
+        var times = sorted.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
+        var totals = sorted.Select(d => d.TotalReservedMb + d.UnallocatedMb).ToArray();
+
+        var sizePlot = TempDbSizeChart.Plot.Add.Scatter(times, totals);
+        sizePlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("UnallocatedTempdb"));
+        ChartStyle.StyleScatter(sizePlot);
+
+        TempDbSizeChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ReapplyAxisColors(TempDbSizeChart);
+        TempDbSizeChart.Plot.YLabel("Allocated MB");
+        TempDbSizeChart.Plot.Axes.AutoScaleY();
+        TempDbSizeChart.Refresh();
+    }
+
     private void UpdateTempDbFileIoChart(List<FileIoTrendPoint> data)
     {
         ClearChart(TempDbFileIoChart);

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -395,6 +395,7 @@ public partial class ServerTab : UserControl
             await System.Threading.Tasks.Task.WhenAll(tempDbTask, tempDbFileIoTask);
 
             UpdateTempDbChart(tempDbTask.Result);
+            UpdateTempDbSizeChart(tempDbTask.Result);
             UpdateTempDbFileIoChart(tempDbFileIoTask.Result);
         }
         catch (Exception ex)

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1306,13 +1306,18 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
                     <Border Grid.Row="0" Margin="0,0,0,4">
                         <ScottPlot:WpfPlot x:Name="TempDbChart"/>
                     </Border>
 
-                    <Border Grid.Row="1" Margin="0,4,0,0">
+                    <Border Grid.Row="1" Margin="0,4,0,4">
+                        <ScottPlot:WpfPlot x:Name="TempDbSizeChart"/>
+                    </Border>
+
+                    <Border Grid.Row="2" Margin="0,4,0,0">
                         <ScottPlot:WpfPlot x:Name="TempDbFileIoChart"/>
                     </Border>
                 </Grid>


### PR DESCRIPTION
Replaces the point-in-time TempDB size stat (committed locally, never pushed/merged) with a proper growth trend.

## What changed
- **Usage chart**: the Unallocated free-space series is no longer plotted -- it dominated the Y-axis and flattened the real usage series (user/internal/version-store) into an unreadable sliver.
- **New "TempDB Allocated Size Over Time" chart**: total allocated size (used + unallocated free space) over the window, on its own auto-scaled axis, sitting between the usage and latency charts. This is the growth trend that was asked for, not a single current-size number.
- The size text/stat that briefly lived in the summary/latency area is removed.

Both **Dashboard** and **Lite**, kept at parity. The new chart goes through the shared `ChartStyle.StyleScatter` (gradient area fill + the flat-series crash guard already on dev via b0c1937).

Built green: Dashboard + Lite. Relaunched Dashboard confirmed stable (prior build hard-crashed on this tab); user-approved in the TempDB Stats tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)