### PR TITLE
Extend DMV blocking fallback to count/aggregate surfaces (Bucket 2)

### DIFF
--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -194,21 +194,42 @@ namespace PerformanceMonitorDashboard.Services
                     var connection = tc.Connection;
 
                     var timeFilter = fromDate.HasValue && toDate.HasValue
-                        ? "WHERE b.collection_time >= @from_date AND b.collection_time <= @to_date"
-                        : "WHERE b.collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
+                        ? "WHERE collection_time >= @from_date AND collection_time <= @to_date"
+                        : "WHERE collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
 
+                    // BPR buckets, falling back to the always-on DMV snapshot only when BPR has no buckets in
+                    // the window (AWS RDS) — so a server with both sources never double-counts.
                     string query = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
-SELECT
-    DATEADD(HOUR, DATEDIFF(HOUR, 0, b.collection_time), 0) AS bucket_hour,
-    COUNT(*) AS event_count,
-    ISNULL(SUM(b.wait_time_ms), 0) / 1000.0 AS total_wait_sec,
-    COUNT(DISTINCT b.spid) AS distinct_blocked,
-    COUNT(DISTINCT b.database_name) AS distinct_databases
-FROM collect.blocking_BlockedProcessReport AS b
-{timeFilter}
-GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, b.collection_time), 0)
+WITH bpr AS
+(
+    SELECT
+        bucket_hour = DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0),
+        event_count = COUNT(*),
+        total_wait_sec = ISNULL(SUM(wait_time_ms), 0) / 1000.0,
+        distinct_blocked = COUNT(DISTINCT spid),
+        distinct_databases = COUNT(DISTINCT database_name)
+    FROM collect.blocking_BlockedProcessReport
+    {timeFilter}
+    GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0)
+),
+dmv AS
+(
+    SELECT
+        bucket_hour = DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0),
+        event_count = COUNT(*),
+        total_wait_sec = ISNULL(SUM(wait_time_ms), 0) / 1000.0,
+        distinct_blocked = COUNT(DISTINCT spid),
+        distinct_databases = COUNT(DISTINCT database_name)
+    FROM collect.dmv_blocking_snapshots
+    {timeFilter}
+    GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0)
+)
+SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM bpr
+UNION ALL
+SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM dmv
+WHERE NOT EXISTS (SELECT 1 FROM bpr)
 ORDER BY bucket_hour;";
 
                     using var command = new SqlCommand(query, connection) { CommandTimeout = 120 };

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -215,14 +215,21 @@ ORDER BY collection_time DESC, cpu_time_ms DESC";
 
         var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
 
+        /* blocking_count prefers the blocked-process-report; falls back to the always-on DMV snapshot when
+           BPR captured nothing (AWS RDS). latest_event_time includes DMV blocking recency too. */
         command.CommandText = @"
 SELECT
-    (SELECT COUNT(*) FROM v_blocked_process_reports
-     WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3) AS blocking_count,
+    COALESCE(NULLIF((SELECT COUNT(*) FROM v_blocked_process_reports
+     WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3), 0),
+     (SELECT COUNT(*) FROM v_dmv_blocking_snapshots
+     WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3)) AS blocking_count,
     (SELECT COUNT(*) FROM v_deadlocks
      WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3) AS deadlock_count,
     (SELECT MAX(t) FROM (
         SELECT MAX(event_time) AS t FROM v_blocked_process_reports
+        WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+        UNION ALL
+        SELECT MAX(event_time) AS t FROM v_dmv_blocking_snapshots
         WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
         UNION ALL
         SELECT MAX(deadlock_time) AS t FROM v_deadlocks
@@ -495,19 +502,37 @@ LIMIT 5000";
         using var command = connection.CreateCommand();
         var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
 
+        /* BPR buckets, falling back to the always-on DMV snapshot only when BPR has no buckets in the
+           window (AWS RDS) — so a server with both sources never double-counts. */
         command.CommandText = @"
-SELECT
-    date_trunc('hour', collection_time) AS bucket,
-    COUNT(*) AS event_count,
-    COALESCE(SUM(wait_time_ms), 0) / 1000.0 AS total_wait_sec,
-    COUNT(DISTINCT blocking_spid) AS distinct_blockers,
-    COUNT(DISTINCT blocked_spid) AS distinct_blocked,
-    COUNT(DISTINCT database_name) AS distinct_databases
-FROM v_blocked_process_reports
-WHERE server_id = $1
-AND   collection_time >= $2
-AND   collection_time <= $3
-GROUP BY date_trunc('hour', collection_time)
+WITH bpr AS (
+    SELECT
+        date_trunc('hour', collection_time) AS bucket,
+        COUNT(*) AS event_count,
+        COALESCE(SUM(wait_time_ms), 0) / 1000.0 AS total_wait_sec,
+        COUNT(DISTINCT blocking_spid) AS distinct_blockers,
+        COUNT(DISTINCT blocked_spid) AS distinct_blocked,
+        COUNT(DISTINCT database_name) AS distinct_databases
+    FROM v_blocked_process_reports
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+    GROUP BY date_trunc('hour', collection_time)
+),
+dmv AS (
+    SELECT
+        date_trunc('hour', collection_time) AS bucket,
+        COUNT(*) AS event_count,
+        COALESCE(SUM(wait_time_ms), 0) / 1000.0 AS total_wait_sec,
+        COUNT(DISTINCT blocking_spid) AS distinct_blockers,
+        COUNT(DISTINCT blocked_spid) AS distinct_blocked,
+        COUNT(DISTINCT database_name) AS distinct_databases
+    FROM v_dmv_blocking_snapshots
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
+    GROUP BY date_trunc('hour', collection_time)
+)
+SELECT bucket, event_count, total_wait_sec, distinct_blockers, distinct_blocked, distinct_databases FROM bpr
+UNION ALL
+SELECT bucket, event_count, total_wait_sec, distinct_blockers, distinct_blocked, distinct_databases FROM dmv
+WHERE NOT EXISTS (SELECT 1 FROM bpr)
 ORDER BY bucket";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -589,20 +614,24 @@ ORDER BY bucket";
 
         /* Use blocked_process_reports from XE session - more reliable than point-in-time snapshots
            Group by event_time (when blocking actually occurred) rather than collection_time */
+        /* BPR per-minute buckets, falling back to the always-on DMV snapshot only when BPR has none in the
+           window (AWS RDS) — so a server with both sources never double-counts. */
         command.CommandText = @"
-SELECT
-    bucket,
-    incident_count
-FROM (
-    SELECT
-        DATE_TRUNC('minute', event_time) AS bucket,
-        COUNT(*) AS incident_count
+WITH bpr AS (
+    SELECT DATE_TRUNC('minute', event_time) AS bucket, COUNT(*) AS incident_count
     FROM v_blocked_process_reports
-    WHERE server_id = $1
-    AND   event_time >= $2
-    AND   event_time <= $3
+    WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
     GROUP BY DATE_TRUNC('minute', event_time)
-) sub
+),
+dmv AS (
+    SELECT DATE_TRUNC('minute', event_time) AS bucket, COUNT(*) AS incident_count
+    FROM v_dmv_blocking_snapshots
+    WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+    GROUP BY DATE_TRUNC('minute', event_time)
+)
+SELECT bucket, incident_count FROM bpr
+UNION ALL
+SELECT bucket, incident_count FROM dmv WHERE NOT EXISTS (SELECT 1 FROM bpr)
 ORDER BY bucket";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -59,8 +59,12 @@ SELECT
          AND   collection_time >= $2 AND collection_time < $3), 0
     ) AS deadlock_count,
     COALESCE(
-        (SELECT COUNT(*)
+        NULLIF((SELECT COUNT(*)
          FROM v_blocked_process_reports
+         WHERE server_id = $1
+         AND   collection_time >= $2 AND collection_time < $3), 0),
+        (SELECT COUNT(*)
+         FROM v_dmv_blocking_snapshots
          WHERE server_id = $1
          AND   collection_time >= $2 AND collection_time < $3), 0
     ) AS blocking_events,

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -70,11 +70,11 @@ LIMIT 1";
         /* Blocking count in last hour - uses XE blocked process reports */
         using (var cmd = connection.CreateCommand())
         {
+            /* Prefer the blocked-process-report; fall back to the always-on DMV snapshot (AWS RDS). */
             cmd.CommandText = @"
-SELECT COUNT(*)
-FROM v_blocked_process_reports
-WHERE server_id = $1
-AND   event_time >= $2";
+SELECT COALESCE(NULLIF(
+    (SELECT COUNT(*) FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2), 0),
+    (SELECT COUNT(*) FROM v_dmv_blocking_snapshots WHERE server_id = $1 AND event_time >= $2))";
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
             cmd.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-1) });
             var result = await cmd.ExecuteScalarAsync();


### PR DESCRIPTION
Bucket 2 follow-up to #1227. Extends the always-on DMV blocking fallback to the remaining blocking **count/aggregate** surfaces so the Blocking tab isn't empty on a threshold-0 / AWS RDS box.

- **Lite** (no live-sysprocesses path — all blocking surfaces are collector-based): alert-badge blocking count + latest-event time, blocking slicer, blocking trend, daily-summary `blocking_events`, overview "blocking last hour".
- **Dashboard**: the blocking slicer. (Badge/summary already use the live `sys.sysprocesses` NocHealth path, which works on RDS — so no Dashboard count surfaces needed changing. Confirmed while checking the live path for Bucket 3.)

**Pattern:** counts use `COALESCE(NULLIF(bpr,0), dmv)`; bucketed surfaces use a CTE that adds DMV buckets only `WHERE NOT EXISTS` any BPR bucket in the window. Either way a server with both sources never double-counts (sample-vs-event); on a single server you get one consistent source.

Both apps build green; Dashboard slicer CTE PARSEONLY-validated.

**On Bucket 3:** the live blocking *alert* already fires on RDS via `sys.sysprocesses` (NocHealth), so the only remaining gap is the historical blocking-rate *fact/anomaly* — secondary, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)