### PR TITLE
Deadlock viewer: contended object on nodes + boxed independent cycles

### DIFF
--- a/Dashboard.Tests/DeadlockGraphLayoutTests.cs
+++ b/Dashboard.Tests/DeadlockGraphLayoutTests.cs
@@ -111,4 +111,61 @@ public class DeadlockGraphLayoutTests
         Assert.True(width > 0);
         Assert.True(height > 0);
     }
+
+    private static bool Within(DeadlockProcessNode n, DeadlockComponentBox b, double eps = 0.5) =>
+        n.X >= b.X - eps && n.X + DeadlockGraphLayout.NodeWidth <= b.X + b.Width + eps &&
+        n.Y >= b.Y - eps && n.Y + DeadlockGraphLayout.NodeHeight <= b.Y + b.Height + eps;
+
+    [Theory]
+    [InlineData("deadlock_2proc_real_sql2025.xml", 1)]
+    [InlineData("deadlock_5proc_real_sql2025.xml", 2)]            // 3-cycle + 2-cycle
+    [InlineData("deadlock_8proc_multivictim_real_sql2025.xml", 4)] // four 2-cycles
+    [InlineData("deadlock_single5cycle_synthetic.xml", 1)]
+    [InlineData("deadlock_crossproduct_synthetic.xml", 1)]
+    [InlineData("deadlock_parallel_selfedge_synthetic.xml", 1)]   // a<->b via exchange edges = one component
+    public void Layout_PopulatesOneBoxPerComponent(string fixture, int expectedComponents)
+    {
+        var m = Parse(fixture);
+        DeadlockGraphLayout.Layout(m);
+
+        Assert.Equal(expectedComponents, m.ComponentBoxes.Count);
+        Assert.Equal(m.Processes.Count, m.ComponentBoxes.Sum(b => b.NodeCount)); // every process is in one box
+        Assert.Equal(Enumerable.Range(1, expectedComponents), m.ComponentBoxes.Select(b => b.Index));
+
+        // Every card lands inside exactly one component box (so a drawn frame contains exactly its cycle).
+        foreach (var n in m.Processes)
+            Assert.Equal(1, m.ComponentBoxes.Count(b => Within(n, b)));
+    }
+
+    [Fact]
+    public void ComponentBoxes_LoneNode_IsNotCountedAsACycle()
+    {
+        // The viewer frames/counts only components with >= 2 processes. A node connected solely by a self-edge
+        // is its own 1-node component and must NOT read as an independent cycle. No real fixture produces one,
+        // so build it: a<->b is a real 2-cycle and c carries only a self-edge.
+        var model = new DeadlockGraphModel
+        {
+            Processes = new[]
+            {
+                new DeadlockProcessNode { Id = "a", Spid = 60 },
+                new DeadlockProcessNode { Id = "b", Spid = 61 },
+                new DeadlockProcessNode { Id = "c", Spid = 62 },
+            },
+            Edges = new[]
+            {
+                new DeadlockWaitEdge { WaiterProcessId = "a", OwnerProcessId = "b", ResourceKind = "pagelock", ResourceLabel = "PAGE db.dbo.t" },
+                new DeadlockWaitEdge { WaiterProcessId = "b", OwnerProcessId = "a", ResourceKind = "pagelock", ResourceLabel = "PAGE db.dbo.t" },
+                new DeadlockWaitEdge { WaiterProcessId = "c", OwnerProcessId = "c", ResourceKind = "exchangeEvent", ResourceLabel = "Parallelism" },
+            }
+        };
+
+        DeadlockGraphLayout.Layout(model);
+
+        Assert.Equal(2, model.ComponentBoxes.Count);                          // a<->b, and lone c
+        Assert.Equal(1, model.ComponentBoxes.Count(b => b.NodeCount >= 2));   // only a<->b is a cycle
+
+        var multi = Parse("deadlock_8proc_multivictim_real_sql2025.xml");
+        DeadlockGraphLayout.Layout(multi);
+        Assert.Equal(4, multi.ComponentBoxes.Count(b => b.NodeCount >= 2));   // four real cycles
+    }
 }

--- a/Dashboard.Tests/DeadlockGraphParserTests.cs
+++ b/Dashboard.Tests/DeadlockGraphParserTests.cs
@@ -191,6 +191,46 @@ public class DeadlockGraphParserTests
         }, SpidEdges(m));
     }
 
+    // ── contended object (resolved straight off the deadlock resource-list) ──
+
+    [Fact]
+    public void ContentiousObject_MatchesEachNodesOutgoingEdgeLabel()
+    {
+        var m = DeadlockGraphParser.Parse(LoadFixture("deadlock_2proc_real_sql2025.xml"));
+
+        // A process's contended object is the resolved label of the resource it waits on (its outgoing edge).
+        foreach (var node in m.Processes)
+        {
+            var waitsOn = m.Edges.First(e => e.WaiterProcessId == node.Id && !e.IsSelfEdge);
+            Assert.Equal(waitsOn.ResourceLabel, node.ContentiousObject);
+            Assert.False(string.IsNullOrEmpty(node.ContentiousObject));
+        }
+
+        // Concretely: the victim contends for the page it was blocked on — no DMV lookup, no raw "7:1:..." id.
+        var bySpid = m.Processes.ToDictionary(p => p.Spid);
+        Assert.Equal("PAGE hammerdb_tpcc.dbo.new_order", bySpid[103].ContentiousObject);
+    }
+
+    [Fact]
+    public void ContentiousObject_CrossProduct_IsTheSharedObject()
+    {
+        var m = DeadlockGraphParser.Parse(LoadFixture("deadlock_crossproduct_synthetic.xml"));
+        var bySpid = m.Processes.ToDictionary(p => p.Spid);
+
+        // Both waiters on the single objectlock surface the same resolved object.
+        Assert.Equal("OBJECT StackOverflow.dbo.Votes", bySpid[203].ContentiousObject);
+        Assert.Equal("OBJECT StackOverflow.dbo.Votes", bySpid[204].ContentiousObject);
+    }
+
+    [Fact]
+    public void ContentiousObject_Empty_WhenProcessWaitsOnlyOnAParallelSelfEdge()
+    {
+        var m = DeadlockGraphParser.Parse(LoadFixture("deadlock_parallel_selfedge_synthetic.xml"));
+
+        // Parallel threads wait on the exchange itself (a self-edge) — there is no contended OBJECT to show.
+        Assert.All(m.Processes, p => Assert.Equal(string.Empty, p.ContentiousObject));
+    }
+
     // ── robustness ──
 
     [Theory]

--- a/PerformanceMonitor.Common/DeadlockGraphLayout.cs
+++ b/PerformanceMonitor.Common/DeadlockGraphLayout.cs
@@ -29,7 +29,7 @@ namespace PerformanceMonitor.Common
     public static class DeadlockGraphLayout
     {
         public const double NodeWidth = 240;
-        public const double NodeHeight = 130;
+        public const double NodeHeight = 150;   // fits SPID + proc + contended object + lock/wait + SQL preview
         public const double Padding = 40;
         public const double NodeGap = 70;        // min clear space between two cards on a ring
         public const double ComponentGap = 70;   // gap between component rings when tiled
@@ -94,6 +94,8 @@ namespace PerformanceMonitor.Common
             double rowWidthLimit = targetCols * (maxBoxW + ComponentGap);
 
             double x = Padding, rowTop = Padding, rowMaxH = 0, maxRight = 0;
+            var boxes = new List<DeadlockComponentBox>(laidOut.Count);
+            int cycleIndex = 0;
             foreach (var comp in laidOut)
             {
                 if (x > Padding && x + comp.Width > Padding + rowWidthLimit)
@@ -109,11 +111,24 @@ namespace PerformanceMonitor.Common
                     node.Y = rowTop + localY;
                 }
 
+                // The component's cards span [x, x+Width] x [rowTop, rowTop+Height] — capture it so the viewer
+                // can frame each independent cycle. Index is 1-based in the (biggest-first) tiling order.
+                boxes.Add(new DeadlockComponentBox
+                {
+                    Index = ++cycleIndex,
+                    NodeCount = comp.Nodes.Count,
+                    X = x,
+                    Y = rowTop,
+                    Width = comp.Width,
+                    Height = comp.Height
+                });
+
                 maxRight = Math.Max(maxRight, x + comp.Width);
                 x += comp.Width + ComponentGap;
                 rowMaxH = Math.Max(rowMaxH, comp.Height);
             }
 
+            model.ComponentBoxes = boxes;
             return (maxRight + Padding, rowTop + rowMaxH + Padding);
         }
 

--- a/PerformanceMonitor.Common/DeadlockGraphModel.cs
+++ b/PerformanceMonitor.Common/DeadlockGraphModel.cs
@@ -36,8 +36,36 @@ namespace PerformanceMonitor.Common
         /// null (both apps strip the wrapper before storage); the launch glue supplies the time it knows.</summary>
         public DateTime? EventTime { get; init; }
 
+        /// <summary>
+        /// Bounding boxes of the independent cycles (connected components of the waits-for graph), in canvas
+        /// coordinates, assigned by <see cref="DeadlockGraphLayout"/>. A single &lt;deadlock&gt; element often
+        /// batches several independent cycles that share no resource (the deadlock monitor reports them as one
+        /// graph); the viewer draws one labelled box per entry so they read as the distinct sub-graphs they are.
+        /// One entry per cycle, biggest first. Layout output, so it follows the same set-after-construction
+        /// pattern as <see cref="DeadlockProcessNode.X"/>/<see cref="DeadlockProcessNode.Y"/>.
+        /// </summary>
+        public IReadOnlyList<DeadlockComponentBox> ComponentBoxes { get; set; } = Array.Empty<DeadlockComponentBox>();
+
         /// <summary>True when the XML produced no processes (empty range, unparseable, or non-deadlock XML).</summary>
         public bool IsEmpty => Processes.Count == 0;
+    }
+
+    /// <summary>
+    /// The canvas-space bounding box of one independent cycle (a connected component of the waits-for graph),
+    /// produced by <see cref="DeadlockGraphLayout"/>. <see cref="Index"/> is 1-based for display ("Cycle 1").
+    /// </summary>
+    public sealed class DeadlockComponentBox
+    {
+        /// <summary>1-based cycle number for display (biggest cycle is 1).</summary>
+        public int Index { get; init; }
+
+        /// <summary>How many processes the cycle contains.</summary>
+        public int NodeCount { get; init; }
+
+        public double X { get; init; }
+        public double Y { get; init; }
+        public double Width { get; init; }
+        public double Height { get; init; }
     }
 
     /// <summary>
@@ -68,6 +96,16 @@ namespace PerformanceMonitor.Common
 
         /// <summary>The resource this process was blocked on (raw <c>waitresource</c> string).</summary>
         public string WaitResource { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The resolved contended resource: the friendly lock kind + object name from the first resource this
+        /// process waits on (its first non-self "waits for" edge), e.g. "PAGE hammerdb_tpcc.dbo.new_order".
+        /// Assigned by <see cref="DeadlockGraphParser"/> after edges are built; SQL Server already resolved the
+        /// objectname in the deadlock resource-list, so this needs no DMV lookup. Empty for a process that only
+        /// owns (no outgoing wait), waits solely on a parallelism exchange, or whose wait resource carried no
+        /// object name (system table / Azure). Mirrors the block-chain viewer's contended-object surface.
+        /// </summary>
+        public string ContentiousObject { get; set; } = string.Empty;
 
         /// <summary>How long this process had been waiting, in ms.</summary>
         public long WaitTimeMs { get; init; }

--- a/PerformanceMonitor.Common/DeadlockGraphParser.cs
+++ b/PerformanceMonitor.Common/DeadlockGraphParser.cs
@@ -88,6 +88,11 @@ namespace PerformanceMonitor.Common
 
                 var (edges, isParallel) = ParseEdges(deadlock);
 
+                // Surface the resolved contended resource on each waiting process (parity with the block-chain
+                // viewer). SQL Server already resolved the objectname in the resource-list, so this is a pure
+                // projection of the edges — no DMV/object lookup needed (the whole reason deadlocks are easier).
+                AssignContendedObjects(processes, edges);
+
                 return new DeadlockGraphModel
                 {
                     Processes = processes,
@@ -206,6 +211,31 @@ namespace PerformanceMonitor.Common
             }
 
             return (edges, isParallel);
+        }
+
+        /// <summary>
+        /// Sets <see cref="DeadlockProcessNode.ContentiousObject"/> on each process to the resolved label of
+        /// the first lock resource it waits on (its first non-self lock edge). Pure projection of the edges
+        /// SQL Server already resolved — no object lookup. Empty for a process that only owns (no outgoing
+        /// wait), waits solely on a parallelism exchange (which is coordination, not a contended object), or
+        /// whose wait resource carried no object name.
+        /// </summary>
+        private static void AssignContendedObjects(
+            IReadOnlyList<DeadlockProcessNode> processes,
+            IReadOnlyList<DeadlockWaitEdge> edges)
+        {
+            foreach (var node in processes)
+            {
+                foreach (var edge in edges)
+                {
+                    if (!string.Equals(edge.WaiterProcessId, node.Id, StringComparison.Ordinal)) continue;
+                    if (edge.IsSelfEdge) continue;
+                    if (ParallelElementNames.Contains(edge.ResourceKind)) continue; // the exchange is not a contended object
+                    if (string.IsNullOrEmpty(edge.ResourceLabel)) continue;
+                    node.ContentiousObject = edge.ResourceLabel;
+                    break;
+                }
+            }
         }
 
         /// <summary>The statement to lead the card with: the process input buffer, falling back to the

--- a/PerformanceMonitor.Ui/DeadlockGraphControl.xaml.cs
+++ b/PerformanceMonitor.Ui/DeadlockGraphControl.xaml.cs
@@ -119,9 +119,9 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
             return;
         }
 
-        BuildSummary();
         ShowEmptyState(false);
-        Render();
+        Render();        // assigns _model.ComponentBoxes, which BuildSummary's cycle count reads
+        BuildSummary();
 
         // Open with the most informative node selected so the viewer lands with the details card showing
         // (mirrors the block-chain viewer, which auto-selects the clicked session). Prefer a victim — the
@@ -144,6 +144,11 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         var victims = _model.Processes.Count(p => p.IsVictim);
         var procs = _model.Processes.Count;
         var summary = $"{procs} process{(procs == 1 ? "" : "es")} · {victims} victim{(victims == 1 ? "" : "s")}";
+        // A single <deadlock> can batch several independent cycles that share no resource — call the count out
+        // so the separate boxes don't read as "two unrelated deadlocks shown together by mistake."
+        var cycles = _model.ComponentBoxes.Count(b => b.NodeCount >= 2);
+        if (cycles > 1)
+            summary += $" · {cycles} independent cycles";
         // Shown only when the parsed XML carried an event wrapper with a timestamp (e.g. raw collect XML
         // or the Azure report); the bare <deadlock> the apps store has none, so this stays off there.
         if (_model.EventTime.HasValue)
@@ -179,6 +184,9 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         GraphCanvas.Width = width;
         GraphCanvas.Height = height;
 
+        // Cycle frames first, so they sit behind the edges and cards as a grouping backdrop.
+        RenderCycleBoxes();
+
         var byId = _model.Processes.ToDictionary(p => p.Id, StringComparer.Ordinal);
 
         // Edges (under the cards), then cards, then edge labels on top so they stay legible.
@@ -191,6 +199,54 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
 
         foreach (var (pos, text, tooltip) in labels)
             RenderEdgeLabel(pos, text, tooltip);
+    }
+
+    /// <summary>
+    /// Draws a dashed, labelled frame around each independent cycle when one deadlock batched more than one
+    /// (the cycles share no resource — see <see cref="DeadlockGraphLayout"/>). A lone cycle needs no frame.
+    /// </summary>
+    private void RenderCycleBoxes()
+    {
+        // A "cycle" is a component with >= 2 processes; a lone node (only a parallel self-edge) is not one and
+        // the parallel banner already explains it. Frame the cycles only when one deadlock holds more than one.
+        var cycles = _model!.ComponentBoxes.Where(b => b.NodeCount >= 2).ToList();
+        if (cycles.Count <= 1) return;
+
+        const double pad = 22; // inflate past the cards and leave a strip at the top for the label
+
+        int number = 0;
+        foreach (var box in cycles)
+        {
+            number++;
+            var frame = new System.Windows.Shapes.Rectangle
+            {
+                Width = box.Width + pad * 2,
+                Height = box.Height + pad * 2,
+                RadiusX = 8,
+                RadiusY = 8,
+                Stroke = MutedBrush,
+                StrokeThickness = 1,
+                StrokeDashArray = new DoubleCollection { 4, 3 },
+                Fill = Brushes.Transparent,
+                IsHitTestVisible = false,
+                SnapsToDevicePixels = true
+            };
+            Canvas.SetLeft(frame, box.X - pad);
+            Canvas.SetTop(frame, box.Y - pad);
+            GraphCanvas.Children.Add(frame);
+
+            var label = new TextBlock
+            {
+                Text = $"Cycle {number}",
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = MutedBrush,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(label, box.X - pad + 6);
+            Canvas.SetTop(label, box.Y - pad + 3);
+            GraphCanvas.Children.Add(label);
+        }
     }
 
     private void RenderNode(DeadlockProcessNode node)
@@ -245,6 +301,20 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
                 Text = node.ProcName,
                 FontSize = 11,
                 Foreground = MutedBrush,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Margin = new Thickness(0, 1, 0, 0)
+            });
+        }
+
+        // Contended resource — the object SQL Server resolved for the lock this process waits on. The deadlock
+        // graph names it directly, so this is the at-a-glance answer to "what did they fight over?".
+        if (!string.IsNullOrEmpty(node.ContentiousObject))
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = node.ContentiousObject,
+                FontSize = 11,
+                Foreground = ForegroundBrush,
                 TextTrimming = TextTrimming.CharacterEllipsis,
                 Margin = new Thickness(0, 1, 0, 0)
             });
@@ -305,6 +375,7 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         if (!string.IsNullOrEmpty(node.HostName)) lines.Add($"Host: {node.HostName}");
         if (!string.IsNullOrEmpty(node.ClientApp)) lines.Add($"App: {node.ClientApp}");
         if (!string.IsNullOrEmpty(node.IsolationLevel)) lines.Add($"Isolation: {node.IsolationLevel}");
+        if (!string.IsNullOrEmpty(node.ContentiousObject)) lines.Add($"Contended: {node.ContentiousObject}");
         if (!string.IsNullOrEmpty(node.WaitResource)) lines.Add($"Wait resource: {node.WaitResource}");
         lines.Add("Click for full details");
         return string.Join("\n", lines);
@@ -581,6 +652,7 @@ public partial class DeadlockGraphControl : UserControl, IGraphViewer
         if (!string.IsNullOrEmpty(node.ProcName)) AddPropRow("Procedure", node.ProcName);
         if (!string.IsNullOrEmpty(node.LockMode)) AddPropRow("Requested Lock", node.LockMode);
         if (node.WaitTimeMs > 0) AddPropRow("Wait Time", FormatWait(node.WaitTimeMs));
+        if (!string.IsNullOrEmpty(node.ContentiousObject)) AddPropRow("Contended Object", node.ContentiousObject);
         if (!string.IsNullOrEmpty(node.WaitResource)) AddPropRow("Wait Resource", node.WaitResource);
         AddPropRow("Priority", node.Priority.ToString());
         if (!string.IsNullOrEmpty(node.Status)) AddPropRow("Status", node.Status);


### PR DESCRIPTION
Closes two parity gaps the user flagged on a real 4-process sql2025 deadlock, where the deadlock drill-down lagged the block-chain viewer.

## 1. Contended object on the node
The node detail showed only the raw `waitresource` (e.g. `PAGE: 7:1:4463713`). But SQL Server already resolves the objectname directly in the deadlock `<resource-list>` (the "much easier mechanism" deadlocks have), so we now project it onto each process as `ContentiousObject` — its first non-self, non-exchange *waits-for* edge's resolved label, e.g. `PAGE hammerdb_tpcc.dbo.new_order`. **No DMV lookup** (unlike blocking's `wait_resource` decode).

Surfaced on:
- the node **card** (a foreground line under the procedure),
- the **properties panel** as `Contended Object`, above the raw `Wait Resource`,
- the node **tooltip**.

Parallelism exchanges (`exchangeEvent`/`SyncPoint`) are skipped — coordination, not a contended object.

## 2. Box each independent cycle
A single `<deadlock>` often batches several cycles that share no resource — the user's example was two disjoint 2-cycles reported as one graph, which read as *"two unrelated deadlocks shown together."* The layout already split these into connected components; it now also emits one `DeadlockComponentBox` per component, and the viewer:
- frames each **real cycle** (>= 2 processes) with a dashed **"Cycle N"** box, and
- notes the count in the summary: **"... · N independent cycles"**.

A single cycle draws no box; a lone self-edge node is not counted as a cycle (so a pure parallel deadlock, explained by the existing parallel banner, isn't mislabeled).

## Parity / scope
All changes are in the shared `PerformanceMonitor.Common` parser/model/layout + the `PerformanceMonitor.Ui` control, so **both Dashboard and Lite** get it automatically. Deadlock XML carries the objectname server-side, so Lite needs no collector change (contrast with the blocking viewer, which required a Lite-side `wait_resource` decode).

## Tests
+10 (Dashboard.Tests, shared types tested once): box-per-component across all real + synthetic fixtures, the lone-node-is-not-a-cycle filter, and contended-object resolution including the cross-product and parallel cases. Full suite green (612 passed); both apps build.

## Not yet visually reviewed
UI change — pending the user's visual review of the boxed cycles + contended-object lines on the real multi-cycle deadlock before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)