### PR TITLE
Block-chain viewer redesign: row-scoped single chain + identity cards

### DIFF
--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -198,4 +198,25 @@ public class BlockingChainReconstructorTests
         Assert.Equal(TranFor(200), top.BlockingTranStarted);
         Assert.Equal(TranFor(201), top.BlockedTranStarted);
     }
+
+    [Fact]
+    public void FindChainForSession_AnyMember_ReturnsChainRootedAtApex()
+    {
+        // Two separate chains — A: 200 -> 201 -> 202 ; B: 300 -> 301. The viewer scopes to the ONE chain a
+        // clicked session belongs to, rooted at its apex regardless of where in the chain it sits.
+        var result = Run(new[] { Pair(201, 200), Pair(202, 201), Pair(301, 300) });
+
+        // Mid-level 201 -> chain A, rooted at apex 200 (not at the clicked node).
+        var chainA = BlockingChainReconstructor.FindChainForSession(result, 201, TranFor(201));
+        Assert.NotNull(chainA);
+        Assert.Equal(200, chainA!.ApexSpid);
+
+        // The apex itself and a leaf victim resolve to the same apex-rooted chain.
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 200, TranFor(200))!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 202, TranFor(202))!.ApexSpid);
+
+        // A member of the other chain resolves to that chain; an absent session returns null.
+        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
+        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
+    }
 }

--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -219,4 +219,27 @@ public class BlockingChainReconstructorTests
         Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
         Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
     }
+
+    [Fact]
+    public void FindChainForSession_VictimUnderTwoApexes_DisambiguatesByClickedBlocker()
+    {
+        // Victim 500 (same tran) was blocked by apex 100 and, at another time, apex 200 — two separate
+        // chains, BOTH containing 500. The edge-precise overload returns the chain reached via the clicked
+        // row's blocker, so the clicked row opens the right chain.
+        var result = Run(new[]
+        {
+            Pair(blockedSpid: 500, blockingSpid: 100),
+            Pair(blockedSpid: 500, blockingSpid: 200)
+        });
+
+        Assert.Equal(100, BlockingChainReconstructor
+            .FindChainForSession(result, 500, TranFor(500), 100, TranFor(100))!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor
+            .FindChainForSession(result, 500, TranFor(500), 200, TranFor(200))!.ApexSpid);
+
+        // No recorded blocker -> falls back to the any-level match (one of the chains that contains 500).
+        var fallback = BlockingChainReconstructor.FindChainForSession(result, 500, TranFor(500), 0, null);
+        Assert.NotNull(fallback);
+        Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
+    }
 }

--- a/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
+++ b/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
@@ -29,7 +29,14 @@ public class BlockingChainTreeBuilderTests
             LockMode = lockMode,
             DatabaseName = db,
             BlockingSqlText = $"blocker {blocker}",
-            BlockedSqlText = $"blocked {blocked}"
+            BlockedSqlText = $"blocked {blocked}",
+            // Identity keyed per spid so a node's sourced login/host/app is assertable.
+            BlockedLoginName = $"login{blocked}",
+            BlockedHostName = $"host{blocked}",
+            BlockedClientApp = $"app{blocked}",
+            BlockingLoginName = $"login{blocker}",
+            BlockingHostName = $"host{blocker}",
+            BlockingClientApp = $"app{blocker}"
         };
 
     private static BlockingChainInput Chain(
@@ -97,6 +104,56 @@ public class BlockingChainTreeBuilderTests
         Assert.Equal(3, root.Children.Count);
         Assert.Equal(new[] { 301, 302, 303 }, root.Children.Select(c => c.Spid).ToArray());
         Assert.All(root.Children, c => Assert.Empty(c.Children));
+    }
+
+    [Fact]
+    public void DeepLinearChain_NestsRootToGreatGrandchild_WithIdentity()
+    {
+        // 1 -> 2 -> 3 -> 4 must render NESTED at every level (root -> child -> grandchild -> great-grandchild),
+        // not flattened. Also proves identity is sourced from the right edge side.
+        var model = Build(Chain(1, new[] { Edge(1, 1, 2), Edge(2, 2, 3), Edge(3, 3, 4) }));
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(1, root.Spid);
+        Assert.True(root.IsApex);
+        // Apex identity comes from the blocking side of its outgoing edge.
+        Assert.Equal("login1", root.LoginName);
+        Assert.Equal("host1", root.HostName);
+        Assert.Equal("app1", root.ClientApp);
+
+        var c2 = Assert.Single(root.Children);
+        Assert.Equal(2, c2.Spid);
+        Assert.Equal("login2", c2.LoginName);   // victim identity from the blocked side of its incoming edge
+        Assert.Equal("host2", c2.HostName);
+
+        var c3 = Assert.Single(c2.Children);
+        Assert.Equal(3, c3.Spid);
+
+        var c4 = Assert.Single(c3.Children);
+        Assert.Equal(4, c4.Spid);
+        Assert.Empty(c4.Children);
+
+        Assert.Equal(4, Flatten(root).Count());
+    }
+
+    [Fact]
+    public void MultiLevelBranching_NestsEachBranchSeparately()
+    {
+        // 1 blocks 2 AND 3; 2 blocks 4. Expect 1 -> {2, 3} and 2 -> {4}; no flattening, no duplication.
+        var model = Build(Chain(1, new[] { Edge(1, 1, 2), Edge(1, 1, 3), Edge(2, 2, 4) }));
+
+        var root = Assert.Single(model.Roots);
+        Assert.Equal(new[] { 2, 3 }, root.Children.Select(c => c.Spid).OrderBy(x => x).ToArray());
+
+        var n2 = root.Children.Single(c => c.Spid == 2);
+        var n3 = root.Children.Single(c => c.Spid == 3);
+
+        var n4 = Assert.Single(n2.Children);
+        Assert.Equal(4, n4.Spid);
+        Assert.Empty(n3.Children);
+        Assert.Empty(n4.Children);
+
+        Assert.Equal(4, Flatten(root).Count());   // 1, 2, 3, 4 — each once
     }
 
     [Fact]

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using PerformanceMonitor.Analysis;
@@ -18,33 +19,50 @@ internal static class BlockingChainViewerProjection
         "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
         "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
 
-    public static BlockingChainModel BuildModel(BlockingReconstruction reconstruction)
+    /// <summary>
+    /// Builds the model for the ONE chain that contains the clicked session (matched by SessionKey — the
+    /// clicked session may be the apex, a mid-level blocker, or a leaf victim). The chain is rooted at its
+    /// apex with the full descendant hierarchy. Returns null when the session isn't in any reconstructed
+    /// chain (its wait may not have met the blocked-process threshold in the selected range).
+    /// </summary>
+    public static BlockingChainModel? BuildModelForSession(
+        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
     {
-        var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
-        {
-            ApexSpid = c.ApexSpid,
-            ApexTranStarted = c.ApexTranStarted,
-            ApexSleeping = c.ApexSleeping,
-            Magnitude = c.Magnitude,
-            Edges = c.Levels.Select(static l => new BlockingEdgeInput
-            {
-                Level = l.Level,
-                BlockingSpid = l.BlockingSpid,
-                BlockingTranStarted = l.BlockingTranStarted,
-                BlockedSpid = l.BlockedSpid,
-                BlockedTranStarted = l.BlockedTranStarted,
-                LockMode = l.LockMode,
-                WaitTimeMs = l.WaitTimeMs,
-                DatabaseName = l.DatabaseName,
-                BlockingSqlText = l.BlockingSqlText,
-                BlockedSqlText = l.BlockedSqlText
-            }).ToList()
-        }).ToList();
+        var chain = BlockingChainReconstructor.FindChainForSession(reconstruction, spid, tranStarted);
+        if (chain == null)
+            return null;
 
         return BlockingChainTreeBuilder.Build(
-            inputs,
+            new[] { ToInput(chain) },
             reconstruction.CycleDetected,
             reconstruction.DepthCapped,
             reconstruction.TraversalTruncated);
     }
+
+    private static BlockingChainInput ToInput(ReconstructedChain c) => new()
+    {
+        ApexSpid = c.ApexSpid,
+        ApexTranStarted = c.ApexTranStarted,
+        ApexSleeping = c.ApexSleeping,
+        Magnitude = c.Magnitude,
+        Edges = c.Levels.Select(static l => new BlockingEdgeInput
+        {
+            Level = l.Level,
+            BlockingSpid = l.BlockingSpid,
+            BlockingTranStarted = l.BlockingTranStarted,
+            BlockedSpid = l.BlockedSpid,
+            BlockedTranStarted = l.BlockedTranStarted,
+            LockMode = l.LockMode,
+            WaitTimeMs = l.WaitTimeMs,
+            DatabaseName = l.DatabaseName,
+            BlockingSqlText = l.BlockingSqlText,
+            BlockedSqlText = l.BlockedSqlText,
+            BlockedLoginName = l.BlockedLoginName,
+            BlockedHostName = l.BlockedHostName,
+            BlockedClientApp = l.BlockedClientApp,
+            BlockingLoginName = l.BlockingLoginName,
+            BlockingHostName = l.BlockingHostName,
+            BlockingClientApp = l.BlockingClientApp
+        }).ToList()
+    };
 }

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -26,9 +26,12 @@ internal static class BlockingChainViewerProjection
     /// chain (its wait may not have met the blocked-process threshold in the selected range).
     /// </summary>
     public static BlockingChainModel? BuildModelForSession(
-        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
+        BlockingReconstruction reconstruction,
+        int blockedSpid, DateTime? blockedTran,
+        int blockingSpid, DateTime? blockingTran)
     {
-        var chain = BlockingChainReconstructor.FindChainForSession(reconstruction, spid, tranStarted);
+        var chain = BlockingChainReconstructor.FindChainForSession(
+            reconstruction, blockedSpid, blockedTran, blockingSpid, blockingTran);
         if (chain == null)
             return null;
 

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -30,7 +30,10 @@ SELECT TOP (5000)
     lock_mode,
     blocking_status,
     blocked_sql_text,
-    blocking_sql_text
+    blocking_sql_text,
+    login_name,
+    host_name,
+    client_app
 FROM collect.blocking_BlockedProcessReport
 WHERE collection_time >= @collectionWindow
 AND   event_time >= @startTime
@@ -63,6 +66,13 @@ ORDER BY collection_time DESC";
         LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
         BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
         BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
+        // Blocked-side identity (the 'blocked' row's own session). The Dashboard table does NOT parse the
+        // blocker's login/host/app from the XML (only blocking_status/blocking_last_tran_started/
+        // blocking_sql_text), so the blocking-side identity stays empty here — the pure apex shows SQL + db
+        // but no login/host/app. See BlockingChainViewerProjection / the PR notes for the schema follow-up.
+        BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
+        BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
+        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13)
     };
 }

--- a/Dashboard/Models/BlockingEventItem.cs
+++ b/Dashboard/Models/BlockingEventItem.cs
@@ -45,6 +45,14 @@ namespace PerformanceMonitorDashboard.Models
         public string BlockedProcessReportXml { get; set; } = string.Empty;
 
         /// <summary>
+        /// The blocker parsed from the report XML (populated on activity = 'blocked' rows; NULL on
+        /// 'blocking' rows). Lets the block-chain viewer pick the exact (blocker -> blocked) chain edge
+        /// for the clicked row.
+        /// </summary>
+        public int? BlockingSpid { get; set; }
+        public DateTime? BlockingLastTranStarted { get; set; }
+
+        /// <summary>
         /// True when a blocked process report XML exists for this row. The grid query defers the
         /// (large) XML itself for speed and returns only this flag; the XML is fetched on demand
         /// via DatabaseService.GetBlockedProcessReportAsync when View Plan / Download is clicked.

--- a/Dashboard/ServerTab.BlockChain.cs
+++ b/Dashboard/ServerTab.BlockChain.cs
@@ -10,22 +10,45 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Ui;
 using PerformanceMonitorDashboard.Analysis;
+using PerformanceMonitorDashboard.Models;
 
 namespace PerformanceMonitorDashboard
 {
     public partial class ServerTab : UserControl
     {
-        /// <summary>
-        /// Opens the block-chain viewer for the Locking tab's current blocking window. Reads the slicer's
-        /// narrowed selection (server-local) when set, else the sub-tab's range. Fetch + reconstruct +
-        /// tree-build run off the UI thread; only the render touches the UI.
-        /// </summary>
+        // Right-click "View Block Chain" on a blocking-events row.
         private async void ViewBlockChain_Click(object sender, RoutedEventArgs e)
         {
+            if (sender is not MenuItem menuItem) return;
+            if (menuItem.Parent is not ContextMenu cm) return;
+            var grid = FindDataGridFromContextMenu(cm);
+            if (grid?.SelectedItem is BlockingEventItem row)
+                await OpenBlockChainForRowAsync(row);
+        }
+
+        // Double-click a blocking-events row.
+        private async void BlockingEventsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (BlockingEventsDataGrid.SelectedItem is BlockingEventItem row)
+                await OpenBlockChainForRowAsync(row);
+        }
+
+        /// <summary>
+        /// Opens the block-chain viewer scoped to ONE chain — the chain the clicked session belongs to,
+        /// rooted at its lead blocker, with the clicked session highlighted. Reconstructs over the Locking
+        /// tab's current blocking window; fetch + reconstruct + tree-build run off the UI thread.
+        /// </summary>
+        private async Task OpenBlockChainForRowAsync(BlockingEventItem row)
+        {
             if (_databaseService == null) return;
+
+            var spid = row.Spid ?? 0;
+            if (spid <= 0) return;
+            var rawTran = row.LastTransactionStarted;
 
             try
             {
@@ -42,22 +65,39 @@ namespace PerformanceMonitorDashboard
                     (start, end) = GetLockingSlicerTimeRange(_blockingHoursBack, _blockingFromDate, _blockingToDate);
                 }
 
-                // Fetch (async DB) + reconstruct (CPU-bound over up to 5000 rows) + tree-build, all off the
-                // UI thread. The model that comes back is pure data; the control renders it on the UI thread.
+                // Fetch (async DB) + reconstruct (CPU-bound over up to 5000 rows) + select the one chain
+                // containing the clicked session, all off the UI thread.
                 var model = await Task.Run(async () =>
                 {
                     var rows = await _databaseService.GetBlockingPairRowsAsync(start, end);
                     var reconstruction = BlockingChainReconstructor.Reconstruct(
                         rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
-                    return BlockingChainViewerProjection.BuildModel(reconstruction);
+                    return BlockingChainViewerProjection.BuildModelForSession(reconstruction, spid, rawTran);
                 });
 
+                if (model == null)
+                {
+                    MessageBox.Show(
+                        Window.GetWindow(this)!,
+                        $"No reconstructable blocking chain for SPID {spid} in the selected range.\n\n" +
+                        "The session may not have been part of a blocked-process report whose wait crossed " +
+                        "the blocked-process threshold in this window.",
+                        "No Block Chain",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                    return;
+                }
+
+                // Normalize the clicked tran the same way the reconstructor keyed the nodes, so the control
+                // can match + highlight the clicked session.
+                var key = BlockingChainReconstructor.MakeKey(spid, rawTran);
+
                 var control = new BlockingChainControl();
-                control.LoadModel(model, BlockingChainViewerProjection.EmptyStateDetail);
+                control.LoadModel(model, key.Spid, key.TranStarted, BlockingChainViewerProjection.EmptyStateDetail);
                 GraphViewerWindow.ShowGraph(
                     Window.GetWindow(this),
                     control,
-                    $"Blocking Chains — {_serverConnection.DisplayName}");
+                    $"Block Chain — SPID {spid} on {_serverConnection.DisplayName}");
             }
             catch (Exception ex)
             {

--- a/Dashboard/ServerTab.BlockChain.cs
+++ b/Dashboard/ServerTab.BlockChain.cs
@@ -37,10 +37,17 @@ namespace PerformanceMonitorDashboard
                 await OpenBlockChainForRowAsync(row);
         }
 
+        // Reconstruct around the clicked row's own event time (+/- this many minutes) rather than the
+        // slicer selection, so double-clicking any visible row reliably captures that event's chain (the
+        // row itself is a blocked/blocker pair, so it's always in the window). Wide enough to span a
+        // blocking episode's report re-fires; the SessionKey + edge-precise selection guard against merging
+        // unrelated chains.
+        private const int ChainWindowMinutes = 5;
+
         /// <summary>
         /// Opens the block-chain viewer scoped to ONE chain — the chain the clicked session belongs to,
-        /// rooted at its lead blocker, with the clicked session highlighted. Reconstructs over the Locking
-        /// tab's current blocking window; fetch + reconstruct + tree-build run off the UI thread.
+        /// rooted at its lead blocker, with the clicked session highlighted. Fetch + reconstruct +
+        /// tree-build run off the UI thread.
         /// </summary>
         private async Task OpenBlockChainForRowAsync(BlockingEventItem row)
         {
@@ -49,11 +56,21 @@ namespace PerformanceMonitorDashboard
             var spid = row.Spid ?? 0;
             if (spid <= 0) return;
             var rawTran = row.LastTransactionStarted;
+            var blockerSpid = row.BlockingSpid ?? 0;
+            var blockerTran = row.BlockingLastTranStarted;
 
             try
             {
+                // event_time is server-local (same column the reconstruction query filters), so derive the
+                // window straight from it — no clock conversion needed. Fall back to the tab range only if a
+                // row has no event_time.
                 DateTime start, end;
-                if (BlockingSlicer.HasNarrowedSelection
+                if (row.EventTime.HasValue)
+                {
+                    start = row.EventTime.Value.AddMinutes(-ChainWindowMinutes);
+                    end = row.EventTime.Value.AddMinutes(ChainWindowMinutes);
+                }
+                else if (BlockingSlicer.HasNarrowedSelection
                     && BlockingSlicer.SelectionStart.HasValue
                     && BlockingSlicer.SelectionEnd.HasValue)
                 {
@@ -65,14 +82,15 @@ namespace PerformanceMonitorDashboard
                     (start, end) = GetLockingSlicerTimeRange(_blockingHoursBack, _blockingFromDate, _blockingToDate);
                 }
 
-                // Fetch (async DB) + reconstruct (CPU-bound over up to 5000 rows) + select the one chain
-                // containing the clicked session, all off the UI thread.
+                // Fetch (async DB) + reconstruct (CPU-bound over up to 5000 rows) + select the one chain that
+                // contains the clicked (blocker -> blocked) edge, all off the UI thread.
                 var model = await Task.Run(async () =>
                 {
                     var rows = await _databaseService.GetBlockingPairRowsAsync(start, end);
                     var reconstruction = BlockingChainReconstructor.Reconstruct(
                         rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
-                    return BlockingChainViewerProjection.BuildModelForSession(reconstruction, spid, rawTran);
+                    return BlockingChainViewerProjection.BuildModelForSession(
+                        reconstruction, spid, rawTran, blockerSpid, blockerTran);
                 });
 
                 if (model == null)

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -48,6 +48,7 @@
                 <MenuItem.Icon><TextBlock Text="📊"/></MenuItem.Icon>
             </MenuItem>
             <Separator/>
+            <MenuItem Header="View Block Chain" Click="ViewBlockChain_Click"/>
             <MenuItem Header="View Blocked Plan" Click="ViewBlockedSidePlan_Click"/>
             <MenuItem Header="View Blocking Plan" Click="ViewBlockingSidePlan_Click"/>
         </ContextMenu>
@@ -663,14 +664,9 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <DockPanel Grid.Row="0" LastChildFill="True">
-                                <Button DockPanel.Dock="Right" Content="View Block Chain"
-                                        Click="ViewBlockChain_Click" Height="26" Padding="10,0"
-                                        Margin="6,0,8,0" VerticalAlignment="Center"
-                                        ToolTip="Reconstruct and visualize the blocking chains for the selected time range"/>
-                                <controls:TimeRangeSlicerControl x:Name="BlockingSlicer"/>
-                            </DockPanel>
+                            <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
                         <DataGrid x:Name="BlockingEventsDataGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True"
+                                      MouseDoubleClick="BlockingEventsDataGrid_MouseDoubleClick"
                                       GridLinesVisibility="Horizontal" CanUserResizeColumns="True"
                                       RowStyle="{StaticResource BlockingEventsPlanRowStyle}"
                                       ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
@@ -70,7 +70,9 @@ namespace PerformanceMonitorDashboard.Services
                                 b.login_name,
                                 b.transaction_id,
                                 CONVERT(nvarchar(max), b.blocked_process_report_xml) AS blocked_process_report_xml,
-                                CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report
+                                CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report,
+                                b.blocking_spid,
+                                b.blocking_last_tran_started
                             FROM collect.blocking_BlockedProcessReport AS b
                             WHERE b.collection_time >= @from_date
                             AND   b.collection_time <= @to_date
@@ -117,7 +119,9 @@ namespace PerformanceMonitorDashboard.Services
                                 b.login_name,
                                 b.transaction_id,
                                 CONVERT(nvarchar(max), b.blocked_process_report_xml) AS blocked_process_report_xml,
-                                CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report
+                                CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report,
+                                b.blocking_spid,
+                                b.blocking_last_tran_started
                             FROM collect.blocking_BlockedProcessReport AS b
                             WHERE b.collection_time >= DATEADD(HOUR, @hours_back, SYSDATETIME())
                             ORDER BY
@@ -177,7 +181,9 @@ namespace PerformanceMonitorDashboard.Services
                             LoginName = reader.IsDBNull(28) ? string.Empty : reader.GetString(28),
                             TransactionId = reader.IsDBNull(29) ? (long?)null : reader.GetInt64(29),
                             BlockedProcessReportXml = reader.IsDBNull(30) ? string.Empty : reader.GetString(30),
-                            HasBlockedProcessReport = !reader.IsDBNull(31) && reader.GetBoolean(31)
+                            HasBlockedProcessReport = !reader.IsDBNull(31) && reader.GetBoolean(31),
+                            BlockingSpid = reader.IsDBNull(32) ? (int?)null : reader.GetInt32(32),
+                            BlockingLastTranStarted = reader.IsDBNull(33) ? (DateTime?)null : reader.GetDateTime(33)
                         });
                     }
         

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -198,4 +198,25 @@ public class BlockingChainReconstructorTests
         Assert.Equal(TranFor(200), top.BlockingTranStarted);
         Assert.Equal(TranFor(201), top.BlockedTranStarted);
     }
+
+    [Fact]
+    public void FindChainForSession_AnyMember_ReturnsChainRootedAtApex()
+    {
+        // Two separate chains — A: 200 -> 201 -> 202 ; B: 300 -> 301. The viewer scopes to the ONE chain a
+        // clicked session belongs to, rooted at its apex regardless of where in the chain it sits.
+        var result = Run(new[] { Pair(201, 200), Pair(202, 201), Pair(301, 300) });
+
+        // Mid-level 201 -> chain A, rooted at apex 200 (not at the clicked node).
+        var chainA = BlockingChainReconstructor.FindChainForSession(result, 201, TranFor(201));
+        Assert.NotNull(chainA);
+        Assert.Equal(200, chainA!.ApexSpid);
+
+        // The apex itself and a leaf victim resolve to the same apex-rooted chain.
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 200, TranFor(200))!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 202, TranFor(202))!.ApexSpid);
+
+        // A member of the other chain resolves to that chain; an absent session returns null.
+        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
+        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
+    }
 }

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -219,4 +219,27 @@ public class BlockingChainReconstructorTests
         Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
         Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
     }
+
+    [Fact]
+    public void FindChainForSession_VictimUnderTwoApexes_DisambiguatesByClickedBlocker()
+    {
+        // Victim 500 (same tran) was blocked by apex 100 and, at another time, apex 200 — two separate
+        // chains, BOTH containing 500. The edge-precise overload returns the chain reached via the clicked
+        // row's blocker, so the clicked row opens the right chain.
+        var result = Run(new[]
+        {
+            Pair(blockedSpid: 500, blockingSpid: 100),
+            Pair(blockedSpid: 500, blockingSpid: 200)
+        });
+
+        Assert.Equal(100, BlockingChainReconstructor
+            .FindChainForSession(result, 500, TranFor(500), 100, TranFor(100))!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor
+            .FindChainForSession(result, 500, TranFor(500), 200, TranFor(200))!.ApexSpid);
+
+        // No recorded blocker -> falls back to the any-level match (one of the chains that contains 500).
+        var fallback = BlockingChainReconstructor.FindChainForSession(result, 500, TranFor(500), 0, null);
+        Assert.NotNull(fallback);
+        Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
+    }
 }

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using PerformanceMonitor.Analysis;
@@ -18,33 +19,50 @@ internal static class BlockingChainViewerProjection
         "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
         "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
 
-    public static BlockingChainModel BuildModel(BlockingReconstruction reconstruction)
+    /// <summary>
+    /// Builds the model for the ONE chain that contains the clicked session (matched by SessionKey — the
+    /// clicked session may be the apex, a mid-level blocker, or a leaf victim). The chain is rooted at its
+    /// apex with the full descendant hierarchy. Returns null when the session isn't in any reconstructed
+    /// chain (its wait may not have met the blocked-process threshold in the selected range).
+    /// </summary>
+    public static BlockingChainModel? BuildModelForSession(
+        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
     {
-        var inputs = reconstruction.Chains.Select(static c => new BlockingChainInput
-        {
-            ApexSpid = c.ApexSpid,
-            ApexTranStarted = c.ApexTranStarted,
-            ApexSleeping = c.ApexSleeping,
-            Magnitude = c.Magnitude,
-            Edges = c.Levels.Select(static l => new BlockingEdgeInput
-            {
-                Level = l.Level,
-                BlockingSpid = l.BlockingSpid,
-                BlockingTranStarted = l.BlockingTranStarted,
-                BlockedSpid = l.BlockedSpid,
-                BlockedTranStarted = l.BlockedTranStarted,
-                LockMode = l.LockMode,
-                WaitTimeMs = l.WaitTimeMs,
-                DatabaseName = l.DatabaseName,
-                BlockingSqlText = l.BlockingSqlText,
-                BlockedSqlText = l.BlockedSqlText
-            }).ToList()
-        }).ToList();
+        var chain = BlockingChainReconstructor.FindChainForSession(reconstruction, spid, tranStarted);
+        if (chain == null)
+            return null;
 
         return BlockingChainTreeBuilder.Build(
-            inputs,
+            new[] { ToInput(chain) },
             reconstruction.CycleDetected,
             reconstruction.DepthCapped,
             reconstruction.TraversalTruncated);
     }
+
+    private static BlockingChainInput ToInput(ReconstructedChain c) => new()
+    {
+        ApexSpid = c.ApexSpid,
+        ApexTranStarted = c.ApexTranStarted,
+        ApexSleeping = c.ApexSleeping,
+        Magnitude = c.Magnitude,
+        Edges = c.Levels.Select(static l => new BlockingEdgeInput
+        {
+            Level = l.Level,
+            BlockingSpid = l.BlockingSpid,
+            BlockingTranStarted = l.BlockingTranStarted,
+            BlockedSpid = l.BlockedSpid,
+            BlockedTranStarted = l.BlockedTranStarted,
+            LockMode = l.LockMode,
+            WaitTimeMs = l.WaitTimeMs,
+            DatabaseName = l.DatabaseName,
+            BlockingSqlText = l.BlockingSqlText,
+            BlockedSqlText = l.BlockedSqlText,
+            BlockedLoginName = l.BlockedLoginName,
+            BlockedHostName = l.BlockedHostName,
+            BlockedClientApp = l.BlockedClientApp,
+            BlockingLoginName = l.BlockingLoginName,
+            BlockingHostName = l.BlockingHostName,
+            BlockingClientApp = l.BlockingClientApp
+        }).ToList()
+    };
 }

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -26,9 +26,12 @@ internal static class BlockingChainViewerProjection
     /// chain (its wait may not have met the blocked-process threshold in the selected range).
     /// </summary>
     public static BlockingChainModel? BuildModelForSession(
-        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
+        BlockingReconstruction reconstruction,
+        int blockedSpid, DateTime? blockedTran,
+        int blockingSpid, DateTime? blockingTran)
     {
-        var chain = BlockingChainReconstructor.FindChainForSession(reconstruction, spid, tranStarted);
+        var chain = BlockingChainReconstructor.FindChainForSession(
+            reconstruction, blockedSpid, blockedTran, blockingSpid, blockingTran);
         if (chain == null)
             return null;
 

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -32,6 +32,16 @@ internal static class BlockingPairRowQuery
     lock_mode,
     blocking_status";
 
+    /// <summary>Ordinals 11-16: session identity for each side. Appended after the per-site SQL-text
+    /// expressions so all three queries share one column order for <see cref="Read"/>. Lite denormalizes
+    /// both sides, so unlike Dashboard the apex's identity is available too.</summary>
+    public const string IdentityColumns = @"blocked_login_name,
+    blocked_host_name,
+    blocked_client_app,
+    blocking_login_name,
+    blocking_host_name,
+    blocking_client_app";
+
     /// <summary>Append to the WHERE clause of every pair-row query (covers NULL and the 0 sentinel).</summary>
     public const string SpidFilter = @"AND blocking_spid IS NOT NULL
 AND blocking_spid <> 0";
@@ -48,7 +58,13 @@ AND blocking_spid <> 0";
         LockMode = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
         BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
         BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
-        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10)
+        BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
+        BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
+        BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
+        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
+        BlockingLoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14),
+        BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15),
+        BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16)
     };
 
     /// <summary>

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -120,7 +120,8 @@ LIMIT 5";
 SELECT
     {BlockingPairRowQuery.LeadingColumns},
     LEFT(blocked_sql_text, 500) AS blocked_sql,
-    LEFT(blocking_sql_text, 500) AS blocking_sql
+    LEFT(blocking_sql_text, 500) AS blocking_sql,
+    {BlockingPairRowQuery.IdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {BlockingPairRowQuery.SpidFilter}

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -205,7 +205,8 @@ AND   collection_time <= $3";
 SELECT
     {BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text,
-    blocking_sql_text
+    blocking_sql_text,
+    {BlockingPairRowQuery.IdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   event_time >= $2

--- a/Lite/Controls/ServerTab.BlockChain.cs
+++ b/Lite/Controls/ServerTab.BlockChain.cs
@@ -36,31 +36,49 @@ public partial class ServerTab : UserControl
             await OpenBlockChainForRowAsync(row);
     }
 
+    // Reconstruct around the clicked row's own event time (+/- this many minutes) rather than the slicer
+    // selection, so double-clicking any visible row reliably captures that event's chain. Wide enough to
+    // span a blocking episode's report re-fires; SessionKey + edge-precise selection guard against merging.
+    private const int ChainWindowMinutes = 5;
+
     /// <summary>
     /// Opens the block-chain viewer scoped to ONE chain — the chain the clicked session belongs to, rooted
-    /// at its lead blocker, with the clicked session highlighted. Reconstructs over the Blocking tab's
-    /// current window. The slicer exposes UTC; the DuckDB rows filter on server-local event_time, so convert.
-    /// Fetch + reconstruct + tree-build run off the UI thread; only the render touches the UI.
+    /// at its lead blocker, with the clicked session highlighted. Fetch + reconstruct + tree-build run off
+    /// the UI thread; only the render touches the UI.
     /// </summary>
     private async Task OpenBlockChainForRowAsync(BlockedProcessReportRow row)
     {
         var spid = row.BlockedSpid;
         if (spid <= 0) return;
         var rawTran = row.BlockedLastTranStarted;
+        var blockerSpid = row.BlockingSpid;
+        var blockerTran = row.BlockingLastTranStarted;
 
         try
         {
+            // row.EventTime is read from the same event_time column the reconstruction query filters on, so
+            // derive the window straight from it — NO clock conversion (converting a value that's already in
+            // the column's clock would shift it the wrong way). Fall back to the slicer/tab range only when a
+            // row has no event_time.
             DateTime start, end;
-            var startUtc = BlockingSlicer.SelectionStartUtc;
-            var endUtc = BlockingSlicer.SelectionEndUtc;
-            if (startUtc.HasValue && endUtc.HasValue)
+            if (row.EventTime.HasValue)
             {
-                start = ServerTimeHelper.ToServerTime(startUtc.Value);
-                end = ServerTimeHelper.ToServerTime(endUtc.Value);
+                start = row.EventTime.Value.AddMinutes(-ChainWindowMinutes);
+                end = row.EventTime.Value.AddMinutes(ChainWindowMinutes);
             }
             else
             {
-                (start, end) = GetBlockingServerRange();
+                var startUtc = BlockingSlicer.SelectionStartUtc;
+                var endUtc = BlockingSlicer.SelectionEndUtc;
+                if (startUtc.HasValue && endUtc.HasValue)
+                {
+                    start = ServerTimeHelper.ToServerTime(startUtc.Value);
+                    end = ServerTimeHelper.ToServerTime(endUtc.Value);
+                }
+                else
+                {
+                    (start, end) = GetBlockingServerRange();
+                }
             }
 
             // GetBlockingPairRowsAsync uses OpenConnectionAsync, which already takes the DuckDB read lock —
@@ -70,7 +88,8 @@ public partial class ServerTab : UserControl
                 var rows = await _dataService.GetBlockingPairRowsAsync(_serverId, start, end);
                 var reconstruction = BlockingChainReconstructor.Reconstruct(
                     rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
-                return BlockingChainViewerProjection.BuildModelForSession(reconstruction, spid, rawTran);
+                return BlockingChainViewerProjection.BuildModelForSession(
+                    reconstruction, spid, rawTran, blockerSpid, blockerTran);
             });
 
             if (model == null)

--- a/Lite/Controls/ServerTab.BlockChain.cs
+++ b/Lite/Controls/ServerTab.BlockChain.cs
@@ -10,6 +10,7 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Ui;
 using PerformanceMonitorLite.Analysis;
@@ -19,13 +20,34 @@ namespace PerformanceMonitorLite.Controls;
 
 public partial class ServerTab : UserControl
 {
-    /// <summary>
-    /// Opens the block-chain viewer for the Blocking tab's current window. The slicer exposes UTC
-    /// (SelectionStartUtc/EndUtc); the DuckDB rows are filtered on server-local event_time, so convert.
-    /// Fetch + reconstruct + tree-build run off the UI thread; only the render touches the UI.
-    /// </summary>
+    // Right-click "View Block Chain" on a blocked-process-report row.
     private async void ViewBlockChain_Click(object sender, RoutedEventArgs e)
     {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is BlockedProcessReportRow row)
+            await OpenBlockChainForRowAsync(row);
+    }
+
+    // Double-click a blocked-process-report row.
+    private async void BlockedProcessReportGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (BlockedProcessReportGrid.SelectedItem is BlockedProcessReportRow row)
+            await OpenBlockChainForRowAsync(row);
+    }
+
+    /// <summary>
+    /// Opens the block-chain viewer scoped to ONE chain — the chain the clicked session belongs to, rooted
+    /// at its lead blocker, with the clicked session highlighted. Reconstructs over the Blocking tab's
+    /// current window. The slicer exposes UTC; the DuckDB rows filter on server-local event_time, so convert.
+    /// Fetch + reconstruct + tree-build run off the UI thread; only the render touches the UI.
+    /// </summary>
+    private async Task OpenBlockChainForRowAsync(BlockedProcessReportRow row)
+    {
+        var spid = row.BlockedSpid;
+        if (spid <= 0) return;
+        var rawTran = row.BlockedLastTranStarted;
+
         try
         {
             DateTime start, end;
@@ -48,15 +70,32 @@ public partial class ServerTab : UserControl
                 var rows = await _dataService.GetBlockingPairRowsAsync(_serverId, start, end);
                 var reconstruction = BlockingChainReconstructor.Reconstruct(
                     rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
-                return BlockingChainViewerProjection.BuildModel(reconstruction);
+                return BlockingChainViewerProjection.BuildModelForSession(reconstruction, spid, rawTran);
             });
 
+            if (model == null)
+            {
+                MessageBox.Show(
+                    Window.GetWindow(this)!,
+                    $"No reconstructable blocking chain for SPID {spid} in the selected range.\n\n" +
+                    "The session may not have been part of a blocked-process report whose wait crossed " +
+                    "the blocked-process threshold in this window.",
+                    "No Block Chain",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            // Normalize the clicked tran the same way the reconstructor keyed the nodes, so the control can
+            // match + highlight the clicked session.
+            var key = BlockingChainReconstructor.MakeKey(spid, rawTran);
+
             var control = new BlockingChainControl();
-            control.LoadModel(model, BlockingChainViewerProjection.EmptyStateDetail);
+            control.LoadModel(model, key.Spid, key.TranStarted, BlockingChainViewerProjection.EmptyStateDetail);
             GraphViewerWindow.ShowGraph(
                 Window.GetWindow(this),
                 control,
-                $"Blocking Chains — {_server.DisplayName}");
+                $"Block Chain — SPID {spid} on {_server.DisplayName}");
         }
         catch (Exception ex)
         {

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -50,6 +50,9 @@
                     <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
                 </MenuItem>
                 <Separator/>
+                <MenuItem Header="View Block Chain" Click="ViewBlockChain_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F517;"/></MenuItem.Icon>
+                </MenuItem>
                 <MenuItem Header="View Blocked Plan" Click="ViewBlockedSidePlan_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
                 </MenuItem>
@@ -1365,18 +1368,13 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
-                                <DockPanel Grid.Row="0" LastChildFill="True">
-                                    <Button DockPanel.Dock="Right" Content="View Block Chain"
-                                            Click="ViewBlockChain_Click" Height="26" Padding="10,0"
-                                            Margin="6,0,8,0" VerticalAlignment="Center"
-                                            ToolTip="Reconstruct and visualize the blocking chains for the selected time range"/>
-                                    <controls:TimeRangeSlicerControl x:Name="BlockingSlicer"/>
-                                </DockPanel>
+                                <controls:TimeRangeSlicerControl x:Name="BlockingSlicer" Grid.Row="0"/>
                             <DataGrid x:Name="BlockedProcessReportGrid" Grid.Row="1"
                                       AutoGenerateColumns="False" IsReadOnly="True"
                                       RowStyle="{StaticResource BlockingRowStyle}"
                                       HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                                       HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                                      MouseDoubleClick="BlockedProcessReportGrid_MouseDoubleClick"
                                       Sorting="BlockedProcessReportGrid_Sorting">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="130">

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -368,7 +368,8 @@ LIMIT 200";
         command.CommandText = $@"
 SELECT
     {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.LeadingColumns},
-    blocked_sql_text, blocking_sql_text
+    blocked_sql_text, blocking_sql_text,
+    {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.IdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.SpidFilter}

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -28,6 +28,14 @@ internal sealed class BlockingPairRow
     public string BlockingStatus { get; init; } = string.Empty;
     public string BlockedSqlText { get; init; } = string.Empty;
     public string BlockingSqlText { get; init; } = string.Empty;
+    // Session identity for each side (login / host / client app). Carried so the viewer can show WHO a
+    // session is, not just a SPID. Threaded the same way as the SQL text.
+    public string BlockedLoginName { get; init; } = string.Empty;
+    public string BlockedHostName { get; init; } = string.Empty;
+    public string BlockedClientApp { get; init; } = string.Empty;
+    public string BlockingLoginName { get; init; } = string.Empty;
+    public string BlockingHostName { get; init; } = string.Empty;
+    public string BlockingClientApp { get; init; } = string.Empty;
 }
 
 /// <summary>
@@ -52,6 +60,12 @@ internal sealed class ChainLevel
     public string DatabaseName { get; init; } = string.Empty;
     public string BlockingSqlText { get; init; } = string.Empty;
     public string BlockedSqlText { get; init; } = string.Empty;
+    public string BlockedLoginName { get; init; } = string.Empty;
+    public string BlockedHostName { get; init; } = string.Empty;
+    public string BlockedClientApp { get; init; } = string.Empty;
+    public string BlockingLoginName { get; init; } = string.Empty;
+    public string BlockingHostName { get; init; } = string.Empty;
+    public string BlockingClientApp { get; init; } = string.Empty;
 }
 
 /// <summary>A single reconstructed blocking chain, rooted at an apex head blocker.</summary>
@@ -91,13 +105,46 @@ internal static class BlockingChainReconstructor
     /// </summary>
     private static readonly DateTime SentinelFloor = new(1900, 1, 2);
 
-    private sealed record EdgeInfo(long WaitMs, string LockMode, string BlockingSql, string BlockedSql, string DatabaseName);
+    // Holds the deduped winning row for an edge, so every per-pair field (wait, lock, SQL, identity) is
+    // available when building the ChainLevel without re-listing each one here.
+    private sealed record EdgeInfo(BlockingPairRow Row);
 
     /// <summary>Builds a stable session key, normalizing the 1900-01-01 sentinel to NULL.</summary>
     public static SessionKey MakeKey(int spid, DateTime? tranStarted)
     {
         var normalized = tranStarted.HasValue && tranStarted.Value > SentinelFloor ? tranStarted : null;
         return new SessionKey(spid, normalized);
+    }
+
+    /// <summary>
+    /// Finds the single reconstructed chain that contains the given session (matched by SessionKey — the
+    /// session may be the apex, a mid-level blocker, or a leaf victim). Returns the chain rooted at its
+    /// apex, or null if no chain contains the session. Lets the viewer scope to the one chain the clicked
+    /// row belongs to.
+    /// </summary>
+    public static ReconstructedChain? FindChainForSession(
+        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
+    {
+        var key = MakeKey(spid, tranStarted);
+        foreach (var chain in reconstruction.Chains)
+            if (ChainContains(chain, key))
+                return chain;
+        return null;
+    }
+
+    /// <summary>True if the session appears anywhere in the chain (apex, a blocker, or a victim).</summary>
+    private static bool ChainContains(ReconstructedChain chain, SessionKey key)
+    {
+        if (MakeKey(chain.ApexSpid, chain.ApexTranStarted).Equals(key))
+            return true;
+
+        foreach (var l in chain.Levels)
+        {
+            if (MakeKey(l.BlockingSpid, l.BlockingTranStarted).Equals(key)) return true;
+            if (MakeKey(l.BlockedSpid, l.BlockedTranStarted).Equals(key)) return true;
+        }
+
+        return false;
     }
 
     public static BlockingReconstruction Reconstruct(
@@ -132,12 +179,9 @@ internal static class BlockingChainReconstructor
             if (!adjacency.TryGetValue(blocker, out var dests))
                 adjacency[blocker] = dests = new Dictionary<SessionKey, EdgeInfo>();
 
-            if (!dests.TryGetValue(blocked, out var existing) || row.WaitTimeMs > existing.WaitMs)
+            if (!dests.TryGetValue(blocked, out var existing) || row.WaitTimeMs > existing.Row.WaitTimeMs)
             {
-                dests[blocked] = new EdgeInfo(
-                    row.WaitTimeMs, row.LockMode ?? string.Empty,
-                    row.BlockingSqlText ?? string.Empty, row.BlockedSqlText ?? string.Empty,
-                    row.DatabaseName ?? string.Empty);
+                dests[blocked] = new EdgeInfo(row);
             }
         }
 
@@ -232,7 +276,7 @@ internal static class BlockingChainReconstructor
         {
             // Pick the orphan with the largest outgoing wait time as the fallback root.
             var fallback = orphans
-                .OrderByDescending(n => adjacency[n].Values.Max(e => e.WaitMs))
+                .OrderByDescending(n => adjacency[n].Values.Max(e => e.Row.WaitTimeMs))
                 .First();
             roots.Add(fallback);
             MarkReachable(fallback, adjacency, reached);
@@ -344,8 +388,9 @@ internal static class BlockingChainReconstructor
             foreach (var (child, edge) in dests)
             {
                 victims.Add(child);
-                if (edge.WaitMs > maxWait)
-                    maxWait = edge.WaitMs;
+                var row = edge.Row;
+                if (row.WaitTimeMs > maxWait)
+                    maxWait = row.WaitTimeMs;
 
                 levels.Add(new ChainLevel
                 {
@@ -354,11 +399,17 @@ internal static class BlockingChainReconstructor
                     BlockingTranStarted = node.TranStarted,
                     BlockedSpid = child.Spid,
                     BlockedTranStarted = child.TranStarted,
-                    LockMode = edge.LockMode,
-                    WaitTimeMs = edge.WaitMs,
-                    DatabaseName = edge.DatabaseName,
-                    BlockingSqlText = edge.BlockingSql,
-                    BlockedSqlText = edge.BlockedSql
+                    LockMode = row.LockMode ?? string.Empty,
+                    WaitTimeMs = row.WaitTimeMs,
+                    DatabaseName = row.DatabaseName ?? string.Empty,
+                    BlockingSqlText = row.BlockingSqlText ?? string.Empty,
+                    BlockedSqlText = row.BlockedSqlText ?? string.Empty,
+                    BlockedLoginName = row.BlockedLoginName ?? string.Empty,
+                    BlockedHostName = row.BlockedHostName ?? string.Empty,
+                    BlockedClientApp = row.BlockedClientApp ?? string.Empty,
+                    BlockingLoginName = row.BlockingLoginName ?? string.Empty,
+                    BlockingHostName = row.BlockingHostName ?? string.Empty,
+                    BlockingClientApp = row.BlockingClientApp ?? string.Empty
                 });
 
                 if (enqueued.Add(child))

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -132,6 +132,42 @@ internal static class BlockingChainReconstructor
         return null;
     }
 
+    /// <summary>
+    /// Edge-precise overload: when the clicked row carries its blocker too, prefer the chain that contains
+    /// the exact (blocker -> blocked) edge. This disambiguates a victim that was blocked by two different
+    /// lead blockers at different times in the window (each is a separate chain, both containing the victim).
+    /// Falls back to the any-level match on the blocked session when no chain holds that exact edge (e.g. the
+    /// clicked row has no recorded blocker).
+    /// </summary>
+    public static ReconstructedChain? FindChainForSession(
+        BlockingReconstruction reconstruction,
+        int blockedSpid, DateTime? blockedTran,
+        int blockingSpid, DateTime? blockingTran)
+    {
+        var blockedKey = MakeKey(blockedSpid, blockedTran);
+        var blockerKey = MakeKey(blockingSpid, blockingTran);
+
+        foreach (var chain in reconstruction.Chains)
+            if (ChainContainsEdge(chain, blockerKey, blockedKey))
+                return chain;
+
+        foreach (var chain in reconstruction.Chains)
+            if (ChainContains(chain, blockedKey))
+                return chain;
+
+        return null;
+    }
+
+    /// <summary>True if the chain has the exact blocker -> blocked edge.</summary>
+    private static bool ChainContainsEdge(ReconstructedChain chain, SessionKey blockerKey, SessionKey blockedKey)
+    {
+        foreach (var l in chain.Levels)
+            if (MakeKey(l.BlockingSpid, l.BlockingTranStarted).Equals(blockerKey) &&
+                MakeKey(l.BlockedSpid, l.BlockedTranStarted).Equals(blockedKey))
+                return true;
+        return false;
+    }
+
     /// <summary>True if the session appears anywhere in the chain (apex, a blocker, or a victim).</summary>
     private static bool ChainContains(ReconstructedChain chain, SessionKey key)
     {

--- a/PerformanceMonitor.Common/BlockingChainLayout.cs
+++ b/PerformanceMonitor.Common/BlockingChainLayout.cs
@@ -20,8 +20,8 @@ namespace PerformanceMonitor.Common
     /// </summary>
     public static class BlockingChainLayout
     {
-        public const double NodeWidth = 230;
-        public const double HorizontalSpacing = 290; // NodeWidth + horizontal gap between depths
+        public const double NodeWidth = 260;          // wide enough for login / host / app identity lines
+        public const double HorizontalSpacing = 330;  // NodeWidth + horizontal gap between depths
         public const double VerticalSpacing = 22;
         public const double Padding = 40;
         public const double ForestGap = 36; // extra vertical gap between separate apex trees

--- a/PerformanceMonitor.Common/BlockingChainModel.cs
+++ b/PerformanceMonitor.Common/BlockingChainModel.cs
@@ -66,6 +66,13 @@ namespace PerformanceMonitor.Common
         /// <summary>Database context of the block.</summary>
         public string DatabaseName { get; init; } = string.Empty;
 
+        /// <summary>Who this session is — login, host, and client app. Sourced from the side of the edge
+        /// where this node appears (blocked side for a victim/mid-level blocker; blocking side for the apex).
+        /// May be empty when the source data doesn't carry it (e.g. the Dashboard apex — see the projection).</summary>
+        public string LoginName { get; init; } = string.Empty;
+        public string HostName { get; init; } = string.Empty;
+        public string ClientApp { get; init; } = string.Empty;
+
         /// <summary>Direct victims of this node, ordered deterministically.</summary>
         public List<BlockingChainNode> Children { get; init; } = new();
 
@@ -107,5 +114,14 @@ namespace PerformanceMonitor.Common
         public string DatabaseName { get; init; } = string.Empty;
         public string BlockingSqlText { get; init; } = string.Empty;
         public string BlockedSqlText { get; init; } = string.Empty;
+        // Identity of each side, threaded the same way as the SQL text. A node sources its own identity
+        // from the side it appears on: the blocked side when it's a victim/mid-level blocker, the blocking
+        // side when it's the apex (it only ever appears as a blocker).
+        public string BlockedLoginName { get; init; } = string.Empty;
+        public string BlockedHostName { get; init; } = string.Empty;
+        public string BlockedClientApp { get; init; } = string.Empty;
+        public string BlockingLoginName { get; init; } = string.Empty;
+        public string BlockingHostName { get; init; } = string.Empty;
+        public string BlockingClientApp { get; init; } = string.Empty;
     }
 }

--- a/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
+++ b/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
@@ -102,7 +102,11 @@ namespace PerformanceMonitor.Common
                 WaitTimeMs = 0,
                 LockMode = string.Empty,
                 SqlText = apexEdge?.BlockingSqlText ?? string.Empty,
-                DatabaseName = apexEdge?.DatabaseName ?? string.Empty
+                DatabaseName = apexEdge?.DatabaseName ?? string.Empty,
+                // Apex identity comes from the blocking side of an outgoing edge (it's never blocked).
+                LoginName = apexEdge?.BlockingLoginName ?? string.Empty,
+                HostName = apexEdge?.BlockingHostName ?? string.Empty,
+                ClientApp = apexEdge?.BlockingClientApp ?? string.Empty
             };
 
             // Level-synchronized BFS from the apex. Processing each level in (Spid, Tran) order means the
@@ -137,7 +141,12 @@ namespace PerformanceMonitor.Common
                             WaitTimeMs = edge.WaitTimeMs,
                             LockMode = edge.LockMode,
                             SqlText = edge.BlockedSqlText,
-                            DatabaseName = edge.DatabaseName
+                            DatabaseName = edge.DatabaseName,
+                            // A victim / mid-level blocker sources its identity from the blocked side of its
+                            // incoming edge (where it is the blocked party).
+                            LoginName = edge.BlockedLoginName,
+                            HostName = edge.BlockedHostName,
+                            ClientApp = edge.BlockedClientApp
                         };
                         node.Children.Add(child);
                         next.Add((childKey, child));

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml
@@ -24,12 +24,6 @@
                             ToolTip="Zoom to Fit"/>
                     <TextBlock x:Name="ZoomLevelText" Text="100%" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundMutedBrush}" Margin="8,0,0,0" FontSize="11"/>
-                    <Separator Margin="12,4"/>
-                    <TextBlock Text="Chain:" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11" Margin="0,0,6,0"/>
-                    <ComboBox x:Name="ChainSelector" MinWidth="240" Height="28" VerticalContentAlignment="Center"
-                              SelectionChanged="ChainSelector_SelectionChanged"
-                              ToolTip="Pick a single chain or show all, ranked by magnitude"/>
                 </StackPanel>
                 <TextBlock x:Name="FlagBanner" DockPanel.Dock="Right" VerticalAlignment="Center"
                            HorizontalAlignment="Right" TextAlignment="Right"

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -21,21 +21,26 @@ using WpfPath = System.Windows.Shapes.Path;
 namespace PerformanceMonitor.Ui;
 
 /// <summary>
-/// Shared block-chain viewer: renders the apex (lead blocker) at the left with its transitive victims
-/// flowing right, one tree per chain. Mirrors PlanViewerControl's conventions — Canvas + ScaleTransform
-/// zoom/pan, click-to-select properties, theme lifecycle (subscribe in ctor, never unsubscribe on
-/// Unloaded, expose <see cref="Cleanup"/> for the host window to call on close).
+/// Shared block-chain viewer: renders ONE chain — the lead blocker (apex) at the left with its full
+/// transitive victim hierarchy flowing right — for the session the user opened it from. The clicked
+/// session is highlighted within the tree. Mirrors PlanViewerControl's conventions — Canvas +
+/// ScaleTransform zoom/pan, click-to-select properties, theme lifecycle (subscribe in ctor, never
+/// unsubscribe on Unloaded, expose <see cref="Cleanup"/> for the host window to call on close).
 /// </summary>
 public partial class BlockingChainControl : UserControl, IGraphViewer
 {
     private const double NodeWidth = BlockingChainLayout.NodeWidth;
-    private const double NodeHeight = 112;
+    private const double NodeHeight = 150;
 
     private BlockingChainModel? _model;
     private double _zoomLevel = 1.0;
     private const double ZoomStep = 0.15;
     private const double MinZoom = 0.1;
     private const double MaxZoom = 3.0;
+
+    // The session the viewer was opened from — highlighted (auto-selected) on load.
+    private int _entrySpid;
+    private DateTime? _entryTran;
 
     // Node selection
     private Border? _selectedNodeBorder;
@@ -93,32 +98,30 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         if (_model == null) return;
 
         var nodeToRestore = _selectedNode;
-        RenderSelected();
+        Render();
 
         if (nodeToRestore == null) return;
-        foreach (var child in ChainCanvas.Children)
-        {
-            if (child is Border b && ReferenceEquals(b.Tag, nodeToRestore))
-            {
-                SelectNode(b, nodeToRestore);
-                break;
-            }
-        }
+        SelectNodeByModel(nodeToRestore);
     }
 
     /// <summary>
-    /// Loads a built model into the viewer. Pure UI work — the caller does the (off-UI-thread) fetch,
-    /// reconstruct, and tree-build, then hands the finished <see cref="BlockingChainModel"/> here.
+    /// Loads the single reconstructed chain that contains the clicked session and highlights that session.
+    /// Pure UI work — the caller does the (off-UI-thread) fetch, reconstruct, single-chain select, and
+    /// tree-build, then hands the finished one-root <see cref="BlockingChainModel"/> here.
     /// </summary>
-    public void LoadModel(BlockingChainModel model, string? emptyStateDetail = null)
+    /// <param name="model">The model holding exactly one root (the chain rooted at its apex).</param>
+    /// <param name="entrySpid">SPID of the session the viewer was opened from (highlighted on load).</param>
+    /// <param name="entryTran">Its normalized transaction-start (the SessionKey disambiguator).</param>
+    public void LoadModel(BlockingChainModel model, int entrySpid, DateTime? entryTran, string? emptyStateDetail = null)
     {
         _model = model ?? throw new ArgumentNullException(nameof(model));
+        _entrySpid = entrySpid;
+        _entryTran = entryTran;
 
         if (!string.IsNullOrWhiteSpace(emptyStateDetail))
             EmptyStateDetail.Text = emptyStateDetail;
 
         BuildFlagBanner();
-        PopulateChainSelector();
 
         if (_model.Roots.Count == 0)
         {
@@ -127,9 +130,17 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         }
 
         ShowEmptyState(false);
-        // Default selection (index 0 = "All chains") triggers ChainSelector_SelectionChanged -> render.
-        if (ChainSelector.Items.Count > 0)
-            ChainSelector.SelectedIndex = 0;
+        Render();
+
+        // Highlight (auto-select) the clicked session within the tree so the user lands on "their" node.
+        var entry = _model.Roots
+            .SelectMany(EnumerateTree)
+            .FirstOrDefault(n => n.Spid == _entrySpid && Nullable.Equals(n.TranStarted, _entryTran));
+        if (entry != null)
+        {
+            SelectNodeByModel(entry);
+            ScrollNodeIntoView(entry);
+        }
     }
 
     private void ShowEmptyState(bool empty)
@@ -160,73 +171,32 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         }
     }
 
-    private sealed class ChainSelectorItem
-    {
-        public string Display { get; init; } = "";
-        public BlockingChainNode? Root { get; init; }   // null = all chains
-        public override string ToString() => Display;
-    }
-
-    private void PopulateChainSelector()
-    {
-        ChainSelector.Items.Clear();
-        if (_model == null || _model.Roots.Count == 0) return;
-
-        ChainSelector.Items.Add(new ChainSelectorItem
-        {
-            Display = $"All chains ({_model.Roots.Count})",
-            Root = null
-        });
-
-        foreach (var root in _model.Roots)
-        {
-            var victims = CountDescendants(root);
-            var depth = TreeDepth(root);
-            ChainSelector.Items.Add(new ChainSelectorItem
-            {
-                Display = $"SPID {root.Spid} — {victims} blocked, depth {depth}",
-                Root = root
-            });
-        }
-    }
-
-    private void ChainSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) => RenderSelected();
-
-    private IReadOnlyList<BlockingChainNode> SelectedRoots()
-    {
-        if (_model == null) return Array.Empty<BlockingChainNode>();
-        if (ChainSelector.SelectedItem is ChainSelectorItem item && item.Root != null)
-            return new[] { item.Root };
-        return _model.Roots;
-    }
-
     #region Rendering
 
-    private void RenderSelected()
+    private void Render()
     {
         ChainCanvas.Children.Clear();
         _selectedNodeBorder = null;
 
-        var roots = SelectedRoots();
-        if (roots.Count == 0) return;
+        if (_model == null || _model.Roots.Count == 0) return;
 
         ChainScrollViewer.ScrollToHome();
 
-        var (width, height) = BlockingChainLayout.Layout(roots, _ => NodeHeight);
+        var (width, height) = BlockingChainLayout.Layout(_model.Roots, _ => NodeHeight);
         ChainCanvas.Width = width;
         ChainCanvas.Height = height;
 
-        // Find the longest-wait node across the rendered set to highlight it.
+        // Per-chain longest-wait highlight (only one chain is shown, so it's always meaningful).
         long maxWait = 0;
-        foreach (var root in roots)
+        foreach (var root in _model.Roots)
             Walk(root, n => { if (n.WaitTimeMs > maxWait) maxWait = n.WaitTimeMs; });
         var longestWaitNode = maxWait > 0
-            ? roots.SelectMany(EnumerateTree).FirstOrDefault(n => n.WaitTimeMs == maxWait)
+            ? _model.Roots.SelectMany(EnumerateTree).FirstOrDefault(n => n.WaitTimeMs == maxWait)
             : null;
 
-        foreach (var root in roots)
+        foreach (var root in _model.Roots)
             RenderEdges(root);
-        foreach (var root in roots)
+        foreach (var root in _model.Roots)
             RenderNodes(root, longestWaitNode);
     }
 
@@ -262,34 +232,43 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
 
         var stack = new StackPanel();
 
-        // Header: SPID + role badges
+        // Header: WHO this session is (login) is primary; the SPID is a secondary id. Falls back to the
+        // SPID as the primary label when the source data didn't carry a login (e.g. the Dashboard apex).
         var header = new StackPanel { Orientation = Orientation.Horizontal };
+        var hasLogin = !string.IsNullOrEmpty(node.LoginName);
         header.Children.Add(new TextBlock
         {
-            Text = $"SPID {node.Spid}",
-            FontSize = 13,
+            Text = hasLogin ? node.LoginName : $"SPID {node.Spid}",
+            FontSize = 12,
             FontWeight = FontWeights.Bold,
             Foreground = ForegroundBrush,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxWidth = NodeWidth - 110,
             VerticalAlignment = VerticalAlignment.Center
         });
+        if (hasLogin)
+            header.Children.Add(new TextBlock
+            {
+                Text = $"SPID {node.Spid}",
+                FontSize = 10,
+                Foreground = MutedBrush,
+                Margin = new Thickness(6, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center
+            });
         if (node.IsApex)
             header.Children.Add(MakeBadge("LEAD BLOCKER", ApexBrush));
         if (node.IsApexSleeping)
             header.Children.Add(MakeBadge("SLEEPING", SleepingBrush));
         stack.Children.Add(header);
 
+        // Host · client app
+        var hostApp = JoinNonEmpty(" · ", node.HostName, node.ClientApp);
+        if (!string.IsNullOrEmpty(hostApp))
+            stack.Children.Add(MutedLine(hostApp));
+
         // Database
         if (!string.IsNullOrEmpty(node.DatabaseName))
-        {
-            stack.Children.Add(new TextBlock
-            {
-                Text = node.DatabaseName,
-                FontSize = 11,
-                Foreground = MutedBrush,
-                TextTrimming = TextTrimming.CharacterEllipsis,
-                Margin = new Thickness(0, 1, 0, 0)
-            });
-        }
+            stack.Children.Add(MutedLine(node.DatabaseName));
 
         // Lock mode + wait (victims only — the apex waits on no one)
         if (!node.IsApex && (node.WaitTimeMs > 0 || !string.IsNullOrEmpty(node.LockMode)))
@@ -318,7 +297,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
                 Foreground = MutedBrush,
                 TextWrapping = TextWrapping.Wrap,
                 TextTrimming = TextTrimming.CharacterEllipsis,
-                MaxHeight = 32,
+                MaxHeight = 30,
                 Margin = new Thickness(0, 3, 0, 0)
             });
         }
@@ -326,6 +305,15 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         border.Child = stack;
         return border;
     }
+
+    private TextBlock MutedLine(string text) => new()
+    {
+        Text = text,
+        FontSize = 11,
+        Foreground = MutedBrush,
+        TextTrimming = TextTrimming.CharacterEllipsis,
+        Margin = new Thickness(0, 1, 0, 0)
+    };
 
     private static Border MakeBadge(string text, Brush brush) => new()
     {
@@ -392,6 +380,19 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         }
     }
 
+    /// <summary>Finds the rendered border for a model node and selects it.</summary>
+    private void SelectNodeByModel(BlockingChainNode node)
+    {
+        foreach (var child in ChainCanvas.Children)
+        {
+            if (child is Border b && ReferenceEquals(b.Tag, node))
+            {
+                SelectNode(b, node);
+                return;
+            }
+        }
+    }
+
     private void SelectNode(Border border, BlockingChainNode node)
     {
         if (_selectedNodeBorder != null)
@@ -412,22 +413,23 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         ShowProperties(node);
     }
 
+    /// <summary>Scrolls the canvas so a node is comfortably in view (used for the entry node on load).</summary>
+    private void ScrollNodeIntoView(BlockingChainNode node)
+    {
+        // Defer until the ScrollViewer has its extent (first layout pass may not be done yet).
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            ChainScrollViewer.ScrollToHorizontalOffset(Math.Max(0, node.X * _zoomLevel - 60));
+            ChainScrollViewer.ScrollToVerticalOffset(Math.Max(0, node.Y * _zoomLevel - 60));
+        }), System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+
     private ContextMenu BuildNodeContextMenu(BlockingChainNode node)
     {
         var menu = new ContextMenu();
 
         var propsItem = new MenuItem { Header = "Properties" };
-        propsItem.Click += (_, _) =>
-        {
-            foreach (var child in ChainCanvas.Children)
-            {
-                if (child is Border b && ReferenceEquals(b.Tag, node))
-                {
-                    SelectNode(b, node);
-                    break;
-                }
-            }
-        };
+        propsItem.Click += (_, _) => SelectNodeByModel(node);
         menu.Items.Add(propsItem);
 
         if (!string.IsNullOrEmpty(node.SqlText))
@@ -447,6 +449,12 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
 
         AddPropRow("SPID", node.Spid.ToString());
         AddPropRow("Role", node.IsApex ? (node.IsApexSleeping ? "Lead blocker (sleeping)" : "Lead blocker") : "Blocked");
+        if (!string.IsNullOrEmpty(node.LoginName))
+            AddPropRow("Login", node.LoginName);
+        if (!string.IsNullOrEmpty(node.HostName))
+            AddPropRow("Host", node.HostName);
+        if (!string.IsNullOrEmpty(node.ClientApp))
+            AddPropRow("Client App", node.ClientApp);
         if (node.TranStarted.HasValue)
             AddPropRow("Transaction Started", node.TranStarted.Value.ToString("yyyy-MM-dd HH:mm:ss"));
         if (!string.IsNullOrEmpty(node.DatabaseName))
@@ -551,16 +559,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         }
     }
 
-    private void BlockingChainControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-    {
-        // Don't steal focus from the chain selector dropdown.
-        if (e.OriginalSource is ComboBox
-            || e.OriginalSource is ComboBoxItem
-            || FindVisualParent<ComboBox>(e.OriginalSource as DependencyObject) != null
-            || FindVisualParent<ComboBoxItem>(e.OriginalSource as DependencyObject) != null)
-            return;
-        Focus();
-    }
+    private void BlockingChainControl_PreviewMouseDown(object sender, MouseButtonEventArgs e) => Focus();
 
     private void ChainScrollViewer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
@@ -615,16 +614,6 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         return false;
     }
 
-    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
-    {
-        while (child != null)
-        {
-            if (child is T parent) return parent;
-            child = VisualTreeHelper.GetParent(child);
-        }
-        return null;
-    }
-
     #endregion
 
     #region Helpers
@@ -636,6 +625,9 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         if (ms < 60_000) return $"{ms / 1000.0:F1} s";
         return $"{ms / 60_000}m {(ms % 60_000) / 1000}s";
     }
+
+    private static string JoinNonEmpty(string separator, params string[] parts) =>
+        string.Join(separator, parts.Where(p => !string.IsNullOrEmpty(p)));
 
     private static string CollapseWhitespace(string s)
     {
@@ -656,23 +648,6 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
             }
         }
         return sb.ToString();
-    }
-
-    private static int CountDescendants(BlockingChainNode node)
-    {
-        var count = 0;
-        foreach (var child in node.Children)
-            count += 1 + CountDescendants(child);
-        return count;
-    }
-
-    private static int TreeDepth(BlockingChainNode node)
-    {
-        if (node.Children.Count == 0) return 0;
-        var max = 0;
-        foreach (var child in node.Children)
-            max = Math.Max(max, TreeDepth(child));
-        return max + 1;
     }
 
     private static IEnumerable<BlockingChainNode> EnumerateTree(BlockingChainNode node)


### PR DESCRIPTION
## Block-chain viewer redesign — row-scoped single chain

Reworks the block-chain viewer's interaction model. The previous version reconstructed **every** chain in the slicer window and showed a scrollable forest with a bare-SPID chain-picker — an alert-overview model jammed into an interactive viewer. This makes it **row-scoped**: one row → that row's single chain, rooted at its apex, full hierarchy, with the clicked session highlighted.

Does **not** touch the deadlock viewer (separate PR).

### Entry points (both apps)
- Removed the "View Block Chain" toolbar button + the slicer `DockPanel`; the `BlockingSlicer` is back to full width.
- Added a **"View Block Chain" context-menu item** + **row double-click** on the blocking grids (Dashboard `BlockingEventsDataGrid`, Lite `BlockedProcessReportGrid`).
- The handler reads the clicked row's blocked SPID + transaction-start (its `SessionKey`).

### Semantics — one chain
- Reconstructs over the Locking/Blocking tab's **current slicer range** (`GetBlockingPairRowsAsync` + `Reconstruct(rows, 50, 5000, 100_000)`), off the UI thread.
- `BlockingChainReconstructor.FindChainForSession(reconstruction, spid, tran)` selects the **single** chain that contains the clicked session — matched by `SessionKey`, so it resolves whether the clicked session is the apex, a mid-level blocker, or a leaf victim. The chain is rooted at its **apex** with the full descendant hierarchy.
- The clicked node is **auto-selected + scrolled into view** (purple highlight + properties).
- Session not in any chain → a clear "No reconstructable blocking chain for SPID N…" message; the viewer doesn't open an empty view.
- No forest, no chain picker, no magnitude ranking UI.

### Hierarchy is a true tree
`BlockingChainTreeBuilder` already nests to arbitrary depth; the row-scoping passes the **full** selected chain (all levels). New tests prove 1→2→3→4 nests root→child→grandchild→great-grandchild and that branching (1→{2,3}, 2→4) nests each branch separately.

### Node identity — "who", not just a SPID
Threaded blocked-/blocking-side **login / host / client app** through the stack (`BlockingPairRow` → `EdgeInfo(row)` → `ChainLevel` → `BlockingEdgeInput` → `BlockingChainNode` → projection → card), the same way `SqlText`/`DatabaseName` already flow. A node sources identity from the side it appears on (blocked for victims/mid, blocking for the apex). Cards now show login (primary) + SPID (secondary) + host·app + database + lock·wait + SQL preview; widened to 260 and 150px tall.

### ⚠ One data-asymmetry flagged for your call
The **Dashboard** `collect.blocking_BlockedProcessReport` table parses only blocked-side identity (`login_name/host_name/client_app`) and the blocker's *status/tran/SQL* — it does **not** parse `blocking_login_name/host/app`. So on Dashboard, victims and mid-level blockers show full identity, but the **pure apex** shows SPID + db + SQL and degrades login/host/app gracefully (falls back to "SPID N" as the primary label). **Lite** denormalizes both sides, so its apex shows full identity. Closing this gap needs a Dashboard schema + `install/23_process_blocked_process_xml.sql` parse + an `upgrades/` script (a 3-attribute mirror of the existing `blocking_sql_text` parse) — left out of this UX PR because it touches the install/upgrade subsystem and needs live install testing. Easy follow-up if you want true apex parity.

### Files changed
- `.Analysis/BlockingChainReconstructor.cs` — identity on `BlockingPairRow`/`ChainLevel`; `EdgeInfo` carries the row; new `FindChainForSession`.
- `.Common` — identity on `BlockingChainNode`/`BlockingEdgeInput`; builder sources identity per edge side; `BlockingChainLayout` card size.
- `.Ui/BlockingChainControl.xaml(.cs)` — picker removed; single-chain render; identity cards; entry-node highlight + scroll.
- Dashboard + Lite: `BlockingPairRowQuery` (identity columns), `BlockingChainViewerProjection` (`BuildModelForSession`), `ServerTab.BlockChain.cs` (row-aware handlers), `ServerTab.xaml` (slicer revert + context menu + double-click); Lite `DrillDownCollector`/`DuckDbFactCollector`/`LocalDataService` queries select the shared identity columns.
- Tests: `Dashboard.Tests/BlockingChainTreeBuilderTests.cs` (+deep-linear, +multi-level branching); both `BlockingChainReconstructorTests` mirrors (+`FindChainForSession`).

### Test results
- Both apps build green (0 errors).
- `Dashboard.Tests`: **572 passed**. `Lite.Tests`: **548 passed** (incl. `FactScorerTests`/`ScenarioTests` — the live Lite collector exercises the new identity columns + harmonized filter).

### Visual-test checklist (for review)
- [ ] Right-click a blocking row → "View Block Chain"; also row double-click — both open the viewer.
- [ ] The viewer shows ONE chain rooted at the lead blocker; the clicked session is highlighted (purple) + scrolled into view + its properties shown.
- [ ] A deep chain (3+ levels) renders nested at every level; a branching blocker shows multiple children.
- [ ] Node cards show login / host / app / database / SQL preview / lock·wait, SPID secondary. (Dashboard apex: login/host/app blank by design — see the flag above.)
- [ ] Clicking a different node moves the selection; zoom/pan/fit; theme switch re-renders.
- [ ] A row whose session has no reconstructable chain → the clear message, not an empty viewer.
- [ ] Both apps; cloud (Azure SQL DB / AWS RDS).

**Do NOT merge** — pending your verification of hierarchy rendering, row-scoping, and node content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
