### PR TITLE
Blocking DMV collector: layered wait thresholds + RESOURCE_SEMAPHORE; guard slicer/drill-down vs missing table

### DIFF
--- a/Dashboard/Analysis/BlockingPairRowQuery.cs
+++ b/Dashboard/Analysis/BlockingPairRowQuery.cs
@@ -217,4 +217,21 @@ ORDER BY collection_time DESC";
 
         BlockingPairRowMerge.MergeInto(rows, dmv);
     }
+
+    /// <summary>
+    /// Cheap existence probe for collect.dmv_blocking_snapshots. The slicer and the flat top-blocking
+    /// drill-down inline this table in a single combined CTE / UNION batch, which fails to COMPILE (Msg 208)
+    /// on a not-yet-upgraded database — a runtime try/catch can't rescue one combined batch the way the
+    /// separate <see cref="AppendDmvSnapshotRowsAsync"/> fetch can. Those callers use this to drop the DMV
+    /// branch from the query text entirely on such servers, degrading to BPR-only instead of throwing.
+    /// </summary>
+    internal static async Task<bool> DmvSnapshotsTableExistsAsync(SqlConnection connection)
+    {
+        using var cmd = new SqlCommand(
+            "SELECT CASE WHEN OBJECT_ID(N'collect.dmv_blocking_snapshots', N'U') IS NOT NULL THEN 1 ELSE 0 END;",
+            connection);
+        cmd.CommandTimeout = 30;
+        var result = await cmd.ExecuteScalarAsync();
+        return result is not null && result != DBNull.Value && Convert.ToInt32(result) == 1;
+    }
 }

--- a/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
+++ b/Dashboard/Analysis/SqlServerDrillDownCollector.Blocking.cs
@@ -67,8 +67,27 @@ ORDER BY collection_time DESC;";
         using var cmd = connection.CreateCommand();
         /* BPR + always-on DMV blocking snapshot, so the flat top-blocking list isn't empty when the
            blocked-process-report XE captured nothing (AWS RDS). Worst-by-wait surfaces regardless of
-           source; on a box with both, BPR and DMV may each contribute (this is a top-5 list, not a count). */
-        cmd.CommandText = @"
+           source; on a box with both, BPR and DMV may each contribute (this is a top-5 list, not a count).
+           The DMV UNION branch is dropped on a not-yet-upgraded server (no dmv_blocking_snapshots table) --
+           inlining a missing table here would fail the whole combined batch at compile (Msg 208). */
+        bool dmvExists = await BlockingPairRowQuery.DmvSnapshotsTableExistsAsync(connection);
+        string dmvUnion = dmvExists ? @"
+
+    UNION ALL
+
+    SELECT
+        collection_time,
+        database_name,
+        blocked_spid = spid,
+        blocking_spid,
+        wait_time_ms,
+        lock_mode,
+        blocked_sql = LEFT(CAST(blocked_sql_text AS NVARCHAR(MAX)), 500),
+        blocking_sql = LEFT(CAST(blocking_sql_text AS NVARCHAR(MAX)), 500),
+        contentious_object
+    FROM collect.dmv_blocking_snapshots
+    WHERE collection_time >= @startTime AND collection_time <= @endTime" : "";
+        cmd.CommandText = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT TOP 5
@@ -94,22 +113,7 @@ FROM
         blocking_sql = LEFT(blocking_tree, 500),
         contentious_object
     FROM collect.blocking_BlockedProcessReport
-    WHERE collection_time >= @startTime AND collection_time <= @endTime
-
-    UNION ALL
-
-    SELECT
-        collection_time,
-        database_name,
-        blocked_spid = spid,
-        blocking_spid,
-        wait_time_ms,
-        lock_mode,
-        blocked_sql = LEFT(CAST(blocked_sql_text AS NVARCHAR(MAX)), 500),
-        blocking_sql = LEFT(CAST(blocking_sql_text AS NVARCHAR(MAX)), 500),
-        contentious_object
-    FROM collect.dmv_blocking_snapshots
-    WHERE collection_time >= @startTime AND collection_time <= @endTime
+    WHERE collection_time >= @startTime AND collection_time <= @endTime{dmvUnion}
 ) AS combined
 ORDER BY wait_time_ms DESC;";
 

--- a/Dashboard/Services/DatabaseService.QueryPerformance.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Ui;
+using PerformanceMonitorDashboard.Analysis;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitor.Common;
@@ -198,7 +199,27 @@ namespace PerformanceMonitorDashboard.Services
                         : "WHERE collection_time >= DATEADD(HOUR, -@hours_back, SYSDATETIME())";
 
                     // BPR buckets, falling back to the always-on DMV snapshot only when BPR has no buckets in
-                    // the window (AWS RDS) — so a server with both sources never double-counts.
+                    // the window (AWS RDS) — so a server with both sources never double-counts. The DMV branch is
+                    // dropped entirely on a not-yet-upgraded server (no dmv_blocking_snapshots table): inlining a
+                    // missing table in the CTE would fail the whole batch at compile (Msg 208).
+                    bool dmvExists = await BlockingPairRowQuery.DmvSnapshotsTableExistsAsync(connection);
+                    string dmvCte = dmvExists ? $@",
+dmv AS
+(
+    SELECT
+        bucket_hour = DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0),
+        event_count = COUNT(*),
+        total_wait_sec = ISNULL(SUM(wait_time_ms), 0) / 1000.0,
+        distinct_blocked = COUNT(DISTINCT spid),
+        distinct_databases = COUNT(DISTINCT database_name)
+    FROM collect.dmv_blocking_snapshots
+    {timeFilter}
+    GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0)
+)" : "";
+                    string dmvUnion = dmvExists ? @"
+UNION ALL
+SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM dmv
+WHERE NOT EXISTS (SELECT 1 FROM bpr)" : "";
                     string query = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -213,23 +234,8 @@ WITH bpr AS
     FROM collect.blocking_BlockedProcessReport
     {timeFilter}
     GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0)
-),
-dmv AS
-(
-    SELECT
-        bucket_hour = DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0),
-        event_count = COUNT(*),
-        total_wait_sec = ISNULL(SUM(wait_time_ms), 0) / 1000.0,
-        distinct_blocked = COUNT(DISTINCT spid),
-        distinct_databases = COUNT(DISTINCT database_name)
-    FROM collect.dmv_blocking_snapshots
-    {timeFilter}
-    GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, collection_time), 0)
-)
-SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM bpr
-UNION ALL
-SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM dmv
-WHERE NOT EXISTS (SELECT 1 FROM bpr)
+){dmvCte}
+SELECT bucket_hour, event_count, total_wait_sec, distinct_blocked, distinct_databases FROM bpr{dmvUnion}
 ORDER BY bucket_hour;";
 
                     using var command = new SqlCommand(query, connection) { CommandTimeout = 120 };

--- a/Lite/Services/RemoteCollectorService.DmvBlockingSnapshot.cs
+++ b/Lite/Services/RemoteCollectorService.DmvBlockingSnapshot.cs
@@ -103,7 +103,18 @@ AND   (
           wt.wait_type LIKE N'LCK[_]%'
           OR wt.wait_type LIKE N'PAGELATCH[_]%'
           OR wt.wait_type LIKE N'PAGEIOLATCH[_]%'
+          OR wt.wait_type LIKE N'RESOURCE_SEMAPHORE%'
       )
+/* Layered minimum-wait floor (kept in lockstep with install/56): locks must persist to matter (2s); page
+   latches churn faster (PAGELATCH 0.5s, PAGEIOLATCH 1s); memory-grant / compile-gate waits run long, so 5s. */
+AND   wt.wait_duration_ms >=
+      CASE
+          WHEN wt.wait_type LIKE N'LCK[_]%'             THEN 2000
+          WHEN wt.wait_type LIKE N'PAGELATCH[_]%'       THEN 500
+          WHEN wt.wait_type LIKE N'PAGEIOLATCH[_]%'     THEN 1000
+          WHEN wt.wait_type LIKE N'RESOURCE_SEMAPHORE%' THEN 5000
+          ELSE 1000
+      END
 OPTION(RECOMPILE);";
 
         var serverId = GetServerId(server);

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -1167,7 +1167,7 @@ BEGIN
         blocking_ecid integer NOT NULL,
         blocking_last_tran_started datetime2(7) NULL,
         wait_time_ms bigint NULL,
-        lock_mode nvarchar(20) NULL,
+        lock_mode nvarchar(64) NULL, /* 64 not 20: holds RESOURCE_SEMAPHORE_QUERY_COMPILE (32) whole as the contention tag */
         blocking_status nvarchar(30) NULL,
         contentious_object nvarchar(4000) NULL,
         blocked_sql_text nvarchar(max) NULL,

--- a/install/06_ensure_collection_table.sql
+++ b/install/06_ensure_collection_table.sql
@@ -1079,7 +1079,7 @@ BEGIN
                 blocking_ecid integer NOT NULL,
                 blocking_last_tran_started datetime2(7) NULL,
                 wait_time_ms bigint NULL,
-                lock_mode nvarchar(20) NULL,
+                lock_mode nvarchar(64) NULL, /* 64 not 20: holds RESOURCE_SEMAPHORE_QUERY_COMPILE (32) whole as the contention tag */
                 blocking_status nvarchar(30) NULL,
                 contentious_object nvarchar(4000) NULL,
                 blocked_sql_text nvarchar(max) NULL,

--- a/install/56_collect_dmv_blocking_snapshot.sql
+++ b/install/56_collect_dmv_blocking_snapshot.sql
@@ -148,7 +148,8 @@ BEGIN
             blocking_ecid = ISNULL(wt.blocking_exec_context_id, 0),
             blocking_last_tran_started = tat_k.transaction_begin_time,
             wait_time_ms = wt.wait_duration_ms,
-            /* LCK_M_X -> X, PAGELATCH_EX -> EX, etc. */
+            /* LCK_M_X -> X, PAGELATCH_EX -> EX, etc. RESOURCE_SEMAPHORE[_QUERY_COMPILE] has no mode prefix to
+               strip, so it stays whole and doubles as the contention-type tag (why lock_mode is nvarchar(64)). */
             lock_mode =
                 REPLACE(REPLACE(REPLACE(wt.wait_type, N'LCK_M_', N''), N'PAGEIOLATCH_', N''), N'PAGELATCH_', N''),
             /* Blocker status from its SESSION (a sleeping/idle blocker has no request row). */
@@ -219,7 +220,19 @@ BEGIN
                   wt.wait_type LIKE N'LCK[_]%'
                   OR wt.wait_type LIKE N'PAGELATCH[_]%'
                   OR wt.wait_type LIKE N'PAGEIOLATCH[_]%'
+                  OR wt.wait_type LIKE N'RESOURCE_SEMAPHORE%'
               )
+        /* Layered minimum-wait floor: cut grid/chain noise by contention class. Locks must persist to matter
+           (2s); page latches churn faster, so a lower floor (PAGELATCH 0.5s, PAGEIOLATCH 1s); memory-grant /
+           compile-gate waits (RESOURCE_SEMAPHORE and RESOURCE_SEMAPHORE_QUERY_COMPILE) run long, so 5s. */
+        AND   wt.wait_duration_ms >=
+              CASE
+                  WHEN wt.wait_type LIKE N'LCK[_]%'             THEN 2000
+                  WHEN wt.wait_type LIKE N'PAGELATCH[_]%'       THEN 500
+                  WHEN wt.wait_type LIKE N'PAGEIOLATCH[_]%'     THEN 1000
+                  WHEN wt.wait_type LIKE N'RESOURCE_SEMAPHORE%' THEN 5000
+                  ELSE 1000
+              END
         AND   ISNULL(der_b.database_id, 0) <> DB_ID(N'PerformanceMonitor')
         OPTION(RECOMPILE);
 


### PR DESCRIPTION
## What

Follow-up to the always-on DMV blocking fallback (#1227/#1230/#1233/#1234). Two things:

### 1. Layered wait-type thresholds + RESOURCE_SEMAPHORE (collector, both apps)
- Added `RESOURCE_SEMAPHORE%` to the edge scope (covers both `RESOURCE_SEMAPHORE` and `RESOURCE_SEMAPHORE_QUERY_COMPILE`). Confirmed live that these waits **do** carry `blocking_session_id` (the memory-grant holders) -- they form real blocker->blocked edges, including the many-to-many case where one memory waiter is reported blocked by every current grant holder.
- Layered minimum-wait floor to cut grid/chain noise by contention class:

  | class | floor |
  |---|---|
  | LCK_* | 2s |
  | PAGELATCH_* | 0.5s |
  | PAGEIOLATCH_* | 1s |
  | RESOURCE_SEMAPHORE(_QUERY_COMPILE) | 5s |

  THREADPOOL deliberately excluded -- no `blocking_session_id`, and unobservable during real worker starvation.

### 2. Guard the slicer + flat drill-down against a missing DMV table (regression fix)
The slicer (`DatabaseService.QueryPerformance.cs`) and flat drill-down (`SqlServerDrillDownCollector.Blocking.cs`) inline `collect.dmv_blocking_snapshots` in a single combined CTE/UNION, which **fails to compile (Msg 208)** on a not-yet-upgraded server -- so the slicer blanked and the drill-down errored. A runtime `try/catch` can't rescue a single combined batch (unlike the already-guarded pair-row + grid paths, which fetch DMV separately). New `BlockingPairRowQuery.DmvSnapshotsTableExistsAsync` probe lets both surfaces drop the DMV branch entirely when the table is absent, degrading to BPR-only.

### Schema
`collect.dmv_blocking_snapshots.lock_mode` widened `nvarchar(20)` -> `nvarchar(64)` (`install/02` + `install/06`) so the `RESOURCE_SEMAPHORE_QUERY_COMPILE` tag (32 chars) fits whole. Lite's DuckDB `VARCHAR` is unbounded (no change).

## Testing
- Both apps build clean (0 errors).
- Dashboard 652 / Lite 578 / Installer 80 -- all pass.
- `install/56` PARSEONLY-clean.

## Not in this PR (held)
- Live apply to SQL2025 (ALTER column + redeploy proc) + Lite rebuild/relaunch -- deferred so as not to perturb the HammerDB validation / evict the running Lite.
- Proper diagnosis of the pre-existing `CollectBlockingChainFactsAsync` load-error (capture the real exception, not a blind timeout bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
