### PR TITLE
Overview lanes: render empty Blocking/Deadlocking lane as a live 0-1 grid

### DIFF
--- a/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Dashboard/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -644,19 +644,27 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         chart.Plot.Clear();
     }
 
-    private static void ShowEmpty(ScottPlot.WPF.WpfPlot chart, string title)
+    /* Render an empty lane as a live, gridded chart instead of a dead black box. This is most often
+       the Blocking/Deadlocking lane on a healthy server (no events = good news), so make it match the
+       populated lanes: keep the grid and show a 0-1 Y axis. We no longer blank the axes or add the old
+       "No Data" text (which SyncXAxes pushed off-screen anyway). X limits and the vertical gridlines are
+       set afterward by SyncXAxes so the time axis aligns with the other lanes; the left axis keeps its
+       default numeric ticks, so 0/1 labels and horizontal gridlines render. SyncXAxes also issues the
+       Refresh. The title arg is retained for call-site readability. */
+    private void ShowEmpty(ScottPlot.WPF.WpfPlot chart, string title)
     {
+        chart.Plot.Axes.DateTimeTicksBottomDateChange();
+        // Only the bottom (File I/O) lane shows time labels; the upper lanes hide them (matches UpdateLane).
+        if (chart != FileIoChart)
+            chart.Plot.Axes.Bottom.TickLabelStyle.IsVisible = false;
+
         TabHelpers.ReapplyAxisColors(chart);
-        var text = chart.Plot.Add.Text($"{title}\nNo Data", 0, 0);
-        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
-        text.LabelFontSize = 12;
-        text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
-        chart.Plot.HideGrid();
-        chart.Plot.Axes.SetLimitsX(-1, 1);
-        chart.Plot.Axes.SetLimitsY(-1, 1);
-        chart.Plot.Axes.Bottom.TickGenerator = new ScottPlot.TickGenerators.EmptyTickGenerator();
-        chart.Plot.Axes.Left.TickGenerator = new ScottPlot.TickGenerators.EmptyTickGenerator();
+
+        chart.Plot.Title("");
+        chart.Plot.YLabel("");
         chart.Plot.Legend.IsVisible = false;
+        chart.Plot.Axes.Margins(bottom: 0);
+        chart.Plot.Axes.SetLimitsY(0, 1);
     }
 
     /// <summary>

--- a/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Lite/Controls/CorrelatedTimelineLanesControl.xaml.cs
@@ -624,19 +624,28 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         chart.Plot.Clear();
     }
 
-    private static void ShowEmpty(ScottPlot.WPF.WpfPlot chart, string title)
+    /* Render an empty lane as a live, gridded chart instead of a dead black box. This is most often
+       the Blocking/Deadlocking lane on a healthy server (no events = good news), so make it match the
+       populated lanes: keep the grid and show a 0-1 Y axis. We no longer blank the axes or add the old
+       "No Data" text (which SyncXAxes pushed off-screen anyway). X limits and the vertical gridlines are
+       set afterward by SyncXAxes so the time axis aligns with the other lanes; the left axis keeps its
+       default numeric ticks, so 0/1 labels and horizontal gridlines render. The title arg is retained
+       for call-site readability. */
+    private void ShowEmpty(ScottPlot.WPF.WpfPlot chart, string title)
     {
+        chart.Plot.Axes.DateTimeTicksBottomDateChange();
+        // Only the bottom (File I/O) lane shows time labels; the upper lanes hide them (matches UpdateLane).
+        if (chart != FileIoChart)
+            chart.Plot.Axes.Bottom.TickLabelStyle.IsVisible = false;
+
         ReapplyAxisColors(chart);
-        var text = chart.Plot.Add.Text($"{title}\nNo Data", 0, 0);
-        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
-        text.LabelFontSize = 12;
-        text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
-        chart.Plot.HideGrid();
-        chart.Plot.Axes.SetLimitsX(-1, 1);
-        chart.Plot.Axes.SetLimitsY(-1, 1);
-        chart.Plot.Axes.Bottom.TickGenerator = new ScottPlot.TickGenerators.EmptyTickGenerator();
-        chart.Plot.Axes.Left.TickGenerator = new ScottPlot.TickGenerators.EmptyTickGenerator();
+
+        chart.Plot.Title("");
+        chart.Plot.YLabel("");
         chart.Plot.Legend.IsVisible = false;
+        chart.Plot.Axes.Margins(bottom: 0);
+        chart.Plot.Axes.SetLimitsY(0, 1);
+
         chart.Refresh();
     }
 


### PR DESCRIPTION
## What

On the Overview screen, a lane with no data — most commonly **Blocking & Deadlocking** on a healthy server — rendered as a dead black box: no grid, no axis labels. This makes that empty lane render like the populated ones: a visible grid with a **0–1 Y axis**.

## Why it looked dead

`ShowEmpty` called `HideGrid()`, set an `EmptyTickGenerator` on both axes (so no tick labels), and dropped a "No Data" label at coordinate `(0,0)`. That label was never actually visible: `SyncXAxes` runs immediately afterward and overrides the X limits to the real time range (~2026), so the text at X=0 (≈ year 1899) sat far off the left edge.

## Change

- Keep the grid; stop blanking the axes.
- Fix the Y axis at **0–1** with normal numeric ticks → horizontal gridlines + `0`/`1` labels. (Counts are never negative, so `0–1` rather than `-1 0 1`.)
- `DateTimeTicksBottomDateChange()` on the bottom axis → vertical gridlines that line up with the other lanes; time labels still show only on the bottom File I/O lane.
- Drop the never-visible "No Data" text.
- `ShowEmpty` becomes an instance method (was `static`) in both apps so it can reference `FileIoChart`.

Applies to all five lanes' empty state, so any no-data lane is now consistent instead of a black box.

## Parity

Mirrored in **Lite** and **Dashboard** (`CorrelatedTimelineLanesControl.xaml.cs` is a sync-paired control). Lite keeps its self-`Refresh()`; Dashboard relies on `SyncXAxes` for the refresh, matching each app's existing convention.

## Testing

- Both apps build clean (`0 errors`) against `dev`.
- Manually verified in Lite: rebuilt + relaunched, empty Blocking lane now shows the 0–1 grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
