### PR TITLE
Collection Health: count SKIPPED as a healthy run (no false STALE for dedup collectors)

### DIFF
--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -29,7 +29,8 @@ SELECT
     SUM(CASE WHEN status = 'SUCCESS' THEN 1 ELSE 0 END) AS success_count,
     SUM(CASE WHEN status = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
     AVG(duration_ms) AS avg_duration_ms,
-    MAX(CASE WHEN status = 'SUCCESS' THEN collection_time END) AS last_success_time,
+    -- SKIPPED counts as a healthy run (dedup / version-gated collectors no-op without being stale)
+    MAX(CASE WHEN status IN ('SUCCESS', 'SKIPPED') THEN collection_time END) AS last_success_time,
     MAX(collection_time) AS last_run_time,
     MAX(CASE WHEN status IN ('ERROR', 'PERMISSIONS') THEN error_message END) AS last_error,
     MAX(CASE WHEN status IN ('ERROR', 'PERMISSIONS') THEN collection_time END) AS last_error_time,

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -25,8 +25,10 @@ These views provide ready-to-query interfaces for common troubleshooting scenari
 
 /*
 Collection Health View - CRITICAL for detecting silent failures
-Shows last successful collection time and failure rate for each collector
-ALERT if any collector hasn't run successfully in 24 hours
+Shows last successful collection time and failure rate for each collector.
+A SKIPPED status counts as a healthy run: dedup-snapshot collectors (e.g. server_properties)
+log SKIPPED when nothing changed, which is a successful no-op -- not staleness.
+ALERT if any collector hasn't run (success or skip) in 24 hours
 */
 CREATE OR ALTER VIEW
     report.collection_health
@@ -40,7 +42,8 @@ WITH
             MAX
             (
                 CASE
-                    WHEN cl.collection_status = N'SUCCESS'
+                    /* SKIPPED counts as a successful run -- dedup collectors no-op when unchanged. */
+                    WHEN cl.collection_status IN (N'SUCCESS', N'SKIPPED')
                     THEN cl.collection_time
                     ELSE NULL
                 END
@@ -50,7 +53,7 @@ WITH
             COUNT_BIG
             (
                 CASE
-                    WHEN cl.collection_status NOT IN (N'CONFIG_CHANGE', N'TABLE_MISSING', N'TABLE_CREATED', N'SKIPPED')
+                    WHEN cl.collection_status NOT IN (N'CONFIG_CHANGE', N'TABLE_MISSING', N'TABLE_CREATED')
                     THEN 1
                     ELSE NULL
                 END
@@ -118,7 +121,7 @@ WITH
                     cl.collection_time DESC
             )
         FROM config.collection_log AS cl
-        WHERE cl.collection_status NOT IN (N'CONFIG_CHANGE', N'TABLE_MISSING', N'TABLE_CREATED', N'SKIPPED')
+        WHERE cl.collection_status NOT IN (N'CONFIG_CHANGE', N'TABLE_MISSING', N'TABLE_CREATED')
         AND   cl.collection_time >= DATEADD(DAY, -7, SYSDATETIME())
     ) AS r
     WHERE r.rn <= 20


### PR DESCRIPTION
Dedup-snapshot collectors (`server_properties` + the config snapshots) log `SKIPPED` when nothing changed — a successful no-op. But per-collector Collection Health computed `last_success_time` from `SUCCESS` only, so a collector that's correctly skipping showed **STALE**, then **NEVER_RUN** once its last real `SUCCESS` aged out of log retention. (Same "SKIPPED is fine" semantics #1246's freshness backstop already uses — now consistent.)

**Dashboard** (`report.collection_health` view, `install/47`): `SKIPPED` now counts toward `last_success_time` and `total_runs`, and is included in the `recent_failures` window so a skip-only collector doesn't fall through to the `consecutive_failures → FAILING` branch.

**Lite** (`LocalDataService.CollectionHealth`): `SKIPPED` counts toward `last_success_time` too, so a version-gated/dedup collector not on the `OnLoadCollectors` exemption list no longer false-STALEs.

**Validated live:** `server_properties` on SQL2016/2017/2025 flips `STALE`/`NEVER_RUN` → `HEALTHY` against real on-disk data. Lite build clean; 618 Lite.Tests pass. Parity fix, both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)