### PR TITLE
Blocking-chain reconstruction: key by (monitor_loop, spid, ecid)

### DIFF
--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -282,4 +282,27 @@ public class BlockingChainReconstructorTests
         Assert.NotNull(fromBlocker);
         Assert.Equal(59, fromBlocker!.ApexSpid);
     }
+
+    [Fact]
+    public void DeepChain_WithNullBlockerTran_StillFormsOneChain()
+    {
+        // Real-world shape: blocking_last_tran_started is ALWAYS NULL (SQL omits @lasttranstarted on the
+        // <blocking-process> node), while each blocked session carries its real tran. So a mid-chain session
+        // is keyed (spid, realTran) where it is the BLOCKED party but (spid, NULL) where it is the BLOCKER.
+        // The chain 116 -> 111 -> 80 must reconstruct as ONE depth-2 chain, not split at 111. The existing
+        // tests miss this because Pair() gives every blocker a real tran (TranFor), masking the asymmetry.
+        var t111 = new DateTime(2026, 6, 23, 7, 9, 9, 440);
+        var t80  = new DateTime(2026, 6, 23, 7, 9, 9, 460);
+
+        var result = Run(new[]
+        {
+            new BlockingPairRow { EventTime = new DateTime(2026,6,23,7,9,15), BlockedSpid = 111, BlockedTranStarted = t111, BlockingSpid = 116, BlockingTranStarted = null, WaitTimeMs = 5000, BlockingStatus = "suspended" },
+            new BlockingPairRow { EventTime = new DateTime(2026,6,23,7,9,15), BlockedSpid = 80,  BlockedTranStarted = t80,  BlockingSpid = 111, BlockingTranStarted = null, WaitTimeMs = 5000, BlockingStatus = "suspended" },
+        });
+
+        var chain = Assert.Single(result.Chains);   // currently FAILS: splits into 116->111 and 111->80
+        Assert.Equal(116, chain.ApexSpid);
+        Assert.Equal(2, chain.Depth);
+        Assert.Equal(2, chain.VictimCount);
+    }
 }

--- a/Dashboard.Tests/BlockingChainReconstructorTests.cs
+++ b/Dashboard.Tests/BlockingChainReconstructorTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace PerformanceMonitorDashboard.Tests;
 
 /// <summary>
-/// Pure unit tests for BlockingChainReconstructor — apex/depth/victim reconstruction,
-/// the composite session identity that defeats SPID reuse, the 1900-01-01 sentinel,
-/// cycle handling, and the traversal caps. No database.
+/// Pure unit tests for BlockingChainReconstructor — apex/depth/victim reconstruction, the (monitor_loop,
+/// spid, ecid) session identity (mirroring sp_HumanEventsBlockViewer), cumulative-vs-per-scan scoping, cycle
+/// handling, and the traversal caps. No database.
 /// </summary>
 public class BlockingChainReconstructorTests
 {
@@ -21,7 +21,7 @@ public class BlockingChainReconstructorTests
 
     private static BlockingPairRow Pair(
         int blockedSpid, int blockingSpid,
-        DateTime? blockedTran = null, DateTime? blockingTran = null,
+        int? monitorLoop = null, int blockedEcid = 0, int blockingEcid = 0,
         long waitMs = 1000, string blockingStatus = "running")
     {
         return new BlockingPairRow
@@ -29,9 +29,12 @@ public class BlockingChainReconstructorTests
             EventTime = new DateTime(2026, 5, 22, 10, 0, 0),
             DatabaseName = "TestDb",
             BlockedSpid = blockedSpid,
-            BlockedTranStarted = blockedTran ?? TranFor(blockedSpid),
+            BlockedTranStarted = TranFor(blockedSpid),
             BlockingSpid = blockingSpid,
-            BlockingTranStarted = blockingTran ?? TranFor(blockingSpid),
+            BlockingTranStarted = TranFor(blockingSpid),
+            MonitorLoop = monitorLoop,
+            BlockedEcid = blockedEcid,
+            BlockingEcid = blockingEcid,
             WaitTimeMs = waitMs,
             LockMode = "X",
             BlockingStatus = blockingStatus,
@@ -40,8 +43,9 @@ public class BlockingChainReconstructorTests
         };
     }
 
-    private static BlockingReconstruction Run(IEnumerable<BlockingPairRow> rows) =>
-        BlockingChainReconstructor.Reconstruct(rows, MaxDepth, MaxPairs, StepBudget);
+    // Default scope is cumulative (the collector path); the viewer-style tests pass scopeByMonitorLoop: true.
+    private static BlockingReconstruction Run(IEnumerable<BlockingPairRow> rows, bool scopeByMonitorLoop = false) =>
+        BlockingChainReconstructor.Reconstruct(rows, MaxDepth, MaxPairs, StepBudget, scopeByMonitorLoop);
 
     [Fact]
     public void Empty_ProducesNoChains()
@@ -79,35 +83,88 @@ public class BlockingChainReconstructorTests
     }
 
     [Fact]
-    public void SpidReuse_DifferentTransactionStart_DoesNotSplice()
+    public void DeepChain_WithNullBlockerTran_StillFormsOneChain()
     {
-        // Real chain 200 → 201 → 202, plus SPID 201 reused (different tran) blocking 203.
-        var reusedTran = TranFor(201).AddHours(3);
+        // The bug this whole change fixes: blocking_last_tran_started is always NULL, so the old (spid, tran)
+        // key split a mid-chain node. Keying by spid:ecid within monitor_loop, 116 → 111 → 80 is ONE depth-2
+        // chain — 111 unifies as (loop, 111, 0) whether it is the blocker or the blocked party.
         var result = Run(new[]
         {
-            Pair(201, 200),
-            Pair(202, 201),
-            Pair(203, 201, blockingTran: reusedTran) // reused 201 — a distinct session
-        });
+            Pair(111, 116, monitorLoop: 620365),
+            Pair(80, 111, monitorLoop: 620365),
+        }, scopeByMonitorLoop: true);
 
-        // Two distinct chains: apex 200 depth 2, and the reused-201 apex depth 1.
-        Assert.Equal(2, result.Chains.Count);
-        Assert.Contains(result.Chains, c => c.ApexSpid == 200 && c.Depth == 2);
-        Assert.Contains(result.Chains, c => c.ApexSpid == 201 && c.Depth == 1);
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(116, chain.ApexSpid);
+        Assert.Equal(2, chain.Depth);
+        Assert.Equal(2, chain.VictimCount);
     }
 
     [Fact]
-    public void Sentinel_TransactionStart_NormalizesToNull()
+    public void SeparateEpisodes_SameSpid_DoNotLeak()
     {
-        // SQL Server's 1900-01-01 "no transaction" sentinel must key the same as NULL.
-        Assert.Equal(
-            BlockingChainReconstructor.MakeKey(100, null),
-            BlockingChainReconstructor.MakeKey(100, new DateTime(1900, 1, 1)));
+        // The same blocker→blocked pair in two different monitor_loops (episodes) must stay two chains, not
+        // merge — the cross-episode leakage the monitor_loop scope prevents for the viewer.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(201, 200, monitorLoop: 2),
+        }, scopeByMonitorLoop: true);
 
-        // And a real transaction start must NOT collapse to the sentinel key.
-        Assert.NotEqual(
-            BlockingChainReconstructor.MakeKey(100, null),
-            BlockingChainReconstructor.MakeKey(100, TranFor(100)));
+        Assert.Equal(2, result.Chains.Count);
+        Assert.All(result.Chains, c => Assert.Equal(200, c.ApexSpid));
+        Assert.Contains(result.Chains, c => c.MonitorLoop == 1);
+        Assert.Contains(result.Chains, c => c.MonitorLoop == 2);
+    }
+
+    [Fact]
+    public void ParallelBlocker_DistinctEcid_AreDistinctNodes()
+    {
+        // Same SPID, different ecid (parallel workers) are distinct sessions: spid 200 ecid 0 and ecid 1 each
+        // head their own chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1, blockingEcid: 0),
+            Pair(202, 200, monitorLoop: 1, blockingEcid: 1),
+        }, scopeByMonitorLoop: true);
+
+        Assert.Equal(2, result.Chains.Count);
+        Assert.Contains(result.Chains, c => c.ApexEcid == 0);
+        Assert.Contains(result.Chains, c => c.ApexEcid == 1);
+    }
+
+    [Fact]
+    public void Cumulative_MergesAcrossScans()
+    {
+        // The collector (scopeByMonitorLoop:false) ignores monitor_loop, so an episode's per-scan re-fires
+        // merge into ONE chain — preserving window-level depth/victims for the severity fact (per-scan scoping
+        // would under-count). 200 → 201 (scan 1) and 201 → 202 (scan 2) form one depth-2 chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(202, 201, monitorLoop: 2),
+        }, scopeByMonitorLoop: false);
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(200, chain.ApexSpid);
+        Assert.Equal(2, chain.Depth);
+        Assert.Null(chain.MonitorLoop);   // cumulative chains carry no episode
+    }
+
+    [Fact]
+    public void SpidReuse_DifferentMonitorLoop_DoesNotSplice()
+    {
+        // SPID 201 reused across two episodes is two distinct sessions, not one spliced chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(202, 201, monitorLoop: 1),   // 200 → 201 → 202 in episode 1
+            Pair(203, 201, monitorLoop: 2),   // reused 201 heads its own chain in episode 2
+        }, scopeByMonitorLoop: true);
+
+        Assert.Equal(2, result.Chains.Count);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 200 && c.Depth == 2);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 201 && c.Depth == 1);
     }
 
     [Fact]
@@ -129,7 +186,7 @@ public class BlockingChainReconstructorTests
     {
         // A 12-edge line, reconstructed with a maxDepth of 4.
         var rows = Enumerable.Range(0, 12).Select(i => Pair(501 + i, 500 + i)).ToList();
-        var result = BlockingChainReconstructor.Reconstruct(rows, maxDepth: 4, MaxPairs, StepBudget);
+        var result = BlockingChainReconstructor.Reconstruct(rows, maxDepth: 4, MaxPairs, StepBudget, scopeByMonitorLoop: false);
 
         Assert.True(result.DepthCapped);
         var chain = Assert.Single(result.Chains);
@@ -184,7 +241,7 @@ public class BlockingChainReconstructorTests
     [Fact]
     public void ReconstructedOutput_CarriesTranStartedAndDatabaseName()
     {
-        // The additive output fields (Phase 0) the block-chain tree builder rebuilds the tree from.
+        // Transaction start is display-only now, sourced from the rows (apex from its first outgoing edge).
         var result = Run(new[] { Pair(201, 200), Pair(202, 201) });
 
         var chain = Assert.Single(result.Chains);
@@ -202,107 +259,50 @@ public class BlockingChainReconstructorTests
     [Fact]
     public void FindChainForSession_AnyMember_ReturnsChainRootedAtApex()
     {
-        // Two separate chains — A: 200 -> 201 -> 202 ; B: 300 -> 301. The viewer scopes to the ONE chain a
+        // Two separate chains — A: 200 → 201 → 202 ; B: 300 → 301. The viewer scopes to the ONE chain a
         // clicked session belongs to, rooted at its apex regardless of where in the chain it sits.
         var result = Run(new[] { Pair(201, 200), Pair(202, 201), Pair(301, 300) });
 
-        // Mid-level 201 -> chain A, rooted at apex 200 (not at the clicked node).
-        var chainA = BlockingChainReconstructor.FindChainForSession(result, 201, TranFor(201));
+        // Mid-level 201 -> chain A, rooted at apex 200 (not at the clicked node). monitor_loop null -> matches
+        // by spid:ecid.
+        var chainA = BlockingChainReconstructor.FindChainForSession(result, null, 201, 0);
         Assert.NotNull(chainA);
         Assert.Equal(200, chainA!.ApexSpid);
 
-        // The apex itself and a leaf victim resolve to the same apex-rooted chain.
-        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 200, TranFor(200))!.ApexSpid);
-        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 202, TranFor(202))!.ApexSpid);
-
-        // A member of the other chain resolves to that chain; an absent session returns null.
-        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
-        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, null, 200, 0)!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, null, 202, 0)!.ApexSpid);
+        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, null, 301, 0)!.ApexSpid);
+        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, null, 999, 0));
     }
 
     [Fact]
-    public void FindChainForSession_VictimUnderTwoApexes_DisambiguatesByClickedBlocker()
+    public void FindChainForSession_DisambiguatesByMonitorLoop()
     {
-        // Victim 500 (same tran) was blocked by apex 100 and, at another time, apex 200 — two separate
-        // chains, BOTH containing 500. The edge-precise overload returns the chain reached via the clicked
-        // row's blocker, so the clicked row opens the right chain.
+        // Victim 500 was blocked by apex 100 in episode 1 and apex 200 in episode 2 — two scoped chains, both
+        // containing 500. The clicked row's monitor_loop selects the right one.
         var result = Run(new[]
         {
-            Pair(blockedSpid: 500, blockingSpid: 100),
-            Pair(blockedSpid: 500, blockingSpid: 200)
-        });
+            Pair(blockedSpid: 500, blockingSpid: 100, monitorLoop: 1),
+            Pair(blockedSpid: 500, blockingSpid: 200, monitorLoop: 2)
+        }, scopeByMonitorLoop: true);
 
-        Assert.Equal(100, BlockingChainReconstructor
-            .FindChainForSession(result, 500, TranFor(500), 100, TranFor(100))!.ApexSpid);
-        Assert.Equal(200, BlockingChainReconstructor
-            .FindChainForSession(result, 500, TranFor(500), 200, TranFor(200))!.ApexSpid);
-
-        // No recorded blocker -> falls back to the any-level match (one of the chains that contains 500).
-        var fallback = BlockingChainReconstructor.FindChainForSession(result, 500, TranFor(500), 0, null);
-        Assert.NotNull(fallback);
-        Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
+        Assert.Equal(100, BlockingChainReconstructor.FindChainForSession(result, 1, 500, 0)!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 2, 500, 0)!.ApexSpid);
     }
 
     [Fact]
-    public void FindChainForSession_BlockerSideClick_ResolvesViaSpidWhenBlockerTranIsNull()
+    public void FindChainForSession_NullMonitorLoop_FallsBackToSpidEcid()
     {
-        // Real shape from collect.blocking_BlockedProcessReport: the 'blocked' row (75) names its blocker's
-        // SPID (59) but a NULL blocking_last_tran_started, so the reconstruction keys the apex (59, NULL). The
-        // separate 'blocking' row for 59 carries its OWN real last_transaction_started. Clicking that blocking
-        // row must still open the chain (regression: it previously returned null -> "no reconstructable chain").
-        var blockedTran = new DateTime(2026, 6, 23, 7, 21, 14, 897);
-        var blockerOwnTran = new DateTime(2026, 6, 23, 7, 21, 14, 890); // 59's real tran, from its 'blocking' row
-
+        // A lead-blocker grid row may not supply its monitor_loop; the click must still resolve via spid:ecid
+        // rather than reporting "no reconstructable chain" (supersedes the #1222 SPID-only fallback).
         var result = Run(new[]
         {
-            new BlockingPairRow
-            {
-                EventTime = new DateTime(2026, 6, 23, 7, 21, 14),
-                DatabaseName = "hammerdb_tpcc",
-                BlockedSpid = 75,
-                BlockedTranStarted = blockedTran,
-                BlockingSpid = 59,
-                BlockingTranStarted = null,   // blocker's tran is NULL on the blocked row -> apex keyed (59, NULL)
-                WaitTimeMs = 6893,
-                LockMode = "X",
-                BlockingStatus = "suspended"
-            }
-        });
+            Pair(201, 200, monitorLoop: 7),
+            Pair(202, 201, monitorLoop: 7),
+        }, scopeByMonitorLoop: true);
 
-        var chain = Assert.Single(result.Chains);
-        Assert.Equal(59, chain.ApexSpid);
-        Assert.Null(chain.ApexTranStarted);   // keyed with no tran
-
-        // Blocked-row click carries the exact (59 -> 75) edge and already worked.
-        Assert.NotNull(BlockingChainReconstructor.FindChainForSession(result, 75, blockedTran, 59, null));
-
-        // Blocking-row click: spid 59 with its REAL tran, no recorded blocker. The precise SessionKey can't
-        // match (59, NULL), so the SPID-only fallback must still find the chain.
-        var fromBlocker = BlockingChainReconstructor.FindChainForSession(result, 59, blockerOwnTran, 0, null);
-        Assert.NotNull(fromBlocker);
-        Assert.Equal(59, fromBlocker!.ApexSpid);
-    }
-
-    [Fact]
-    public void DeepChain_WithNullBlockerTran_StillFormsOneChain()
-    {
-        // Real-world shape: blocking_last_tran_started is ALWAYS NULL (SQL omits @lasttranstarted on the
-        // <blocking-process> node), while each blocked session carries its real tran. So a mid-chain session
-        // is keyed (spid, realTran) where it is the BLOCKED party but (spid, NULL) where it is the BLOCKER.
-        // The chain 116 -> 111 -> 80 must reconstruct as ONE depth-2 chain, not split at 111. The existing
-        // tests miss this because Pair() gives every blocker a real tran (TranFor), masking the asymmetry.
-        var t111 = new DateTime(2026, 6, 23, 7, 9, 9, 440);
-        var t80  = new DateTime(2026, 6, 23, 7, 9, 9, 460);
-
-        var result = Run(new[]
-        {
-            new BlockingPairRow { EventTime = new DateTime(2026,6,23,7,9,15), BlockedSpid = 111, BlockedTranStarted = t111, BlockingSpid = 116, BlockingTranStarted = null, WaitTimeMs = 5000, BlockingStatus = "suspended" },
-            new BlockingPairRow { EventTime = new DateTime(2026,6,23,7,9,15), BlockedSpid = 80,  BlockedTranStarted = t80,  BlockingSpid = 111, BlockingTranStarted = null, WaitTimeMs = 5000, BlockingStatus = "suspended" },
-        });
-
-        var chain = Assert.Single(result.Chains);   // currently FAILS: splits into 116->111 and 111->80
-        Assert.Equal(116, chain.ApexSpid);
-        Assert.Equal(2, chain.Depth);
-        Assert.Equal(2, chain.VictimCount);
+        var chain = BlockingChainReconstructor.FindChainForSession(result, null, 200, 0);
+        Assert.NotNull(chain);
+        Assert.Equal(200, chain!.ApexSpid);
     }
 }

--- a/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
+++ b/Dashboard.Tests/BlockingChainTreeBuilderTests.cs
@@ -18,12 +18,15 @@ public class BlockingChainTreeBuilderTests
     private static BlockingEdgeInput Edge(
         int level, int blocker, int blocked,
         long wait = 1000, string lockMode = "X", string db = "TestDb",
-        DateTime? blockerTran = null, DateTime? blockedTran = null) => new()
+        DateTime? blockerTran = null, DateTime? blockedTran = null,
+        int blockerEcid = 0, int blockedEcid = 0) => new()
         {
             Level = level,
             BlockingSpid = blocker,
+            BlockingEcid = blockerEcid,
             BlockingTranStarted = blockerTran ?? Tran(blocker),
             BlockedSpid = blocked,
+            BlockedEcid = blockedEcid,
             BlockedTranStarted = blockedTran ?? Tran(blocked),
             WaitTimeMs = wait,
             LockMode = lockMode,
@@ -157,23 +160,20 @@ public class BlockingChainTreeBuilderTests
     }
 
     [Fact]
-    public void SameSpidDifferentTransaction_AreKeptAsSeparateNodes()
+    public void SameSpidDifferentEcid_AreKeptAsSeparateNodes()
     {
-        // Apex 200 blocks SPID 201 twice — but two DIFFERENT sessions (distinct tran starts). The
-        // builder must NOT collapse them into one node.
-        var tranA = Tran(201);
-        var tranB = Tran(201).AddHours(3);
+        // Apex 200 blocks SPID 201 on two DIFFERENT execution contexts (ecid 0 and 1 — parallel workers).
+        // The builder keys on spid:ecid, so it must NOT collapse them into one node.
         var model = Build(Chain(200, new[]
         {
-            Edge(1, 200, 201, blockedTran: tranA),
-            Edge(1, 200, 201, blockedTran: tranB)
+            Edge(1, 200, 201, blockedEcid: 0),
+            Edge(1, 200, 201, blockedEcid: 1)
         }));
 
         var root = Assert.Single(model.Roots);
         Assert.Equal(2, root.Children.Count);
         Assert.All(root.Children, c => Assert.Equal(201, c.Spid));
-        Assert.Equal(new[] { tranA, tranB }.OrderBy(t => t),
-                     root.Children.Select(c => c.TranStarted!.Value).OrderBy(t => t));
+        Assert.Equal(new[] { 0, 1 }, root.Children.Select(c => c.Ecid).OrderBy(e => e));
     }
 
     [Fact]

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -27,11 +27,10 @@ internal static class BlockingChainViewerProjection
     /// </summary>
     public static BlockingChainModel? BuildModelForSession(
         BlockingReconstruction reconstruction,
-        int blockedSpid, DateTime? blockedTran,
-        int blockingSpid, DateTime? blockingTran)
+        int? monitorLoop, int spid, int ecid)
     {
         var chain = BlockingChainReconstructor.FindChainForSession(
-            reconstruction, blockedSpid, blockedTran, blockingSpid, blockingTran);
+            reconstruction, monitorLoop, spid, ecid);
         if (chain == null)
             return null;
 
@@ -45,6 +44,7 @@ internal static class BlockingChainViewerProjection
     private static BlockingChainInput ToInput(ReconstructedChain c) => new()
     {
         ApexSpid = c.ApexSpid,
+        ApexEcid = c.ApexEcid,
         ApexTranStarted = c.ApexTranStarted,
         ApexSleeping = c.ApexSleeping,
         Magnitude = c.Magnitude,
@@ -52,8 +52,10 @@ internal static class BlockingChainViewerProjection
         {
             Level = l.Level,
             BlockingSpid = l.BlockingSpid,
+            BlockingEcid = l.BlockingEcid,
             BlockingTranStarted = l.BlockingTranStarted,
             BlockedSpid = l.BlockedSpid,
+            BlockedEcid = l.BlockedEcid,
             BlockedTranStarted = l.BlockedTranStarted,
             LockMode = l.LockMode,
             WaitTimeMs = l.WaitTimeMs,

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -42,7 +42,10 @@ SELECT TOP (5000)
     login_name,
     host_name,
     client_app,
-    contentious_object
+    contentious_object,
+    ecid,
+    blocking_ecid,
+    monitor_loop
 FROM collect.blocking_BlockedProcessReport
 WHERE collection_time >= @collectionWindow
 AND   event_time >= @startTime
@@ -128,19 +131,25 @@ OUTER APPLY
         BlockedLoginName = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
         BlockedHostName = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
         BlockedClientApp = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
-        ContentiousObject = reader.IsDBNull(14) ? string.Empty : reader.GetString(14)
+        ContentiousObject = reader.IsDBNull(14) ? string.Empty : reader.GetString(14),
+        // 15-17: spid:ecid + monitor_loop typed columns (populated at collect time by install/23). The
+        // collector reconstructs cumulatively (scopeByMonitorLoop:false) so MonitorLoop is read but ignored;
+        // the viewer scopes by it.
+        BlockedEcid = reader.IsDBNull(15) ? 0 : Convert.ToInt32(reader.GetValue(15)),
+        BlockingEcid = reader.IsDBNull(16) ? 0 : Convert.ToInt32(reader.GetValue(16)),
+        MonitorLoop = reader.IsDBNull(17) ? (int?)null : Convert.ToInt32(reader.GetValue(17))
     };
 
     /// <summary>
-    /// Maps the viewer's <see cref="SqlWithBlockerIdentity"/> result: the core <see cref="Read"/> (0-14)
-    /// plus the correlated blocker identity at ordinals 15-17, so the apex node carries login/host/app.
+    /// Maps the viewer's <see cref="SqlWithBlockerIdentity"/> result: the core <see cref="Read"/> (0-17)
+    /// plus the correlated blocker identity at ordinals 18-20, so the apex node carries login/host/app.
     /// </summary>
     public static BlockingPairRow ReadWithBlockerIdentity(DbDataReader reader)
     {
         var row = Read(reader);
-        row.BlockingLoginName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15);
-        row.BlockingHostName = reader.IsDBNull(16) ? string.Empty : reader.GetString(16);
-        row.BlockingClientApp = reader.IsDBNull(17) ? string.Empty : reader.GetString(17);
+        row.BlockingLoginName = reader.IsDBNull(18) ? string.Empty : reader.GetString(18);
+        row.BlockingHostName = reader.IsDBNull(19) ? string.Empty : reader.GetString(19);
+        row.BlockingClientApp = reader.IsDBNull(20) ? string.Empty : reader.GetString(20);
         return row;
     }
 }

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
@@ -133,7 +133,7 @@ ORDER BY wait_time_ms DESC;";
         if (rows.Count == 0) return;
 
         var reconstruction = BlockingChainReconstructor.Reconstruct(
-            rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+            rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000, scopeByMonitorLoop: false);
 
         var items = new List<object>();
         foreach (var chain in reconstruction.Chains.Take(3))

--- a/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
@@ -233,7 +233,9 @@ AND   collection_time <= @endTime";
 
             if (rows.Count == 0) return;
 
-            var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget);
+            // Cumulative (not per-scan): merges an episode's re-fires across the window so the severity fact
+            // keeps window-level depth/victim counts (per-scan scoping would under-count and under-fire).
+            var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget, scopeByMonitorLoop: false);
             if (reconstruction.Chains.Count == 0) return;
 
             var worst = reconstruction.Chains[0];

--- a/Dashboard/Models/BlockingEventItem.cs
+++ b/Dashboard/Models/BlockingEventItem.cs
@@ -23,6 +23,9 @@ namespace PerformanceMonitorDashboard.Models
         public string BlockingTree { get; set; } = string.Empty;
         public int? Spid { get; set; }
         public int? Ecid { get; set; }
+        /// <summary>The blocked-process-report monitorLoop (episode) for this row; scopes the block-chain
+        /// viewer to the clicked event. Typed column populated at collect time (install/23).</summary>
+        public int? MonitorLoop { get; set; }
         public string QueryText { get; set; } = string.Empty;
         public long? WaitTimeMs { get; set; }
         public string Status { get; set; } = string.Empty;

--- a/Dashboard/ServerTab.BlockChain.cs
+++ b/Dashboard/ServerTab.BlockChain.cs
@@ -55,9 +55,8 @@ namespace PerformanceMonitorDashboard
 
             var spid = row.Spid ?? 0;
             if (spid <= 0) return;
-            var rawTran = row.LastTransactionStarted;
-            var blockerSpid = row.BlockingSpid ?? 0;
-            var blockerTran = row.BlockingLastTranStarted;
+            var ecid = row.Ecid ?? 0;
+            var monitorLoop = row.MonitorLoop;   // the clicked event's episode; scopes the reconstruction match
 
             try
             {
@@ -88,9 +87,9 @@ namespace PerformanceMonitorDashboard
                 {
                     var rows = await _databaseService.GetBlockingPairRowsAsync(start, end);
                     var reconstruction = BlockingChainReconstructor.Reconstruct(
-                        rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+                        rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000, scopeByMonitorLoop: true);
                     return BlockingChainViewerProjection.BuildModelForSession(
-                        reconstruction, spid, rawTran, blockerSpid, blockerTran);
+                        reconstruction, monitorLoop, spid, ecid);
                 });
 
                 if (model == null)
@@ -106,12 +105,8 @@ namespace PerformanceMonitorDashboard
                     return;
                 }
 
-                // Normalize the clicked tran the same way the reconstructor keyed the nodes, so the control
-                // can match + highlight the clicked session.
-                var key = BlockingChainReconstructor.MakeKey(spid, rawTran);
-
                 var control = new BlockingChainControl();
-                control.LoadModel(model, key.Spid, key.TranStarted, BlockingChainViewerProjection.EmptyStateDetail);
+                control.LoadModel(model, spid, ecid, BlockingChainViewerProjection.EmptyStateDetail);
                 GraphViewerWindow.ShowGraph(
                     Window.GetWindow(this),
                     control,

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
@@ -72,7 +72,8 @@ namespace PerformanceMonitorDashboard.Services
                                 CONVERT(nvarchar(max), b.blocked_process_report_xml) AS blocked_process_report_xml,
                                 CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report,
                                 b.blocking_spid,
-                                b.blocking_last_tran_started
+                                b.blocking_last_tran_started,
+                                b.monitor_loop
                             FROM collect.blocking_BlockedProcessReport AS b
                             WHERE b.collection_time >= @from_date
                             AND   b.collection_time <= @to_date
@@ -121,7 +122,8 @@ namespace PerformanceMonitorDashboard.Services
                                 CONVERT(nvarchar(max), b.blocked_process_report_xml) AS blocked_process_report_xml,
                                 CAST(CASE WHEN b.blocked_process_report_xml IS NOT NULL THEN 1 ELSE 0 END AS bit) AS has_blocked_process_report,
                                 b.blocking_spid,
-                                b.blocking_last_tran_started
+                                b.blocking_last_tran_started,
+                                b.monitor_loop
                             FROM collect.blocking_BlockedProcessReport AS b
                             WHERE b.collection_time >= DATEADD(HOUR, @hours_back, SYSDATETIME())
                             ORDER BY
@@ -183,7 +185,8 @@ namespace PerformanceMonitorDashboard.Services
                             BlockedProcessReportXml = reader.IsDBNull(30) ? string.Empty : reader.GetString(30),
                             HasBlockedProcessReport = !reader.IsDBNull(31) && reader.GetBoolean(31),
                             BlockingSpid = reader.IsDBNull(32) ? (int?)null : reader.GetInt32(32),
-                            BlockingLastTranStarted = reader.IsDBNull(33) ? (DateTime?)null : reader.GetDateTime(33)
+                            BlockingLastTranStarted = reader.IsDBNull(33) ? (DateTime?)null : reader.GetDateTime(33),
+                            MonitorLoop = reader.IsDBNull(34) ? (int?)null : reader.GetInt32(34)
                         });
                     }
         

--- a/Lite.Tests/BlockingChainReconstructorTests.cs
+++ b/Lite.Tests/BlockingChainReconstructorTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace PerformanceMonitorLite.Tests;
 
 /// <summary>
-/// Pure unit tests for BlockingChainReconstructor — apex/depth/victim reconstruction,
-/// the composite session identity that defeats SPID reuse, the 1900-01-01 sentinel,
-/// cycle handling, and the traversal caps. No database.
+/// Pure unit tests for BlockingChainReconstructor — apex/depth/victim reconstruction, the (monitor_loop,
+/// spid, ecid) session identity (mirroring sp_HumanEventsBlockViewer), cumulative-vs-per-scan scoping, cycle
+/// handling, and the traversal caps. No database.
 /// </summary>
 public class BlockingChainReconstructorTests
 {
@@ -21,7 +21,7 @@ public class BlockingChainReconstructorTests
 
     private static BlockingPairRow Pair(
         int blockedSpid, int blockingSpid,
-        DateTime? blockedTran = null, DateTime? blockingTran = null,
+        int? monitorLoop = null, int blockedEcid = 0, int blockingEcid = 0,
         long waitMs = 1000, string blockingStatus = "running")
     {
         return new BlockingPairRow
@@ -29,9 +29,12 @@ public class BlockingChainReconstructorTests
             EventTime = new DateTime(2026, 5, 22, 10, 0, 0),
             DatabaseName = "TestDb",
             BlockedSpid = blockedSpid,
-            BlockedTranStarted = blockedTran ?? TranFor(blockedSpid),
+            BlockedTranStarted = TranFor(blockedSpid),
             BlockingSpid = blockingSpid,
-            BlockingTranStarted = blockingTran ?? TranFor(blockingSpid),
+            BlockingTranStarted = TranFor(blockingSpid),
+            MonitorLoop = monitorLoop,
+            BlockedEcid = blockedEcid,
+            BlockingEcid = blockingEcid,
             WaitTimeMs = waitMs,
             LockMode = "X",
             BlockingStatus = blockingStatus,
@@ -40,8 +43,9 @@ public class BlockingChainReconstructorTests
         };
     }
 
-    private static BlockingReconstruction Run(IEnumerable<BlockingPairRow> rows) =>
-        BlockingChainReconstructor.Reconstruct(rows, MaxDepth, MaxPairs, StepBudget);
+    // Default scope is cumulative (the collector path); the viewer-style tests pass scopeByMonitorLoop: true.
+    private static BlockingReconstruction Run(IEnumerable<BlockingPairRow> rows, bool scopeByMonitorLoop = false) =>
+        BlockingChainReconstructor.Reconstruct(rows, MaxDepth, MaxPairs, StepBudget, scopeByMonitorLoop);
 
     [Fact]
     public void Empty_ProducesNoChains()
@@ -79,35 +83,88 @@ public class BlockingChainReconstructorTests
     }
 
     [Fact]
-    public void SpidReuse_DifferentTransactionStart_DoesNotSplice()
+    public void DeepChain_WithNullBlockerTran_StillFormsOneChain()
     {
-        // Real chain 200 → 201 → 202, plus SPID 201 reused (different tran) blocking 203.
-        var reusedTran = TranFor(201).AddHours(3);
+        // The bug this whole change fixes: blocking_last_tran_started is always NULL, so the old (spid, tran)
+        // key split a mid-chain node. Keying by spid:ecid within monitor_loop, 116 → 111 → 80 is ONE depth-2
+        // chain — 111 unifies as (loop, 111, 0) whether it is the blocker or the blocked party.
         var result = Run(new[]
         {
-            Pair(201, 200),
-            Pair(202, 201),
-            Pair(203, 201, blockingTran: reusedTran) // reused 201 — a distinct session
-        });
+            Pair(111, 116, monitorLoop: 620365),
+            Pair(80, 111, monitorLoop: 620365),
+        }, scopeByMonitorLoop: true);
 
-        // Two distinct chains: apex 200 depth 2, and the reused-201 apex depth 1.
-        Assert.Equal(2, result.Chains.Count);
-        Assert.Contains(result.Chains, c => c.ApexSpid == 200 && c.Depth == 2);
-        Assert.Contains(result.Chains, c => c.ApexSpid == 201 && c.Depth == 1);
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(116, chain.ApexSpid);
+        Assert.Equal(2, chain.Depth);
+        Assert.Equal(2, chain.VictimCount);
     }
 
     [Fact]
-    public void Sentinel_TransactionStart_NormalizesToNull()
+    public void SeparateEpisodes_SameSpid_DoNotLeak()
     {
-        // SQL Server's 1900-01-01 "no transaction" sentinel must key the same as NULL.
-        Assert.Equal(
-            BlockingChainReconstructor.MakeKey(100, null),
-            BlockingChainReconstructor.MakeKey(100, new DateTime(1900, 1, 1)));
+        // The same blocker→blocked pair in two different monitor_loops (episodes) must stay two chains, not
+        // merge — the cross-episode leakage the monitor_loop scope prevents for the viewer.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(201, 200, monitorLoop: 2),
+        }, scopeByMonitorLoop: true);
 
-        // And a real transaction start must NOT collapse to the sentinel key.
-        Assert.NotEqual(
-            BlockingChainReconstructor.MakeKey(100, null),
-            BlockingChainReconstructor.MakeKey(100, TranFor(100)));
+        Assert.Equal(2, result.Chains.Count);
+        Assert.All(result.Chains, c => Assert.Equal(200, c.ApexSpid));
+        Assert.Contains(result.Chains, c => c.MonitorLoop == 1);
+        Assert.Contains(result.Chains, c => c.MonitorLoop == 2);
+    }
+
+    [Fact]
+    public void ParallelBlocker_DistinctEcid_AreDistinctNodes()
+    {
+        // Same SPID, different ecid (parallel workers) are distinct sessions: spid 200 ecid 0 and ecid 1 each
+        // head their own chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1, blockingEcid: 0),
+            Pair(202, 200, monitorLoop: 1, blockingEcid: 1),
+        }, scopeByMonitorLoop: true);
+
+        Assert.Equal(2, result.Chains.Count);
+        Assert.Contains(result.Chains, c => c.ApexEcid == 0);
+        Assert.Contains(result.Chains, c => c.ApexEcid == 1);
+    }
+
+    [Fact]
+    public void Cumulative_MergesAcrossScans()
+    {
+        // The collector (scopeByMonitorLoop:false) ignores monitor_loop, so an episode's per-scan re-fires
+        // merge into ONE chain — preserving window-level depth/victims for the severity fact (per-scan scoping
+        // would under-count). 200 → 201 (scan 1) and 201 → 202 (scan 2) form one depth-2 chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(202, 201, monitorLoop: 2),
+        }, scopeByMonitorLoop: false);
+
+        var chain = Assert.Single(result.Chains);
+        Assert.Equal(200, chain.ApexSpid);
+        Assert.Equal(2, chain.Depth);
+        Assert.Null(chain.MonitorLoop);   // cumulative chains carry no episode
+    }
+
+    [Fact]
+    public void SpidReuse_DifferentMonitorLoop_DoesNotSplice()
+    {
+        // SPID 201 reused across two episodes is two distinct sessions, not one spliced chain.
+        var result = Run(new[]
+        {
+            Pair(201, 200, monitorLoop: 1),
+            Pair(202, 201, monitorLoop: 1),   // 200 → 201 → 202 in episode 1
+            Pair(203, 201, monitorLoop: 2),   // reused 201 heads its own chain in episode 2
+        }, scopeByMonitorLoop: true);
+
+        Assert.Equal(2, result.Chains.Count);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 200 && c.Depth == 2);
+        Assert.Contains(result.Chains, c => c.ApexSpid == 201 && c.Depth == 1);
     }
 
     [Fact]
@@ -129,7 +186,7 @@ public class BlockingChainReconstructorTests
     {
         // A 12-edge line, reconstructed with a maxDepth of 4.
         var rows = Enumerable.Range(0, 12).Select(i => Pair(501 + i, 500 + i)).ToList();
-        var result = BlockingChainReconstructor.Reconstruct(rows, maxDepth: 4, MaxPairs, StepBudget);
+        var result = BlockingChainReconstructor.Reconstruct(rows, maxDepth: 4, MaxPairs, StepBudget, scopeByMonitorLoop: false);
 
         Assert.True(result.DepthCapped);
         var chain = Assert.Single(result.Chains);
@@ -184,7 +241,7 @@ public class BlockingChainReconstructorTests
     [Fact]
     public void ReconstructedOutput_CarriesTranStartedAndDatabaseName()
     {
-        // The additive output fields (Phase 0) the block-chain tree builder rebuilds the tree from.
+        // Transaction start is display-only now, sourced from the rows (apex from its first outgoing edge).
         var result = Run(new[] { Pair(201, 200), Pair(202, 201) });
 
         var chain = Assert.Single(result.Chains);
@@ -202,84 +259,48 @@ public class BlockingChainReconstructorTests
     [Fact]
     public void FindChainForSession_AnyMember_ReturnsChainRootedAtApex()
     {
-        // Two separate chains — A: 200 -> 201 -> 202 ; B: 300 -> 301. The viewer scopes to the ONE chain a
+        // Two separate chains — A: 200 → 201 → 202 ; B: 300 → 301. The viewer scopes to the ONE chain a
         // clicked session belongs to, rooted at its apex regardless of where in the chain it sits.
         var result = Run(new[] { Pair(201, 200), Pair(202, 201), Pair(301, 300) });
 
-        // Mid-level 201 -> chain A, rooted at apex 200 (not at the clicked node).
-        var chainA = BlockingChainReconstructor.FindChainForSession(result, 201, TranFor(201));
+        var chainA = BlockingChainReconstructor.FindChainForSession(result, null, 201, 0);
         Assert.NotNull(chainA);
         Assert.Equal(200, chainA!.ApexSpid);
 
-        // The apex itself and a leaf victim resolve to the same apex-rooted chain.
-        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 200, TranFor(200))!.ApexSpid);
-        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 202, TranFor(202))!.ApexSpid);
-
-        // A member of the other chain resolves to that chain; an absent session returns null.
-        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, 301, TranFor(301))!.ApexSpid);
-        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, 999, TranFor(999)));
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, null, 200, 0)!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, null, 202, 0)!.ApexSpid);
+        Assert.Equal(300, BlockingChainReconstructor.FindChainForSession(result, null, 301, 0)!.ApexSpid);
+        Assert.Null(BlockingChainReconstructor.FindChainForSession(result, null, 999, 0));
     }
 
     [Fact]
-    public void FindChainForSession_VictimUnderTwoApexes_DisambiguatesByClickedBlocker()
+    public void FindChainForSession_DisambiguatesByMonitorLoop()
     {
-        // Victim 500 (same tran) was blocked by apex 100 and, at another time, apex 200 — two separate
-        // chains, BOTH containing 500. The edge-precise overload returns the chain reached via the clicked
-        // row's blocker, so the clicked row opens the right chain.
+        // Victim 500 was blocked by apex 100 in episode 1 and apex 200 in episode 2 — two scoped chains, both
+        // containing 500. The clicked row's monitor_loop selects the right one.
         var result = Run(new[]
         {
-            Pair(blockedSpid: 500, blockingSpid: 100),
-            Pair(blockedSpid: 500, blockingSpid: 200)
-        });
+            Pair(blockedSpid: 500, blockingSpid: 100, monitorLoop: 1),
+            Pair(blockedSpid: 500, blockingSpid: 200, monitorLoop: 2)
+        }, scopeByMonitorLoop: true);
 
-        Assert.Equal(100, BlockingChainReconstructor
-            .FindChainForSession(result, 500, TranFor(500), 100, TranFor(100))!.ApexSpid);
-        Assert.Equal(200, BlockingChainReconstructor
-            .FindChainForSession(result, 500, TranFor(500), 200, TranFor(200))!.ApexSpid);
-
-        // No recorded blocker -> falls back to the any-level match (one of the chains that contains 500).
-        var fallback = BlockingChainReconstructor.FindChainForSession(result, 500, TranFor(500), 0, null);
-        Assert.NotNull(fallback);
-        Assert.Contains(fallback!.ApexSpid, new[] { 100, 200 });
+        Assert.Equal(100, BlockingChainReconstructor.FindChainForSession(result, 1, 500, 0)!.ApexSpid);
+        Assert.Equal(200, BlockingChainReconstructor.FindChainForSession(result, 2, 500, 0)!.ApexSpid);
     }
 
     [Fact]
-    public void FindChainForSession_BlockerSideClick_ResolvesViaSpidWhenBlockerTranIsNull()
+    public void FindChainForSession_NullMonitorLoop_FallsBackToSpidEcid()
     {
-        // Real shape from collect.blocking_BlockedProcessReport: the 'blocked' row (75) names its blocker's
-        // SPID (59) but a NULL blocking_last_tran_started, so the reconstruction keys the apex (59, NULL). The
-        // separate 'blocking' row for 59 carries its OWN real last_transaction_started. Clicking that blocking
-        // row must still open the chain (regression: it previously returned null -> "no reconstructable chain").
-        var blockedTran = new DateTime(2026, 6, 23, 7, 21, 14, 897);
-        var blockerOwnTran = new DateTime(2026, 6, 23, 7, 21, 14, 890); // 59's real tran, from its 'blocking' row
-
+        // A lead-blocker grid row may not supply its monitor_loop; the click must still resolve via spid:ecid
+        // rather than reporting "no reconstructable chain" (supersedes the #1222 SPID-only fallback).
         var result = Run(new[]
         {
-            new BlockingPairRow
-            {
-                EventTime = new DateTime(2026, 6, 23, 7, 21, 14),
-                DatabaseName = "hammerdb_tpcc",
-                BlockedSpid = 75,
-                BlockedTranStarted = blockedTran,
-                BlockingSpid = 59,
-                BlockingTranStarted = null,   // blocker's tran is NULL on the blocked row -> apex keyed (59, NULL)
-                WaitTimeMs = 6893,
-                LockMode = "X",
-                BlockingStatus = "suspended"
-            }
-        });
+            Pair(201, 200, monitorLoop: 7),
+            Pair(202, 201, monitorLoop: 7),
+        }, scopeByMonitorLoop: true);
 
-        var chain = Assert.Single(result.Chains);
-        Assert.Equal(59, chain.ApexSpid);
-        Assert.Null(chain.ApexTranStarted);   // keyed with no tran
-
-        // Blocked-row click carries the exact (59 -> 75) edge and already worked.
-        Assert.NotNull(BlockingChainReconstructor.FindChainForSession(result, 75, blockedTran, 59, null));
-
-        // Blocking-row click: spid 59 with its REAL tran, no recorded blocker. The precise SessionKey can't
-        // match (59, NULL), so the SPID-only fallback must still find the chain.
-        var fromBlocker = BlockingChainReconstructor.FindChainForSession(result, 59, blockerOwnTran, 0, null);
-        Assert.NotNull(fromBlocker);
-        Assert.Equal(59, fromBlocker!.ApexSpid);
+        var chain = BlockingChainReconstructor.FindChainForSession(result, null, 200, 0);
+        Assert.NotNull(chain);
+        Assert.Equal(200, chain!.ApexSpid);
     }
 }

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -27,11 +27,10 @@ internal static class BlockingChainViewerProjection
     /// </summary>
     public static BlockingChainModel? BuildModelForSession(
         BlockingReconstruction reconstruction,
-        int blockedSpid, DateTime? blockedTran,
-        int blockingSpid, DateTime? blockingTran)
+        int? monitorLoop, int spid, int ecid)
     {
         var chain = BlockingChainReconstructor.FindChainForSession(
-            reconstruction, blockedSpid, blockedTran, blockingSpid, blockingTran);
+            reconstruction, monitorLoop, spid, ecid);
         if (chain == null)
             return null;
 
@@ -45,6 +44,7 @@ internal static class BlockingChainViewerProjection
     private static BlockingChainInput ToInput(ReconstructedChain c) => new()
     {
         ApexSpid = c.ApexSpid,
+        ApexEcid = c.ApexEcid,
         ApexTranStarted = c.ApexTranStarted,
         ApexSleeping = c.ApexSleeping,
         Magnitude = c.Magnitude,
@@ -52,8 +52,10 @@ internal static class BlockingChainViewerProjection
         {
             Level = l.Level,
             BlockingSpid = l.BlockingSpid,
+            BlockingEcid = l.BlockingEcid,
             BlockingTranStarted = l.BlockingTranStarted,
             BlockedSpid = l.BlockedSpid,
+            BlockedEcid = l.BlockedEcid,
             BlockedTranStarted = l.BlockedTranStarted,
             LockMode = l.LockMode,
             WaitTimeMs = l.WaitTimeMs,

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -42,6 +42,13 @@ internal static class BlockingPairRowQuery
     blocking_host_name,
     blocking_client_app";
 
+    /// <summary>Ordinals 18-20: spid:ecid + monitor_loop, the reconstruction's session identity. Every
+    /// pair-row site appends this after contentious_object (ordinal 17) so the shared <see cref="Read"/> sees
+    /// one column order across all three call sites.</summary>
+    public const string TrailingIdentityColumns = @"blocked_ecid,
+    blocking_ecid,
+    monitor_loop";
+
     /// <summary>Append to the WHERE clause of every pair-row query (covers NULL and the 0 sentinel).</summary>
     public const string SpidFilter = @"AND blocking_spid IS NOT NULL
 AND blocking_spid <> 0";
@@ -66,7 +73,11 @@ AND blocking_spid <> 0";
         BlockingHostName = reader.IsDBNull(15) ? string.Empty : reader.GetString(15),
         BlockingClientApp = reader.IsDBNull(16) ? string.Empty : reader.GetString(16),
         // Ordinal 17: the contended object (every pair-row site appends contentious_object after IdentityColumns).
-        ContentiousObject = reader.IsDBNull(17) ? string.Empty : reader.GetString(17)
+        ContentiousObject = reader.IsDBNull(17) ? string.Empty : reader.GetString(17),
+        // 18-20: spid:ecid + monitor_loop (every site appends TrailingIdentityColumns after contentious_object).
+        BlockedEcid = reader.IsDBNull(18) ? 0 : Convert.ToInt32(reader.GetValue(18)),
+        BlockingEcid = reader.IsDBNull(19) ? 0 : Convert.ToInt32(reader.GetValue(19)),
+        MonitorLoop = reader.IsDBNull(20) ? (int?)null : Convert.ToInt32(reader.GetValue(20))
     };
 
     /// <summary>

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -122,7 +122,8 @@ SELECT
     LEFT(blocked_sql_text, 500) AS blocked_sql,
     LEFT(blocking_sql_text, 500) AS blocking_sql,
     {BlockingPairRowQuery.IdentityColumns},
-    contentious_object
+    contentious_object,
+    {BlockingPairRowQuery.TrailingIdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {BlockingPairRowQuery.SpidFilter}
@@ -143,7 +144,7 @@ LIMIT 5000";
         if (rows.Count == 0) return;
 
         var reconstruction = BlockingChainReconstructor.Reconstruct(
-            rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+            rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000, scopeByMonitorLoop: false);
 
         var items = new List<object>();
         foreach (var chain in reconstruction.Chains.Take(3))

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -207,7 +207,8 @@ SELECT
     blocked_sql_text,
     blocking_sql_text,
     {BlockingPairRowQuery.IdentityColumns},
-    contentious_object
+    contentious_object,
+    {BlockingPairRowQuery.TrailingIdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   event_time >= $2
@@ -229,7 +230,7 @@ LIMIT 5000";
 
             if (rows.Count == 0) return;
 
-            var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget);
+            var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget, scopeByMonitorLoop: false);
             if (reconstruction.Chains.Count == 0) return;
 
             var worst = reconstruction.Chains[0];

--- a/Lite/Analysis/TestDataSeeder.cs
+++ b/Lite/Analysis/TestDataSeeder.cs
@@ -931,24 +931,25 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)";
         var baseTran = TestPeriodStart;
         DateTime Tran(int spid) => baseTran.AddSeconds(spid);
 
-        // blocked spid, blocked tran, blocking spid, blocking tran, blocking status
-        var pairs = new (int BlockedSpid, DateTime BlockedTran, int BlockingSpid, DateTime BlockingTran, string BlockingStatus)[]
+        // blocked spid, blocked tran, blocking spid, blocking tran, blocking status, blocked ecid
+        var pairs = new (int BlockedSpid, DateTime BlockedTran, int BlockingSpid, DateTime BlockingTran, string BlockingStatus, int BlockedEcid)[]
         {
             // Chain A — depth 4, apex 200 sleeping
-            (201, Tran(201), 200, Tran(200), "sleeping"),
-            (202, Tran(202), 201, Tran(201), "running"),
-            (203, Tran(203), 202, Tran(202), "running"),
-            (204, Tran(204), 203, Tran(203), "running"),
+            (201, Tran(201), 200, Tran(200), "sleeping", 0),
+            (202, Tran(202), 201, Tran(201), "running", 0),
+            (203, Tran(203), 202, Tran(202), "running", 0),
+            (204, Tran(204), 203, Tran(203), "running", 0),
             // Chain B — depth 1, apex 300, five victims
-            (301, Tran(301), 300, Tran(300), "running"),
-            (302, Tran(302), 300, Tran(300), "running"),
-            (303, Tran(303), 300, Tran(300), "running"),
-            (304, Tran(304), 300, Tran(300), "running"),
-            (305, Tran(305), 300, Tran(300), "running"),
-            // SPID reuse — spid 201 again, a different transaction start; must not join Chain A
-            (201, Tran(201).AddHours(2), 210, Tran(210), "running"),
+            (301, Tran(301), 300, Tran(300), "running", 0),
+            (302, Tran(302), 300, Tran(300), "running", 0),
+            (303, Tran(303), 300, Tran(300), "running", 0),
+            (304, Tran(304), 300, Tran(300), "running", 0),
+            (305, Tran(305), 300, Tran(300), "running", 0),
+            // SPID reuse — spid 201 again on a DIFFERENT execution context (ecid 1); the (spid, ecid) key
+            // keeps this distinct session off Chain A (transaction start is no longer the disambiguator).
+            (201, Tran(201).AddHours(2), 210, Tran(210), "running", 1),
             // 1900-01-01 sentinel transaction start on the blocked session
-            (220, new DateTime(1900, 1, 1), 221, Tran(221), "running"),
+            (220, new DateTime(1900, 1, 1), 221, Tran(221), "running", 0),
         };
 
         for (var i = 0; i < pairs.Length; i++)
@@ -962,8 +963,9 @@ INSERT INTO blocked_process_reports
     (blocked_report_id, collection_time, server_id, server_name,
      event_time, database_name, blocked_spid, blocked_last_tran_started,
      blocking_spid, blocking_last_tran_started, wait_time_ms,
-     lock_mode, blocked_status, blocking_status, blocked_sql_text, blocking_sql_text)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)";
+     lock_mode, blocked_status, blocking_status, blocked_sql_text, blocking_sql_text,
+     blocked_ecid)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = _nextId-- });
             cmd.Parameters.Add(new DuckDBParameter { Value = eventTime });
@@ -981,6 +983,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)";
             cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockingStatus });
             cmd.Parameters.Add(new DuckDBParameter { Value = $"SELECT * FROM dbo.T WHERE id = {p.BlockedSpid}" });
             cmd.Parameters.Add(new DuckDBParameter { Value = $"UPDATE dbo.T SET v = 1 WHERE id = {p.BlockingSpid}" });
+            cmd.Parameters.Add(new DuckDBParameter { Value = p.BlockedEcid });
             await cmd.ExecuteNonQueryAsync();
         }
     }

--- a/Lite/Controls/ServerTab.BlockChain.cs
+++ b/Lite/Controls/ServerTab.BlockChain.cs
@@ -50,9 +50,8 @@ public partial class ServerTab : UserControl
     {
         var spid = row.BlockedSpid;
         if (spid <= 0) return;
-        var rawTran = row.BlockedLastTranStarted;
-        var blockerSpid = row.BlockingSpid;
-        var blockerTran = row.BlockingLastTranStarted;
+        var ecid = row.BlockedEcid;
+        var monitorLoop = row.MonitorLoop;   // the clicked event's episode; scopes the reconstruction match
 
         try
         {
@@ -87,9 +86,9 @@ public partial class ServerTab : UserControl
             {
                 var rows = await _dataService.GetBlockingPairRowsAsync(_serverId, start, end);
                 var reconstruction = BlockingChainReconstructor.Reconstruct(
-                    rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000);
+                    rows, maxDepth: 50, maxPairs: 5000, stepBudget: 100_000, scopeByMonitorLoop: true);
                 return BlockingChainViewerProjection.BuildModelForSession(
-                    reconstruction, spid, rawTran, blockerSpid, blockerTran);
+                    reconstruction, monitorLoop, spid, ecid);
             });
 
             if (model == null)
@@ -105,12 +104,8 @@ public partial class ServerTab : UserControl
                 return;
             }
 
-            // Normalize the clicked tran the same way the reconstructor keyed the nodes, so the control can
-            // match + highlight the clicked session.
-            var key = BlockingChainReconstructor.MakeKey(spid, rawTran);
-
             var control = new BlockingChainControl();
-            control.LoadModel(model, key.Spid, key.TranStarted, BlockingChainViewerProjection.EmptyStateDetail);
+            control.LoadModel(model, spid, ecid, BlockingChainViewerProjection.EmptyStateDetail);
             GraphViewerWindow.ShowGraph(
                 Window.GetWindow(this),
                 control,

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 31;
+    internal const int CurrentSchemaVersion = 32;
 
     private readonly string _archivePath;
 
@@ -788,6 +788,24 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v31 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 32)
+        {
+            /* v32: block-chain reconstruction now keys sessions by spid:ecid within monitor_loop (mirroring
+               sp_HumanEventsBlockViewer). blocked_process_reports gains monitor_loop (the blocked-process-report
+               episode). Appended at the end to keep the positional appender aligned; the v_ view (SELECT *,
+               recreated on startup) surfaces it; old parquet reads back NULL (union BY NAME). The collector
+               appender now writes monitor_loop, so an un-migrated DB would mis-align — this ALTER is required. */
+            _logger?.LogInformation("Running migration to v32: blocked_process_reports.monitor_loop");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE blocked_process_reports ADD COLUMN IF NOT EXISTS monitor_loop INTEGER");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v32 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -472,7 +472,8 @@ CREATE TABLE IF NOT EXISTS blocked_process_reports (
     blocked_process_report_xml VARCHAR,
     object_id INTEGER,
     database_id INTEGER,
-    contentious_object VARCHAR
+    contentious_object VARCHAR,
+    monitor_loop INTEGER
 )";
 
     public const string CreateDatabaseConfigTable = @"

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -291,7 +291,8 @@ SELECT
     blocking_last_batch_completed,
     blocked_priority,
     blocking_priority,
-    contentious_object
+    contentious_object,
+    monitor_loop
 FROM v_blocked_process_reports
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -344,7 +345,8 @@ LIMIT 200";
                 BlockingLastBatchCompleted = reader.IsDBNull(32) ? null : reader.GetDateTime(32),
                 BlockedPriority = reader.IsDBNull(33) ? 0 : reader.GetInt32(33),
                 BlockingPriority = reader.IsDBNull(34) ? 0 : reader.GetInt32(34),
-                ContentiousObject = reader.IsDBNull(35) ? "" : reader.GetString(35)
+                ContentiousObject = reader.IsDBNull(35) ? "" : reader.GetString(35),
+                MonitorLoop = reader.IsDBNull(36) ? (int?)null : reader.GetInt32(36)
             });
         }
 
@@ -370,7 +372,8 @@ SELECT
     {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.LeadingColumns},
     blocked_sql_text, blocking_sql_text,
     {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.IdentityColumns},
-    contentious_object
+    contentious_object,
+    {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.TrailingIdentityColumns}
 FROM v_blocked_process_reports
 WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
 {PerformanceMonitorLite.Analysis.BlockingPairRowQuery.SpidFilter}
@@ -874,6 +877,7 @@ public class BlockedProcessReportRow
     public int BlockedEcid { get; set; }
     public int BlockingSpid { get; set; }
     public int BlockingEcid { get; set; }
+    public int? MonitorLoop { get; set; }
     public long WaitTimeMs { get; set; }
     public string WaitResource { get; set; } = "";
     public string LockMode { get; set; } = "";

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -696,6 +696,7 @@ OPTION(RECOMPILE);";
                            .AppendValue(objectId)
                            .AppendValue(databaseId)
                            .AppendValue(contentiousObject)
+                           .AppendValue(parsed.MonitorLoop)
                            .EndRow();
 
                         rowsCollected++;
@@ -741,6 +742,8 @@ OPTION(RECOMPILE);";
             return new ParsedBlockedProcessReport
             {
                 EventTime = eventTime,
+                // Lite's stored XML is rooted at <blocked-process-report>, so monitorLoop is a root attribute.
+                MonitorLoop = int.TryParse(doc.Attribute("monitorLoop")?.Value, out var ml) ? ml : (int?)null,
                 DatabaseName = blockedProcess.Attribute("currentdbname")?.Value,
                 BlockedSpid = int.TryParse(blockedProcess.Attribute("spid")?.Value, out var bs) ? bs : 0,
                 BlockedEcid = int.TryParse(blockedProcess.Attribute("ecid")?.Value, out var be) ? be : 0,
@@ -787,6 +790,7 @@ OPTION(RECOMPILE);";
     private class ParsedBlockedProcessReport
     {
         public DateTime? EventTime { get; set; }
+        public int? MonitorLoop { get; set; }
         public string? DatabaseName { get; set; }
         public int BlockedSpid { get; set; }
         public int BlockedEcid { get; set; }

--- a/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
+++ b/PerformanceMonitor.Analysis/BlockingChainReconstructor.cs
@@ -23,6 +23,13 @@ internal sealed class BlockingPairRow
     public DateTime? BlockedTranStarted { get; init; }
     public int BlockingSpid { get; init; }
     public DateTime? BlockingTranStarted { get; init; }
+    /// <summary>The blocked-process-report's monitorLoop — the episode (one monitor scan) the row belongs to.
+    /// Nullable: only the viewer scopes by it; the collector passes scopeByMonitorLoop=false (treated as null).</summary>
+    public int? MonitorLoop { get; init; }
+    /// <summary>Execution-context id of each side; with spid it forms the session identity the reconstruction
+    /// keys on (mirrors sp_HumanEventsBlockViewer's spid:ecid). 0 for the common non-parallel case.</summary>
+    public int BlockedEcid { get; init; }
+    public int BlockingEcid { get; init; }
     public long WaitTimeMs { get; init; }
     public string LockMode { get; init; } = string.Empty;
     public string BlockingStatus { get; init; } = string.Empty;
@@ -44,21 +51,25 @@ internal sealed class BlockingPairRow
 }
 
 /// <summary>
-/// Stable session identity. A SPID is reused across the analysis window, so the bare
-/// integer is not a session identity — the transaction start time disambiguates two
-/// sessions that reused one SPID.
+/// Stable session identity mirroring sp_HumanEventsBlockViewer: spid:ecid scoped to a monitor_loop (one
+/// blocked-process-report scan = one episode). MonitorLoop is null when the caller reconstructs cumulatively
+/// across the window (the collector) rather than per-scan (the viewer); ecid distinguishes parallel workers.
+/// Transaction start is NOT part of the identity — the blocking-process node omits it, so it is null on every
+/// blocker and cannot disambiguate.
 /// </summary>
-internal readonly record struct SessionKey(int Spid, DateTime? TranStarted);
+internal readonly record struct SessionKey(int? MonitorLoop, int Spid, int Ecid);
 
 /// <summary>One level (one blocked/blocker edge) of a reconstructed chain, for drill-down.</summary>
 internal sealed class ChainLevel
 {
     public int Level { get; init; }
     public int BlockingSpid { get; init; }
-    /// <summary>Transaction start of the blocking side — the identity disambiguator a faithful
-    /// tree rebuild needs (a SPID reused by two sessions in the window is two real nodes).</summary>
+    public int BlockingEcid { get; init; }
+    /// <summary>Transaction start of the blocking side — display only (sentinel-normalized); not part of the
+    /// session identity, which is spid:ecid within monitor_loop.</summary>
     public DateTime? BlockingTranStarted { get; init; }
     public int BlockedSpid { get; init; }
+    public int BlockedEcid { get; init; }
     public DateTime? BlockedTranStarted { get; init; }
     public string LockMode { get; init; } = string.Empty;
     public long WaitTimeMs { get; init; }
@@ -79,7 +90,11 @@ internal sealed class ChainLevel
 internal sealed class ReconstructedChain
 {
     public int ApexSpid { get; init; }
-    /// <summary>Transaction start of the apex — pairs with <see cref="ApexSpid"/> as its session identity.</summary>
+    public int ApexEcid { get; init; }
+    /// <summary>The chain's episode (monitor_loop) when scoped per-scan; null for a cumulative reconstruction.
+    /// All nodes in a scoped chain share it (one report's two sides carry the same monitor_loop).</summary>
+    public int? MonitorLoop { get; init; }
+    /// <summary>Transaction start of the apex — display only (null for a blocker, which has none).</summary>
     public DateTime? ApexTranStarted { get; init; }
     public bool ApexSleeping { get; init; }
     public int Depth { get; init; }
@@ -116,111 +131,55 @@ internal static class BlockingChainReconstructor
     // available when building the ChainLevel without re-listing each one here.
     private sealed record EdgeInfo(BlockingPairRow Row);
 
-    /// <summary>Builds a stable session key, normalizing the 1900-01-01 sentinel to NULL.</summary>
-    public static SessionKey MakeKey(int spid, DateTime? tranStarted)
-    {
-        var normalized = tranStarted.HasValue && tranStarted.Value > SentinelFloor ? tranStarted : null;
-        return new SessionKey(spid, normalized);
-    }
+    /// <summary>Builds a session key. MonitorLoop is null when reconstructing cumulatively (collector).</summary>
+    public static SessionKey MakeKey(int? monitorLoop, int spid, int ecid) => new(monitorLoop, spid, ecid);
+
+    /// <summary>Normalizes the 1900-01-01 sentinel to NULL for display tran values.</summary>
+    private static DateTime? NormalizeTran(DateTime? tranStarted) =>
+        tranStarted.HasValue && tranStarted.Value > SentinelFloor ? tranStarted : null;
 
     /// <summary>
-    /// Finds the single reconstructed chain that contains the given session (matched by SessionKey — the
-    /// session may be the apex, a mid-level blocker, or a leaf victim). Returns the chain rooted at its
-    /// apex, or null if no chain contains the session. Lets the viewer scope to the one chain the clicked
-    /// row belongs to.
+    /// Finds the single reconstructed chain that contains the clicked session, matched by spid:ecid within
+    /// its episode (monitor_loop). The session may be the apex, a mid-level blocker, or a leaf victim. When
+    /// the clicked monitor_loop is unavailable (e.g. a lead-blocker grid row), it falls back to a
+    /// monitor_loop-agnostic spid:ecid match — the reconstruction window is already tight, so this still lands
+    /// on the right chain rather than reporting "no reconstructable chain." Returns null when no chain holds
+    /// the session. Only the viewer calls this, on a per-scan (scoped) reconstruction; the collector takes the
+    /// worst chain directly.
     /// </summary>
     public static ReconstructedChain? FindChainForSession(
-        BlockingReconstruction reconstruction, int spid, DateTime? tranStarted)
+        BlockingReconstruction reconstruction, int? monitorLoop, int spid, int ecid)
     {
-        var key = MakeKey(spid, tranStarted);
         foreach (var chain in reconstruction.Chains)
-            if (ChainContains(chain, key))
-                return chain;
-        return null;
-    }
-
-    /// <summary>
-    /// Edge-precise overload: when the clicked row carries its blocker too, prefer the chain that contains
-    /// the exact (blocker -> blocked) edge. This disambiguates a victim that was blocked by two different
-    /// lead blockers at different times in the window (each is a separate chain, both containing the victim).
-    /// Falls back to the any-level SessionKey match on the blocked session when no chain holds that exact edge
-    /// (e.g. the clicked row has no recorded blocker), and finally to a SPID-only match: the blocked-process
-    /// report keys a blocker with a NULL transaction start (it is not recorded on the blocked row), so a click
-    /// on that session's own 'blocking' row — which carries its real last_transaction_started — would otherwise
-    /// never match the (spid, NULL) apex node and the viewer would wrongly report "no reconstructable chain."
-    /// </summary>
-    public static ReconstructedChain? FindChainForSession(
-        BlockingReconstruction reconstruction,
-        int blockedSpid, DateTime? blockedTran,
-        int blockingSpid, DateTime? blockingTran)
-    {
-        var blockedKey = MakeKey(blockedSpid, blockedTran);
-        var blockerKey = MakeKey(blockingSpid, blockingTran);
-
-        foreach (var chain in reconstruction.Chains)
-            if (ChainContainsEdge(chain, blockerKey, blockedKey))
+            if ((!monitorLoop.HasValue || chain.MonitorLoop == monitorLoop) &&
+                ChainContainsSpidEcid(chain, spid, ecid))
                 return chain;
 
-        foreach (var chain in reconstruction.Chains)
-            if (ChainContains(chain, blockedKey))
-                return chain;
-
-        // Last resort: SPID alone, ignoring the transaction-start identity. A blocker is keyed (spid, NULL) in
-        // the reconstruction (its tran start is NULL on the blocked row), but a click on its 'blocking' row
-        // supplies the session's real tran start, so neither precise pass above can match it. Precise matches
-        // run first and the reconstruction is scoped to a tight time window, so SPID reuse is unlikely to
-        // mislead here — and returning the chain this SPID participates in beats a false "no chain" dialog.
-        foreach (var chain in reconstruction.Chains)
-            if (ChainContainsSpid(chain, blockedSpid))
-                return chain;
+        if (monitorLoop.HasValue)
+            foreach (var chain in reconstruction.Chains)
+                if (ChainContainsSpidEcid(chain, spid, ecid))
+                    return chain;
 
         return null;
     }
 
-    /// <summary>True if the chain has the exact blocker -> blocked edge.</summary>
-    private static bool ChainContainsEdge(ReconstructedChain chain, SessionKey blockerKey, SessionKey blockedKey)
+    /// <summary>True if the session (spid:ecid) appears anywhere in the chain — apex, a blocker, or a victim.</summary>
+    private static bool ChainContainsSpidEcid(ReconstructedChain chain, int spid, int ecid)
     {
-        foreach (var l in chain.Levels)
-            if (MakeKey(l.BlockingSpid, l.BlockingTranStarted).Equals(blockerKey) &&
-                MakeKey(l.BlockedSpid, l.BlockedTranStarted).Equals(blockedKey))
-                return true;
-        return false;
-    }
-
-    /// <summary>True if the session appears anywhere in the chain (apex, a blocker, or a victim).</summary>
-    private static bool ChainContains(ReconstructedChain chain, SessionKey key)
-    {
-        if (MakeKey(chain.ApexSpid, chain.ApexTranStarted).Equals(key))
+        if (chain.ApexSpid == spid && chain.ApexEcid == ecid)
             return true;
 
         foreach (var l in chain.Levels)
         {
-            if (MakeKey(l.BlockingSpid, l.BlockingTranStarted).Equals(key)) return true;
-            if (MakeKey(l.BlockedSpid, l.BlockedTranStarted).Equals(key)) return true;
+            if (l.BlockingSpid == spid && l.BlockingEcid == ecid) return true;
+            if (l.BlockedSpid == spid && l.BlockedEcid == ecid) return true;
         }
 
         return false;
     }
 
-    /// <summary>
-    /// True if the SPID appears anywhere in the chain, ignoring the transaction-start identity. The coarse
-    /// last-resort match for the edge-precise <see cref="FindChainForSession(BlockingReconstruction,int,DateTime?,int,DateTime?)"/>,
-    /// for when a blocker is keyed (spid, NULL) in the reconstruction but the clicked row carries a real tran start.
-    /// </summary>
-    private static bool ChainContainsSpid(ReconstructedChain chain, int spid)
-    {
-        if (chain.ApexSpid == spid)
-            return true;
-
-        foreach (var l in chain.Levels)
-            if (l.BlockingSpid == spid || l.BlockedSpid == spid)
-                return true;
-
-        return false;
-    }
-
     public static BlockingReconstruction Reconstruct(
-        IEnumerable<BlockingPairRow> rows, int maxDepth, int maxPairs, int stepBudget)
+        IEnumerable<BlockingPairRow> rows, int maxDepth, int maxPairs, int stepBudget, bool scopeByMonitorLoop)
     {
         var pairs = rows.Take(maxPairs).ToList();
         if (pairs.Count == 0)
@@ -235,8 +194,11 @@ internal static class BlockingChainReconstructor
 
         foreach (var row in pairs)
         {
-            var blocker = MakeKey(row.BlockingSpid, row.BlockingTranStarted);
-            var blocked = MakeKey(row.BlockedSpid, row.BlockedTranStarted);
+            // The collector reconstructs cumulatively (loop = null) so an episode's per-scan re-fires merge into
+            // one chain (preserves window-level depth/victims for the severity fact); the viewer scopes per scan.
+            var loop = scopeByMonitorLoop ? row.MonitorLoop : null;
+            var blocker = MakeKey(loop, row.BlockingSpid, row.BlockingEcid);
+            var blocked = MakeKey(loop, row.BlockedSpid, row.BlockedEcid);
 
             allNodes.Add(blocker);
             allNodes.Add(blocked);
@@ -280,10 +242,18 @@ internal static class BlockingChainReconstructor
                 FactScorer.ApplyThresholdFormula(depth, 3, 8),
                 FactScorer.ApplyThresholdFormula(victimCount, 5, 25));
 
+            // Apex display tran comes from its first outgoing edge's blocking side (the apex never appears as a
+            // blocked row); a blocker has no tran on Dashboard (null) but Lite carries it.
+            var apexTran = adjacency.TryGetValue(root, out var apexDests) && apexDests.Count > 0
+                ? NormalizeTran(apexDests.Values.First().Row.BlockingTranStarted)
+                : null;
+
             chains.Add(new ReconstructedChain
             {
                 ApexSpid = root.Spid,
-                ApexTranStarted = root.TranStarted,
+                ApexEcid = root.Ecid,
+                MonitorLoop = root.MonitorLoop,
+                ApexTranStarted = apexTran,
                 ApexSleeping = sleepingBlockers.Contains(root),
                 Depth = depth,
                 VictimCount = victimCount,
@@ -468,9 +438,11 @@ internal static class BlockingChainReconstructor
                 {
                     Level = level + 1,
                     BlockingSpid = node.Spid,
-                    BlockingTranStarted = node.TranStarted,
+                    BlockingEcid = node.Ecid,
+                    BlockingTranStarted = NormalizeTran(row.BlockingTranStarted),
                     BlockedSpid = child.Spid,
-                    BlockedTranStarted = child.TranStarted,
+                    BlockedEcid = child.Ecid,
+                    BlockedTranStarted = NormalizeTran(row.BlockedTranStarted),
                     LockMode = row.LockMode ?? string.Empty,
                     WaitTimeMs = row.WaitTimeMs,
                     DatabaseName = row.DatabaseName ?? string.Empty,

--- a/PerformanceMonitor.Common/BlockingChainModel.cs
+++ b/PerformanceMonitor.Common/BlockingChainModel.cs
@@ -41,8 +41,11 @@ namespace PerformanceMonitor.Common
     {
         public int Spid { get; init; }
 
-        /// <summary>Transaction start; the identity disambiguator that defeats SPID reuse. May be null
-        /// (no open transaction / sentinel-normalized).</summary>
+        /// <summary>Execution-context id; with <see cref="Spid"/> forms the node identity (spid:ecid, mirroring
+        /// sp_HumanEventsBlockViewer). 0 for the common non-parallel case.</summary>
+        public int Ecid { get; init; }
+
+        /// <summary>Transaction start — display only now (identity is spid:ecid). May be null.</summary>
         public DateTime? TranStarted { get; init; }
 
         /// <summary>True for the lead/head blocker at the root of its tree.</summary>
@@ -94,6 +97,7 @@ namespace PerformanceMonitor.Common
     public sealed class BlockingChainInput
     {
         public int ApexSpid { get; init; }
+        public int ApexEcid { get; init; }
         public DateTime? ApexTranStarted { get; init; }
         public bool ApexSleeping { get; init; }
         public double Magnitude { get; init; }
@@ -110,8 +114,10 @@ namespace PerformanceMonitor.Common
         /// not read this, so a reorder of the source edges can't change the built tree.</summary>
         public int Level { get; init; }
         public int BlockingSpid { get; init; }
+        public int BlockingEcid { get; init; }
         public DateTime? BlockingTranStarted { get; init; }
         public int BlockedSpid { get; init; }
+        public int BlockedEcid { get; init; }
         public DateTime? BlockedTranStarted { get; init; }
         public string LockMode { get; init; } = string.Empty;
         public long WaitTimeMs { get; init; }

--- a/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
+++ b/PerformanceMonitor.Common/BlockingChainTreeBuilder.cs
@@ -19,16 +19,16 @@ namespace PerformanceMonitor.Common
     /// </summary>
     public static class BlockingChainTreeBuilder
     {
-        // (Spid, TranStarted) is the session identity — see BlockingChainNode. ValueTuple gives correct
-        // structural equality for the dictionary keys (Nullable&lt;DateTime&gt; compares by value).
+        // (Spid, Ecid) is the session identity — see BlockingChainNode (mirrors sp_HumanEventsBlockViewer's
+        // spid:ecid). Transaction start is display-only and no longer part of the key.
         private readonly struct NodeKey : IEquatable<NodeKey>
         {
             public readonly int Spid;
-            public readonly DateTime? Tran;
-            public NodeKey(int spid, DateTime? tran) { Spid = spid; Tran = tran; }
-            public bool Equals(NodeKey other) => Spid == other.Spid && Nullable.Equals(Tran, other.Tran);
+            public readonly int Ecid;
+            public NodeKey(int spid, int ecid) { Spid = spid; Ecid = ecid; }
+            public bool Equals(NodeKey other) => Spid == other.Spid && Ecid == other.Ecid;
             public override bool Equals(object? obj) => obj is NodeKey k && Equals(k);
-            public override int GetHashCode() => HashCode.Combine(Spid, Tran);
+            public override int GetHashCode() => HashCode.Combine(Spid, Ecid);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace PerformanceMonitor.Common
                 // Rank worst-first; deterministic tiebreak so the layout is stable regardless of input order.
                 .OrderByDescending(r => r.Magnitude)
                 .ThenBy(r => r.Spid)
-                .ThenBy(r => r.TranStarted ?? DateTime.MinValue)
+                .ThenBy(r => r.Ecid)
                 .ToList();
 
             return new BlockingChainModel
@@ -66,13 +66,13 @@ namespace PerformanceMonitor.Common
 
         private static BlockingChainNode? BuildOne(BlockingChainInput chain)
         {
-            var apexKey = new NodeKey(chain.ApexSpid, chain.ApexTranStarted);
+            var apexKey = new NodeKey(chain.ApexSpid, chain.ApexEcid);
 
             // Group edges by parent (blocking side); within a parent, sort children deterministically.
             var childrenByParent = new Dictionary<NodeKey, List<BlockingEdgeInput>>();
             foreach (var edge in chain.Edges)
             {
-                var parent = new NodeKey(edge.BlockingSpid, edge.BlockingTranStarted);
+                var parent = new NodeKey(edge.BlockingSpid, edge.BlockingEcid);
                 if (!childrenByParent.TryGetValue(parent, out var list))
                     childrenByParent[parent] = list = new List<BlockingEdgeInput>();
                 list.Add(edge);
@@ -82,7 +82,7 @@ namespace PerformanceMonitor.Common
                 {
                     var c = a.BlockedSpid.CompareTo(b.BlockedSpid);
                     if (c != 0) return c;
-                    return Nullable.Compare(a.BlockedTranStarted, b.BlockedTranStarted);
+                    return a.BlockedEcid.CompareTo(b.BlockedEcid);
                 });
 
             // The apex sources its own SqlText / DatabaseName from its FIRST outgoing edge (it has no
@@ -95,6 +95,7 @@ namespace PerformanceMonitor.Common
             var root = new BlockingChainNode
             {
                 Spid = chain.ApexSpid,
+                Ecid = chain.ApexEcid,
                 TranStarted = chain.ApexTranStarted,
                 IsApex = true,
                 IsApexSleeping = chain.ApexSleeping,
@@ -121,7 +122,7 @@ namespace PerformanceMonitor.Common
                 {
                     var c = a.Key.Spid.CompareTo(b.Key.Spid);
                     if (c != 0) return c;
-                    return Nullable.Compare(a.Key.Tran, b.Key.Tran);
+                    return a.Key.Ecid.CompareTo(b.Key.Ecid);
                 });
 
                 var next = new List<(NodeKey, BlockingChainNode)>();
@@ -130,12 +131,13 @@ namespace PerformanceMonitor.Common
                     if (!childrenByParent.TryGetValue(key, out var edges)) continue;
                     foreach (var edge in edges)
                     {
-                        var childKey = new NodeKey(edge.BlockedSpid, edge.BlockedTranStarted);
+                        var childKey = new NodeKey(edge.BlockedSpid, edge.BlockedEcid);
                         if (!visited.Add(childKey)) continue; // already placed (diamond back-edge) or a cycle
 
                         var child = new BlockingChainNode
                         {
                             Spid = edge.BlockedSpid,
+                            Ecid = edge.BlockedEcid,
                             TranStarted = edge.BlockedTranStarted,
                             IsApex = false,
                             WaitTimeMs = edge.WaitTimeMs,

--- a/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
+++ b/PerformanceMonitor.Ui/BlockingChainControl.xaml.cs
@@ -40,7 +40,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
 
     // The session the viewer was opened from — highlighted (auto-selected) on load.
     private int _entrySpid;
-    private DateTime? _entryTran;
+    private int _entryEcid;
 
     // Node selection
     private Border? _selectedNodeBorder;
@@ -111,12 +111,12 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
     /// </summary>
     /// <param name="model">The model holding exactly one root (the chain rooted at its apex).</param>
     /// <param name="entrySpid">SPID of the session the viewer was opened from (highlighted on load).</param>
-    /// <param name="entryTran">Its normalized transaction-start (the SessionKey disambiguator).</param>
-    public void LoadModel(BlockingChainModel model, int entrySpid, DateTime? entryTran, string? emptyStateDetail = null)
+    /// <param name="entryEcid">Its execution-context id — the spid:ecid identity disambiguator.</param>
+    public void LoadModel(BlockingChainModel model, int entrySpid, int entryEcid, string? emptyStateDetail = null)
     {
         _model = model ?? throw new ArgumentNullException(nameof(model));
         _entrySpid = entrySpid;
-        _entryTran = entryTran;
+        _entryEcid = entryEcid;
 
         if (!string.IsNullOrWhiteSpace(emptyStateDetail))
             EmptyStateDetail.Text = emptyStateDetail;
@@ -135,7 +135,7 @@ public partial class BlockingChainControl : UserControl, IGraphViewer
         // Highlight (auto-select) the clicked session within the tree so the user lands on "their" node.
         var entry = _model.Roots
             .SelectMany(EnumerateTree)
-            .FirstOrDefault(n => n.Spid == _entrySpid && Nullable.Equals(n.TranStarted, _entryTran));
+            .FirstOrDefault(n => n.Spid == _entrySpid && n.Ecid == _entryEcid);
         if (entry != null)
         {
             SelectNodeByModel(entry);

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1122,6 +1122,11 @@ BEGIN
         blocking_spid integer NULL,
         blocking_last_tran_started datetime2(7) NULL,
         blocking_status nvarchar(10) NULL,
+        /* Session identity for (monitor_loop, spid, ecid) chain reconstruction; populated by install/23.
+           blocking_ecid is the blocker's exec-context (blocked side uses the ecid column above); monitor_loop
+           is the blocked-process-report episode. */
+        blocking_ecid integer NULL,
+        monitor_loop integer NULL,
         blocked_sql_text nvarchar(max) NULL,
         blocking_sql_text nvarchar(max) NULL,
         CONSTRAINT

--- a/install/23_process_blocked_process_xml.sql
+++ b/install/23_process_blocked_process_xml.sql
@@ -314,7 +314,23 @@ BEGIN
                         (
                             N'(//blocked-process-report/blocking-process/process/inputbuf/text())[1]',
                             N'nvarchar(max)'
-                        )))
+                        ))),
+                    /* Session identity for the (monitor_loop, spid, ecid) chain reconstruction. monitor_loop
+                       is the report's episode; blocking_ecid is the blocker's exec-context (the blocked side's
+                       ecid is already populated by sp_HumanEventsBlockViewer). Descendant axis: the stored XML
+                       is <event>-rooted. */
+                    b.monitor_loop =
+                        b.blocked_process_report_xml.value
+                        (
+                            N'(//blocked-process-report/@monitorLoop)[1]',
+                            N'integer'
+                        ),
+                    b.blocking_ecid =
+                        b.blocked_process_report_xml.value
+                        (
+                            N'(//blocked-process-report/blocking-process/process/@ecid)[1]',
+                            N'integer'
+                        )
                 FROM collect.blocking_BlockedProcessReport AS b
                 WHERE b.event_time >= @start_date_local
                 AND   b.event_time <= @end_date_local

--- a/upgrades/3.0.0-to-3.1.0/01_blocking_chain_monitor_loop.sql
+++ b/upgrades/3.0.0-to-3.1.0/01_blocking_chain_monitor_loop.sql
@@ -1,0 +1,38 @@
+/*
+    Blocking-chain reconstruction now keys sessions by (monitor_loop, spid, ecid), mirroring
+    sp_HumanEventsBlockViewer (spid:ecid within a monitor_loop episode). Add the two identity columns the
+    Dashboard reconstruction reads; install/23 populates them from the stored blocked_process_report_xml via
+    the existing descendant-axis XQuery (the blocked-side ecid is already the existing `ecid` column).
+
+    Existing rows stay NULL until install/23 backfills them opportunistically; the reconstruction is
+    null-tolerant (falls back to spid:ecid for the viewer; the collector ignores monitor_loop entirely), so
+    historical blocking chains keep working in the meantime.
+
+    Idempotent: only adds a column that isn't already present. install/02 carries these on fresh installs.
+*/
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'collect.blocking_BlockedProcessReport')
+    AND   c.name = N'blocking_ecid'
+)
+BEGIN
+    ALTER TABLE collect.blocking_BlockedProcessReport
+        ADD blocking_ecid integer NULL;
+END;
+
+IF NOT EXISTS
+(
+    SELECT
+        1/0
+    FROM sys.columns AS c
+    WHERE c.object_id = OBJECT_ID(N'collect.blocking_BlockedProcessReport')
+    AND   c.name = N'monitor_loop'
+)
+BEGIN
+    ALTER TABLE collect.blocking_BlockedProcessReport
+        ADD monitor_loop integer NULL;
+END;


### PR DESCRIPTION
## Problem
The shared blocking-chain reconstruction keyed a session by `(spid, transaction_start)`. SQL Server's blocked-process-report omits `@lasttranstarted` on the `<blocking-process>` node, so **every blocker was keyed `(spid, NULL)`** while the same session as a blocked party was `(spid, realTran)`. Consequences (verified on live sql2025):
- **Deep chains fragmented** — `A→B→C` split into `A→B` + `B→C`. The `BLOCKING_CHAIN` fact's `Value = worst.Depth` drives alert thresholds, so deep chains were scored depth-1 and **blocking alerts under-fired**. (60 distinct mid-chain sessions live.)
- Clicking a lead-blocker grid row → "no reconstructable blocking chain".

## Fix
Mirror `sp_HumanEventsBlockViewer`'s recursive CTE: identity = **spid:ecid within a monitor_loop episode**, never transaction-start.

- **Shared** (`Analysis`/`Common`/`Ui`): `SessionKey` → `(monitor_loop, spid, ecid)`; `Reconstruct(…, scopeByMonitorLoop)` — the **viewer** scopes per-scan (precise to the clicked event), the **collector** stays **window-cumulative** so the severity fact keeps max-depth/union-victims (per-scan would *under*-count conveyor/hot-lock chains → under-fire); `FindChainForSession(monitor_loop, spid, ecid)` with a `(spid, ecid)` fallback for the lead-blocker click; `ecid` threaded through model/tree/control; transaction-start demoted to display.
- **Dashboard**: two nullable typed columns (`monitor_loop`, `blocking_ecid`) populated at collect time via the existing `install/23` descendant-axis XQuery (no read-path XML, no proc change); `install/02` + `upgrades/3.0.0-to-3.1.0` ALTER; pair query / projection / click handler / grid wired; both background collectors `scopeByMonitorLoop:false`.
- **Lite**: collect-time `monitorLoop` parse + appender; `Schema` + **v32** migration; the three pair-row SELECTs in lockstep; projection / handler / grid wired.

`monitor_loop` is read from the **stored** report XML, so **no backfill** — historical Dashboard rows degrade gracefully (null-tolerant key: viewer falls back to spid:ecid, collector ignores monitor_loop).

## Decisions (planned + 2-lens adversarial review)
collector window-cumulative (not per-scan); typed columns via the existing collect-time pattern (no read-path XML); keep a click fallback. See `plans/blocking-chain-monitor-loop-keying.md` (local).

## Tests / status
Reconstructor + tree-builder tests rewritten for the new identity + new cases (deep-chain, cross-episode isolation, parallel-ecid, cumulative-merge, monitor_loop disambiguation). **616 Dashboard + 553 Lite green; both apps build.**

**Not yet done — gating merge:** deploy the schema to sql2025 via the Installer (upgrade-path rule) + visually verify the viewer (lead-blocker click opens the chain; deep chains intact) and the collector counts. Cloud (Azure SQL DB / RDS) per the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)