### PR TITLE
Correlate-and-focus: cluster findings into incidents by graph-connectivity

### DIFF
--- a/Dashboard.Tests/IncidentIdTests.cs
+++ b/Dashboard.Tests/IncidentIdTests.cs
@@ -65,4 +65,19 @@ public class IncidentIdTests
         var s2 = new List<AnalysisStory> { Story("BBB", 1.0), Story("AAA", 1.0) }; // same set, reversed order
         Assert.Equal(IncidentId.Compute("SQL1", s1), IncidentId.Compute("SQL1", s2)); // tiebroken by root key
     }
+
+    // ── StampClusters: per-component ids (the clustering refinement) ──
+
+    [Fact]
+    public void StampClusters_GivesEachComponentItsOwnId()
+    {
+        var component1 = new List<AnalysisStory> { Story("CPU_SQL_PERCENT", 1.6), Story("CXPACKET", 0.9) };
+        var component2 = new List<AnalysisStory> { Story("DISK_SPACE", 1.5) };
+
+        IncidentId.StampClusters("SQL1", new[] { component1, component2 });
+
+        Assert.NotEmpty(component1[0].IncidentId);
+        Assert.Equal(component1[0].IncidentId, component1[1].IncidentId); // same incident -> same id
+        Assert.NotEqual(component1[0].IncidentId, component2[0].IncidentId); // different incidents -> different ids
+    }
 }

--- a/Dashboard.Tests/InferenceEngineTests.cs
+++ b/Dashboard.Tests/InferenceEngineTests.cs
@@ -283,4 +283,65 @@ public class InferenceEngineTests
         Assert.Equal("SOS_SCHEDULER_YIELD", story.LeafFactKey);
         Assert.Equal(0.5, story.LeafFactValue);              // SOS value, not 0.67
     }
+
+    // ── correlate-and-focus: graph-connectivity incident clustering ──
+
+    [Fact]
+    public void ClusterIntoIncidents_MergesGraphConnectedStories()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var stories = new List<AnalysisStory>
+        {
+            new() { RootFactKey = "CPU_SQL_PERCENT", Severity = 1.6, Path = ["CPU_SQL_PERCENT"] },
+            new() { RootFactKey = "PLAN_REGRESSION", Severity = 0.6, Path = ["PLAN_REGRESSION"] },
+        };
+        var facts = new List<Fact>
+        {
+            new() { Key = "CPU_SQL_PERCENT", Source = "cpu", Value = 90, Severity = 1.6 },
+            new() { Key = "PLAN_REGRESSION", Source = "queries", Value = 1, Severity = 0.6, BaseSeverity = 0.6 },
+        };
+
+        // CPU_SQL_PERCENT -> PLAN_REGRESSION is an active edge (PLAN_REGRESSION.BaseSeverity > 0),
+        // so the two stories are one incident even though the greedy traversal left them separate.
+        Assert.Single(engine.ClusterIntoIncidents(stories, facts));
+    }
+
+    [Fact]
+    public void ClusterIntoIncidents_KeepsIndependentStoriesSeparate()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var stories = new List<AnalysisStory>
+        {
+            new() { RootFactKey = "CPU_SQL_PERCENT", Severity = 1.6, Path = ["CPU_SQL_PERCENT"] },
+            new() { RootFactKey = "DISK_SPACE", Severity = 1.6, Path = ["DISK_SPACE"] },
+        };
+        var facts = new List<Fact>
+        {
+            new() { Key = "CPU_SQL_PERCENT", Source = "cpu", Value = 90, Severity = 1.6 },
+            new() { Key = "DISK_SPACE", Source = "disk", Value = 5, Severity = 1.6 },
+        };
+
+        // No graph edge between CPU and disk space -> two separate incidents.
+        Assert.Equal(2, engine.ClusterIntoIncidents(stories, facts).Count);
+    }
+
+    [Fact]
+    public void ClusterIntoIncidents_NormalizesThreadpoolRelabel_AndBridgesToBlocking()
+    {
+        var engine = new InferenceEngine(new RelationshipGraph());
+        var stories = new List<AnalysisStory>
+        {
+            new() { RootFactKey = "THREADPOOL_BLOCKING", Severity = 0.9, Path = ["THREADPOOL_BLOCKING"] },
+            new() { RootFactKey = "LCK", Severity = 0.9, Path = ["LCK"] },
+        };
+        var facts = new List<Fact>
+        {
+            new() { Key = "THREADPOOL", Source = "waits", Value = 0.5, Severity = 0.9 },
+            new() { Key = "LCK", Source = "waits", Value = 0.5, Severity = 0.9 },
+        };
+
+        // The relabeled THREADPOOL_BLOCKING path key normalizes to THREADPOOL, whose active
+        // THREADPOOL->LCK bridge (LCK severity >= 0.5) merges it with the blocking story.
+        Assert.Single(engine.ClusterIntoIncidents(stories, facts));
+    }
 }

--- a/Dashboard/Analysis/AnalysisService.cs
+++ b/Dashboard/Analysis/AnalysisService.cs
@@ -190,10 +190,12 @@ public class AnalysisService
             // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
             FactAdvice.PopulateStoryText(stories, facts);
 
-            // 3.6. Stamp the run's incident id onto the stories (correlate-and-focus slice 2), BEFORE
-            // the store copies it onto the finding. One run = one incident (v1); the id fingerprints
-            // the primary finding so the same recurring incident is trackable across runs.
-            IncidentId.StampStories(context.ServerName, stories);
+            // 3.6. Cluster the run's stories into causally-related incidents (graph-connectivity) and
+            // stamp each with its own trackable id, BEFORE the store copies it onto the finding. The
+            // grouped surface renders one report per incident; the id fingerprints the incident's
+            // primary so the same recurring incident is trackable across runs.
+            var incidents = _engine.ClusterIntoIncidents(stories, facts);
+            IncidentId.StampClusters(context.ServerName, incidents);
 
             // 4. Mute-filter the stories into the surviving findings (P2 reorder) — WITHOUT
             //    inserting yet, so enrichment + action-build happen on the survivors first

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -147,10 +147,12 @@ public class AnalysisService
             // (FactAdvice.GetComposedForFinding) instead of generic folklore. No schema change.
             FactAdvice.PopulateStoryText(stories, facts);
 
-            // 3.6. Stamp the run's incident id onto the stories (correlate-and-focus slice 2), BEFORE
-            // the store copies it onto the finding. One run = one incident (v1); the id fingerprints
-            // the primary finding so the same recurring incident is trackable across runs.
-            IncidentId.StampStories(context.ServerName, stories);
+            // 3.6. Cluster the run's stories into causally-related incidents (graph-connectivity) and
+            // stamp each with its own trackable id, BEFORE the store copies it onto the finding. The
+            // grouped surface renders one report per incident; the id fingerprints the incident's
+            // primary so the same recurring incident is trackable across runs.
+            var incidents = _engine.ClusterIntoIncidents(stories, facts);
+            IncidentId.StampClusters(context.ServerName, incidents);
 
             // 4. Persist findings (filtering out muted)
             var findings = await _findingStore.SaveFindingsAsync(stories, context);

--- a/PerformanceMonitor.Analysis/IncidentId.cs
+++ b/PerformanceMonitor.Analysis/IncidentId.cs
@@ -22,8 +22,24 @@ namespace PerformanceMonitor.Analysis;
 public static class IncidentId
 {
     /// <summary>
-    /// Stamps the run's incident id onto every non-absolution story. No-op when the run has no
-    /// incident stories (a healthy / absolution-only run leaves the ids empty).
+    /// Stamps each incident component with its OWN id — the primary fingerprint of that component
+    /// (see <see cref="InferenceEngine.ClusterIntoIncidents"/>). This is the per-component refinement
+    /// of <see cref="StampStories"/>: instead of one id for the whole run, each causally-related
+    /// group of findings gets its own trackable id, so the surface can render one report per real
+    /// incident rather than lumping a run's unrelated problems together.
+    /// </summary>
+    public static void StampClusters(
+        string serverName, IReadOnlyList<IReadOnlyList<AnalysisStory>> components)
+    {
+        if (components is null)
+            return;
+        foreach (var component in components)
+            StampStories(serverName, component);
+    }
+
+    /// <summary>
+    /// Stamps a single incident's id onto every non-absolution story in the group. No-op for an
+    /// empty / absolution-only group. Used per-component by <see cref="StampClusters"/>.
     /// </summary>
     public static void StampStories(string serverName, IReadOnlyList<AnalysisStory> stories)
     {

--- a/PerformanceMonitor.Analysis/InferenceEngine.cs
+++ b/PerformanceMonitor.Analysis/InferenceEngine.cs
@@ -237,6 +237,68 @@ public class InferenceEngine
     }
 
     /// <summary>
+    /// Groups a run's stories into INCIDENTS — sets of stories that are causally related — via
+    /// connected components over the relationship graph's ACTIVE edges (correlate-and-focus). The
+    /// greedy traversal in <see cref="BuildStories"/> only follows the single highest-severity edge
+    /// from each node, so it splits one root cause across several stories (e.g. a PLAN_REGRESSION that
+    /// is really a facet of the CPU incident); this re-merges them. Two graph families merge only when
+    /// a bridge edge actually fires (THREADPOOL→LCK when both are elevated = one blocking-driven
+    /// thread-exhaustion incident), and a genuinely-independent finding (a standalone disk advisory
+    /// with no active edge to anything present) stays its own incident.
+    ///
+    /// <para>Absolution stories are excluded. Returns one list per incident; a lone story is a
+    /// one-member incident. The fact a story OWNS is its <see cref="AnalysisStory.Path"/> keys,
+    /// normalized for the THREADPOOL relabel (the story path carries THREADPOOL_PARALLEL etc. while
+    /// the graph + facts use the base THREADPOOL key — see <see cref="ClassifyThreadpool"/>).</para>
+    /// </summary>
+    public List<List<AnalysisStory>> ClusterIntoIncidents(IReadOnlyList<AnalysisStory> stories, List<Fact> facts)
+    {
+        var incidentStories = (stories ?? [])
+            .Where(s => s is not null && !s.IsAbsolution)
+            .ToList();
+        if (incidentStories.Count <= 1)
+            return incidentStories.Select(s => new List<AnalysisStory> { s }).ToList();
+
+        // Same >0 working set BuildStories used, so the edge predicates evaluate identically.
+        var factsByKey = (facts ?? []).Where(f => f.Severity > 0).ToFactLookup();
+
+        // Each fact (normalized) is consumed by exactly one story; map it to that story's index.
+        var owner = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < incidentStories.Count; i++)
+            foreach (var key in incidentStories[i].Path)
+                owner[NormalizeKey(key)] = i;
+
+        // Union-find over story indices.
+        var parent = Enumerable.Range(0, incidentStories.Count).ToArray();
+        int Find(int x) { while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; }
+        void Union(int a, int b) { var ra = Find(a); var rb = Find(b); if (ra != rb) parent[ra] = rb; }
+
+        for (var i = 0; i < incidentStories.Count; i++)
+            foreach (var key in incidentStories[i].Path)
+                foreach (var edge in _graph.GetActiveEdges(NormalizeKey(key), factsByKey))
+                    if (owner.TryGetValue(NormalizeKey(edge.Destination), out var j) && j != i)
+                        Union(i, j);
+
+        var components = new Dictionary<int, List<AnalysisStory>>();
+        for (var i = 0; i < incidentStories.Count; i++)
+        {
+            var root = Find(i);
+            if (!components.TryGetValue(root, out var list))
+                components[root] = list = new List<AnalysisStory>();
+            list.Add(incidentStories[i]);
+        }
+        return components.Values.ToList();
+    }
+
+    /// <summary>
+    /// Maps a relabeled THREADPOOL story root (THREADPOOL_PARALLEL / _BLOCKING / _MIXED) back to the
+    /// base THREADPOOL key the relationship graph and fact set use, so clustering sees its edges.
+    /// Every other key passes through unchanged.
+    /// </summary>
+    private static string NormalizeKey(string key) =>
+        key.StartsWith("THREADPOOL_", StringComparison.Ordinal) ? "THREADPOOL" : key;
+
+    /// <summary>
     /// Stable hash for story path deduplication and muting.
     /// </summary>
     private static string ComputeHash(string storyPath)


### PR DESCRIPTION
Refines `incident_id` from per-run (slice 2) to **per-incident-component**, so a run's genuinely-distinct problems get distinct incidents and the grouped surface (next slice) won't lump unrelated findings together (the over-grouping risk from review §6).

`InferenceEngine.ClusterIntoIncidents`: connected components over the run's stories using the relationship graph's **active** edges —
- re-merges facets the greedy traversal split off (a PLAN_REGRESSION that's really part of the CPU incident),
- merges two graph families only when a **bridge** edge actually fires (THREADPOOL→LCK when both elevated = one blocking-driven thread-exhaustion incident),
- leaves a genuinely-independent finding (a standalone disk advisory) as its own incident,
- normalizes the THREADPOOL relabel (story path carries `THREADPOOL_PARALLEL`/`_BLOCKING` while the graph + facts use the base `THREADPOOL`).

`IncidentId.StampClusters` stamps each component with its own primary fingerprint. Both `AnalysisService`s cluster then stamp. **Still write-only** — the grouped report UI consumes `incident_id` next.

## Verify
- Dashboard.Tests **568/568** (+4), Lite.Tests **547/547**.

You can sanity-check the clustering on a real server now: `get_analysis_findings` returns the per-incident `incident_id`, so you can see how this run's findings group before I build the UI on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
