### PR TITLE
Batch picker-chart trend queries to fix N+1 query loops (Lite)

### DIFF
--- a/Lite/Controls/ServerTab.Pickers.cs
+++ b/Lite/Controls/ServerTab.Pickers.cs
@@ -173,11 +173,13 @@ public partial class ServerTab : UserControl
             }
             double globalMax = 0;
 
+            // Batched fetch: one query for all selected wait types (was an N+1 query-per-type loop).
+            var trendsByType = await Task.Run(() => _dataService.GetWaitStatsTrendsByTypesAsync(_serverId, selected.Select(s => s.DisplayName).ToList(), hoursBack, fromDate, toDate));
+            if (gen != _waitStatsPickerGen) return;
+
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await Task.Run(() => _dataService.GetWaitStatsTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
-                if (gen != _waitStatsPickerGen) return;
-                if (trend.Count == 0) continue;
+                if (!trendsByType.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
                 var values = useAvgPerWait
@@ -332,11 +334,13 @@ public partial class ServerTab : UserControl
             string topNonBpClerk = "";
             double topNonBpMb = 0;
 
+            // Batched fetch: one query for all selected clerk types (was an N+1 query-per-clerk loop).
+            var trendsByType = await Task.Run(() => _dataService.GetMemoryClerkTrendsByTypesAsync(_serverId, selected.Select(s => s.DisplayName).ToList(), hoursBack, fromDate, toDate));
+            if (gen != _memoryClerksPickerGen) return;
+
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await Task.Run(() => _dataService.GetMemoryClerkTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
-                if (gen != _memoryClerksPickerGen) return;
-                if (trend.Count == 0) continue;
+                if (!trendsByType.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
                 var values = trend.Select(t => t.MemoryMb).ToArray();
@@ -543,11 +547,13 @@ public partial class ServerTab : UserControl
             }
             double globalMax = 0;
 
+            // Batched fetch: one query for all selected counters (was an N+1 query-per-counter loop).
+            var trendsByCounter = await Task.Run(() => _dataService.GetPerfmonTrendsByCountersAsync(_serverId, selected.Select(s => s.DisplayName).ToList(), hoursBack, fromDate, toDate));
+            if (gen != _perfmonPickerGen) return;
+
             for (int i = 0; i < selected.Count; i++)
             {
-                var trend = await Task.Run(() => _dataService.GetPerfmonTrendAsync(_serverId, selected[i].DisplayName, hoursBack, fromDate, toDate));
-                if (gen != _perfmonPickerGen) return;
-                if (trend.Count == 0) continue;
+                if (!trendsByCounter.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
                 var times = trend.Select(t => t.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
                 var values = trend.Select(t => (double)t.DeltaValue).ToArray();

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -417,6 +417,10 @@ public partial class ServerTab : UserControl
                 toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
             }
         }
+        var navContext = MainTabControl.SelectedIndex == 2
+            ? $"TabNav-Queries.sub{QueriesSubTabControl.SelectedIndex}"
+            : $"TabNav-tab{MainTabControl.SelectedIndex}";
+        using var _navTimer = Helpers.MethodProfiler.StartTiming(navContext);
         await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
     }
 

--- a/Lite/Services/LocalDataService.Memory.cs
+++ b/Lite/Services/LocalDataService.Memory.cs
@@ -182,6 +182,59 @@ ORDER BY collection_time";
     }
 
     /// <summary>
+    /// Batched sibling of <see cref="GetMemoryClerkTrendAsync"/>: fetches the trend for ALL selected
+    /// clerk types in ONE query (replacing an N+1 query-per-clerk loop), grouped by clerk type.
+    /// </summary>
+    public async Task<Dictionary<string, List<MemoryClerkTrendPoint>>> GetMemoryClerkTrendsByTypesAsync(int serverId, List<string> clerkTypes, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var _q = TimeQuery("GetMemoryClerkTrendsByTypesAsync", "v_memory_clerks trends batched by type");
+        var result = new Dictionary<string, List<MemoryClerkTrendPoint>>();
+        if (clerkTypes.Count == 0) return result;
+
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+        var typeParams = string.Join(", ", clerkTypes.Select((_, i) => "$" + (i + 4)));
+
+        command.CommandText = $@"
+SELECT
+    clerk_type,
+    collection_time,
+    memory_mb
+FROM v_memory_clerks
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   clerk_type IN ({typeParams})
+ORDER BY clerk_type, collection_time";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+        foreach (var ct in clerkTypes)
+            command.Parameters.Add(new DuckDBParameter { Value = ct });
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var ct = reader.GetString(0);
+            if (!result.TryGetValue(ct, out var list))
+            {
+                list = new List<MemoryClerkTrendPoint>();
+                result[ct] = list;
+            }
+            list.Add(new MemoryClerkTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(1),
+                MemoryMb = reader.IsDBNull(2) ? 0 : ToDouble(reader.GetValue(2))
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets memory pressure events (from RING_BUFFER_RESOURCE_MONITOR) for charting.
     /// </summary>
     public async Task<List<MemoryPressureEventRow>> GetMemoryPressureEventsAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)

--- a/Lite/Services/LocalDataService.Perfmon.cs
+++ b/Lite/Services/LocalDataService.Perfmon.cs
@@ -125,6 +125,62 @@ ORDER BY collection_time";
         return items;
     }
 
+    /// <summary>
+    /// Batched sibling of <see cref="GetPerfmonTrendAsync"/>: fetches the trend for ALL selected
+    /// counters in ONE query (replacing an N+1 query-per-counter loop), grouped by counter name.
+    /// </summary>
+    public async Task<Dictionary<string, List<PerfmonTrendPoint>>> GetPerfmonTrendsByCountersAsync(int serverId, List<string> counterNames, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var _q = TimeQuery("GetPerfmonTrendsByCountersAsync", "v_perfmon_stats trends batched by counter");
+        var result = new Dictionary<string, List<PerfmonTrendPoint>>();
+        if (counterNames.Count == 0) return result;
+
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+        var nameParams = string.Join(", ", counterNames.Select((_, i) => "$" + (i + 4)));
+
+        command.CommandText = $@"
+SELECT
+    counter_name,
+    collection_time,
+    SUM(cntr_value) AS cntr_value,
+    SUM(delta_cntr_value) AS delta_cntr_value
+FROM v_perfmon_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   collection_time <= $3
+AND   counter_name IN ({nameParams})
+GROUP BY counter_name, collection_time
+ORDER BY counter_name, collection_time";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+        foreach (var cn in counterNames)
+            command.Parameters.Add(new DuckDBParameter { Value = cn });
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var cn = reader.GetString(0);
+            if (!result.TryGetValue(cn, out var list))
+            {
+                list = new List<PerfmonTrendPoint>();
+                result[cn] = list;
+            }
+            list.Add(new PerfmonTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(1),
+                Value = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                DeltaValue = reader.IsDBNull(3) ? 0 : reader.GetInt64(3)
+            });
+        }
+
+        return result;
+    }
+
 }
 
 public class PerfmonRow

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -151,6 +151,75 @@ ORDER BY collection_time";
     }
 
     /// <summary>
+    /// Batched sibling of <see cref="GetWaitStatsTrendAsync"/>: fetches the per-second trend for
+    /// ALL selected wait types in ONE query (replacing an N+1 query-per-type loop), grouped by type.
+    /// The LAG window is partitioned by wait_type so each type's per-second rate is computed independently.
+    /// </summary>
+    public async Task<Dictionary<string, List<WaitStatsTrendPoint>>> GetWaitStatsTrendsByTypesAsync(int serverId, List<string> waitTypes, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)
+    {
+        using var _q = TimeQuery("GetWaitStatsTrendsByTypesAsync", "v_wait_stats trends batched by type");
+        var result = new Dictionary<string, List<WaitStatsTrendPoint>>();
+        if (waitTypes.Count == 0) return result;
+
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+        var typeParams = string.Join(", ", waitTypes.Select((_, i) => "$" + (i + 4)));
+
+        command.CommandText = $@"
+WITH raw AS
+(
+    SELECT
+        wait_type,
+        collection_time,
+        delta_wait_time_ms,
+        delta_signal_wait_time_ms,
+        delta_waiting_tasks,
+        date_diff('second', LAG(collection_time) OVER (PARTITION BY wait_type ORDER BY collection_time), collection_time) AS interval_seconds
+    FROM v_wait_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    AND   collection_time <= $3
+    AND   wait_type IN ({typeParams})
+)
+SELECT
+    wait_type,
+    collection_time,
+    CASE WHEN interval_seconds > 0 THEN CAST(delta_wait_time_ms AS DOUBLE) / interval_seconds ELSE 0 END AS wait_time_ms_per_second,
+    CASE WHEN interval_seconds > 0 THEN CAST(delta_signal_wait_time_ms AS DOUBLE) / interval_seconds ELSE 0 END AS signal_wait_time_ms_per_second,
+    CASE WHEN delta_waiting_tasks > 0 THEN CAST(delta_wait_time_ms AS DOUBLE) / delta_waiting_tasks ELSE 0 END AS avg_ms_per_wait
+FROM raw
+ORDER BY wait_type, collection_time";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
+        foreach (var wt in waitTypes)
+            command.Parameters.Add(new DuckDBParameter { Value = wt });
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var wt = reader.GetString(0);
+            if (!result.TryGetValue(wt, out var list))
+            {
+                list = new List<WaitStatsTrendPoint>();
+                result[wt] = list;
+            }
+            list.Add(new WaitStatsTrendPoint
+            {
+                CollectionTime = reader.GetDateTime(1),
+                WaitTimeMsPerSecond = reader.IsDBNull(2) ? 0 : reader.GetDouble(2),
+                SignalWaitTimeMsPerSecond = reader.IsDBNull(3) ? 0 : reader.GetDouble(3),
+                AvgMsPerWait = reader.IsDBNull(4) ? 0 : reader.GetDouble(4)
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets total wait time trend across all wait types as a single aggregated time-series.
     /// Used by the correlated timeline lanes for a single-line wait stats overview.
     /// </summary>


### PR DESCRIPTION
Wait Stats, Memory Clerks, and Perfmon each fetched one trend query **per selected picker item** in a sequential `await` loop (`Take` 12-20) -- loading them with several items checked ran 12-20 serial DuckDB queries (~3.6s under load for Wait Stats). Each query was <500ms individually, so it never showed in the slow-query log; only an end-to-end tab-load timer surfaced it.

Fix mirrors Dashboard's already-batched pattern: one query per chart (`...TrendsByTypesAsync` / `...ByCountersAsync`, `IN (...)`, grouped by type), then a client-side plot loop. Wait Stats' query partitions its `LAG` window by `wait_type` so each type's per-second rate is independent.

**Measured under load:** Wait Stats chart-build 3628ms -> <500ms (off the log); Perfmon tab 3126ms -> 534ms. Dashboard already batched, so this also restores Lite<->Dashboard parity.

Also adds a lightweight `TabNav` end-to-end timer (MethodProfiler) to catch future slow tab loads.

Verified: builds clean, manually tested (all three tabs load quickly), timer confirms the collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)