### PR TITLE
Exclude muted alerts from the sidebar Alert badge count (#1225)

### DIFF
--- a/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
+++ b/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using PerformanceMonitorDashboard.Services;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// #1225: muted alerts are written to history for audit but must not count toward the sidebar
+/// Alert badge. Proves GetAlertHistory(includeMuted: false) drops muted rows, that the default
+/// (includeMuted: true) still returns them for the history grid / MCP tool, and — the regression
+/// that bit the reporter — that the muted filter runs BEFORE the row limit, so a flood of muted
+/// noise can't evict a real alert from the counted window. A unique serverId keeps the test
+/// isolated from any on-disk alert_history.json the store loads in its constructor.
+/// </summary>
+public class JsonAlertHistoryStoreMutedFilterTests
+{
+    /// <summary>Minimal IUserPreferencesService over one UserPreferences instance (mirrors the other Dashboard tests).</summary>
+    private sealed class FakePreferencesService : IUserPreferencesService
+    {
+        public UserPreferences Preferences { get; } = new();
+        public UserPreferences GetPreferences() => Preferences;
+        public void SavePreferences(UserPreferences preferences) { }
+        public void UpdateWaitStatsRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCpuRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateMemoryRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateFileIoRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateExpensiveQueriesRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateBlockingRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+        public void UpdateCollectionHealthRange(int hoursBack, DateTime? fromDate = null, DateTime? toDate = null) { }
+    }
+
+    private static Task RecordAsync(JsonAlertHistoryStore store, string serverId, string metric, bool muted)
+        => store.RecordAlertAsync(new AlertHistoryRecord(
+            serverId, "Srv", metric, "4", "1", null, null,
+            AlertSent: !muted, NotificationType: muted ? "muted" : "tray", SendError: null,
+            Muted: muted, DetailText: null, ContextJson: null));
+
+    [Fact]
+    public async Task GetAlertHistory_ExcludeMuted_DropsMutedRows_ButDefaultKeepsThem()
+    {
+        var store = new JsonAlertHistoryStore(new FakePreferencesService());
+        var srv = "test-" + Guid.NewGuid().ToString("N"); // unique -> isolated from on-disk history
+
+        await RecordAsync(store, srv, "Long Running Query", muted: false);
+        await RecordAsync(store, srv, "Long Running Query", muted: true);
+        await RecordAsync(store, srv, "Deadlocks Detected", muted: false);
+        await RecordAsync(store, srv, "Long Running Query", muted: true);
+
+        var all = store.GetAlertHistory(hoursBack: 24, limit: 100);                            // history grid / MCP
+        var actionable = store.GetAlertHistory(hoursBack: 24, limit: 100, includeMuted: false); // sidebar badge
+
+        Assert.Equal(4, all.Count(a => a.ServerId == srv));            // default: muted rows still shown for audit
+        var mine = actionable.Where(a => a.ServerId == srv).ToList();
+        Assert.Equal(2, mine.Count);                                   // only the two unmuted alerts count
+        Assert.All(mine, a => Assert.False(a.Muted));
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_ExcludeMuted_FiltersBeforeLimit_SoMutedNoiseCannotEvictRealAlert()
+    {
+        var store = new JsonAlertHistoryStore(new FakePreferencesService());
+        var srv = "test-" + Guid.NewGuid().ToString("N");
+
+        // One real alert first (oldest), then a flood of newer muted noise (the reporter's scenario:
+        // a muted trace-reader session re-firing every cooldown).
+        await RecordAsync(store, srv, "Deadlocks Detected", muted: false);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        for (int i = 0; i < 5; i++)
+            await RecordAsync(store, srv, "Long Running Query", muted: true);
+
+        // Newest-first ordering + a small limit: the muted flood crowds the real alert out of the
+        // window when muted rows are included (this is what made the old badge under/over-count).
+        var withMuted = store.GetAlertHistory(hoursBack: 24, limit: 3);
+        Assert.DoesNotContain(withMuted, a => a.ServerId == srv && !a.Muted);
+
+        // Excluding muted BEFORE the limit keeps the real alert inside the counted window (#1225).
+        var actionable = store.GetAlertHistory(hoursBack: 24, limit: 3, includeMuted: false);
+        var mine = actionable.Where(a => a.ServerId == srv).ToList();
+        Assert.Single(mine);
+        Assert.False(mine[0].Muted);
+    }
+}

--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -83,7 +83,11 @@ namespace PerformanceMonitorDashboard
 
         private void UpdateAlertBadge()
         {
-            var alerts = _alertHistoryStore.GetAlertHistory(hoursBack: 24, limit: 100);
+            /* Muted alerts stay in history for audit but must not inflate the sidebar Alert badge —
+               otherwise known recurring noise (e.g. a muted trace-reader session) makes the dashboard
+               look like it has actionable alerts (#1225). Excluded inside the query, before the limit,
+               so a flood of muted rows can't push real alerts out of the counted window. */
+            var alerts = _alertHistoryStore.GetAlertHistory(hoursBack: 24, limit: 100, includeMuted: false);
             var count = alerts.Count;
 
             if (count > 0)

--- a/Dashboard/Services/JsonAlertHistoryStore.cs
+++ b/Dashboard/Services/JsonAlertHistoryStore.cs
@@ -187,14 +187,20 @@ namespace PerformanceMonitorDashboard.Services
         /// <summary>
         /// Gets alert history from the log (excludes hidden alerts).
         /// </summary>
-        public List<AlertLogEntry> GetAlertHistory(int hoursBack = 24, int limit = 50)
+        /// <param name="includeMuted">
+        /// When true (default), muted rows are returned for audit/history display. When false,
+        /// muted rows are filtered out <em>before</em> the limit is applied — used by the sidebar
+        /// Alert badge count so known recurring noise (a muted source firing every cooldown) can
+        /// neither inflate the badge nor push real alerts out of the counted window (#1225).
+        /// </param>
+        public List<AlertLogEntry> GetAlertHistory(int hoursBack = 24, int limit = 50, bool includeMuted = true)
         {
             var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
             lock (_alertLogLock)
             {
                 return _alertLog
-                    .Where(a => a.AlertTime >= cutoff && !a.Hidden)
+                    .Where(a => a.AlertTime >= cutoff && !a.Hidden && (includeMuted || !a.Muted))
                     .OrderByDescending(a => a.AlertTime)
                     .Take(limit)
                     .ToList();


### PR DESCRIPTION
Fixes #1225.

## Problem
Muted alerts are recorded to history for audit (they show in Alert History with `Channel = muted`), but the sidebar **Alerts** badge counted *every* non-hidden history row, muted included. A known recurring muted source — the reporter's SolarWinds SQL Sentry trace-reader session re-firing every cooldown — kept the badge lit, making the dashboard look like it had actionable alerts.

This is the reporter's preferred **Option A**: keep muted alerts in history for audit, but stop them incrementing the badge.

## Fix
- `JsonAlertHistoryStore.GetAlertHistory` gains `bool includeMuted = true`. The muted filter sits in the same `Where` as `!a.Hidden`, so it runs **before** `.Take(limit)`.
- `UpdateAlertBadge` calls it with `includeMuted: false`.

Default `true` leaves the two display callers unchanged — the Alert History grid and the MCP `get_alert_history` tool still surface muted rows for audit. Filtering before the limit matters for the reporter's exact scenario: a flood of muted rows could otherwise fill the 100-row window and crowd real alerts out of the count.

## Scope / parity
Dashboard-only by design. The per-server health badges (Dashboard tab badges and Lite's badge) are a separate, blocking/deadlock-health-driven system, not an alert-history count — Lite has no equivalent sidebar history-count badge, so there is nothing to mirror.

## Tests
New `JsonAlertHistoryStoreMutedFilterTests` (2):
1. `includeMuted: false` drops muted rows; the default keeps them.
2. A flood of newer muted rows can't evict an older real alert from a limited window (proves the filter precedes the limit).

Build green (0 errors); full Dashboard.Tests suite **618 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)