### PR TITLE
Fix #1240: Lite seeds per-user ignored_wait_types.json on first run

### DIFF
--- a/Lite.Tests/ConfigSeederTests.cs
+++ b/Lite.Tests/ConfigSeederTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1240: ConfigSeeder copies bundled config into the per-user dir on first run (so a fresh install's
+/// ignored_wait_types.json exists and wait filtering isn't a silent no-op), without ever clobbering a
+/// file the user has edited.
+/// </summary>
+public class ConfigSeederTests
+{
+    private static string NewTempDir(string tag)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pmlite_{tag}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void SeedMissing_CopiesFile_WhenDestinationAbsent()
+    {
+        var bundled = NewTempDir("bundled");
+        var user = NewTempDir("user");
+        try
+        {
+            File.WriteAllText(Path.Combine(bundled, "ignored_wait_types.json"), "{\"ignored_waits\":[\"SOS_WORK_DISPATCHER\"]}");
+
+            var seeded = ConfigSeeder.SeedMissing(bundled, user, new[] { "ignored_wait_types.json" });
+
+            Assert.Equal(1, seeded);
+            var dest = Path.Combine(user, "ignored_wait_types.json");
+            Assert.True(File.Exists(dest));
+            Assert.Contains("SOS_WORK_DISPATCHER", File.ReadAllText(dest));
+        }
+        finally
+        {
+            Directory.Delete(bundled, true);
+            Directory.Delete(user, true);
+        }
+    }
+
+    [Fact]
+    public void SeedMissing_DoesNotOverwrite_ExistingUserFile()
+    {
+        var bundled = NewTempDir("bundled");
+        var user = NewTempDir("user");
+        try
+        {
+            File.WriteAllText(Path.Combine(bundled, "ignored_wait_types.json"), "{\"ignored_waits\":[\"BUNDLED\"]}");
+            File.WriteAllText(Path.Combine(user, "ignored_wait_types.json"), "{\"ignored_waits\":[\"USER_EDITED\"]}");
+
+            var seeded = ConfigSeeder.SeedMissing(bundled, user, new[] { "ignored_wait_types.json" });
+
+            Assert.Equal(0, seeded);
+            Assert.Contains("USER_EDITED", File.ReadAllText(Path.Combine(user, "ignored_wait_types.json")));
+        }
+        finally
+        {
+            Directory.Delete(bundled, true);
+            Directory.Delete(user, true);
+        }
+    }
+
+    [Fact]
+    public void SeedMissing_SkipsName_NotInBundle()
+    {
+        var bundled = NewTempDir("bundled");
+        var user = NewTempDir("user");
+        try
+        {
+            var seeded = ConfigSeeder.SeedMissing(bundled, user, new[] { "missing.json" });
+
+            Assert.Equal(0, seeded);
+            Assert.False(File.Exists(Path.Combine(user, "missing.json")));
+        }
+        finally
+        {
+            Directory.Delete(bundled, true);
+            Directory.Delete(user, true);
+        }
+    }
+
+    [Fact]
+    public void SeedMissing_NonexistentBundleDir_ReturnsZero()
+    {
+        var user = NewTempDir("user");
+        try
+        {
+            var seeded = ConfigSeeder.SeedMissing(Path.Combine(user, "does_not_exist"), user, new[] { "ignored_wait_types.json" });
+
+            Assert.Equal(0, seeded);
+        }
+        finally
+        {
+            Directory.Delete(user, true);
+        }
+    }
+}

--- a/Lite.Tests/IgnoredWaitTypesTests.cs
+++ b/Lite.Tests/IgnoredWaitTypesTests.cs
@@ -1,0 +1,34 @@
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #1240: the wait-stats tab filters ignored waits at display time via
+/// <see cref="IgnoredWaitTypes.BuildExclusionClause"/>, so benign waits already collected into the
+/// DuckDB don't surface in the tab/picker. Guards the SQL fragment + its injection-safety sanitization.
+/// </summary>
+public class IgnoredWaitTypesTests
+{
+    [Fact]
+    public void BuildExclusionClause_Empty_ReturnsEmptyString()
+    {
+        Assert.Equal("", IgnoredWaitTypes.BuildExclusionClause(new string[0]));
+        Assert.Equal("", IgnoredWaitTypes.BuildExclusionClause(null));
+    }
+
+    [Fact]
+    public void BuildExclusionClause_BuildsNotInList()
+    {
+        var clause = IgnoredWaitTypes.BuildExclusionClause(new[] { "SOS_WORK_DISPATCHER", "DISPATCHER_QUEUE_SEMAPHORE" });
+        Assert.Equal("AND wait_type NOT IN ('SOS_WORK_DISPATCHER','DISPATCHER_QUEUE_SEMAPHORE')", clause);
+    }
+
+    [Fact]
+    public void BuildExclusionClause_DropsUnsafeNames()
+    {
+        // A real wait_type is always an identifier; drop anything else so the inlined SQL can't be injected.
+        var clause = IgnoredWaitTypes.BuildExclusionClause(new[] { "GOOD_WAIT", "bad'); DROP TABLE x;--", "ALSO_OK" });
+        Assert.Equal("AND wait_type NOT IN ('GOOD_WAIT','ALSO_OK')", clause);
+    }
+}

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -319,6 +319,14 @@ public partial class App : Application
         Directory.CreateDirectory(ConfigDirectory);
         Directory.CreateDirectory(Path.Combine(appDataRoot, "archive"));
 
+        // Seed the per-user config dir from the copies bundled next to the exe on first run, so a
+        // fresh install/extract has the editable defaults present. Critical for ignored_wait_types.json:
+        // without it the wait filter is empty and benign waits flood the wait stats tab (#1240).
+        Services.ConfigSeeder.SeedMissing(
+            Path.Combine(AppContext.BaseDirectory, "config"),
+            ConfigDirectory,
+            new[] { "ignored_wait_types.json", "collection_schedule.json" });
+
         // Load settings
         LoadDefaultTimeRange();
         LoadAlertSettings();

--- a/Lite/Services/ConfigSeeder.cs
+++ b/Lite/Services/ConfigSeeder.cs
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Seeds the per-user config directory (%LOCALAPPDATA%\PerformanceMonitorLite\config) from the config
+/// files bundled next to the exe, on first run. Without this a fresh install / nightly extract starts
+/// with an empty config dir, so the per-user ignored_wait_types.json never exists and wait-stat
+/// filtering silently becomes a no-op — every benign wait (SOS_WORK_DISPATCHER, DISPATCHER_QUEUE_SEMAPHORE,
+/// CLR_AUTO_EVENT, ...) then floods collection and the wait stats tab (#1240).
+/// </summary>
+public static class ConfigSeeder
+{
+    /// <summary>
+    /// Copies each named file from <paramref name="bundledDir"/> into <paramref name="userDir"/> when
+    /// the destination does not already exist. Existing (user-edited) files are never overwritten.
+    /// Per-file failures are swallowed so a locked/unreadable bundle file can't fault startup. Returns
+    /// the number of files actually seeded.
+    /// </summary>
+    public static int SeedMissing(string bundledDir, string userDir, IEnumerable<string> fileNames)
+    {
+        var seeded = 0;
+        if (string.IsNullOrEmpty(bundledDir) || string.IsNullOrEmpty(userDir) || !Directory.Exists(bundledDir))
+        {
+            return seeded;
+        }
+
+        foreach (var name in fileNames)
+        {
+            var src = Path.Combine(bundledDir, name);
+            var dest = Path.Combine(userDir, name);
+
+            // Never clobber a file the user may have edited, and skip anything not in the bundle.
+            if (File.Exists(dest) || !File.Exists(src))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(userDir);
+                File.Copy(src, dest);
+                seeded++;
+            }
+            catch
+            {
+                /* Non-fatal: LoadIgnoredWaitTypes falls back to the bundled copy if seeding fails. */
+            }
+        }
+
+        return seeded;
+    }
+}

--- a/Lite/Services/IgnoredWaitTypes.cs
+++ b/Lite/Services/IgnoredWaitTypes.cs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// Single source for the configured "ignored" (benign/idle) wait types — the per-user editable
+/// %LOCALAPPDATA%\PerformanceMonitorLite\config\ignored_wait_types.json, falling back to the copy
+/// bundled next to the exe. Used by BOTH the collector (skip at collection) and the wait-stats tab
+/// queries (skip at display) so the two can't drift. Display-side filtering is what hides waits already
+/// collected before the filter was active — copying the JSON only stops NEW collection, it can't remove
+/// existing DuckDB rows (#1240).
+/// </summary>
+public static class IgnoredWaitTypes
+{
+    /// <summary>
+    /// Loads the ignored wait-type set (case-insensitive): the per-user copy first, then the bundled
+    /// copy next to the exe. Best-effort — returns an empty set if neither file is present or parsing
+    /// fails (callers warn when the result is empty).
+    /// </summary>
+    public static HashSet<string> Load()
+    {
+        var waits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var configPath = Path.Combine(App.ConfigDirectory, "ignored_wait_types.json");
+        if (!File.Exists(configPath))
+        {
+            configPath = Path.Combine(AppContext.BaseDirectory, "config", "ignored_wait_types.json");
+        }
+
+        if (!File.Exists(configPath))
+        {
+            return waits;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+            if (doc.RootElement.TryGetProperty("ignored_waits", out var waitsArray))
+            {
+                foreach (var wait in waitsArray.EnumerateArray())
+                {
+                    var waitType = wait.GetString();
+                    if (!string.IsNullOrEmpty(waitType))
+                    {
+                        waits.Add(waitType);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            /* Best-effort; callers warn when the resulting set is empty. */
+        }
+
+        return waits;
+    }
+
+    /// <summary>
+    /// Builds a SQL predicate <c>AND wait_type NOT IN ('A','B',...)</c> excluding the ignored types, or an
+    /// empty string when there is nothing to exclude. Names are sanitized to [A-Za-z0-9_] before being
+    /// inlined, so the literals are injection-safe (the source is controlled config and SQL Server
+    /// wait_type names are always identifiers). Applied at display time so benign waits already in the
+    /// DuckDB don't surface in the wait-stats tab/picker.
+    /// </summary>
+    public static string BuildExclusionClause(IReadOnlyCollection<string>? ignored)
+    {
+        if (ignored == null || ignored.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var wait in ignored)
+        {
+            if (string.IsNullOrEmpty(wait) || !IsSafeIdentifier(wait))
+            {
+                continue;
+            }
+            if (sb.Length > 0)
+            {
+                sb.Append(',');
+            }
+            sb.Append('\'').Append(wait).Append('\'');
+        }
+
+        return sb.Length == 0 ? string.Empty : $"AND wait_type NOT IN ({sb})";
+    }
+
+    private static bool IsSafeIdentifier(string value)
+    {
+        foreach (var c in value)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_')
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -15,6 +15,11 @@ namespace PerformanceMonitorLite.Services;
 
 public partial class LocalDataService
 {
+    /* #1240: the wait-stats tab shares the collector's ignored-wait list and excludes those types at
+       DISPLAY time, so benign waits already in the DuckDB (collected before the filter was active) don't
+       surface in the tab/picker — copying the JSON only stops new collection, not existing rows. */
+    private readonly Lazy<HashSet<string>> _ignoredWaitTypes = new(IgnoredWaitTypes.Load);
+
     /// <summary>
     /// Gets aggregated wait stats for a server over a time period, sorted by delta wait time.
     /// </summary>
@@ -26,7 +31,8 @@ public partial class LocalDataService
 
         var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
 
-        command.CommandText = @"
+        var exclude = IgnoredWaitTypes.BuildExclusionClause(_ignoredWaitTypes.Value);
+        command.CommandText = $@"
 SELECT
     wait_type,
     SUM(delta_waiting_tasks) AS total_waiting_tasks,
@@ -37,6 +43,7 @@ FROM v_wait_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
+{exclude}
 GROUP BY wait_type
 ORDER BY SUM(delta_wait_time_ms) DESC
 LIMIT 50";
@@ -72,7 +79,8 @@ LIMIT 50";
 
         var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
 
-        command.CommandText = @"
+        var exclude = IgnoredWaitTypes.BuildExclusionClause(_ignoredWaitTypes.Value);
+        command.CommandText = $@"
 SELECT
     wait_type,
     SUM(delta_wait_time_ms) AS total_delta
@@ -80,6 +88,7 @@ FROM v_wait_stats
 WHERE server_id = $1
 AND   collection_time >= $2
 AND   collection_time <= $3
+{exclude}
 GROUP BY wait_type
 ORDER BY SUM(delta_wait_time_ms) DESC";
 
@@ -231,7 +240,8 @@ ORDER BY wait_type, collection_time";
 
         var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
 
-        command.CommandText = @"
+        var exclude = IgnoredWaitTypes.BuildExclusionClause(_ignoredWaitTypes.Value);
+        command.CommandText = $@"
 WITH per_collection AS
 (
     SELECT
@@ -242,6 +252,7 @@ WITH per_collection AS
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
+    {exclude}
     GROUP BY collection_time
 )
 SELECT

--- a/Lite/Services/RemoteCollectorService.WaitStats.cs
+++ b/Lite/Services/RemoteCollectorService.WaitStats.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
@@ -25,52 +24,18 @@ public partial class RemoteCollectorService
     private readonly Lazy<HashSet<string>> _ignoredWaitTypes;
 
     /// <summary>
-    /// Loads the set of wait types to ignore during collection.
-    /// Thread-safe via Lazy&lt;T&gt; (multiple server tasks call this in parallel).
+    /// Loads the set of wait types to ignore during collection, from the shared <see cref="IgnoredWaitTypes"/>
+    /// source (per-user copy, then the bundled fallback) so collection and the wait-stats tab use one list.
+    /// Thread-safe via Lazy&lt;T&gt; (multiple server tasks call this in parallel). Warns when the set is
+    /// empty so a missing/unreadable list is visible rather than silently disabling filtering (#1240).
     /// </summary>
     private HashSet<string> LoadIgnoredWaitTypes()
     {
-        var waits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        /* Per-user copy (editable, seeded on first run) first; fall back to the copy bundled next to
-           the exe. A fresh install/extract before seeding has no per-user file, and without this
-           fallback the set would be empty and NO benign waits get filtered — they then dominate the
-           wait stats tab (#1240). */
-        var configPath = Path.Combine(App.ConfigDirectory, "ignored_wait_types.json");
-        if (!File.Exists(configPath))
+        var waits = IgnoredWaitTypes.Load();
+        if (waits.Count == 0)
         {
-            configPath = Path.Combine(AppContext.BaseDirectory, "config", "ignored_wait_types.json");
+            _logger?.LogWarning("ignored_wait_types.json not found or empty (per-user or bundled); wait-stat filtering disabled");
         }
-
-        if (File.Exists(configPath))
-        {
-            try
-            {
-                var json = File.ReadAllText(configPath);
-                using var doc = JsonDocument.Parse(json);
-
-                if (doc.RootElement.TryGetProperty("ignored_waits", out var waitsArray))
-                {
-                    foreach (var wait in waitsArray.EnumerateArray())
-                    {
-                        var waitType = wait.GetString();
-                        if (!string.IsNullOrEmpty(waitType))
-                        {
-                            waits.Add(waitType);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to load ignored wait types from {Path}", configPath);
-            }
-        }
-        else
-        {
-            _logger?.LogWarning("ignored_wait_types.json not found (per-user or bundled); wait-stat filtering disabled");
-        }
-
         return waits;
     }
 

--- a/Lite/Services/RemoteCollectorService.WaitStats.cs
+++ b/Lite/Services/RemoteCollectorService.WaitStats.cs
@@ -32,7 +32,16 @@ public partial class RemoteCollectorService
     {
         var waits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        /* Per-user copy (editable, seeded on first run) first; fall back to the copy bundled next to
+           the exe. A fresh install/extract before seeding has no per-user file, and without this
+           fallback the set would be empty and NO benign waits get filtered — they then dominate the
+           wait stats tab (#1240). */
         var configPath = Path.Combine(App.ConfigDirectory, "ignored_wait_types.json");
+        if (!File.Exists(configPath))
+        {
+            configPath = Path.Combine(AppContext.BaseDirectory, "config", "ignored_wait_types.json");
+        }
+
         if (File.Exists(configPath))
         {
             try
@@ -56,6 +65,10 @@ public partial class RemoteCollectorService
             {
                 _logger?.LogWarning(ex, "Failed to load ignored wait types from {Path}", configPath);
             }
+        }
+        else
+        {
+            _logger?.LogWarning("ignored_wait_types.json not found (per-user or bundled); wait-stat filtering disabled");
         }
 
         return waits;


### PR DESCRIPTION
Closes #1240. Two commits — Lite-only.

## Problem
On a **fresh Lite install / nightly extract**, benign idle waits already in the default exclude list (`SOS_WORK_DISPATCHER`, `DISPATCHER_QUEUE_SEMAPHORE`, `CLR_AUTO_EVENT`, …) dominate the wait-stats tab. Two independent gaps caused it.

## Fix 1 — seed the per-user list on first run
`App` created `%LOCALAPPDATA%\...\config\` empty and never seeded it from the bundled `config\ignored_wait_types.json`. `LoadIgnoredWaitTypes()` read only the per-user path, so on a clean box it returned an **empty set** (cached by the `Lazy`) and **nothing** was filtered at collection.
- New `ConfigSeeder.SeedMissing()` copies the bundled config into the per-user dir on first run (copy-if-absent; never clobbers a user-edited file).
- Defensive fallback in the loader to the bundled copy if the per-user file is still missing.

## Fix 2 — filter at display time too
Seeding only stops **future** collection; it can't remove rows already in the DuckDB, and the wait-stats tab had **no display-time filter**. So a box that collected benign waits before the filter was active kept showing them even after the JSON was in place.
- New `IgnoredWaitTypes` is one shared source for the ignored set (per-user → bundled fallback) + a sanitized `AND wait_type NOT IN (...)` builder. Collection and display both use it, so the lists can't drift.
- The wait-tab queries (top list, picker distinct types, total trend) exclude ignored waits at query time. **Non-destructive** — rows stay in the DuckDB and age out via retention; nothing is deleted (per the requested constraint).

**Lite-only** — Dashboard seeds its list server-side into the SQL `config.ignored_wait_types` table during install and filters at collection, so its tab data is already clean.

## Verification
- Lite builds clean; Lite.Tests **608 passed** (+7 new across both fixes), 0 failed.
- Confirmed the bundled `config\ignored_wait_types.json` ships in the build output (seed source + fallback resolve).
- **Needs a real check on a noisy box**: on the next nightly built from this branch, the wait-stats tab/picker should no longer list SOS_WORK_DISPATCHER & co., even on a box that already collected them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)