### PR TITLE
Surface DMV blocking snapshot in the flat top-blocking drill-down

### DIFF
--- a/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
@@ -65,21 +65,52 @@ ORDER BY collection_time DESC;";
         await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
+        /* BPR + always-on DMV blocking snapshot, so the flat top-blocking list isn't empty when the
+           blocked-process-report XE captured nothing (AWS RDS). Worst-by-wait surfaces regardless of
+           source; on a box with both, BPR and DMV may each contribute (this is a top-5 list, not a count). */
         cmd.CommandText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT TOP 5
     collection_time,
     database_name,
-    spid AS blocked_spid,
-    0 AS blocking_spid,
+    blocked_spid,
+    blocking_spid,
     wait_time_ms,
     lock_mode,
-    LEFT(CAST(query_text AS NVARCHAR(MAX)), 500) AS blocked_sql,
-    LEFT(blocking_tree, 500) AS blocking_sql,
+    blocked_sql,
+    blocking_sql,
     contentious_object
-FROM collect.blocking_BlockedProcessReport
-WHERE collection_time >= @startTime AND collection_time <= @endTime
+FROM
+(
+    SELECT
+        collection_time,
+        database_name,
+        blocked_spid = spid,
+        blocking_spid = 0,
+        wait_time_ms,
+        lock_mode,
+        blocked_sql = LEFT(CAST(query_text AS NVARCHAR(MAX)), 500),
+        blocking_sql = LEFT(blocking_tree, 500),
+        contentious_object
+    FROM collect.blocking_BlockedProcessReport
+    WHERE collection_time >= @startTime AND collection_time <= @endTime
+
+    UNION ALL
+
+    SELECT
+        collection_time,
+        database_name,
+        blocked_spid = spid,
+        blocking_spid,
+        wait_time_ms,
+        lock_mode,
+        blocked_sql = LEFT(CAST(blocked_sql_text AS NVARCHAR(MAX)), 500),
+        blocking_sql = LEFT(CAST(blocking_sql_text AS NVARCHAR(MAX)), 500),
+        contentious_object
+    FROM collect.dmv_blocking_snapshots
+    WHERE collection_time >= @startTime AND collection_time <= @endTime
+) AS combined
 ORDER BY wait_time_ms DESC;";
 
         cmd.Parameters.Add(new SqlParameter("@startTime", context.TimeRangeStart));

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -64,14 +64,32 @@ LIMIT 3";
         await connection.OpenAsync();
 
         using var cmd = connection.CreateCommand();
+        /* BPR + always-on DMV blocking snapshot, so the flat top-blocking list isn't empty when the
+           blocked-process-report XE captured nothing (AWS RDS). Worst-by-wait surfaces regardless of
+           source; on a box with both, each may contribute (this is a top-5 list, not a count). */
         cmd.CommandText = @"
 SELECT collection_time, database_name, blocked_spid, blocking_spid,
-       wait_time_ms, lock_mode,
-       LEFT(blocked_sql_text, 500) AS blocked_sql,
-       LEFT(blocking_sql_text, 500) AS blocking_sql,
-       contentious_object
-FROM v_blocked_process_reports
-WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+       wait_time_ms, lock_mode, blocked_sql, blocking_sql, contentious_object
+FROM
+(
+    SELECT collection_time, database_name, blocked_spid, blocking_spid,
+           wait_time_ms, lock_mode,
+           LEFT(blocked_sql_text, 500) AS blocked_sql,
+           LEFT(blocking_sql_text, 500) AS blocking_sql,
+           contentious_object
+    FROM v_blocked_process_reports
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+
+    UNION ALL
+
+    SELECT collection_time, database_name, blocked_spid, blocking_spid,
+           wait_time_ms, lock_mode,
+           LEFT(blocked_sql_text, 500) AS blocked_sql,
+           LEFT(blocking_sql_text, 500) AS blocking_sql,
+           contentious_object
+    FROM v_dmv_blocking_snapshots
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+) AS combined
 ORDER BY wait_time_ms DESC
 LIMIT 5";
 


### PR DESCRIPTION
Bucket 1 follow-up to #1227. The reconstructed blocking-chain drill-down already merges the always-on DMV snapshot, but the sibling flat `top_blocking_chains` list in the same finding still read the blocked-process-report table only — so on a threshold-0 / AWS RDS box the reconstructed chains showed DMV data while the flat list sat empty. This `UNION ALL`s the DMV snapshot into both apps' `CollectTopBlockingChains` (top-5 by wait). It's a top-5 list, not a count, so no dedup is needed; on a server with both sources each may contribute.

Both apps build green; the Dashboard UNION grammar PARSEONLY-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)