### PR TITLE
Correlate-and-focus slice 1: "what else fired in this window" cross-reference

### DIFF
--- a/Dashboard.Tests/CoFiredSummaryTests.cs
+++ b/Dashboard.Tests/CoFiredSummaryTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Services.Recommendations;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests the shared "what else fired in this window" cross-reference (correlate-and-focus slice 1,
+/// review §1d): the pure <see cref="CoFiredSummary"/> helper and the Dashboard reader's per-card
+/// append. The Lite reader's append is covered in LiteRecommendationsReaderTests.
+/// </summary>
+public class CoFiredSummaryTests
+{
+    [Fact]
+    public void OtherTitles_ExcludesSelf_OrdersBySeverityDesc_Dedups()
+    {
+        var window = new List<(string, double)> { ("A", 0.5), ("B", 1.9), ("C", 0.8), ("B", 1.0) };
+        var others = CoFiredSummary.OtherTitles("A", window);
+        Assert.Equal(new[] { "B", "C" }, others); // self A excluded; B(1.9) before C(0.8); duplicate B collapsed
+    }
+
+    [Fact]
+    public void Line_CapsAndCountsTheRest()
+    {
+        var others = new List<string> { "A", "B", "C", "D", "E" };
+        Assert.Equal(
+            "Also surfaced in this analysis window: A; B; C (+2 more).",
+            CoFiredSummary.Line(others, cap: 3));
+    }
+
+    [Fact]
+    public void Line_NoExtra_OmitsTheCount()
+    {
+        Assert.Equal(
+            "Also surfaced in this analysis window: A; B.",
+            CoFiredSummary.Line(new List<string> { "A", "B" }, cap: 3));
+    }
+
+    [Fact]
+    public void Line_NullForEmpty()
+    {
+        Assert.Null(CoFiredSummary.Line(new List<string>()));
+    }
+
+    [Fact]
+    public void DashboardReader_AppendCoFired_AppendsTheOthersToEachCard()
+    {
+        var items = new List<RecommendationItem>
+        {
+            new() { Title = "High problem", RawSeverity = 1.9, AdviceText = "fix high." },
+            new() { Title = "Low problem", RawSeverity = 0.5, AdviceText = "fix low." },
+        };
+
+        RecommendationsReader.AppendCoFired(items);
+
+        Assert.Contains("fix high.", items[0].AdviceText);
+        Assert.Contains("Also surfaced in this analysis window: Low problem.", items[0].AdviceText);
+        Assert.Contains("Also surfaced in this analysis window: High problem.", items[1].AdviceText);
+    }
+
+    [Fact]
+    public void DashboardReader_AppendCoFired_SingleCard_NoOp()
+    {
+        var items = new List<RecommendationItem>
+        {
+            new() { Title = "Only problem", RawSeverity = 1.0, AdviceText = "fix it." },
+        };
+
+        RecommendationsReader.AppendCoFired(items);
+
+        Assert.Equal("fix it.", items[0].AdviceText); // nothing else fired -> unchanged
+    }
+}

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
@@ -65,6 +66,11 @@ public sealed class McpAnalysisTools
                 }, McpHelpers.JsonOptions);
             }
 
+            // Correlate-and-focus slice 1 (review §1d): each finding's "what else fired this window".
+            var coFiredTitles = new List<(string, double)>(findings.Count);
+            foreach (var wf in findings)
+                coFiredTitles.Add((FactAdvice.GetForFinding(wf)?.Headline ?? wf.RootFactKey, wf.Severity));
+
             return JsonSerializer.Serialize(new
             {
                 server = resolved.Value.ServerName,
@@ -93,6 +99,7 @@ public sealed class McpAnalysisTools
                         fact_count = f.FactCount,
                         drill_down = f.DrillDown,
                         next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredTitles),
                         advice = advice is null ? null : new
                         {
                             headline = advice.Headline,
@@ -361,6 +368,16 @@ public sealed class McpAnalysisTools
             if (findings.Count == 0)
                 return JsonSerializer.Serialize(new { server = resolved.Value.ServerName, finding_count = 0, message = "No findings. Run analyze_server to generate new findings." }, McpHelpers.JsonOptions);
 
+            // Correlate-and-focus slice 1 (review §1d): "what else fired", scoped per analysis run
+            // (this read can span multiple runs, unlike analyze_server's single run).
+            var coFiredByRun = new Dictionary<DateTime, List<(string, double)>>();
+            foreach (var wf in findings)
+            {
+                if (!coFiredByRun.TryGetValue(wf.AnalysisTime, out var list))
+                    coFiredByRun[wf.AnalysisTime] = list = new List<(string, double)>();
+                list.Add((FactAdvice.GetComposedForFinding(wf)?.Headline ?? wf.RootFactKey, wf.Severity));
+            }
+
             return JsonSerializer.Serialize(new
             {
                 server = resolved.Value.ServerName,
@@ -383,6 +400,7 @@ public sealed class McpAnalysisTools
                         story_path = f.StoryPath,
                         story_path_hash = f.StoryPathHash,
                         analysis_time = f.AnalysisTime.ToString("o"),
+                        co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredByRun[f.AnalysisTime]),
                         advice = advice is null ? null : new
                         {
                             headline = advice.Headline,

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -105,6 +105,12 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
             foreach (var finding in findings)
                 engineItems.AddRange(MapEngineFindings(finding));
 
+            // Correlate-and-focus slice 1 (review §1d): append a "what else fired in this analysis
+            // window" cross-reference to each engine card's advice so related findings link to each
+            // other instead of the operator hunting across cards. Engine findings only (the legacy
+            // store is a separate producer). Render-time, not frozen.
+            AppendCoFired(engineItems);
+
             var legacyItems = new List<RecommendationItem>(legacy.Count);
             foreach (var issue in legacy)
             {
@@ -115,6 +121,29 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
             }
 
             return RecommendationDeduper.Merge(engineItems, legacyItems);
+        }
+
+        /// <summary>
+        /// Appends a "what else fired in this analysis window" cross-reference to each engine card's
+        /// advice text (correlate-and-focus slice 1, review §1d). Render-time, not frozen; no-op for a
+        /// single card. Mirrors the Lite reader so both apps surface the same cross-reference.
+        /// </summary>
+        internal static void AppendCoFired(List<RecommendationItem> engineItems)
+        {
+            if (engineItems.Count <= 1)
+                return;
+
+            var windowTitles = new List<(string Title, double Severity)>(engineItems.Count);
+            foreach (var it in engineItems)
+                windowTitles.Add((it.Title, it.RawSeverity));
+
+            foreach (var it in engineItems)
+            {
+                var line = CoFiredSummary.Line(CoFiredSummary.OtherTitles(it.Title, windowTitles));
+                if (line is null)
+                    continue;
+                it.AdviceText = string.IsNullOrEmpty(it.AdviceText) ? line : it.AdviceText + " " + line;
+            }
         }
 
         /// <summary>

--- a/Lite.Tests/LiteRecommendationsReaderTests.cs
+++ b/Lite.Tests/LiteRecommendationsReaderTests.cs
@@ -243,4 +243,33 @@ public class LiteRecommendationsReaderTests
     {
         Assert.Empty(LiteRecommendationsReader.MapFindings(Array.Empty<AnalysisFinding>(), ServerName));
     }
+
+    // Correlate-and-focus slice 1 (review §1d): each card's advice gains a "what else fired in this
+    // window" cross-reference listing the other findings, so the operator stops hunting across cards.
+    [Fact]
+    public void MapFindings_AppendsCoFiredCrossReference_WhenMultipleFindings()
+    {
+        var t = DateTime.UtcNow;
+        var items = LiteRecommendationsReader.MapFindings(new List<AnalysisFinding>
+        {
+            Finding("CPU_SQL_PERCENT", 1.6, analysisTime: t),
+            Finding("BLOCKING_EVENTS", 1.0, analysisTime: t),
+        }, ServerName);
+
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.Contains("Also surfaced in this analysis window:", i.AdviceText!));
+        // each card cross-references the OTHER finding's title
+        Assert.Contains(items[1].Title, items[0].AdviceText!);
+        Assert.Contains(items[0].Title, items[1].AdviceText!);
+    }
+
+    [Fact]
+    public void MapFindings_NoCoFiredLine_ForSingleFinding()
+    {
+        var items = LiteRecommendationsReader.MapFindings(
+            new List<AnalysisFinding> { Finding("CPU_SQL_PERCENT", 1.6) }, ServerName);
+
+        Assert.Single(items);
+        Assert.DoesNotContain("Also surfaced in this analysis window:", items[0].AdviceText ?? string.Empty);
+    }
 }

--- a/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
@@ -79,7 +79,31 @@ public sealed class LiteRecommendationsReader
         }
 
         items.Sort(CompareForDisplay);
+        AppendCoFired(items);
         return items;
+    }
+
+    /// <summary>
+    /// Appends a "what else fired in this analysis window" cross-reference to each card's advice text
+    /// (correlate-and-focus slice 1, review §1d) so the operator can see related findings without
+    /// hunting. Render-time, not frozen — always reflects the current batch. No-op for a single card.
+    /// </summary>
+    private static void AppendCoFired(List<LiteRecommendationItem> items)
+    {
+        if (items.Count <= 1)
+            return;
+
+        var windowTitles = new List<(string Title, double Severity)>(items.Count);
+        foreach (var it in items)
+            windowTitles.Add((it.Title, it.RawSeverity));
+
+        foreach (var it in items)
+        {
+            var line = CoFiredSummary.Line(CoFiredSummary.OtherTitles(it.Title, windowTitles));
+            if (line is null)
+                continue;
+            it.AdviceText = string.IsNullOrEmpty(it.AdviceText) ? line : it.AdviceText + " " + line;
+        }
     }
 
     /// <summary>

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -53,6 +53,11 @@ public sealed class McpAnalysisTools
                 }, McpHelpers.JsonOptions);
             }
 
+            // Correlate-and-focus slice 1 (review §1d): each finding's "what else fired this window".
+            var coFiredTitles = new List<(string, double)>(findings.Count);
+            foreach (var wf in findings)
+                coFiredTitles.Add((FactAdvice.GetForFinding(wf)?.Headline ?? wf.RootFactKey, wf.Severity));
+
             return JsonSerializer.Serialize(new
             {
                 server = resolved.Value.ServerName,
@@ -81,6 +86,7 @@ public sealed class McpAnalysisTools
                         fact_count = f.FactCount,
                         drill_down = f.DrillDown,
                         next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredTitles),
                         advice = advice is null ? null : new
                         {
                             headline = advice.Headline,
@@ -529,6 +535,16 @@ public sealed class McpAnalysisTools
                 }, McpHelpers.JsonOptions);
             }
 
+            // Correlate-and-focus slice 1 (review §1d): "what else fired", scoped per analysis run
+            // (this read can span multiple runs, unlike analyze_server's single run).
+            var coFiredByRun = new Dictionary<DateTime, List<(string, double)>>();
+            foreach (var wf in findings)
+            {
+                if (!coFiredByRun.TryGetValue(wf.AnalysisTime, out var list))
+                    coFiredByRun[wf.AnalysisTime] = list = new List<(string, double)>();
+                list.Add((FactAdvice.GetComposedForFinding(wf)?.Headline ?? wf.RootFactKey, wf.Severity));
+            }
+
             return JsonSerializer.Serialize(new
             {
                 server = resolved.Value.ServerName,
@@ -558,6 +574,7 @@ public sealed class McpAnalysisTools
                         story_path = f.StoryPath,
                         story_path_hash = f.StoryPathHash,
                         fact_count = f.FactCount,
+                        co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredByRun[f.AnalysisTime]),
                         time_range = new
                         {
                             start = f.TimeRangeStart?.ToString("o"),

--- a/PerformanceMonitor.Analysis/CoFiredSummary.cs
+++ b/PerformanceMonitor.Analysis/CoFiredSummary.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Builds the "what else fired in this analysis window" cross-reference shared by both apps'
+/// recommendation surfaces and both MCP tools. This is the first, deliberately small slice of the
+/// correlate-and-focus work (review §1d): it does NOT group or persist anything — it just lets each
+/// finding point at the others from the same run, so the operator stops hunting across cards to see
+/// that they are related. The content is a flat factual list (no synthesis / reasoning — that is the
+/// MCP/LLM consumer's job), capped, highest-severity first.
+/// </summary>
+public static class CoFiredSummary
+{
+    /// <summary>How many sibling titles to name before collapsing the rest into "(+N more)".</summary>
+    public const int DefaultCap = 3;
+
+    /// <summary>
+    /// The distinct OTHER finding titles in the same analysis window, highest-severity first,
+    /// excluding the caller's own title. <paramref name="windowTitles"/> is every finding/card title in
+    /// the window paired with its raw severity; the caller passes its own title as <paramref name="ownTitle"/>.
+    /// </summary>
+    public static IReadOnlyList<string> OtherTitles(
+        string? ownTitle, IEnumerable<(string Title, double Severity)> windowTitles)
+    {
+        if (windowTitles is null)
+            return Array.Empty<string>();
+
+        return windowTitles
+            .Where(t => !string.IsNullOrWhiteSpace(t.Title)
+                     && !string.Equals(t.Title, ownTitle, StringComparison.Ordinal))
+            .OrderByDescending(t => t.Severity)
+            .Select(t => t.Title)
+            .Distinct(StringComparer.Ordinal) // LINQ-to-objects Distinct keeps first (highest-severity) occurrence
+            .ToList();
+    }
+
+    /// <summary>
+    /// A demarcated one-line cross-reference ("Also surfaced in this analysis window: A; B; C (+N more).")
+    /// for appending to a card's advice text, or null when nothing else fired in the window.
+    /// </summary>
+    public static string? Line(IReadOnlyList<string> others, int cap = DefaultCap)
+    {
+        if (others is null || others.Count == 0)
+            return null;
+
+        var shown = others.Take(cap).ToList();
+        var extra = others.Count - shown.Count;
+        var list = string.Join("; ", shown);
+        if (extra > 0)
+            list += $" (+{extra} more)";
+        return "Also surfaced in this analysis window: " + list + ".";
+    }
+}


### PR DESCRIPTION
First incremental slice of `plans/correlate-and-focus-design.md` (review §1d: "one cohesive result, not a sea of firing warnings"). Deliberately small — **no engine, no schema, no grouping** — it just lets each finding point at the others from the same analysis window so the operator stops hunting across cards.

- Shared `CoFiredSummary`: `OtherTitles` (distinct other titles in the window, severity-desc, self excluded) + `Line` (capped factual list, "(+N more)"). Flat list, **no synthesis** — that's the MCP/LLM consumer's job (your D3).
- Both readers append the line to each card's `AdviceText` at read time (not frozen). No new card field / XAML.
- Both MCP `analyze_server` + `get_analysis_findings` emit a `co_fired` array per finding (`get_analysis_findings` scopes it per run, since that read can span runs).

`incident_id` (persisted, trackable — your L2 pick) is **slice 2**, where it earns its keep beyond the batch; this slice derives "what else fired" from the existing run batch.

## Verify
- Dashboard.Tests **545/545** (+6), Lite.Tests **545/545** (+2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
