### PR TITLE
Structured status envelope for non-data MCP outcomes (Lite + Dashboard)

### DIFF
--- a/Dashboard/Mcp/McpActiveQueryTools.cs
+++ b/Dashboard/Mcp/McpActiveQueryTools.cs
@@ -31,7 +31,7 @@ public sealed class McpActiveQueryTools
         {
             var rows = await resolved.Value.Service.GetQuerySnapshotsAsync(hours_back);
             if (rows.Count == 0)
-                return "No active query snapshots found in the requested time range.";
+                return McpHelpers.Status("empty", "No active query snapshots found in the requested time range.");
 
             var result = rows.Take(limit).Select(r => new
             {

--- a/Dashboard/Mcp/McpAnalysisTools.cs
+++ b/Dashboard/Mcp/McpAnalysisTools.cs
@@ -57,13 +57,12 @@ public sealed class McpAnalysisTools
 
             if (findings.Count == 0)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    server = resolved.Value.ServerName,
-                    status = "healthy",
-                    message = "No significant findings. All metrics are within normal ranges.",
-                    analysis_time = analysisService.LastAnalysisTime?.ToString("o")
-                }, McpHelpers.JsonOptions);
+                /* A successful analysis that found nothing wrong: a true negative ("all clear"),
+                   surfaced with the shared miss vocabulary so callers branch on it uniformly. */
+                return McpHelpers.Status(
+                    "empty",
+                    "No significant findings. All metrics are within normal ranges.",
+                    new { analysis_time = analysisService.LastAnalysisTime?.ToString("o") });
             }
 
             // Correlate-and-focus slice 1 (review §1d): each finding's "what else fired this window".
@@ -150,12 +149,9 @@ public sealed class McpAnalysisTools
 
             if (facts.Count == 0)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    server = resolved.Value.ServerName,
-                    fact_count = 0,
-                    message = "No facts collected."
-                }, McpHelpers.JsonOptions);
+                /* No scored facts means the underlying collectors produced nothing for the window —
+                   not retrievable now rather than an all-clear (mirrors get_perfmon_trend's empty case). */
+                return McpHelpers.Status("unavailable", "No facts collected.");
             }
 
             var filtered = facts.AsEnumerable();
@@ -367,7 +363,7 @@ public sealed class McpAnalysisTools
             var findings = await analysisService.GetRecentFindingsAsync(serverId, hours_back);
 
             if (findings.Count == 0)
-                return JsonSerializer.Serialize(new { server = resolved.Value.ServerName, finding_count = 0, message = "No findings. Run analyze_server to generate new findings." }, McpHelpers.JsonOptions);
+                return McpHelpers.Status("empty", "No findings. Run analyze_server to generate new findings.");
 
             // Correlate-and-focus slice 1 (review §1d): "what else fired", scoped per analysis run
             // (this read can span multiple runs, unlike analyze_server's single run).

--- a/Dashboard/Mcp/McpBlockingTools.cs
+++ b/Dashboard/Mcp/McpBlockingTools.cs
@@ -37,7 +37,7 @@ public sealed class McpBlockingTools
             var rows = await resolved.Value.Service.GetBlockingEventsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No blocking events found in the specified time range.";
+                return McpHelpers.Status("empty", "No blocking events found in the specified time range.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -103,7 +103,7 @@ public sealed class McpBlockingTools
             var rows = await resolved.Value.Service.GetDeadlocksAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No deadlocks found in the specified time range.";
+                return McpHelpers.Status("empty", "No deadlocks found in the specified time range.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -172,7 +172,7 @@ public sealed class McpBlockingTools
             var withXml = rows.Where(r => !string.IsNullOrEmpty(r.DeadlockGraph)).Take(limit).ToList();
             if (withXml.Count == 0)
             {
-                return "No deadlock XML available in the specified time range.";
+                return McpHelpers.Status("empty", "No deadlock XML available in the specified time range.");
             }
 
             var result = withXml.Select(r => new
@@ -222,7 +222,7 @@ public sealed class McpBlockingTools
             var withXml = rows.Where(r => !string.IsNullOrEmpty(r.BlockedProcessReportXml)).Take(limit).ToList();
             if (withXml.Count == 0)
             {
-                return "No blocked process report XML available in the specified time range.";
+                return McpHelpers.Status("empty", "No blocked process report XML available in the specified time range.");
             }
 
             var result = withXml.Select(r => new
@@ -268,7 +268,7 @@ public sealed class McpBlockingTools
             var rows = await resolved.Value.Service.GetBlockingDeadlockStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No blocking/deadlock statistics available.";
+                return McpHelpers.Status("unavailable", "No blocking/deadlock statistics available.");
             }
 
             return JsonSerializer.Serialize(new

--- a/Dashboard/Mcp/McpConfigHistoryTools.cs
+++ b/Dashboard/Mcp/McpConfigHistoryTools.cs
@@ -30,7 +30,7 @@ public sealed class McpConfigHistoryTools
         {
             var rows = await resolved.Value.Service.GetServerConfigChangesAsync(hours_back);
             if (rows.Count == 0)
-                return "No server configuration changes found in the requested time range.";
+                return McpHelpers.Status("empty", "No server configuration changes found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -75,7 +75,7 @@ public sealed class McpConfigHistoryTools
         {
             var rows = await resolved.Value.Service.GetDatabaseConfigChangesAsync(hours_back);
             if (rows.Count == 0)
-                return "No database configuration changes found in the requested time range.";
+                return McpHelpers.Status("empty", "No database configuration changes found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -118,7 +118,7 @@ public sealed class McpConfigHistoryTools
         {
             var rows = await resolved.Value.Service.GetTraceFlagChangesAsync(hours_back);
             if (rows.Count == 0)
-                return "No trace flag changes found in the requested time range.";
+                return McpHelpers.Status("empty", "No trace flag changes found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Dashboard/Mcp/McpCpuTools.cs
+++ b/Dashboard/Mcp/McpCpuTools.cs
@@ -33,7 +33,7 @@ public sealed class McpCpuTools
             var rows = await resolved.Value.Service.GetCpuUtilizationAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No CPU utilization data available.";
+                return McpHelpers.Status("unavailable", "No CPU utilization data available.");
             }
 
             /* Downsample to 1-minute buckets to avoid overwhelming LLM context */

--- a/Dashboard/Mcp/McpDiagnosticTools.cs
+++ b/Dashboard/Mcp/McpDiagnosticTools.cs
@@ -30,7 +30,7 @@ public sealed class McpDiagnosticTools
         {
             var rows = await resolved.Value.Service.GetPlanCacheStatsAsync(hours_back);
             if (rows.Count == 0)
-                return "No plan cache statistics available in the requested time range.";
+                return McpHelpers.Status("unavailable", "No plan cache statistics available in the requested time range.");
 
             // Service returns all snapshots (for UI charting).
             // For MCP, return only the latest snapshot per cache/object type.
@@ -93,7 +93,7 @@ public sealed class McpDiagnosticTools
         {
             var rows = await resolved.Value.Service.GetCriticalIssuesAsync(hours_back);
             if (rows.Count == 0)
-                return "No critical issues found in the requested time range.";
+                return McpHelpers.Status("empty", "No critical issues found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -141,7 +141,7 @@ public sealed class McpDiagnosticTools
         {
             var rows = await resolved.Value.Service.GetSessionStatsAsync(hours_back);
             if (rows.Count == 0)
-                return "No session statistics available in the requested time range.";
+                return McpHelpers.Status("unavailable", "No session statistics available in the requested time range.");
 
             var latest = rows[0];
             return JsonSerializer.Serialize(new

--- a/Dashboard/Mcp/McpHealthParserTools.cs
+++ b/Dashboard/Mcp/McpHealthParserTools.cs
@@ -27,7 +27,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserSystemHealthAsync(hours_back);
-            if (rows.Count == 0) return "No system health data found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No system health data found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -56,7 +56,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserSevereErrorsAsync(hours_back);
-            if (rows.Count == 0) return "No severe errors found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No severe errors found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -85,7 +85,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserIOIssuesAsync(hours_back);
-            if (rows.Count == 0) return "No I/O issues found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No I/O issues found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -114,7 +114,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserSchedulerIssuesAsync(hours_back);
-            if (rows.Count == 0) return "No scheduler issues found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No scheduler issues found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -143,7 +143,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserMemoryConditionsAsync(hours_back);
-            if (rows.Count == 0) return "No memory condition events found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No memory condition events found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -172,7 +172,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserCPUTasksAsync(hours_back);
-            if (rows.Count == 0) return "No CPU task events found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No CPU task events found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -201,7 +201,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserMemoryBrokerAsync(hours_back);
-            if (rows.Count == 0) return "No memory broker events found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No memory broker events found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {
@@ -230,7 +230,7 @@ public sealed class McpHealthParserTools
         try
         {
             var rows = await resolved.Value.Service.GetHealthParserMemoryNodeOOMAsync(hours_back);
-            if (rows.Count == 0) return "No memory node OOM events found in the requested time range.";
+            if (rows.Count == 0) return McpHelpers.Status("empty", "No memory node OOM events found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Dashboard/Mcp/McpHealthTools.cs
+++ b/Dashboard/Mcp/McpHealthTools.cs
@@ -29,7 +29,7 @@ public sealed class McpHealthTools
             var rows = await resolved.Value.Service.GetCollectionHealthAsync();
             if (rows.Count == 0)
             {
-                return "No collection health data available.";
+                return McpHelpers.Status("unavailable", "No collection health data available.");
             }
 
             var result = rows.Select(r => new
@@ -88,7 +88,7 @@ public sealed class McpHealthTools
             var rows = await resolved.Value.Service.GetDailySummaryAsync(date);
             if (rows.Count == 0)
             {
-                return "No daily summary data available.";
+                return McpHelpers.Status("unavailable", "No daily summary data available.");
             }
 
             var result = rows.Select(r => new

--- a/Dashboard/Mcp/McpIoTools.cs
+++ b/Dashboard/Mcp/McpIoTools.cs
@@ -29,7 +29,7 @@ public sealed class McpIoTools
             var rows = await resolved.Value.Service.GetFileIoLatencyAsync();
             if (rows.Count == 0)
             {
-                return "No file I/O stats available.";
+                return McpHelpers.Status("unavailable", "No file I/O stats available.");
             }
 
             var result = rows.Select(r => new
@@ -79,7 +79,7 @@ public sealed class McpIoTools
             var points = await resolved.Value.Service.GetFileIoDataAsync(hours_back);
             if (points.Count == 0)
             {
-                return "No I/O trend data available.";
+                return McpHelpers.Status("unavailable", "No I/O trend data available.");
             }
 
             var result = points.Select(p => new

--- a/Dashboard/Mcp/McpJobTools.cs
+++ b/Dashboard/Mcp/McpJobTools.cs
@@ -37,7 +37,7 @@ public sealed class McpJobTools
             var rows = await resolved.Value.Service.GetRunningJobsAsync();
             if (rows.Count == 0)
             {
-                return "No running SQL Agent jobs found (or no data in report.running_jobs).";
+                return McpHelpers.Status("empty", "No running SQL Agent jobs found (or no data in report.running_jobs).");
             }
 
             var result = rows.Select(r => new

--- a/Dashboard/Mcp/McpLatchSpinlockTools.cs
+++ b/Dashboard/Mcp/McpLatchSpinlockTools.cs
@@ -31,7 +31,7 @@ public sealed class McpLatchSpinlockTools
         {
             var rows = await resolved.Value.Service.GetLatchStatsTopNAsync(top, hours_back);
             if (rows.Count == 0)
-                return "No latch statistics available in the requested time range.";
+                return McpHelpers.Status("unavailable", "No latch statistics available in the requested time range.");
 
             // Service returns all snapshots for top N classes (for UI charting).
             // For MCP, return only the latest snapshot per class with aggregated deltas.
@@ -94,7 +94,7 @@ public sealed class McpLatchSpinlockTools
         {
             var rows = await resolved.Value.Service.GetSpinlockStatsTopNAsync(top, hours_back);
             if (rows.Count == 0)
-                return "No spinlock statistics available in the requested time range.";
+                return McpHelpers.Status("unavailable", "No spinlock statistics available in the requested time range.");
 
             // Aggregate to one row per spinlock class with totals over the period
             var latestPerClass = rows

--- a/Dashboard/Mcp/McpMemoryTools.cs
+++ b/Dashboard/Mcp/McpMemoryTools.cs
@@ -33,14 +33,14 @@ public sealed class McpMemoryTools
             var rows = await resolved.Value.Service.GetMemoryStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No memory stats available.";
+                return McpHelpers.Status("unavailable", "No memory stats available.");
             }
 
             /* Return only the latest snapshot */
             var stats = rows.OrderByDescending(r => r.CollectionTime).FirstOrDefault();
             if (stats == null)
             {
-                return "No memory stats available.";
+                return McpHelpers.Status("unavailable", "No memory stats available.");
             }
 
             return JsonSerializer.Serialize(new
@@ -85,7 +85,7 @@ public sealed class McpMemoryTools
             var rows = await resolved.Value.Service.GetMemoryStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No memory trend data available.";
+                return McpHelpers.Status("unavailable", "No memory trend data available.");
             }
 
             var result = rows.Select(r => new
@@ -131,7 +131,7 @@ public sealed class McpMemoryTools
             var rows = await resolved.Value.Service.GetMemoryClerksAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No memory clerk data available.";
+                return McpHelpers.Status("unavailable", "No memory clerk data available.");
             }
 
             /* Return latest snapshot only */
@@ -180,7 +180,7 @@ public sealed class McpMemoryTools
             var rows = await resolved.Value.Service.GetMemoryGrantStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No memory grant data available.";
+                return McpHelpers.Status("unavailable", "No memory grant data available.");
             }
 
             /* Return latest snapshot */

--- a/Dashboard/Mcp/McpObjectStatsTools.cs
+++ b/Dashboard/Mcp/McpObjectStatsTools.cs
@@ -29,7 +29,7 @@ public sealed class McpObjectStatsTools
             var rows = await resolved.Value.Service.GetObjectSizeGrowthAsync();
             if (rows.Count == 0)
             {
-                return "No object size data available. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No object size data available. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new
@@ -76,7 +76,7 @@ public sealed class McpObjectStatsTools
             var rows = await resolved.Value.Service.GetIndexUsageAsync();
             if (rows.Count == 0)
             {
-                return "No index usage data available. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No index usage data available. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new
@@ -126,7 +126,7 @@ public sealed class McpObjectStatsTools
             var rows = await resolved.Value.Service.GetIndexLockingAsync();
             if (rows.Count == 0)
             {
-                return "No locking/contention data recorded. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No locking/contention data recorded. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new

--- a/Dashboard/Mcp/McpPerfmonTools.cs
+++ b/Dashboard/Mcp/McpPerfmonTools.cs
@@ -37,7 +37,7 @@ public sealed class McpPerfmonTools
             var rows = await resolved.Value.Service.GetPerfmonStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No perfmon stats available.";
+                return McpHelpers.Status("unavailable", "No perfmon stats available.");
             }
 
             /* Return latest snapshot */
@@ -94,7 +94,7 @@ public sealed class McpPerfmonTools
             var rows = await resolved.Value.Service.GetPerfmonStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No perfmon trend data available.";
+                return McpHelpers.Status("unavailable", "No perfmon trend data available.");
             }
 
             IEnumerable<PerfmonStatsItem> filtered = rows;

--- a/Dashboard/Mcp/McpPlanTools.cs
+++ b/Dashboard/Mcp/McpPlanTools.cs
@@ -32,7 +32,9 @@ public sealed class McpPlanTools
         {
             var xml = await resolved.Value.Service.GetPlanXmlByQueryHashAsync(query_hash);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
         }
@@ -60,7 +62,9 @@ public sealed class McpPlanTools
         {
             var xml = await resolved.Value.Service.GetProcedurePlanXmlBySqlHandleAsync(sql_handle);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for sql_handle '{sql_handle}'. The procedure may have been evicted from the plan cache since the last collection.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for sql_handle '{sql_handle}'. The procedure may have been evicted from the plan cache since the last collection.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", sql_handle);
         }
@@ -89,7 +93,9 @@ public sealed class McpPlanTools
         {
             var xml = await resolved.Value.Service.GetQueryStorePlanXmlAsync(database_name, query_id);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for query_id {query_id} in database '{database_name}'. Query Store may not be enabled or the query may have been purged.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for query_id {query_id} in database '{database_name}'. Query Store may not be enabled or the query may have been purged.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{query_id}");
         }
@@ -137,7 +143,7 @@ public sealed class McpPlanTools
         {
             var xml = await resolved.Value.Service.GetPlanXmlByQueryHashAsync(query_hash);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for query_hash '{query_hash}'.";
+                return McpHelpers.Status("unavailable", $"No plan found for query_hash '{query_hash}'.");
 
             return McpHelpers.Truncate(xml, 512_000) ?? "No plan XML available.";
         }

--- a/Dashboard/Mcp/McpQueryTools.cs
+++ b/Dashboard/Mcp/McpQueryTools.cs
@@ -42,7 +42,7 @@ public sealed class McpQueryTools
             var rows = await resolved.Value.Service.GetQueryStatsForMcpAsync(hours_back, top, database_name, parallel_only, min_dop);
             if (rows.Count == 0)
             {
-                return "No query stats available for the specified time range.";
+                return McpHelpers.Status("unavailable", "No query stats available for the specified time range.");
             }
 
             var result = rows.Select(r => new
@@ -114,7 +114,7 @@ public sealed class McpQueryTools
             var rows = await resolved.Value.Service.GetProcedureStatsForMcpAsync(hours_back, top, database_name);
             if (rows.Count == 0)
             {
-                return "No procedure stats available for the specified time range.";
+                return McpHelpers.Status("unavailable", "No procedure stats available for the specified time range.");
             }
 
             var result = rows.Select(r => new
@@ -181,7 +181,7 @@ public sealed class McpQueryTools
             var rows = await resolved.Value.Service.GetQueryStoreDataForMcpAsync(hours_back, top, database_name, parallel_only, min_dop);
             if (rows.Count == 0)
             {
-                return "No Query Store data available. Query Store may not be enabled on target databases.";
+                return McpHelpers.Status("unavailable", "No Query Store data available. Query Store may not be enabled on target databases.");
             }
 
             var result = rows.Select(r => new
@@ -245,7 +245,7 @@ public sealed class McpQueryTools
             var rows = await resolved.Value.Service.GetExpensiveQueriesAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No expensive query data available.";
+                return McpHelpers.Status("unavailable", "No expensive query data available.");
             }
 
             IEnumerable<ExpensiveQueryItem> filtered = rows;
@@ -304,7 +304,7 @@ public sealed class McpQueryTools
             var rows = await resolved.Value.Service.GetQueryStatsHistoryAsync(database_name, query_hash);
             if (rows.Count == 0)
             {
-                return $"No history found for query_hash '{query_hash}' in database '{database_name}'.";
+                return McpHelpers.Status("empty", $"No history found for query_hash '{query_hash}' in database '{database_name}'.");
             }
 
             var result = rows.Select(r => new

--- a/Dashboard/Mcp/McpSchedulerTools.cs
+++ b/Dashboard/Mcp/McpSchedulerTools.cs
@@ -25,7 +25,7 @@ public sealed class McpSchedulerTools
         {
             var item = await resolved.Value.Service.GetCpuPressureAsync();
             if (item == null)
-                return "No CPU scheduler data available. The scheduler collector may not have run yet.";
+                return McpHelpers.Status("unavailable", "No CPU scheduler data available. The scheduler collector may not have run yet.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Dashboard/Mcp/McpServerInventoryTools.cs
+++ b/Dashboard/Mcp/McpServerInventoryTools.cs
@@ -26,7 +26,7 @@ public sealed class McpServerInventoryTools
         {
             var rows = await resolved.Value.Service.GetFinOpsDatabaseSizeStatsAsync();
             if (rows.Count == 0)
-                return "No database size data available. The size collector may not have run yet.";
+                return McpHelpers.Status("unavailable", "No database size data available. The size collector may not have run yet.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Dashboard/Mcp/McpSystemEventTools.cs
+++ b/Dashboard/Mcp/McpSystemEventTools.cs
@@ -31,7 +31,7 @@ public sealed class McpSystemEventTools
         {
             var rows = await resolved.Value.Service.GetDefaultTraceEventsAsync(hours_back);
             if (rows.Count == 0)
-                return "No default trace events found in the requested time range.";
+                return McpHelpers.Status("empty", "No default trace events found in the requested time range.");
 
             var result = rows.Take(limit).Select(r => new
             {
@@ -83,7 +83,7 @@ public sealed class McpSystemEventTools
         {
             var rows = await resolved.Value.Service.GetTraceAnalysisAsync(hours_back);
             if (rows.Count == 0)
-                return "No trace analysis data found in the requested time range.";
+                return McpHelpers.Status("empty", "No trace analysis data found in the requested time range.");
 
             var result = rows.Take(limit).Select(r => new
             {
@@ -146,7 +146,7 @@ For actionable interpretation and suggested follow-up tools, see the 'Interpreti
         {
             var rows = await resolved.Value.Service.GetMemoryPressureEventsAsync(hours_back);
             if (rows.Count == 0)
-                return "No memory pressure events found in the requested time range.";
+                return McpHelpers.Status("empty", "No memory pressure events found in the requested time range.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Dashboard/Mcp/McpTempDbTools.cs
+++ b/Dashboard/Mcp/McpTempDbTools.cs
@@ -33,7 +33,7 @@ public sealed class McpTempDbTools
             var rows = await resolved.Value.Service.GetTempdbStatsAsync(hours_back);
             if (rows.Count == 0)
             {
-                return "No TempDB data available.";
+                return McpHelpers.Status("unavailable", "No TempDB data available.");
             }
 
             var result = rows.Select(r => new

--- a/Dashboard/Mcp/McpWaitTools.cs
+++ b/Dashboard/Mcp/McpWaitTools.cs
@@ -33,7 +33,7 @@ public sealed class McpWaitTools
             var rows = await resolved.Value.Service.GetWaitStatsAsync();
             if (rows.Count == 0)
             {
-                return "No wait stats data available.";
+                return McpHelpers.Status("unavailable", "No wait stats data available.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -85,7 +85,7 @@ public sealed class McpWaitTools
             var points = await resolved.Value.Service.GetWaitStatsDataAsync(hours_back, topWaitTypes: top_wait_types);
             if (points.Count == 0)
             {
-                return "No wait stats trend data available.";
+                return McpHelpers.Status("unavailable", "No wait stats trend data available.");
             }
 
             var result = points.Select(p => new

--- a/Lite.Tests/McpStatusEnvelopeTests.cs
+++ b/Lite.Tests/McpStatusEnvelopeTests.cs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Mcp;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Behavioral tests for the structured non-data envelope (McpHelpers.Status) added to Lite's MCP
+/// tools. These invoke the real tool methods against a seeded temp DuckDB + a real ServerManager,
+/// asserting that a legitimate miss is machine-readable: an uncollected perfmon counter returns
+/// "not_collected" with the list of counters that ARE collected, while a genuine absence (no
+/// deadlocks) returns "empty". Successful, data-bearing results are intentionally not exercised
+/// here — this change does not touch them.
+/// </summary>
+public class McpStatusEnvelopeTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+    private readonly LocalDataService _dataService;
+    private readonly ServerManager _serverManager;
+    private readonly int _serverId;
+    private long _nextId = -1;
+
+    public McpStatusEnvelopeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "McpStatusTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+
+        _duckDb = new DuckDbInitializer(Path.Combine(_tempDir, "test.duckdb"));
+        _dataService = new LocalDataService(_duckDb);
+
+        /* A real ServerManager with one enabled, Windows-auth server. Windows auth means AddServer
+           never touches the credential store, so no DPAPI / OS keychain side effects in the test. */
+        _serverManager = new ServerManager(configDir);
+        var server = new ServerConnection { ServerName = "TestServer", DisplayName = "TestServer" };
+        _serverManager.AddServer(server);
+
+        /* The server_id the tools resolve to — same derivation ServerResolver uses. */
+        _serverId = RemoteCollectorService.GetDeterministicHashCode(
+            RemoteCollectorService.GetServerNameForStorage(server));
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    // ── helpers ──
+
+    private async Task SeedPerfmonCountersAsync(params string[] counterNames)
+    {
+        await _duckDb.InitializeAsync();
+
+        using var readLock = _duckDb.AcquireReadLock();
+        using var conn = _duckDb.CreateConnection();
+        await conn.OpenAsync();
+
+        foreach (var name in counterNames)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"INSERT INTO perfmon_stats
+                (collection_id, collection_time, server_id, server_name, object_name, counter_name,
+                 instance_name, cntr_value, delta_cntr_value, sample_interval_seconds)
+                VALUES ($1, $2, $3, 'TestServer', 'SQLServer:Buffer Manager', $4, '', 100, 5, 15)";
+            void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+            P(_nextId--);
+            P(DateTime.UtcNow.AddMinutes(-5));
+            P(_serverId);
+            P(name);
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task SeedWaitStatsAsync(params string[] waitTypes)
+    {
+        await _duckDb.InitializeAsync();
+
+        using var readLock = _duckDb.AcquireReadLock();
+        using var conn = _duckDb.CreateConnection();
+        await conn.OpenAsync();
+
+        foreach (var wt in waitTypes)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"INSERT INTO wait_stats
+                (collection_id, collection_time, server_id, server_name, wait_type,
+                 waiting_tasks_count, wait_time_ms, signal_wait_time_ms,
+                 delta_waiting_tasks, delta_wait_time_ms, delta_signal_wait_time_ms)
+                VALUES ($1, $2, $3, 'TestServer', $4, 10, 1000, 100, 5, 500, 50)";
+            void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+            P(_nextId--);
+            P(DateTime.UtcNow.AddMinutes(-5));
+            P(_serverId);
+            P(wt);
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    private static List<string> CollectedCounters(JsonElement root) =>
+        root.GetProperty("hints").GetProperty("collected_counters")
+            .EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+
+    // ── tests ──
+
+    [Fact]
+    public async Task GetPerfmonTrend_UncollectedCounter_ReturnsNotCollectedWithCollectedList()
+    {
+        await SeedPerfmonCountersAsync("Batch Requests/sec", "SQL Compilations/sec");
+
+        var json = await McpPerfmonTools.GetPerfmonTrend(_dataService, _serverManager, "Buffer cache hit ratio");
+        var root = Parse(json);
+
+        Assert.Equal("not_collected", root.GetProperty("status").GetString());
+
+        var collected = CollectedCounters(root);
+        Assert.Contains("Batch Requests/sec", collected);
+        Assert.Contains("SQL Compilations/sec", collected);
+    }
+
+    [Fact]
+    public async Task GetPerfmonTrend_PageLifeExpectancy_ReturnsNotCollectedWithLegacyNote()
+    {
+        await SeedPerfmonCountersAsync("Batch Requests/sec");
+
+        var json = await McpPerfmonTools.GetPerfmonTrend(_dataService, _serverManager, "Page life expectancy");
+        var root = Parse(json);
+
+        Assert.Equal("not_collected", root.GetProperty("status").GetString());
+
+        var message = root.GetProperty("message").GetString() ?? "";
+        Assert.Contains("legacy", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("get_memory_stats", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetPerfmonTrend_NoCountersCollectedAtAll_ReturnsUnavailable()
+    {
+        await _duckDb.InitializeAsync(); // schema + views exist, but no perfmon rows seeded
+
+        var json = await McpPerfmonTools.GetPerfmonTrend(_dataService, _serverManager, "Batch Requests/sec");
+        var root = Parse(json);
+
+        Assert.Equal("unavailable", root.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task GetWaitTrend_UncollectedWaitType_ReturnsNotCollectedWithCollectedList()
+    {
+        await SeedWaitStatsAsync("CXPACKET", "PAGEIOLATCH_SH");
+
+        var json = await McpWaitTools.GetWaitTrend(_dataService, _serverManager, "SOS_SCHEDULER_YIELD");
+        var root = Parse(json);
+
+        Assert.Equal("not_collected", root.GetProperty("status").GetString());
+
+        var collected = root.GetProperty("hints").GetProperty("collected_wait_types")
+            .EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+        Assert.Contains("CXPACKET", collected);
+        Assert.Contains("PAGEIOLATCH_SH", collected);
+    }
+
+    [Fact]
+    public async Task GetDeadlocks_NoDeadlocks_ReturnsEmpty()
+    {
+        await _duckDb.InitializeAsync(); // no deadlock rows seeded => a true negative
+
+        var json = await McpBlockingTools.GetDeadlocks(_dataService, _serverManager);
+        var root = Parse(json);
+
+        Assert.Equal("empty", root.GetProperty("status").GetString());
+    }
+}

--- a/Lite/Mcp/McpAlertTools.cs
+++ b/Lite/Mcp/McpAlertTools.cs
@@ -28,7 +28,7 @@ public sealed class McpAlertTools
 
             if (rows.Count == 0)
             {
-                return "No alerts found in the specified time range.";
+                return McpHelpers.Status("empty", "No alerts found in the specified time range.");
             }
 
             var alerts = rows.Select(r => new

--- a/Lite/Mcp/McpAnalysisTools.cs
+++ b/Lite/Mcp/McpAnalysisTools.cs
@@ -44,13 +44,12 @@ public sealed class McpAnalysisTools
 
             if (findings.Count == 0)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    server = resolved.Value.ServerName,
-                    status = "healthy",
-                    message = "No significant findings. All metrics are within normal ranges.",
-                    analysis_time = analysisService.LastAnalysisTime?.ToString("o")
-                }, McpHelpers.JsonOptions);
+                /* A successful analysis that found nothing wrong: a true negative ("all clear"),
+                   surfaced with the shared miss vocabulary so callers branch on it uniformly. */
+                return McpHelpers.Status(
+                    "empty",
+                    "No significant findings. All metrics are within normal ranges.",
+                    new { analysis_time = analysisService.LastAnalysisTime?.ToString("o") });
             }
 
             // Correlate-and-focus slice 1 (review §1d): each finding's "what else fired this window".
@@ -138,12 +137,11 @@ public sealed class McpAnalysisTools
 
             if (facts.Count == 0)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    server = resolved.Value.ServerName,
-                    fact_count = 0,
-                    message = "No facts collected. The collector may not have run yet, or no data exists in the requested time range."
-                }, McpHelpers.JsonOptions);
+                /* No scored facts means the underlying collectors produced nothing for the window —
+                   not retrievable now rather than an all-clear (mirrors get_perfmon_trend's empty case). */
+                return McpHelpers.Status(
+                    "unavailable",
+                    "No facts collected. The collector may not have run yet, or no data exists in the requested time range.");
             }
 
             var filtered = facts.AsEnumerable();
@@ -528,12 +526,9 @@ public sealed class McpAnalysisTools
 
             if (findings.Count == 0)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    server = resolved.Value.ServerName,
-                    finding_count = 0,
-                    message = "No findings in the requested time range. Run analyze_server to generate new findings."
-                }, McpHelpers.JsonOptions);
+                return McpHelpers.Status(
+                    "empty",
+                    "No findings in the requested time range. Run analyze_server to generate new findings.");
             }
 
             // Correlate-and-focus slice 1 (review §1d): "what else fired", scoped per analysis run

--- a/Lite/Mcp/McpBlockingTools.cs
+++ b/Lite/Mcp/McpBlockingTools.cs
@@ -34,7 +34,7 @@ public sealed class McpBlockingTools
             var rows = await dataService.GetRecentDeadlocksAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No deadlocks found in the specified time range.";
+                return McpHelpers.Status("empty", "No deadlocks found in the specified time range.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -87,7 +87,7 @@ public sealed class McpBlockingTools
             var withXml = rows.Where(r => r.HasDeadlockXml).Take(limit).ToList();
             if (withXml.Count == 0)
             {
-                return "No deadlock XML available in the specified time range.";
+                return McpHelpers.Status("empty", "No deadlock XML available in the specified time range.");
             }
 
             var result = withXml.Select(r => new
@@ -136,7 +136,7 @@ public sealed class McpBlockingTools
             var rows = await dataService.GetRecentBlockedProcessReportsAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No blocked process reports found.";
+                return McpHelpers.Status("empty", "No blocked process reports found.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -215,7 +215,7 @@ public sealed class McpBlockingTools
             var withXml = rows.Where(r => r.HasReportXml).Take(limit).ToList();
             if (withXml.Count == 0)
             {
-                return "No blocked process report XML available in the specified time range.";
+                return McpHelpers.Status("empty", "No blocked process report XML available in the specified time range.");
             }
 
             var result = withXml.Select(r => new

--- a/Lite/Mcp/McpConfigTools.cs
+++ b/Lite/Mcp/McpConfigTools.cs
@@ -23,7 +23,9 @@ public sealed class McpConfigTools
         {
             var rows = await dataService.GetLatestServerConfigAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No server configuration data available. The config collector may not have run yet.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    "No server configuration data available. The config collector may not have run yet.");
 
             return JsonSerializer.Serialize(new
             {
@@ -61,7 +63,9 @@ public sealed class McpConfigTools
         {
             var rows = await dataService.GetLatestDatabaseConfigAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No database configuration data available. The config collector may not have run yet.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    "No database configuration data available. The config collector may not have run yet.");
 
             IEnumerable<DatabaseConfigRow> filtered = rows;
             if (!string.IsNullOrEmpty(database_name))
@@ -119,7 +123,9 @@ public sealed class McpConfigTools
         {
             var rows = await dataService.GetLatestDatabaseScopedConfigAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No database-scoped configuration data available. The config collector may not have run yet.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    "No database-scoped configuration data available. The config collector may not have run yet.");
 
             IEnumerable<DatabaseScopedConfigRow> filtered = rows;
             if (!string.IsNullOrEmpty(database_name))
@@ -165,7 +171,7 @@ public sealed class McpConfigTools
         {
             var rows = await dataService.GetLatestTraceFlagsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No trace flags found (none enabled, or the config collector has not run yet).";
+                return McpHelpers.Status("empty", "No trace flags found (none enabled, or the config collector has not run yet).");
 
             return JsonSerializer.Serialize(new
             {

--- a/Lite/Mcp/McpCpuTools.cs
+++ b/Lite/Mcp/McpCpuTools.cs
@@ -30,7 +30,7 @@ public sealed class McpCpuTools
             var rows = await dataService.GetCpuUtilizationAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No CPU utilization data available.";
+                return McpHelpers.Status("unavailable", "No CPU utilization data available.");
             }
 
             /* Downsample to 1-minute buckets to avoid overwhelming LLM context */

--- a/Lite/Mcp/McpHealthTools.cs
+++ b/Lite/Mcp/McpHealthTools.cs
@@ -26,7 +26,9 @@ public sealed class McpHealthTools
             var summary = await dataService.GetServerSummaryAsync(resolved.Value.ServerId, resolved.Value.ServerName);
             if (summary == null)
             {
-                return $"No data available for {resolved.Value.ServerName}. The collector may not have run yet.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No data available for {resolved.Value.ServerName}. The collector may not have run yet.");
             }
 
             return JsonSerializer.Serialize(new
@@ -62,7 +64,7 @@ public sealed class McpHealthTools
             var rows = await dataService.GetCollectionHealthAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No collection health data available.";
+                return McpHelpers.Status("unavailable", "No collection health data available.");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpIoTools.cs
+++ b/Lite/Mcp/McpIoTools.cs
@@ -26,7 +26,7 @@ public sealed class McpIoTools
             var rows = await dataService.GetLatestFileIoStatsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No file I/O stats available.";
+                return McpHelpers.Status("unavailable", "No file I/O stats available.");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpJobTools.cs
+++ b/Lite/Mcp/McpJobTools.cs
@@ -26,7 +26,7 @@ public sealed class McpJobTools
             var rows = await dataService.GetRunningJobsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No running SQL Agent jobs found (or collector has not run yet).";
+                return McpHelpers.Status("empty", "No running SQL Agent jobs found (or collector has not run yet).");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpMemoryTools.cs
+++ b/Lite/Mcp/McpMemoryTools.cs
@@ -26,7 +26,7 @@ public sealed class McpMemoryTools
             var stats = await dataService.GetLatestMemoryStatsAsync(resolved.Value.ServerId);
             if (stats == null)
             {
-                return "No memory stats available.";
+                return McpHelpers.Status("unavailable", "No memory stats available.");
             }
 
             return JsonSerializer.Serialize(new
@@ -156,7 +156,7 @@ Not available on Azure SQL DB (ring buffer not exposed). For actionable interpre
             var rows = await dataService.GetMemoryPressureEventsAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No memory pressure events found in the requested time range.";
+                return McpHelpers.Status("empty", "No memory pressure events found in the requested time range.");
             }
 
             return JsonSerializer.Serialize(new
@@ -199,7 +199,7 @@ Not available on Azure SQL DB (ring buffer not exposed). For actionable interpre
             var rows = await dataService.GetMemoryGrantChartDataAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No memory grant data available.";
+                return McpHelpers.Status("unavailable", "No memory grant data available.");
             }
 
             /* Return latest snapshot */

--- a/Lite/Mcp/McpObjectStatsTools.cs
+++ b/Lite/Mcp/McpObjectStatsTools.cs
@@ -26,7 +26,7 @@ public sealed class McpObjectStatsTools
             var rows = await dataService.GetObjectSizeGrowthAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No object size data available. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No object size data available. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new
@@ -73,7 +73,7 @@ public sealed class McpObjectStatsTools
             var rows = await dataService.GetIndexUsageAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No index usage data available. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No index usage data available. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new
@@ -123,7 +123,7 @@ public sealed class McpObjectStatsTools
             var rows = await dataService.GetIndexLockingAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No locking/contention data recorded. Index/object stats are collected daily.";
+                return McpHelpers.Status("unavailable", "No locking/contention data recorded. Index/object stats are collected daily.");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpPerfmonTools.cs
+++ b/Lite/Mcp/McpPerfmonTools.cs
@@ -28,7 +28,7 @@ public sealed class McpPerfmonTools
             var rows = await dataService.GetLatestPerfmonStatsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
             {
-                return "No perfmon stats available.";
+                return McpHelpers.Status("unavailable", "No perfmon stats available.");
             }
 
             IEnumerable<PerfmonRow> filtered = rows;
@@ -79,7 +79,33 @@ public sealed class McpPerfmonTools
             var points = await dataService.GetPerfmonTrendAsync(resolved.Value.ServerId, counter_name, hours_back);
             if (points.Count == 0)
             {
-                return $"No trend data for counter '{counter_name}'.";
+                /* No points can mean three different things to a caller. Distinguish them so an LLM
+                   doesn't read a bad counter name as "this metric looks fine." */
+                var collected = await dataService.GetDistinctPerfmonCountersAsync(resolved.Value.ServerId, hours_back);
+
+                /* Page Life Expectancy is the counter people reach for by habit; it is intentionally
+                   not collected, so an empty trend would otherwise be misread as "PLE looks fine." */
+                if (IsPageLifeExpectancy(counter_name))
+                    return McpHelpers.Status(
+                        "not_collected",
+                        $"No trend data for counter '{counter_name}'. Page Life Expectancy is a legacy metric and is intentionally not collected. " +
+                        "Use get_memory_stats for buffer pool / memory pressure instead.",
+                        new { collected_counters = collected });
+
+                /* Nothing collected at all for this server in the window: the collector likely hasn't
+                   produced perfmon data yet (delta counters need two cycles). Not retrievable now. */
+                if (collected.Count == 0)
+                    return McpHelpers.Status(
+                        "unavailable",
+                        $"No trend data for counter '{counter_name}'. No perfmon counters have been collected for this server in the last {hours_back}h yet " +
+                        "(the collector may not have run, or delta counters need a second collection cycle).");
+
+                /* Other counters exist but not this one: the name is almost certainly wrong. Hand back
+                   the collected names so the caller can correct it. */
+                return McpHelpers.Status(
+                    "not_collected",
+                    $"No trend data for counter '{counter_name}'. It may not be a counter this server collects — see hints.collected_counters for the {collected.Count} that are.",
+                    new { collected_counters = collected });
             }
 
             var result = points.Select(p => new
@@ -102,4 +128,13 @@ public sealed class McpPerfmonTools
             return McpHelpers.FormatError("get_perfmon_trend", ex);
         }
     }
+
+    /// <summary>
+    /// True when the caller asked for Page Life Expectancy by any common spelling. Matches the full
+    /// counter name (case-insensitive) or an exact "PLE" — but not "PLE" as a substring, so counters
+    /// like "samples" don't false-positive.
+    /// </summary>
+    private static bool IsPageLifeExpectancy(string counterName) =>
+        counterName.Contains("page life expectancy", StringComparison.OrdinalIgnoreCase) ||
+        counterName.Trim().Equals("PLE", StringComparison.OrdinalIgnoreCase);
 }

--- a/Lite/Mcp/McpPlanTools.cs
+++ b/Lite/Mcp/McpPlanTools.cs
@@ -30,7 +30,9 @@ public sealed class McpPlanTools
         {
             var xml = await dataService.GetCachedQueryPlanAsync(resolved.Value.ServerId, query_hash);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for query_hash '{query_hash}'. The query may have been evicted from the plan cache since the last collection.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
         }
@@ -58,7 +60,9 @@ public sealed class McpPlanTools
         {
             var xml = await dataService.GetCachedProcedurePlanAsync(resolved.Value.ServerId, plan_handle);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for plan_handle '{plan_handle}'. The procedure may have been evicted from the plan cache since the last collection.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for plan_handle '{plan_handle}'. The procedure may have been evicted from the plan cache since the last collection.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", plan_handle);
         }
@@ -98,7 +102,9 @@ public sealed class McpPlanTools
             var xml = await LocalDataService.FetchQueryStorePlanAsync(connectionString, database_name, plan_id);
 
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for plan_id {plan_id} in database '{database_name}'. Query Store may not be enabled or the plan may have been purged.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No plan found for plan_id {plan_id} in database '{database_name}'. Query Store may not be enabled or the plan may have been purged.");
 
             return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", $"{database_name}:{plan_id}");
         }
@@ -146,7 +152,7 @@ public sealed class McpPlanTools
         {
             var xml = await dataService.GetCachedQueryPlanAsync(resolved.Value.ServerId, query_hash);
             if (string.IsNullOrEmpty(xml))
-                return $"No plan found for query_hash '{query_hash}'.";
+                return McpHelpers.Status("unavailable", $"No plan found for query_hash '{query_hash}'.");
 
             return McpHelpers.Truncate(xml, 512_000) ?? "No plan XML available.";
         }

--- a/Lite/Mcp/McpQueryTools.cs
+++ b/Lite/Mcp/McpQueryTools.cs
@@ -37,7 +37,7 @@ public sealed class McpQueryTools
             var rows = await dataService.GetTopQueriesByCpuAsync(resolved.Value.ServerId, hours_back, top, databaseName: database_name);
             if (rows.Count == 0)
             {
-                return "No query stats available for the specified time range.";
+                return McpHelpers.Status("unavailable", "No query stats available for the specified time range.");
             }
 
             IEnumerable<QueryStatsRow> filtered = rows;
@@ -111,7 +111,9 @@ public sealed class McpQueryTools
             var rows = await dataService.GetTopProceduresByCpuAsync(resolved.Value.ServerId, hours_back, top, databaseName: database_name);
             if (rows.Count == 0)
             {
-                return "No procedure stats available. Delta-based collection requires at least two collection cycles (~30 minutes) to produce non-zero values.";
+                return McpHelpers.Status(
+                    "unavailable",
+                    "No procedure stats available. Delta-based collection requires at least two collection cycles (~30 minutes) to produce non-zero values.");
             }
 
             var result = rows.Select(r => new
@@ -176,7 +178,7 @@ public sealed class McpQueryTools
             var rows = await dataService.GetQueryStoreTopQueriesAsync(resolved.Value.ServerId, hours_back, top, databaseName: database_name);
             if (rows.Count == 0)
             {
-                return "No Query Store data available. Query Store may not be enabled on target databases.";
+                return McpHelpers.Status("unavailable", "No Query Store data available. Query Store may not be enabled on target databases.");
             }
 
             var result = rows.Select(r => new
@@ -272,7 +274,7 @@ public sealed class McpQueryTools
             var rows = await dataService.GetQueryStatsHistoryAsync(resolved.Value.ServerId, database_name, query_hash, hours_back);
             if (rows.Count == 0)
             {
-                return $"No history found for query_hash '{query_hash}' in database '{database_name}' within the last {hours_back} hours.";
+                return McpHelpers.Status("empty", $"No history found for query_hash '{query_hash}' in database '{database_name}' within the last {hours_back} hours.");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpServerInfoTools.cs
+++ b/Lite/Mcp/McpServerInfoTools.cs
@@ -23,7 +23,7 @@ public sealed class McpServerInfoTools
         {
             var row = await dataService.GetLatestServerPropertiesAsync(resolved.Value.ServerId);
             if (row == null)
-                return "No server properties available. The properties collector may not have run yet.";
+                return McpHelpers.Status("unavailable", "No server properties available. The properties collector may not have run yet.");
 
             return JsonSerializer.Serialize(new
             {
@@ -65,7 +65,7 @@ public sealed class McpServerInfoTools
         {
             var rows = await dataService.GetLatestDatabaseSizeStatsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No database size data available. The size collector may not have run yet.";
+                return McpHelpers.Status("unavailable", "No database size data available. The size collector may not have run yet.");
 
             return JsonSerializer.Serialize(new
             {

--- a/Lite/Mcp/McpSessionTools.cs
+++ b/Lite/Mcp/McpSessionTools.cs
@@ -30,7 +30,7 @@ public sealed class McpSessionTools
         {
             var rows = await dataService.GetLatestQuerySnapshotsAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
-                return "No active query snapshots found in the requested time range.";
+                return McpHelpers.Status("empty", "No active query snapshots found in the requested time range.");
 
             IEnumerable<QuerySnapshotRow> filtered = rows;
 
@@ -96,7 +96,7 @@ public sealed class McpSessionTools
         {
             var rows = await dataService.GetLatestSessionStatsAsync(resolved.Value.ServerId);
             if (rows.Count == 0)
-                return "No session statistics available. The session collector may not have run yet.";
+                return McpHelpers.Status("unavailable", "No session statistics available. The session collector may not have run yet.");
 
             var totalConnections = rows.Sum(r => r.ConnectionCount);
             var totalRunning = rows.Sum(r => r.RunningCount);

--- a/Lite/Mcp/McpTempDbTools.cs
+++ b/Lite/Mcp/McpTempDbTools.cs
@@ -30,7 +30,7 @@ public sealed class McpTempDbTools
             var rows = await dataService.GetTempDbTrendAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No TempDB data available.";
+                return McpHelpers.Status("unavailable", "No TempDB data available.");
             }
 
             var result = rows.Select(r => new

--- a/Lite/Mcp/McpWaitTools.cs
+++ b/Lite/Mcp/McpWaitTools.cs
@@ -34,7 +34,7 @@ public sealed class McpWaitTools
             var rows = await dataService.GetWaitStatsAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No wait stats data available for the specified time range.";
+                return McpHelpers.Status("unavailable", "No wait stats data available for the specified time range.");
             }
 
             var result = rows.Take(limit).Select(r => new
@@ -114,7 +114,19 @@ public sealed class McpWaitTools
             var points = await dataService.GetWaitStatsTrendAsync(resolved.Value.ServerId, wait_type, hours_back);
             if (points.Count == 0)
             {
-                return $"No trend data for wait type '{wait_type}'.";
+                /* Same shape as get_perfmon_trend: tell the caller whether the wait type is just
+                   unknown here vs. nothing collected at all, and hand back the ones that do have data. */
+                var collected = await dataService.GetDistinctWaitTypesAsync(resolved.Value.ServerId, hours_back);
+                if (collected.Count == 0)
+                    return McpHelpers.Status(
+                        "unavailable",
+                        $"No trend data for wait type '{wait_type}'. No wait stats have been collected for this server in the last {hours_back}h yet " +
+                        "(the collector may not have run, or delta wait stats need a second collection cycle).");
+
+                return McpHelpers.Status(
+                    "not_collected",
+                    $"No trend data for wait type '{wait_type}'. It may not be a wait type observed on this server in this window — see hints.collected_wait_types for the {collected.Count} that have data.",
+                    new { collected_wait_types = collected });
             }
 
             var result = points.Select(p => new
@@ -163,7 +175,7 @@ public sealed class McpWaitTools
             var rows = await dataService.GetWaitingTasksAsync(resolved.Value.ServerId, hours_back);
             if (rows.Count == 0)
             {
-                return "No waiting tasks found.";
+                return McpHelpers.Status("empty", "No waiting tasks found.");
             }
 
             var result = rows.Take(limit).Select(r => new

--- a/PerformanceMonitor.Common/Mcp/McpHelpers.cs
+++ b/PerformanceMonitor.Common/Mcp/McpHelpers.cs
@@ -71,4 +71,26 @@ internal static class McpHelpers
     {
         return $"Error during {operation}: {ex.Message}";
     }
+
+    /// <summary>
+    /// Builds a consistent JSON envelope for a NON-DATA outcome — a legitimate miss — so an LLM
+    /// consumer can branch on the kind of nothing it got back. Data-bearing results keep their own
+    /// shape and must NOT use this.
+    /// </summary>
+    /// <param name="status">
+    /// One word from the small miss vocabulary:
+    /// <list type="bullet">
+    /// <item><c>empty</c> — a true negative: we looked and there is genuinely nothing (all clear).</item>
+    /// <item><c>not_collected</c> — the input names something this server does not collect.</item>
+    /// <item><c>unavailable</c> — it existed but is not retrievable now (evicted, purged, or not collected yet).</item>
+    /// </list>
+    /// </param>
+    /// <param name="message">The human-readable explanation (kept intact from the prior bare-string text).</param>
+    /// <param name="hints">Optional structured payload to help the caller recover (e.g. the counters that ARE collected). Omitted from the JSON when null.</param>
+    public static string Status(string status, string message, object? hints = null)
+    {
+        return hints is null
+            ? JsonSerializer.Serialize(new { status, message }, JsonOptions)
+            : JsonSerializer.Serialize(new { status, message, hints }, JsonOptions);
+    }
 }


### PR DESCRIPTION
## What

Adds a shared `McpHelpers.Status(status, message, hints?)` helper and routes every **non-data (miss) outcome** in both apps' MCP tools through it, so an LLM consumer can branch on a small status vocabulary instead of parsing prose:

- `empty` - a true negative ("we looked, there is genuinely nothing / all clear")
- `not_collected` - the input names something this server does not collect
- `unavailable` - it existed but is not retrievable now (evicted, purged, or not collected yet)

## Why

Previously a miss returned a bare string (e.g. `"No trend data for counter 'X'."`), so a model could not tell a true negative ("PLE looks fine") from a bad input ("you asked for something not collected"). This makes that distinction machine-readable.

## Scope

- **102 `McpHelpers.Status(...)` call sites** across **17 Lite + 21 Dashboard** tool files.
- Lite `get_perfmon_trend` / `get_wait_trend` return the actually-collected list as `hints` (`collected_counters` / `collected_wait_types`); Page Life Expectancy is special-cased as an intentionally-excluded legacy metric.
- `analyze_server` no-findings -> `empty` (was `"healthy"`) in both apps; the three analysis tools are kept in parity.
- Setup / validation / resolution messages (`no servers configured`, `no plan XML provided`, `could not resolve server`) are intentionally left as plain strings.
- **Data-returning success paths are byte-for-byte unchanged.**

## Known follow-up

Dashboard's `get_perfmon_trend` / `get_wait_trend` filter in memory, so they cannot emit the per-entity `not_collected` + collected-list without a behavior change; they return `unavailable` for the no-data case. The richer trend-tool parity is left as a separate, deliberate decision.

## Testing

- 5 new envelope tests (`Lite.Tests/McpStatusEnvelopeTests.cs`) invoke the real tool methods against a seeded temp DuckDB + real `ServerManager`: uncollected perfmon counter -> `not_collected` + list, PLE -> legacy note, no counters -> `unavailable`, uncollected wait type -> `not_collected` + list, no deadlocks -> `empty`.
- **Lite.Tests: 558 green. Dashboard.Tests: 616 green. Both apps build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
