### PR TITLE
Correlate-and-focus slice 3a: expose incident_id in the MCP findings

### DIFF
--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -99,6 +99,7 @@ public sealed class McpAnalysisTools
                         fact_count = f.FactCount,
                         drill_down = f.DrillDown,
                         next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        incident_id = f.IncidentId,
                         co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredTitles),
                         advice = advice is null ? null : new
                         {
@@ -400,6 +401,7 @@ public sealed class McpAnalysisTools
                         story_path = f.StoryPath,
                         story_path_hash = f.StoryPathHash,
                         analysis_time = f.AnalysisTime.ToString("o"),
+                        incident_id = f.IncidentId,
                         co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredByRun[f.AnalysisTime]),
                         advice = advice is null ? null : new
                         {

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -86,6 +86,7 @@ public sealed class McpAnalysisTools
                         fact_count = f.FactCount,
                         drill_down = f.DrillDown,
                         next_tools = ToolRecommendations.GetForStoryPath(f.StoryPath),
+                        incident_id = f.IncidentId,
                         co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredTitles),
                         advice = advice is null ? null : new
                         {
@@ -574,6 +575,7 @@ public sealed class McpAnalysisTools
                         story_path = f.StoryPath,
                         story_path_hash = f.StoryPathHash,
                         fact_count = f.FactCount,
+                        incident_id = f.IncidentId,
                         co_fired = CoFiredSummary.OtherTitles(advice?.Headline ?? f.RootFactKey, coFiredByRun[f.AnalysisTime]),
                         time_range = new
                         {


### PR DESCRIPTION
Both apps' `analyze_server` + `get_analysis_findings` now emit `incident_id` per finding, so an AI client can group a run's findings by incident (complementing the slice-1 `co_fired` list). Passthrough of the slice-2 persisted/stamped id — no logic change.

## Verify
- Dashboard.Tests **564/564**, Lite.Tests **547/547** (build-verified passthrough; the id's stamping + persistence are covered by slice 2's tests).

The human-facing collapsible-group UI (3b) is next — held for your visual check, and there's a sequencing question on it (see chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
