### PR TITLE
Block-chain viewer: show the contended object + fix Lite resolution to match #812

### DIFF
--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -65,7 +65,8 @@ internal static class BlockingChainViewerProjection
             BlockedClientApp = l.BlockedClientApp,
             BlockingLoginName = l.BlockingLoginName,
             BlockingHostName = l.BlockingHostName,
-            BlockingClientApp = l.BlockingClientApp
+            BlockingClientApp = l.BlockingClientApp,
+            ContentiousObject = l.ContentiousObject
         }).ToList()
     };
 }

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -19,11 +19,12 @@ internal static class BlockingPairRowQuery
     private const string ReadUncommitted = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n";
 
     /// <summary>
-    /// The core pair SELECT (no SET preamble; ordinals 0-13). Kept separate from <see cref="Sql"/> so the
+    /// The core pair SELECT (no SET preamble; ordinals 0-14). Kept separate from <see cref="Sql"/> so the
     /// viewer variant <see cref="SqlWithBlockerIdentity"/> can reuse it verbatim as a derived table — the
     /// column list and the apex filter live in exactly one place and can't drift between the two queries.
-    /// Ordinals 11-13 are the BLOCKED row's own identity (login/host/app); the blocker's identity is not
-    /// stored on the blocked row, so a pure apex has no identity from this query alone (see the variant).
+    /// Ordinals 11-13 are the BLOCKED row's own identity (login/host/app); ordinal 14 is the contended
+    /// object (resolved by the collector / sp_HumanEventsBlockViewer). The blocker's identity is not stored
+    /// on the blocked row, so a pure apex has no identity from this query alone (see the variant).
     /// </summary>
     public const string SelectBody = @"
 SELECT TOP (5000)
@@ -40,7 +41,8 @@ SELECT TOP (5000)
     blocking_sql_text,
     login_name,
     host_name,
-    client_app
+    client_app,
+    contentious_object
 FROM collect.blocking_BlockedProcessReport
 WHERE collection_time >= @collectionWindow
 AND   event_time >= @startTime
@@ -62,7 +64,7 @@ ORDER BY collection_time DESC";
     /// same <c>collection_time</c> window as the core query, so the clustered PK (collection_time,
     /// blocking_id) range-limits the lookup. The background collectors keep the lighter <see cref="Sql"/>
     /// (they score chains and never display identity), so this extra correlation is paid only on the
-    /// infrequent, small-window viewer open. Maps via <see cref="ReadWithBlockerIdentity"/> (adds 14-16).
+    /// infrequent, small-window viewer open. Maps via <see cref="ReadWithBlockerIdentity"/> (adds 15-17).
     /// Result row order is intentionally unspecified: the inner TOP (5000) / ORDER BY selects the
     /// most-recent pairs, reconstruction is order-independent, and the sole caller's maxPairs equals the
     /// cap — so no outer ORDER BY is added (and collection_time is deliberately not projected, so don't
@@ -125,19 +127,20 @@ OUTER APPLY
         BlockingSqlText = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
         BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
         BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
-        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13)
+        BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
+        ContentiousObject = reader.IsDBNull(14) ? string.Empty : reader.GetString(14)
     };
 
     /// <summary>
-    /// Maps the viewer's <see cref="SqlWithBlockerIdentity"/> result: the core <see cref="Read"/> (0-13)
-    /// plus the correlated blocker identity at ordinals 14-16, so the apex node carries login/host/app.
+    /// Maps the viewer's <see cref="SqlWithBlockerIdentity"/> result: the core <see cref="Read"/> (0-14)
+    /// plus the correlated blocker identity at ordinals 15-17, so the apex node carries login/host/app.
     /// </summary>
     public static BlockingPairRow ReadWithBlockerIdentity(DbDataReader reader)
     {
         var row = Read(reader);
-        row.BlockingLoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14);
-        row.BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15);
-        row.BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16);
+        row.BlockingLoginName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15);
+        row.BlockingHostName = reader.IsDBNull(16) ? string.Empty : reader.GetString(16);
+        row.BlockingClientApp = reader.IsDBNull(17) ? string.Empty : reader.GetString(17);
         return row;
     }
 }

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -65,7 +65,8 @@ internal static class BlockingChainViewerProjection
             BlockedClientApp = l.BlockedClientApp,
             BlockingLoginName = l.BlockingLoginName,
             BlockingHostName = l.BlockingHostName,
-            BlockingClientApp = l.BlockingClientApp
+            BlockingClientApp = l.BlockingClientApp,
+            ContentiousObject = l.ContentiousObject
         }).ToList()
     };
 }

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -64,7 +64,9 @@ AND blocking_spid <> 0";
         BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
         BlockingLoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14),
         BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15),
-        BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16)
+        BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16),
+        // Ordinal 17: the contended object (every pair-row site appends contentious_object after IdentityColumns).
+        ContentiousObject = reader.IsDBNull(17) ? string.Empty : reader.GetString(17)
     };
 
     /// <summary>

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -121,7 +121,8 @@ SELECT
     {BlockingPairRowQuery.LeadingColumns},
     LEFT(blocked_sql_text, 500) AS blocked_sql,
     LEFT(blocking_sql_text, 500) AS blocking_sql,
-    {BlockingPairRowQuery.IdentityColumns}
+    {BlockingPairRowQuery.IdentityColumns},
+    contentious_object
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {BlockingPairRowQuery.SpidFilter}

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -206,7 +206,8 @@ SELECT
     {BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text,
     blocking_sql_text,
-    {BlockingPairRowQuery.IdentityColumns}
+    {BlockingPairRowQuery.IdentityColumns},
+    contentious_object
 FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   event_time >= $2

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -369,7 +369,8 @@ LIMIT 200";
 SELECT
     {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text, blocking_sql_text,
-    {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.IdentityColumns}
+    {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.IdentityColumns},
+    contentious_object
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.SpidFilter}

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -273,75 +273,47 @@ ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON DATABASE STATE = START;",
         var serverStatus = _serverManager.GetConnectionStatus(server.Id);
         bool isAzureSqlDb = serverStatus.SqlEngineEdition == 5;
 
-        string query;
-        if (isAzureSqlDb)
-        {
-            /* Azure SQL DB: read from ring_buffer (database-scoped session)
-               Use .query() to get XML with structure intact, then CONVERT to nvarchar(max) */
-            query = $@"
-SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-DECLARE
-    @PerformanceMonitor_BlockedProcess TABLE
-(
-    ring_buffer xml NOT NULL
-);
-
-INSERT
-    @PerformanceMonitor_BlockedProcess
-(
-    ring_buffer
-)
-SELECT /* PerformanceMonitorLite */
-    ring_xml = TRY_CAST(xet.target_data AS xml)
-FROM sys.dm_xe_database_session_targets AS xet
+        /* The ring-buffer source DMV is the only engine difference (database-scoped on Azure SQL DB,
+           server-scoped elsewhere); event extraction and the wait_resource -> object decode are shared. */
+        string ringBufferSource = isAzureSqlDb
+            ? @"sys.dm_xe_database_session_targets AS xet
 JOIN sys.dm_xe_database_sessions AS xes
-  ON xes.address = xet.event_session_address
-WHERE xes.name = N'{BlockedProcessXeSessionName}'
-AND   xet.target_name = N'ring_buffer'
-OPTION(RECOMPILE);
+  ON xes.address = xet.event_session_address"
+            : @"sys.dm_xe_session_targets AS xet
+JOIN sys.dm_xe_sessions AS xes
+  ON xes.address = xet.event_session_address";
 
-SELECT
-    x.event_time,
-    x.blocked_process_report_xml,
-    x.object_id,
-    x.database_id,
-    /* #1140: resolve the contentious object the blocked_process_report event already carries
-       (object_id/database_id). Mirrors sp_HumanEventsBlockViewer's contentious_object EXACTLY
-       (2-part schema.object + the same 'Unresolved: ...' fallback) so the dedup fingerprint
-       matches the Dashboard for the same object. OBJECT_NAME with the database_id arg resolves
-       cross-DB with no USE; NULL (cross-db perms / dropped object) -> the stable id fallback. */
-    contentious_object =
-        ISNULL
-        (
-            OBJECT_SCHEMA_NAME(x.object_id, x.database_id) + N'.' + OBJECT_NAME(x.object_id, x.database_id),
-            N'Unresolved: database: ' + ISNULL(DB_NAME(x.database_id), N'unknown') +
-            N' object_id: ' + ISNULL(CONVERT(nvarchar(20), x.object_id), N'unknown')
-        )
-FROM
-(
-    SELECT
-        event_time = evt.value('(@timestamp)[1]', 'datetime2'),
-        blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report')),
-        object_id = evt.value('(data[@name=""object_id""]/value/text())[1]', 'integer'),
-        database_id = evt.value('(data[@name=""database_id""]/value/text())[1]', 'integer')
-    FROM
-    (
-        SELECT
-            pmd.ring_buffer
-        FROM @PerformanceMonitor_BlockedProcess AS pmd
-    ) AS rb
-    CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
-    WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
-) AS x
-OPTION(RECOMPILE);";
-        }
-        else
-        {
-            /* On-prem / Azure MI: read from ring_buffer (server-scoped session)
-               Use .query() to get XML with structure intact, then CONVERT to nvarchar(max) */
-            query = $@"
+        /* Resolve contentious_object from wait_resource (KEY hobt -> sys.partitions, OBJECT objid,
+           PAGE/RID -> sys.dm_db_page_info), mirroring sp_HumanEventsBlockViewer (DarlingData #812) so
+           Dashboard and Lite -- and the #1140 dedup fingerprint -- agree. The event object_id/database_id
+           is unreliable for lock waits, kept only as a COALESCE fallback. Cross-db lookups are per-database
+           dynamic SQL guarded by DB-online + TRY/CATCH; the 2019+ DMV is version-gated (or @azure, which
+           reports ProductVersion 12 on Azure SQL DB). #bpr is a #temp (not a table var) so the dynamic SQL
+           can see it. The final SELECT keeps the original 5 columns, so the reader/appender is unchanged. */
+        string query = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+DECLARE
+    @product_version integer =
+        CONVERT
+        (
+            integer,
+            PARSENAME
+            (
+                CONVERT(sysname, SERVERPROPERTY('ProductVersion')),
+                4
+            )
+        ),
+    @azure bit =
+        CASE
+            WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) = 5
+            THEN 1
+            ELSE 0
+        END,
+    @resolve_sql nvarchar(max),
+    @resolve_database_id integer,
+    @key_dbs CURSOR,
+    @page_dbs CURSOR;
 
 DECLARE
     @PerformanceMonitor_BlockedProcess TABLE
@@ -356,9 +328,7 @@ INSERT
 )
 SELECT /* PerformanceMonitorLite */
     ring_xml = TRY_CAST(xet.target_data AS xml)
-FROM sys.dm_xe_session_targets AS xet
-JOIN sys.dm_xe_sessions AS xes
-  ON xes.address = xet.event_session_address
+FROM {ringBufferSource}
 WHERE xes.name = N'{BlockedProcessXeSessionName}'
 AND   xet.target_name = N'ring_buffer'
 OPTION(RECOMPILE);
@@ -368,36 +338,250 @@ SELECT
     x.blocked_process_report_xml,
     x.object_id,
     x.database_id,
-    /* #1140: resolve the contentious object the blocked_process_report event already carries
-       (object_id/database_id). Mirrors sp_HumanEventsBlockViewer's contentious_object EXACTLY
-       (2-part schema.object + the same 'Unresolved: ...' fallback) so the dedup fingerprint
-       matches the Dashboard for the same object. OBJECT_NAME with the database_id arg resolves
-       cross-DB with no USE; NULL (cross-db perms / dropped object) -> the stable id fallback. */
-    contentious_object =
-        ISNULL
-        (
-            OBJECT_SCHEMA_NAME(x.object_id, x.database_id) + N'.' + OBJECT_NAME(x.object_id, x.database_id),
-            N'Unresolved: database: ' + ISNULL(DB_NAME(x.database_id), N'unknown') +
-            N' object_id: ' + ISNULL(CONVERT(nvarchar(20), x.object_id), N'unknown')
-        )
+    x.wait_resource,
+    lock_type = CONVERT(varchar(32), NULL),
+    frag = CONVERT(nvarchar(1024), NULL),
+    resource_database_id = CONVERT(integer, NULL),
+    resource_hobt_id = CONVERT(bigint, NULL),
+    resource_file_id = CONVERT(integer, NULL),
+    resource_page_id = CONVERT(bigint, NULL),
+    resource_object_id = CONVERT(integer, NULL),
+    contentious_object = CONVERT(nvarchar(4000), NULL)
+INTO #bpr
 FROM
 (
     SELECT
         event_time = evt.value('(@timestamp)[1]', 'datetime2'),
         blocked_process_report_xml = CONVERT(nvarchar(max), evt.query('data[@name=""blocked_process""]/value/blocked-process-report')),
         object_id = evt.value('(data[@name=""object_id""]/value/text())[1]', 'integer'),
-        database_id = evt.value('(data[@name=""database_id""]/value/text())[1]', 'integer')
-    FROM
-    (
-        SELECT
-            pmd.ring_buffer
-        FROM @PerformanceMonitor_BlockedProcess AS pmd
-    ) AS rb
+        database_id = evt.value('(data[@name=""database_id""]/value/text())[1]', 'integer'),
+        wait_resource = evt.value('(data[@name=""blocked_process""]/value/blocked-process-report/blocked-process/process/@waitresource)[1]', 'nvarchar(1024)')
+    FROM @PerformanceMonitor_BlockedProcess AS rb
     CROSS APPLY rb.ring_buffer.nodes('RingBufferTarget/event[@name=""blocked_process_report""]') AS q(evt)
     WHERE evt.value('(@timestamp)[1]', 'datetime2') > @cutoff_time
 ) AS x
+OPTION(RECOMPILE);
+
+/* Classify the lock resource (prefers an embedded KEY/PAGE in a compound resource). */
+UPDATE
+    b
+SET
+    b.lock_type =
+        CASE
+            WHEN b.wait_resource LIKE N'%KEY: %'    THEN 'KEY'
+            WHEN b.wait_resource LIKE N'%OBJECT: %' THEN 'OBJECT'
+            WHEN b.wait_resource LIKE N'%RID: %'    THEN 'RID'
+            WHEN b.wait_resource LIKE N'%PAGE: %'   THEN 'PAGE'
+            ELSE LEFT(UPPER(LEFT(b.wait_resource, CHARINDEX(N':', b.wait_resource + N':') - 1)), 32)
+        END
+FROM #bpr AS b
+WHERE b.wait_resource IS NOT NULL
+AND   b.wait_resource <> N''
+OPTION(RECOMPILE);
+
+UPDATE
+    b
+SET
+    b.frag =
+        SUBSTRING
+        (
+            b.wait_resource,
+            CHARINDEX(b.lock_type + N': ', b.wait_resource) + LEN(b.lock_type) + 2,
+            1024
+        )
+FROM #bpr AS b
+WHERE b.lock_type IN ('KEY', 'OBJECT', 'RID', 'PAGE')
+OPTION(RECOMPILE);
+
+UPDATE
+    b
+SET
+    b.resource_database_id =
+        TRY_CONVERT(integer, LEFT(b.frag, CHARINDEX(N':', b.frag + N':') - 1))
+FROM #bpr AS b
+WHERE b.frag IS NOT NULL
+OPTION(RECOMPILE);
+
+UPDATE
+    b
+SET
+    b.resource_hobt_id =
+        TRY_CONVERT(bigint, LTRIM(LEFT(r.rest, CHARINDEX(N' ', r.rest + N' ') - 1)))
+FROM #bpr AS b
+CROSS APPLY
+(
+    SELECT
+        rest = SUBSTRING(b.frag, CHARINDEX(N':', b.frag) + 1, 1024)
+) AS r
+WHERE b.lock_type = 'KEY'
+OPTION(RECOMPILE);
+
+UPDATE
+    b
+SET
+    b.resource_object_id =
+        TRY_CONVERT(integer, LEFT(r.rest, CHARINDEX(N':', r.rest + N':') - 1))
+FROM #bpr AS b
+CROSS APPLY
+(
+    SELECT
+        rest = SUBSTRING(b.frag, CHARINDEX(N':', b.frag) + 1, 1024)
+) AS r
+WHERE b.lock_type = 'OBJECT'
+OPTION(RECOMPILE);
+
+UPDATE
+    b
+SET
+    b.resource_file_id =
+        TRY_CONVERT(integer, LEFT(r.rest, CHARINDEX(N':', r.rest + N':') - 1)),
+    b.resource_page_id =
+        TRY_CONVERT(bigint, LEFT(p.rest2, CHARINDEX(N':', p.rest2 + N':') - 1))
+FROM #bpr AS b
+CROSS APPLY
+(
+    SELECT
+        rest = SUBSTRING(b.frag, CHARINDEX(N':', b.frag) + 1, 1024)
+) AS r
+CROSS APPLY
+(
+    SELECT
+        rest2 = SUBSTRING(r.rest, CHARINDEX(N':', r.rest) + 1, 1024)
+) AS p
+WHERE b.lock_type IN ('PAGE', 'RID')
+OPTION(RECOMPILE);
+
+/* KEY -> object_id via sys.partitions, per contended database (no cross-db form of the view). */
+SET @key_dbs =
+    CURSOR
+    LOCAL FAST_FORWARD
+    FOR
+    SELECT DISTINCT
+        b.resource_database_id
+    FROM #bpr AS b
+    WHERE b.lock_type = 'KEY'
+    AND   b.resource_database_id IS NOT NULL
+    AND   b.resource_hobt_id IS NOT NULL;
+
+OPEN @key_dbs;
+FETCH NEXT FROM @key_dbs INTO @resolve_database_id;
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    IF DB_NAME(@resolve_database_id) IS NOT NULL
+    AND DATABASEPROPERTYEX(DB_NAME(@resolve_database_id), 'Status') = N'ONLINE'
+    BEGIN
+        SET @resolve_sql = N'
+        BEGIN TRY
+            UPDATE b
+            SET b.resource_object_id = p.object_id
+            FROM #bpr AS b
+            JOIN ' + QUOTENAME(DB_NAME(@resolve_database_id)) + N'.sys.partitions AS p
+              ON p.hobt_id = b.resource_hobt_id
+            WHERE b.lock_type = ''KEY''
+            AND   b.resource_database_id = @resolve_database_id
+            OPTION(RECOMPILE);
+        END TRY
+        BEGIN CATCH
+            /* no metadata access to the database -> leave for labeling */
+        END CATCH;';
+        EXECUTE sys.sp_executesql
+            @resolve_sql,
+          N'@resolve_database_id integer',
+            @resolve_database_id;
+    END;
+    FETCH NEXT FROM @key_dbs INTO @resolve_database_id;
+END;
+
+/* PAGE / RID -> object_id via sys.dm_db_page_info (2019+ or Azure SQL DB; VIEW DATABASE STATE -> TRY/CATCH). */
+IF @product_version >= 15
+OR @azure = 1
+BEGIN
+    SET @page_dbs =
+        CURSOR
+        LOCAL FAST_FORWARD
+        FOR
+        SELECT DISTINCT
+            b.resource_database_id
+        FROM #bpr AS b
+        WHERE b.lock_type IN ('PAGE', 'RID')
+        AND   b.resource_database_id IS NOT NULL
+        AND   b.resource_page_id IS NOT NULL;
+
+    OPEN @page_dbs;
+    FETCH NEXT FROM @page_dbs INTO @resolve_database_id;
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        IF DB_NAME(@resolve_database_id) IS NOT NULL
+        AND DATABASEPROPERTYEX(DB_NAME(@resolve_database_id), 'Status') = N'ONLINE'
+        BEGIN
+            SET @resolve_sql = N'
+            BEGIN TRY
+                UPDATE b
+                SET b.resource_object_id = pi.object_id
+                FROM #bpr AS b
+                CROSS APPLY sys.dm_db_page_info(b.resource_database_id, b.resource_file_id, b.resource_page_id, ''LIMITED'') AS pi
+                WHERE b.lock_type IN (''PAGE'', ''RID'')
+                AND   b.resource_database_id = @resolve_database_id
+                OPTION(RECOMPILE);
+            END TRY
+            BEGIN CATCH
+                /* no VIEW DATABASE STATE / page reallocated -> leave for labeling */
+            END CATCH;';
+            EXECUTE sys.sp_executesql
+                @resolve_sql,
+              N'@resolve_database_id integer',
+                @resolve_database_id;
+        END;
+        FETCH NEXT FROM @page_dbs INTO @resolve_database_id;
+    END;
+END;
+
+/* Format (plain schema.object) + label; the event object_id is the fallback, then the Unresolved sentinel. */
+UPDATE
+    b
+SET
+    b.contentious_object =
+        COALESCE
+        (
+            CASE
+                WHEN b.resource_object_id > 0
+                AND  OBJECT_NAME(b.resource_object_id, b.resource_database_id) IS NOT NULL
+                THEN CONCAT
+                     (
+                         OBJECT_SCHEMA_NAME(b.resource_object_id, b.resource_database_id),
+                         N'.',
+                         OBJECT_NAME(b.resource_object_id, b.resource_database_id)
+                     )
+            END,
+            CASE
+                WHEN b.object_id > 0
+                AND  OBJECT_NAME(b.object_id, b.database_id) IS NOT NULL
+                THEN CONCAT
+                     (
+                         OBJECT_SCHEMA_NAME(b.object_id, b.database_id),
+                         N'.',
+                         OBJECT_NAME(b.object_id, b.database_id)
+                     )
+            END,
+            N'Unresolved: ' +
+            CASE
+                WHEN b.lock_type IS NULL
+                THEN N''
+                ELSE LOWER(b.lock_type) + N' lock, '
+            END +
+            N'database: ' + ISNULL(DB_NAME(b.database_id), N'unknown')
+        )
+FROM #bpr AS b
+OPTION(RECOMPILE);
+
+SELECT
+    b.event_time,
+    b.blocked_process_report_xml,
+    b.object_id,
+    b.database_id,
+    b.contentious_object
+FROM #bpr AS b
 OPTION(RECOMPILE);";
-        }
 
         var serverId = GetServerId(server);
         var collectionTime = DateTime.UtcNow;

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -39,6 +39,8 @@ internal sealed class BlockingPairRow
     public string BlockingLoginName { get; set; } = string.Empty;
     public string BlockingHostName { get; set; } = string.Empty;
     public string BlockingClientApp { get; set; } = string.Empty;
+    /// <summary>The contended object (schema.object where resolvable) — the blocked row's contentious_object.</summary>
+    public string ContentiousObject { get; init; } = string.Empty;
 }
 
 /// <summary>
@@ -69,6 +71,8 @@ internal sealed class ChainLevel
     public string BlockingLoginName { get; init; } = string.Empty;
     public string BlockingHostName { get; init; } = string.Empty;
     public string BlockingClientApp { get; init; } = string.Empty;
+    /// <summary>The contended object for this edge — the blocked side's contentious_object.</summary>
+    public string ContentiousObject { get; init; } = string.Empty;
 }
 
 /// <summary>A single reconstructed blocking chain, rooted at an apex head blocker.</summary>
@@ -448,7 +452,8 @@ internal static class BlockingChainReconstructor
                     BlockedClientApp = row.BlockedClientApp ?? string.Empty,
                     BlockingLoginName = row.BlockingLoginName ?? string.Empty,
                     BlockingHostName = row.BlockingHostName ?? string.Empty,
-                    BlockingClientApp = row.BlockingClientApp ?? string.Empty
+                    BlockingClientApp = row.BlockingClientApp ?? string.Empty,
+                    ContentiousObject = row.ContentiousObject ?? string.Empty
                 });
 
                 if (enqueued.Add(child))

--- a/PerformanceMonitor.Common/BlockingChainModel.cs
+++ b/PerformanceMonitor.Common/BlockingChainModel.cs
@@ -73,6 +73,10 @@ namespace PerformanceMonitor.Common
         public string HostName { get; init; } = string.Empty;
         public string ClientApp { get; init; } = string.Empty;
 
+        /// <summary>The object this session is waiting on (the contended resource), resolved to
+        /// schema.object where possible. Empty for the apex — it waits on no one.</summary>
+        public string ContentiousObject { get; init; } = string.Empty;
+
         /// <summary>Direct victims of this node, ordered deterministically.</summary>
         public List<BlockingChainNode> Children { get; init; } = new();
 
@@ -123,5 +127,8 @@ namespace PerformanceMonitor.Common
         public string BlockingLoginName { get; init; } = string.Empty;
         public string BlockingHostName { get; init; } = string.Empty;
         public string BlockingClientApp { get; init; } = string.Empty;
+        /// <summary>The contended object on this edge (what the blocked side waits on). The victim node
+        /// takes its ContentiousObject from its incoming edge; the apex has none.</summary>
+        public string ContentiousObject { get; init; } = string.Empty;
     }
 }

--- a/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
+++ b/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
@@ -146,7 +146,9 @@ namespace PerformanceMonitor.Common
                             // incoming edge (where it is the blocked party).
                             LoginName = edge.BlockedLoginName,
                             HostName = edge.BlockedHostName,
-                            ClientApp = edge.BlockedClientApp
+                            ClientApp = edge.BlockedClientApp,
+                            // The object this victim is waiting on — its incoming edge's contended resource.
+                            ContentiousObject = edge.ContentiousObject
                         };
                         node.Children.Add(child);
                         next.Add((childKey, child));

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -30,7 +30,7 @@ namespace PerformanceMonitor.Ui;
 public partial class BlockingChainControl : UserControl, IGraphViewer
 {
     private const double NodeWidth = BlockingChainLayout.NodeWidth;
-    private const double NodeHeight = 150;
+    private const double NodeHeight = 166;
 
     private BlockingChainModel? _model;
     private double _zoomLevel = 1.0;
@@ -270,6 +270,10 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         if (!string.IsNullOrEmpty(node.DatabaseName))
             stack.Children.Add(MutedLine(node.DatabaseName));
 
+        // Contended object — what this victim is waiting on (the apex waits on no one, so has none)
+        if (!string.IsNullOrEmpty(node.ContentiousObject))
+            stack.Children.Add(MutedLine(node.ContentiousObject));
+
         // Lock mode + wait (victims only — the apex waits on no one)
         if (!node.IsApex && (node.WaitTimeMs > 0 || !string.IsNullOrEmpty(node.LockMode)))
         {
@@ -459,6 +463,8 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
             AddPropRow("Transaction Started", node.TranStarted.Value.ToString("yyyy-MM-dd HH:mm:ss"));
         if (!string.IsNullOrEmpty(node.DatabaseName))
             AddPropRow("Database", node.DatabaseName);
+        if (!string.IsNullOrEmpty(node.ContentiousObject))
+            AddPropRow("Contended Object", node.ContentiousObject);
         if (!node.IsApex)
         {
             if (!string.IsNullOrEmpty(node.LockMode))


### PR DESCRIPTION
Completes the contended-object work, with full Dashboard/Lite parity.

### (a) Surface the contended object on the viewer nodes (both apps)
A single `ContentiousObject` is threaded the same way as the apex identity (#1218): pair-row query column -> `BlockingPairRow` -> `ChainLevel` -> `BlockingEdgeInput` -> the **victim** node (the apex waits on nothing) -> rendered on the node card + the properties panel. Dashboard `SelectBody` adds the column (ordinal 14; `ReadWithBlockerIdentity` shifts to 15-17); Lite's three pair-row sites append it (shared `Read` ordinal 17). `NodeHeight` bumped to fit the extra line.

### (b) Fix Lite's `contentious_object` resolution to match #812
#812 changed `sp_HumanEventsBlockViewer` (Dashboard) to decode the object from `wait_resource`, but Lite's `RemoteCollectorService` still resolved via the unreliable event `object_id` — drifting Lite from Dashboard and breaking the #1140 cross-app dedup fingerprint. Lite's collection query now runs the **same** wait_resource decode (KEY hobt -> `sys.partitions`, OBJECT objid, PAGE/RID -> `sys.dm_db_page_info`; per-database dynamic SQL, version/Azure gated, `TRY/CATCH` for permission/access), unifying the two ring-buffer variants. The event `object_id` is kept as a `COALESCE` fallback, and the final SELECT keeps the original five columns so the reader/appender is unchanged.

### Verification
- Both apps build green.
- Lite decode validated on SQL 2025: ~0.3% -> ~97% resolved (matches the Dashboard #812 rate).
- Review (correctness + T-SQL style): fixed the `Unresolved` label to use the event database (matches #812, re-aligns the #1140 fingerprint) and reformatted the decode to #812's layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
