### PR TITLE
Add upgrade manifest for blocking chain columns

### DIFF
--- a/upgrades/3.0.0-to-3.1.0/upgrade.txt
+++ b/upgrades/3.0.0-to-3.1.0/upgrade.txt
@@ -1,0 +1,1 @@
+01_blocking_chain_monitor_loop.sql


### PR DESCRIPTION
## What does this PR do?

Adds the missing `upgrade.txt` manifest for the `upgrades/3.0.0-to-3.1.0` folder.

The upgrade script `01_blocking_chain_monitor_loop.sql` already exists and adds the required `blocking_ecid` and `monitor_loop` columns to `collect.blocking_BlockedProcessReport`. However, during testing with the `20260626` nightly installer against existing `v3.0.0.0` installs, the installer reported that there were no pending upgrades and did not run the existing upgrade script.

Because those columns were missing from existing installs, `23_process_blocked_process_xml.sql` failed with:

```text
Invalid column name 'monitor_loop'
```

Adding the manifest should allow the existing upgrade script to be discovered and run for upgrades from `3.0.0` to `3.1.0`.

## Which component(s) does this affect?

* [ ] Full Dashboard
* [ ] Lite Dashboard
* [ ] Lite Tests
* [x] SQL collection scripts
* [x] CLI Installer
* [ ] GUI Installer
* [ ] Documentation

## How was this tested?

Tested against two existing `v3.0.0.0` installs using the `20260626` nightly installer.

Steps validated:

1. Confirmed `collect.blocking_BlockedProcessReport` was missing:

   * `blocking_ecid`
   * `monitor_loop`
2. Confirmed the nightly installer failed on `23_process_blocked_process_xml.sql` with:

   * `Invalid column name 'monitor_loop'`
3. Manually added the two missing columns to validate the expected schema change.
4. Reran the same nightly installer with `--preserve-jobs`.
5. Confirmed the installer completed successfully:

   * `Installation: 56 succeeded, 0 failed`
   * `47 collectors ran successfully`
6. Confirmed `collect.process_blocked_process_xml` was successfully updated after the schema change.

This PR does not change the SQL upgrade script itself. It only adds the missing manifest entry so the existing upgrade script can be discovered and run.

## Checklist

* [x] I have read the contributing guide
* [ ] My code builds with zero warnings (`dotnet build -c Debug`)
* [x] I have tested my changes against at least one SQL Server version
* [x] I have not introduced any hardcoded credentials or server names
