### PR TITLE
Exclude resolved alerts from the badge; share the metric classifier (#1225)

### DIFF
--- a/Dashboard.Tests/AlertMetricClassifierTests.cs
+++ b/Dashboard.Tests/AlertMetricClassifierTests.cs
@@ -1,0 +1,80 @@
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// #1225: the shared metric-name classifier that both apps' Alert History grids and the Dashboard
+/// sidebar Alert badge rely on. Locks in the resolution suffix set (Cleared/Resolved/Restored) —
+/// the "Restored" cases (Capture/Server Restored) are the ones the old duplicated inline copies
+/// missed — plus the critical (Deadlock/Poison) and warning buckets, over the metric names the
+/// alert engines actually emit.
+/// </summary>
+public class AlertMetricClassifierTests
+{
+    [Theory]
+    [InlineData("Blocking Cleared")]
+    [InlineData("Deadlocks Cleared")]
+    [InlineData("Poison Waits Cleared")]
+    [InlineData("Long-Running Queries Cleared")]
+    [InlineData("Long-Running Jobs Cleared")]
+    [InlineData("CPU Resolved")]
+    [InlineData("TempDB Space Resolved")]
+    [InlineData("Volume Free Space Resolved")]
+    [InlineData("Capture Restored")]
+    [InlineData("Server Restored")]
+    public void IsResolution_True_ForEveryResolutionNotice(string metric)
+    {
+        Assert.True(AlertMetricClassifier.IsResolution(metric));
+        Assert.False(AlertMetricClassifier.IsWarning(metric)); // a resolution notice is never a warning
+    }
+
+    [Theory]
+    [InlineData("Blocking Detected")]
+    [InlineData("Deadlocks Detected")]
+    [InlineData("High CPU")]
+    [InlineData("Poison Wait")]
+    [InlineData("Long-Running Query")]
+    [InlineData("TempDB Space")]
+    [InlineData("Volume Free Space")]
+    [InlineData("Long-Running Job")]
+    [InlineData("Failed Agent Job")]
+    [InlineData("Capture Down")]
+    [InlineData("Server Unreachable")]
+    public void IsResolution_False_ForActionableAlerts(string metric)
+    {
+        Assert.False(AlertMetricClassifier.IsResolution(metric));
+    }
+
+    [Theory]
+    [InlineData("Deadlocks Detected")]
+    [InlineData("Poison Wait")]
+    public void IsCritical_True_ForDeadlockAndPoison(string metric)
+    {
+        Assert.True(AlertMetricClassifier.IsCritical(metric));
+    }
+
+    [Theory]
+    [InlineData("Blocking Detected")]
+    [InlineData("High CPU")]
+    [InlineData("Long-Running Query")]
+    public void IsWarning_True_ForOrdinaryActionableAlerts(string metric)
+    {
+        Assert.True(AlertMetricClassifier.IsWarning(metric));
+        Assert.False(AlertMetricClassifier.IsCritical(metric));
+        Assert.False(AlertMetricClassifier.IsResolution(metric));
+    }
+
+    [Fact]
+    public void Classifiers_AreFalse_ForNullOrEmpty()
+    {
+        Assert.False(AlertMetricClassifier.IsResolution(null));
+        Assert.False(AlertMetricClassifier.IsResolution(""));
+        Assert.False(AlertMetricClassifier.IsCritical(null));
+        Assert.False(AlertMetricClassifier.IsCritical(""));
+        // IsWarning is the complement of the two signals, so an absent name defaults to warning —
+        // matching the long-standing display behavior this classifier replaced.
+        Assert.True(AlertMetricClassifier.IsWarning(null));
+        Assert.True(AlertMetricClassifier.IsWarning(""));
+    }
+}

--- a/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
+++ b/Dashboard.Tests/JsonAlertHistoryStoreMutedFilterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Models;
@@ -10,12 +11,13 @@ using Xunit;
 namespace PerformanceMonitorDashboard.Tests;
 
 /// <summary>
-/// #1225: muted alerts are written to history for audit but must not count toward the sidebar
-/// Alert badge. Proves GetAlertHistory(includeMuted: false) drops muted rows, that the default
-/// (includeMuted: true) still returns them for the history grid / MCP tool, and — the regression
-/// that bit the reporter — that the muted filter runs BEFORE the row limit, so a flood of muted
-/// noise can't evict a real alert from the counted window. A unique serverId keeps the test
-/// isolated from any on-disk alert_history.json the store loads in its constructor.
+/// #1225: muted alerts and resolution notices ("... Cleared/Resolved/Restored") are written to
+/// history for audit but must not count toward the sidebar Alert badge. Proves GetAlertHistory's
+/// includeMuted/includeResolved filters drop those rows, that the defaults still return them for
+/// the history grid / MCP tool, and — the regression that bit the reporter — that both filters run
+/// BEFORE the row limit, so noise can't evict a real alert from the counted window. A unique
+/// serverId keeps the test isolated from any on-disk alert_history.json the store loads in its
+/// constructor.
 /// </summary>
 public class JsonAlertHistoryStoreMutedFilterTests
 {
@@ -83,5 +85,30 @@ public class JsonAlertHistoryStoreMutedFilterTests
         var mine = actionable.Where(a => a.ServerId == srv).ToList();
         Assert.Single(mine);
         Assert.False(mine[0].Muted);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_ExcludeResolved_DropsResolutionRows_FiltersBeforeLimit()
+    {
+        var store = new JsonAlertHistoryStore(new FakePreferencesService());
+        var srv = "test-" + Guid.NewGuid().ToString("N");
+
+        // One real alert first (oldest), then a flood of newer resolution notices. "Capture Restored"
+        // and "Server Restored" are included deliberately: the pre-#1225 classifier matched only
+        // Cleared/Resolved, so those "Restored" rows would have slipped into the badge count.
+        await RecordAsync(store, srv, "Deadlocks Detected", muted: false);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        foreach (var resolved in new[] { "Blocking Cleared", "CPU Resolved", "Capture Restored", "TempDB Space Resolved", "Server Restored" })
+            await RecordAsync(store, srv, resolved, muted: false);
+
+        // Default includes resolution rows for audit (history grid / MCP); a small limit fills with them.
+        var all = store.GetAlertHistory(hoursBack: 24, limit: 3);
+        Assert.DoesNotContain(all, a => a.ServerId == srv && !AlertMetricClassifier.IsResolution(a.MetricName));
+
+        // Excluding resolution rows before the limit keeps the one real alert in the counted window.
+        var actionable = store.GetAlertHistory(hoursBack: 24, limit: 3, includeResolved: false);
+        var mine = actionable.Where(a => a.ServerId == srv).ToList();
+        Assert.Single(mine);
+        Assert.Equal("Deadlocks Detected", mine[0].MetricName);
     }
 }

--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -99,10 +99,9 @@ namespace PerformanceMonitorDashboard.Controls
                 ThresholdValue = e.ThresholdValue,
                 NotificationType = e.NotificationType,
                 StatusDisplay = GetStatusDisplay(e),
-                IsResolved = e.MetricName.Contains("Cleared") || e.MetricName.Contains("Resolved"),
-                IsCritical = e.MetricName.Contains("Deadlock") || e.MetricName.Contains("Poison"),
-                IsWarning = !e.MetricName.Contains("Cleared") && !e.MetricName.Contains("Resolved")
-                            && !e.MetricName.Contains("Deadlock") && !e.MetricName.Contains("Poison"),
+                IsResolved = AlertMetricClassifier.IsResolution(e.MetricName),
+                IsCritical = AlertMetricClassifier.IsCritical(e.MetricName),
+                IsWarning = AlertMetricClassifier.IsWarning(e.MetricName),
                 Muted = e.Muted,
                 DetailText = e.DetailText,
                 ContextJson = e.ContextJson

--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -83,11 +83,12 @@ namespace PerformanceMonitorDashboard
 
         private void UpdateAlertBadge()
         {
-            /* Muted alerts stay in history for audit but must not inflate the sidebar Alert badge —
-               otherwise known recurring noise (e.g. a muted trace-reader session) makes the dashboard
-               look like it has actionable alerts (#1225). Excluded inside the query, before the limit,
-               so a flood of muted rows can't push real alerts out of the counted window. */
-            var alerts = _alertHistoryStore.GetAlertHistory(hoursBack: 24, limit: 100, includeMuted: false);
+            /* The badge counts only actionable alerts. Muted alerts (known recurring noise) and
+               resolution notices ("... Cleared/Resolved/Restored" — a condition that already
+               recovered) both stay in Alert History for audit but must not inflate the badge, or the
+               dashboard looks like it has unhandled alerts when it doesn't (#1225). Both are excluded
+               inside the query, before the limit, so neither can push real alerts out of the count. */
+            var alerts = _alertHistoryStore.GetAlertHistory(hoursBack: 24, limit: 100, includeMuted: false, includeResolved: false);
             var count = alerts.Count;
 
             if (count > 0)

--- a/Dashboard/Services/JsonAlertHistoryStore.cs
+++ b/Dashboard/Services/JsonAlertHistoryStore.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Interfaces;
@@ -193,14 +194,23 @@ namespace PerformanceMonitorDashboard.Services
         /// Alert badge count so known recurring noise (a muted source firing every cooldown) can
         /// neither inflate the badge nor push real alerts out of the counted window (#1225).
         /// </param>
-        public List<AlertLogEntry> GetAlertHistory(int hoursBack = 24, int limit = 50, bool includeMuted = true)
+        /// <param name="includeResolved">
+        /// When true (default), resolution / good-news rows ("&#8230; Cleared/Resolved/Restored")
+        /// are returned for audit/history display. When false, they are filtered out before the
+        /// limit — also used by the sidebar Alert badge so a resolved condition is not counted as
+        /// an actionable alert (#1225). See <see cref="AlertMetricClassifier.IsResolution"/>.
+        /// </param>
+        public List<AlertLogEntry> GetAlertHistory(int hoursBack = 24, int limit = 50, bool includeMuted = true, bool includeResolved = true)
         {
             var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
             lock (_alertLogLock)
             {
                 return _alertLog
-                    .Where(a => a.AlertTime >= cutoff && !a.Hidden && (includeMuted || !a.Muted))
+                    .Where(a => a.AlertTime >= cutoff
+                        && !a.Hidden
+                        && (includeMuted || !a.Muted)
+                        && (includeResolved || !AlertMetricClassifier.IsResolution(a.MetricName)))
                     .OrderByDescending(a => a.AlertTime)
                     .Take(limit)
                     .ToList();

--- a/Lite/Services/LocalDataService.AlertHistory.cs
+++ b/Lite/Services/LocalDataService.AlertHistory.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
+using PerformanceMonitor.Common;
 using PerformanceMonitorLite.Database;
 
 namespace PerformanceMonitorLite.Services;
@@ -425,9 +426,9 @@ public class AlertHistoryRow
         }
     }
 
-    public bool IsResolved => MetricName.Contains("Cleared") || MetricName.Contains("Resolved");
-    public bool IsCritical => MetricName.Contains("Deadlock") || MetricName.Contains("Poison");
-    public bool IsWarning => !IsResolved && !IsCritical;
+    public bool IsResolved => AlertMetricClassifier.IsResolution(MetricName);
+    public bool IsCritical => AlertMetricClassifier.IsCritical(MetricName);
+    public bool IsWarning => AlertMetricClassifier.IsWarning(MetricName);
 
     private static string FormatValue(string metricName, double value)
     {

--- a/PerformanceMonitor.Common/AlertMetricClassifier.cs
+++ b/PerformanceMonitor.Common/AlertMetricClassifier.cs
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// The single, app-agnostic source of truth for classifying an alert-history row by its metric
+    /// NAME. Used by both apps' Alert History grids (resolved / critical / warning row styling) and
+    /// by the Dashboard sidebar Alert badge count.
+    ///
+    /// Alert classification across this codebase is metric-name based — there is no structural "kind"
+    /// field on a row — so this centralizes a string convention that was previously duplicated inline
+    /// in Dashboard's AlertsHistoryContent and Lite's AlertHistoryRow, and had drifted: both copies
+    /// recognized only the "Cleared"/"Resolved" resolution suffixes and missed "Restored", even though
+    /// the UI legend documents "Server Restored" as a resolved/green state (#1225).
+    /// </summary>
+    public static class AlertMetricClassifier
+    {
+        /// <summary>
+        /// True when the metric name denotes a resolution / good-news notice — a condition that
+        /// previously alerted has cleared — rather than an actionable alert. Recognizes every
+        /// resolution suffix the alert engines emit: "&#8230; Cleared", "&#8230; Resolved",
+        /// "&#8230; Restored" (e.g. Blocking Cleared, CPU Resolved, Capture Restored, Server Restored).
+        /// </summary>
+        public static bool IsResolution(string? metricName)
+        {
+            if (string.IsNullOrEmpty(metricName))
+                return false;
+
+            return metricName.Contains("Cleared", StringComparison.Ordinal)
+                || metricName.Contains("Resolved", StringComparison.Ordinal)
+                || metricName.Contains("Restored", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// True when the metric name denotes a critical-severity alert (deadlock or poison wait),
+        /// used for row emphasis in the history grids. Mirrors the long-standing inline convention.
+        /// </summary>
+        public static bool IsCritical(string? metricName)
+        {
+            if (string.IsNullOrEmpty(metricName))
+                return false;
+
+            return metricName.Contains("Deadlock", StringComparison.Ordinal)
+                || metricName.Contains("Poison", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// True for an ordinary (warning-severity) alert: actionable, neither a resolution notice
+        /// nor critical.
+        /// </summary>
+        public static bool IsWarning(string? metricName) =>
+            !IsResolution(metricName) && !IsCritical(metricName);
+    }
+}


### PR DESCRIPTION
Follow-up to #1226 (same issue, #1225).

## Problem
After #1226 stopped *muted* alerts from inflating the sidebar **Alerts** badge, the badge still counted **resolution notices** — `Blocking Cleared`, `Deadlocks Cleared`, `Poison Waits Cleared`, `Long-Running Queries/Jobs Cleared`, `CPU Resolved`, `TempDB Space Resolved`, `Volume Free Space Resolved`, `Capture Restored`, `Server Restored`. A condition that already recovered is not an actionable alert and shouldn't light the badge.

While fixing it I found both apps classify alert-history rows with **duplicated inline string checks**, and both copies recognized only `Cleared`/`Resolved` — they **missed `Restored`**, even though Lite's own settings legend documents "Server Restored" as a resolved/green state. A `Cleared`/`Resolved`-only badge fix would therefore have been incomplete (it would still count `Capture Restored` / `Server Restored`).

## Fix
New shared `PerformanceMonitor.Common.AlertMetricClassifier` (`IsResolution` / `IsCritical` / `IsWarning`) — one source of truth for the metric-name convention. Every consumer routed through it:

- **Dashboard badge:** `GetAlertHistory` gains `includeResolved` (default `true`; the badge passes `false`). Filtered in the same `Where` as muted/hidden, **before** the row limit, so resolution rows can't crowd real alerts out of the count.
- **Dashboard `AlertsHistoryContent`** and **Lite `AlertHistoryRow`** display classifiers now call the shared helper. This also fixes the `Restored` gap consistently in **both** grids: `Capture Restored` / `Server Restored` rows now style as resolved (green), matching the documented legend.

Defaults are unchanged, so the Alert History grid and the MCP `get_alert_history` tool still show every row (muted + resolved) for audit.

## Scope / parity
- The badge change is Dashboard-only (Lite has no history-count badge — its badge is blocking/deadlock-health-driven).
- The classifier unification touches **both** apps' display grids — that's the parity fix: the duplicated logic is now single-sourced and the `Restored` behavior matches across apps.

## Tests
- `AlertMetricClassifierTests` — exhaustive over the metric names the alert engines actually emit, including the `Restored` cases the old copies missed, plus null/empty.
- Extended the store-filter test with a resolution case proving `includeResolved: false` drops resolution rows before the limit.

Build clean (0 errors). **Dashboard.Tests 646 passed, Lite.Tests 558 passed**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)