### PR TITLE
Dashboard apex-identity parity: parse blocker login/host/app

### DIFF
--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -33,7 +33,10 @@ SELECT TOP (5000)
     blocking_sql_text,
     login_name,
     host_name,
-    client_app
+    client_app,
+    blocking_login_name,
+    blocking_host_name,
+    blocking_client_app
 FROM collect.blocking_BlockedProcessReport
 WHERE collection_time >= @collectionWindow
 AND   event_time >= @startTime
@@ -67,12 +70,14 @@ ORDER BY collection_time DESC";
         BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
         BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
         BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
-        // Blocked-side identity (the 'blocked' row's own session). The Dashboard table does NOT parse the
-        // blocker's login/host/app from the XML (only blocking_status/blocking_last_tran_started/
-        // blocking_sql_text), so the blocking-side identity stays empty here — the pure apex shows SQL + db
-        // but no login/host/app. See BlockingChainViewerProjection / the PR notes for the schema follow-up.
+        // Blocked-side identity (the 'blocked' row's own session) and, since 3.1.0, the blocker's identity
+        // parsed from the XML by collect.process_blocked_process_xml — so the block-chain viewer's apex
+        // shows login/host/app on Dashboard too, matching Lite.
         BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
         BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
-        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13)
+        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
+        BlockingLoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14),
+        BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15),
+        BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16)
     };
 }

--- a/Installer.Core/Installer.Core.csproj
+++ b/Installer.Core/Installer.Core.csproj
@@ -7,10 +7,10 @@
     <RootNamespace>Installer.Core</RootNamespace>
     <AssemblyName>Installer.Core</AssemblyName>
     <Product>SQL Server Performance Monitor Installer Core</Product>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
-    <InformationalVersion>3.0.0</InformationalVersion>
+    <Version>3.1.0</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
+    <InformationalVersion>3.1.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright (c) 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Installer/PerformanceMonitorInstaller.csproj
+++ b/Installer/PerformanceMonitorInstaller.csproj
@@ -20,10 +20,10 @@
     <!-- Application metadata -->
     <AssemblyName>PerformanceMonitorInstaller</AssemblyName>
     <Product>SQL Server Performance Monitor Installer</Product>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
-    <InformationalVersion>3.0.0</InformationalVersion>
+    <Version>3.1.0</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
+    <InformationalVersion>3.1.0</InformationalVersion>
     <Company>Darling Data, LLC</Company>
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <Description>Installation utility for SQL Server Performance Monitor - Supports SQL Server 2016-2025</Description>

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1124,6 +1124,9 @@ BEGIN
         blocking_status nvarchar(10) NULL,
         blocked_sql_text nvarchar(max) NULL,
         blocking_sql_text nvarchar(max) NULL,
+        blocking_login_name nvarchar(256) NULL,
+        blocking_host_name nvarchar(256) NULL,
+        blocking_client_app nvarchar(256) NULL,
         CONSTRAINT
             PK_collect_blocking_BlockedProcessReport
         PRIMARY KEY CLUSTERED

--- a/install/23_process_blocked_process_xml.sql
+++ b/install/23_process_blocked_process_xml.sql
@@ -303,6 +303,24 @@ BEGIN
                             N'(//blocked-process-report/blocking-process/process/@status)[1]',
                             N'nvarchar(10)'
                         ),
+                    b.blocking_login_name =
+                        b.blocked_process_report_xml.value
+                        (
+                            N'(//blocked-process-report/blocking-process/process/@loginname)[1]',
+                            N'nvarchar(256)'
+                        ),
+                    b.blocking_host_name =
+                        b.blocked_process_report_xml.value
+                        (
+                            N'(//blocked-process-report/blocking-process/process/@hostname)[1]',
+                            N'nvarchar(256)'
+                        ),
+                    b.blocking_client_app =
+                        b.blocked_process_report_xml.value
+                        (
+                            N'(//blocked-process-report/blocking-process/process/@clientapp)[1]',
+                            N'nvarchar(256)'
+                        ),
                     b.blocked_sql_text =
                         LTRIM(RTRIM(b.blocked_process_report_xml.value
                         (

--- a/upgrades/3.0.0-to-3.1.0/01_add_blocking_identity_columns.sql
+++ b/upgrades/3.0.0-to-3.1.0/01_add_blocking_identity_columns.sql
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+Upgrade from 3.0.0 to 3.1.0
+Adds blocking-side identity columns (login / host / client app) to
+collect.blocking_BlockedProcessReport so the Dashboard block-chain viewer can
+show WHO the lead blocker (apex) is, not just a SPID — matching Lite, which
+already denormalizes both sides. The 3.0.0 upgrade added the other blocker-side
+typed columns (spid / tran / status / sql); this completes the set with the
+identity attributes. Backfills existing activity='blocked' rows from their
+stored XML in one pass.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+/*
+Add columns idempotently. Each column gets its own guarded ALTER so a re-run
+after a partial failure resumes cleanly. Separate GO batches are required
+because the backfill below references the new columns by name and the parser
+needs them to exist at compile time. Types mirror the blocked-side identity
+columns (login_name / host_name / client_app are nvarchar(256)).
+*/
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'collect.blocking_BlockedProcessReport')
+    AND   c.name = N'blocking_login_name'
+)
+BEGIN
+    ALTER TABLE collect.blocking_BlockedProcessReport
+        ADD blocking_login_name nvarchar(256) NULL;
+
+    PRINT 'Added blocking_login_name to collect.blocking_BlockedProcessReport';
+END;
+GO
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'collect.blocking_BlockedProcessReport')
+    AND   c.name = N'blocking_host_name'
+)
+BEGIN
+    ALTER TABLE collect.blocking_BlockedProcessReport
+        ADD blocking_host_name nvarchar(256) NULL;
+
+    PRINT 'Added blocking_host_name to collect.blocking_BlockedProcessReport';
+END;
+GO
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'collect.blocking_BlockedProcessReport')
+    AND   c.name = N'blocking_client_app'
+)
+BEGIN
+    ALTER TABLE collect.blocking_BlockedProcessReport
+        ADD blocking_client_app nvarchar(256) NULL;
+
+    PRINT 'Added blocking_client_app to collect.blocking_BlockedProcessReport';
+END;
+GO
+
+/*
+One-time backfill of existing activity='blocked' rows. Idempotent: the WHERE
+filter targets only rows where blocking_login_name IS NULL (i.e., not yet
+populated). Safe to re-run; once a row is populated the predicate excludes it.
+
+XQuery uses the descendant axis (//blocked-process-report/...) for the same
+reason as the 3.0.0 backfill: the stored XML is <event>-rooted with the report
+nested two levels deep, so a leading-slash path returns NULL on every row. The
+<process> element carries loginname / hostname / clientapp (lowercase, no
+underscores) — the same attribute schema as a deadlock-graph process node, and
+unchanged across SQL Server 2016+, Azure SQL DB, and Managed Instance. On the
+Azure blocked_process_report_filtered variant these come back as the literal
+"filtered" (value masked, attribute present), which is the expected behavior.
+*/
+UPDATE
+    b
+SET
+    b.blocking_login_name =
+        b.blocked_process_report_xml.value
+        (
+            N'(//blocked-process-report/blocking-process/process/@loginname)[1]',
+            N'nvarchar(256)'
+        ),
+    b.blocking_host_name =
+        b.blocked_process_report_xml.value
+        (
+            N'(//blocked-process-report/blocking-process/process/@hostname)[1]',
+            N'nvarchar(256)'
+        ),
+    b.blocking_client_app =
+        b.blocked_process_report_xml.value
+        (
+            N'(//blocked-process-report/blocking-process/process/@clientapp)[1]',
+            N'nvarchar(256)'
+        )
+FROM collect.blocking_BlockedProcessReport AS b
+WHERE b.activity = 'blocked'
+AND   b.blocking_login_name IS NULL
+AND   b.blocked_process_report_xml IS NOT NULL;
+
+PRINT 'Backfilled blocker-side identity columns for existing activity=''blocked'' rows';
+GO

--- a/upgrades/3.0.0-to-3.1.0/upgrade.txt
+++ b/upgrades/3.0.0-to-3.1.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_add_blocking_identity_columns.sql


### PR DESCRIPTION
## Dashboard apex-identity parity — parse blocker login / host / app

Follow-up to the block-chain viewer PRs (#1207, #1215). A lead-blocker (apex) node in the **Dashboard** block-chain viewer now shows **login / host / client app**, like Lite already does. Today it degrades to SPID + db + SQL because Dashboard's `collect.blocking_BlockedProcessReport` only parsed the blocker's *status / tran / SQL* from the report XML — never its identity. Dashboard-only (Lite denormalizes both sides already; the `BlockingPairRow.Blocking{Login,Host,App}` fields exist from #1215, just unpopulated on Dashboard).

### Changes
- **Schema (fresh installs)** — `install/02_create_tables.sql`: add `blocking_login_name`, `blocking_host_name`, `blocking_client_app` (`nvarchar(256) NULL`) to `collect.blocking_BlockedProcessReport`, matching the blocked-side identity column types.
- **Proc parse** — `install/23_process_blocked_process_xml.sql`: extract the three blocking-side identity attributes from `<blocking-process><process @loginname @hostname @clientapp>` in the same `UPDATE` that already types `blocking_status` (exact mirror — same `.value()` pattern, descendant axis, N-prefixed literals).
- **Upgrade (existing installs)** — `upgrades/3.0.0-to-3.1.0/01_add_blocking_identity_columns.sql` (+ `upgrade.txt`): idempotent guarded `ALTER ... ADD` per column (separate `GO` batches) + a one-pass backfill of existing `activity='blocked'` rows from their stored XML, guarded on `blocking_login_name IS NULL`. Mirrors the `2.11.0-to-3.0.0` column-extend upgrade.
- **Query** — Dashboard `BlockingPairRowQuery.Sql`: SELECT the 3 new columns and map them into `BlockingPairRow.Blocking{Login,Host,App}` at **appended ordinals 14/15/16** — existing ordinals (fed to the alert engine via the shared `Read`) are unchanged.
- **Version** — bumped `Version`/`AssemblyVersion`/`FileVersion`/`InformationalVersion` `3.0.0 → 3.1.0` in **both** installer csprojs (`Installer/PerformanceMonitorInstaller.csproj`, `Installer.Core/Installer.Core.csproj`) so the upgrade path triggers.

### Upgrade folder / version used
- New folder: **`upgrades/3.0.0-to-3.1.0/`** (current installer version is 3.0.0; latest existing folder was `2.11.0-to-3.0.0`).
- New installer version: **3.1.0**.
- The installer auto-embeds `upgrades/**/*` + `install/**/*.sql` (Installer.Core.csproj), so the new folder is packaged with no csproj glob change; `targetVersion` comes from the assembly version, so the bump drives `GetApplicableUpgrades(installed, 3.1.0)`.

### XML attribute names — verified against MS Learn
`loginname` / `hostname` / `clientapp` (all lowercase, no underscores), identical on the `<process>` node across the blocked-process-report and deadlock-graph shapes, and across SQL Server 2016+, Azure SQL DB, and Managed Instance. The BPR nests `<process>` directly under `<blocking-process>` (no `<process-list>` wrapper), so the descendant-axis path is correct. Note: the Azure `blocked_process_report_filtered` variant returns these values as the literal `"filtered"` (masked value, attribute still present) — the parse still works.

### Build
Dashboard, Lite, and Installer all build green (0 errors). T-SQL style reviewed against the guide — clean (mirrors the proven scripts).

### Not tested here / your gate
Per instruction, I did **not** run the Installer CLI against the shared test servers — live **fresh + upgrade** install testing (verifying the columns are added, the proc parses, and the backfill populates existing rows) is the pre-merge gate you'll coordinate. Idempotency was written to the established pattern but not exercised against a live DB by me.

**Do NOT merge** — pending your verification + install test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
