### PR TITLE
Correlate-and-focus slice 2: persist a trackable incident_id on findings

### DIFF
--- a/Dashboard.Tests/IncidentIdTests.cs
+++ b/Dashboard.Tests/IncidentIdTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Tests the incident id (correlate-and-focus slice 2): one analysis run = one incident, so every
+/// non-absolution story shares the id; the id fingerprints the primary (highest-severity) finding +
+/// database so the same recurring incident is trackable across runs.
+/// </summary>
+public class IncidentIdTests
+{
+    private static AnalysisStory Story(string key, double sev, string? db = null, bool absolution = false) =>
+        new() { RootFactKey = key, Severity = sev, DatabaseName = db, IsAbsolution = absolution };
+
+    [Fact]
+    public void StampStories_StampsAllNonAbsolution_WithTheSameId()
+    {
+        var stories = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.6), Story("BLOCKING_EVENTS", 1.0) };
+        IncidentId.StampStories("SQL1", stories);
+
+        Assert.NotEmpty(stories[0].IncidentId);
+        Assert.Equal(stories[0].IncidentId, stories[1].IncidentId); // one incident per run
+    }
+
+    [Fact]
+    public void StampStories_SamePrimaryProblem_SameIdAcrossRuns()
+    {
+        // Different co-fired members, SAME primary (CPU on Sales) -> trackable as one recurring incident.
+        var run1 = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.6, "Sales"), Story("CXPACKET", 0.9) };
+        var run2 = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.7, "Sales"), Story("WRITELOG", 0.8) };
+        IncidentId.StampStories("SQL1", run1);
+        IncidentId.StampStories("SQL1", run2);
+
+        Assert.Equal(run1[0].IncidentId, run2[0].IncidentId);
+    }
+
+    [Fact]
+    public void StampStories_DifferentPrimaryServerOrDb_DifferentId()
+    {
+        var a = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.6, "Sales") };
+        var b = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.6, "Orders") }; // different database
+        var c = new List<AnalysisStory> { Story("BLOCKING_EVENTS", 1.6, "Sales") }; // different primary key
+        IncidentId.StampStories("SQL1", a);
+        IncidentId.StampStories("SQL1", b);
+        IncidentId.StampStories("SQL2", c);
+
+        Assert.NotEqual(a[0].IncidentId, b[0].IncidentId);
+        Assert.NotEqual(a[0].IncidentId, c[0].IncidentId);
+    }
+
+    [Fact]
+    public void StampStories_AbsolutionOnly_LeavesIdsEmpty()
+    {
+        var stories = new List<AnalysisStory> { Story("server_health", 0, absolution: true) };
+        IncidentId.StampStories("SQL1", stories);
+        Assert.Equal(string.Empty, stories[0].IncidentId);
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic_OnSeverityTies()
+    {
+        var s1 = new List<AnalysisStory> { Story("AAA", 1.0), Story("BBB", 1.0) };
+        var s2 = new List<AnalysisStory> { Story("BBB", 1.0), Story("AAA", 1.0) }; // same set, reversed order
+        Assert.Equal(IncidentId.Compute("SQL1", s1), IncidentId.Compute("SQL1", s2)); // tiebroken by root key
+    }
+}

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -190,6 +190,11 @@ public class AnalysisService
             // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
             FactAdvice.PopulateStoryText(stories, facts);
 
+            // 3.6. Stamp the run's incident id onto the stories (correlate-and-focus slice 2), BEFORE
+            // the store copies it onto the finding. One run = one incident (v1); the id fingerprints
+            // the primary finding so the same recurring incident is trackable across runs.
+            IncidentId.StampStories(context.ServerName, stories);
+
             // 4. Mute-filter the stories into the surviving findings (P2 reorder) — WITHOUT
             //    inserting yet, so enrichment + action-build happen on the survivors first
             //    and the BUILT RemediationAction is persisted on each row (D2). Muted/

--- a/Dashboard/Analysis/SqlServerFindingStore.cs
+++ b/Dashboard/Analysis/SqlServerFindingStore.cs
@@ -56,6 +56,7 @@ BEGIN
         leaf_fact_key nvarchar(256) NULL,
         leaf_fact_value float NULL,
         fact_count integer NOT NULL,
+        incident_id nvarchar(64) NULL,
         remediation_action_json nvarchar(max) NULL,
         CONSTRAINT PK_analysis_findings PRIMARY KEY CLUSTERED (finding_id)
             WITH (DATA_COMPRESSION = PAGE)
@@ -96,7 +97,11 @@ IF COL_LENGTH(N'config.analysis_findings', N'remediation_action_json') IS NULL
    DBs — removes the truncation cliff and matches Lite's unbounded story_text. COL_LENGTH returns
    -1 for nvarchar(max); any other value means the column still needs widening. NOT NULL is kept. */
 IF COL_LENGTH(N'config.analysis_findings', N'story_text') <> -1
-    ALTER TABLE config.analysis_findings ALTER COLUMN story_text nvarchar(max) NOT NULL;";
+    ALTER TABLE config.analysis_findings ALTER COLUMN story_text nvarchar(max) NOT NULL;
+
+/* Correlate-and-focus slice 2: the incident grouping id, added idempotently on existing DBs. */
+IF COL_LENGTH(N'config.analysis_findings', N'incident_id') IS NULL
+    ALTER TABLE config.analysis_findings ADD incident_id nvarchar(64) NULL;";
 
         await cmd.ExecuteNonQueryAsync();
     }
@@ -153,6 +158,7 @@ IF COL_LENGTH(N'config.analysis_findings', N'story_text') <> -1
                     Category = story.Category,
                     StoryPath = story.StoryPath,
                     StoryPathHash = story.StoryPathHash,
+                    IncidentId = story.IncidentId,
                     StoryText = story.StoryText,
                     RootFactKey = story.RootFactKey,
                     RootFactValue = story.RootFactValue,
@@ -226,7 +232,7 @@ SELECT TOP (@limit)
     time_range_start, time_range_end, severity, confidence, category,
     story_path, story_path_hash, story_text,
     root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count,
-    remediation_action_json
+    incident_id, remediation_action_json
 FROM config.analysis_findings
 WHERE server_id = @serverId
 AND   analysis_time >= @cutoff
@@ -271,7 +277,8 @@ SELECT
     finding_id, analysis_time, server_id, server_name, database_name,
     time_range_start, time_range_end, severity, confidence, category,
     story_path, story_path_hash, story_text,
-    root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count
+    root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count,
+    incident_id
 FROM config.analysis_findings
 WHERE server_id = @serverId
 AND   analysis_time = (
@@ -418,13 +425,13 @@ INSERT INTO config.analysis_findings
      time_range_start, time_range_end, severity, confidence, category,
      story_path, story_path_hash, story_text,
      root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count,
-     remediation_action_json)
+     incident_id, remediation_action_json)
 VALUES
     (@findingId, @analysisTime, @serverId, @serverName, @databaseName,
      @timeRangeStart, @timeRangeEnd, @severity, @confidence, @category,
      @storyPath, @storyPathHash, @storyText,
      @rootFactKey, @rootFactValue, @leafFactKey, @leafFactValue, @factCount,
-     @remediationActionJson);";
+     @incidentId, @remediationActionJson);";
 
             cmd.Parameters.Add(new SqlParameter("@findingId", finding.FindingId));
             cmd.Parameters.Add(new SqlParameter("@analysisTime", finding.AnalysisTime));
@@ -444,6 +451,8 @@ VALUES
             cmd.Parameters.Add(new SqlParameter("@leafFactKey", (object?)finding.LeafFactKey ?? DBNull.Value));
             cmd.Parameters.Add(new SqlParameter("@leafFactValue", (object?)finding.LeafFactValue ?? DBNull.Value));
             cmd.Parameters.Add(new SqlParameter("@factCount", finding.FactCount));
+            cmd.Parameters.Add(new SqlParameter("@incidentId",
+                (object?)(string.IsNullOrEmpty(finding.IncidentId) ? null : finding.IncidentId) ?? DBNull.Value));
             // D2: persist the BUILT action (mirrors the alert path's ContextJson) so the
             // Recommendations reader can drive Apply + consent from a stored finding.
             cmd.Parameters.Add(new SqlParameter("@remediationActionJson",
@@ -481,15 +490,17 @@ VALUES
             RootFactValue = reader.IsDBNull(14) ? null : reader.GetDouble(14),
             LeafFactKey = reader.IsDBNull(15) ? null : reader.GetString(15),
             LeafFactValue = reader.IsDBNull(16) ? null : reader.GetDouble(16),
-            FactCount = reader.GetInt32(17)
+            FactCount = reader.GetInt32(17),
+            // incident_id is ordinal 18 in BOTH SELECTs (correlate-and-focus slice 2).
+            IncidentId = reader.FieldCount > 18 && !reader.IsDBNull(18) ? reader.GetString(18) : string.Empty
         };
 
-        // D2: only GetRecentFindingsAsync selects remediation_action_json (ordinal 18);
-        // GetLatestFindingsAsync omits it, so guard by field count before reading. The
+        // D2: GetRecentFindingsAsync selects remediation_action_json (now ordinal 19, after
+        // incident_id); GetLatestFindingsAsync omits it, so guard by field count before reading. The
         // BUILT action is deserialized via the SAME serializer the alert path uses, so the
         // Recommendations surface can drive Apply + the two-sided consent gate from storage.
-        if (reader.FieldCount > 18 && !reader.IsDBNull(18))
-            finding.Remediation = AlertContextSerializer.DeserializeAction(reader.GetString(18));
+        if (reader.FieldCount > 19 && !reader.IsDBNull(19))
+            finding.Remediation = AlertContextSerializer.DeserializeAction(reader.GetString(19));
 
         return finding;
     }

--- a/Lite.Tests/FindingStoreTests.cs
+++ b/Lite.Tests/FindingStoreTests.cs
@@ -76,6 +76,26 @@ public class FindingStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveFindings_RoundTripsIncidentId()
+    {
+        // Correlate-and-focus slice 2: the incident id persists through the schema (incident_id
+        // column added at analysis-schema v3) and reads back on every finding.
+        await InitializeWithAnalysisAsync();
+
+        var store = new FindingStore(_duckDb);
+        var context = TestDataSeeder.CreateTestContext();
+        var stories = CreateTestStories();
+        foreach (var s in stories)
+            s.IncidentId = "incident_abc";
+
+        await store.SaveFindingsAsync(stories, context);
+        var findings = await store.GetLatestFindingsAsync(context.ServerId);
+
+        Assert.Equal(2, findings.Count);
+        Assert.All(findings, f => Assert.Equal("incident_abc", f.IncidentId));
+    }
+
+    [Fact]
     public async Task GetRecentFindings_RespectsTimeRange()
     {
         await InitializeWithAnalysisAsync();

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -147,6 +147,11 @@ public class AnalysisService
             // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
             FactAdvice.PopulateStoryText(stories, facts);
 
+            // 3.6. Stamp the run's incident id onto the stories (correlate-and-focus slice 2), BEFORE
+            // the store copies it onto the finding. One run = one incident (v1); the id fingerprints
+            // the primary finding so the same recurring incident is trackable across runs.
+            IncidentId.StampStories(context.ServerName, stories);
+
             // 4. Persist findings (filtering out muted)
             var findings = await _findingStore.SaveFindingsAsync(stories, context);
 

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -66,6 +66,7 @@ public class FindingStore
                 Category = story.Category,
                 StoryPath = story.StoryPath,
                 StoryPathHash = story.StoryPathHash,
+                IncidentId = story.IncidentId,
                 StoryText = story.StoryText,
                 RootFactKey = story.RootFactKey,
                 RootFactValue = story.RootFactValue,
@@ -99,7 +100,7 @@ public class FindingStore
 SELECT finding_id, analysis_time, server_id, server_name, database_name,
        time_range_start, time_range_end, severity, confidence, category,
        story_path, story_path_hash, story_text,
-       root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count
+       root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count, incident_id
 FROM analysis_findings
 WHERE server_id = $1
 AND   analysis_time >= $2
@@ -132,7 +133,8 @@ LIMIT $3";
                 RootFactValue = reader.IsDBNull(14) ? null : reader.GetDouble(14),
                 LeafFactKey = reader.IsDBNull(15) ? null : reader.GetString(15),
                 LeafFactValue = reader.IsDBNull(16) ? null : reader.GetDouble(16),
-                FactCount = reader.GetInt32(17)
+                FactCount = reader.GetInt32(17),
+                IncidentId = reader.IsDBNull(18) ? string.Empty : reader.GetString(18)
             });
         }
 
@@ -155,7 +157,7 @@ LIMIT $3";
 SELECT finding_id, analysis_time, server_id, server_name, database_name,
        time_range_start, time_range_end, severity, confidence, category,
        story_path, story_path_hash, story_text,
-       root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count
+       root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count, incident_id
 FROM analysis_findings
 WHERE server_id = $1
 AND   analysis_time = (
@@ -187,7 +189,8 @@ ORDER BY severity DESC";
                 RootFactValue = reader.IsDBNull(14) ? null : reader.GetDouble(14),
                 LeafFactKey = reader.IsDBNull(15) ? null : reader.GetString(15),
                 LeafFactValue = reader.IsDBNull(16) ? null : reader.GetDouble(16),
-                FactCount = reader.GetInt32(17)
+                FactCount = reader.GetInt32(17),
+                IncidentId = reader.IsDBNull(18) ? string.Empty : reader.GetString(18)
             });
         }
 
@@ -284,8 +287,8 @@ INSERT INTO analysis_findings
     (finding_id, analysis_time, server_id, server_name, database_name,
      time_range_start, time_range_end, severity, confidence, category,
      story_path, story_path_hash, story_text,
-     root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)";
+     root_fact_key, root_fact_value, leaf_fact_key, leaf_fact_value, fact_count, incident_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)";
 
         cmd.Parameters.Add(new DuckDBParameter { Value = finding.FindingId });
         cmd.Parameters.Add(new DuckDBParameter { Value = finding.AnalysisTime });
@@ -305,6 +308,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
         cmd.Parameters.Add(new DuckDBParameter { Value = finding.LeafFactKey ?? (object)DBNull.Value });
         cmd.Parameters.Add(new DuckDBParameter { Value = finding.LeafFactValue ?? (object)DBNull.Value });
         cmd.Parameters.Add(new DuckDBParameter { Value = finding.FactCount });
+        cmd.Parameters.Add(new DuckDBParameter { Value = finding.IncidentId ?? string.Empty });
 
         await cmd.ExecuteNonQueryAsync();
     }

--- a/Lite/Database/AnalysisSchema.cs
+++ b/Lite/Database/AnalysisSchema.cs
@@ -11,7 +11,7 @@ public static class AnalysisSchema
     /// <summary>
     /// Analysis schema version. Independent of main schema version.
     /// </summary>
-    public const int CurrentVersion = 2;
+    public const int CurrentVersion = 3;
 
     public const string CreateAnalysisFindingsTable = @"
 CREATE TABLE IF NOT EXISTS analysis_findings (
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS analysis_findings (
     root_fact_value DOUBLE,
     leaf_fact_key VARCHAR,
     leaf_fact_value DOUBLE,
-    fact_count INTEGER NOT NULL
+    fact_count INTEGER NOT NULL,
+    incident_id VARCHAR
 )";
 
     public const string CreateAnalysisMutedTable = @"
@@ -108,6 +109,13 @@ CREATE INDEX IF NOT EXISTS idx_analysis_thresholds_lookup
             // v2: Add server metadata columns for edition-aware analysis
             yield return "ALTER TABLE servers ADD COLUMN IF NOT EXISTS sql_engine_edition INTEGER DEFAULT 0";
             yield return "ALTER TABLE servers ADD COLUMN IF NOT EXISTS sql_major_version INTEGER DEFAULT 0";
+        }
+
+        if (fromVersion < 3)
+        {
+            // v3: incident grouping (correlate-and-focus slice 2). Nullable — DuckDB ADD COLUMN
+            // cannot be NOT NULL; the writer always supplies a value (empty for healthy runs).
+            yield return "ALTER TABLE analysis_findings ADD COLUMN IF NOT EXISTS incident_id VARCHAR";
         }
     }
 

--- a/PerformanceMonitor.Analysis/AnalysisModels.cs
+++ b/PerformanceMonitor.Analysis/AnalysisModels.cs
@@ -78,6 +78,15 @@ public class AnalysisStory
     public bool IsAbsolution { get; set; }
 
     /// <summary>
+    /// Stable id for the incident this story belongs to (correlate-and-focus slice 2). All findings
+    /// from one analysis run share it, and it is a fingerprint of the run's PRIMARY (highest-severity)
+    /// finding + database, so the same recurring incident keeps one id across runs (trackable). Set by
+    /// <see cref="IncidentId.StampStories"/> after stories are built; copied onto the finding + persisted.
+    /// Empty for a healthy/absolution-only run.
+    /// </summary>
+    public string IncidentId { get; set; } = string.Empty;
+
+    /// <summary>
     /// Metadata from the root fact (raw metric values used to assemble the story).
     /// Ephemeral — copied onto the finding for the notification layer, not persisted.
     /// </summary>
@@ -108,6 +117,9 @@ public class AnalysisFinding
     public string Category { get; set; } = string.Empty;
     public string StoryPath { get; set; } = string.Empty;
     public string StoryPathHash { get; set; } = string.Empty;
+    /// <summary>Stable id for the incident this finding belongs to — see
+    /// <see cref="AnalysisStory.IncidentId"/>. Persisted to analysis_findings.incident_id.</summary>
+    public string IncidentId { get; set; } = string.Empty;
     public string StoryText { get; set; } = string.Empty;
     public string RootFactKey { get; set; } = string.Empty;
     /// <summary>The root fact's RAW collected value (the setting/metric), NOT its severity — see

--- a/PerformanceMonitor.Analysis/IncidentId.cs
+++ b/PerformanceMonitor.Analysis/IncidentId.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Computes the stable, trackable incident id for an analysis run (correlate-and-focus slice 2,
+/// review §1d / §1). v1 treats one analysis run — one time window — as one incident, so every
+/// non-absolution finding in the run shares the id (this is what lets the surface stop sprawling
+/// into a sea of warnings, and what "what else fired" in slice 1 means). The id is a fingerprint of
+/// the run's PRIMARY (highest-severity) finding — its root key + database, scoped to the server — so
+/// the SAME recurring incident keeps the SAME id across runs and users can track it over time
+/// ("the CPU incident on Sales recurred"), rather than a per-run GUID that changes every run.
+///
+/// <para>Finer time-clustering within a run (multiple incidents per run) and cross-database focus are
+/// later slices; this is the deliberately small substrate (write-only — nothing reads it for
+/// behaviour yet).</para>
+/// </summary>
+public static class IncidentId
+{
+    /// <summary>
+    /// Stamps the run's incident id onto every non-absolution story. No-op when the run has no
+    /// incident stories (a healthy / absolution-only run leaves the ids empty).
+    /// </summary>
+    public static void StampStories(string serverName, IReadOnlyList<AnalysisStory> stories)
+    {
+        if (stories is null)
+            return;
+
+        var incidentStories = stories.Where(s => s is not null && !s.IsAbsolution).ToList();
+        if (incidentStories.Count == 0)
+            return;
+
+        var id = Compute(serverName, incidentStories);
+        foreach (var s in incidentStories)
+            s.IncidentId = id;
+    }
+
+    /// <summary>
+    /// The fingerprint of a run's incident: server + the primary (highest-severity, root-key-tiebroken)
+    /// story's root key + database. Stable across runs for the same recurring primary problem.
+    /// </summary>
+    public static string Compute(string serverName, IReadOnlyList<AnalysisStory> incidentStories)
+    {
+        var primary = incidentStories
+            .OrderByDescending(s => s.Severity)
+            .ThenBy(s => s.RootFactKey, StringComparer.Ordinal) // deterministic on ties
+            .First();
+
+        var seed = (serverName ?? string.Empty) + "|" + primary.RootFactKey + "|" + (primary.DatabaseName ?? string.Empty);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+        return Convert.ToHexString(bytes).ToLowerInvariant()[..16];
+    }
+}


### PR DESCRIPTION
Second slice of `plans/correlate-and-focus-design.md`. **Write-only substrate** — nothing reads it for behaviour yet (that's slice 3's grouped report); it lands first because it's safe.

Per the locked decisions: `incident_id` (not a `co_fired` blob); **one run = one incident** (v1; finer time-clustering is later); the id fingerprints the run's **primary** (highest-severity, root-key-tiebroken) finding's root key + database, scoped to the server — so the **same recurring incident keeps the same id across runs** (trackable), not a per-run GUID.

- Shared `IncidentId.StampStories` — stamps every non-absolution story; empty for a healthy run.
- Both `AnalysisService`s stamp it after `BuildStories`, before the store copies it onto the finding (mirrors how `StoryText` flows).
- Persisted in both stores: Lite analysis-schema **v3** (column + idempotent `ADD COLUMN` migration); Dashboard column + idempotent `ALTER`. Dashboard SELECT ordinals kept consistent (`incident_id` at 18 in both reads; `remediation_action_json` moved to 19 in the recent read).

## Verify
- Dashboard.Tests **550/550** (+5), Lite.Tests **546/546** (+1 round-trip through the schema).

Next: slice 3 surfaces incident_id (group the cards into one report + expose it in MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
