### PR TITLE
Block-chain viewer (PR #1): shared apex->victim chain visualizer in both apps

### DIFF
--- a/Dashboard.Tests/BlockingChainLayoutTests.cs
+++ b/Dashboard.Tests/BlockingChainLayoutTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Pure unit tests for the shared <see cref="BlockingChainLayout"/> — determinism and no-overlap of the
+/// left-to-right tree/forest placement. No WPF (a constant measure callback supplies node heights).
+/// </summary>
+public class BlockingChainLayoutTests
+{
+    private const double H = 100.0;
+    private static double Measure(BlockingChainNode _) => H;
+
+    private static BlockingChainNode Node(int spid, params BlockingChainNode[] children) =>
+        new() { Spid = spid, Children = children.ToList() };
+
+    // A representative forest: a multi-level tree plus a second apex tree.
+    private static IReadOnlyList<BlockingChainNode> SampleForest() => new[]
+    {
+        Node(1,
+            Node(2, Node(4), Node(5)),
+            Node(3)),
+        Node(10,
+            Node(11),
+            Node(12, Node(13)))
+    };
+
+    private static IEnumerable<BlockingChainNode> Flatten(IReadOnlyList<BlockingChainNode> roots)
+    {
+        foreach (var r in roots)
+            foreach (var n in FlattenOne(r))
+                yield return n;
+    }
+
+    private static IEnumerable<BlockingChainNode> FlattenOne(BlockingChainNode n)
+    {
+        yield return n;
+        foreach (var c in n.Children)
+            foreach (var d in FlattenOne(c))
+                yield return d;
+    }
+
+    [Fact]
+    public void Layout_IsDeterministic_AcrossIdenticalForests()
+    {
+        var a = SampleForest();
+        var b = SampleForest();
+
+        BlockingChainLayout.Layout(a, Measure);
+        BlockingChainLayout.Layout(b, Measure);
+
+        var fa = Flatten(a).ToList();
+        var fb = Flatten(b).ToList();
+        Assert.Equal(fa.Count, fb.Count);
+        for (int i = 0; i < fa.Count; i++)
+        {
+            Assert.Equal(fa[i].Spid, fb[i].Spid);
+            Assert.Equal(fa[i].X, fb[i].X);
+            Assert.Equal(fa[i].Y, fb[i].Y);
+        }
+    }
+
+    [Fact]
+    public void Layout_PlacesDepthByColumn()
+    {
+        var roots = SampleForest();
+        BlockingChainLayout.Layout(roots, Measure);
+
+        double depth0 = BlockingChainLayout.Padding;
+        double depth1 = BlockingChainLayout.Padding + BlockingChainLayout.HorizontalSpacing;
+        double depth2 = BlockingChainLayout.Padding + 2 * BlockingChainLayout.HorizontalSpacing;
+
+        Assert.Equal(depth0, roots[0].X);                 // apex
+        Assert.Equal(depth1, roots[0].Children[0].X);     // direct victim
+        Assert.Equal(depth2, roots[0].Children[0].Children[0].X); // grand-victim
+    }
+
+    [Fact]
+    public void Layout_ProducesNoOverlappingNodes()
+    {
+        var roots = SampleForest();
+        BlockingChainLayout.Layout(roots, Measure);
+
+        var nodes = Flatten(roots).ToList();
+        const double w = BlockingChainLayout.NodeWidth;
+        const double eps = 0.5;
+
+        for (int i = 0; i < nodes.Count; i++)
+        {
+            for (int j = i + 1; j < nodes.Count; j++)
+            {
+                var a = nodes[i];
+                var b = nodes[j];
+                bool overlapX = a.X < b.X + w - eps && b.X < a.X + w - eps;
+                bool overlapY = a.Y < b.Y + H - eps && b.Y < a.Y + H - eps;
+                Assert.False(overlapX && overlapY,
+                    $"SPID {a.Spid} ({a.X},{a.Y}) overlaps SPID {b.Spid} ({b.X},{b.Y})");
+            }
+        }
+    }
+
+    [Fact]
+    public void Layout_ReturnsPositiveExtentCoveringAllNodes()
+    {
+        var roots = SampleForest();
+        var (width, height) = BlockingChainLayout.Layout(roots, Measure);
+
+        Assert.True(width > 0);
+        Assert.True(height > 0);
+
+        var nodes = Flatten(roots).ToList();
+        Assert.True(width >= nodes.Max(n => n.X) + BlockingChainLayout.NodeWidth);
+        Assert.True(height >= nodes.Max(n => n.Y) + H);
+    }
+
+    [Fact]
+    public void Layout_EmptyForest_ReturnsPaddingExtent()
+    {
+        var (width, height) = BlockingChainLayout.Layout(Array.Empty<BlockingChainNode>(), Measure);
+        Assert.True(width > 0);   // padding only
+        Assert.True(height > 0);
+    }
+}

--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -189,7 +189,7 @@ public class BlockingChainReconstructorTests
 
         var chain = Assert.Single(result.Chains);
         Assert.Equal(200, chain.ApexSpid);
-        Assert.Equal(TranFor(200), chain.TranStarted);
+        Assert.Equal(TranFor(200), chain.ApexTranStarted);
 
         Assert.NotEmpty(chain.Levels);
         Assert.All(chain.Levels, l => Assert.Equal("TestDb", l.DatabaseName));

--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -180,4 +180,22 @@ public class BlockingChainReconstructorTests
         // The 8-victim fan-out out-scores the depth-2 / 2-victim chain.
         Assert.Equal(800, result.Chains[0].ApexSpid);
     }
+
+    [Fact]
+    public void ReconstructedOutput_CarriesTranStartedAndDatabaseName()
+    {
+        // The additive output fields (Phase 0) the block-chain tree builder rebuilds the tree from.
+        var result = Run(new[] { Pair(201, 200), Pair(202, 201) });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(200, chain.ApexSpid);
+        Assert.Equal(TranFor(200), chain.TranStarted);
+
+        Assert.NotEmpty(chain.Levels);
+        Assert.All(chain.Levels, l => Assert.Equal("TestDb", l.DatabaseName));
+
+        var top = chain.Levels.Single(l => l.BlockingSpid == 200 && l.BlockedSpid == 201);
+        Assert.Equal(TranFor(200), top.BlockingTranStarted);
+        Assert.Equal(TranFor(201), top.BlockedTranStarted);
+    }
 }

--- a/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
+++ b/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Pure unit tests for the shared <see cref="BlockingChainTreeBuilder"/> — the DAG -> tree logic that
+/// turns the analysis engine's edge lists into renderable trees. Tested once in Common (not duplicated
+/// per app). No database, no WPF.
+/// </summary>
+public class BlockingChainTreeBuilderTests
+{
+    private static DateTime Tran(int spid) => new DateTime(2026, 5, 22, 9, 0, 0).AddSeconds(spid);
+
+    private static BlockingEdgeInput Edge(
+        int level, int blocker, int blocked,
+        long wait = 1000, string lockMode = "X", string db = "TestDb",
+        DateTime? blockerTran = null, DateTime? blockedTran = null) => new()
+        {
+            Level = level,
+            BlockingSpid = blocker,
+            BlockingTranStarted = blockerTran ?? Tran(blocker),
+            BlockedSpid = blocked,
+            BlockedTranStarted = blockedTran ?? Tran(blocked),
+            WaitTimeMs = wait,
+            LockMode = lockMode,
+            DatabaseName = db,
+            BlockingSqlText = $"blocker {blocker}",
+            BlockedSqlText = $"blocked {blocked}"
+        };
+
+    private static BlockingChainInput Chain(
+        int apex, IEnumerable<BlockingEdgeInput> edges,
+        double magnitude = 1.0, bool sleeping = false, DateTime? apexTran = null) => new()
+        {
+            ApexSpid = apex,
+            ApexTranStarted = apexTran ?? Tran(apex),
+            ApexSleeping = sleeping,
+            Magnitude = magnitude,
+            Edges = edges.ToList()
+        };
+
+    private static BlockingChainModel Build(params BlockingChainInput[] chains) =>
+        BlockingChainTreeBuilder.Build(chains, false, false, false);
+
+    private static IEnumerable<BlockingChainNode> Flatten(BlockingChainNode n)
+    {
+        yield return n;
+        foreach (var c in n.Children)
+            foreach (var d in Flatten(c))
+                yield return d;
+    }
+
+    [Fact]
+    public void SingleChain_BuildsLinearTree_WithSourcedFields()
+    {
+        // 200 -> 201 -> 202 -> 203
+        var model = Build(Chain(200, new[]
+        {
+            Edge(1, 200, 201), Edge(2, 201, 202), Edge(3, 202, 203)
+        }));
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(200, root.Spid);
+        Assert.True(root.IsApex);
+        Assert.Equal(0, root.WaitTimeMs);          // apex waits on no one
+        Assert.Equal(string.Empty, root.LockMode);
+        Assert.Equal("blocker 200", root.SqlText); // apex SQL sourced from its outgoing edge
+        Assert.Equal("TestDb", root.DatabaseName);
+
+        var n201 = Assert.Single(root.Children);
+        Assert.Equal(201, n201.Spid);
+        Assert.False(n201.IsApex);
+        Assert.Equal(1000, n201.WaitTimeMs);
+        Assert.Equal("X", n201.LockMode);
+        Assert.Equal("blocked 201", n201.SqlText); // victim SQL sourced from its incoming edge
+
+        var n202 = Assert.Single(n201.Children);
+        var n203 = Assert.Single(n202.Children);
+        Assert.Equal(203, n203.Spid);
+        Assert.Empty(n203.Children);
+        Assert.Equal(4, Flatten(root).Count());
+    }
+
+    [Fact]
+    public void BranchingBlocker_AttachesAllVictimsToApex_OrderedBySpid()
+    {
+        var model = Build(Chain(300, new[]
+        {
+            Edge(1, 300, 303), Edge(1, 300, 301), Edge(1, 300, 302)
+        }));
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(3, root.Children.Count);
+        Assert.Equal(new[] { 301, 302, 303 }, root.Children.Select(c => c.Spid).ToArray());
+        Assert.All(root.Children, c => Assert.Empty(c.Children));
+    }
+
+    [Fact]
+    public void SameSpidDifferentTransaction_AreKeptAsSeparateNodes()
+    {
+        // Apex 200 blocks SPID 201 twice — but two DIFFERENT sessions (distinct tran starts). The
+        // builder must NOT collapse them into one node.
+        var tranA = Tran(201);
+        var tranB = Tran(201).AddHours(3);
+        var model = Build(Chain(200, new[]
+        {
+            Edge(1, 200, 201, blockedTran: tranA),
+            Edge(1, 200, 201, blockedTran: tranB)
+        }));
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(2, root.Children.Count);
+        Assert.All(root.Children, c => Assert.Equal(201, c.Spid));
+        Assert.Equal(new[] { tranA, tranB }.OrderBy(t => t),
+                     root.Children.Select(c => c.TranStarted!.Value).OrderBy(t => t));
+    }
+
+    [Fact]
+    public void Diamond_AttachesVictimToLowestParentSpid_DroppingExtraInEdge()
+    {
+        // 400 -> 401, 400 -> 402, and BOTH 401 and 402 block 403 at the same level. Tie on level breaks
+        // to the lowest parent SPID (401); the 402 -> 403 in-edge is dropped, and 403 appears once.
+        var model = Build(Chain(400, new[]
+        {
+            Edge(1, 400, 401), Edge(1, 400, 402),
+            Edge(2, 401, 403), Edge(2, 402, 403)
+        }));
+
+        var root = Assert.Single(model.Roots);
+        var n401 = root.Children.Single(c => c.Spid == 401);
+        var n402 = root.Children.Single(c => c.Spid == 402);
+
+        Assert.Single(n401.Children);
+        Assert.Equal(403, n401.Children[0].Spid);
+        Assert.Empty(n402.Children);
+        Assert.Equal(4, Flatten(root).Count());        // 403 is not duplicated
+        Assert.Single(Flatten(root).Where(n => n.Spid == 403));
+    }
+
+    [Fact]
+    public void Flags_ArePropagatedToModel()
+    {
+        var model = BlockingChainTreeBuilder.Build(
+            new[] { Chain(200, new[] { Edge(1, 200, 201) }) },
+            cycleDetected: true, depthCapped: true, traversalTruncated: true);
+
+        Assert.True(model.CycleDetected);
+        Assert.True(model.DepthCapped);
+        Assert.True(model.TraversalTruncated);
+    }
+
+    [Fact]
+    public void SleepingApex_IsFlaggedOnRoot()
+    {
+        var model = Build(Chain(200, new[] { Edge(1, 200, 201) }, sleeping: true));
+        var root = Assert.Single(model.Roots);
+        Assert.True(root.IsApex);
+        Assert.True(root.IsApexSleeping);
+    }
+
+    [Fact]
+    public void Roots_AreRankedByMagnitudeDescending()
+    {
+        var weak = Chain(200, new[] { Edge(1, 200, 201) }, magnitude: 0.2);
+        var strong = Chain(300, new[] { Edge(1, 300, 301) }, magnitude: 0.9);
+
+        var model = BlockingChainTreeBuilder.Build(new[] { weak, strong }, false, false, false);
+
+        Assert.Equal(2, model.Roots.Count);
+        Assert.Equal(300, model.Roots[0].Spid);   // higher magnitude first
+        Assert.Equal(0.9, model.Roots[0].Magnitude);
+        Assert.Equal(200, model.Roots[1].Spid);
+    }
+
+    [Fact]
+    public void Cycle_DoesNotInfiniteLoop_AndPlacesEachNodeOnce()
+    {
+        // 500 -> 501 -> 502, plus a back-edge 502 -> 500. The visited set must stop the cycle and the
+        // apex must never be re-parented; each session appears once.
+        var model = BlockingChainTreeBuilder.Build(
+            new[]
+            {
+                Chain(500, new[]
+                {
+                    Edge(1, 500, 501), Edge(2, 501, 502), Edge(3, 502, 500)
+                })
+            },
+            cycleDetected: true, depthCapped: false, traversalTruncated: false);
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(500, root.Spid);
+        Assert.Equal(3, Flatten(root).Count());                 // 500, 501, 502 — no duplicate 500
+        Assert.Single(Flatten(root).Where(n => n.Spid == 500));
+    }
+}

--- a/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
+++ b/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
@@ -138,7 +138,7 @@ public class BlockingChainTreeBuilderTests
         Assert.Equal(403, n401.Children[0].Spid);
         Assert.Empty(n402.Children);
         Assert.Equal(4, Flatten(root).Count());        // 403 is not duplicated
-        Assert.Single(Flatten(root).Where(n => n.Spid == 403));
+        Assert.Single(Flatten(root), n => n.Spid == 403);
     }
 
     [Fact]
@@ -194,6 +194,6 @@ public class BlockingChainTreeBuilderTests
         var root = Assert.Single(model.Roots);
         Assert.Equal(500, root.Spid);
         Assert.Equal(3, Flatten(root).Count());                 // 500, 501, 502 — no duplicate 500
-        Assert.Single(Flatten(root).Where(n => n.Spid == 500));
+        Assert.Single(Flatten(root), n => n.Spid == 500);
     }
 }

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorDashboard.Analysis;
+
+/// <summary>
+/// The trivial, mechanical projection from the analysis engine's (internal) reconstruction into the shared
+/// public <see cref="BlockingChainModel"/> for the viewer. This is the only per-app block-chain code — it
+/// must bridge an internal analysis type to a Common type, and no shared assembly can see both (Ui sees
+/// Common but not Analysis; Analysis does not reference Common by design). Kept byte-identical to Lite's copy.
+/// </summary>
+internal static class BlockingChainViewerProjection
+{
+    public const string EmptyStateDetail =
+        "No blocked-process reports were collected in the selected time range. " +
+        "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
+        "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
+
+    public static BlockingChainModel BuildModel(BlockingReconstruction reconstruction)
+    {
+        var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
+        {
+            ApexSpid = c.ApexSpid,
+            ApexTranStarted = c.TranStarted,
+            ApexSleeping = c.ApexSleeping,
+            Magnitude = c.Magnitude,
+            Edges = c.Levels.Select(static l => new BlockingEdgeInput
+            {
+                Level = l.Level,
+                BlockingSpid = l.BlockingSpid,
+                BlockingTranStarted = l.BlockingTranStarted,
+                BlockedSpid = l.BlockedSpid,
+                BlockedTranStarted = l.BlockedTranStarted,
+                LockMode = l.LockMode,
+                WaitTimeMs = l.WaitTimeMs,
+                DatabaseName = l.DatabaseName,
+                BlockingSqlText = l.BlockingSqlText,
+                BlockedSqlText = l.BlockedSqlText
+            }).ToList()
+        }).ToList();
+
+        return BlockingChainTreeBuilder.Build(
+            inputs,
+            reconstruction.CycleDetected,
+            reconstruction.DepthCapped,
+            reconstruction.TraversalTruncated);
+    }
+}

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -23,7 +23,7 @@ internal static class BlockingChainViewerProjection
         var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
         {
             ApexSpid = c.ApexSpid,
-            ApexTranStarted = c.TranStarted,
+            ApexTranStarted = c.ApexTranStarted,
             ApexSleeping = c.ApexSleeping,
             Magnitude = c.Magnitude,
             Edges = c.Levels.Select(static l => new BlockingEdgeInput

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorDashboard.Analysis;
+
+/// <summary>
+/// The single source of the blocked-process-report pair-row query used to reconstruct blocking chains.
+/// Shared by the three Dashboard consumers — the drill-down collector, the BLOCKING_CHAIN fact collector,
+/// and the viewer's data-service fetch — so the apex-determining <c>blocking_spid IS NOT NULL</c> filter
+/// (and the SELECT/ordinals) stay in lockstep. <c>activity = 'blocked'</c> picks the canonical per-event
+/// side; <c>blocking_spid IS NOT NULL</c> drops rows whose source XML had an empty
+/// <c>&lt;blocking-process&gt;&lt;process/&gt;&lt;/blocking-process&gt;</c> (system task / torn-down session),
+/// which cannot contribute to a chain.
+/// </summary>
+internal static class BlockingPairRowQuery
+{
+    public const string Sql = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP (5000)
+    event_time,
+    database_name,
+    spid,
+    last_transaction_started,
+    blocking_spid,
+    blocking_last_tran_started,
+    wait_time_ms,
+    lock_mode,
+    blocking_status,
+    blocked_sql_text,
+    blocking_sql_text
+FROM collect.blocking_BlockedProcessReport
+WHERE collection_time >= @collectionWindow
+AND   event_time >= @startTime
+AND   event_time <= @endTime
+AND   activity = 'blocked'
+AND   blocking_spid IS NOT NULL
+ORDER BY collection_time DESC";
+
+    /// <summary>
+    /// Adds the three parameters. The collection-time floor is a generous bound (window start minus an
+    /// hour) so rows whose event_time is inside the window but whose collection_time lags slightly are
+    /// still caught.
+    /// </summary>
+    public static void AddParameters(SqlCommand cmd, DateTime start, DateTime end)
+    {
+        cmd.Parameters.Add(new SqlParameter("@collectionWindow", start.AddHours(-1)));
+        cmd.Parameters.Add(new SqlParameter("@startTime", start));
+        cmd.Parameters.Add(new SqlParameter("@endTime", end));
+    }
+
+    public static BlockingPairRow Read(DbDataReader reader) => new()
+    {
+        EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
+        DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+        BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+        BlockedTranStarted = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3),
+        BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+        BlockingTranStarted = reader.IsDBNull(5) ? (DateTime?)null : reader.GetDateTime(5),
+        WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+        LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+        BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+        BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
+        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+    };
+}

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
@@ -118,56 +118,16 @@ ORDER BY wait_time_ms DESC;";
         await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
-        // blocking_spid IS NOT NULL filters out rows whose source XML had an empty
-        // <blocking-process><process/></blocking-process> (system task / torn-down session) —
-        // those can't contribute to a reconstructed chain.
-        cmd.CommandText = @"
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-SELECT TOP (5000)
-    event_time,
-    database_name,
-    spid,
-    last_transaction_started,
-    blocking_spid,
-    blocking_last_tran_started,
-    wait_time_ms,
-    lock_mode,
-    blocking_status,
-    blocked_sql_text,
-    blocking_sql_text
-FROM collect.blocking_BlockedProcessReport
-WHERE collection_time >= @collectionWindow
-AND   event_time >= @startTime
-AND   event_time <= @endTime
-AND   activity = 'blocked'
-AND   blocking_spid IS NOT NULL
-ORDER BY collection_time DESC";
-
-        cmd.Parameters.Add(new SqlParameter("@collectionWindow", context.TimeRangeStart.AddHours(-1)));
-        cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));
-        cmd.Parameters.Add(new SqlParameter("@endTime", context.TimeRangeEnd));
+        // Shared query/filter — see BlockingPairRowQuery (keeps the drill-down, the BLOCKING_CHAIN fact
+        // collector, and the viewer fetch in lockstep on the apex-determining blocking_spid filter).
+        cmd.CommandText = BlockingPairRowQuery.Sql;
+        BlockingPairRowQuery.AddParameters(cmd, context.TimeRangeStart, context.TimeRangeEnd);
 
         var rows = new List<BlockingPairRow>();
         using (var reader = await cmd.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
-            {
-                rows.Add(new BlockingPairRow
-                {
-                    EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
-                    DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                    BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
-                    BlockedTranStarted = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3),
-                    BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                    BlockingTranStarted = reader.IsDBNull(5) ? (DateTime?)null : reader.GetDateTime(5),
-                    WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-                    LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
-                    BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
-                    BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-                    BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
-                });
-            }
+                rows.Add(BlockingPairRowQuery.Read(reader));
         }
 
         if (rows.Count == 0) return;

--- a/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
@@ -218,60 +218,17 @@ AND   collection_time <= @endTime";
             await connection.OpenAsync();
 
             using var cmd = connection.CreateCommand();
-            // ORDER BY collection_time DESC is a backward CIX scan (sort-free); event_time
-            // is a residual predicate. activity='blocked' picks the canonical per-event side.
-            // blocking_spid IS NOT NULL filters out rows whose source XML had an empty
-            // <blocking-process><process/></blocking-process> (system task / torn-down session) —
-            // those can't contribute to a reconstructed chain.
-            cmd.CommandText = @"
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-SELECT TOP (5000)
-    event_time,
-    database_name,
-    spid,
-    last_transaction_started,
-    blocking_spid,
-    blocking_last_tran_started,
-    wait_time_ms,
-    lock_mode,
-    blocking_status,
-    blocked_sql_text,
-    blocking_sql_text
-FROM collect.blocking_BlockedProcessReport
-WHERE collection_time >= @collectionWindow
-AND   event_time >= @startTime
-AND   event_time <= @endTime
-AND   activity = 'blocked'
-AND   blocking_spid IS NOT NULL
-ORDER BY collection_time DESC";
-
-            // Generous bound — analysis window plus an hour — to catch rows whose
-            // event_time is inside the window but whose collection_time may lag slightly.
-            cmd.Parameters.Add(new SqlParameter("@collectionWindow", context.TimeRangeStart.AddHours(-1)));
-            cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));
-            cmd.Parameters.Add(new SqlParameter("@endTime", context.TimeRangeEnd));
+            // Shared query/filter — see BlockingPairRowQuery. ORDER BY collection_time DESC is a backward
+            // CIX scan (sort-free); event_time is a residual predicate. Keeping this in lockstep with the
+            // drill-down + viewer fetch is the whole point: all three agree on the apex.
+            cmd.CommandText = BlockingPairRowQuery.Sql;
+            BlockingPairRowQuery.AddParameters(cmd, context.TimeRangeStart, context.TimeRangeEnd);
 
             var rows = new List<BlockingPairRow>();
             using (var reader = await cmd.ExecuteReaderAsync())
             {
                 while (await reader.ReadAsync())
-                {
-                    rows.Add(new BlockingPairRow
-                    {
-                        EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
-                        DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                        BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
-                        BlockedTranStarted = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3),
-                        BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                        BlockingTranStarted = reader.IsDBNull(5) ? (DateTime?)null : reader.GetDateTime(5),
-                        WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-                        LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
-                        BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
-                        BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-                        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
-                    });
-                }
+                    rows.Add(BlockingPairRowQuery.Read(reader));
             }
 
             if (rows.Count == 0) return;

--- a/Dashboard/ServerTab.BlockChain.cs
+++ b/Dashboard/ServerTab.BlockChain.cs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Ui;
+using PerformanceMonitorDashboard.Analysis;
+
+namespace PerformanceMonitorDashboard
+{
+    public partial class ServerTab : UserControl
+    {
+        /// <summary>
+        /// Opens the block-chain viewer for the Locking tab's current blocking window. Reads the slicer's
+        /// narrowed selection (server-local) when set, else the sub-tab's range. Fetch + reconstruct +
+        /// tree-build run off the UI thread; only the render touches the UI.
+        /// </summary>
+        private async void ViewBlockChain_Click(object sender, RoutedEventArgs e)
+        {
+            if (_databaseService == null) return;
+
+            try
+            {
+                DateTime start, end;
+                if (BlockingSlicer.HasNarrowedSelection
+                    && BlockingSlicer.SelectionStart.HasValue
+                    && BlockingSlicer.SelectionEnd.HasValue)
+                {
+                    start = BlockingSlicer.SelectionStart.Value;
+                    end = BlockingSlicer.SelectionEnd.Value;
+                }
+                else
+                {
+                    (start, end) = GetLockingSlicerTimeRange(_blockingHoursBack, _blockingFromDate, _blockingToDate);
+                }
+
+                // Fetch (async DB) + reconstruct (CPU-bound over up to 5000 rows) + tree-build, all off the
+                // UI thread. The model that comes back is pure data; the control renders it on the UI thread.
+                var model = await Task.Run(async () =>
+                {
+                    var rows = await _databaseService.GetBlockingPairRowsAsync(start, end);
+                    var reconstruction = BlockingChainReconstructor.Reconstruct(
+                        rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+                    return BlockingChainViewerProjection.BuildModel(reconstruction);
+                });
+
+                var control = new BlockingChainControl();
+                control.LoadModel(model, BlockingChainViewerProjection.EmptyStateDetail);
+                GraphViewerWindow.ShowGraph(
+                    Window.GetWindow(this),
+                    control,
+                    $"Blocking Chains — {_serverConnection.DisplayName}");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    Window.GetWindow(this)!,
+                    $"Failed to build the blocking-chain view:\n\n{ex.Message}",
+                    "Block Chain Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+        }
+    }
+}

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -663,7 +663,13 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
+                            <DockPanel Grid.Row="0" LastChildFill="True">
+                                <Button DockPanel.Dock="Right" Content="View Block Chain"
+                                        Click="ViewBlockChain_Click" Height="26" Padding="10,0"
+                                        Margin="6,0,8,0" VerticalAlignment="Center"
+                                        ToolTip="Reconstruct and visualize the blocking chains for the selected time range"/>
+                                <controls:TimeRangeSlicerControl x:Name="BlockingSlicer"/>
+                            </DockPanel>
                         <DataGrid x:Name="BlockingEventsDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True"
                                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource BlockingEventsPlanRowStyle}"

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
@@ -12,6 +12,8 @@ using System.Data;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorDashboard.Analysis;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 
@@ -413,6 +415,31 @@ namespace PerformanceMonitorDashboard.Services
 
                     var result = await command.ExecuteScalarAsync();
                     return result == DBNull.Value ? null : result as string;
+                }
+
+                /// <summary>
+                /// Fetches the blocked/blocker pair rows for a window, for the block-chain viewer to feed
+                /// <see cref="BlockingChainReconstructor"/>. Internal (not public): <see cref="BlockingPairRow"/>
+                /// is internal to the analysis assembly — a public method returning it would be CS0050. Uses
+                /// the shared <see cref="BlockingPairRowQuery"/> so it filters apex rows identically to the
+                /// drill-down + fact collectors.
+                /// </summary>
+                internal async Task<List<BlockingPairRow>> GetBlockingPairRowsAsync(DateTime start, DateTime end)
+                {
+                    var rows = new List<BlockingPairRow>();
+
+                    await using var tc = await OpenThrottledConnectionAsync();
+                    var connection = tc.Connection;
+
+                    using var command = new SqlCommand(BlockingPairRowQuery.Sql, connection);
+                    command.CommandTimeout = 120;
+                    BlockingPairRowQuery.AddParameters(command, start, end);
+
+                    using var reader = await command.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                        rows.Add(BlockingPairRowQuery.Read(reader));
+
+                    return rows;
                 }
 
                 public async Task<List<BlockingDeadlockStatsItem>> GetBlockingDeadlockStatsAsync(int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)

--- a/Dashboard/Themes/CoolBreezeTheme.xaml
+++ b/Dashboard/Themes/CoolBreezeTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Dashboard/Themes/CoolBreezeTheme.xaml
+++ b/Dashboard/Themes/CoolBreezeTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
+    <!-- Apex (lead-blocker) node + legend border. Darker blue on light themes so it clears >=3:1 as a
+         graphical border on the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER
+         badge fill keeps the bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#1976D2"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Tuned per theme so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#FFB347"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Tuned per theme so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#FFB347"/>
+    <!-- Apex (lead-blocker) node + legend border. Theme-aware so it clears >=3:1 as a graphical border on
+         the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER badge fill keeps the
+         bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#4FA3FF"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Dashboard/Themes/LightTheme.xaml
+++ b/Dashboard/Themes/LightTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Dashboard/Themes/LightTheme.xaml
+++ b/Dashboard/Themes/LightTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
+    <!-- Apex (lead-blocker) node + legend border. Darker blue on light themes so it clears >=3:1 as a
+         graphical border on the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER
+         badge fill keeps the bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#1976D2"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -189,7 +189,7 @@ public class BlockingChainReconstructorTests
 
         var chain = Assert.Single(result.Chains);
         Assert.Equal(200, chain.ApexSpid);
-        Assert.Equal(TranFor(200), chain.TranStarted);
+        Assert.Equal(TranFor(200), chain.ApexTranStarted);
 
         Assert.NotEmpty(chain.Levels);
         Assert.All(chain.Levels, l => Assert.Equal("TestDb", l.DatabaseName));

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -180,4 +180,22 @@ public class BlockingChainReconstructorTests
         // The 8-victim fan-out out-scores the depth-2 / 2-victim chain.
         Assert.Equal(800, result.Chains[0].ApexSpid);
     }
+
+    [Fact]
+    public void ReconstructedOutput_CarriesTranStartedAndDatabaseName()
+    {
+        // The additive output fields (Phase 0) the block-chain tree builder rebuilds the tree from.
+        var result = Run(new[] { Pair(201, 200), Pair(202, 201) });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(200, chain.ApexSpid);
+        Assert.Equal(TranFor(200), chain.TranStarted);
+
+        Assert.NotEmpty(chain.Levels);
+        Assert.All(chain.Levels, l => Assert.Equal("TestDb", l.DatabaseName));
+
+        var top = chain.Levels.Single(l => l.BlockingSpid == 200 && l.BlockedSpid == 201);
+        Assert.Equal(TranFor(200), top.BlockingTranStarted);
+        Assert.Equal(TranFor(201), top.BlockedTranStarted);
+    }
 }

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitorLite.Analysis;
+
+/// <summary>
+/// The trivial, mechanical projection from the analysis engine's (internal) reconstruction into the shared
+/// public <see cref="BlockingChainModel"/> for the viewer. This is the only per-app block-chain code — it
+/// must bridge an internal analysis type to a Common type, and no shared assembly can see both (Ui sees
+/// Common but not Analysis; Analysis does not reference Common by design). Kept byte-identical to Dashboard's copy.
+/// </summary>
+internal static class BlockingChainViewerProjection
+{
+    public const string EmptyStateDetail =
+        "No blocked-process reports were collected in the selected time range. " +
+        "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
+        "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
+
+    public static BlockingChainModel BuildModel(BlockingReconstruction reconstruction)
+    {
+        var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
+        {
+            ApexSpid = c.ApexSpid,
+            ApexTranStarted = c.TranStarted,
+            ApexSleeping = c.ApexSleeping,
+            Magnitude = c.Magnitude,
+            Edges = c.Levels.Select(static l => new BlockingEdgeInput
+            {
+                Level = l.Level,
+                BlockingSpid = l.BlockingSpid,
+                BlockingTranStarted = l.BlockingTranStarted,
+                BlockedSpid = l.BlockedSpid,
+                BlockedTranStarted = l.BlockedTranStarted,
+                LockMode = l.LockMode,
+                WaitTimeMs = l.WaitTimeMs,
+                DatabaseName = l.DatabaseName,
+                BlockingSqlText = l.BlockingSqlText,
+                BlockedSqlText = l.BlockedSqlText
+            }).ToList()
+        }).ToList();
+
+        return BlockingChainTreeBuilder.Build(
+            inputs,
+            reconstruction.CycleDetected,
+            reconstruction.DepthCapped,
+            reconstruction.TraversalTruncated);
+    }
+}

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -23,7 +23,7 @@ internal static class BlockingChainViewerProjection
         var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
         {
             ApexSpid = c.ApexSpid,
-            ApexTranStarted = c.TranStarted,
+            ApexTranStarted = c.ApexTranStarted,
             ApexSleeping = c.ApexSleeping,
             Magnitude = c.Magnitude,
             Edges = c.Levels.Select(static l => new BlockingEdgeInput

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data.Common;
+using System.Numerics;
 using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitorLite.Analysis;
@@ -7,16 +8,30 @@ namespace PerformanceMonitorLite.Analysis;
 /// <summary>
 /// Shared pieces of the blocked-process-report pair-row query used to reconstruct blocking chains, so
 /// Lite's three consumers — the drill-down collector, the BLOCKING_CHAIN fact collector, and the viewer's
-/// data-service fetch — agree on the apex.
+/// data-service fetch — agree on the apex AND on the column order the shared <see cref="Read"/> depends on.
 ///
 /// <para><see cref="SpidFilter"/> is the behavioral fix: Lite maps a missing blocker to spid 0 (a phantom
 /// root); without filtering it out, the fact/drill-down/viewer would each invent a SPID-0 apex. This brings
-/// Lite in line with Dashboard's long-standing <c>blocking_spid IS NOT NULL</c>. The SELECT list (and thus
-/// the SQL-text truncation) deliberately stays per-site — only the filter and the reader mapping are shared,
-/// because the column count/order is identical across all three.</para>
+/// Lite in line with Dashboard's long-standing <c>blocking_spid IS NOT NULL</c>.</para>
+///
+/// <para><see cref="LeadingColumns"/> is the single source of truth for ordinals 0-8 so the three queries
+/// can't drift and silently feed <see cref="Read"/> mismapped columns. Only the two SQL-text expressions
+/// (ordinals 9-10) stay per-site — drill-down truncates with <c>LEFT(...,500)</c>; the fact collector and
+/// the viewer fetch select the full text.</para>
 /// </summary>
 internal static class BlockingPairRowQuery
 {
+    /// <summary>Ordinals 0-8 of the pair-row SELECT. Each query appends its own SQL-text expressions (9-10).</summary>
+    public const string LeadingColumns = @"event_time,
+    database_name,
+    blocked_spid,
+    blocked_last_tran_started,
+    blocking_spid,
+    blocking_last_tran_started,
+    wait_time_ms,
+    lock_mode,
+    blocking_status";
+
     /// <summary>Append to the WHERE clause of every pair-row query (covers NULL and the 0 sentinel).</summary>
     public const string SpidFilter = @"AND blocking_spid IS NOT NULL
 AND blocking_spid <> 0";
@@ -29,10 +44,22 @@ AND blocking_spid <> 0";
         BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
         BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
         BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
-        WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+        WaitTimeMs = reader.IsDBNull(6) ? 0L : ToInt64(reader.GetValue(6)),
         LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
         BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
         BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
         BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
     };
+
+    /// <summary>
+    /// BigInteger-tolerant long conversion — DuckDB can hand wide / aggregate values back boxed as a
+    /// <see cref="BigInteger"/>, which is not <see cref="IConvertible"/>, so plain Convert.ToInt64 throws.
+    /// The single home for the idiom every Lite numeric reader uses (DuckDbFactCollector delegates here).
+    /// </summary>
+    public static long ToInt64(object value)
+    {
+        if (value is BigInteger bi)
+            return (long)bi;
+        return Convert.ToInt64(value);
+    }
 }

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Data.Common;
+using PerformanceMonitor.Analysis;
+
+namespace PerformanceMonitorLite.Analysis;
+
+/// <summary>
+/// Shared pieces of the blocked-process-report pair-row query used to reconstruct blocking chains, so
+/// Lite's three consumers — the drill-down collector, the BLOCKING_CHAIN fact collector, and the viewer's
+/// data-service fetch — agree on the apex.
+///
+/// <para><see cref="SpidFilter"/> is the behavioral fix: Lite maps a missing blocker to spid 0 (a phantom
+/// root); without filtering it out, the fact/drill-down/viewer would each invent a SPID-0 apex. This brings
+/// Lite in line with Dashboard's long-standing <c>blocking_spid IS NOT NULL</c>. The SELECT list (and thus
+/// the SQL-text truncation) deliberately stays per-site — only the filter and the reader mapping are shared,
+/// because the column count/order is identical across all three.</para>
+/// </summary>
+internal static class BlockingPairRowQuery
+{
+    /// <summary>Append to the WHERE clause of every pair-row query (covers NULL and the 0 sentinel).</summary>
+    public const string SpidFilter = @"AND blocking_spid IS NOT NULL
+AND blocking_spid <> 0";
+
+    public static BlockingPairRow Read(DbDataReader reader) => new()
+    {
+        EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
+        DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+        BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
+        BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+        BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
+        BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
+        WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+        LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+        BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+        BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
+        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+    };
+}

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -113,7 +113,10 @@ LIMIT 5";
         await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
+        // SpidFilter keeps Lite's drill-down, fact collector, and viewer fetch in lockstep on the apex
+        // (Lite maps a missing blocker to spid 0 — see BlockingPairRowQuery). SQL text is truncated here
+        // for the drill-down payload; the shared reader mapping is unaffected (same column order).
+        cmd.CommandText = $@"
 SELECT
     event_time, database_name,
     blocked_spid, blocked_last_tran_started,
@@ -123,6 +126,7 @@ SELECT
     LEFT(blocking_sql_text, 500) AS blocking_sql
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+{BlockingPairRowQuery.SpidFilter}
 ORDER BY event_time DESC
 LIMIT 5000";
 
@@ -134,22 +138,7 @@ LIMIT 5000";
         using (var reader = await cmd.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
-            {
-                rows.Add(new BlockingPairRow
-                {
-                    EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
-                    DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                    BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
-                    BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
-                    BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                    BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
-                    WaitTimeMs = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-                    LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
-                    BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
-                    BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-                    BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
-                });
-            }
+                rows.Add(BlockingPairRowQuery.Read(reader));
         }
 
         if (rows.Count == 0) return;

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -118,10 +118,7 @@ LIMIT 5";
         // for the drill-down payload; the shared reader mapping is unaffected (same column order).
         cmd.CommandText = $@"
 SELECT
-    event_time, database_name,
-    blocked_spid, blocked_last_tran_started,
-    blocking_spid, blocking_last_tran_started,
-    wait_time_ms, lock_mode, blocking_status,
+    {BlockingPairRowQuery.LeadingColumns},
     LEFT(blocked_sql_text, 500) AS blocked_sql,
     LEFT(blocking_sql_text, 500) AS blocking_sql
 FROM v_blocked_process_reports

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -203,15 +203,7 @@ AND   collection_time <= $3";
             // (Lite maps a missing blocker to spid 0 — see BlockingPairRowQuery).
             command.CommandText = $@"
 SELECT
-    event_time,
-    database_name,
-    blocked_spid,
-    blocked_last_tran_started,
-    blocking_spid,
-    blocking_last_tran_started,
-    wait_time_ms,
-    lock_mode,
-    blocking_status,
+    {BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text,
     blocking_sql_text
 FROM v_blocked_process_reports

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -199,7 +199,9 @@ AND   collection_time <= $3";
             await connection.OpenAsync();
 
             using var command = connection.CreateCommand();
-            command.CommandText = @"
+            // SpidFilter keeps this in lockstep with the drill-down + viewer fetch on the apex
+            // (Lite maps a missing blocker to spid 0 — see BlockingPairRowQuery).
+            command.CommandText = $@"
 SELECT
     event_time,
     database_name,
@@ -216,6 +218,7 @@ FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   event_time >= $2
 AND   event_time <= $3
+{BlockingPairRowQuery.SpidFilter}
 ORDER BY event_time DESC
 LIMIT 5000";
 
@@ -227,22 +230,7 @@ LIMIT 5000";
             using (var reader = await command.ExecuteReaderAsync())
             {
                 while (await reader.ReadAsync())
-                {
-                    rows.Add(new BlockingPairRow
-                    {
-                        EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
-                        DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                        BlockedSpid = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
-                        BlockedTranStarted = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
-                        BlockingSpid = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),
-                        BlockingTranStarted = reader.IsDBNull(5) ? null : reader.GetDateTime(5),
-                        WaitTimeMs = reader.IsDBNull(6) ? 0L : ToInt64(reader.GetValue(6)),
-                        LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
-                        BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
-                        BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-                        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
-                    });
-                }
+                    rows.Add(BlockingPairRowQuery.Read(reader));
             }
 
             if (rows.Count == 0) return;

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
@@ -61,10 +60,7 @@ public partial class DuckDbFactCollector : IFactCollector
         return facts;
     }
 
-    private static long ToInt64(object value)
-    {
-        if (value is BigInteger bi)
-            return (long)bi;
-        return Convert.ToInt64(value);
-    }
+    // Single BigInteger-tolerant impl lives in BlockingPairRowQuery (shared with the pair-row reader);
+    // delegate so the check isn't duplicated.
+    private static long ToInt64(object value) => BlockingPairRowQuery.ToInt64(value);
 }

--- a/Lite/Controls/ServerTab.BlockChain.cs
+++ b/Lite/Controls/ServerTab.BlockChain.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Ui;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Controls;
+
+public partial class ServerTab : UserControl
+{
+    /// <summary>
+    /// Opens the block-chain viewer for the Blocking tab's current window. The slicer exposes UTC
+    /// (SelectionStartUtc/EndUtc); the DuckDB rows are filtered on server-local event_time, so convert.
+    /// Fetch + reconstruct + tree-build run off the UI thread; only the render touches the UI.
+    /// </summary>
+    private async void ViewBlockChain_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            DateTime start, end;
+            var startUtc = BlockingSlicer.SelectionStartUtc;
+            var endUtc = BlockingSlicer.SelectionEndUtc;
+            if (startUtc.HasValue && endUtc.HasValue)
+            {
+                start = ServerTimeHelper.ToServerTime(startUtc.Value);
+                end = ServerTimeHelper.ToServerTime(endUtc.Value);
+            }
+            else
+            {
+                (start, end) = GetBlockingServerRange();
+            }
+
+            // GetBlockingPairRowsAsync uses OpenConnectionAsync, which already takes the DuckDB read lock —
+            // running it inside Task.Run keeps the lock acquire/release on a background thread (never the UI).
+            var model = await Task.Run(async () =>
+            {
+                var rows = await _dataService.GetBlockingPairRowsAsync(_serverId, start, end);
+                var reconstruction = BlockingChainReconstructor.Reconstruct(
+                    rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+                return BlockingChainViewerProjection.BuildModel(reconstruction);
+            });
+
+            var control = new BlockingChainControl();
+            control.LoadModel(model, BlockingChainViewerProjection.EmptyStateDetail);
+            GraphViewerWindow.ShowGraph(
+                Window.GetWindow(this),
+                control,
+                $"Blocking Chains — {_server.DisplayName}");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                Window.GetWindow(this)!,
+                $"Failed to build the blocking-chain view:\n\n{ex.Message}",
+                "Block Chain Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+        }
+    }
+
+    /// <summary>
+    /// The current Blocking-tab server-local range, used when the slicer has no narrowed selection /
+    /// no data. Mirrors LoadBlockingSlicerAsync's range computation.
+    /// </summary>
+    private (DateTime start, DateTime end) GetBlockingServerRange()
+    {
+        var hoursBack = GetHoursBack();
+        DateTime? fromDate = null, toDate = null;
+        if (IsCustomRange)
+        {
+            var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+            var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+            if (fromLocal.HasValue && toLocal.HasValue)
+            {
+                fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+                toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
+            }
+        }
+        return GetSlicerTimeRange(hoursBack, fromDate, toDate);
+    }
+}

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1365,7 +1365,13 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
-                                <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
+                                <DockPanel Grid.Row="0" LastChildFill="True">
+                                    <Button DockPanel.Dock="Right" Content="View Block Chain"
+                                            Click="ViewBlockChain_Click" Height="26" Padding="10,0"
+                                            Margin="6,0,8,0" VerticalAlignment="Center"
+                                            ToolTip="Reconstruct and visualize the blocking chains for the selected time range"/>
+                                    <controls:TimeRangeSlicerControl x:Name="BlockingSlicer"/>
+                                </DockPanel>
                             <DataGrid x:Name="BlockedProcessReportGrid" Grid.Row="1"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource BlockingRowStyle}"

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
+using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Ui;
 using PerformanceMonitor.Common;
 
@@ -348,6 +349,44 @@ LIMIT 200";
         }
 
         return items;
+    }
+
+    /// <summary>
+    /// Fetches the blocked/blocker pair rows for a window, for the block-chain viewer to feed
+    /// <see cref="BlockingChainReconstructor"/>. Internal (not public): <see cref="BlockingPairRow"/> is
+    /// internal to the analysis assembly — a public method returning it would be CS0050.
+    /// <see cref="OpenConnectionAsync"/> already takes the DuckDB read lock, so do NOT acquire it again
+    /// (the lock is NoRecursion). Uses <see cref="Analysis.BlockingPairRowQuery.SpidFilter"/> so it agrees
+    /// with the drill-down + fact collectors on the apex.
+    /// </summary>
+    internal async Task<List<BlockingPairRow>> GetBlockingPairRowsAsync(int serverId, DateTime start, DateTime end)
+    {
+        var rows = new List<BlockingPairRow>();
+
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = $@"
+SELECT
+    event_time, database_name,
+    blocked_spid, blocked_last_tran_started,
+    blocking_spid, blocking_last_tran_started,
+    wait_time_ms, lock_mode, blocking_status,
+    blocked_sql_text, blocking_sql_text
+FROM v_blocked_process_reports
+WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+{PerformanceMonitorLite.Analysis.BlockingPairRowQuery.SpidFilter}
+ORDER BY event_time DESC
+LIMIT 5000";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = start });
+        command.Parameters.Add(new DuckDBParameter { Value = end });
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            rows.Add(PerformanceMonitorLite.Analysis.BlockingPairRowQuery.Read(reader));
+
+        return rows;
     }
 
     /// <summary>

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -367,10 +367,7 @@ LIMIT 200";
         using var command = connection.CreateCommand();
         command.CommandText = $@"
 SELECT
-    event_time, database_name,
-    blocked_spid, blocked_last_tran_started,
-    blocking_spid, blocking_last_tran_started,
-    wait_time_ms, lock_mode, blocking_status,
+    {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text, blocking_sql_text
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3

--- a/Lite/Themes/CoolBreezeTheme.xaml
+++ b/Lite/Themes/CoolBreezeTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite/Themes/CoolBreezeTheme.xaml
+++ b/Lite/Themes/CoolBreezeTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
+    <!-- Apex (lead-blocker) node + legend border. Darker blue on light themes so it clears >=3:1 as a
+         graphical border on the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER
+         badge fill keeps the bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#1976D2"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Tuned per theme so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#FFB347"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Tuned per theme so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#FFB347"/>
+    <!-- Apex (lead-blocker) node + legend border. Theme-aware so it clears >=3:1 as a graphical border on
+         the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER badge fill keeps the
+         bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#4FA3FF"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite/Themes/LightTheme.xaml
+++ b/Lite/Themes/LightTheme.xaml
@@ -67,6 +67,9 @@
 
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}"/>
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}"/>
+    <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
+         Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/Lite/Themes/LightTheme.xaml
+++ b/Lite/Themes/LightTheme.xaml
@@ -70,6 +70,10 @@
     <!-- Legible warning amber for content text/borders (block-chain longest-wait, flag banner).
          Darker on light themes so it clears >=4.5:1 as TEXT on content backgrounds; any control may adopt it. -->
     <SolidColorBrush x:Key="WarningTextBrush" Color="#92400E"/>
+    <!-- Apex (lead-blocker) node + legend border. Darker blue on light themes so it clears >=3:1 as a
+         graphical border on the light node card (bright #4FA3FF is only ~2.6:1 on white). The LEAD BLOCKER
+         badge fill keeps the bright ApexBrush constant so the apex still pops. -->
+    <SolidColorBrush x:Key="ApexBorderBrush" Color="#1976D2"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -42,9 +42,14 @@ internal sealed class ChainLevel
 {
     public int Level { get; init; }
     public int BlockingSpid { get; init; }
+    /// <summary>Transaction start of the blocking side — the identity disambiguator a faithful
+    /// tree rebuild needs (a SPID reused by two sessions in the window is two real nodes).</summary>
+    public DateTime? BlockingTranStarted { get; init; }
     public int BlockedSpid { get; init; }
+    public DateTime? BlockedTranStarted { get; init; }
     public string LockMode { get; init; } = string.Empty;
     public long WaitTimeMs { get; init; }
+    public string DatabaseName { get; init; } = string.Empty;
     public string BlockingSqlText { get; init; } = string.Empty;
     public string BlockedSqlText { get; init; } = string.Empty;
 }
@@ -53,6 +58,8 @@ internal sealed class ChainLevel
 internal sealed class ReconstructedChain
 {
     public int ApexSpid { get; init; }
+    /// <summary>Transaction start of the apex — pairs with <see cref="ApexSpid"/> as its session identity.</summary>
+    public DateTime? TranStarted { get; init; }
     public bool ApexSleeping { get; init; }
     public int Depth { get; init; }
     public int VictimCount { get; init; }
@@ -84,7 +91,7 @@ internal static class BlockingChainReconstructor
     /// </summary>
     private static readonly DateTime SentinelFloor = new(1900, 1, 2);
 
-    private sealed record EdgeInfo(long WaitMs, string LockMode, string BlockingSql, string BlockedSql);
+    private sealed record EdgeInfo(long WaitMs, string LockMode, string BlockingSql, string BlockedSql, string DatabaseName);
 
     /// <summary>Builds a stable session key, normalizing the 1900-01-01 sentinel to NULL.</summary>
     public static SessionKey MakeKey(int spid, DateTime? tranStarted)
@@ -129,7 +136,8 @@ internal static class BlockingChainReconstructor
             {
                 dests[blocked] = new EdgeInfo(
                     row.WaitTimeMs, row.LockMode ?? string.Empty,
-                    row.BlockingSqlText ?? string.Empty, row.BlockedSqlText ?? string.Empty);
+                    row.BlockingSqlText ?? string.Empty, row.BlockedSqlText ?? string.Empty,
+                    row.DatabaseName ?? string.Empty);
             }
         }
 
@@ -159,6 +167,7 @@ internal static class BlockingChainReconstructor
             chains.Add(new ReconstructedChain
             {
                 ApexSpid = root.Spid,
+                TranStarted = root.TranStarted,
                 ApexSleeping = sleepingBlockers.Contains(root),
                 Depth = depth,
                 VictimCount = victimCount,
@@ -342,9 +351,12 @@ internal static class BlockingChainReconstructor
                 {
                     Level = level + 1,
                     BlockingSpid = node.Spid,
+                    BlockingTranStarted = node.TranStarted,
                     BlockedSpid = child.Spid,
+                    BlockedTranStarted = child.TranStarted,
                     LockMode = edge.LockMode,
                     WaitTimeMs = edge.WaitMs,
+                    DatabaseName = edge.DatabaseName,
                     BlockingSqlText = edge.BlockingSql,
                     BlockedSqlText = edge.BlockedSql
                 });

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -59,7 +59,7 @@ internal sealed class ReconstructedChain
 {
     public int ApexSpid { get; init; }
     /// <summary>Transaction start of the apex — pairs with <see cref="ApexSpid"/> as its session identity.</summary>
-    public DateTime? TranStarted { get; init; }
+    public DateTime? ApexTranStarted { get; init; }
     public bool ApexSleeping { get; init; }
     public int Depth { get; init; }
     public int VictimCount { get; init; }
@@ -167,7 +167,7 @@ internal static class BlockingChainReconstructor
             chains.Add(new ReconstructedChain
             {
                 ApexSpid = root.Spid,
-                TranStarted = root.TranStarted,
+                ApexTranStarted = root.TranStarted,
                 ApexSleeping = sleepingBlockers.Contains(root),
                 Depth = depth,
                 VictimCount = victimCount,

--- a/PerformanceMonitor.Common/BlockingChainLayout.cs
+++ b/PerformanceMonitor.Common/BlockingChainLayout.cs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// Left-to-right tree/forest layout for blocking chains — apex at the left, victims flowing right.
+    /// The algorithm mirrors the query-plan layout's SSMS-style "parent aligns to its first child"
+    /// approach, but is reimplemented against <see cref="BlockingChainNode"/> (Common cannot reference
+    /// the plan-analysis layout engine without a dependency cycle). Pure; node heights come from a caller
+    /// measure callback so this stays WPF-free and unit-testable.
+    /// </summary>
+    public static class BlockingChainLayout
+    {
+        public const double NodeWidth = 230;
+        public const double HorizontalSpacing = 290; // NodeWidth + horizontal gap between depths
+        public const double VerticalSpacing = 22;
+        public const double Padding = 40;
+        public const double ForestGap = 36; // extra vertical gap between separate apex trees
+
+        /// <summary>
+        /// Assigns X/Y to every node and returns the total canvas extent. Roots stack vertically into a
+        /// forest. Deterministic for a deterministic tree + measure.
+        /// </summary>
+        public static (double Width, double Height) Layout(
+            IReadOnlyList<BlockingChainNode> roots,
+            Func<BlockingChainNode, double> measureHeight)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (measureHeight == null) throw new ArgumentNullException(nameof(measureHeight));
+
+            double nextY = Padding;
+            foreach (var root in roots)
+            {
+                SetXPositions(root, 0);
+                SetYPositions(root, measureHeight, ref nextY);
+                nextY += ForestGap;
+            }
+
+            double maxX = 0, maxBottom = 0;
+            foreach (var root in roots)
+                CollectExtents(root, measureHeight, ref maxX, ref maxBottom);
+
+            return (maxX + NodeWidth + Padding, maxBottom + Padding);
+        }
+
+        private static void SetXPositions(BlockingChainNode node, int depth)
+        {
+            node.X = Padding + depth * HorizontalSpacing;
+            foreach (var child in node.Children)
+                SetXPositions(child, depth + 1);
+        }
+
+        private static void SetYPositions(BlockingChainNode node, Func<BlockingChainNode, double> measureHeight, ref double nextY)
+        {
+            if (node.Children.Count == 0)
+            {
+                node.Y = nextY;
+                nextY += measureHeight(node) + VerticalSpacing;
+                return;
+            }
+
+            foreach (var child in node.Children)
+                SetYPositions(child, measureHeight, ref nextY);
+
+            // Align the parent with its first child (SSMS-style horizontal spine).
+            node.Y = node.Children[0].Y;
+        }
+
+        private static void CollectExtents(BlockingChainNode node, Func<BlockingChainNode, double> measureHeight, ref double maxX, ref double maxBottom)
+        {
+            if (node.X > maxX) maxX = node.X;
+            var bottom = node.Y + measureHeight(node);
+            if (bottom > maxBottom) maxBottom = bottom;
+
+            foreach (var child in node.Children)
+                CollectExtents(child, measureHeight, ref maxX, ref maxBottom);
+        }
+    }
+}

--- a/PerformanceMonitor.Common/BlockingChainModel.cs
+++ b/PerformanceMonitor.Common/BlockingChainModel.cs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// A rendered, tree-shaped view of one or more reconstructed blocking chains. Each root is an apex
+    /// (lead/head blocker) with its transitive victims beneath it. Built by <see cref="BlockingChainTreeBuilder"/>
+    /// from the per-app projection of the analysis engine's reconstruction; laid out by
+    /// <see cref="BlockingChainLayout"/>. App-agnostic (no WPF), so it lives in Common and is shared by
+    /// the Dashboard and Lite block-chain viewers.
+    /// </summary>
+    public sealed class BlockingChainModel
+    {
+        /// <summary>One node per apex, ranked worst-first (by chain magnitude).</summary>
+        public IReadOnlyList<BlockingChainNode> Roots { get; init; } = Array.Empty<BlockingChainNode>();
+
+        /// <summary>A cycle was detected in the source blocking graph (mutual block / deadlock-shaped).</summary>
+        public bool CycleDetected { get; init; }
+
+        /// <summary>The reconstruction hit its depth cap; the deepest chains may be truncated.</summary>
+        public bool DepthCapped { get; init; }
+
+        /// <summary>The reconstruction exhausted its step budget; some edges may be missing.</summary>
+        public bool TraversalTruncated { get; init; }
+    }
+
+    /// <summary>
+    /// One session in a blocking tree. Keyed internally by (Spid, TranStarted) — a SPID reused by two
+    /// sessions in the window is two distinct nodes, never collapsed.
+    /// </summary>
+    public sealed class BlockingChainNode
+    {
+        public int Spid { get; init; }
+
+        /// <summary>Transaction start; the identity disambiguator that defeats SPID reuse. May be null
+        /// (no open transaction / sentinel-normalized).</summary>
+        public DateTime? TranStarted { get; init; }
+
+        /// <summary>True for the lead/head blocker at the root of its tree.</summary>
+        public bool IsApex { get; init; }
+
+        /// <summary>True when the apex is sleeping (an abandoned open transaction holding locks).</summary>
+        public bool IsApexSleeping { get; init; }
+
+        /// <summary>Chain magnitude for ranking the chain selector. Set on the root only; 0 elsewhere.</summary>
+        public double Magnitude { get; init; }
+
+        /// <summary>This node's wait time on its parent, in ms. 0 for the apex (it waits on no one).</summary>
+        public long WaitTimeMs { get; init; }
+
+        /// <summary>Lock mode this node is waiting for on its parent. Empty for the apex.</summary>
+        public string LockMode { get; init; } = string.Empty;
+
+        /// <summary>The SQL this session was running (its own statement).</summary>
+        public string SqlText { get; init; } = string.Empty;
+
+        /// <summary>Database context of the block.</summary>
+        public string DatabaseName { get; init; } = string.Empty;
+
+        /// <summary>Direct victims of this node, ordered deterministically.</summary>
+        public List<BlockingChainNode> Children { get; init; } = new();
+
+        /// <summary>Layout position, assigned by <see cref="BlockingChainLayout"/>.</summary>
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
+    /// <summary>
+    /// Public input to <see cref="BlockingChainTreeBuilder.Build"/> — one per reconstructed chain. The
+    /// per-app launch handler fills this by a mechanical field copy from the analysis engine's
+    /// reconstruction (which is internal to the analysis assembly and invisible here). Magnitude and the
+    /// sleeping flag live here because they are per-chain, not per-edge.
+    /// </summary>
+    public sealed class BlockingChainInput
+    {
+        public int ApexSpid { get; init; }
+        public DateTime? ApexTranStarted { get; init; }
+        public bool ApexSleeping { get; init; }
+        public double Magnitude { get; init; }
+
+        /// <summary>The chain's level-by-level edges (one per blocker -> blocked relationship).</summary>
+        public IReadOnlyList<BlockingEdgeInput> Edges { get; init; } = Array.Empty<BlockingEdgeInput>();
+    }
+
+    /// <summary>One blocker -> blocked edge of a chain.</summary>
+    public sealed class BlockingEdgeInput
+    {
+        public int Level { get; init; }
+        public int BlockingSpid { get; init; }
+        public DateTime? BlockingTranStarted { get; init; }
+        public int BlockedSpid { get; init; }
+        public DateTime? BlockedTranStarted { get; init; }
+        public string LockMode { get; init; } = string.Empty;
+        public long WaitTimeMs { get; init; }
+        public string DatabaseName { get; init; } = string.Empty;
+        public string BlockingSqlText { get; init; } = string.Empty;
+        public string BlockedSqlText { get; init; } = string.Empty;
+    }
+}

--- a/PerformanceMonitor.Common/BlockingChainModel.cs
+++ b/PerformanceMonitor.Common/BlockingChainModel.cs
@@ -94,6 +94,9 @@ namespace PerformanceMonitor.Common
     /// <summary>One blocker -> blocked edge of a chain.</summary>
     public sealed class BlockingEdgeInput
     {
+        /// <summary>The reconstructor's BFS level for this edge. Carried for parity/diagnostics only —
+        /// <see cref="BlockingChainTreeBuilder"/> re-derives depth structurally via its own BFS and does
+        /// not read this, so a reorder of the source edges can't change the built tree.</summary>
         public int Level { get; init; }
         public int BlockingSpid { get; init; }
         public DateTime? BlockingTranStarted { get; init; }

--- a/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
+++ b/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// Turns the analysis engine's per-chain edge lists into renderable trees (one per apex). This is the
+    /// single, shared home for the non-trivial DAG -> tree logic; both apps feed it the same public DTO so
+    /// the rule lives in exactly one place. Pure and app-agnostic.
+    /// </summary>
+    public static class BlockingChainTreeBuilder
+    {
+        // (Spid, TranStarted) is the session identity — see BlockingChainNode. ValueTuple gives correct
+        // structural equality for the dictionary keys (Nullable&lt;DateTime&gt; compares by value).
+        private readonly struct NodeKey : IEquatable<NodeKey>
+        {
+            public readonly int Spid;
+            public readonly DateTime? Tran;
+            public NodeKey(int spid, DateTime? tran) { Spid = spid; Tran = tran; }
+            public bool Equals(NodeKey other) => Spid == other.Spid && Nullable.Equals(Tran, other.Tran);
+            public override bool Equals(object? obj) => obj is NodeKey k && Equals(k);
+            public override int GetHashCode() => HashCode.Combine(Spid, Tran);
+        }
+
+        /// <summary>
+        /// Builds the tree forest. DAG -> tree policy: a victim reachable from more than one blocker (a
+        /// diamond) attaches to its lowest-<c>Level</c> parent; ties break to the lowest parent SPID then
+        /// transaction start. Extra in-edges are dropped. Sessions that share a reused SPID but differ in
+        /// transaction start are kept as separate nodes (never collapsed). Cycle-safe via a visited set.
+        /// </summary>
+        public static BlockingChainModel Build(
+            IReadOnlyList<BlockingChainInput> chains,
+            bool cycleDetected,
+            bool depthCapped,
+            bool traversalTruncated)
+        {
+            if (chains == null) throw new ArgumentNullException(nameof(chains));
+
+            var roots = chains
+                .Select(BuildOne)
+                .Where(r => r != null)
+                .Select(r => r!)
+                // Rank worst-first; deterministic tiebreak so the layout is stable regardless of input order.
+                .OrderByDescending(r => r.Magnitude)
+                .ThenBy(r => r.Spid)
+                .ThenBy(r => r.TranStarted ?? DateTime.MinValue)
+                .ToList();
+
+            return new BlockingChainModel
+            {
+                Roots = roots,
+                CycleDetected = cycleDetected,
+                DepthCapped = depthCapped,
+                TraversalTruncated = traversalTruncated
+            };
+        }
+
+        private static BlockingChainNode? BuildOne(BlockingChainInput chain)
+        {
+            var apexKey = new NodeKey(chain.ApexSpid, chain.ApexTranStarted);
+
+            // Group edges by parent (blocking side); within a parent, sort children deterministically.
+            var childrenByParent = new Dictionary<NodeKey, List<BlockingEdgeInput>>();
+            foreach (var edge in chain.Edges)
+            {
+                var parent = new NodeKey(edge.BlockingSpid, edge.BlockingTranStarted);
+                if (!childrenByParent.TryGetValue(parent, out var list))
+                    childrenByParent[parent] = list = new List<BlockingEdgeInput>();
+                list.Add(edge);
+            }
+            foreach (var list in childrenByParent.Values)
+                list.Sort(static (a, b) =>
+                {
+                    var c = a.BlockedSpid.CompareTo(b.BlockedSpid);
+                    if (c != 0) return c;
+                    return Nullable.Compare(a.BlockedTranStarted, b.BlockedTranStarted);
+                });
+
+            // The apex sources its own SqlText / DatabaseName from any OUTGOING edge (it has no incoming
+            // edge); its wait/lock are empty because it waits on no one.
+            var apexEdge = childrenByParent.TryGetValue(apexKey, out var apexOut) && apexOut.Count > 0
+                ? apexOut[0]
+                : null;
+
+            var root = new BlockingChainNode
+            {
+                Spid = chain.ApexSpid,
+                TranStarted = chain.ApexTranStarted,
+                IsApex = true,
+                IsApexSleeping = chain.ApexSleeping,
+                Magnitude = chain.Magnitude,
+                WaitTimeMs = 0,
+                LockMode = string.Empty,
+                SqlText = apexEdge?.BlockingSqlText ?? string.Empty,
+                DatabaseName = apexEdge?.DatabaseName ?? string.Empty
+            };
+
+            // Level-synchronized BFS from the apex. Processing each level in (Spid, Tran) order means the
+            // lowest-level / lowest-SPID parent claims a shared victim first; the visited set both
+            // implements the diamond "drop extra in-edge" rule and guards against cycles.
+            var visited = new HashSet<NodeKey> { apexKey };
+            var current = new List<(NodeKey Key, BlockingChainNode Node)> { (apexKey, root) };
+
+            while (current.Count > 0)
+            {
+                current.Sort(static (a, b) =>
+                {
+                    var c = a.Key.Spid.CompareTo(b.Key.Spid);
+                    if (c != 0) return c;
+                    return Nullable.Compare(a.Key.Tran, b.Key.Tran);
+                });
+
+                var next = new List<(NodeKey, BlockingChainNode)>();
+                foreach (var (key, node) in current)
+                {
+                    if (!childrenByParent.TryGetValue(key, out var edges)) continue;
+                    foreach (var edge in edges)
+                    {
+                        var childKey = new NodeKey(edge.BlockedSpid, edge.BlockedTranStarted);
+                        if (!visited.Add(childKey)) continue; // already placed (diamond back-edge) or a cycle
+
+                        var child = new BlockingChainNode
+                        {
+                            Spid = edge.BlockedSpid,
+                            TranStarted = edge.BlockedTranStarted,
+                            IsApex = false,
+                            WaitTimeMs = edge.WaitTimeMs,
+                            LockMode = edge.LockMode,
+                            SqlText = edge.BlockedSqlText,
+                            DatabaseName = edge.DatabaseName
+                        };
+                        node.Children.Add(child);
+                        next.Add((childKey, child));
+                    }
+                }
+                current = next;
+            }
+
+            return root;
+        }
+    }
+}

--- a/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
+++ b/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
@@ -85,8 +85,9 @@ namespace PerformanceMonitor.Common
                     return Nullable.Compare(a.BlockedTranStarted, b.BlockedTranStarted);
                 });
 
-            // The apex sources its own SqlText / DatabaseName from any OUTGOING edge (it has no incoming
-            // edge); its wait/lock are empty because it waits on no one.
+            // The apex sources its own SqlText / DatabaseName from its FIRST outgoing edge (it has no
+            // incoming edge); its wait/lock are empty because it waits on no one. Note: a cross-database
+            // lead blocker therefore shows only its first victim's database here.
             var apexEdge = childrenByParent.TryGetValue(apexKey, out var apexOut) && apexOut.Count > 0
                 ? apexOut[0]
                 : null;

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml
@@ -42,10 +42,10 @@
         <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,4"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <StackPanel Orientation="Horizontal">
-                <!-- Apex swatch is set in code from ApexBrush; long-wait tracks the theme warning brush —
-                     so the legend can't drift from what the nodes actually render. -->
-                <Border x:Name="ApexLegendSwatch" Width="12" Height="12" CornerRadius="2" Background="Transparent"
-                        BorderThickness="2" VerticalAlignment="Center"/>
+                <!-- Both swatches track the same theme brushes the nodes render with, so the legend can't
+                     drift: apex border = ApexBorderBrush, long-wait = WarningTextBrush. -->
+                <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"
+                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="{DynamicResource ApexBorderBrush}"/>
                 <TextBlock Text="Lead blocker (apex)" VerticalAlignment="Center" FontSize="11"
                            Foreground="{DynamicResource ForegroundMutedBrush}" Margin="4,0,16,0"/>
                 <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml
@@ -27,13 +27,13 @@
                     <Separator Margin="12,4"/>
                     <TextBlock Text="Chain:" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11" Margin="0,0,6,0"/>
-                    <ComboBox x:Name="ChainSelector" MinWidth="240" Height="26" VerticalContentAlignment="Center"
+                    <ComboBox x:Name="ChainSelector" MinWidth="240" Height="28" VerticalContentAlignment="Center"
                               SelectionChanged="ChainSelector_SelectionChanged"
                               ToolTip="Pick a single chain or show all, ranked by magnitude"/>
                 </StackPanel>
                 <TextBlock x:Name="FlagBanner" DockPanel.Dock="Right" VerticalAlignment="Center"
                            HorizontalAlignment="Right" TextAlignment="Right"
-                           Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                           Foreground="{DynamicResource WarningTextBrush}" FontSize="11" FontWeight="SemiBold"
                            Visibility="Collapsed"/>
             </DockPanel>
         </Border>
@@ -42,16 +42,16 @@
         <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,4"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <StackPanel Orientation="Horizontal">
-                <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"
-                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="#4FA3FF"/>
+                <!-- Apex swatch is set in code from ApexBrush; long-wait tracks the theme warning brush —
+                     so the legend can't drift from what the nodes actually render. -->
+                <Border x:Name="ApexLegendSwatch" Width="12" Height="12" CornerRadius="2" Background="Transparent"
+                        BorderThickness="2" VerticalAlignment="Center"/>
                 <TextBlock Text="Lead blocker (apex)" VerticalAlignment="Center" FontSize="11"
                            Foreground="{DynamicResource ForegroundMutedBrush}" Margin="4,0,16,0"/>
                 <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"
-                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="#FFB347"/>
+                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="{DynamicResource WarningTextBrush}"/>
                 <TextBlock Text="Longest wait" VerticalAlignment="Center" FontSize="11"
                            Foreground="{DynamicResource ForegroundMutedBrush}" Margin="4,0,16,0"/>
-                <TextBlock Text="Edge label = lock mode + wait time" VerticalAlignment="Center" FontSize="11"
-                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,0"/>
             </StackPanel>
         </Border>
 

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml
@@ -1,0 +1,128 @@
+<UserControl x:Class="PerformanceMonitor.Ui.BlockingChainControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="{DynamicResource BackgroundBrush}"
+             Focusable="True"
+             PreviewMouseDown="BlockingChainControl_PreviewMouseDown">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+            <DockPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                    <Button Content="+" Click="ZoomIn_Click" Width="28" Height="28" Padding="0" FontSize="16"
+                            FontWeight="Bold" ToolTip="Zoom In"/>
+                    <Button Content="&#x2212;" Click="ZoomOut_Click" Width="28" Height="28" Padding="0" FontSize="16"
+                            FontWeight="Bold" Margin="4,0,0,0" ToolTip="Zoom Out"/>
+                    <Button Content="Fit" Click="ZoomFit_Click" Height="28" Padding="8,0" Margin="4,0,0,0"
+                            ToolTip="Zoom to Fit"/>
+                    <TextBlock x:Name="ZoomLevelText" Text="100%" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundMutedBrush}" Margin="8,0,0,0" FontSize="11"/>
+                    <Separator Margin="12,4"/>
+                    <TextBlock Text="Chain:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11" Margin="0,0,6,0"/>
+                    <ComboBox x:Name="ChainSelector" MinWidth="240" Height="26" VerticalContentAlignment="Center"
+                              SelectionChanged="ChainSelector_SelectionChanged"
+                              ToolTip="Pick a single chain or show all, ranked by magnitude"/>
+                </StackPanel>
+                <TextBlock x:Name="FlagBanner" DockPanel.Dock="Right" VerticalAlignment="Center"
+                           HorizontalAlignment="Right" TextAlignment="Right"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                           Visibility="Collapsed"/>
+            </DockPanel>
+        </Border>
+
+        <!-- Legend -->
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,4"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+            <StackPanel Orientation="Horizontal">
+                <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"
+                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="#4FA3FF"/>
+                <TextBlock Text="Lead blocker (apex)" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="4,0,16,0"/>
+                <Border Width="12" Height="12" CornerRadius="2" Background="Transparent"
+                        BorderThickness="2" VerticalAlignment="Center" BorderBrush="#FFB347"/>
+                <TextBlock Text="Longest wait" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="4,0,16,0"/>
+                <TextBlock Text="Edge label = lock mode + wait time" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Canvas + Properties Panel -->
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition x:Name="PropertiesColumn" Width="0"/>
+            </Grid.ColumnDefinitions>
+
+            <ScrollViewer Grid.Column="0" x:Name="ChainScrollViewer"
+                          HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto"
+                          Background="{DynamicResource BackgroundBrush}"
+                          PreviewMouseWheel="ChainScrollViewer_PreviewMouseWheel"
+                          PreviewMouseLeftButtonDown="ChainScrollViewer_PreviewMouseLeftButtonDown"
+                          PreviewMouseMove="ChainScrollViewer_PreviewMouseMove"
+                          PreviewMouseLeftButtonUp="ChainScrollViewer_PreviewMouseLeftButtonUp">
+                <Canvas x:Name="ChainCanvas" ClipToBounds="False"
+                        HorizontalAlignment="Left" VerticalAlignment="Top">
+                    <Canvas.LayoutTransform>
+                        <ScaleTransform x:Name="ZoomTransform" ScaleX="1" ScaleY="1"/>
+                    </Canvas.LayoutTransform>
+                </Canvas>
+            </ScrollViewer>
+
+            <!-- Empty State -->
+            <StackPanel x:Name="EmptyState" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock Text="No Blocking Chains" FontSize="20" FontWeight="Light"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="EmptyStateDetail"
+                           Text="No blocked-process reports were collected in the selected time range."
+                           FontSize="13" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,8,0,0" TextWrapping="Wrap" MaxWidth="520"
+                           TextAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Properties Splitter -->
+            <GridSplitter x:Name="PropertiesSplitter" Grid.Column="1" Width="5"
+                          HorizontalAlignment="Center" VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrush}"
+                          Visibility="Collapsed"/>
+
+            <!-- Properties Panel -->
+            <Border x:Name="PropertiesPanel" Grid.Column="2"
+                    Background="{DynamicResource BackgroundDarkBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1,0,0,0"
+                    Visibility="Collapsed">
+                <DockPanel>
+                    <Border DockPanel.Dock="Top" Padding="10,8"
+                            Background="{DynamicResource BackgroundBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+                        <DockPanel>
+                            <Button DockPanel.Dock="Right" Content="&#x2715;" Click="CloseProperties_Click"
+                                    Width="24" Height="24" Padding="0" FontSize="12"
+                                    VerticalAlignment="Center" ToolTip="Close Properties"
+                                    Background="Transparent" BorderThickness="0"
+                                    Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                            <TextBlock x:Name="PropertiesHeader" Text="Session Properties"
+                                       FontWeight="SemiBold" FontSize="13"
+                                       Foreground="{DynamicResource ForegroundBrush}"
+                                       VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </Border>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                                  Padding="0">
+                        <StackPanel x:Name="PropertiesContent" Margin="10,8"/>
+                    </ScrollViewer>
+                </DockPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -1,0 +1,706 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using PerformanceMonitor.Common;
+
+using WpfPath = System.Windows.Shapes.Path;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Shared block-chain viewer: renders the apex (lead blocker) at the left with its transitive victims
+/// flowing right, one tree per chain. Mirrors PlanViewerControl's conventions — Canvas + ScaleTransform
+/// zoom/pan, click-to-select properties, theme lifecycle (subscribe in ctor, never unsubscribe on
+/// Unloaded, expose <see cref="Cleanup"/> for the host window to call on close).
+/// </summary>
+public partial class BlockingChainControl : UserControl, IGraphViewer
+{
+    private const double NodeWidth = BlockingChainLayout.NodeWidth;
+    private const double NodeHeight = 112;
+
+    private BlockingChainModel? _model;
+    private double _zoomLevel = 1.0;
+    private const double ZoomStep = 0.15;
+    private const double MinZoom = 0.1;
+    private const double MaxZoom = 3.0;
+
+    // Node selection
+    private Border? _selectedNodeBorder;
+    private Brush? _selectedNodeOriginalBorder;
+    private Thickness _selectedNodeOriginalThickness;
+    private BlockingChainNode? _selectedNode;
+
+    // Canvas panning
+    private bool _isPanning;
+    private Point _panStart;
+    private double _panStartOffsetX;
+    private double _panStartOffsetY;
+
+    // Accent brushes — chosen to read on every theme (same palette as PlanViewerControl).
+    private static readonly SolidColorBrush ApexBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));
+    private static readonly SolidColorBrush LongWaitBrush = new(Color.FromRgb(0xFF, 0xB3, 0x47));
+    private static readonly SolidColorBrush EdgeBrush = new(Color.FromRgb(0x6B, 0x72, 0x80));
+    private static readonly SolidColorBrush SelectionBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));
+
+    // Theme-aware chrome resolved at call time from the app's merged resource dictionaries.
+    private Brush NodeBackgroundBrush =>
+        (TryFindResource("BackgroundLightBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0x2A, 0x2D, 0x35));
+    private Brush NodeBorderBrush =>
+        (TryFindResource("BorderBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0x3A, 0x3D, 0x45));
+    private Brush ForegroundBrush =>
+        (TryFindResource("ForegroundBrush") as Brush) ?? Brushes.White;
+    private Brush MutedBrush =>
+        (TryFindResource("ForegroundMutedBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0x9A, 0x9A, 0x9A));
+
+    public BlockingChainControl()
+    {
+        InitializeComponent();
+        /* Subscribe for the life of the control. Do NOT unsubscribe on Unloaded — a TabControl fires
+           Unloaded on tab switch, which would permanently detach this handler. The host window calls
+           Cleanup() when it is actually closed. */
+        ThemeManager.ThemeChanged += OnThemeChanged;
+    }
+
+    /// <summary>Unsubscribes from theme changes. The host window calls this on close.</summary>
+    public void Cleanup()
+    {
+        ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged(string _)
+    {
+        if (_model == null) return;
+
+        var nodeToRestore = _selectedNode;
+        RenderSelected();
+
+        if (nodeToRestore == null) return;
+        foreach (var child in ChainCanvas.Children)
+        {
+            if (child is Border b && ReferenceEquals(b.Tag, nodeToRestore))
+            {
+                SelectNode(b, nodeToRestore);
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads a built model into the viewer. Pure UI work — the caller does the (off-UI-thread) fetch,
+    /// reconstruct, and tree-build, then hands the finished <see cref="BlockingChainModel"/> here.
+    /// </summary>
+    public void LoadModel(BlockingChainModel model, string? emptyStateDetail = null)
+    {
+        _model = model ?? throw new ArgumentNullException(nameof(model));
+
+        if (!string.IsNullOrWhiteSpace(emptyStateDetail))
+            EmptyStateDetail.Text = emptyStateDetail;
+
+        BuildFlagBanner();
+        PopulateChainSelector();
+
+        if (_model.Roots.Count == 0)
+        {
+            ShowEmptyState(true);
+            return;
+        }
+
+        ShowEmptyState(false);
+        // Default selection (index 0 = "All chains") triggers ChainSelector_SelectionChanged -> render.
+        if (ChainSelector.Items.Count > 0)
+            ChainSelector.SelectedIndex = 0;
+    }
+
+    private void ShowEmptyState(bool empty)
+    {
+        EmptyState.Visibility = empty ? Visibility.Visible : Visibility.Collapsed;
+        ChainScrollViewer.Visibility = empty ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private void BuildFlagBanner()
+    {
+        if (_model == null) return;
+        var parts = new List<string>();
+        if (_model.CycleDetected) parts.Add("⚠ cycle detected");
+        if (_model.DepthCapped) parts.Add("depth capped");
+        if (_model.TraversalTruncated) parts.Add("traversal truncated");
+
+        if (parts.Count == 0)
+        {
+            FlagBanner.Visibility = Visibility.Collapsed;
+            FlagBanner.Text = "";
+        }
+        else
+        {
+            FlagBanner.Visibility = Visibility.Visible;
+            FlagBanner.Text = string.Join("  ·  ", parts);
+        }
+    }
+
+    private sealed class ChainSelectorItem
+    {
+        public string Display { get; init; } = "";
+        public BlockingChainNode? Root { get; init; }   // null = all chains
+        public override string ToString() => Display;
+    }
+
+    private void PopulateChainSelector()
+    {
+        ChainSelector.Items.Clear();
+        if (_model == null || _model.Roots.Count == 0) return;
+
+        ChainSelector.Items.Add(new ChainSelectorItem
+        {
+            Display = $"All chains ({_model.Roots.Count})",
+            Root = null
+        });
+
+        foreach (var root in _model.Roots)
+        {
+            var victims = CountDescendants(root);
+            var depth = TreeDepth(root);
+            ChainSelector.Items.Add(new ChainSelectorItem
+            {
+                Display = $"SPID {root.Spid} — {victims} blocked, depth {depth}",
+                Root = root
+            });
+        }
+    }
+
+    private void ChainSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) => RenderSelected();
+
+    private IReadOnlyList<BlockingChainNode> SelectedRoots()
+    {
+        if (_model == null) return Array.Empty<BlockingChainNode>();
+        if (ChainSelector.SelectedItem is ChainSelectorItem item && item.Root != null)
+            return new[] { item.Root };
+        return _model.Roots;
+    }
+
+    #region Rendering
+
+    private void RenderSelected()
+    {
+        ChainCanvas.Children.Clear();
+        _selectedNodeBorder = null;
+
+        var roots = SelectedRoots();
+        if (roots.Count == 0) return;
+
+        ChainScrollViewer.ScrollToHome();
+
+        var (width, height) = BlockingChainLayout.Layout(roots, _ => NodeHeight);
+        ChainCanvas.Width = width;
+        ChainCanvas.Height = height;
+
+        // Find the longest-wait node across the rendered set to highlight it.
+        long maxWait = 0;
+        foreach (var root in roots)
+            Walk(root, n => { if (n.WaitTimeMs > maxWait) maxWait = n.WaitTimeMs; });
+        var longestWaitNode = maxWait > 0
+            ? roots.SelectMany(EnumerateTree).FirstOrDefault(n => n.WaitTimeMs == maxWait)
+            : null;
+
+        foreach (var root in roots)
+            RenderEdges(root);
+        foreach (var root in roots)
+            RenderNodes(root, longestWaitNode);
+    }
+
+    private void RenderNodes(BlockingChainNode node, BlockingChainNode? longestWaitNode)
+    {
+        var visual = CreateNodeVisual(node, ReferenceEquals(node, longestWaitNode));
+        Canvas.SetLeft(visual, node.X);
+        Canvas.SetTop(visual, node.Y);
+        ChainCanvas.Children.Add(visual);
+
+        foreach (var child in node.Children)
+            RenderNodes(child, longestWaitNode);
+    }
+
+    private Border CreateNodeVisual(BlockingChainNode node, bool isLongestWait)
+    {
+        var border = new Border
+        {
+            Width = NodeWidth,
+            Height = NodeHeight,
+            Background = NodeBackgroundBrush,
+            BorderBrush = node.IsApex ? ApexBrush : (isLongestWait ? LongWaitBrush : NodeBorderBrush),
+            BorderThickness = new Thickness(node.IsApex || isLongestWait ? 2 : 1),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(8, 6, 8, 6),
+            Cursor = Cursors.Hand,
+            SnapsToDevicePixels = true,
+            ClipToBounds = true,
+            Tag = node
+        };
+        border.MouseLeftButtonUp += Node_Click;
+        border.ContextMenu = BuildNodeContextMenu(node);
+
+        var stack = new StackPanel();
+
+        // Header: SPID + role badges
+        var header = new StackPanel { Orientation = Orientation.Horizontal };
+        header.Children.Add(new TextBlock
+        {
+            Text = $"SPID {node.Spid}",
+            FontSize = 13,
+            FontWeight = FontWeights.Bold,
+            Foreground = ForegroundBrush,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+        if (node.IsApex)
+            header.Children.Add(MakeBadge("LEAD BLOCKER", ApexBrush));
+        if (node.IsApexSleeping)
+            header.Children.Add(MakeBadge("SLEEPING", LongWaitBrush));
+        stack.Children.Add(header);
+
+        // Database
+        if (!string.IsNullOrEmpty(node.DatabaseName))
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = node.DatabaseName,
+                FontSize = 11,
+                Foreground = MutedBrush,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Margin = new Thickness(0, 1, 0, 0)
+            });
+        }
+
+        // Lock mode + wait (victims only — the apex waits on no one)
+        if (!node.IsApex && (node.WaitTimeMs > 0 || !string.IsNullOrEmpty(node.LockMode)))
+        {
+            var waitText = string.IsNullOrEmpty(node.LockMode)
+                ? FormatWait(node.WaitTimeMs)
+                : $"{node.LockMode} · {FormatWait(node.WaitTimeMs)}";
+            stack.Children.Add(new TextBlock
+            {
+                Text = waitText,
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = isLongestWait ? LongWaitBrush : ForegroundBrush,
+                Margin = new Thickness(0, 1, 0, 0)
+            });
+        }
+
+        // SQL preview (clipped to fit the fixed-height card)
+        if (!string.IsNullOrEmpty(node.SqlText))
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = CollapseWhitespace(node.SqlText),
+                FontSize = 10,
+                FontFamily = new FontFamily("Consolas"),
+                Foreground = MutedBrush,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxHeight = 32,
+                Margin = new Thickness(0, 3, 0, 0)
+            });
+        }
+
+        border.Child = stack;
+        return border;
+    }
+
+    private static Border MakeBadge(string text, Brush brush) => new()
+    {
+        Background = brush,
+        CornerRadius = new CornerRadius(3),
+        Padding = new Thickness(4, 0, 4, 0),
+        Margin = new Thickness(6, 0, 0, 0),
+        VerticalAlignment = VerticalAlignment.Center,
+        Child = new TextBlock
+        {
+            Text = text,
+            FontSize = 9,
+            FontWeight = FontWeights.Bold,
+            Foreground = Brushes.Black
+        }
+    };
+
+    private void RenderEdges(BlockingChainNode node)
+    {
+        foreach (var child in node.Children)
+        {
+            var (path, label) = CreateElbowConnector(node, child);
+            ChainCanvas.Children.Add(path);
+            if (label != null)
+                ChainCanvas.Children.Add(label);
+            RenderEdges(child);
+        }
+    }
+
+    private (WpfPath Path, Border? Label) CreateElbowConnector(BlockingChainNode parent, BlockingChainNode child)
+    {
+        var parentRight = parent.X + NodeWidth;
+        var parentCenterY = parent.Y + NodeHeight / 2;
+        var childLeft = child.X;
+        var childCenterY = child.Y + NodeHeight / 2;
+        var midX = (parentRight + childLeft) / 2;
+
+        var geometry = new PathGeometry();
+        var figure = new PathFigure { StartPoint = new Point(parentRight, parentCenterY), IsClosed = false };
+        figure.Segments.Add(new LineSegment(new Point(midX, parentCenterY), true));
+        figure.Segments.Add(new LineSegment(new Point(midX, childCenterY), true));
+        figure.Segments.Add(new LineSegment(new Point(childLeft, childCenterY), true));
+        geometry.Figures.Add(figure);
+
+        var path = new WpfPath
+        {
+            Data = geometry,
+            Stroke = EdgeBrush,
+            StrokeThickness = 2,
+            StrokeLineJoin = PenLineJoin.Round,
+            SnapsToDevicePixels = true
+        };
+
+        // Edge label = the child's lock mode + wait time (its wait on this parent).
+        Border? label = null;
+        var labelText = string.IsNullOrEmpty(child.LockMode)
+            ? FormatWait(child.WaitTimeMs)
+            : $"{child.LockMode} · {FormatWait(child.WaitTimeMs)}";
+        if (!string.IsNullOrWhiteSpace(labelText) && (child.WaitTimeMs > 0 || !string.IsNullOrEmpty(child.LockMode)))
+        {
+            label = new Border
+            {
+                Background = NodeBackgroundBrush,
+                BorderBrush = NodeBorderBrush,
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(4, 1, 4, 1),
+                Child = new TextBlock { Text = labelText, FontSize = 9, Foreground = MutedBrush }
+            };
+            // Place just left of the child, centered on its inbound line.
+            Canvas.SetLeft(label, midX + 4);
+            Canvas.SetTop(label, childCenterY - 9);
+        }
+
+        return (path, label);
+    }
+
+    #endregion
+
+    #region Node selection & properties
+
+    private void Node_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is Border border && border.Tag is BlockingChainNode node)
+        {
+            SelectNode(border, node);
+            e.Handled = true;
+        }
+    }
+
+    private void SelectNode(Border border, BlockingChainNode node)
+    {
+        if (_selectedNodeBorder != null)
+        {
+            _selectedNodeBorder.BorderBrush = _selectedNodeOriginalBorder;
+            _selectedNodeBorder.BorderThickness = _selectedNodeOriginalThickness;
+        }
+
+        _selectedNodeOriginalBorder = border.BorderBrush;
+        _selectedNodeOriginalThickness = border.BorderThickness;
+        _selectedNodeBorder = border;
+        _selectedNode = node;
+        border.BorderBrush = SelectionBrush;
+        border.BorderThickness = new Thickness(2);
+
+        ShowProperties(node);
+    }
+
+    private ContextMenu BuildNodeContextMenu(BlockingChainNode node)
+    {
+        var menu = new ContextMenu();
+
+        var propsItem = new MenuItem { Header = "Properties" };
+        propsItem.Click += (_, _) =>
+        {
+            foreach (var child in ChainCanvas.Children)
+            {
+                if (child is Border b && ReferenceEquals(b.Tag, node))
+                {
+                    SelectNode(b, node);
+                    break;
+                }
+            }
+        };
+        menu.Items.Add(propsItem);
+
+        if (!string.IsNullOrEmpty(node.SqlText))
+        {
+            var copySql = new MenuItem { Header = "Copy SQL Text" };
+            copySql.Click += (_, _) => Clipboard.SetDataObject(node.SqlText, false);
+            menu.Items.Add(copySql);
+        }
+
+        return menu;
+    }
+
+    private void ShowProperties(BlockingChainNode node)
+    {
+        PropertiesContent.Children.Clear();
+        PropertiesHeader.Text = $"SPID {node.Spid}{(node.IsApex ? " (lead blocker)" : "")}";
+
+        AddPropRow("SPID", node.Spid.ToString());
+        AddPropRow("Role", node.IsApex ? (node.IsApexSleeping ? "Lead blocker (sleeping)" : "Lead blocker") : "Blocked");
+        if (node.TranStarted.HasValue)
+            AddPropRow("Transaction Started", node.TranStarted.Value.ToString("yyyy-MM-dd HH:mm:ss"));
+        if (!string.IsNullOrEmpty(node.DatabaseName))
+            AddPropRow("Database", node.DatabaseName);
+        if (!node.IsApex)
+        {
+            if (!string.IsNullOrEmpty(node.LockMode))
+                AddPropRow("Lock Mode", node.LockMode);
+            AddPropRow("Wait Time", FormatWait(node.WaitTimeMs));
+        }
+        AddPropRow("Direct Victims", node.Children.Count.ToString());
+
+        if (!string.IsNullOrEmpty(node.SqlText))
+        {
+            PropertiesContent.Children.Add(new TextBlock
+            {
+                Text = "SQL Text",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = MutedBrush,
+                FontSize = 11,
+                Margin = new Thickness(0, 10, 0, 4)
+            });
+            PropertiesContent.Children.Add(new TextBox
+            {
+                Text = node.SqlText,
+                IsReadOnly = true,
+                FontFamily = new FontFamily("Consolas"),
+                FontSize = 11,
+                Background = NodeBackgroundBrush,
+                Foreground = ForegroundBrush,
+                BorderThickness = new Thickness(0),
+                TextWrapping = TextWrapping.Wrap,
+                MaxHeight = 240,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto
+            });
+        }
+
+        OpenPropertiesPanel();
+    }
+
+    private void AddPropRow(string label, string value)
+    {
+        var grid = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(120) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        var lbl = new TextBlock { Text = label, Foreground = MutedBrush, FontSize = 11, TextWrapping = TextWrapping.Wrap };
+        var val = new TextBlock { Text = value, Foreground = ForegroundBrush, FontSize = 11, FontWeight = FontWeights.SemiBold, TextWrapping = TextWrapping.Wrap };
+        Grid.SetColumn(lbl, 0);
+        Grid.SetColumn(val, 1);
+        grid.Children.Add(lbl);
+        grid.Children.Add(val);
+        PropertiesContent.Children.Add(grid);
+    }
+
+    private void OpenPropertiesPanel()
+    {
+        PropertiesColumn.Width = new GridLength(340);
+        PropertiesSplitter.Visibility = Visibility.Visible;
+        PropertiesPanel.Visibility = Visibility.Visible;
+    }
+
+    private void CloseProperties_Click(object sender, RoutedEventArgs e)
+    {
+        PropertiesPanel.Visibility = Visibility.Collapsed;
+        PropertiesSplitter.Visibility = Visibility.Collapsed;
+        PropertiesColumn.Width = new GridLength(0);
+    }
+
+    #endregion
+
+    #region Zoom & pan (mirrors PlanViewerControl.Interaction)
+
+    private void ZoomIn_Click(object sender, RoutedEventArgs e) => SetZoom(_zoomLevel + ZoomStep);
+    private void ZoomOut_Click(object sender, RoutedEventArgs e) => SetZoom(_zoomLevel - ZoomStep);
+
+    private void ZoomFit_Click(object sender, RoutedEventArgs e)
+    {
+        if (ChainCanvas.Width <= 0 || ChainCanvas.Height <= 0) return;
+        var viewWidth = ChainScrollViewer.ActualWidth;
+        var viewHeight = ChainScrollViewer.ActualHeight;
+        if (viewWidth <= 0 || viewHeight <= 0) return;
+
+        var fitZoom = Math.Min(viewWidth / ChainCanvas.Width, viewHeight / ChainCanvas.Height);
+        SetZoom(Math.Min(fitZoom, 1.0));
+    }
+
+    private void SetZoom(double level)
+    {
+        _zoomLevel = Math.Max(MinZoom, Math.Min(MaxZoom, level));
+        ZoomTransform.ScaleX = _zoomLevel;
+        ZoomTransform.ScaleY = _zoomLevel;
+        ZoomLevelText.Text = $"{(int)(_zoomLevel * 100)}%";
+    }
+
+    private void ChainScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            e.Handled = true;
+            SetZoom(_zoomLevel + (e.Delta > 0 ? ZoomStep : -ZoomStep));
+        }
+    }
+
+    private void BlockingChainControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        // Don't steal focus from the chain selector dropdown.
+        if (e.OriginalSource is ComboBox
+            || e.OriginalSource is ComboBoxItem
+            || FindVisualParent<ComboBox>(e.OriginalSource as DependencyObject) != null
+            || FindVisualParent<ComboBoxItem>(e.OriginalSource as DependencyObject) != null)
+            return;
+        Focus();
+    }
+
+    private void ChainScrollViewer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (IsScrollBarAtPoint(e) || IsNodeAtPoint(e)) return;
+
+        _isPanning = true;
+        _panStart = e.GetPosition(ChainScrollViewer);
+        _panStartOffsetX = ChainScrollViewer.HorizontalOffset;
+        _panStartOffsetY = ChainScrollViewer.VerticalOffset;
+        ChainScrollViewer.Cursor = Cursors.SizeAll;
+        ChainScrollViewer.CaptureMouse();
+        e.Handled = true;
+    }
+
+    private void ChainScrollViewer_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isPanning) return;
+        var current = e.GetPosition(ChainScrollViewer);
+        ChainScrollViewer.ScrollToHorizontalOffset(Math.Max(0, _panStartOffsetX - (current.X - _panStart.X)));
+        ChainScrollViewer.ScrollToVerticalOffset(Math.Max(0, _panStartOffsetY - (current.Y - _panStart.Y)));
+        e.Handled = true;
+    }
+
+    private void ChainScrollViewer_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_isPanning) return;
+        _isPanning = false;
+        ChainScrollViewer.Cursor = Cursors.Arrow;
+        ChainScrollViewer.ReleaseMouseCapture();
+        e.Handled = true;
+    }
+
+    private static bool IsScrollBarAtPoint(MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        while (source != null)
+        {
+            if (source is System.Windows.Controls.Primitives.ScrollBar) return true;
+            source = VisualTreeHelper.GetParent(source);
+        }
+        return false;
+    }
+
+    private static bool IsNodeAtPoint(MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        while (source != null)
+        {
+            if (source is Border b && b.Tag is BlockingChainNode) return true;
+            source = VisualTreeHelper.GetParent(source);
+        }
+        return false;
+    }
+
+    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
+    {
+        while (child != null)
+        {
+            if (child is T parent) return parent;
+            child = VisualTreeHelper.GetParent(child);
+        }
+        return null;
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string FormatWait(long ms)
+    {
+        if (ms <= 0) return "0 ms";
+        if (ms < 1000) return $"{ms} ms";
+        if (ms < 60_000) return $"{ms / 1000.0:F1} s";
+        return $"{ms / 60_000}m {(ms % 60_000) / 1000}s";
+    }
+
+    private static string CollapseWhitespace(string s)
+    {
+        var trimmed = s.Trim();
+        var sb = new System.Text.StringBuilder(trimmed.Length);
+        var lastWasSpace = false;
+        foreach (var c in trimmed)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                if (!lastWasSpace) sb.Append(' ');
+                lastWasSpace = true;
+            }
+            else
+            {
+                sb.Append(c);
+                lastWasSpace = false;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static int CountDescendants(BlockingChainNode node)
+    {
+        var count = 0;
+        foreach (var child in node.Children)
+            count += 1 + CountDescendants(child);
+        return count;
+    }
+
+    private static int TreeDepth(BlockingChainNode node)
+    {
+        if (node.Children.Count == 0) return 0;
+        var max = 0;
+        foreach (var child in node.Children)
+            max = Math.Max(max, TreeDepth(child));
+        return max + 1;
+    }
+
+    private static IEnumerable<BlockingChainNode> EnumerateTree(BlockingChainNode node)
+    {
+        yield return node;
+        foreach (var child in node.Children)
+            foreach (var d in EnumerateTree(child))
+                yield return d;
+    }
+
+    private static void Walk(BlockingChainNode node, Action<BlockingChainNode> action)
+    {
+        action(node);
+        foreach (var child in node.Children)
+            Walk(child, action);
+    }
+
+    #endregion
+}

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -50,10 +50,10 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     private double _panStartOffsetY;
 
     // Accent brushes — chosen to read on every theme (same palette as PlanViewerControl).
-    private static readonly SolidColorBrush ApexBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));
-    private static readonly SolidColorBrush LongWaitBrush = new(Color.FromRgb(0xFF, 0xB3, 0x47));
+    private static readonly SolidColorBrush ApexBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));        // lead-blocker border + badge (blue)
+    private static readonly SolidColorBrush SelectionBrush = new(Color.FromRgb(0x8E, 0x5B, 0xFF));   // selected node border (purple — distinct from apex)
+    private static readonly SolidColorBrush SleepingBrush = new(Color.FromRgb(0x90, 0xA4, 0xAE));    // sleeping-apex badge (slate — distinct from the warning amber)
     private static readonly SolidColorBrush EdgeBrush = new(Color.FromRgb(0x6B, 0x72, 0x80));
-    private static readonly SolidColorBrush SelectionBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));
 
     // Theme-aware chrome resolved at call time from the app's merged resource dictionaries.
     private Brush NodeBackgroundBrush =>
@@ -63,11 +63,18 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     private Brush ForegroundBrush =>
         (TryFindResource("ForegroundBrush") as Brush) ?? Brushes.White;
     private Brush MutedBrush =>
-        (TryFindResource("ForegroundMutedBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0x9A, 0x9A, 0x9A));
+        (TryFindResource("ForegroundMutedBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0xE4, 0xE6, 0xEB));
+    // Longest-wait emphasis (border + the wait number). Theme-aware so it stays legible on Light/CoolBreeze
+    // (orange-on-white fails AA); fallback is the Dark amber.
+    private Brush WarningBrush =>
+        (TryFindResource("WarningTextBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0xFF, 0xB3, 0x47));
 
     public BlockingChainControl()
     {
         InitializeComponent();
+        // Keep the apex legend swatch bound to the same constant the nodes use (the longest-wait swatch
+        // and flag banner use {DynamicResource WarningTextBrush} in XAML, so they track the theme).
+        ApexLegendSwatch.BorderBrush = ApexBrush;
         /* Subscribe for the life of the control. Do NOT unsubscribe on Unloaded — a TabControl fires
            Unloaded on tab switch, which would permanently detach this handler. The host window calls
            Cleanup() when it is actually closed. */
@@ -134,7 +141,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     {
         if (_model == null) return;
         var parts = new List<string>();
-        if (_model.CycleDetected) parts.Add("⚠ cycle detected");
+        if (_model.CycleDetected) parts.Add("cycle detected");
         if (_model.DepthCapped) parts.Add("depth capped");
         if (_model.TraversalTruncated) parts.Add("traversal truncated");
 
@@ -145,8 +152,10 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         }
         else
         {
+            // Reads as a warning (⚠ + the theme-aware amber via FlagBanner's Foreground) — these caveats
+            // mean the rendered chain may be incomplete or misleading.
             FlagBanner.Visibility = Visibility.Visible;
-            FlagBanner.Text = string.Join("  ·  ", parts);
+            FlagBanner.Text = "⚠ " + string.Join("  ·  ", parts);
         }
     }
 
@@ -238,7 +247,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
             Width = NodeWidth,
             Height = NodeHeight,
             Background = NodeBackgroundBrush,
-            BorderBrush = node.IsApex ? ApexBrush : (isLongestWait ? LongWaitBrush : NodeBorderBrush),
+            BorderBrush = node.IsApex ? ApexBrush : (isLongestWait ? WarningBrush : NodeBorderBrush),
             BorderThickness = new Thickness(node.IsApex || isLongestWait ? 2 : 1),
             CornerRadius = new CornerRadius(4),
             Padding = new Thickness(8, 6, 8, 6),
@@ -265,7 +274,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         if (node.IsApex)
             header.Children.Add(MakeBadge("LEAD BLOCKER", ApexBrush));
         if (node.IsApexSleeping)
-            header.Children.Add(MakeBadge("SLEEPING", LongWaitBrush));
+            header.Children.Add(MakeBadge("SLEEPING", SleepingBrush));
         stack.Children.Add(header);
 
         // Database
@@ -292,7 +301,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
                 Text = waitText,
                 FontSize = 11,
                 FontWeight = FontWeights.SemiBold,
-                Foreground = isLongestWait ? LongWaitBrush : ForegroundBrush,
+                Foreground = isLongestWait ? WarningBrush : ForegroundBrush,
                 Margin = new Thickness(0, 1, 0, 0)
             });
         }
@@ -337,15 +346,14 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     {
         foreach (var child in node.Children)
         {
-            var (path, label) = CreateElbowConnector(node, child);
-            ChainCanvas.Children.Add(path);
-            if (label != null)
-                ChainCanvas.Children.Add(label);
+            ChainCanvas.Children.Add(CreateElbowConnector(node, child));
             RenderEdges(child);
         }
     }
 
-    private (WpfPath Path, Border? Label) CreateElbowConnector(BlockingChainNode parent, BlockingChainNode child)
+    // Connector only — no edge label. The child's lock mode + wait already live on its card (with the
+    // longest-wait emphasis), and a label here would be painted over by the child card anyway.
+    private WpfPath CreateElbowConnector(BlockingChainNode parent, BlockingChainNode child)
     {
         var parentRight = parent.X + NodeWidth;
         var parentCenterY = parent.Y + NodeHeight / 2;
@@ -360,7 +368,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         figure.Segments.Add(new LineSegment(new Point(childLeft, childCenterY), true));
         geometry.Figures.Add(figure);
 
-        var path = new WpfPath
+        return new WpfPath
         {
             Data = geometry,
             Stroke = EdgeBrush,
@@ -368,29 +376,6 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
             StrokeLineJoin = PenLineJoin.Round,
             SnapsToDevicePixels = true
         };
-
-        // Edge label = the child's lock mode + wait time (its wait on this parent).
-        Border? label = null;
-        var labelText = string.IsNullOrEmpty(child.LockMode)
-            ? FormatWait(child.WaitTimeMs)
-            : $"{child.LockMode} · {FormatWait(child.WaitTimeMs)}";
-        if (!string.IsNullOrWhiteSpace(labelText) && (child.WaitTimeMs > 0 || !string.IsNullOrEmpty(child.LockMode)))
-        {
-            label = new Border
-            {
-                Background = NodeBackgroundBrush,
-                BorderBrush = NodeBorderBrush,
-                BorderThickness = new Thickness(1),
-                CornerRadius = new CornerRadius(3),
-                Padding = new Thickness(4, 1, 4, 1),
-                Child = new TextBlock { Text = labelText, FontSize = 9, Foreground = MutedBrush }
-            };
-            // Place just left of the child, centered on its inbound line.
-            Canvas.SetLeft(label, midX + 4);
-            Canvas.SetTop(label, childCenterY - 9);
-        }
-
-        return (path, label);
     }
 
     #endregion
@@ -418,8 +403,10 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         _selectedNodeOriginalThickness = border.BorderThickness;
         _selectedNodeBorder = border;
         _selectedNode = node;
+        // Purple at 3px — distinct hue AND weight from the apex (blue, 2px) and longest-wait (amber, 2px),
+        // so a selected victim can never be mistaken for the lead blocker.
         border.BorderBrush = SelectionBrush;
-        border.BorderThickness = new Thickness(2);
+        border.BorderThickness = new Thickness(3);
 
         ShowProperties(node);
     }

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -50,7 +50,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     private double _panStartOffsetY;
 
     // Accent brushes — chosen to read on every theme (same palette as PlanViewerControl).
-    private static readonly SolidColorBrush ApexBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));        // lead-blocker border + badge (blue)
+    private static readonly SolidColorBrush ApexBrush = new(Color.FromRgb(0x4F, 0xA3, 0xFF));        // LEAD BLOCKER badge fill only (kept bright so the apex pops; the border is theme-aware below)
     private static readonly SolidColorBrush SelectionBrush = new(Color.FromRgb(0x8E, 0x5B, 0xFF));   // selected node border (purple — distinct from apex)
     private static readonly SolidColorBrush SleepingBrush = new(Color.FromRgb(0x90, 0xA4, 0xAE));    // sleeping-apex badge (slate — distinct from the warning amber)
     private static readonly SolidColorBrush EdgeBrush = new(Color.FromRgb(0x6B, 0x72, 0x80));
@@ -68,13 +68,14 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     // (orange-on-white fails AA); fallback is the Dark amber.
     private Brush WarningBrush =>
         (TryFindResource("WarningTextBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0xFF, 0xB3, 0x47));
+    // Apex node border. Theme-aware so it clears >=3:1 as a border on the light node card (bright #4FA3FF
+    // is only ~2.6:1 on white); fallback is the Dark blue. (The badge fill keeps the bright ApexBrush.)
+    private Brush ApexBorderBrush =>
+        (TryFindResource("ApexBorderBrush") as Brush) ?? new SolidColorBrush(Color.FromRgb(0x4F, 0xA3, 0xFF));
 
     public BlockingChainControl()
     {
         InitializeComponent();
-        // Keep the apex legend swatch bound to the same constant the nodes use (the longest-wait swatch
-        // and flag banner use {DynamicResource WarningTextBrush} in XAML, so they track the theme).
-        ApexLegendSwatch.BorderBrush = ApexBrush;
         /* Subscribe for the life of the control. Do NOT unsubscribe on Unloaded — a TabControl fires
            Unloaded on tab switch, which would permanently detach this handler. The host window calls
            Cleanup() when it is actually closed. */
@@ -247,7 +248,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
             Width = NodeWidth,
             Height = NodeHeight,
             Background = NodeBackgroundBrush,
-            BorderBrush = node.IsApex ? ApexBrush : (isLongestWait ? WarningBrush : NodeBorderBrush),
+            BorderBrush = node.IsApex ? ApexBorderBrush : (isLongestWait ? WarningBrush : NodeBorderBrush),
             BorderThickness = new Thickness(node.IsApex || isLongestWait ? 2 : 1),
             CornerRadius = new CornerRadius(4),
             Padding = new Thickness(8, 6, 8, 6),

--- a/PerformanceMonitor.Ui/GraphViewerWindow.xaml
+++ b/PerformanceMonitor.Ui/GraphViewerWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="PerformanceMonitor.Ui.GraphViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Graph Viewer" Width="1200" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid x:Name="ContentHost"/>
+</Window>

--- a/PerformanceMonitor.Ui/GraphViewerWindow.xaml.cs
+++ b/PerformanceMonitor.Ui/GraphViewerWindow.xaml.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Shared, app-agnostic host window for a graph viewer control (block-chain today, deadlock graph next).
+/// Hosts any <see cref="FrameworkElement"/>; if it implements <see cref="IGraphViewer"/>, the window
+/// calls <see cref="IGraphViewer.Cleanup"/> on close so the control unsubscribes from theme changes.
+/// Shown owned + non-modal so it stays interactive above a modal host and closes with it — same model as
+/// the per-app PlanViewerWindow.
+/// </summary>
+public partial class GraphViewerWindow : Window
+{
+    private readonly IGraphViewer? _viewer;
+
+    public GraphViewerWindow(FrameworkElement content, string title)
+    {
+        InitializeComponent();
+
+        if (!string.IsNullOrWhiteSpace(title))
+            Title = title.Length > 100 ? title[..100] : title;
+
+        _viewer = content as IGraphViewer;
+        ContentHost.Children.Add(content);
+        Closed += (_, _) => _viewer?.Cleanup();
+    }
+
+    /// <summary>
+    /// Opens a new, owned, non-modal graph window hosting <paramref name="content"/>. A new window per
+    /// call lets the user compare graphs side by side; owned so it stays usable above a modal host window.
+    /// </summary>
+    public static GraphViewerWindow ShowGraph(Window? owner, FrameworkElement content, string title)
+    {
+        var window = new GraphViewerWindow(content, title) { Owner = owner };
+        window.Show();
+        return window;
+    }
+}

--- a/PerformanceMonitor.Ui/IGraphViewer.cs
+++ b/PerformanceMonitor.Ui/IGraphViewer.cs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// A graph viewer control hosted by <see cref="GraphViewerWindow"/>. Implementers subscribe to
+/// <see cref="ThemeManager.ThemeChanged"/> in their constructor and must unsubscribe in
+/// <see cref="Cleanup"/> — the host window calls it on close (mirrors the PlanViewerControl lifecycle).
+/// </summary>
+public interface IGraphViewer
+{
+    /// <summary>Unsubscribes from theme changes / releases handlers. Called by the host on window close.</summary>
+    void Cleanup();
+}


### PR DESCRIPTION
## Block-chain viewer (PR #1)

Implements **Phase 0 + Phase 1** of `plans/deadlock-and-blocking-viewers.md` — the **block-chain viewer** only. The deadlock-graph viewer (Phase 2) is a separate PR.

A new visual viewer that renders the blocker -> blocked hierarchy (lead/apex blocker at the root, victims to the right), one tree per chain, for a selected time window. Shipped in **both apps** with the rendering shared in `.Ui`/`.Common` and only fetch + projection + launch glue per app.

### What's here

**`PerformanceMonitor.Analysis` — additive output change**
- `ChainLevel` gains `BlockingTranStarted` / `BlockedTranStarted` (the `SessionKey` identity the reconstructor used internally but discarded) and `DatabaseName`; `ReconstructedChain` gains `TranStarted`. `EdgeInfo` now threads `DatabaseName` (previously dropped). Purely additive — all four existing consumers project named fields, so they don't see the new ones.

**`PerformanceMonitor.Common` — shared, app-agnostic logic (tested once here)**
- `BlockingChainModel` / `BlockingChainNode` + public input DTOs `BlockingChainInput` / `BlockingEdgeInput`.
- `BlockingChainTreeBuilder.Build(...)` — DAG->tree: a multi-parent victim (diamond) attaches to its lowest-`Level` parent, tiebreak lowest parent SPID; same-SPID/different-transaction sessions are kept as **separate** nodes; cycle-safe via a visited set; node fields sourced from the incoming edge (apex from an outgoing edge).
- `BlockingChainLayout` — left-to-right tree/forest layout (reimplemented, not `PlanLayoutEngine`).

**`PerformanceMonitor.Ui` — shared controls**
- `GraphViewerWindow` + `IGraphViewer` — generic host window that calls `Cleanup()` on close (reusable by the Phase-2 deadlock control).
- `BlockingChainControl` — Canvas + `ScaleTransform` zoom/pan + fit, node cards (SPID/db/lock mode/wait/SQL preview), edge labels (lock mode + wait), chain selector ranked by magnitude, click -> properties panel. Mirrors `PlanViewerControl` conventions (subscribe to `ThemeManager` in ctor, never unsubscribe on `Unloaded`, expose `Cleanup()`, brushes via `TryFindResource` with hardcoded fallbacks).

**Both apps — data path + four-site harmonization**
- New `internal GetBlockingPairRowsAsync(...)` at the data-service tier (`internal` because `BlockingPairRow` is internal to `.Analysis` — a public method would be CS0050).
- Harmonized the non-zero `blocking_spid` filter across **all four** `Reconstruct` sites (drill-down + `BLOCKING_CHAIN` fact, both apps) via a shared per-app query/filter helper. Dashboard already filtered; **Lite's two sites previously didn't**, so they could invent a phantom SPID-0 apex — now fixed. Fixture-neutral: `Lite.Tests/FactScorerTests` + `ScenarioTests` stay green.

**Both apps — launch**
- "View Block Chain" button on the Lite **Blocking** sub-tab and the Dashboard **Locking → Blocking** sub-tab, next to the time slicer. Clock-aware reads (Lite `SelectionStartUtc/EndUtc` -> server time; Dashboard `SelectionStart/End` + `HasNarrowedSelection`). Fetch + reconstruct + tree-build run off the UI thread (`Task.Run`; Lite via `OpenConnectionAsync`, which already read-locks — no manual `AcquireReadLock`).

### Test results
- `Dashboard.Tests`: **559 passed** (incl. 8 tree-builder + 5 layout + the reconstructor field test).
- `Lite.Tests`: **546 passed** (incl. `FactScorerTests`, `ScenarioTests`, reconstructor — confirms the four-site harmonization is fixture-neutral).
- Both apps build clean (0 errors).

### Decisions where the plan was silent
- **Chain selector UX:** a "All chains (N)" entry (default) renders the whole forest; selecting a single chain renders just that tree. Satisfies both "forest" and "ranked selector".
- **Node-card height:** fixed (112px) so layout measure and render can't drift; SQL preview is clipped. Apex border = blue accent, longest-wait victim = orange, with a legend.
- **`PlanViewerWindow` -> `GraphViewerWindow` collapse:** the plan lists this as "tracked, not silently deferred." I built `GraphViewerWindow` to make the collapse trivial but did **not** rewire the existing (just-merged) `PlanViewerWindow` in this PR, to avoid touching a shipped feature mid-task. Filing explicitly: it's now a ~10-line per-app change (have `PlanViewerControl` implement `IGraphViewer`, route the two `ShowPlanAsync` helpers through `GraphViewerWindow`).

### Visual-test checklist (for the reviewer to run locally)
- [ ] Open the viewer from **both** apps via "View Block Chain" over a slicer window (Lite Blocking; Dashboard Locking → Blocking).
- [ ] Apex (lead blocker) renders at the root with victims to the right; longest-wait victim highlighted.
- [ ] Multi-chain selector lists chains ranked by magnitude; "All chains" shows the forest; selecting one shows a single tree.
- [ ] Node card shows SPID / db / lock mode / wait / SQL preview; click -> properties panel (full SQL).
- [ ] Zoom in/out/fit, scroll-wheel + Ctrl-zoom, click-drag pan.
- [ ] Theme switch (Dark / Light / CoolBreeze) re-renders with readable chrome.
- [ ] Empty range -> empty state (note the Azure SQL DB blocked-process-report caveat).
- [ ] Open/close the window repeatedly (verifies `Cleanup()` unsubscribes from `ThemeManager`).
- [ ] Cloud: confirm against Azure SQL DB / AWS RDS.

**Do not merge yet** — pending diff verification + adversarial review + the visual checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
