### PR TITLE
Per-server override for alert delivery mode (#1236)

### DIFF
--- a/Dashboard.Tests/AlertDeliveryModeOverrideTests.cs
+++ b/Dashboard.Tests/AlertDeliveryModeOverrideTests.cs
@@ -1,0 +1,46 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System.Text.Json;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorDashboard.Models;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// #1236 per-server alert delivery override persists on <see cref="ServerConnection"/> (servers.json,
+/// same WriteIndented options ServerManager uses). A pre-#1236 file with no field inherits the global.
+/// The shared precedence rule (<see cref="AlertDeliveryModeResolver"/>) is covered in Lite.Tests.
+/// </summary>
+public class AlertDeliveryModeOverrideTests
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    [Fact]
+    public void Override_RoundTripsThroughJson()
+    {
+        var server = new ServerConnection { ServerName = "S1", AlertDeliveryModeOverride = AlertNotificationMode.PerEvent };
+        var back = JsonSerializer.Deserialize<ServerConnection>(JsonSerializer.Serialize(server, s_jsonOptions), s_jsonOptions);
+        Assert.Equal(AlertNotificationMode.PerEvent, back!.AlertDeliveryModeOverride);
+    }
+
+    [Fact]
+    public void NullOverride_RoundTripsAsNull()
+    {
+        var server = new ServerConnection { ServerName = "S1", AlertDeliveryModeOverride = null };
+        var back = JsonSerializer.Deserialize<ServerConnection>(JsonSerializer.Serialize(server, s_jsonOptions), s_jsonOptions);
+        Assert.Null(back!.AlertDeliveryModeOverride);
+    }
+
+    [Fact]
+    public void LegacyServersJson_WithoutField_InheritsGlobal()
+    {
+        // A servers.json written before #1236 has no AlertDeliveryModeOverride property -> null -> inherit.
+        var back = JsonSerializer.Deserialize<ServerConnection>("{\"ServerName\":\"S1\",\"DisplayName\":\"S1\"}", s_jsonOptions);
+        Assert.Null(back!.AlertDeliveryModeOverride);
+    }
+}

--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -129,6 +129,18 @@
                                  ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
                     </StackPanel>
 
+                    <!-- Alert Delivery Override (#1236) -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="Alert delivery:" Width="110" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource ForegroundBrush}"/>
+                        <ComboBox x:Name="AlertDeliveryOverrideComboBox" Width="240" SelectedIndex="0"
+                                  ToolTip="How deadlock/blocking alerts for THIS server are delivered. 'Use global setting' follows the app-wide Alerts setting; override to force Summary or Per-event for just this server.">
+                            <ComboBoxItem Content="Use global setting"/>
+                            <ComboBoxItem Content="Summary — one card per cycle"/>
+                            <ComboBoxItem Content="Per-event — one notification per incident"/>
+                        </ComboBox>
+                    </StackPanel>
+
                     <!-- Description -->
                     <TextBlock Text="Description (optional):" Margin="0,4,0,4"
                                Foreground="{DynamicResource ForegroundBrush}"/>

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -21,6 +21,7 @@ using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Models;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorDashboard
 {
@@ -83,6 +84,12 @@ namespace PerformanceMonitorDashboard
             TrustServerCertificateCheckBox.IsChecked = existingServer.TrustServerCertificate;
             ReadOnlyIntentCheckBox.IsChecked = existingServer.ReadOnlyIntent;
             MultiSubnetFailoverCheckBox.IsChecked = existingServer.MultiSubnetFailover;
+            AlertDeliveryOverrideComboBox.SelectedIndex = existingServer.AlertDeliveryModeOverride switch
+            {
+                AlertNotificationMode.Summary => 1,
+                AlertNotificationMode.PerEvent => 2,
+                _ => 0
+            };
 
             if (existingServer.AuthenticationType == AuthenticationTypes.EntraMFA)
             {
@@ -134,6 +141,13 @@ namespace PerformanceMonitorDashboard
                     : System.Windows.Visibility.Collapsed;
             }
         }
+
+        private AlertNotificationMode? GetSelectedDeliveryOverride() => AlertDeliveryOverrideComboBox.SelectedIndex switch
+        {
+            1 => AlertNotificationMode.Summary,
+            2 => AlertNotificationMode.PerEvent,
+            _ => null
+        };
 
         private string GetSelectedEncryptMode()
         {
@@ -847,6 +861,7 @@ namespace PerformanceMonitorDashboard
             MultiSubnetFailoverCheckBox.IsEnabled = enabled;
             IsFavoriteCheckBox.IsEnabled = enabled;
             MonthlyCostTextBox.IsEnabled = enabled;
+            AlertDeliveryOverrideComboBox.IsEnabled = enabled;
             DescriptionTextBox.IsEnabled = enabled;
             TestConnectionButton.IsEnabled = enabled;
             SaveButton.IsEnabled = enabled;
@@ -942,6 +957,7 @@ namespace PerformanceMonitorDashboard
                 ServerConnection.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostTextBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     ServerConnection.MonthlyCostUsd = editCost;
+                ServerConnection.AlertDeliveryModeOverride = GetSelectedDeliveryOverride();
             }
             else
             {
@@ -962,7 +978,8 @@ namespace PerformanceMonitorDashboard
                     TrustServerCertificate = TrustServerCertificateCheckBox.IsChecked == true,
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
                     MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
-                    MonthlyCostUsd = monthlyCost
+                    MonthlyCostUsd = monthlyCost,
+                    AlertDeliveryModeOverride = GetSelectedDeliveryOverride()
                 };
             }
 

--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -803,7 +803,11 @@ namespace PerformanceMonitorDashboard
             UserPreferences prefs, string metricName, string serverName, string summaryCurrentValue,
             string thresholdValue, string serverId, AlertContext? context)
         {
-            if (prefs.AlertDeliveryMode == AlertNotificationMode.PerEvent && context?.Incidents is { Count: > 0 })
+            /* #1236: a per-server override (Manage Servers -> Edit) wins over the global delivery mode;
+               null inherits prefs.AlertDeliveryMode. */
+            var deliveryMode = AlertDeliveryModeResolver.Resolve(
+                _serverManager.GetServerById(serverId)?.AlertDeliveryModeOverride, prefs.AlertDeliveryMode);
+            if (deliveryMode == AlertNotificationMode.PerEvent && context?.Incidents is { Count: > 0 })
             {
                 foreach (var msg in PerEventNotification.Split(context, prefs.AlertPerEventMaxPerCycle))
                 {

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -13,6 +13,7 @@ using Microsoft.Data.SqlClient;
 using PerformanceMonitorDashboard.Interfaces;
 using PerformanceMonitorDashboard.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorDashboard.Models
 {
@@ -82,6 +83,14 @@ namespace PerformanceMonitorDashboard.Models
         /// Set to 0 to hide cost columns. All FinOps costs are proportional to this budget.
         /// </summary>
         public decimal MonthlyCostUsd { get; set; } = 0m;
+
+        /// <summary>
+        /// #1236: per-server override for the alert delivery mode (deadlock/blocking notifications).
+        /// null = inherit the global AlertDeliveryMode setting; Summary/PerEvent forces that mode for
+        /// this server regardless of the global default (e.g. Per-event for one noisy prod box, Summary
+        /// everywhere else). Resolved via <see cref="PerformanceMonitor.Notifications.AlertDeliveryModeResolver"/>.
+        /// </summary>
+        public AlertNotificationMode? AlertDeliveryModeOverride { get; set; }
 
         /// <summary>
         /// Display name with "(Read-Only)" suffix when ReadOnlyIntent is enabled.

--- a/Lite.Tests/AlertDeliveryModeOverrideTests.cs
+++ b/Lite.Tests/AlertDeliveryModeOverrideTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitorLite.Models;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1236 per-server alert delivery override. Two concerns: the shared precedence rule
+/// (<see cref="AlertDeliveryModeResolver"/> — a per-server override wins, a null override inherits the
+/// global default) and that the override persists on <see cref="ServerConnection"/> with the same
+/// WriteIndented options ServerManager uses (a pre-#1236 servers.json with no field inherits the global).
+/// </summary>
+public class AlertDeliveryModeOverrideTests
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    [Fact]
+    public void Resolve_NullOverride_InheritsGlobalSummary()
+        => Assert.Equal(AlertNotificationMode.Summary, AlertDeliveryModeResolver.Resolve(null, AlertNotificationMode.Summary));
+
+    [Fact]
+    public void Resolve_NullOverride_InheritsGlobalPerEvent()
+        => Assert.Equal(AlertNotificationMode.PerEvent, AlertDeliveryModeResolver.Resolve(null, AlertNotificationMode.PerEvent));
+
+    [Fact]
+    public void Resolve_PerEventOverride_WinsOverGlobalSummary()
+        => Assert.Equal(AlertNotificationMode.PerEvent, AlertDeliveryModeResolver.Resolve(AlertNotificationMode.PerEvent, AlertNotificationMode.Summary));
+
+    [Fact]
+    public void Resolve_SummaryOverride_WinsOverGlobalPerEvent()
+        => Assert.Equal(AlertNotificationMode.Summary, AlertDeliveryModeResolver.Resolve(AlertNotificationMode.Summary, AlertNotificationMode.PerEvent));
+
+    [Fact]
+    public void Override_RoundTripsThroughJson()
+    {
+        var server = new ServerConnection { ServerName = "S1", AlertDeliveryModeOverride = AlertNotificationMode.PerEvent };
+        var back = JsonSerializer.Deserialize<ServerConnection>(JsonSerializer.Serialize(server, s_jsonOptions), s_jsonOptions);
+        Assert.Equal(AlertNotificationMode.PerEvent, back!.AlertDeliveryModeOverride);
+    }
+
+    [Fact]
+    public void NullOverride_RoundTripsAsNull()
+    {
+        var server = new ServerConnection { ServerName = "S1", AlertDeliveryModeOverride = null };
+        var back = JsonSerializer.Deserialize<ServerConnection>(JsonSerializer.Serialize(server, s_jsonOptions), s_jsonOptions);
+        Assert.Null(back!.AlertDeliveryModeOverride);
+    }
+
+    [Fact]
+    public void LegacyServersJson_WithoutField_InheritsGlobal()
+    {
+        // A servers.json written before #1236 has no AlertDeliveryModeOverride property -> null -> inherit.
+        var back = JsonSerializer.Deserialize<ServerConnection>("{\"ServerName\":\"S1\",\"DisplayName\":\"S1\"}", s_jsonOptions);
+        Assert.Null(back!.AlertDeliveryModeOverride);
+    }
+}

--- a/Lite/MainWindow.AlertEngine.cs
+++ b/Lite/MainWindow.AlertEngine.cs
@@ -756,7 +756,10 @@ public partial class MainWindow : Window
             string metricName, string serverName, string summaryCurrentValue, string thresholdValue,
             int serverId, AlertContext? context, bool isMuted, string? summaryDetailText)
         {
-            if (App.AlertDeliveryMode == AlertNotificationMode.PerEvent && context?.Incidents is { Count: > 0 })
+            /* #1236: a per-server override (Manage Servers -> Edit) wins over the global delivery mode;
+               null inherits App.AlertDeliveryMode. */
+            var deliveryMode = AlertDeliveryModeResolver.Resolve(ResolveServerDeliveryOverride(serverId), App.AlertDeliveryMode);
+            if (deliveryMode == AlertNotificationMode.PerEvent && context?.Incidents is { Count: > 0 })
             {
                 foreach (var msg in PerEventNotification.Split(context, App.AlertPerEventMaxPerCycle))
                 {
@@ -771,6 +774,14 @@ public partial class MainWindow : Window
                 metricName, serverName, summaryCurrentValue, thresholdValue, serverId,
                 context, muted: isMuted, detailText: summaryDetailText);
         }
+
+        /* #1236: the per-server delivery-mode override for serverId, or null to inherit the global
+           App.AlertDeliveryMode. serverId is the deterministic hash of the storage name (the same
+           mapping the alert loop uses), so map it back to the ServerConnection to read its override. */
+        private AlertNotificationMode? ResolveServerDeliveryOverride(int serverId) =>
+            _serverManager.GetAllServers().FirstOrDefault(s =>
+                RemoteCollectorService.GetDeterministicHashCode(RemoteCollectorService.GetServerNameForStorage(s)) == serverId)
+                ?.AlertDeliveryModeOverride;
 
         private static string? ContextToDetailText(AlertContext? context)
         {

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -12,6 +12,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitorLite.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorLite.Models;
 
@@ -98,6 +99,14 @@ public class ServerConnection : INotifyPropertyChanged
     /// Set to 0 to hide cost columns. All FinOps costs are proportional to this budget.
     /// </summary>
     public decimal MonthlyCostUsd { get; set; } = 0m;
+
+    /// <summary>
+    /// #1236: per-server override for the alert delivery mode (deadlock/blocking notifications).
+    /// null = inherit the global AlertDeliveryMode setting; Summary/PerEvent forces that mode for
+    /// this server regardless of the global default (e.g. Per-event for one noisy prod box, Summary
+    /// everywhere else). Resolved via <see cref="PerformanceMonitor.Notifications.AlertDeliveryModeResolver"/>.
+    /// </summary>
+    public AlertNotificationMode? AlertDeliveryModeOverride { get; set; }
 
     /// <summary>
     /// Optional database name for the initial connection.

--- a/Lite/Windows/AddServerDialog.xaml
+++ b/Lite/Windows/AddServerDialog.xaml
@@ -152,6 +152,15 @@
                 <TextBox x:Name="MonthlyCostBox" Width="100" TextAlignment="Right" Text="0"
                          ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Alert delivery:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
+                <ComboBox x:Name="AlertDeliveryOverrideBox" Width="240" SelectedIndex="0"
+                          ToolTip="How deadlock/blocking alerts for THIS server are delivered. 'Use global setting' follows the app-wide Alerts setting; override to force Summary or Per-event for just this server.">
+                    <ComboBoxItem Content="Use global setting"/>
+                    <ComboBoxItem Content="Summary — one card per cycle"/>
+                    <ComboBoxItem Content="Per-event — one notification per incident"/>
+                </ComboBox>
+            </StackPanel>
         </StackPanel>
 
         <!-- Status -->

--- a/Lite/Windows/AddServerDialog.xaml.cs
+++ b/Lite/Windows/AddServerDialog.xaml.cs
@@ -14,6 +14,7 @@ using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitorLite.Windows;
 
@@ -85,6 +86,12 @@ public partial class AddServerDialog : Window
         ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
         MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
         MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        AlertDeliveryOverrideBox.SelectedIndex = existing.AlertDeliveryModeOverride switch
+        {
+            AlertNotificationMode.Summary => 1,
+            AlertNotificationMode.PerEvent => 2,
+            _ => 0
+        };
 
         // Profile-backed server (M-3 edit-load): preselect "use profile" + the dropdown, and do NOT
         // call GetCredential(existing.Id) — there is intentionally no per-server secret to load.
@@ -212,6 +219,13 @@ public partial class AddServerDialog : Window
                 : Visibility.Collapsed;
         }
     }
+
+    private AlertNotificationMode? GetSelectedDeliveryOverride() => AlertDeliveryOverrideBox.SelectedIndex switch
+    {
+        1 => AlertNotificationMode.Summary,
+        2 => AlertNotificationMode.PerEvent,
+        _ => null
+    };
 
     private string GetSelectedEncryptMode()
     {
@@ -549,6 +563,7 @@ public partial class AddServerDialog : Window
                 AddedServer.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
                 if (decimal.TryParse(MonthlyCostBox.Text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var editCost) && editCost >= 0)
                     AddedServer.MonthlyCostUsd = editCost;
+                AddedServer.AlertDeliveryModeOverride = GetSelectedDeliveryOverride();
 
                 AddedServer.CredentialProfileId = useProfile ? selectedProfile!.Id : null;
 
@@ -599,6 +614,7 @@ public partial class AddServerDialog : Window
                     ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
                     MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
                     MonthlyCostUsd = monthlyCost,
+                    AlertDeliveryModeOverride = GetSelectedDeliveryOverride(),
                     CredentialProfileId = useProfile ? selectedProfile!.Id : null
                 };
 

--- a/PerformanceMonitor.Notifications/PerEventNotification.cs
+++ b/PerformanceMonitor.Notifications/PerEventNotification.cs
@@ -25,6 +25,18 @@ public enum AlertNotificationMode
 }
 
 /// <summary>
+/// #1236: resolves the effective alert delivery mode for a single server. A per-server override wins;
+/// a null override inherits the global <see cref="AlertNotificationMode"/> default. Centralized here so
+/// Lite and Dashboard apply identical precedence (e.g. Per-event for one noisy prod box while the global
+/// default stays Summary everywhere else).
+/// </summary>
+public static class AlertDeliveryModeResolver
+{
+    public static AlertNotificationMode Resolve(AlertNotificationMode? perServerOverride, AlertNotificationMode global)
+        => perServerOverride ?? global;
+}
+
+/// <summary>
 /// Splits a built alert <see cref="AlertContext"/> into per-incident messages for #1141 Per-event mode.
 /// Each distinct incident (already grouped + fingerprinted by #1140) becomes one message carrying that
 /// single incident; when the incident count exceeds the per-cycle cap, the overflow incidents are


### PR DESCRIPTION
Closes #1236.

The per-event vs batched-summary delivery mode shipped as a **global** setting in #1141. This adds the optional **per-server override** the original issue (#1141) asked for ("global and/or per-server") — e.g. Per-event for one noisy prod box, Summary everywhere else.

### The issue's "blocked on infrastructure" premise was stale
#1236 said the Dashboard "has no per-server settings store." It does: `ServerConnection` (servers.json) already persists per-server *settings* — `MonthlyCostUsd`, `IsFavorite`, `EncryptMode`, etc. The override rides that serialization for free; no new store.

### Changes (both apps, in parity)
- **Model:** `ServerConnection` gains a nullable `AlertDeliveryModeOverride`. `null` = inherit the global `AlertDeliveryMode`; `Summary`/`PerEvent` forces that mode for the one server. Persists in the existing `servers.json`.
- **Shared resolver:** `AlertDeliveryModeResolver.Resolve(override, global)` in `PerformanceMonitor.Notifications` centralizes the precedence (override wins, null inherits) so Lite and Dashboard can't drift.
- **Resolution:** `SendDetectedAlertAsync` (both apps) resolves the effective mode per server before the per-event split. Dashboard uses `GetServerById`; Lite maps its `int serverId` hash back to the `ServerConnection` (same idiom the alert loop already uses).
- **UI:** the Add/Edit Server dialog (both apps) gets an **"Alert delivery"** combo — *Use global setting* / *Summary* / *Per-event* — wired through load + save, next to the existing per-server fields.

### Tests
- Resolver precedence (override wins; null inherits global).
- `ServerConnection` JSON round-trip, including a **pre-#1236 file with no field deserializes to null** (inherits global).
- Dashboard.Tests **667 passed**, Lite.Tests **601 passed**, 0 failed. Both apps build clean.

### Not yet verified
The combo's **visual rendering + in-dialog persistence** needs an eyeball in both apps (I can't launch the worktree apps). Open **Manage Servers -> Edit** on a server and confirm the "Alert delivery" row renders/aligns and the selection round-trips. Logic + serialization are test-covered; this is the UI sign-off gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)