### PR TITLE
Correlate-and-focus slice 3b: collapsible incident groups on the Recommendations surface

### DIFF
--- a/Dashboard.Tests/RecommendationsViewModelTests.cs
+++ b/Dashboard.Tests/RecommendationsViewModelTests.cs
@@ -50,7 +50,8 @@ public class RecommendationsViewModelTests
         DateTime? windowStartUtc = null,
         DateTime? windowEndUtc = null,
         string? storyHash = "hash",
-        string? storyPath = "root>leaf")
+        string? storyPath = "root>leaf",
+        string incidentId = "")
     {
         return new RecommendationItem
         {
@@ -66,7 +67,8 @@ public class RecommendationsViewModelTests
             WindowStartUtc = windowStartUtc,
             WindowEndUtc = windowEndUtc,
             StoryPathHash = source == RecommendationSource.Engine ? storyHash : null,
-            StoryPath = source == RecommendationSource.Engine ? storyPath : null
+            StoryPath = source == RecommendationSource.Engine ? storyPath : null,
+            IncidentId = incidentId
         };
     }
 
@@ -129,33 +131,29 @@ public class RecommendationsViewModelTests
     // ---- grouping ---------------------------------------------------------
 
     [Fact]
-    public void FromItems_GroupsBySeverity_IntoThreeSectionsInFixedOrder()
+    public void FromItems_GroupsByIncidentId()
     {
+        // Reader-sorted (severity desc); two findings share incident "inc1", a third is its own.
         var items = new[]
         {
-            Item(CanonicalSeverity.Info, title: "i1"),
-            Item(CanonicalSeverity.Critical, title: "c1"),
-            Item(CanonicalSeverity.Warning, title: "w1"),
-            Item(CanonicalSeverity.Critical, title: "c2"),
+            Item(CanonicalSeverity.Critical, title: "c1", rawSeverity: 1.9, incidentId: "inc1"),
+            Item(CanonicalSeverity.Warning, title: "w1", rawSeverity: 1.0, incidentId: "inc1"),
+            Item(CanonicalSeverity.Warning, title: "w2", rawSeverity: 0.9, incidentId: "inc2"),
         };
 
         var vm = RecommendationsViewModel.FromItems(items);
 
-        // Fixed display order Critical -> Warning -> Info, regardless of input order.
-        Assert.Equal(3, vm.Sections.Count);
-        Assert.Equal(CanonicalSeverity.Critical, vm.Sections[0].Severity);
-        Assert.Equal(CanonicalSeverity.Warning, vm.Sections[1].Severity);
-        Assert.Equal(CanonicalSeverity.Info, vm.Sections[2].Severity);
-
-        Assert.Equal(2, vm.Sections[0].Count);
-        Assert.Equal(1, vm.Sections[1].Count);
-        Assert.Equal(1, vm.Sections[2].Count);
-        Assert.Equal(4, vm.TotalCount);
+        Assert.Equal(2, vm.Sections.Count);                                // two incidents
+        Assert.Equal(2, vm.Sections[0].Count);                             // inc1: c1 + w1
+        Assert.Equal(CanonicalSeverity.Critical, vm.Sections[0].Severity); // primary = c1
+        Assert.Single(vm.Sections[1].Cards);                               // inc2: w2 only
+        Assert.Equal(3, vm.TotalCount);
     }
 
     [Fact]
-    public void FromItems_OmitsEmptySeveritySections()
+    public void FromItems_NoIncidentId_EachItemIsItsOwnGroup()
     {
+        // Legacy / pre-incident_id rows carry no id, so each is a standalone single-card group.
         var items = new[]
         {
             Item(CanonicalSeverity.Warning, title: "w1"),
@@ -164,20 +162,19 @@ public class RecommendationsViewModelTests
 
         var vm = RecommendationsViewModel.FromItems(items);
 
-        Assert.Single(vm.Sections);
-        Assert.Equal(CanonicalSeverity.Warning, vm.Sections[0].Severity);
-        Assert.Equal(2, vm.Sections[0].Count);
+        Assert.Equal(2, vm.Sections.Count);
+        Assert.All(vm.Sections, s => Assert.Single(s.Cards));
     }
 
     [Fact]
-    public void FromItems_PreservesReaderOrderWithinASection()
+    public void FromItems_PreservesReaderOrderWithinAnIncident()
     {
-        // The reader returns severity-desc; within a band the order must be preserved as-is.
+        // The reader returns severity-desc; within an incident the order must be preserved as-is.
         var items = new[]
         {
-            Item(CanonicalSeverity.Critical, title: "first", rawSeverity: 1.9),
-            Item(CanonicalSeverity.Critical, title: "second", rawSeverity: 1.6),
-            Item(CanonicalSeverity.Critical, title: "third", rawSeverity: 1.51),
+            Item(CanonicalSeverity.Critical, title: "first", rawSeverity: 1.9, incidentId: "inc1"),
+            Item(CanonicalSeverity.Critical, title: "second", rawSeverity: 1.6, incidentId: "inc1"),
+            Item(CanonicalSeverity.Critical, title: "third", rawSeverity: 1.51, incidentId: "inc1"),
         };
 
         var vm = RecommendationsViewModel.FromItems(items);
@@ -204,18 +201,27 @@ public class RecommendationsViewModelTests
     }
 
     [Fact]
-    public void SectionHeader_IncludesCount()
+    public void IncidentHeader_NamesPrimaryFindingCountAndSeverity()
     {
         var items = new[]
         {
-            Item(CanonicalSeverity.Critical, title: "c1"),
-            Item(CanonicalSeverity.Critical, title: "c2"),
-            Item(CanonicalSeverity.Critical, title: "c3"),
+            Item(CanonicalSeverity.Critical, title: "SQL CPU pegged", rawSeverity: 1.9, incidentId: "inc1"),
+            Item(CanonicalSeverity.Warning, title: "Plan regression", rawSeverity: 1.0, incidentId: "inc1"),
         };
 
         var vm = RecommendationsViewModel.FromItems(items);
 
-        Assert.Equal("Critical (3)", vm.Sections[0].Header);
+        Assert.Equal("SQL CPU pegged · 2 findings · CRITICAL", vm.Sections[0].Header);
+    }
+
+    [Fact]
+    public void IncidentHeader_SingleFinding_OmitsCount()
+    {
+        var items = new[] { Item(CanonicalSeverity.Warning, title: "RCSI is OFF — Sales", incidentId: "inc1") };
+
+        var vm = RecommendationsViewModel.FromItems(items);
+
+        Assert.Equal("RCSI is OFF — Sales · WARNING", vm.Sections[0].Header);
     }
 
     [Fact]

--- a/Dashboard/Controls/RecommendationsViewModel.cs
+++ b/Dashboard/Controls/RecommendationsViewModel.cs
@@ -237,12 +237,17 @@ namespace PerformanceMonitorDashboard.Controls
     public sealed class RecommendationSectionViewModel
     {
         public RecommendationSectionViewModel(
-            CanonicalSeverity severity, IReadOnlyList<RecommendationCardViewModel> cards, bool expanded)
+            CanonicalSeverity severity, IReadOnlyList<RecommendationCardViewModel> cards, bool expanded,
+            string? header = null)
         {
             Severity = severity;
             Cards = cards ?? throw new ArgumentNullException(nameof(cards));
             IsExpanded = expanded;
+            _header = header;
         }
+
+        // When set (incident grouping), overrides the severity-derived header.
+        private readonly string? _header;
 
         /// <summary>The severity this section groups.</summary>
         public CanonicalSeverity Severity { get; }
@@ -256,13 +261,16 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>Whether the section's expander starts expanded.</summary>
         public bool IsExpanded { get; }
 
-        /// <summary>The header label, e.g. "Critical (3)".</summary>
-        public string Header => Severity switch
+        /// <summary>
+        /// The header label. For incident groups it's the supplied incident header (primary finding +
+        /// count + severity); falls back to the severity label ("Critical (3)") when no header was set.
+        /// </summary>
+        public string Header => _header ?? (Severity switch
         {
             CanonicalSeverity.Critical => $"Critical ({Count})",
             CanonicalSeverity.Warning => $"Warning ({Count})",
             _ => $"Info ({Count})"
-        };
+        });
     }
 
     /// <summary>
@@ -343,31 +351,66 @@ namespace PerformanceMonitorDashboard.Controls
             if (list.Count == 0)
                 return new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Empty, string.Empty);
 
-            var sections = new List<RecommendationSectionViewModel>(3);
-            // Fixed display order Critical → Warning → Info, regardless of which bands are present.
-            AppendSection(sections, list, CanonicalSeverity.Critical, expanded: true, serverName, utcOffsetMinutes);
-            AppendSection(sections, list, CanonicalSeverity.Warning, expanded: true, serverName, utcOffsetMinutes);
-            AppendSection(sections, list, CanonicalSeverity.Info, expanded: false, serverName, utcOffsetMinutes);
-
-            return new(sections, RecommendationsState.Loaded, string.Empty);
+            return new(GroupByIncident(list, serverName, utcOffsetMinutes), RecommendationsState.Loaded, string.Empty);
         }
 
-        private static void AppendSection(
-            List<RecommendationSectionViewModel> sections,
-            IReadOnlyList<RecommendationItem> all,
-            CanonicalSeverity severity,
-            bool expanded,
-            string serverName,
-            int utcOffsetMinutes)
+        /// <summary>
+        /// Groups the reader's flat, severity-sorted list into one collapsible section per INCIDENT
+        /// (correlate-and-focus): cards sharing an <see cref="RecommendationItem.IncidentId"/> form one
+        /// group headed by their primary (highest-severity) finding, so related findings read as one
+        /// report instead of a sea of cards. An item with no incident id (legacy rows; engine rows from
+        /// before incident_id existed) is its own single-card group. Groups appear in severity order —
+        /// the input is already severity-desc sorted, so each group's first-appearance (its primary
+        /// card) is in severity-desc order. A group expands unless it is Info-only.
+        /// </summary>
+        private static List<RecommendationSectionViewModel> GroupByIncident(
+            IReadOnlyList<RecommendationItem> list, string serverName, int utcOffsetMinutes)
         {
-            // Preserve the reader's order within the band (it is already severity-desc sorted).
-            var cards = all
-                .Where(i => i.CanonicalSeverity == severity)
+            var order = new List<string>();
+            var buckets = new Dictionary<string, List<RecommendationItem>>(StringComparer.Ordinal);
+            var soloCount = 0;
+            foreach (var item in list)
+            {
+                var key = string.IsNullOrEmpty(item.IncidentId) ? "__solo_" + soloCount++ : item.IncidentId;
+                if (!buckets.TryGetValue(key, out var bucket))
+                {
+                    bucket = new List<RecommendationItem>();
+                    buckets[key] = bucket;
+                    order.Add(key);
+                }
+                bucket.Add(item);
+            }
+
+            var sections = new List<RecommendationSectionViewModel>(order.Count);
+            foreach (var key in order)
+                sections.Add(BuildIncidentSection(buckets[key], serverName, utcOffsetMinutes));
+            return sections;
+        }
+
+        /// <summary>
+        /// Builds one incident section from its cards (kept in the reader's severity-desc order). The
+        /// header names the primary (first) finding, the finding count, and the incident severity; the
+        /// section expands unless the incident is Info-only.
+        /// </summary>
+        private static RecommendationSectionViewModel BuildIncidentSection(
+            IReadOnlyList<RecommendationItem> incidentItems, string serverName, int utcOffsetMinutes)
+        {
+            var cards = incidentItems
                 .Select(i => new RecommendationCardViewModel(i, serverName, utcOffsetMinutes))
                 .ToList();
-
-            if (cards.Count > 0)
-                sections.Add(new RecommendationSectionViewModel(severity, cards, expanded));
+            var primary = cards[0]; // reader sorted severity-desc -> the first card is the incident primary
+            var severity = primary.Severity;
+            var label = severity switch
+            {
+                CanonicalSeverity.Critical => "CRITICAL",
+                CanonicalSeverity.Warning => "WARNING",
+                _ => "INFO"
+            };
+            var header = cards.Count > 1
+                ? $"{primary.Title} · {cards.Count} findings · {label}"
+                : $"{primary.Title} · {label}";
+            return new RecommendationSectionViewModel(
+                severity, cards, expanded: severity != CanonicalSeverity.Info, header);
         }
 
         /// <summary>

--- a/Dashboard/Services/Recommendations/RecommendationItem.cs
+++ b/Dashboard/Services/Recommendations/RecommendationItem.cs
@@ -139,6 +139,14 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
         public string? StoryPath { get; set; }
 
         /// <summary>
+        /// The engine finding's incident id (correlate-and-focus) — the group key the surface
+        /// collapses cards under, so related findings render as one report. Empty for legacy rows and
+        /// for engine rows analyzed before incident_id existed; the view-model treats an empty id as a
+        /// standalone single-card incident.
+        /// </summary>
+        public string IncidentId { get; set; } = string.Empty;
+
+        /// <summary>
         /// The canonical de-dupe setting (or <see cref="RecommendationSetting.None"/>). See
         /// <see cref="RecommendationSetting"/>. Drives the (database, setting) de-dupe key.
         /// </summary>

--- a/Dashboard/Services/Recommendations/RecommendationsReader.cs
+++ b/Dashboard/Services/Recommendations/RecommendationsReader.cs
@@ -197,6 +197,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                                 ServerConfigTargets: new[] { target })
                             : null,
                         StoryPathHash = finding.StoryPathHash,
+                        IncidentId = finding.IncidentId,
                         StoryPath = finding.StoryPath,
                         Setting = RecommendationSetting.None,  // server-level — never de-dupes with legacy
                         IsServerConfigAdvisory = true,
@@ -240,6 +241,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                         Remediation = new RemediationAction(
                             "DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(), new[] { target }),
                         StoryPathHash = finding.StoryPathHash,
+                        IncidentId = finding.IncidentId,
                         StoryPath = finding.StoryPath,
                         Setting = setting,
                         WindowStartUtc = AsUtc(finding.TimeRangeStart),
@@ -277,6 +279,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                             new[] { new DbConfigTarget(t.Database, DbConfigSetting.ReadCommittedSnapshotOn, "OFF") },
                             RcsiFigures: t.Figures),
                         StoryPathHash = finding.StoryPathHash,
+                        IncidentId = finding.IncidentId,
                         StoryPath = finding.StoryPath,
                         Setting = RecommendationSetting.Rcsi,
                         WindowStartUtc = AsUtc(finding.TimeRangeStart),
@@ -389,6 +392,7 @@ namespace PerformanceMonitorDashboard.Services.Recommendations
                 Remediation = isMissingIndex ? null : finding.Remediation,
                 IsMissingIndexAdvisory = isMissingIndex,
                 StoryPathHash = finding.StoryPathHash,
+                IncidentId = finding.IncidentId,
                 StoryPath = finding.StoryPath,
                 Setting = SettingFromAction(finding.Remediation),
                 WindowStartUtc = AsUtc(finding.TimeRangeStart),

--- a/Lite.Tests/LiteRecommendationsViewModelTests.cs
+++ b/Lite.Tests/LiteRecommendationsViewModelTests.cs
@@ -16,7 +16,7 @@ public class LiteRecommendationsViewModelTests
     private static LiteRecommendationItem Item(
         LiteRecommendationSeverity severity, double raw, string title = "T",
         string? database = null, string? sql = null, string? advice = "advice",
-        string serverName = "SQL2022")
+        string serverName = "SQL2022", string incidentId = "")
     {
         return new LiteRecommendationItem
         {
@@ -27,6 +27,7 @@ public class LiteRecommendationsViewModelTests
             CopyPasteSql = sql,
             AdviceText = advice,
             RootFactKey = "CPU_SQL_PERCENT",
+            IncidentId = incidentId,
             ServerName = serverName,
             WindowStartUtc = new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc),
             WindowEndUtc = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc)
@@ -78,23 +79,22 @@ public class LiteRecommendationsViewModelTests
     // ── grouping ────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void FromItems_GroupsByBand_InFixedOrder_OmittingEmpty()
+    public void FromItems_GroupsByIncidentId()
     {
+        // Reader-sorted (severity desc); two findings share incident "inc1", a third is its own.
         var items = new[]
         {
-            Item(LiteRecommendationSeverity.Info, 0.5),
-            Item(LiteRecommendationSeverity.Critical, 1.6),
-            Item(LiteRecommendationSeverity.Critical, 1.9),
+            Item(LiteRecommendationSeverity.Critical, 1.9, title: "c1", incidentId: "inc1"),
+            Item(LiteRecommendationSeverity.Warning, 1.0, title: "w1", incidentId: "inc1"),
+            Item(LiteRecommendationSeverity.Warning, 0.9, title: "w2", incidentId: "inc2"),
         };
 
         var vm = LiteRecommendationsViewModel.FromItems(items);
 
-        // Critical present, Warning omitted (no items), Info present -> 2 sections, Critical first.
-        Assert.Equal(2, vm.Sections.Count);
-        Assert.Equal(LiteRecommendationSeverity.Critical, vm.Sections[0].Severity);
-        Assert.Equal(2, vm.Sections[0].Count);
-        Assert.Equal(LiteRecommendationSeverity.Info, vm.Sections[1].Severity);
-        Assert.Equal(1, vm.Sections[1].Count);
+        Assert.Equal(2, vm.Sections.Count);                                       // two incidents
+        Assert.Equal(2, vm.Sections[0].Count);                                    // inc1: c1 + w1
+        Assert.Equal(LiteRecommendationSeverity.Critical, vm.Sections[0].Severity); // primary = c1
+        Assert.Single(vm.Sections[1].Cards);                                      // inc2: w2 only
     }
 
     [Fact]
@@ -116,15 +116,15 @@ public class LiteRecommendationsViewModelTests
     }
 
     [Fact]
-    public void Section_Header_ShowsBandAndCount()
+    public void IncidentHeader_NamesPrimaryFindingCountAndSeverity()
     {
         var vm = LiteRecommendationsViewModel.FromItems(new[]
         {
-            Item(LiteRecommendationSeverity.Warning, 0.8),
-            Item(LiteRecommendationSeverity.Warning, 0.9),
+            Item(LiteRecommendationSeverity.Critical, 1.9, title: "SQL CPU pegged", incidentId: "inc1"),
+            Item(LiteRecommendationSeverity.Warning, 1.0, title: "Plan regression", incidentId: "inc1"),
         });
 
-        Assert.Equal("Warning (2)", vm.Sections.Single().Header);
+        Assert.Equal("SQL CPU pegged · 2 findings · CRITICAL", vm.Sections.Single().Header);
     }
 
     // ── card affordances (advise-only) ──────────────────────────────────────────

--- a/Lite/Analysis/Recommendations/LiteRecommendationItem.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationItem.cs
@@ -80,6 +80,13 @@ public sealed class LiteRecommendationItem
     /// <summary>The finding's root fact key — drives the advice lookup and the Ask-AI prompt.</summary>
     public string RootFactKey { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The finding's incident id (correlate-and-focus) — the group key the surface collapses cards
+    /// under, so related findings render as one report. Empty for findings analyzed before incident_id
+    /// existed; the view-model treats an empty id as a standalone single-card incident.
+    /// </summary>
+    public string IncidentId { get; set; } = string.Empty;
+
     /// <summary>The monitored server's display name (for the Ask-AI prompt).</summary>
     public string ServerName { get; set; } = string.Empty;
 

--- a/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
@@ -152,6 +152,7 @@ public sealed class LiteRecommendationsReader
             AdviceText = ComposeAdvice(advice),
             CopyPasteSql = NullIfEmpty(FactRemediation.GenerateForFinding(finding)),
             RootFactKey = finding.RootFactKey,
+            IncidentId = finding.IncidentId,
             ServerName = serverName ?? string.Empty,
             WindowStartUtc = AsUtc(finding.TimeRangeStart),
             WindowEndUtc = AsUtc(finding.TimeRangeEnd)

--- a/Lite/Analysis/Recommendations/LiteRecommendationsViewModel.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationsViewModel.cs
@@ -152,12 +152,17 @@ public sealed class LiteRecommendationCardViewModel
 public sealed class LiteRecommendationSectionViewModel
 {
     public LiteRecommendationSectionViewModel(
-        LiteRecommendationSeverity severity, IReadOnlyList<LiteRecommendationCardViewModel> cards, bool expanded)
+        LiteRecommendationSeverity severity, IReadOnlyList<LiteRecommendationCardViewModel> cards, bool expanded,
+        string? header = null)
     {
         Severity = severity;
         Cards = cards ?? throw new ArgumentNullException(nameof(cards));
         IsExpanded = expanded;
+        _header = header;
     }
+
+    // When set (incident grouping), overrides the severity-derived header.
+    private readonly string? _header;
 
     /// <summary>The severity this section groups.</summary>
     public LiteRecommendationSeverity Severity { get; }
@@ -171,13 +176,16 @@ public sealed class LiteRecommendationSectionViewModel
     /// <summary>Whether the section's expander starts expanded.</summary>
     public bool IsExpanded { get; }
 
-    /// <summary>The header label, e.g. "Critical (3)".</summary>
-    public string Header => Severity switch
+    /// <summary>
+    /// The header label. For incident groups it's the supplied incident header (primary finding +
+    /// count + severity); falls back to the severity label ("Critical (3)") when no header was set.
+    /// </summary>
+    public string Header => _header ?? (Severity switch
     {
         LiteRecommendationSeverity.Critical => $"Critical ({Count})",
         LiteRecommendationSeverity.Warning => $"Warning ({Count})",
         _ => $"Info ({Count})"
-    };
+    });
 }
 
 /// <summary>
@@ -256,30 +264,66 @@ public sealed class LiteRecommendationsViewModel
         if (list.Count == 0)
             return new(Array.Empty<LiteRecommendationSectionViewModel>(), LiteRecommendationsState.Empty, string.Empty);
 
-        var sections = new List<LiteRecommendationSectionViewModel>(3);
-        // Fixed display order Critical → Warning → Info, regardless of which bands are present.
-        AppendSection(sections, list, LiteRecommendationSeverity.Critical, expanded: true, utcOffsetMinutes);
-        AppendSection(sections, list, LiteRecommendationSeverity.Warning, expanded: true, utcOffsetMinutes);
-        AppendSection(sections, list, LiteRecommendationSeverity.Info, expanded: false, utcOffsetMinutes);
-
-        return new(sections, LiteRecommendationsState.Loaded, string.Empty);
+        return new(GroupByIncident(list, utcOffsetMinutes), LiteRecommendationsState.Loaded, string.Empty);
     }
 
-    private static void AppendSection(
-        List<LiteRecommendationSectionViewModel> sections,
-        IReadOnlyList<LiteRecommendationItem> all,
-        LiteRecommendationSeverity severity,
-        bool expanded,
-        int utcOffsetMinutes)
+    /// <summary>
+    /// Groups the reader's flat, severity-sorted list into one collapsible section per INCIDENT
+    /// (correlate-and-focus): cards sharing an <see cref="LiteRecommendationItem.IncidentId"/> form one
+    /// group headed by their primary (highest-severity) finding, so related findings read as one report
+    /// instead of a sea of cards. A finding with no incident id (from before incident_id existed) is its
+    /// own single-card group. Groups appear in severity order (the input is already severity-desc
+    /// sorted, so each group's primary card is in severity order). A group expands unless it is Info-only.
+    /// Mirrors the Dashboard's GroupByIncident.
+    /// </summary>
+    private static List<LiteRecommendationSectionViewModel> GroupByIncident(
+        IReadOnlyList<LiteRecommendationItem> list, int utcOffsetMinutes)
     {
-        // Preserve the reader's order within the band (it is already severity-desc sorted).
-        var cards = all
-            .Where(i => i.Severity == severity)
+        var order = new List<string>();
+        var buckets = new Dictionary<string, List<LiteRecommendationItem>>(StringComparer.Ordinal);
+        var soloCount = 0;
+        foreach (var item in list)
+        {
+            var key = string.IsNullOrEmpty(item.IncidentId) ? "__solo_" + soloCount++ : item.IncidentId;
+            if (!buckets.TryGetValue(key, out var bucket))
+            {
+                bucket = new List<LiteRecommendationItem>();
+                buckets[key] = bucket;
+                order.Add(key);
+            }
+            bucket.Add(item);
+        }
+
+        var sections = new List<LiteRecommendationSectionViewModel>(order.Count);
+        foreach (var key in order)
+            sections.Add(BuildIncidentSection(buckets[key], utcOffsetMinutes));
+        return sections;
+    }
+
+    /// <summary>
+    /// Builds one incident section from its cards (kept in the reader's severity-desc order). The
+    /// header names the primary (first) finding, the finding count, and the incident severity; the
+    /// section expands unless the incident is Info-only.
+    /// </summary>
+    private static LiteRecommendationSectionViewModel BuildIncidentSection(
+        IReadOnlyList<LiteRecommendationItem> incidentItems, int utcOffsetMinutes)
+    {
+        var cards = incidentItems
             .Select(i => new LiteRecommendationCardViewModel(i, utcOffsetMinutes))
             .ToList();
-
-        if (cards.Count > 0)
-            sections.Add(new LiteRecommendationSectionViewModel(severity, cards, expanded));
+        var primary = cards[0]; // reader sorted severity-desc -> the first card is the incident primary
+        var severity = primary.Severity;
+        var label = severity switch
+        {
+            LiteRecommendationSeverity.Critical => "CRITICAL",
+            LiteRecommendationSeverity.Warning => "WARNING",
+            _ => "INFO"
+        };
+        var header = cards.Count > 1
+            ? $"{primary.Title} · {cards.Count} findings · {label}"
+            : $"{primary.Title} · {label}";
+        return new LiteRecommendationSectionViewModel(
+            severity, cards, expanded: severity != LiteRecommendationSeverity.Info, header);
     }
 
     /// <summary>


### PR DESCRIPTION
The Recommendations surfaces now group cards by `incident_id` into **one collapsible report per incident** instead of a flat severity-sorted sea of cards (review §1d). The layout you picked: a group header per incident (primary finding + count + severity) with the existing per-finding cards nested under it — each card keeps its own advice / Copy / Apply (D1), and the header is a factual label (D3).

- Both card models carry `IncidentId`; both readers map it from the finding.
- Both view-models' `FromItems` now `GroupByIncident`: cards sharing an `incident_id` form one section headed by their primary (highest-severity) finding; an item with no incident id (legacy / pre-incident_id rows) is its own single-card group. Groups fall out in severity order; a group expands unless Info-only.
- **The existing section XAML template (Expander header + nested cards) is reused unchanged** — only the grouping key + header text moved from severity to incident. (This is why I could verify it by unit tests despite not running the apps.)

## Verify
- Dashboard.Tests **569/569**, Lite.Tests **547/547** (severity-grouping VM tests rewritten to incident grouping in both apps).

Visual layout is yours to eyeball on dev — the header wording especially (`{primary} · N findings · SEVERITY`) is easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
