### PR TITLE
Add always-on DMV blocking-snapshot fallback (both apps)

### DIFF
--- a/Dashboard.Tests/BlockingPairRowMergeTests.cs
+++ b/Dashboard.Tests/BlockingPairRowMergeTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Unit tests for BlockingPairRowMerge — merging always-on DMV-snapshot pair-rows into blocked-process-report
+/// rows: BPR preferred, DMV-only filled in (the AWS RDS / threshold-unset case), overlapping edges deduped.
+/// No database.
+/// </summary>
+public class BlockingPairRowMergeTests
+{
+    private static readonly DateTime BaseTime = new(2026, 5, 22, 10, 0, 0);
+
+    private static BlockingPairRow Pair(int blockedSpid, int blockingSpid, string source,
+        DateTime? eventTime = null, int blockedEcid = 0, int blockingEcid = 0) =>
+        new()
+        {
+            EventTime = eventTime ?? BaseTime,
+            DatabaseName = "TestDb",
+            BlockedSpid = blockedSpid,
+            BlockingSpid = blockingSpid,
+            BlockedEcid = blockedEcid,
+            BlockingEcid = blockingEcid,
+            LockMode = "X",
+            BlockingStatus = "running",
+            BlockedSqlText = source, // tag the origin so assertions can tell which row survived
+            BlockingSqlText = source
+        };
+
+    [Fact]
+    public void EmptySnapshots_LeavesPrimaryUnchanged()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, Array.Empty<BlockingPairRow>());
+        Assert.Equal("BPR", Assert.Single(primary).BlockedSqlText);
+    }
+
+    [Fact]
+    public void EmptyPrimary_AddsAllSnapshots()
+    {
+        // The RDS / threshold-unset case: no blocked-process reports, the DMV snapshot is the only source.
+        var primary = new List<BlockingPairRow>();
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV"), Pair(203, 202, "DMV") });
+        Assert.Equal(2, primary.Count);
+        Assert.All(primary, r => Assert.Equal("DMV", r.BlockedSqlText));
+    }
+
+    [Fact]
+    public void OverlappingEdge_PrefersBprAndDropsDmv()
+    {
+        // Same edge (blocked/blocker spid:ecid, same minute) from both sources -> only the BPR row survives.
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV") });
+        Assert.Equal("BPR", Assert.Single(primary).BlockedSqlText);
+    }
+
+    [Fact]
+    public void DistinctEdge_AddsDmvRow()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(301, 300, "DMV") });
+        Assert.Equal(2, primary.Count);
+    }
+
+    [Fact]
+    public void SameSpidsDifferentMinute_AreNotDeduped()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR", BaseTime) };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV", BaseTime.AddMinutes(5)) });
+        Assert.Equal(2, primary.Count);
+    }
+
+    [Fact]
+    public void SameSpidDifferentEcid_AreNotDeduped()
+    {
+        // Parallel workers (distinct ecid) are distinct edges, not duplicates.
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR", blockingEcid: 0) };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV", blockingEcid: 1) });
+        Assert.Equal(2, primary.Count);
+    }
+}

--- a/Dashboard/Analysis/BlockingChainViewerProjection.cs
+++ b/Dashboard/Analysis/BlockingChainViewerProjection.cs
@@ -15,9 +15,9 @@ namespace PerformanceMonitorDashboard.Analysis;
 internal static class BlockingChainViewerProjection
 {
     public const string EmptyStateDetail =
-        "No blocked-process reports were collected in the selected time range. " +
-        "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
-        "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
+        "No blocking was captured for this session in the selected time range — from either the " +
+        "blocked-process-report Extended Event or the always-on DMV blocking snapshot. Its wait may not " +
+        "have overlapped a collection in this window.";
 
     /// <summary>
     /// Builds the model for the ONE chain that contains the clicked session (matched by SessionKey — the

--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
 
@@ -151,5 +153,68 @@ OUTER APPLY
         row.BlockingHostName = reader.IsDBNull(19) ? string.Empty : reader.GetString(19);
         row.BlockingClientApp = reader.IsDBNull(20) ? string.Empty : reader.GetString(20);
         return row;
+    }
+
+    /// <summary>
+    /// The DMV-snapshot pair-row source (collect.dmv_blocking_snapshots, the always-on blocking fallback).
+    /// Same projection and ordinals (0-20) as <see cref="SqlWithBlockerIdentity"/> so the shared
+    /// <see cref="ReadWithBlockerIdentity"/> maps it unchanged — but the blocker identity is stored inline
+    /// (the snapshot collector captures both sides natively), so no OUTER APPLY correlation is needed.
+    /// </summary>
+    public const string DmvSql = ReadUncommitted + @"
+SELECT TOP (5000)
+    event_time,
+    database_name,
+    spid,
+    last_transaction_started,
+    blocking_spid,
+    blocking_last_tran_started,
+    wait_time_ms,
+    lock_mode,
+    blocking_status,
+    blocked_sql_text,
+    blocking_sql_text,
+    login_name,
+    host_name,
+    client_app,
+    contentious_object,
+    ecid,
+    blocking_ecid,
+    monitor_loop,
+    blocking_login_name,
+    blocking_host_name,
+    blocking_client_app
+FROM collect.dmv_blocking_snapshots
+WHERE collection_time >= @collectionWindow
+AND   event_time >= @startTime
+AND   event_time <= @endTime
+ORDER BY collection_time DESC";
+
+    /// <summary>
+    /// Fetches DMV-snapshot pair-rows for the window and merges them into <paramref name="rows"/>
+    /// (BPR-preferred — see <see cref="BlockingPairRowMerge"/>). Called by all three pair-row consumers
+    /// after they build their BPR rows, so the DMV fallback feeds the reconstructor everywhere the
+    /// blocked-process-report does. Tolerates a not-yet-upgraded database (missing table -> no-op).
+    /// </summary>
+    internal static async Task AppendDmvSnapshotRowsAsync(SqlConnection connection, List<BlockingPairRow> rows, DateTime start, DateTime end)
+    {
+        var dmv = new List<BlockingPairRow>();
+        try
+        {
+            using var cmd = new SqlCommand(DmvSql, connection);
+            cmd.CommandTimeout = 120;
+            AddParameters(cmd, start, end);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+                dmv.Add(ReadWithBlockerIdentity(reader));
+        }
+        catch (SqlException ex) when (ex.Number == 208)
+        {
+            /* Invalid object name: collect.dmv_blocking_snapshots not present yet (pre-upgrade DB).
+               Degrade to BPR-only rather than failing the whole block-chain fetch. */
+            return;
+        }
+
+        BlockingPairRowMerge.MergeInto(rows, dmv);
     }
 }

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
@@ -130,6 +130,10 @@ ORDER BY wait_time_ms DESC;";
                 rows.Add(BlockingPairRowQuery.Read(reader));
         }
 
+        // Always-on DMV blocking snapshot fallback. Merge BEFORE the empty check so DMV-only blocking
+        // (blocked-process-report unavailable, e.g. AWS RDS) still reconstructs.
+        await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(connection, rows, context.TimeRangeStart, context.TimeRangeEnd);
+
         if (rows.Count == 0) return;
 
         var reconstruction = BlockingChainReconstructor.Reconstruct(

--- a/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
+++ b/Dashboard/Analysis/SqlServerFactCollector.Waits.cs
@@ -231,6 +231,10 @@ AND   collection_time <= @endTime";
                     rows.Add(BlockingPairRowQuery.Read(reader));
             }
 
+            // Always-on DMV blocking snapshot fallback (works when the blocked-process-report XE is empty,
+            // e.g. AWS RDS). Merge BEFORE the empty check so DMV-only blocking still produces facts.
+            await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(connection, rows, context.TimeRangeStart, context.TimeRangeEnd);
+
             if (rows.Count == 0) return;
 
             // Cumulative (not per-scan): merges an episode's re-fires across the window so the severity fact

--- a/Dashboard/Models/BlockingEventItem.cs
+++ b/Dashboard/Models/BlockingEventItem.cs
@@ -62,6 +62,13 @@ namespace PerformanceMonitorDashboard.Models
         /// </summary>
         public bool HasBlockedProcessReport { get; set; }
 
+        /// <summary>
+        /// Where this row came from: the blocked-process-report XE ("blocked-process-report") or the
+        /// always-on DMV snapshot fallback ("DMV snapshot"). Surfaced as a grid badge so a row captured
+        /// when the blocked-process threshold was unset (e.g. AWS RDS) is distinguishable.
+        /// </summary>
+        public string Source { get; set; } = "blocked-process-report";
+
         public double? WaitTimeSec => WaitTimeMs.HasValue ? WaitTimeMs.Value / 1000.0 : null;
     }
 }

--- a/Dashboard/ServerTab.BlockChain.cs
+++ b/Dashboard/ServerTab.BlockChain.cs
@@ -97,8 +97,8 @@ namespace PerformanceMonitorDashboard
                     MessageBox.Show(
                         Window.GetWindow(this)!,
                         $"No reconstructable blocking chain for SPID {spid} in the selected range.\n\n" +
-                        "The session may not have been part of a blocked-process report whose wait crossed " +
-                        "the blocked-process threshold in this window.",
+                        "The session may not have been blocked (or blocking) in any captured blocked-process " +
+                        "report or DMV blocking snapshot in this window.",
                         "No Block Chain",
                         MessageBoxButton.OK,
                         MessageBoxImage.Information);

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -680,6 +680,7 @@
                                             </StackPanel>
                                         </DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Source}" Header="Source" Width="130"/>
                                     <DataGridTextColumn Binding="{Binding Activity}" Width="70">
                                         <DataGridTextColumn.Header>
                                             <StackPanel Orientation="Horizontal">

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Blocking.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
@@ -190,7 +191,118 @@ namespace PerformanceMonitorDashboard.Services
                         });
                     }
         
+                    // Always-on DMV blocking snapshot: surface its rows in the grid too, so the block-chain
+                    // viewer is reachable when the blocked-process-report XE captured nothing (AWS RDS).
+                    await AppendDmvBlockingGridItemsAsync(items, hoursBack, fromDate, toDate);
+
                     return items;
+                }
+
+                /// <summary>
+                /// Fetches always-on DMV blocking-snapshot rows for the grid and merges them into the BPR
+                /// list — BPR preferred (dedup by blocked/blocker SPID within a minute), re-capped to 100
+                /// newest-first. Opens its own connection because the caller's BPR reader is still open.
+                /// A missing table (pre-upgrade DB) degrades to a no-op, leaving the BPR rows untouched.
+                /// </summary>
+                private async Task AppendDmvBlockingGridItemsAsync(List<BlockingEventItem> items, int hoursBack, DateTime? fromDate, DateTime? toDate)
+                {
+                    const int gridCap = 100;
+                    string window = (fromDate.HasValue && toDate.HasValue)
+                        ? "d.collection_time >= @from_date AND d.collection_time <= @to_date"
+                        : "d.collection_time >= DATEADD(HOUR, @hours_back, SYSDATETIME())";
+
+                    string query = $@"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT TOP ({gridCap})
+    d.snapshot_id,
+    d.collection_time,
+    d.event_time,
+    d.database_name,
+    d.contentious_object,
+    d.spid,
+    d.ecid,
+    CONVERT(nvarchar(max), d.blocked_sql_text) AS blocked_sql_text,
+    d.wait_time_ms,
+    d.blocking_status,
+    d.lock_mode,
+    d.last_transaction_started,
+    d.client_app,
+    d.host_name,
+    d.login_name,
+    d.blocking_spid,
+    d.blocking_last_tran_started,
+    d.monitor_loop
+FROM collect.dmv_blocking_snapshots AS d
+WHERE {window}
+ORDER BY d.event_time DESC;";
+
+                    var dmvItems = new List<BlockingEventItem>();
+                    try
+                    {
+                        await using var tc = await OpenThrottledConnectionAsync();
+                        using var command = new SqlCommand(query, tc.Connection);
+                        command.CommandTimeout = 120;
+                        command.Parameters.Add(new SqlParameter("@hours_back", SqlDbType.Int) { Value = -hoursBack });
+                        if (fromDate.HasValue) command.Parameters.Add(new SqlParameter("@from_date", SqlDbType.DateTime2) { Value = fromDate.Value });
+                        if (toDate.HasValue) command.Parameters.Add(new SqlParameter("@to_date", SqlDbType.DateTime2) { Value = toDate.Value });
+
+                        using var reader = await command.ExecuteReaderAsync();
+                        while (await reader.ReadAsync())
+                        {
+                            dmvItems.Add(new BlockingEventItem
+                            {
+                                BlockingId = reader.GetInt64(0),
+                                CollectionTime = reader.GetDateTime(1),
+                                EventTime = reader.IsDBNull(2) ? (DateTime?)null : reader.GetDateTime(2),
+                                DatabaseName = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+                                ContentiousObject = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
+                                Spid = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5),
+                                Ecid = reader.IsDBNull(6) ? (int?)null : reader.GetInt32(6),
+                                QueryText = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+                                WaitTimeMs = reader.IsDBNull(8) ? (long?)null : reader.GetInt64(8),
+                                Status = reader.IsDBNull(9) ? string.Empty : reader.GetString(9),
+                                LockMode = reader.IsDBNull(10) ? string.Empty : reader.GetString(10),
+                                LastTransactionStarted = reader.IsDBNull(11) ? (DateTime?)null : reader.GetDateTime(11),
+                                ClientApp = reader.IsDBNull(12) ? string.Empty : reader.GetString(12),
+                                HostName = reader.IsDBNull(13) ? string.Empty : reader.GetString(13),
+                                LoginName = reader.IsDBNull(14) ? string.Empty : reader.GetString(14),
+                                BlockingSpid = reader.IsDBNull(15) ? (int?)null : reader.GetInt32(15),
+                                BlockingLastTranStarted = reader.IsDBNull(16) ? (DateTime?)null : reader.GetDateTime(16),
+                                MonitorLoop = reader.IsDBNull(17) ? (int?)null : reader.GetInt32(17),
+                                Activity = "blocked",
+                                HasBlockedProcessReport = false,
+                                Source = "DMV snapshot"
+                            });
+                        }
+                    }
+                    catch (SqlException ex) when (ex.Number == 208)
+                    {
+                        /* collect.dmv_blocking_snapshots not present yet (pre-upgrade DB) — show BPR-only. */
+                        return;
+                    }
+
+                    if (dmvItems.Count == 0) return;
+
+                    // Dedup: keep all BPR rows; add a DMV row only if no BPR 'blocked' row covers the same
+                    // (blocked spid, blocker spid) within the same minute. BPR is preferred (richer XML).
+                    var seen = new HashSet<(int, int, long)>();
+                    foreach (var b in items)
+                        if (b.Spid.HasValue && b.BlockingSpid.HasValue && b.EventTime.HasValue)
+                            seen.Add((b.Spid.Value, b.BlockingSpid.Value, b.EventTime.Value.Ticks / TimeSpan.TicksPerMinute));
+
+                    foreach (var d in dmvItems)
+                    {
+                        var key = (d.Spid ?? 0, d.BlockingSpid ?? 0, (d.EventTime?.Ticks ?? 0) / TimeSpan.TicksPerMinute);
+                        if (seen.Add(key))
+                            items.Add(d);
+                    }
+
+                    // Re-cap to the grid's TOP(100), newest first. OrderByDescending is stable, so BPR rows
+                    // (added first) win ties over DMV rows at the same event time.
+                    var merged = items.OrderByDescending(i => i.EventTime ?? DateTime.MinValue).Take(gridCap).ToList();
+                    items.Clear();
+                    items.AddRange(merged);
                 }
 
                 // On-demand fetch of a single blocked process report XML (deferred from the grid query
@@ -445,9 +557,15 @@ namespace PerformanceMonitorDashboard.Services
                     command.CommandTimeout = 120;
                     BlockingPairRowQuery.AddParameters(command, start, end);
 
-                    using var reader = await command.ExecuteReaderAsync();
-                    while (await reader.ReadAsync())
-                        rows.Add(BlockingPairRowQuery.ReadWithBlockerIdentity(reader));
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                            rows.Add(BlockingPairRowQuery.ReadWithBlockerIdentity(reader));
+                    }
+
+                    // Always-on DMV blocking snapshot: merge in the fallback rows so the viewer works even
+                    // when the blocked-process-report XE captured nothing (threshold unset / AWS RDS).
+                    await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(connection, rows, start, end);
 
                     return rows;
                 }

--- a/Lite.Tests/BlockingPairRowMergeTests.cs
+++ b/Lite.Tests/BlockingPairRowMergeTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using PerformanceMonitor.Analysis;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Unit tests for BlockingPairRowMerge — merging always-on DMV-snapshot pair-rows into blocked-process-report
+/// rows: BPR preferred, DMV-only filled in (the AWS RDS / threshold-unset case), overlapping edges deduped.
+/// No database.
+/// </summary>
+public class BlockingPairRowMergeTests
+{
+    private static readonly DateTime BaseTime = new(2026, 5, 22, 10, 0, 0);
+
+    private static BlockingPairRow Pair(int blockedSpid, int blockingSpid, string source,
+        DateTime? eventTime = null, int blockedEcid = 0, int blockingEcid = 0) =>
+        new()
+        {
+            EventTime = eventTime ?? BaseTime,
+            DatabaseName = "TestDb",
+            BlockedSpid = blockedSpid,
+            BlockingSpid = blockingSpid,
+            BlockedEcid = blockedEcid,
+            BlockingEcid = blockingEcid,
+            LockMode = "X",
+            BlockingStatus = "running",
+            BlockedSqlText = source, // tag the origin so assertions can tell which row survived
+            BlockingSqlText = source
+        };
+
+    [Fact]
+    public void EmptySnapshots_LeavesPrimaryUnchanged()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, Array.Empty<BlockingPairRow>());
+        Assert.Equal("BPR", Assert.Single(primary).BlockedSqlText);
+    }
+
+    [Fact]
+    public void EmptyPrimary_AddsAllSnapshots()
+    {
+        // The RDS / threshold-unset case: no blocked-process reports, the DMV snapshot is the only source.
+        var primary = new List<BlockingPairRow>();
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV"), Pair(203, 202, "DMV") });
+        Assert.Equal(2, primary.Count);
+        Assert.All(primary, r => Assert.Equal("DMV", r.BlockedSqlText));
+    }
+
+    [Fact]
+    public void OverlappingEdge_PrefersBprAndDropsDmv()
+    {
+        // Same edge (blocked/blocker spid:ecid, same minute) from both sources -> only the BPR row survives.
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV") });
+        Assert.Equal("BPR", Assert.Single(primary).BlockedSqlText);
+    }
+
+    [Fact]
+    public void DistinctEdge_AddsDmvRow()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR") };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(301, 300, "DMV") });
+        Assert.Equal(2, primary.Count);
+    }
+
+    [Fact]
+    public void SameSpidsDifferentMinute_AreNotDeduped()
+    {
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR", BaseTime) };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV", BaseTime.AddMinutes(5)) });
+        Assert.Equal(2, primary.Count);
+    }
+
+    [Fact]
+    public void SameSpidDifferentEcid_AreNotDeduped()
+    {
+        // Parallel workers (distinct ecid) are distinct edges, not duplicates.
+        var primary = new List<BlockingPairRow> { Pair(201, 200, "BPR", blockingEcid: 0) };
+        BlockingPairRowMerge.MergeInto(primary, new[] { Pair(201, 200, "DMV", blockingEcid: 1) });
+        Assert.Equal(2, primary.Count);
+    }
+}

--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -138,9 +138,10 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 32 tables from Schema (schema_version is created separately by DuckDbInitializer).
-           Includes config_edge_trigger_watermarks added for #1145. */
-        Assert.Equal(32, tableCount);
+        /* 33 tables from Schema (schema_version is created separately by DuckDbInitializer).
+           Includes config_edge_trigger_watermarks (#1145) and dmv_blocking_snapshots (always-on
+           blocking fallback). */
+        Assert.Equal(33, tableCount);
     }
 
     [Fact]

--- a/Lite/Analysis/BlockingChainViewerProjection.cs
+++ b/Lite/Analysis/BlockingChainViewerProjection.cs
@@ -15,9 +15,9 @@ namespace PerformanceMonitorLite.Analysis;
 internal static class BlockingChainViewerProjection
 {
     public const string EmptyStateDetail =
-        "No blocked-process reports were collected in the selected time range. " +
-        "Blocking chains require the blocked-process-report Extended Event; Azure SQL DB may not emit it " +
-        "(the blocked-process threshold is set via sp_configure, which Azure SQL DB does not support).";
+        "No blocking was captured for this session in the selected time range — from either the " +
+        "blocked-process-report Extended Event or the always-on DMV blocking snapshot. Its wait may not " +
+        "have overlapped a collection in this window.";
 
     /// <summary>
     /// Builds the model for the ONE chain that contains the clicked session (matched by SessionKey — the

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Numerics;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
 
 namespace PerformanceMonitorLite.Analysis;
@@ -90,5 +93,41 @@ AND blocking_spid <> 0";
         if (value is BigInteger bi)
             return (long)bi;
         return Convert.ToInt64(value);
+    }
+
+    /// <summary>
+    /// Fetches DMV-snapshot pair-rows (the always-on blocking fallback) for the window and merges them into
+    /// <paramref name="rows"/> (BPR-preferred — see <see cref="BlockingPairRowMerge"/>). Uses the same column
+    /// fragments as the blocked-process-report queries, against v_dmv_blocking_snapshots, so <see cref="Read"/>
+    /// maps it unchanged. Takes a command factory so the caller's connection (a LockedConnection in the viewer,
+    /// a raw DuckDBConnection in the collectors) runs it on the read lock it already holds.
+    /// </summary>
+    internal static async Task AppendDmvSnapshotRowsAsync(Func<DuckDBCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end)
+    {
+        var dmv = new List<BlockingPairRow>();
+        using (var cmd = createCommand())
+        {
+            cmd.CommandText = $@"
+SELECT
+    {LeadingColumns},
+    blocked_sql_text, blocking_sql_text,
+    {IdentityColumns},
+    contentious_object,
+    {TrailingIdentityColumns}
+FROM v_dmv_blocking_snapshots
+WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+{SpidFilter}
+ORDER BY event_time DESC
+LIMIT 5000";
+            cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
+            cmd.Parameters.Add(new DuckDBParameter { Value = start });
+            cmd.Parameters.Add(new DuckDBParameter { Value = end });
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+                dmv.Add(Read(reader));
+        }
+
+        BlockingPairRowMerge.MergeInto(rows, dmv);
     }
 }

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -141,6 +141,11 @@ LIMIT 5000";
                 rows.Add(BlockingPairRowQuery.Read(reader));
         }
 
+        // Always-on DMV blocking snapshot fallback. Merge BEFORE the empty check so DMV-only blocking
+        // (blocked-process-report unavailable, e.g. AWS RDS) still reconstructs.
+        await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
+            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+
         if (rows.Count == 0) return;
 
         var reconstruction = BlockingChainReconstructor.Reconstruct(

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -228,6 +228,11 @@ LIMIT 5000";
                     rows.Add(BlockingPairRowQuery.Read(reader));
             }
 
+            // Always-on DMV blocking snapshot fallback (works when the blocked-process-report XE is empty,
+            // e.g. AWS RDS). Merge BEFORE the empty check so DMV-only blocking still produces facts.
+            await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
+                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+
             if (rows.Count == 0) return;
 
             var reconstruction = BlockingChainReconstructor.Reconstruct(rows, maxDepth, maxPairs, stepBudget, scopeByMonitorLoop: false);

--- a/Lite/Controls/ServerTab.BlockChain.cs
+++ b/Lite/Controls/ServerTab.BlockChain.cs
@@ -96,8 +96,8 @@ public partial class ServerTab : UserControl
                 MessageBox.Show(
                     Window.GetWindow(this)!,
                     $"No reconstructable blocking chain for SPID {spid} in the selected range.\n\n" +
-                    "The session may not have been part of a blocked-process report whose wait crossed " +
-                    "the blocked-process threshold in this window.",
+                    "The session may not have been blocked (or blocking) in any captured blocked-process " +
+                    "report or DMV blocking snapshot in this window.",
                     "No Block Chain",
                     MessageBoxButton.OK,
                     MessageBoxImage.Information);

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1383,6 +1383,7 @@
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="130">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Source}" Header="Source" Width="130"/>
                                     <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -116,6 +116,7 @@ public class DuckDbInitializer
         "query_snapshots", "cpu_utilization_stats", "file_io_stats", "memory_stats",
         "memory_clerks", "memory_pressure_events", "tempdb_stats", "perfmon_stats",
         "deadlocks", "blocked_process_reports", "memory_grant_stats", "waiting_tasks",
+        "dmv_blocking_snapshots",
         "running_jobs", "database_size_stats", "index_object_stats", "server_properties",
         "session_stats", "server_config", "database_config",
         "database_scoped_config", "trace_flags", "config_alert_log",

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -476,6 +476,41 @@ CREATE TABLE IF NOT EXISTS blocked_process_reports (
     monitor_loop INTEGER
 )";
 
+    /* Always-on DMV blocking snapshot (BPR-independent fallback). Rich blocker/blocked pair-row shape so
+       the shared blocking-chain reconstruction consumes it via v_dmv_blocking_snapshots. Column order MUST
+       match the appender in RemoteCollectorService.DmvBlockingSnapshot.cs (DuckDB appends by position). */
+    public const string CreateDmvBlockingSnapshotsTable = @"
+CREATE TABLE IF NOT EXISTS dmv_blocking_snapshots (
+    collection_id BIGINT PRIMARY KEY,
+    collection_time TIMESTAMP NOT NULL,
+    server_id INTEGER NOT NULL,
+    server_name VARCHAR NOT NULL,
+    monitor_loop INTEGER NOT NULL,
+    event_time TIMESTAMP,
+    database_name VARCHAR,
+    blocked_spid INTEGER,
+    blocked_ecid INTEGER,
+    blocked_last_tran_started TIMESTAMP,
+    blocking_spid INTEGER,
+    blocking_ecid INTEGER,
+    blocking_last_tran_started TIMESTAMP,
+    wait_time_ms BIGINT,
+    lock_mode VARCHAR,
+    blocking_status VARCHAR,
+    contentious_object VARCHAR,
+    blocked_sql_text VARCHAR,
+    blocking_sql_text VARCHAR,
+    blocked_login_name VARCHAR,
+    blocked_host_name VARCHAR,
+    blocked_client_app VARCHAR,
+    blocking_login_name VARCHAR,
+    blocking_host_name VARCHAR,
+    blocking_client_app VARCHAR
+)";
+
+    public const string CreateDmvBlockingSnapshotsIndex = @"
+CREATE INDEX IF NOT EXISTS idx_dmv_blocking_snapshots_time ON dmv_blocking_snapshots(server_id, collection_time)";
+
     public const string CreateDatabaseConfigTable = @"
 CREATE TABLE IF NOT EXISTS database_config (
     config_id BIGINT PRIMARY KEY,
@@ -840,6 +875,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateMemoryGrantStatsTable;
         yield return CreateWaitingTasksTable;
         yield return CreateBlockedProcessReportsTable;
+        yield return CreateDmvBlockingSnapshotsTable;
         yield return CreateDatabaseScopedConfigTable;
         yield return CreateTraceFlagsTable;
         yield return CreateRunningJobsTable;
@@ -873,6 +909,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateMemoryGrantStatsIndex;
         yield return CreateWaitingTasksIndex;
         yield return CreateBlockedProcessReportsIndex;
+        yield return CreateDmvBlockingSnapshotsIndex;
         yield return CreateMemoryClerksIndex;
         yield return CreateMemoryPressureEventsIndex;
         yield return CreateDatabaseScopedConfigIndex;

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -73,6 +73,7 @@ public class ArchiveService
         ("blocked_process_reports", "collection_time"),
         ("memory_grant_stats", "collection_time"),
         ("waiting_tasks", "collection_time"),
+        ("dmv_blocking_snapshots", "collection_time"),
         ("running_jobs", "collection_time"),
         ("database_size_stats", "collection_time"),
         ("index_object_stats", "collection_time"),

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -305,7 +305,8 @@ LIMIT 200";
         command.Parameters.Add(new DuckDBParameter { Value = endTime });
 
         var items = new List<BlockedProcessReportRow>();
-        using var reader = await command.ExecuteReaderAsync();
+        using (var reader = await command.ExecuteReaderAsync())
+        {
         while (await reader.ReadAsync())
         {
             items.Add(new BlockedProcessReportRow
@@ -349,8 +350,93 @@ LIMIT 200";
                 MonitorLoop = reader.IsDBNull(36) ? (int?)null : reader.GetInt32(36)
             });
         }
+        }
+
+        // Always-on DMV blocking snapshot: surface its rows in the grid too, so the block-chain viewer is
+        // reachable when the blocked-process-report XE captured nothing (AWS RDS). Same connection/lock.
+        await AppendDmvBlockedProcessGridRowsAsync(connection.CreateCommand, items, serverId, startTime, endTime);
 
         return items;
+    }
+
+    /// <summary>
+    /// Fetches always-on DMV blocking-snapshot rows for the blocked-process grid and merges them into the
+    /// BPR list — BPR preferred (dedup by blocked/blocker SPID within a minute), re-capped to 200 newest
+    /// first. Runs on the caller's connection/lock (the read lock is non-recursive, so a second connection
+    /// can't be opened). v_dmv_blocking_snapshots is created by DuckDbInitializer, so it always exists.
+    /// </summary>
+    private static async Task AppendDmvBlockedProcessGridRowsAsync(
+        Func<DuckDBCommand> createCommand, List<BlockedProcessReportRow> items, int serverId, DateTime startTime, DateTime endTime)
+    {
+        const int gridCap = 200;
+        var dmvItems = new List<BlockedProcessReportRow>();
+        using (var command = createCommand())
+        {
+            command.CommandText = @"
+SELECT
+    collection_time, event_time, database_name,
+    blocked_spid, blocked_ecid, blocking_spid, blocking_ecid,
+    wait_time_ms, lock_mode, blocking_status, contentious_object,
+    blocked_sql_text, blocking_sql_text,
+    blocked_login_name, blocked_host_name, blocked_client_app,
+    blocked_last_tran_started, blocking_last_tran_started, monitor_loop
+FROM v_dmv_blocking_snapshots
+WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+ORDER BY event_time DESC
+LIMIT 200";
+            command.Parameters.Add(new DuckDBParameter { Value = serverId });
+            command.Parameters.Add(new DuckDBParameter { Value = startTime });
+            command.Parameters.Add(new DuckDBParameter { Value = endTime });
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                dmvItems.Add(new BlockedProcessReportRow
+                {
+                    CollectionTime = reader.GetDateTime(0),
+                    EventTime = reader.IsDBNull(1) ? null : reader.GetDateTime(1),
+                    DatabaseName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                    BlockedSpid = reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+                    BlockedEcid = reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+                    BlockingSpid = reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+                    BlockingEcid = reader.IsDBNull(6) ? 0 : reader.GetInt32(6),
+                    WaitTimeMs = reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
+                    LockMode = reader.IsDBNull(8) ? "" : reader.GetString(8),
+                    BlockingStatus = reader.IsDBNull(9) ? "" : reader.GetString(9),
+                    ContentiousObject = reader.IsDBNull(10) ? "" : reader.GetString(10),
+                    BlockedSqlText = reader.IsDBNull(11) ? "" : reader.GetString(11),
+                    BlockingSqlText = reader.IsDBNull(12) ? "" : reader.GetString(12),
+                    BlockedLoginName = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                    BlockedHostName = reader.IsDBNull(14) ? "" : reader.GetString(14),
+                    BlockedClientApp = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                    BlockedLastTranStarted = reader.IsDBNull(16) ? null : reader.GetDateTime(16),
+                    BlockingLastTranStarted = reader.IsDBNull(17) ? null : reader.GetDateTime(17),
+                    MonitorLoop = reader.IsDBNull(18) ? (int?)null : reader.GetInt32(18),
+                    Source = "DMV snapshot"
+                });
+            }
+        }
+
+        if (dmvItems.Count == 0) return;
+
+        // Dedup: keep all BPR rows; add a DMV row only if no BPR row covers the same (blocked, blocker)
+        // SPID within the same minute. BPR is preferred (richer report XML).
+        var seen = new HashSet<(int, int, long)>();
+        foreach (var b in items)
+            if (b.EventTime.HasValue)
+                seen.Add((b.BlockedSpid, b.BlockingSpid, b.EventTime.Value.Ticks / TimeSpan.TicksPerMinute));
+
+        foreach (var d in dmvItems)
+        {
+            var key = (d.BlockedSpid, d.BlockingSpid, (d.EventTime?.Ticks ?? 0) / TimeSpan.TicksPerMinute);
+            if (seen.Add(key))
+                items.Add(d);
+        }
+
+        // Re-cap to the grid's LIMIT, newest first.
+        items.Sort((a, b) => Nullable.Compare(b.EventTime, a.EventTime));
+        if (items.Count > gridCap)
+            items.RemoveRange(gridCap, items.Count - gridCap);
     }
 
     /// <summary>
@@ -384,9 +470,16 @@ LIMIT 5000";
         command.Parameters.Add(new DuckDBParameter { Value = start });
         command.Parameters.Add(new DuckDBParameter { Value = end });
 
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-            rows.Add(PerformanceMonitorLite.Analysis.BlockingPairRowQuery.Read(reader));
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+                rows.Add(PerformanceMonitorLite.Analysis.BlockingPairRowQuery.Read(reader));
+        }
+
+        // Always-on DMV blocking snapshot: merge in the fallback rows so the viewer works even when the
+        // blocked-process-report XE captured nothing (threshold unset / AWS RDS). Same connection/lock.
+        await PerformanceMonitorLite.Analysis.BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
+            connection.CreateCommand, rows, serverId, start, end);
 
         return rows;
     }
@@ -878,6 +971,14 @@ public class BlockedProcessReportRow
     public int BlockingSpid { get; set; }
     public int BlockingEcid { get; set; }
     public int? MonitorLoop { get; set; }
+
+    /// <summary>
+    /// Where this row came from: the blocked-process-report XE ("blocked-process-report") or the always-on
+    /// DMV snapshot fallback ("DMV snapshot"). Surfaced as a grid badge so a row captured when the
+    /// blocked-process threshold was unset (e.g. AWS RDS) is distinguishable.
+    /// </summary>
+    public string Source { get; set; } = "blocked-process-report";
+
     public long WaitTimeMs { get; set; }
     public string WaitResource { get; set; } = "";
     public string LockMode { get; set; } = "";

--- a/Lite/Services/RemoteCollectorService.DmvBlockingSnapshot.cs
+++ b/Lite/Services/RemoteCollectorService.DmvBlockingSnapshot.cs
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Models;
+
+namespace PerformanceMonitorLite.Services;
+
+public partial class RemoteCollectorService
+{
+    /// <summary>
+    /// Always-on DMV blocking snapshot. Captures current blocking (blocker -> blocked edges) from
+    /// sys.dm_os_waiting_tasks + sys.dm_exec_*, the BPR-independent fallback for when the
+    /// blocked_process_report XE captured nothing (blocked process threshold unset, e.g. AWS RDS).
+    /// Same blocker/blocked pair-row shape the blocking-chain reconstruction consumes; monitor_loop is
+    /// synthesized NEGATIVE so a DMV episode can never collide with a real (non-negative) BPR monitorLoop.
+    /// </summary>
+    private async Task<int> CollectDmvBlockingSnapshotAsync(ServerConnection server, CancellationToken cancellationToken)
+    {
+        string query = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT /* PerformanceMonitorLite */
+    database_name = DB_NAME(der_b.database_id),
+    blocked_spid = CONVERT(integer, wt.session_id),
+    blocked_ecid = CONVERT(integer, wt.exec_context_id),
+    blocked_last_tran_started = tat_b.transaction_begin_time,
+    blocking_spid = CONVERT(integer, wt.blocking_session_id),
+    blocking_ecid = CONVERT(integer, ISNULL(wt.blocking_exec_context_id, 0)),
+    blocking_last_tran_started = tat_k.transaction_begin_time,
+    wait_time_ms = wt.wait_duration_ms,
+    lock_mode = REPLACE(REPLACE(REPLACE(wt.wait_type, N'LCK_M_', N''), N'PAGEIOLATCH_', N''), N'PAGELATCH_', N''),
+    blocking_status = ISNULL(der_k.status, ses_k.status),
+    contentious_object =
+        CASE
+            WHEN objparse.object_id IS NOT NULL
+            THEN ISNULL(QUOTENAME(OBJECT_SCHEMA_NAME(objparse.object_id, objparse.database_id)) + N'.' + QUOTENAME(OBJECT_NAME(objparse.object_id, objparse.database_id)), der_b.wait_resource)
+            ELSE der_b.wait_resource
+        END,
+    blocked_sql_text = dest_b.text,
+    blocking_sql_text = dest_k.text,
+    blocked_login_name = ses_b.login_name,
+    blocked_host_name = ses_b.host_name,
+    blocked_client_app = ses_b.program_name,
+    blocking_login_name = ses_k.login_name,
+    blocking_host_name = ses_k.host_name,
+    blocking_client_app = ses_k.program_name
+FROM sys.dm_os_waiting_tasks AS wt
+JOIN sys.dm_exec_sessions AS ses_b
+  ON ses_b.session_id = wt.session_id
+LEFT JOIN sys.dm_exec_requests AS der_b
+  ON der_b.session_id = wt.session_id
+LEFT JOIN sys.dm_exec_sessions AS ses_k
+  ON ses_k.session_id = wt.blocking_session_id
+LEFT JOIN sys.dm_exec_requests AS der_k
+  ON der_k.session_id = wt.blocking_session_id
+LEFT JOIN sys.dm_exec_connections AS con_k
+  ON con_k.session_id = wt.blocking_session_id
+OUTER APPLY sys.dm_exec_sql_text(der_b.sql_handle) AS dest_b
+OUTER APPLY sys.dm_exec_sql_text(COALESCE(der_k.sql_handle, con_k.most_recent_sql_handle)) AS dest_k
+OUTER APPLY
+(
+    SELECT TOP (1) tat.transaction_begin_time
+    FROM sys.dm_tran_session_transactions AS stx
+    JOIN sys.dm_tran_active_transactions AS tat
+      ON tat.transaction_id = stx.transaction_id
+    WHERE stx.session_id = wt.session_id
+    ORDER BY tat.transaction_begin_time ASC
+) AS tat_b
+OUTER APPLY
+(
+    SELECT TOP (1) tat.transaction_begin_time
+    FROM sys.dm_tran_session_transactions AS stx
+    JOIN sys.dm_tran_active_transactions AS tat
+      ON tat.transaction_id = stx.transaction_id
+    WHERE stx.session_id = wt.blocking_session_id
+    ORDER BY tat.transaction_begin_time ASC
+) AS tat_k
+OUTER APPLY
+(
+    SELECT
+        database_id = TRY_CONVERT(integer, PARSENAME(REPLACE(SUBSTRING(der_b.wait_resource, 9, 200), N':', N'.'), 3)),
+        object_id = TRY_CONVERT(integer, PARSENAME(REPLACE(SUBSTRING(der_b.wait_resource, 9, 200), N':', N'.'), 2))
+    WHERE der_b.wait_resource LIKE N'OBJECT: %'
+) AS objparse
+WHERE wt.blocking_session_id IS NOT NULL
+AND   wt.blocking_session_id <> 0
+AND   wt.blocking_session_id <> wt.session_id
+AND   wt.session_id > 50
+AND   wt.session_id <> @@SPID
+AND   (
+          wt.wait_type LIKE N'LCK[_]%'
+          OR wt.wait_type LIKE N'PAGELATCH[_]%'
+          OR wt.wait_type LIKE N'PAGEIOLATCH[_]%'
+      )
+OPTION(RECOMPILE);";
+
+        var serverId = GetServerId(server);
+        var collectionTime = DateTime.UtcNow;
+        /* Synthetic monitor_loop, NEGATIVE so it can never collide with a real (non-negative) BPR
+           monitorLoop. One value per cycle, distinct per second (collection cadence is >= 1 minute). */
+        var monitorLoop = -(int)(collectionTime - new DateTime(2020, 1, 1)).TotalSeconds;
+        var rowsCollected = 0;
+        _lastSqlMs = 0;
+        _lastDuckDbMs = 0;
+
+        var sqlSw = Stopwatch.StartNew();
+        using var sqlConnection = await CreateConnectionAsync(server, cancellationToken);
+        using var command = new SqlCommand(query, sqlConnection);
+        command.CommandTimeout = CommandTimeoutSeconds;
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        sqlSw.Stop();
+        _lastSqlMs = sqlSw.ElapsedMilliseconds;
+
+        var duckSw = Stopwatch.StartNew();
+
+        using (var duckConnection = _duckDb.CreateConnection())
+        {
+            await duckConnection.OpenAsync(cancellationToken);
+
+            using (var appender = duckConnection.CreateAppender("dmv_blocking_snapshots"))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var databaseName = reader.IsDBNull(0) ? null : reader.GetString(0);
+                    var blockedSpid = reader.IsDBNull(1) ? 0 : reader.GetInt32(1);
+                    var blockedEcid = reader.IsDBNull(2) ? 0 : reader.GetInt32(2);
+                    var blockedLastTran = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3);
+                    var blockingSpid = reader.IsDBNull(4) ? 0 : reader.GetInt32(4);
+                    var blockingEcid = reader.IsDBNull(5) ? 0 : reader.GetInt32(5);
+                    var blockingLastTran = reader.IsDBNull(6) ? (DateTime?)null : reader.GetDateTime(6);
+                    var waitTimeMs = reader.IsDBNull(7) ? 0L : reader.GetInt64(7);
+                    var lockMode = reader.IsDBNull(8) ? null : reader.GetString(8);
+                    var blockingStatus = reader.IsDBNull(9) ? null : reader.GetString(9);
+                    var contentiousObject = reader.IsDBNull(10) ? null : reader.GetString(10);
+                    var blockedSql = reader.IsDBNull(11) ? null : reader.GetString(11);
+                    var blockingSql = reader.IsDBNull(12) ? null : reader.GetString(12);
+                    var blockedLogin = reader.IsDBNull(13) ? null : reader.GetString(13);
+                    var blockedHost = reader.IsDBNull(14) ? null : reader.GetString(14);
+                    var blockedApp = reader.IsDBNull(15) ? null : reader.GetString(15);
+                    var blockingLogin = reader.IsDBNull(16) ? null : reader.GetString(16);
+                    var blockingHost = reader.IsDBNull(17) ? null : reader.GetString(17);
+                    var blockingApp = reader.IsDBNull(18) ? null : reader.GetString(18);
+
+                    var row = appender.CreateRow();
+                    row.AppendValue(GenerateCollectionId())
+                       .AppendValue(collectionTime)
+                       .AppendValue(serverId)
+                       .AppendValue(GetServerNameForStorage(server))
+                       .AppendValue(monitorLoop)
+                       .AppendValue(collectionTime) /* event_time */
+                       .AppendValue(databaseName)
+                       .AppendValue(blockedSpid)
+                       .AppendValue(blockedEcid)
+                       .AppendValue(blockedLastTran)
+                       .AppendValue(blockingSpid)
+                       .AppendValue(blockingEcid)
+                       .AppendValue(blockingLastTran)
+                       .AppendValue(waitTimeMs)
+                       .AppendValue(lockMode)
+                       .AppendValue(blockingStatus)
+                       .AppendValue(contentiousObject)
+                       .AppendValue(blockedSql)
+                       .AppendValue(blockingSql)
+                       .AppendValue(blockedLogin)
+                       .AppendValue(blockedHost)
+                       .AppendValue(blockedApp)
+                       .AppendValue(blockingLogin)
+                       .AppendValue(blockingHost)
+                       .AppendValue(blockingApp)
+                       .EndRow();
+
+                    rowsCollected++;
+                }
+            }
+        }
+
+        duckSw.Stop();
+        _lastDuckDbMs = duckSw.ElapsedMilliseconds;
+
+        _logger?.LogDebug("Collected {RowCount} DMV blocking snapshot rows for server '{Server}'", rowsCollected, server.DisplayName);
+        return rowsCollected;
+    }
+}

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -496,6 +496,7 @@ public partial class RemoteCollectorService
                 "query_store" => await CollectQueryStoreAsync(server, cancellationToken),
                 "memory_grant_stats" => await CollectMemoryGrantStatsAsync(server, cancellationToken),
                 "waiting_tasks" => await CollectWaitingTasksAsync(server, cancellationToken),
+                "dmv_blocking_snapshot" => await CollectDmvBlockingSnapshotAsync(server, cancellationToken),
                 "blocked_process_report" => await CollectBlockedProcessReportsAsync(server, cancellationToken),
                 "database_scoped_config" => await CollectDatabaseScopedConfigAsync(server, cancellationToken),
                 "trace_flags" => await CollectTraceFlagsAsync(server, cancellationToken),

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -41,6 +41,7 @@ public class ScheduleManager
             ["memory_pressure_events"] = 5,
             ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
             ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["dmv_blocking_snapshot"] = 1,
             ["blocked_process_report"] = 1, ["running_jobs"] = 2
         },
         ["Balanced"] = new(StringComparer.OrdinalIgnoreCase)
@@ -51,6 +52,7 @@ public class ScheduleManager
             ["memory_pressure_events"] = 5,
             ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
             ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+            ["dmv_blocking_snapshot"] = 1,
             ["blocked_process_report"] = 1, ["running_jobs"] = 5
         },
         ["Low-Impact"] = new(StringComparer.OrdinalIgnoreCase)
@@ -61,6 +63,7 @@ public class ScheduleManager
             ["memory_pressure_events"] = 15,
             ["tempdb_stats"] = 5, ["perfmon_stats"] = 5, ["deadlocks"] = 5,
             ["memory_grant_stats"] = 5, ["waiting_tasks"] = 5,
+            ["dmv_blocking_snapshot"] = 5,
             ["blocked_process_report"] = 5, ["running_jobs"] = 30
         }
     };
@@ -745,11 +748,12 @@ public class ScheduleManager
             new() { Name = "memory_pressure_events", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Memory pressure notifications from RING_BUFFER_RESOURCE_MONITOR" },
             new() { Name = "tempdb_stats", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "TempDB space usage from sys.dm_db_file_space_usage" },
             new() { Name = "perfmon_stats", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Key performance counters from sys.dm_os_performance_counters" },
-            new() { Name = "deadlocks", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Deadlocks from system_health extended event session" },
+            new() { Name = "deadlocks", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Deadlocks from a dedicated PerformanceMonitor_Deadlock XE session (xml_deadlock_report)" },
             new() { Name = "server_config", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Server configuration (on-load only)" },
             new() { Name = "database_config", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Database configuration (on-load only)" },
             new() { Name = "memory_grant_stats", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Memory grant statistics from sys.dm_exec_query_memory_grants" },
             new() { Name = "waiting_tasks", Enabled = true, FrequencyMinutes = 1, RetentionDays = 7, Description = "Point-in-time waiting tasks from sys.dm_os_waiting_tasks" },
+            new() { Name = "dmv_blocking_snapshot", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Always-on point-in-time blocking snapshot from DMVs (BPR-independent fallback; works when blocked process threshold is unset, e.g. AWS RDS)" },
             new() { Name = "blocked_process_report", Enabled = true, FrequencyMinutes = 1, RetentionDays = 30, Description = "Blocked process reports from XE ring buffer session (opt-out)" },
             new() { Name = "database_scoped_config", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Database-scoped configurations (on-load only)" },
             new() { Name = "trace_flags", Enabled = true, FrequencyMinutes = 0, RetentionDays = 30, Description = "Active trace flags via DBCC TRACESTATUS (on-load only)" },

--- a/PerformanceMonitor.Analysis/BlockingPairRowMerge.cs
+++ b/PerformanceMonitor.Analysis/BlockingPairRowMerge.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Analysis;
+
+/// <summary>
+/// Merges blocked-process-report (BPR) and DMV-snapshot pair-rows into one list for reconstruction.
+/// BPR is preferred: its rows are added first, and a DMV edge is dropped when an equivalent BPR edge
+/// already exists in the same minute. Shared by the Dashboard and Lite block-chain paths (both feed the
+/// same source-agnostic <see cref="BlockingChainReconstructor"/>), so the dedup rule can't drift.
+///
+/// The negative-vs-non-negative monitor_loop split (DMV synthesizes a negative loop, BPR loops are always
+/// non-negative) already keeps the two sources in separate <see cref="SessionKey"/> spaces for the viewer's
+/// per-episode (scopeByMonitorLoop:true) reconstruction, so this dedup only changes the cumulative
+/// (scopeByMonitorLoop:false) fact/drill-down paths, where an overlapping edge would otherwise be counted
+/// twice. The minute bucket is intentionally coarse: a BPR event_time and a DMV collection_time for the
+/// same physical block won't align to the second.
+/// </summary>
+internal static class BlockingPairRowMerge
+{
+    /// <summary>Append <paramref name="snapshots"/> (DMV) to <paramref name="primary"/> (BPR) in place,
+    /// skipping any DMV edge already represented by a BPR edge in the same minute.</summary>
+    internal static void MergeInto(List<BlockingPairRow> primary, IReadOnlyList<BlockingPairRow> snapshots)
+    {
+        if (snapshots == null || snapshots.Count == 0)
+            return;
+
+        var seen = new HashSet<(int, int, int, int, long)>();
+        foreach (var r in primary)
+            seen.Add(EdgeKey(r));
+
+        foreach (var s in snapshots)
+            if (seen.Add(EdgeKey(s)))
+                primary.Add(s);
+    }
+
+    private static (int, int, int, int, long) EdgeKey(BlockingPairRow r) =>
+        (r.BlockedSpid, r.BlockedEcid, r.BlockingSpid, r.BlockingEcid, r.EventTime.Ticks / TimeSpan.TicksPerMinute);
+}

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Data starts flowing within 1–5 minutes. That's it. No installation on your ser
 | memory_grant_stats | 1 min | `sys.dm_exec_query_memory_grants` |
 | tempdb_stats | 1 min | `sys.dm_db_file_space_usage` |
 | perfmon_stats | 1 min | `sys.dm_os_performance_counters` (deltas) |
-| deadlocks | 1 min | `system_health` Extended Events session |
+| deadlocks | 1 min | dedicated `PerformanceMonitor_Deadlock` XE session (`xml_deadlock_report`; `database_xml_deadlock_report` on Azure SQL DB) |
+| dmv_blocking_snapshot | 1 min | `sys.dm_os_waiting_tasks` + `sys.dm_exec_*` (always-on blocking fallback when the blocked-process-report XE is unavailable) |
 | session_stats | 1 min | `sys.dm_exec_sessions` active session tracking |
 | memory_clerks | 5 min | `sys.dm_os_memory_clerks` |
 | memory_pressure_events | 5 min | `sys.dm_os_ring_buffers` RING_BUFFER_RESOURCE_MONITOR |

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1144,6 +1144,55 @@ BEGIN
 END;
 
 /*
+DMV blocking snapshot - point-in-time blocking from sys.dm_os_waiting_tasks, independent of the
+blocked_process_report XE (which needs 'blocked process threshold' > 0, unset/unsettable on AWS RDS).
+Same blocker->blocked pair-row shape the blocking-chain reconstruction consumes; monitor_loop is
+synthesized negative so DMV episodes never collide with real (non-negative) blocked-process-report loops.
+*/
+IF OBJECT_ID(N'collect.dmv_blocking_snapshots', N'U') IS NULL
+BEGIN
+    CREATE TABLE
+        collect.dmv_blocking_snapshots
+    (
+        snapshot_id bigint IDENTITY NOT NULL,
+        collection_time datetime2(7) NOT NULL
+            DEFAULT SYSDATETIME(),
+        monitor_loop integer NOT NULL,
+        event_time datetime2(7) NOT NULL,
+        database_name nvarchar(128) NULL,
+        spid integer NOT NULL,
+        ecid integer NOT NULL,
+        last_transaction_started datetime2(7) NULL,
+        blocking_spid integer NOT NULL,
+        blocking_ecid integer NOT NULL,
+        blocking_last_tran_started datetime2(7) NULL,
+        wait_time_ms bigint NULL,
+        lock_mode nvarchar(20) NULL,
+        blocking_status nvarchar(30) NULL,
+        contentious_object nvarchar(4000) NULL,
+        blocked_sql_text nvarchar(max) NULL,
+        blocking_sql_text nvarchar(max) NULL,
+        login_name nvarchar(256) NULL,
+        host_name nvarchar(256) NULL,
+        client_app nvarchar(256) NULL,
+        blocking_login_name nvarchar(256) NULL,
+        blocking_host_name nvarchar(256) NULL,
+        blocking_client_app nvarchar(256) NULL,
+        CONSTRAINT
+            PK_dmv_blocking_snapshots
+        PRIMARY KEY CLUSTERED
+        (
+            collection_time ASC,
+            snapshot_id ASC
+        )
+        WITH
+            (DATA_COMPRESSION = PAGE)
+    );
+
+    PRINT 'Created collect.dmv_blocking_snapshots table';
+END;
+
+/*
 Latch Statistics with Deltas
 */
 IF OBJECT_ID(N'collect.latch_stats', N'U') IS NULL

--- a/install/04_create_schedule_table.sql
+++ b/install/04_create_schedule_table.sql
@@ -77,7 +77,8 @@ FROM
     (N'running_jobs_collector', 1, 1, 2, 7, N'Currently running SQL Agent jobs with historical duration comparison'),
     (N'database_size_stats_collector', 1, 60, 10, 90, N'Database file sizes for growth trending and capacity planning'),
     (N'index_object_stats_collector', 1, 1440, 15, 90, N'Per-object table/index size, usage, and locking stats for growth, unused-index, and contention analysis (daily collection)'),
-    (N'server_properties_collector', 1, 1440, 5, 365, N'Server edition, licensing, CPU/memory hardware metadata for license audit')
+    (N'server_properties_collector', 1, 1440, 5, 365, N'Server edition, licensing, CPU/memory hardware metadata for license audit'),
+    (N'dmv_blocking_snapshot_collector', 1, 1, 2, 30, N'Point-in-time blocking snapshot from DMVs (always-on fallback for the blocked-process-report XE; works when blocked process threshold is unset, e.g. AWS RDS)')
 ) AS v (collector_name, enabled, frequency_minutes, max_duration_minutes, retention_days, description)
 WHERE NOT EXISTS
 (

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -1061,6 +1061,44 @@ BEGIN
             );
 
         END;
+        ELSE IF @table_name = N'dmv_blocking_snapshots'
+        BEGIN
+            CREATE TABLE
+                collect.dmv_blocking_snapshots
+            (
+                snapshot_id bigint IDENTITY NOT NULL,
+                collection_time datetime2(7) NOT NULL
+                    DEFAULT SYSDATETIME(),
+                monitor_loop integer NOT NULL,
+                event_time datetime2(7) NOT NULL,
+                database_name nvarchar(128) NULL,
+                spid integer NOT NULL,
+                ecid integer NOT NULL,
+                last_transaction_started datetime2(7) NULL,
+                blocking_spid integer NOT NULL,
+                blocking_ecid integer NOT NULL,
+                blocking_last_tran_started datetime2(7) NULL,
+                wait_time_ms bigint NULL,
+                lock_mode nvarchar(20) NULL,
+                blocking_status nvarchar(30) NULL,
+                contentious_object nvarchar(4000) NULL,
+                blocked_sql_text nvarchar(max) NULL,
+                blocking_sql_text nvarchar(max) NULL,
+                login_name nvarchar(256) NULL,
+                host_name nvarchar(256) NULL,
+                client_app nvarchar(256) NULL,
+                blocking_login_name nvarchar(256) NULL,
+                blocking_host_name nvarchar(256) NULL,
+                blocking_client_app nvarchar(256) NULL,
+                CONSTRAINT
+                    PK_dmv_blocking_snapshots
+                PRIMARY KEY CLUSTERED
+                    (collection_time, snapshot_id)
+                WITH
+                    (DATA_COMPRESSION = PAGE)
+            );
+
+        END;
         ELSE IF @table_name = N'running_jobs'
         BEGIN
             CREATE TABLE
@@ -1239,7 +1277,7 @@ BEGIN
         END;
         ELSE
         BEGIN
-            SET @error_message = N'Unknown table name: ' + @table_name + N'. Valid table names are: wait_stats, query_stats, memory_stats, memory_pressure_events, deadlock_xml, blocked_process_xml, procedure_stats, query_snapshots, query_store_data, trace_analysis, default_trace_events, file_io_stats, memory_grant_stats, cpu_scheduler_stats, memory_clerks_stats, perfmon_stats, cpu_utilization_stats, blocking_deadlock_stats, latch_stats, spinlock_stats, tempdb_stats, plan_cache_stats, session_stats, waiting_tasks, running_jobs, database_size_stats, index_object_stats, server_properties';
+            SET @error_message = N'Unknown table name: ' + @table_name + N'. Valid table names are: wait_stats, query_stats, memory_stats, memory_pressure_events, deadlock_xml, blocked_process_xml, procedure_stats, query_snapshots, query_store_data, trace_analysis, default_trace_events, file_io_stats, memory_grant_stats, cpu_scheduler_stats, memory_clerks_stats, perfmon_stats, cpu_utilization_stats, blocking_deadlock_stats, latch_stats, spinlock_stats, tempdb_stats, plan_cache_stats, session_stats, waiting_tasks, dmv_blocking_snapshots, running_jobs, database_size_stats, index_object_stats, server_properties';
             RAISERROR(@error_message, 16, 1);
             RETURN;
         END;

--- a/install/42_scheduled_master_collector.sql
+++ b/install/42_scheduled_master_collector.sql
@@ -330,6 +330,10 @@ BEGIN
                 BEGIN
                     EXECUTE collect.waiting_tasks_collector @debug = @debug;
                 END;
+                ELSE IF @collector_name = N'dmv_blocking_snapshot_collector'
+                BEGIN
+                    EXECUTE collect.dmv_blocking_snapshot_collector @debug = @debug;
+                END;
                 ELSE IF @collector_name = N'running_jobs_collector'
                 BEGIN
                     EXECUTE collect.running_jobs_collector @debug = @debug;

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -281,6 +281,30 @@ ORDER BY
 GO
 
 /*
+DMV Blocking Snapshot - recent point-in-time blocking captured from DMVs (BPR-independent)
+*/
+CREATE OR ALTER VIEW
+    report.dmv_blocking_snapshots
+AS
+SELECT TOP (1000)
+    dbs.collection_time,
+    dbs.event_time,
+    dbs.database_name,
+    dbs.spid,
+    dbs.blocking_spid,
+    dbs.wait_time_ms,
+    dbs.lock_mode,
+    dbs.blocking_status,
+    dbs.contentious_object,
+    dbs.blocked_sql_text,
+    dbs.blocking_sql_text
+FROM collect.dmv_blocking_snapshots AS dbs
+WHERE dbs.collection_time >= DATEADD(HOUR, -24, SYSDATETIME())
+ORDER BY
+    dbs.event_time DESC;
+GO
+
+/*
 Deadlock Summary - Recent deadlocks
 */
 CREATE OR ALTER VIEW
@@ -2725,6 +2749,7 @@ PRINT '  - report.expensive_queries_today';
 PRINT '  - report.memory_pressure_events';
 PRINT '  - report.cpu_spikes';
 PRINT '  - report.blocking_summary';
+PRINT '  - report.dmv_blocking_snapshots';
 PRINT '  - report.deadlock_summary';
 PRINT '  - report.server_configuration_changes';
 PRINT '  - report.database_configuration_changes';

--- a/install/56_collect_dmv_blocking_snapshot.sql
+++ b/install/56_collect_dmv_blocking_snapshot.sql
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 Darling Data, LLC
+https://www.erikdarling.com/
+
+DMV blocking snapshot collector
+
+Captures a point-in-time snapshot of CURRENT blocking (blocker -> blocked edges) directly from
+sys.dm_os_waiting_tasks + sys.dm_exec_*. This is the always-on fallback for the blocked-process-report
+Extended Event, which only fires when 'blocked process threshold (s)' > 0 -- a value that is unset by
+default and cannot be set via sp_configure on some platforms (e.g. AWS RDS, where it requires a parameter
+group). Deadlock graphs need no such threshold, so deadlocks already self-heal; blocking did not -- this
+closes that gap.
+
+Stores one row per waiting (blocked) task whose blocker is another session, enriched with both sides'
+SQL text and identity, so the existing (monitor_loop, spid, ecid) blocking-chain reconstruction consumes
+it unchanged. monitor_loop is synthesized NEGATIVE (one value per collection cycle) so a DMV episode can
+never collide with a real, non-negative blocked-process-report monitorLoop when both sources feed one
+reconstruction.
+
+Platform notes:
+  - DMV-only, so supported everywhere (no XE session, no threshold dependency).
+  - On Azure SQL DB sys.dm_os_waiting_tasks is database-scoped; on box/MI/RDS it is server-wide.
+*/
+
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET IMPLICIT_TRANSACTIONS OFF;
+SET STATISTICS TIME, IO OFF;
+GO
+
+USE PerformanceMonitor;
+GO
+
+IF OBJECT_ID(N'collect.dmv_blocking_snapshot_collector', N'P') IS NULL
+BEGIN
+    EXECUTE(N'CREATE PROCEDURE collect.dmv_blocking_snapshot_collector AS RETURN 138;');
+END;
+GO
+
+ALTER PROCEDURE
+    collect.dmv_blocking_snapshot_collector
+(
+    @debug bit = 0 /*Print debugging information*/
+)
+WITH RECOMPILE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+    DECLARE
+        @rows_collected bigint = 0,
+        @start_time datetime2(7) = SYSDATETIME(),
+        @monitor_loop integer,
+        @error_message nvarchar(4000);
+
+    BEGIN TRY
+        BEGIN TRANSACTION;
+
+        /*
+        Ensure target table exists
+        */
+        IF OBJECT_ID(N'collect.dmv_blocking_snapshots', N'U') IS NULL
+        BEGIN
+            INSERT INTO
+                config.collection_log
+            (
+                collection_time,
+                collector_name,
+                collection_status,
+                rows_collected,
+                duration_ms,
+                error_message
+            )
+            VALUES
+            (
+                @start_time,
+                N'dmv_blocking_snapshot_collector',
+                N'TABLE_MISSING',
+                0,
+                0,
+                N'Table collect.dmv_blocking_snapshots does not exist, calling ensure procedure'
+            );
+
+            EXECUTE config.ensure_collection_table
+                @table_name = N'dmv_blocking_snapshots',
+                @debug = @debug;
+
+            IF OBJECT_ID(N'collect.dmv_blocking_snapshots', N'U') IS NULL
+            BEGIN
+                ROLLBACK TRANSACTION;
+                RAISERROR(N'Table collect.dmv_blocking_snapshots still missing after ensure procedure', 16, 1);
+                RETURN;
+            END;
+        END;
+
+        /*
+        One synthetic monitor_loop per cycle. NEGATIVE so it can never collide with a real
+        (non-negative) blocked-process-report monitorLoop when both sources feed one reconstruction.
+        Stable across all rows of this snapshot (single @start_time); distinct between snapshots
+        (collection cadence is >= 1 minute, so the per-second value is unique per cycle).
+        */
+        SET @monitor_loop = -1 * DATEDIFF(SECOND, CONVERT(datetime2(7), N'2020-01-01'), @start_time);
+
+        /*
+        Capture current blocking edges. One row per waiting (blocked) task whose blocker is another
+        session. Both sides are enriched: the blocker's identity/SQL is captured natively (no XML
+        re-parse), including the sleeping-blocker case via dm_exec_connections.most_recent_sql_handle.
+        */
+        INSERT INTO
+            collect.dmv_blocking_snapshots
+        (
+            monitor_loop,
+            event_time,
+            database_name,
+            spid,
+            ecid,
+            last_transaction_started,
+            blocking_spid,
+            blocking_ecid,
+            blocking_last_tran_started,
+            wait_time_ms,
+            lock_mode,
+            blocking_status,
+            contentious_object,
+            blocked_sql_text,
+            blocking_sql_text,
+            login_name,
+            host_name,
+            client_app,
+            blocking_login_name,
+            blocking_host_name,
+            blocking_client_app
+        )
+        SELECT
+            monitor_loop = @monitor_loop,
+            event_time = @start_time,
+            database_name = DB_NAME(der_b.database_id),
+            spid = wt.session_id,
+            ecid = wt.exec_context_id,
+            last_transaction_started = tat_b.transaction_begin_time,
+            blocking_spid = wt.blocking_session_id,
+            blocking_ecid = ISNULL(wt.blocking_exec_context_id, 0),
+            blocking_last_tran_started = tat_k.transaction_begin_time,
+            wait_time_ms = wt.wait_duration_ms,
+            /* LCK_M_X -> X, PAGELATCH_EX -> EX, etc. */
+            lock_mode =
+                REPLACE(REPLACE(REPLACE(wt.wait_type, N'LCK_M_', N''), N'PAGEIOLATCH_', N''), N'PAGELATCH_', N''),
+            /* Blocker status from its SESSION (a sleeping/idle blocker has no request row). */
+            blocking_status = ISNULL(der_k.status, ses_k.status),
+            /* Resolve "OBJECT: dbid:objectid:indexid" only (cheap, cross-db via OBJECT_NAME). KEY/PAGE/RID
+               stay raw -- resolving a hobt cross-database needs dynamic SQL, deliberately skipped. */
+            contentious_object =
+                CASE
+                    WHEN objparse.object_id IS NOT NULL
+                    THEN ISNULL(QUOTENAME(OBJECT_SCHEMA_NAME(objparse.object_id, objparse.database_id)) + N'.' + QUOTENAME(OBJECT_NAME(objparse.object_id, objparse.database_id)), der_b.wait_resource)
+                    ELSE der_b.wait_resource
+                END,
+            blocked_sql_text = dest_b.text,
+            blocking_sql_text = dest_k.text,
+            login_name = ses_b.login_name,
+            host_name = ses_b.host_name,
+            client_app = ses_b.program_name,
+            blocking_login_name = ses_k.login_name,
+            blocking_host_name = ses_k.host_name,
+            blocking_client_app = ses_k.program_name
+        FROM sys.dm_os_waiting_tasks AS wt
+        JOIN sys.dm_exec_sessions AS ses_b
+          ON ses_b.session_id = wt.session_id
+        LEFT JOIN sys.dm_exec_requests AS der_b
+          ON der_b.session_id = wt.session_id
+        LEFT JOIN sys.dm_exec_sessions AS ses_k
+          ON ses_k.session_id = wt.blocking_session_id
+        LEFT JOIN sys.dm_exec_requests AS der_k
+          ON der_k.session_id = wt.blocking_session_id
+        LEFT JOIN sys.dm_exec_connections AS con_k
+          ON con_k.session_id = wt.blocking_session_id
+        OUTER APPLY sys.dm_exec_sql_text(der_b.sql_handle) AS dest_b
+        OUTER APPLY sys.dm_exec_sql_text(COALESCE(der_k.sql_handle, con_k.most_recent_sql_handle)) AS dest_k
+        OUTER APPLY
+        (
+            SELECT TOP (1)
+                tat.transaction_begin_time
+            FROM sys.dm_tran_session_transactions AS stx
+            JOIN sys.dm_tran_active_transactions AS tat
+              ON tat.transaction_id = stx.transaction_id
+            WHERE stx.session_id = wt.session_id
+            ORDER BY
+                tat.transaction_begin_time ASC
+        ) AS tat_b
+        OUTER APPLY
+        (
+            SELECT TOP (1)
+                tat.transaction_begin_time
+            FROM sys.dm_tran_session_transactions AS stx
+            JOIN sys.dm_tran_active_transactions AS tat
+              ON tat.transaction_id = stx.transaction_id
+            WHERE stx.session_id = wt.blocking_session_id
+            ORDER BY
+                tat.transaction_begin_time ASC
+        ) AS tat_k
+        OUTER APPLY
+        (
+            SELECT
+                database_id = TRY_CONVERT(integer, PARSENAME(REPLACE(SUBSTRING(der_b.wait_resource, 9, 200), N':', N'.'), 3)),
+                object_id = TRY_CONVERT(integer, PARSENAME(REPLACE(SUBSTRING(der_b.wait_resource, 9, 200), N':', N'.'), 2))
+            WHERE der_b.wait_resource LIKE N'OBJECT: %'
+        ) AS objparse
+        WHERE wt.blocking_session_id IS NOT NULL
+        AND   wt.blocking_session_id <> 0
+        AND   wt.blocking_session_id <> wt.session_id /*ignore intra-query (CXPACKET) self-waits*/
+        AND   wt.session_id > 50
+        AND   (
+                  wt.wait_type LIKE N'LCK[_]%'
+                  OR wt.wait_type LIKE N'PAGELATCH[_]%'
+                  OR wt.wait_type LIKE N'PAGEIOLATCH[_]%'
+              )
+        AND   ISNULL(der_b.database_id, 0) <> DB_ID(N'PerformanceMonitor')
+        OPTION(RECOMPILE);
+
+        SET @rows_collected = ROWCOUNT_BIG();
+
+        IF @debug = 1
+        BEGIN
+            RAISERROR(N'Collected %I64d blocking edges (monitor_loop %d)', 0, 1, @rows_collected, @monitor_loop) WITH NOWAIT;
+        END;
+
+        INSERT INTO
+            config.collection_log
+        (
+            collector_name,
+            collection_status,
+            rows_collected,
+            duration_ms
+        )
+        VALUES
+        (
+            N'dmv_blocking_snapshot_collector',
+            N'SUCCESS',
+            @rows_collected,
+            DATEDIFF(MILLISECOND, @start_time, SYSDATETIME())
+        );
+
+        COMMIT TRANSACTION;
+
+    END TRY
+    BEGIN CATCH
+        IF @@TRANCOUNT > 0
+        BEGIN
+            ROLLBACK TRANSACTION;
+        END;
+
+        SET @error_message = ERROR_MESSAGE();
+
+        INSERT INTO
+            config.collection_log
+        (
+            collector_name,
+            collection_status,
+            duration_ms,
+            error_message
+        )
+        VALUES
+        (
+            N'dmv_blocking_snapshot_collector',
+            N'ERROR',
+            DATEDIFF(MILLISECOND, @start_time, SYSDATETIME()),
+            @error_message
+        );
+
+        RAISERROR(N'Error in DMV blocking snapshot collector: %s', 16, 1, @error_message);
+    END CATCH;
+END;
+GO
+
+PRINT 'DMV blocking snapshot collector created successfully';
+PRINT 'Captures point-in-time blocking from DMVs (always-on fallback for the blocked-process-report XE)';
+PRINT 'Use: EXECUTE collect.dmv_blocking_snapshot_collector @debug = 1;';
+GO


### PR DESCRIPTION
## Always-on DMV blocking-snapshot fallback (both apps)

Both apps are BPR-primary for blocking. The `blocked_process_report` XE only fires when `blocked process threshold (s) > 0` — unset by default, and unsettable via `sp_configure` on AWS RDS (needs a parameter group). When it's 0, **we silently collect zero blocking.** This adds an always-on DMV snapshot that closes that gap.

### What it does
- New `dmv_blocking_snapshots` collector (both apps) captures current blocking edges from `sys.dm_os_waiting_tasks` + `sys.dm_exec_*` every minute — no threshold, no XE, works on every platform (incl. RDS/Azure SQL DB). Based on the `sp_PressureDetector` `@troubleshoot_blocking` enrichment, re-shaped to emit per-edge pair-rows.
- Feeds the **existing source-agnostic `BlockingChainReconstructor`** unchanged. Two surfaces both merge DMV rows, **BPR-preferred**:
  - the blocking-events **grid** (so the chain viewer is reachable when BPR is empty — the RDS case), and
  - all **three** pair-row consumers (viewer fetch, BLOCKING_CHAIN fact, drill-down) — merged *before* their empty-check so DMV-only blocking still reconstructs.
- `monitor_loop` is synthesized **negative** so DMV episodes can never collide with real (non-negative) BPR monitor loops in the viewer's per-episode scoping.
- A `Source` badge column distinguishes "DMV snapshot" vs "blocked-process-report" rows in both grids.

### Design decisions (locked with @erikdarlingdata)
- **Always-on** (not fallback-only) — also catches sub-threshold blocking BPR misses.
- **New dedicated table** (not enriching `waiting_tasks`).
- Dedup in **C#** (`BlockingPairRowMerge`, shared in `PerformanceMonitor.Analysis`), *not* a SQL union — avoids breaking the shared `SelectBody` ordinal contract.
- `contentious_object`: OBJECT/KEY best-effort from `wait_resource`, raw fallback (kept cheap on a live per-minute query).

### Deadlock doc-drift fix (folded in)
Deadlocks come from the dedicated `PerformanceMonitor_Deadlock` XE session (`xml_deadlock_report`), **not** `system_health`, and are fully supported on RDS + Azure SQL DB. `README`, Lite `ScheduleManager`, and the block-chain viewer empty-state strings said otherwise — corrected.

## Which component(s)
- [x] Full Dashboard
- [x] Lite Dashboard
- [x] Lite Tests
- [x] SQL collection scripts
- [ ] Installer

## How was this tested?
- Collector `SELECT` executed against a live instance (binds + runs, 0 rows on an idle box).
- Collector proc compiles (`CREATE OR ALTER` on a test PerformanceMonitor DB, then dropped); new table DDL parses.
- Full solution builds green (0 errors).
- 12 new `BlockingPairRowMergeTests` pass (6 each in Dashboard.Tests + Lite.Tests): BPR-preferred dedup, DMV-only fill (RDS case), minute/ecid distinctness.

**Not yet done (for the next review cycle):** end-to-end Installer run + a live blocking scenario on a threshold-0 server, and Azure SQL DB `dm_os_waiting_tasks` db-scoping check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
