### PR TITLE
Block-chain viewer: open the chain when the lead-blocker row is clicked

### DIFF
--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -242,4 +242,44 @@ public class BlockingChainReconstructorTests
         Assert.NotNull(fallback);
         Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
     }
+
+    [Fact]
+    public void FindChainForSession_BlockerSideClick_ResolvesViaSpidWhenBlockerTranIsNull()
+    {
+        // Real shape from collect.blocking_BlockedProcessReport: the 'blocked' row (75) names its blocker's
+        // SPID (59) but a NULL blocking_last_tran_started, so the reconstruction keys the apex (59, NULL). The
+        // separate 'blocking' row for 59 carries its OWN real last_transaction_started. Clicking that blocking
+        // row must still open the chain (regression: it previously returned null -> "no reconstructable chain").
+        var blockedTran = new DateTime(2026, 6, 23, 7, 21, 14, 897);
+        var blockerOwnTran = new DateTime(2026, 6, 23, 7, 21, 14, 890); // 59's real tran, from its 'blocking' row
+
+        var result = Run(new[]
+        {
+            new BlockingPairRow
+            {
+                EventTime = new DateTime(2026, 6, 23, 7, 21, 14),
+                DatabaseName = "hammerdb_tpcc",
+                BlockedSpid = 75,
+                BlockedTranStarted = blockedTran,
+                BlockingSpid = 59,
+                BlockingTranStarted = null,   // blocker's tran is NULL on the blocked row -> apex keyed (59, NULL)
+                WaitTimeMs = 6893,
+                LockMode = "X",
+                BlockingStatus = "suspended"
+            }
+        });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(59, chain.ApexSpid);
+        Assert.Null(chain.ApexTranStarted);   // keyed with no tran
+
+        // Blocked-row click carries the exact (59 -> 75) edge and already worked.
+        Assert.NotNull(BlockingChainReconstructor.FindChainForSession(result, 75, blockedTran, 59, null));
+
+        // Blocking-row click: spid 59 with its REAL tran, no recorded blocker. The precise SessionKey can't
+        // match (59, NULL), so the SPID-only fallback must still find the chain.
+        var fromBlocker = BlockingChainReconstructor.FindChainForSession(result, 59, blockerOwnTran, 0, null);
+        Assert.NotNull(fromBlocker);
+        Assert.Equal(59, fromBlocker!.ApexSpid);
+    }
 }

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -242,4 +242,44 @@ public class BlockingChainReconstructorTests
         Assert.NotNull(fallback);
         Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
     }
+
+    [Fact]
+    public void FindChainForSession_BlockerSideClick_ResolvesViaSpidWhenBlockerTranIsNull()
+    {
+        // Real shape from collect.blocking_BlockedProcessReport: the 'blocked' row (75) names its blocker's
+        // SPID (59) but a NULL blocking_last_tran_started, so the reconstruction keys the apex (59, NULL). The
+        // separate 'blocking' row for 59 carries its OWN real last_transaction_started. Clicking that blocking
+        // row must still open the chain (regression: it previously returned null -> "no reconstructable chain").
+        var blockedTran = new DateTime(2026, 6, 23, 7, 21, 14, 897);
+        var blockerOwnTran = new DateTime(2026, 6, 23, 7, 21, 14, 890); // 59's real tran, from its 'blocking' row
+
+        var result = Run(new[]
+        {
+            new BlockingPairRow
+            {
+                EventTime = new DateTime(2026, 6, 23, 7, 21, 14),
+                DatabaseName = "hammerdb_tpcc",
+                BlockedSpid = 75,
+                BlockedTranStarted = blockedTran,
+                BlockingSpid = 59,
+                BlockingTranStarted = null,   // blocker's tran is NULL on the blocked row -> apex keyed (59, NULL)
+                WaitTimeMs = 6893,
+                LockMode = "X",
+                BlockingStatus = "suspended"
+            }
+        });
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(59, chain.ApexSpid);
+        Assert.Null(chain.ApexTranStarted);   // keyed with no tran
+
+        // Blocked-row click carries the exact (59 -> 75) edge and already worked.
+        Assert.NotNull(BlockingChainReconstructor.FindChainForSession(result, 75, blockedTran, 59, null));
+
+        // Blocking-row click: spid 59 with its REAL tran, no recorded blocker. The precise SessionKey can't
+        // match (59, NULL), so the SPID-only fallback must still find the chain.
+        var fromBlocker = BlockingChainReconstructor.FindChainForSession(result, 59, blockerOwnTran, 0, null);
+        Assert.NotNull(fromBlocker);
+        Assert.Equal(59, fromBlocker!.ApexSpid);
+    }
 }

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -143,8 +143,11 @@ internal static class BlockingChainReconstructor
     /// Edge-precise overload: when the clicked row carries its blocker too, prefer the chain that contains
     /// the exact (blocker -> blocked) edge. This disambiguates a victim that was blocked by two different
     /// lead blockers at different times in the window (each is a separate chain, both containing the victim).
-    /// Falls back to the any-level match on the blocked session when no chain holds that exact edge (e.g. the
-    /// clicked row has no recorded blocker).
+    /// Falls back to the any-level SessionKey match on the blocked session when no chain holds that exact edge
+    /// (e.g. the clicked row has no recorded blocker), and finally to a SPID-only match: the blocked-process
+    /// report keys a blocker with a NULL transaction start (it is not recorded on the blocked row), so a click
+    /// on that session's own 'blocking' row — which carries its real last_transaction_started — would otherwise
+    /// never match the (spid, NULL) apex node and the viewer would wrongly report "no reconstructable chain."
     /// </summary>
     public static ReconstructedChain? FindChainForSession(
         BlockingReconstruction reconstruction,
@@ -160,6 +163,15 @@ internal static class BlockingChainReconstructor
 
         foreach (var chain in reconstruction.Chains)
             if (ChainContains(chain, blockedKey))
+                return chain;
+
+        // Last resort: SPID alone, ignoring the transaction-start identity. A blocker is keyed (spid, NULL) in
+        // the reconstruction (its tran start is NULL on the blocked row), but a click on its 'blocking' row
+        // supplies the session's real tran start, so neither precise pass above can match it. Precise matches
+        // run first and the reconstruction is scoped to a tight time window, so SPID reuse is unlikely to
+        // mislead here — and returning the chain this SPID participates in beats a false "no chain" dialog.
+        foreach (var chain in reconstruction.Chains)
+            if (ChainContainsSpid(chain, blockedSpid))
                 return chain;
 
         return null;
@@ -186,6 +198,23 @@ internal static class BlockingChainReconstructor
             if (MakeKey(l.BlockingSpid, l.BlockingTranStarted).Equals(key)) return true;
             if (MakeKey(l.BlockedSpid, l.BlockedTranStarted).Equals(key)) return true;
         }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True if the SPID appears anywhere in the chain, ignoring the transaction-start identity. The coarse
+    /// last-resort match for the edge-precise <see cref="FindChainForSession(BlockingReconstruction,int,DateTime?,int,DateTime?)"/>,
+    /// for when a blocker is keyed (spid, NULL) in the reconstruction but the clicked row carries a real tran start.
+    /// </summary>
+    private static bool ChainContainsSpid(ReconstructedChain chain, int spid)
+    {
+        if (chain.ApexSpid == spid)
+            return true;
+
+        foreach (var l in chain.Levels)
+            if (l.BlockingSpid == spid || l.BlockedSpid == spid)
+                return true;
 
         return false;
     }


### PR DESCRIPTION
## Symptom
Double/right-clicking a **blocking** (lead-blocker) row on the Dashboard blocking tab raised **"no reconstructable blocking chain…"**, while the matching **blocked** row for the *same* relationship opened the chain fine. Reported live on sql2025:

| activity | spid | last_transaction_started | blocking_spid | blocking_last_tran_started |
|---|---|---|---|---|
| blocked | 75 | 07:21:14.**897** | 59 | **NULL** |
| blocking | 59 | 07:21:14.**890** | NULL | NULL |

## Root cause
`collect.blocking_BlockedProcessReport` stores the blocker's transaction start as **NULL** on the `'blocked'` row (`blocking_last_tran_started`), so reconstruction (built only from `'blocked'` rows) keys the apex/blocker as `(59, NULL)`.

- Clicking the **blocked** row works: the edge-precise match uses exactly `(59, NULL) → (75, .897)`.
- Clicking the **blocking** row fails: that row carries the blocker session's *own* real `last_transaction_started` (`.890`) and has `blocking_spid = NULL`, so `FindChainForSession` searched for `(59, .890)` with no blocker edge — which never equals the `(59, NULL)` apex node → null → the error dialog.

## Fix
Add a **SPID-only last-resort match** to the edge-precise `FindChainForSession`, after the edge and full-`SessionKey` passes. A blocker legitimately can't always be keyed by transaction start (it's NULL in the blocked-row representation), so a blocker-side click matches on SPID alone. Precise passes still run first, and the reconstruction is scoped to a tight time window, so SPID reuse is unlikely to mislead — and returning the chain the SPID participates in beats a false "no chain" dialog. The fix only ever converts a former *null* into a chain; it never changes an existing non-null result.

## Scope / parity
Shared `PerformanceMonitor.Analysis` change → **both** apps' block-chain viewers get it (Lite didn't surface the row, but shares the reconstructor). +1 regression test in **each** test project, built from the exact live row shape. Both test projects green (14 reconstructor tests each); both apps build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)