### PR TITLE
Block-chain viewer: show the Dashboard apex's login/host/app (Lite/Dashboard parity)

### DIFF
--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -63,13 +63,17 @@ ORDER BY collection_time DESC";
     /// blocking_id) range-limits the lookup. The background collectors keep the lighter <see cref="Sql"/>
     /// (they score chains and never display identity), so this extra correlation is paid only on the
     /// infrequent, small-window viewer open. Maps via <see cref="ReadWithBlockerIdentity"/> (adds 14-16).
+    /// Result row order is intentionally unspecified: the inner TOP (5000) / ORDER BY selects the
+    /// most-recent pairs, reconstruction is order-independent, and the sole caller's maxPairs equals the
+    /// cap — so no outer ORDER BY is added (and collection_time is deliberately not projected, so don't
+    /// "fix" this with ORDER BY c.collection_time — it isn't a column of the derived table).
     /// </summary>
     public const string SqlWithBlockerIdentity = ReadUncommitted + @"
 SELECT
     c.*,
-    bk.login_name AS blocking_login_name,
-    bk.host_name AS blocking_host_name,
-    bk.client_app AS blocking_client_app
+    blocking_login_name = bk.login_name,
+    blocking_host_name = bk.host_name,
+    blocking_client_app = bk.client_app
 FROM
 (" + SelectBody + @"
 ) AS c

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -16,9 +16,16 @@ namespace PerformanceMonitorDashboard.Analysis;
 /// </summary>
 internal static class BlockingPairRowQuery
 {
-    public const string Sql = @"
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+    private const string ReadUncommitted = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n";
 
+    /// <summary>
+    /// The core pair SELECT (no SET preamble; ordinals 0-13). Kept separate from <see cref="Sql"/> so the
+    /// viewer variant <see cref="SqlWithBlockerIdentity"/> can reuse it verbatim as a derived table — the
+    /// column list and the apex filter live in exactly one place and can't drift between the two queries.
+    /// Ordinals 11-13 are the BLOCKED row's own identity (login/host/app); the blocker's identity is not
+    /// stored on the blocked row, so a pure apex has no identity from this query alone (see the variant).
+    /// </summary>
+    public const string SelectBody = @"
 SELECT TOP (5000)
     event_time,
     database_name,
@@ -42,10 +49,49 @@ AND   activity = 'blocked'
 AND   blocking_spid IS NOT NULL
 ORDER BY collection_time DESC";
 
+    /// <summary>The collector/fact query: the core SELECT under READ UNCOMMITTED. Maps via <see cref="Read"/>.</summary>
+    public const string Sql = ReadUncommitted + SelectBody;
+
+    /// <summary>
+    /// Viewer-only variant that also resolves the BLOCKER's identity (login / host / client app) per pair,
+    /// so the apex node — which only ever appears as a blocker, never as a blocked row — shows WHO it is
+    /// instead of a bare SPID. The Dashboard table stores identity per process row, so the blocker's lives
+    /// on its <c>activity='blocking'</c> row for the same event; we correlate to it by (event_time, spid)
+    /// via OUTER APPLY. TOP (1) collapses the one-to-many 'blocking' rows a lead blocker emits when it
+    /// blocks several victims in one report (identity is identical across them). The apply is bounded by the
+    /// same <c>collection_time</c> window as the core query, so the clustered PK (collection_time,
+    /// blocking_id) range-limits the lookup. The background collectors keep the lighter <see cref="Sql"/>
+    /// (they score chains and never display identity), so this extra correlation is paid only on the
+    /// infrequent, small-window viewer open. Maps via <see cref="ReadWithBlockerIdentity"/> (adds 14-16).
+    /// </summary>
+    public const string SqlWithBlockerIdentity = ReadUncommitted + @"
+SELECT
+    c.*,
+    bk.login_name AS blocking_login_name,
+    bk.host_name AS blocking_host_name,
+    bk.client_app AS blocking_client_app
+FROM
+(" + SelectBody + @"
+) AS c
+OUTER APPLY
+(
+    SELECT TOP (1)
+        k.login_name,
+        k.host_name,
+        k.client_app
+    FROM collect.blocking_BlockedProcessReport AS k
+    WHERE k.activity = 'blocking'
+    AND   k.spid = c.blocking_spid
+    AND   k.event_time = c.event_time
+    AND   k.collection_time >= @collectionWindow
+    ORDER BY k.collection_time DESC
+) AS bk";
+
     /// <summary>
     /// Adds the three parameters. The collection-time floor is a generous bound (window start minus an
     /// hour) so rows whose event_time is inside the window but whose collection_time lags slightly are
-    /// still caught.
+    /// still caught. Shared by both <see cref="Sql"/> and <see cref="SqlWithBlockerIdentity"/> (the apply
+    /// reuses @collectionWindow to bound its own lookup).
     /// </summary>
     public static void AddParameters(SqlCommand cmd, DateTime start, DateTime end)
     {
@@ -54,6 +100,12 @@ ORDER BY collection_time DESC";
         cmd.Parameters.Add(new SqlParameter("@endTime", end));
     }
 
+    /// <summary>
+    /// Maps ordinals 0-13 of the core query: per-event fields plus the BLOCKED row's own identity. The
+    /// blocking-side identity stays empty here — the Dashboard table parses only the blocker's
+    /// status/tran/SQL from the report XML, not its login/host/app — so a pure apex read via the collector
+    /// path shows SQL + db but no identity. The viewer fills it via <see cref="ReadWithBlockerIdentity"/>.
+    /// </summary>
     public static BlockingPairRow Read(DbDataReader reader) => new()
     {
         EventTime = reader.IsDBNull(0) ? default : reader.GetDateTime(0),
@@ -67,12 +119,21 @@ ORDER BY collection_time DESC";
         BlockingStatus = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
         BlockedSqlText = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
         BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
-        // Blocked-side identity (the 'blocked' row's own session). The Dashboard table does NOT parse the
-        // blocker's login/host/app from the XML (only blocking_status/blocking_last_tran_started/
-        // blocking_sql_text), so the blocking-side identity stays empty here — the pure apex shows SQL + db
-        // but no login/host/app. See BlockingChainViewerProjection / the PR notes for the schema follow-up.
         BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
         BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
         BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13)
     };
+
+    /// <summary>
+    /// Maps the viewer's <see cref="SqlWithBlockerIdentity"/> result: the core <see cref="Read"/> (0-13)
+    /// plus the correlated blocker identity at ordinals 14-16, so the apex node carries login/host/app.
+    /// </summary>
+    public static BlockingPairRow ReadWithBlockerIdentity(DbDataReader reader)
+    {
+        var row = Read(reader);
+        row.BlockingLoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14);
+        row.BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15);
+        row.BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16);
+        return row;
+    }
 }

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
@@ -427,8 +427,9 @@ namespace PerformanceMonitorDashboard.Services
                 /// Fetches the blocked/blocker pair rows for a window, for the block-chain viewer to feed
                 /// <see cref="BlockingChainReconstructor"/>. Internal (not public): <see cref="BlockingPairRow"/>
                 /// is internal to the analysis assembly — a public method returning it would be CS0050. Uses
-                /// the shared <see cref="BlockingPairRowQuery"/> so it filters apex rows identically to the
-                /// drill-down + fact collectors.
+                /// the viewer variant <see cref="BlockingPairRowQuery.SqlWithBlockerIdentity"/>: the same apex
+                /// filter as the drill-down + fact collectors, plus the correlated blocker identity so the apex
+                /// node shows login/host/app (the collectors keep the lighter query; they don't display it).
                 /// </summary>
                 internal async Task<List<BlockingPairRow>> GetBlockingPairRowsAsync(DateTime start, DateTime end)
                 {
@@ -437,13 +438,13 @@ namespace PerformanceMonitorDashboard.Services
                     await using var tc = await OpenThrottledConnectionAsync();
                     var connection = tc.Connection;
 
-                    using var command = new SqlCommand(BlockingPairRowQuery.Sql, connection);
+                    using var command = new SqlCommand(BlockingPairRowQuery.SqlWithBlockerIdentity, connection);
                     command.CommandTimeout = 120;
                     BlockingPairRowQuery.AddParameters(command, start, end);
 
                     using var reader = await command.ExecuteReaderAsync();
                     while (await reader.ReadAsync())
-                        rows.Add(BlockingPairRowQuery.Read(reader));
+                        rows.Add(BlockingPairRowQuery.ReadWithBlockerIdentity(reader));
 
                     return rows;
                 }

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -33,9 +33,12 @@ internal sealed class BlockingPairRow
     public string BlockedLoginName { get; init; } = string.Empty;
     public string BlockedHostName { get; init; } = string.Empty;
     public string BlockedClientApp { get; init; } = string.Empty;
-    public string BlockingLoginName { get; init; } = string.Empty;
-    public string BlockingHostName { get; init; } = string.Empty;
-    public string BlockingClientApp { get; init; } = string.Empty;
+    // Blocker-side identity is settable (not init) so the Dashboard viewer can enrich it after Read from
+    // the correlated activity='blocking' row — its table denormalizes only the blocked side (see Dashboard
+    // BlockingPairRowQuery.ReadWithBlockerIdentity). Lite sets all six in its Read object initializer.
+    public string BlockingLoginName { get; set; } = string.Empty;
+    public string BlockingHostName { get; set; } = string.Empty;
+    public string BlockingClientApp { get; set; } = string.Empty;
 }
 
 /// <summary>


### PR DESCRIPTION
## Resolve the Dashboard apex's login / host / app

Closes the Lite/Dashboard parity gap the block-chain viewer shipped with. The shared `BlockingChainControl` already renders session identity (login as the primary node label, a host/app line, and Login/Host/Client App in the properties panel), and **Lite already populates it for both sides** from its denormalized columns. **Dashboard only carried the _blocked_ side's identity**, so the apex (lead blocker) -- which never appears as a blocked row -- degraded to a bare `SPID`. Now both apps show who the lead blocker is. This is what "parity" meant; it is **not** a scope-down (Lite already worked).

### Approach -- app-side, no schema change
The blocker's identity already lives on its own `activity='blocking'` row in `collect.blocking_BlockedProcessReport` (`login_name`/`host_name`/`client_app` per process). The viewer's pair-row fetch correlates to it by `(event_time, spid)` via `OUTER APPLY ... TOP (1)`:
- `TOP (1)` collapses the one-to-many `'blocking'` rows a lead blocker emits when it blocks several victims in one report (identity is identical across them) -- prevents fan-out that would duplicate edges.
- bounded by the same `collection_time` window as the core query, so the clustered PK `(collection_time, blocking_id)` range-limits the lookup.

Scoped to the **viewer fetch only** (`SqlWithBlockerIdentity` / `ReadWithBlockerIdentity`); the background **fact + drill-down collectors keep the lighter shared query** (they score chains, never display identity), so no extra per-row correlation on the collection hot path.

Replaces the abandoned schema approach in #1217 (which added `blocking_*` columns nothing read, via an upgrade folder + version bump). No schema, no upgrade folder, no version bump.

### Files
- `PerformanceMonitor.Analysis/BlockingChainReconstructor.cs` -- `BlockingPairRow`'s 3 blocker-identity fields `init`->`set` (viewer enriches post-Read; `ChainLevel`'s stay `init`).
- `Dashboard/Analysis/BlockingPairRowQuery.cs` -- split `SelectBody` out of `Sql` (reused verbatim, no column/filter drift), add `SqlWithBlockerIdentity` + `ReadWithBlockerIdentity`.
- `Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs` -- viewer fetch uses the identity variant.

### Verification
- Dashboard + Lite build green (0 errors).
- Live on sql2025: **982/1000** pairs resolve the blocker identity; the rest are system sessions with no `'blocking'` row and fall back to SPID as before. Fan-out confirmed handled (341 duplicate `(event_time, spid)` groups, collapsed by `TOP (1)`).
- Pure tree-builder logic (apex identity from the blocking-side edge) already covered by `BlockingChainTreeBuilderTests.DeepLinearChain_NestsRootToGreatGrandchild_WithIdentity`.
- Adversarial code review: no blocker/major findings. T-SQL style review: one alias-form fix, applied.

### Your gate
Visual only: the Dashboard apex card now leads with the login (SPID secondary), matching Lite. Final visual check is yours from dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
