### PR TITLE
Deadlock viewer: drop victim strikethrough + open details card on load

### DIFF
--- a/PerformanceMonitor.Ui/DeadlockGraphControl.xaml.cs
+++ b/PerformanceMonitor.Ui/DeadlockGraphControl.xaml.cs
@@ -96,15 +96,8 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         var nodeToRestore = _selectedNode;
         Render();
 
-        if (nodeToRestore == null) return;
-        foreach (var child in GraphCanvas.Children)
-        {
-            if (child is Border b && ReferenceEquals(b.Tag, nodeToRestore))
-            {
-                SelectNode(b, nodeToRestore);
-                break;
-            }
-        }
+        if (nodeToRestore != null)
+            SelectNodeByModel(nodeToRestore);
     }
 
     /// <summary>
@@ -129,6 +122,13 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         BuildSummary();
         ShowEmptyState(false);
         Render();
+
+        // Open with the most informative node selected so the viewer lands with the details card showing
+        // (mirrors the block-chain viewer, which auto-selects the clicked session). Prefer a victim — the
+        // rolled-back process is the one you most want to inspect — else the first process.
+        var initial = _model.Processes.FirstOrDefault(p => p.IsVictim) ?? _model.Processes.FirstOrDefault();
+        if (initial != null)
+            SelectNodeByModel(initial);
     }
 
     private void ShowEmptyState(bool empty)
@@ -264,7 +264,8 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
             });
         }
 
-        // SQL preview (clipped). Victims are struck through — they were rolled back.
+        // SQL preview (clipped). The victim's red border already flags the rolled-back process — no
+        // strikethrough on the text (it hurt readability for no added signal).
         if (!string.IsNullOrEmpty(node.SqlText))
         {
             stack.Children.Add(new TextBlock
@@ -275,7 +276,6 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
                 Foreground = MutedBrush,
                 TextWrapping = TextWrapping.Wrap,
                 TextTrimming = TextTrimming.CharacterEllipsis,
-                TextDecorations = node.IsVictim ? TextDecorations.Strikethrough : null,
                 MaxHeight = 46,
                 Margin = new Thickness(0, 3, 0, 0)
             });
@@ -518,6 +518,19 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         }
     }
 
+    /// <summary>Finds the rendered border for a model node and selects it.</summary>
+    private void SelectNodeByModel(DeadlockProcessNode node)
+    {
+        foreach (var child in GraphCanvas.Children)
+        {
+            if (child is Border b && ReferenceEquals(b.Tag, node))
+            {
+                SelectNode(b, node);
+                return;
+            }
+        }
+    }
+
     private void SelectNode(Border border, DeadlockProcessNode node)
     {
         if (_selectedNodeBorder != null)
@@ -543,17 +556,7 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         var menu = new ContextMenu();
 
         var propsItem = new MenuItem { Header = "Properties" };
-        propsItem.Click += (_, _) =>
-        {
-            foreach (var child in GraphCanvas.Children)
-            {
-                if (child is Border b && ReferenceEquals(b.Tag, node))
-                {
-                    SelectNode(b, node);
-                    break;
-                }
-            }
-        };
+        propsItem.Click += (_, _) => SelectNodeByModel(node);
         menu.Items.Add(propsItem);
 
         if (!string.IsNullOrEmpty(node.SqlText))


### PR DESCRIPTION
Two pieces of viewer feedback, both in the shared `DeadlockGraphControl` (so both apps):

1. **Drop the victim strikethrough.** The red victim border already marks the rolled-back process; striking through its SQL text only hurt readability. Removed `TextDecorations = ... Strikethrough`.
2. **Open the details card on load.** The block-chain viewer auto-selects the clicked session and opens its properties panel, so it lands with an info card showing. The deadlock viewer opened with the panel collapsed and nothing selected. Now it auto-selects a node on load -- **prefers a victim** (the rolled-back process you most want to inspect), else the first process -- and opens the properties card, matching the block-chain viewer.

Also de-dups the "find the rendered border for a model node" loop (used by the theme re-select, the context menu, and the new load-time select) into a `SelectNodeByModel` helper, mirroring the block-chain control.

### Verification
- Dashboard + Lite build green (0 errors). Shared-control change, so both viewers get it.
- `SelectNodeByModel` no-ops safely if the node isn't found; `Render()` populates the canvas before the load-time select runs.

### Your gate
Visual, from dev: open a deadlock graph -- it should land with the (first) victim selected and its details panel open, and victim SQL text should no longer be struck through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
