### PR TITLE
Make click-to-isolate dim-only (no Y auto-fit)

### DIFF
--- a/Dashboard.Tests/ChartClickIsolateTests.cs
+++ b/Dashboard.Tests/ChartClickIsolateTests.cs
@@ -6,7 +6,6 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System.Collections.Generic;
 using PerformanceMonitor.Ui;
 using Xunit;
 
@@ -14,10 +13,9 @@ namespace PerformanceMonitorDashboard.Tests;
 
 /// <summary>
 /// Tests the pure, app-agnostic logic behind the shared chart click-to-isolate mechanic
-/// (<see cref="ChartHoverHelper"/>): toggle transitions, the dim-vs-restore visual decision, the
-/// isolate Y-fit range math (incl. the degenerate-flat guard and the deliberate no-zero-anchor),
-/// and the axis-rules save/clear/restore bookkeeping. No live WpfPlot needed. Mirror of
-/// Lite.Tests for parity.
+/// (<see cref="ChartHoverHelper"/>): toggle transitions, the dim-vs-full visual decision, and faithful
+/// per-series restore for fill vs line-only charts. Isolate dims the other series and leaves the Y axis
+/// untouched (no auto-fit). Mirror of Lite.Tests for parity.
 /// </summary>
 public class ChartClickIsolateTests
 {
@@ -48,7 +46,7 @@ public class ChartClickIsolateTests
         Assert.Equal("cxpacket", ChartHoverHelper.NextIsolate("CXPACKET", "cxpacket"));
     }
 
-    // ── ResolveSeriesVisual: dim vs restore decision + FillY flag ─────────────────────────────
+    // ── ResolveSeriesVisual: dim vs full decision ────────────────────────────────────────────
 
     [Fact]
     public void ResolveSeriesVisual_NothingIsolated_EverySeriesIsFull()
@@ -82,128 +80,6 @@ public class ChartClickIsolateTests
         Assert.Equal((byte)40, ChartHoverHelper.IsolateVisual.Dimmed.LineAlpha);
         Assert.True(ChartHoverHelper.IsolateVisual.Full.FillRibbon);
         Assert.False(ChartHoverHelper.IsolateVisual.Full.Dim);
-    }
-
-    // ── ComputeIsolateYLimits: AutoFitY range math ────────────────────────────────────────────
-
-    private static IReadOnlyList<(double X, double Y)> Pts(params (double X, double Y)[] p) => p;
-
-    [Fact]
-    public void ComputeIsolateYLimits_FitsVisibleMinMax_WithFivePercentMargin()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 0), (2, 10), (3, 5)), xMin: 1, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(-0.5, r!.Value.Min, 6);        // 0 - (10-0)*0.05
-        Assert.Equal(10.5, r.Value.Max, 6);         // 10 + (10-0)*0.05
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_OnlyConsidersPointsInVisibleXRange()
-    {
-        // The x=1 spike at y=100 is outside the visible window [2,3] and must be excluded.
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 100), (2, 0), (3, 10)), xMin: 2, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(-0.5, r!.Value.Min, 6);
-        Assert.Equal(10.5, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_DegenerateFlatSeries_WidensToNonZeroHeight()
-    {
-        // A flat line (min == max) would give a zero-height axis; the guard widens it to [min, min+1].
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 5), (2, 5), (3, 5)), xMin: 1, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(4.95, r!.Value.Min, 6);        // 5   - (6-5)*0.05
-        Assert.Equal(6.05, r.Value.Max, 6);         // 5+1 + (6-5)*0.05
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_HighBaseline_DoesNotAnchorToZero()
-    {
-        // The whole point of isolate: reveal a series' own variation even at a high baseline.
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 5000), (2, 5100)), xMin: 1, xMax: 2);
-        Assert.NotNull(r);
-        Assert.Equal(4995, r!.Value.Min, 6);        // 5000 - (5100-5000)*0.05  — NOT 0
-        Assert.Equal(5105, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_NoPointsVisible_FallsBackToWholeSeries()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 2), (2, 4)), xMin: 10, xMax: 20);
-        Assert.NotNull(r);
-        Assert.Equal(1.9, r!.Value.Min, 6);         // falls back to the full series: 2 - (4-2)*0.05
-        Assert.Equal(4.1, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_IgnoresNaNAndInfinity()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(
-            Pts((1, double.NaN), (2, 10), (3, double.PositiveInfinity), (4, 20)), xMin: 1, xMax: 4);
-        Assert.NotNull(r);
-        Assert.Equal(9.5, r!.Value.Min, 6);         // only y=10 and y=20 count
-        Assert.Equal(20.5, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_EmptySeries_ReturnsNull()
-    {
-        Assert.Null(ChartHoverHelper.ComputeIsolateYLimits(Pts(), xMin: 0, xMax: 1));
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_AllNonFinite_ReturnsNull()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(
-            Pts((1, double.NaN), (2, double.NegativeInfinity)), xMin: 1, xMax: 2);
-        Assert.Null(r);
-    }
-
-    // ── SaveAndClearRules / RestoreAxisRules: bookkeeping ─────────────────────────────────────
-
-    [Fact]
-    public void SaveAndClearRules_SnapshotsThenEmptiesLiveList()
-    {
-        var live = new List<string> { "LockedVertical", "OtherRule" };
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-
-        Assert.Equal(new[] { "LockedVertical", "OtherRule" }, saved);
-        Assert.Empty(live);                          // cleared so the isolate Y-fit can stick
-    }
-
-    [Fact]
-    public void RestoreAxisRules_ReplacesWhateverARerenderInstalled_WithTheSavedRules()
-    {
-        var live = new List<string> { "LockedVertical" };
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-
-        // Simulate a re-render installing a fresh rule into the now-empty live list.
-        live.Add("FreshlyInstalledRule");
-
-        ChartHoverHelper.RestoreAxisRules(live, saved);
-        Assert.Equal(new[] { "LockedVertical" }, live);
-    }
-
-    [Fact]
-    public void RestoreAxisRules_NullSaved_IsNoOp_AndLeavesLiveRulesIntact()
-    {
-        // Lite installs no rules, so _savedRules is null there — restore must NOT clear the live list.
-        var live = new List<string> { "SomeLiveRule" };
-        ChartHoverHelper.RestoreAxisRules(live, (IReadOnlyList<string>?)null);
-        Assert.Equal(new[] { "SomeLiveRule" }, live);
-    }
-
-    [Fact]
-    public void SaveAndRestore_RoundTrips_EmptyRuleSet()
-    {
-        var live = new List<string>();
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-        Assert.Empty(saved);
-
-        live.Add("AddedDuringIsolate");
-        ChartHoverHelper.RestoreAxisRules(live, saved);
-        Assert.Empty(live);                          // back to the original (empty) rule set
     }
 
     // ── RestoreSeriesVisual: faithful restore for line-only AND fill charts (regression) ─────────

--- a/Lite.Tests/ChartClickIsolateTests.cs
+++ b/Lite.Tests/ChartClickIsolateTests.cs
@@ -6,7 +6,6 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System.Collections.Generic;
 using PerformanceMonitor.Ui;
 using Xunit;
 
@@ -14,10 +13,9 @@ namespace PerformanceMonitorLite.Tests;
 
 /// <summary>
 /// Tests the pure, app-agnostic logic behind the shared chart click-to-isolate mechanic
-/// (<see cref="ChartHoverHelper"/>): toggle transitions, the dim-vs-restore visual decision, the
-/// isolate Y-fit range math (incl. the degenerate-flat guard and the deliberate no-zero-anchor),
-/// and the axis-rules save/clear/restore bookkeeping. No live WpfPlot needed. Mirror of
-/// Dashboard.Tests for parity.
+/// (<see cref="ChartHoverHelper"/>): toggle transitions, the dim-vs-full visual decision, and faithful
+/// per-series restore for fill vs line-only charts. Isolate dims the other series and leaves the Y axis
+/// untouched (no auto-fit). Mirror of Dashboard.Tests for parity.
 /// </summary>
 public class ChartClickIsolateTests
 {
@@ -48,7 +46,7 @@ public class ChartClickIsolateTests
         Assert.Equal("cxpacket", ChartHoverHelper.NextIsolate("CXPACKET", "cxpacket"));
     }
 
-    // ── ResolveSeriesVisual: dim vs restore decision + FillY flag ─────────────────────────────
+    // ── ResolveSeriesVisual: dim vs full decision ────────────────────────────────────────────
 
     [Fact]
     public void ResolveSeriesVisual_NothingIsolated_EverySeriesIsFull()
@@ -82,128 +80,6 @@ public class ChartClickIsolateTests
         Assert.Equal((byte)40, ChartHoverHelper.IsolateVisual.Dimmed.LineAlpha);
         Assert.True(ChartHoverHelper.IsolateVisual.Full.FillRibbon);
         Assert.False(ChartHoverHelper.IsolateVisual.Full.Dim);
-    }
-
-    // ── ComputeIsolateYLimits: AutoFitY range math ────────────────────────────────────────────
-
-    private static IReadOnlyList<(double X, double Y)> Pts(params (double X, double Y)[] p) => p;
-
-    [Fact]
-    public void ComputeIsolateYLimits_FitsVisibleMinMax_WithFivePercentMargin()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 0), (2, 10), (3, 5)), xMin: 1, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(-0.5, r!.Value.Min, 6);        // 0 - (10-0)*0.05
-        Assert.Equal(10.5, r.Value.Max, 6);         // 10 + (10-0)*0.05
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_OnlyConsidersPointsInVisibleXRange()
-    {
-        // The x=1 spike at y=100 is outside the visible window [2,3] and must be excluded.
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 100), (2, 0), (3, 10)), xMin: 2, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(-0.5, r!.Value.Min, 6);
-        Assert.Equal(10.5, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_DegenerateFlatSeries_WidensToNonZeroHeight()
-    {
-        // A flat line (min == max) would give a zero-height axis; the guard widens it to [min, min+1].
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 5), (2, 5), (3, 5)), xMin: 1, xMax: 3);
-        Assert.NotNull(r);
-        Assert.Equal(4.95, r!.Value.Min, 6);        // 5   - (6-5)*0.05
-        Assert.Equal(6.05, r.Value.Max, 6);         // 5+1 + (6-5)*0.05
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_HighBaseline_DoesNotAnchorToZero()
-    {
-        // The whole point of isolate: reveal a series' own variation even at a high baseline.
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 5000), (2, 5100)), xMin: 1, xMax: 2);
-        Assert.NotNull(r);
-        Assert.Equal(4995, r!.Value.Min, 6);        // 5000 - (5100-5000)*0.05  — NOT 0
-        Assert.Equal(5105, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_NoPointsVisible_FallsBackToWholeSeries()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(Pts((1, 2), (2, 4)), xMin: 10, xMax: 20);
-        Assert.NotNull(r);
-        Assert.Equal(1.9, r!.Value.Min, 6);         // falls back to the full series: 2 - (4-2)*0.05
-        Assert.Equal(4.1, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_IgnoresNaNAndInfinity()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(
-            Pts((1, double.NaN), (2, 10), (3, double.PositiveInfinity), (4, 20)), xMin: 1, xMax: 4);
-        Assert.NotNull(r);
-        Assert.Equal(9.5, r!.Value.Min, 6);         // only y=10 and y=20 count
-        Assert.Equal(20.5, r.Value.Max, 6);
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_EmptySeries_ReturnsNull()
-    {
-        Assert.Null(ChartHoverHelper.ComputeIsolateYLimits(Pts(), xMin: 0, xMax: 1));
-    }
-
-    [Fact]
-    public void ComputeIsolateYLimits_AllNonFinite_ReturnsNull()
-    {
-        var r = ChartHoverHelper.ComputeIsolateYLimits(
-            Pts((1, double.NaN), (2, double.NegativeInfinity)), xMin: 1, xMax: 2);
-        Assert.Null(r);
-    }
-
-    // ── SaveAndClearRules / RestoreAxisRules: bookkeeping ─────────────────────────────────────
-
-    [Fact]
-    public void SaveAndClearRules_SnapshotsThenEmptiesLiveList()
-    {
-        var live = new List<string> { "LockedVertical", "OtherRule" };
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-
-        Assert.Equal(new[] { "LockedVertical", "OtherRule" }, saved);
-        Assert.Empty(live);                          // cleared so the isolate Y-fit can stick
-    }
-
-    [Fact]
-    public void RestoreAxisRules_ReplacesWhateverARerenderInstalled_WithTheSavedRules()
-    {
-        var live = new List<string> { "LockedVertical" };
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-
-        // Simulate a re-render installing a fresh rule into the now-empty live list.
-        live.Add("FreshlyInstalledRule");
-
-        ChartHoverHelper.RestoreAxisRules(live, saved);
-        Assert.Equal(new[] { "LockedVertical" }, live);
-    }
-
-    [Fact]
-    public void RestoreAxisRules_NullSaved_IsNoOp_AndLeavesLiveRulesIntact()
-    {
-        // Lite installs no rules, so _savedRules is null there — restore must NOT clear the live list.
-        var live = new List<string> { "SomeLiveRule" };
-        ChartHoverHelper.RestoreAxisRules(live, (IReadOnlyList<string>?)null);
-        Assert.Equal(new[] { "SomeLiveRule" }, live);
-    }
-
-    [Fact]
-    public void SaveAndRestore_RoundTrips_EmptyRuleSet()
-    {
-        var live = new List<string>();
-        var saved = ChartHoverHelper.SaveAndClearRules(live);
-        Assert.Empty(saved);
-
-        live.Add("AddedDuringIsolate");
-        ChartHoverHelper.RestoreAxisRules(live, saved);
-        Assert.Empty(live);                          // back to the original (empty) rule set
     }
 
     // ── RestoreSeriesVisual: faithful restore for line-only AND fill charts (regression) ─────────

--- a/PerformanceMonitor.Ui/ChartHoverHelper.cs
+++ b/PerformanceMonitor.Ui/ChartHoverHelper.cs
@@ -42,8 +42,6 @@ internal sealed class ChartHoverHelper
     // ── Click-to-isolate state ─────────────────────────────────────────────────────────────────
     private readonly bool _enableClickIsolate;
     private string? _isolatedLabel;                              // null = nothing isolated
-    private ScottPlot.AxisLimits? _preIsolateLimits;            // axis limits captured at isolate time
-    private IReadOnlyList<ScottPlot.IAxisRule>? _savedRules;    // axis rules cleared during isolate
     private bool _leftPressed;
     private Point _pressPos;
     private bool _suppressNextLeftUp;                          // set on double-click so the 2nd up can't re-isolate
@@ -148,10 +146,8 @@ internal sealed class ChartHoverHelper
 
     public void Clear()
     {
-        // A re-render resets isolate (the build re-installs any LockedVertical rule itself).
+        // A re-render resets isolate.
         _isolatedLabel = null;
-        _preIsolateLimits = null;
-        _savedRules = null;
         _series.Clear();
         _barPlots.Clear();
     }
@@ -465,15 +461,9 @@ internal sealed class ChartHoverHelper
     {
         if (_series.Count == 0) return;
 
-        // Snapshot the restore state ONLY when entering isolate from the full view. Switching straight
-        // from one isolated series to another (A→B, with no Restore in between) must keep the ORIGINAL
-        // limits + rules captured at A: re-capturing here would save A's already-Y-fitted axes and the
-        // already-emptied rule list, so toggling B off later would restore the wrong view (and, on
-        // Dashboard, drop the LockedVertical rule).
-        bool enteringFresh = _isolatedLabel is null;
-        if (enteringFresh)
-            _preIsolateLimits = _chart.Plot.Axes.GetLimits();
-
+        // Dim every other series; leave the isolated one at its true original look. The Y axis is left
+        // untouched — isolate is a focus aid, not a zoom. (To inspect a buried series, deselect the big
+        // ones in the picker, which re-renders + autoscales.)
         foreach (var entry in _series)
         {
             var visual = ResolveSeriesVisual(label, entry.Label);
@@ -491,19 +481,11 @@ internal sealed class ChartHoverHelper
         }
 
         _isolatedLabel = label;
-
-        // Clear axis rules so the Y-fit sticks — Dashboard installs a LockedVertical rule every render
-        // that would otherwise revert SetLimitsY (Lite installs none, so this is a no-op there). On an
-        // A→B switch the rules are already cleared from A's isolate, so B's SetLimitsY still sticks.
-        if (enteringFresh)
-            _savedRules = SaveAndClearRules(_chart.Plot.Axes.Rules);
-        AutoFitYToSeries(label);
         _chart.Refresh();
     }
 
-    /// <summary>Restores the full multi-series view: un-dims every series, puts back the saved axis
-    /// rules and pre-isolate limits. A no-op when nothing is isolated (so the per-app autoscale hook
-    /// can call it unconditionally).</summary>
+    /// <summary>Un-dims every series back to the full multi-series view. A no-op when nothing is isolated
+    /// (so the per-app autoscale hook can call it unconditionally).</summary>
     internal void Restore()
     {
         if (_isolatedLabel is null) return;
@@ -511,13 +493,6 @@ internal sealed class ChartHoverHelper
         foreach (var entry in _series)
             RestoreSeriesVisual(entry);                                   // faithful for fill + line-only charts
         _isolatedLabel = null;
-
-        RestoreAxisRules(_chart.Plot.Axes.Rules, _savedRules);
-        _savedRules = null;
-        if (_preIsolateLimits is not null)
-            _chart.Plot.Axes.SetLimits(_preIsolateLimits.Value);
-        _preIsolateLimits = null;
-
         _chart.Refresh();
     }
 
@@ -544,24 +519,6 @@ internal sealed class ChartHoverHelper
         }
     }
 
-    private void AutoFitYToSeries(string label)
-    {
-        SeriesEntry entry = default;
-        bool found = false;
-        foreach (var e in _series)
-            if (string.Equals(e.Label, label, StringComparison.Ordinal)) { entry = e; found = true; break; }
-        if (!found || entry.Scatter is null) return;
-
-        var limits = _chart.Plot.Axes.GetLimits();
-        var pts = entry.Scatter.Data.GetScatterPoints();
-        var tuples = new List<(double X, double Y)>(pts.Count);
-        foreach (var p in pts) tuples.Add((p.X, p.Y));
-
-        var fit = ComputeIsolateYLimits(tuples, limits.Left, limits.Right);
-        if (fit is not null)
-            _chart.Plot.Axes.SetLimitsY(fit.Value.Min, fit.Value.Max);
-    }
-
     // ── Pure helpers (unit tested; no live WpfPlot needed) ──────────────────────────────────────
 
     /// <summary>The next isolate target given the current one and a freshly clicked label: clicking
@@ -585,60 +542,4 @@ internal sealed class ChartHoverHelper
         public static readonly IsolateVisual Full = new(false, 255, true);
     }
 
-    /// <summary>
-    /// Y-axis limits that fit a single isolated series over the currently visible X-range, padded
-    /// ~5% each side. Prefers points inside [<paramref name="xMin"/>,<paramref name="xMax"/>]; if none
-    /// are visible, falls back to the whole series. Returns null when there is nothing finite to fit
-    /// (caller leaves the axis alone). A degenerate flat series (max &lt;= min) is widened to
-    /// [min, min+1] before padding so the axis keeps a non-zero height (mirrors
-    /// <see cref="ChartStyle.SetChartYLimitsWithLegendPadding"/>). Deliberately does NOT anchor to
-    /// zero — the whole point of isolate is to reveal a series' own variation, even at a high baseline.
-    /// </summary>
-    internal static (double Min, double Max)? ComputeIsolateYLimits(
-        IReadOnlyList<(double X, double Y)> points, double xMin, double xMax)
-    {
-        if (points is null || points.Count == 0) return null;
-
-        static bool Scan(IReadOnlyList<(double X, double Y)> pts, double lo, double hi,
-            out double min, out double max)
-        {
-            min = double.MaxValue; max = double.MinValue; bool any = false;
-            foreach (var (x, y) in pts)
-            {
-                if (x < lo || x > hi) continue;
-                if (double.IsNaN(y) || double.IsInfinity(y)) continue;
-                if (y < min) min = y;
-                if (y > max) max = y;
-                any = true;
-            }
-            return any;
-        }
-
-        if (!Scan(points, xMin, xMax, out double yMin, out double yMax))
-            if (!Scan(points, double.NegativeInfinity, double.PositiveInfinity, out yMin, out yMax))
-                return null;
-
-        if (yMax <= yMin) yMax = yMin + 1;            // degenerate flat guard (mirror ChartStyle.cs:182)
-        double margin = (yMax - yMin) * 0.05;         // small breathing room on each side
-        return (yMin - margin, yMax + margin);
-    }
-
-    /// <summary>Snapshots and clears a chart's axis rules so an isolate Y-fit can override a
-    /// LockedVertical rule. Returns the saved list for <see cref="RestoreAxisRules{T}"/>. Generic so
-    /// it is unit testable without a live plot.</summary>
-    internal static List<T> SaveAndClearRules<T>(IList<T> liveRules)
-    {
-        var saved = new List<T>(liveRules);
-        liveRules.Clear();
-        return saved;
-    }
-
-    /// <summary>Restores rules saved by <see cref="SaveAndClearRules{T}"/> (no-op when null), replacing
-    /// whatever rules a re-render may have installed in the meantime.</summary>
-    internal static void RestoreAxisRules<T>(IList<T> liveRules, IReadOnlyList<T>? saved)
-    {
-        if (saved is null) return;
-        liveRules.Clear();
-        foreach (var r in saved) liveRules.Add(r);
-    }
 }


### PR DESCRIPTION
Follow-up to #1242 (chart click-to-isolate), per UX feedback.

Isolating a series auto-fit the Y axis to that series' own high-water marks every time. That's useful when the line is buried/flat, but jarring when the series is already prominent — so the auto-fit comes out. **Isolate now just dims the other series and leaves the axes untouched.** (To inspect a buried wait, deselect the big ones in the picker, which re-renders + autoscales.)

This also lets the now-unused Y-fit + axis-rule machinery go: `AutoFitYToSeries`, `ComputeIsolateYLimits`, `SaveAndClearRules`/`RestoreAxisRules`, the `_preIsolateLimits`/`_savedRules` fields, and their unit tests. `Restore` just un-dims now. The legend/line hit-test, the dim-vs-full decision, the per-series restore fidelity (fill vs line-only), and the autoscale-coordination hooks are unchanged.

**Verified:** both apps build green; Dashboard.Tests 677, Lite.Tests 618, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)