### PR TITLE
Add "Collection Stopped" alert: warn when collector Agent jobs are disabled

### DIFF
--- a/Dashboard.Tests/CollectionStoppedDetectionTests.cs
+++ b/Dashboard.Tests/CollectionStoppedDetectionTests.cs
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitorDashboard.Services;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Verifies the "collection stopped" decision logic (<see cref="DatabaseService.DecideCollectionStopped"/>):
+/// disabled collector jobs are the immediate, specific signal; a collection-freshness gap is the catch-all
+/// for the Agent service being stopped or collectors silently erroring. This is the one health signal the
+/// app must compute itself, since the collector that fills every other table is exactly what may be off.
+/// </summary>
+public class CollectionStoppedDetectionTests
+{
+    private const int Threshold = 30;
+
+    [Fact]
+    public void AllJobsDisabled_IsStopped_WithAllReason()
+    {
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 6, totalJobs: 6, minutesSince: 2, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+        Assert.Contains("All 6", r.Reason);
+        Assert.Equal(6, r.DisabledJobs);
+    }
+
+    [Fact]
+    public void SomeJobsDisabled_IsStopped_WithPartialReason()
+    {
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 2, totalJobs: 6, minutesSince: 1, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+        Assert.Contains("2 of 6", r.Reason);
+    }
+
+    [Fact]
+    public void DisabledJobs_WinOverFreshness_EvenWhenDataIsFresh()
+    {
+        // Jobs just disabled — collection_log is still fresh, but we must flag it immediately, not wait 30m.
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 1, totalJobs: 6, minutesSince: 0, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+        Assert.Contains("disabled", r.Reason);
+    }
+
+    [Fact]
+    public void NoDisabledJobs_FreshData_IsNotStopped()
+    {
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 6, minutesSince: 3, thresholdMinutes: Threshold);
+
+        Assert.False(r.Stopped);
+        Assert.Null(r.Reason);
+    }
+
+    [Fact]
+    public void NoDisabledJobs_StaleData_IsStopped_WithFreshnessReason()
+    {
+        // Jobs enabled but nothing has run for > threshold — Agent stopped or collectors erroring.
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 6, minutesSince: 45, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+        Assert.Contains("45 minutes", r.Reason);
+    }
+
+    [Fact]
+    public void FreshnessAtThreshold_IsStopped()
+    {
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 6, minutesSince: Threshold, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+    }
+
+    [Fact]
+    public void JobStateUnreadable_FreshData_IsNotStopped()
+    {
+        // msdb unreadable (Azure / RDS / no SQLAgentReaderRole): totalJobs = 0 must NOT read as "all disabled".
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 0, minutesSince: 4, thresholdMinutes: Threshold);
+
+        Assert.False(r.Stopped);
+    }
+
+    [Fact]
+    public void JobStateUnreadable_StaleData_StillCaughtByFreshness()
+    {
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 0, minutesSince: 60, thresholdMinutes: Threshold);
+
+        Assert.True(r.Stopped);
+        Assert.Contains("60 minutes", r.Reason);
+    }
+
+    [Fact]
+    public void NeverCollected_NoDisabledJobs_IsNotStopped()
+    {
+        // minutesSince null = collection_log empty (fresh install / never ran), not "stopped".
+        var r = DatabaseService.DecideCollectionStopped(disabledJobs: 0, totalJobs: 6, minutesSince: null, thresholdMinutes: Threshold);
+
+        Assert.False(r.Stopped);
+    }
+}

--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -352,6 +352,60 @@ namespace PerformanceMonitorDashboard
                     "running", "session running", true, "tray");
             }
 
+            /* Collection Stopped alerts — the collector Agent jobs are disabled, the Agent service is
+               stopped, or the collectors are failing, so no new data is landing. This is the one check
+               the app computes itself (live msdb job state + collection_log freshness), because every
+               collected table the dead collector would have filled is unreliable here. Without it, a
+               stopped collector reads as a calm, all-zero server instead of a warning. */
+            if (prefs.NotifyOnCollectionStopped && health.CollectionStopped)
+            {
+                _activeCollectionStoppedAlert[serverId] = true;
+                if (!_lastCollectionStoppedAlert.TryGetValue(serverId, out var lastAlert) || (now - lastAlert) >= alertCooldown)
+                {
+                    var muteCtx = new AlertMuteContext { ServerName = serverName, MetricName = "Collection Stopped" };
+                    bool isMuted = _muteRuleService.IsAlertMuted(muteCtx);
+                    _lastCollectionStoppedAlert[serverId] = now;
+
+                    var reason = health.CollectionStoppedReason ?? "Data collection has stopped.";
+                    var detailText = reason +
+                        " The Dashboard's history and live cards read from collected data, so a stopped collector makes " +
+                        "the server look quiet (all zeros) rather than broken. Re-enable the PerformanceMonitor SQL Agent " +
+                        "jobs (or restart the SQL Agent service) to resume collection.";
+
+                    if (!isMuted)
+                    {
+                        _notificationService?.ShowSnoozableNotification(
+                            "Collection Stopped",
+                            $"{serverName}: {reason}",
+                            NotificationType.Error,
+                            serverName,
+                            "Collection Stopped",
+                            _muteRuleService);
+                    }
+
+                    _emailAlertService.RecordAlert(serverId, serverName, "Collection Stopped",
+                        health.DisabledCollectorJobs > 0 ? $"{health.DisabledCollectorJobs} job(s) disabled" : "no recent collection",
+                        "collecting", !isMuted, isMuted ? "muted" : "tray", muted: isMuted, detailText: detailText);
+
+                    if (!isMuted)
+                    {
+                        await _emailAlertService.TrySendAlertEmailAsync(
+                            "Collection Stopped",
+                            serverName,
+                            reason,
+                            "collecting",
+                            serverId);
+                    }
+                }
+            }
+            else if (_activeCollectionStoppedAlert.TryRemove(serverId, out var wasCollectionStopped) && wasCollectionStopped)
+            {
+                _notificationService?.ShowStyledNotification("Collection Resumed",
+                    $"{serverName}: Data collection is running again", ToastSeverity.Success);
+                _emailAlertService.RecordAlert(serverId, serverName, "Collection Resumed",
+                    "collecting", "collecting", true, "tray");
+            }
+
             /* High CPU alerts — evaluator picks Total or SQL based on prefs.CpuAlertMode */
             int? alertCpuValue = prefs.CpuAlertMode == CpuAlertMode.Total
                 ? health.TotalCpuPercent

--- a/Dashboard/MainWindow.xaml.cs
+++ b/Dashboard/MainWindow.xaml.cs
@@ -120,6 +120,8 @@ namespace PerformanceMonitorDashboard
         private readonly ConcurrentDictionary<string, DateTime> _lastAlertedFailedJobTime = new();
         private readonly ConcurrentDictionary<string, DateTime> _lastCaptureDownAlert = new();
         private readonly ConcurrentDictionary<string, bool> _activeCaptureDownAlert = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastCollectionStoppedAlert = new();
+        private readonly ConcurrentDictionary<string, bool> _activeCollectionStoppedAlert = new();
         private readonly ConcurrentDictionary<string, long> _previousDeadlockCounts = new();
         /* Time of the last NEW deadlock per server, used to de-flap the "Deadlocks Cleared"
            notification (#1091): deadlock detection is edge-triggered off a delta, so the check

--- a/Dashboard/Models/AlertHealthResult.cs
+++ b/Dashboard/Models/AlertHealthResult.cs
@@ -58,6 +58,39 @@ namespace PerformanceMonitorDashboard.Models
         public List<string> MissingCaptureSessions { get; set; } = new();
 
         /// <summary>
+        /// True when data collection appears to have stopped — either the PerformanceMonitor
+        /// SQL Agent collector jobs are disabled, or nothing has logged a collection within the
+        /// expected window (Agent service stopped, or collectors silently failing). This is the
+        /// one signal that survives the collector being off, because the app computes it directly
+        /// rather than reading a collected table the dead collector would have filled.
+        /// </summary>
+        public bool CollectionStopped { get; set; }
+
+        /// <summary>
+        /// Human-readable cause for <see cref="CollectionStopped"/>
+        /// (e.g. "3 of 6 collector jobs are disabled"). Null when collection is healthy.
+        /// </summary>
+        public string? CollectionStoppedReason { get; set; }
+
+        /// <summary>
+        /// Count of PerformanceMonitor Agent jobs with enabled = 0. 0 when none are disabled,
+        /// or when job state couldn't be read (Azure SQL DB / restricted msdb).
+        /// </summary>
+        public int DisabledCollectorJobs { get; set; }
+
+        /// <summary>
+        /// Total PerformanceMonitor Agent jobs found in msdb. 0 on Azure SQL DB or when
+        /// job state couldn't be read.
+        /// </summary>
+        public int TotalCollectorJobs { get; set; }
+
+        /// <summary>
+        /// Minutes since the most recent entry in config.collection_log. Null when the log is
+        /// empty (never collected) or couldn't be read.
+        /// </summary>
+        public int? MinutesSinceLastCollection { get; set; }
+
+        /// <summary>
         /// Total CPU = SQL + Other.
         /// </summary>
         public int? TotalCpuPercent

--- a/Dashboard/Models/UserPreferences.cs
+++ b/Dashboard/Models/UserPreferences.cs
@@ -113,6 +113,7 @@ namespace PerformanceMonitorDashboard.Models
         public int LongRunningJobMultiplier { get; set; } = 3; // Alert when job runs > Nx historical average
         public bool NotifyOnFailedJobs { get; set; } = true; // Alert when a SQL Agent job has recently failed
         public int FailedJobLookbackMinutes { get; set; } = 60; // Look back this many minutes for failed Agent job runs
+        public bool NotifyOnCollectionStopped { get; set; } = true; // Alert when collection stops (collector jobs disabled, Agent stopped, or collectors failing)
         private int _alertCooldownMinutes = 5;
         public int AlertCooldownMinutes
         {

--- a/Dashboard/ServerTab.Slicers.cs
+++ b/Dashboard/ServerTab.Slicers.cs
@@ -168,6 +168,14 @@ namespace PerformanceMonitorDashboard
                 var healthData = await _databaseService.GetCollectionHealthAsync();
                 HealthDataGrid.ItemsSource = healthData;
                 HealthNoDataMessage.Visibility = healthData.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+
+                // App-side check (disabled jobs / freshness) so a stopped collector is flagged here
+                // immediately, not only once the per-collector rows age into STALE after 24h.
+                var (stopped, reason) = await _databaseService.GetCollectionStatusAsync();
+                CollectionStoppedBanner.Visibility = stopped ? Visibility.Visible : Visibility.Collapsed;
+                if (stopped)
+                    CollectionStoppedBannerText.Text = reason ?? "Data collection has stopped.";
+
                 StatusText.Text = "Ready";
             }
             catch (Exception ex)

--- a/Dashboard/ServerTab.xaml
+++ b/Dashboard/ServerTab.xaml
@@ -304,6 +304,18 @@
 
                     <!-- Collection Health Sub-Tab -->
                     <TabItem Header="Collection Health">
+                      <DockPanel>
+                        <!-- Banner shown when collection has stopped (jobs disabled / Agent down / collectors failing).
+                             Populated by the app's own check, so it surfaces here even when collection is off. -->
+                        <Border x:Name="CollectionStoppedBanner" DockPanel.Dock="Top" Visibility="Collapsed"
+                                Background="#5C2626" BorderBrush="#8B3A3A" BorderThickness="1" CornerRadius="3"
+                                Padding="10,6" Margin="5,5,5,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x26A0;" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0" Foreground="White"/>
+                                <TextBlock x:Name="CollectionStoppedBannerText" VerticalAlignment="Center" Foreground="White"
+                                           TextWrapping="Wrap" FontWeight="SemiBold"/>
+                            </StackPanel>
+                        </Border>
                         <TabControl ItemContainerStyle="{DynamicResource SubTabItemStyle}">
                             <TabItem Header="Health Summary">
                                 <Grid>
@@ -396,6 +408,7 @@
                                 <ScottPlot:WpfPlot x:Name="CollectorDurationChart" Margin="4"/>
                             </TabItem>
                         </TabControl>
+                      </DockPanel>
                     </TabItem>
 
                     <!-- Running Jobs Sub-Tab -->

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -162,10 +162,11 @@ namespace PerformanceMonitorDashboard.Services
                     ? Task.FromResult(new List<FailedJobInfo>())
                     : GetRecentlyFailedJobsAsync(connection, failedJobLookbackMinutes);
                 var missingCaptureTask = GetMissingCaptureSessionsAsync(connection);
+                var collectionStoppedTask = GetCollectionStoppedAsync(connection, engineEdition);
 
                 var allTasks = filteredDeadlockTask != null
-                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, failedJobTask, missingCaptureTask }
-                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, failedJobTask, missingCaptureTask };
+                    ? new Task[] { cpuTask, blockingTask, deadlockTask, filteredDeadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, failedJobTask, missingCaptureTask, collectionStoppedTask }
+                    : new Task[] { cpuTask, blockingTask, deadlockTask, poisonWaitTask, longRunningTask, tempDbTask, volumeTask, anomalousJobTask, failedJobTask, missingCaptureTask, collectionStoppedTask };
                 await Task.WhenAll(allTasks);
 
                 var cpuResult = await cpuTask;
@@ -186,6 +187,13 @@ namespace PerformanceMonitorDashboard.Services
                 result.AnomalousJobs = await anomalousJobTask;
                 result.RecentlyFailedJobs = await failedJobTask;
                 result.MissingCaptureSessions = await missingCaptureTask;
+
+                var collectionStopped = await collectionStoppedTask;
+                result.CollectionStopped = collectionStopped.Stopped;
+                result.CollectionStoppedReason = collectionStopped.Reason;
+                result.DisabledCollectorJobs = collectionStopped.DisabledJobs;
+                result.TotalCollectorJobs = collectionStopped.TotalJobs;
+                result.MinutesSinceLastCollection = collectionStopped.MinutesSince;
             }
             catch (Exception ex)
             {
@@ -194,6 +202,135 @@ namespace PerformanceMonitorDashboard.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Minutes of collection silence beyond which — absent a clearer cause like disabled jobs —
+        /// we treat collection as stopped (Agent service down, or collectors erroring). Generous so a
+        /// slow schedule preset doesn't false-alarm; the disabled-jobs check catches the common case
+        /// immediately regardless of this. Hardcoded by intent (defaults over speculative config).
+        /// </summary>
+        private const int CollectionStaleThresholdMinutes = 30;
+
+        internal readonly record struct CollectionStoppedResult(
+            bool Stopped, string? Reason, int DisabledJobs, int TotalJobs, int? MinutesSince);
+
+        /// <summary>
+        /// Pure decision: given the two probe results (disabled-job counts and minutes-since-last-collection),
+        /// decide whether collection is stopped and why. Disabled jobs win — immediate and specific; the
+        /// freshness gap is the catch-all for Agent-stopped / erroring collectors. Extracted for unit testing.
+        /// </summary>
+        internal static CollectionStoppedResult DecideCollectionStopped(
+            int disabledJobs, int totalJobs, int? minutesSince, int thresholdMinutes)
+        {
+            if (totalJobs > 0 && disabledJobs > 0)
+            {
+                string reason = disabledJobs == totalJobs
+                    ? $"All {totalJobs} PerformanceMonitor collector Agent job(s) are disabled — data collection has stopped."
+                    : $"{disabledJobs} of {totalJobs} PerformanceMonitor collector Agent job(s) are disabled — collection is partially or fully stopped.";
+                return new CollectionStoppedResult(true, reason, disabledJobs, totalJobs, minutesSince);
+            }
+
+            if (minutesSince.HasValue && minutesSince.Value >= thresholdMinutes)
+            {
+                string reason = $"No collector has run in {minutesSince.Value} minutes — the SQL Agent service may be stopped or the collectors are failing.";
+                return new CollectionStoppedResult(true, reason, disabledJobs, totalJobs, minutesSince);
+            }
+
+            return new CollectionStoppedResult(false, null, disabledJobs, totalJobs, minutesSince);
+        }
+
+        /// <summary>
+        /// Detects whether data collection has stopped — the one health signal the app must compute
+        /// itself, since the collector that fills every other table is exactly what may be off.
+        /// Two checks: (1) are the PerformanceMonitor SQL Agent jobs disabled (immediate, definitive),
+        /// and (2) has nothing logged a collection within the expected window (catches Agent-stopped /
+        /// erroring collectors). The msdb job check is skipped on Azure SQL DB (no Agent) and degrades
+        /// gracefully if msdb is unreadable (RDS / missing SQLAgentReaderRole) — it never reports
+        /// "disabled" when it simply couldn't look.
+        /// </summary>
+        private async Task<CollectionStoppedResult> GetCollectionStoppedAsync(SqlConnection connection, int engineEdition)
+        {
+            int disabledJobs = 0;
+            int totalJobs = 0;
+            int? minutesSince = null;
+
+            // (1) Are the collector Agent jobs disabled? Live msdb read — same gating as the failed-job
+            //     query (skip Azure SQL DB; tolerate restricted msdb). enabled = 0 means the job won't fire.
+            if (engineEdition != 5)
+            {
+                try
+                {
+                    const string jobQuery = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                        SELECT
+                            total_jobs = COUNT_BIG(*),
+                            disabled_jobs = SUM(CASE WHEN sj.enabled = 0 THEN 1 ELSE 0 END)
+                        FROM msdb.dbo.sysjobs AS sj
+                        WHERE sj.name LIKE N'PerformanceMonitor%'
+                        OPTION(RECOMPILE);";
+
+                    using var cmd = new SqlCommand(jobQuery, connection);
+                    cmd.CommandTimeout = 10;
+                    using var reader = await cmd.ExecuteReaderAsync();
+                    if (await reader.ReadAsync())
+                    {
+                        totalJobs = reader.IsDBNull(0) ? 0 : (int)reader.GetInt64(0);
+                        disabledJobs = reader.IsDBNull(1) ? 0 : reader.GetInt32(1);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Restricted msdb (e.g. AWS RDS) or no SQLAgentReaderRole — leave counts at 0 so we
+                    // fall through to the freshness check rather than falsely claiming jobs are disabled.
+                    Logger.Warning($"Could not read collector job state: {ex.Message}");
+                }
+            }
+
+            // (2) Freshness backstop: how long since ANY collector logged a run (success, failure, or
+            //     skipped — all mean the master collector fired). NULL = never collected, not "stopped".
+            try
+            {
+                const string freshnessQuery = @"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+                    SELECT minutes_since = DATEDIFF(MINUTE, MAX(cl.collection_time), SYSDATETIME())
+                    FROM config.collection_log AS cl
+                    OPTION(RECOMPILE);";
+
+                using var cmd = new SqlCommand(freshnessQuery, connection);
+                cmd.CommandTimeout = 10;
+                var raw = await cmd.ExecuteScalarAsync();
+                if (raw != null && raw != DBNull.Value)
+                    minutesSince = Convert.ToInt32(raw);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Could not read collection freshness: {ex.Message}");
+            }
+
+            // Decide + explain. Disabled jobs win (immediate, specific); freshness is the catch-all.
+            return DecideCollectionStopped(disabledJobs, totalJobs, minutesSince, CollectionStaleThresholdMinutes);
+        }
+
+        /// <summary>
+        /// Public entry for the Collection Health tab: runs the same disabled-jobs + freshness check the
+        /// alert engine uses and returns whether collection looks stopped, with a human-readable reason.
+        /// Opens its own connection; passing engineEdition 0 lets the inner msdb check try (and degrade
+        /// gracefully on Azure SQL DB / restricted msdb) rather than threading edition through the tab.
+        /// </summary>
+        public async Task<(bool Stopped, string? Reason)> GetCollectionStatusAsync()
+        {
+            try
+            {
+                await using var tc = await OpenThrottledConnectionAsync();
+                var result = await GetCollectionStoppedAsync(tc.Connection, 0);
+                return (result.Stopped, result.Reason);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"GetCollectionStatusAsync failed: {ex.Message}");
+                return (false, null);
+            }
         }
 
         /// <summary>

--- a/Dashboard/SettingsWindow.xaml
+++ b/Dashboard/SettingsWindow.xaml
@@ -308,6 +308,14 @@
                                          TextAlignment="Center"/>
                                 <TextBlock Text="minutes" VerticalAlignment="Center"/>
                             </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <CheckBox x:Name="NotifyOnCollectionStoppedCheckBox"
+                                          Content="Data collection has stopped (collector jobs disabled, Agent down, or collectors failing)"
+                                          VerticalAlignment="Center"
+                                          Checked="NotifyOnCollectionStoppedCheckBox_Changed"
+                                          Unchecked="NotifyOnCollectionStoppedCheckBox_Changed"
+                                          ToolTip="Warn when the PerformanceMonitor SQL Agent jobs are disabled, or nothing has collected recently (Agent service stopped or collectors erroring). The app checks this itself, so it still fires when collection is off."/>
+                            </StackPanel>
                             <TextBlock x:Name="AlertPreviewText" FontSize="11" FontStyle="Italic" Foreground="Gray"
                                        TextWrapping="Wrap" Margin="0,12,0,0"/>
                             <StackPanel Orientation="Horizontal" Margin="0,12,0,0">

--- a/Dashboard/SettingsWindow.xaml.cs
+++ b/Dashboard/SettingsWindow.xaml.cs
@@ -197,6 +197,7 @@ namespace PerformanceMonitorDashboard
             LongRunningJobMultiplierTextBox.Text = prefs.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
             NotifyOnFailedJobsCheckBox.IsChecked = prefs.NotifyOnFailedJobs;
             FailedJobLookbackTextBox.Text = prefs.FailedJobLookbackMinutes.ToString(CultureInfo.InvariantCulture);
+            NotifyOnCollectionStoppedCheckBox.IsChecked = prefs.NotifyOnCollectionStopped;
             AlertCooldownTextBox.Text = prefs.AlertCooldownMinutes.ToString(CultureInfo.InvariantCulture);
             EmailCooldownTextBox.Text = prefs.EmailCooldownMinutes.ToString(CultureInfo.InvariantCulture);
             AlertDeliveryModeCombo.SelectedIndex = prefs.AlertDeliveryMode == AlertNotificationMode.PerEvent ? 1 : 0;
@@ -379,6 +380,12 @@ namespace PerformanceMonitorDashboard
             UpdateAlertNotificationStates();
         }
 
+        private void NotifyOnCollectionStoppedCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            UpdateAlertNotificationStates();
+        }
+
         private void RestoreAlertDefaultsButton_Click(object sender, RoutedEventArgs e)
         {
             BlockingThresholdTextBox.Text = "30";
@@ -429,6 +436,8 @@ namespace PerformanceMonitorDashboard
                 parts.Add($"jobs > {LongRunningJobMultiplierTextBox.Text}x avg");
             if (NotifyOnFailedJobsCheckBox.IsChecked == true)
                 parts.Add($"failed jobs (last {FailedJobLookbackTextBox.Text}m)");
+            if (NotifyOnCollectionStoppedCheckBox.IsChecked == true)
+                parts.Add("collection stopped");
 
             AlertPreviewText.Text = parts.Count > 0
                 ? $"Will alert when: {string.Join(", ", parts)}"
@@ -458,6 +467,7 @@ namespace PerformanceMonitorDashboard
             LongRunningJobMultiplierTextBox.IsEnabled = notificationsEnabled && NotifyOnLongRunningJobsCheckBox.IsChecked == true;
             NotifyOnFailedJobsCheckBox.IsEnabled = notificationsEnabled;
             FailedJobLookbackTextBox.IsEnabled = notificationsEnabled && NotifyOnFailedJobsCheckBox.IsChecked == true;
+            NotifyOnCollectionStoppedCheckBox.IsEnabled = notificationsEnabled;
             UpdateAlertPreviewText();
         }
 
@@ -751,6 +761,8 @@ namespace PerformanceMonitorDashboard
                 prefs.FailedJobLookbackMinutes = failedJobLookback;
             else if (prefs.NotifyOnFailedJobs)
                 validationErrors.Add("Failed-job lookback must be between 1 and 1440 minutes");
+
+            prefs.NotifyOnCollectionStopped = NotifyOnCollectionStoppedCheckBox.IsChecked == true;
 
             if (int.TryParse(AlertCooldownTextBox.Text, out int alertCooldown) && alertCooldown >= 1 && alertCooldown <= 120)
                 prefs.AlertCooldownMinutes = alertCooldown;


### PR DESCRIPTION
## What

The Dashboard tracked collection *health* (did data arrive?) but never collection *state*, so disabling the SQL Agent collector jobs was completely silent — the app kept looking healthy (calmer, even, since the live NOC cards read zero rows from `collect.*`) until a collector aged into STALE on the Collection Health tab after 24 hours.

This adds a proactive **"Collection Stopped"** warning, computed by the app itself (it can't live in the T-SQL collector path — that's exactly what's off):

- **Disabled-jobs check** — live `msdb.dbo.sysjobs.enabled` read for `PerformanceMonitor%` jobs (immediate, specific cause). Gated on Azure SQL DB; degrades gracefully on restricted msdb (RDS / no `SQLAgentReaderRole`) — never reports "disabled" when it simply couldn't look.
- **Freshness backstop** — a `config.collection_log` gap of 30+ min, which also catches the Agent service being stopped or collectors silently erroring.

### Surfaces
- A proactive **tray + email alert** (new `NotifyOnCollectionStopped` pref, default on; Settings checkbox), mirroring the existing **Capture Down** alert — cooldown, mute, and a "Collection Resumed" clear.
- A **banner on the Collection Health tab** so it shows immediately, not only after the 24h STALE lag.

Dashboard-only — Lite has no Agent jobs.

## Files
- `Services/DatabaseService.NocHealth.cs` — `GetCollectionStoppedAsync` (sysjobs + freshness), pure `DecideCollectionStopped`, public `GetCollectionStatusAsync` for the tab.
- `Models/AlertHealthResult.cs`, `Models/UserPreferences.cs` — new fields + `NotifyOnCollectionStopped` (default on).
- `MainWindow.AlertEngine.cs`, `MainWindow.xaml.cs` — the alert block + cooldown/active dictionaries.
- `SettingsWindow.xaml(.cs)` — the toggle.
- `ServerTab.xaml`, `ServerTab.Slicers.cs` — the Collection Health banner.

## Test plan
- `DecideCollectionStopped` extracted as a pure function and unit tested — 9 cases (all/partial disabled, freshness threshold, msdb-unreadable, never-collected). ✅
- `dotnet build Dashboard` ✅ · `dotnet test Dashboard.Tests` (collection-stopped) → 9 passed ✅.
- **Live (recommended before merge):** with the collector Agent jobs disabled, expect the "Collection Stopped" tray alert within one alert tick and the red banner on that server's Collection Health tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
