### PR TITLE
Lite #1251: tolerate 'XE session already exists/started' on Azure SQL DB

### DIFF
--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -55,6 +55,17 @@ public partial class RemoteCollectorService
                 await EnsureBlockedProcessXeSessionOnPremAsync(connection, server, cancellationToken);
             }
         }
+        catch (SqlException ex) when (IsBenignXeSessionAlreadyPresent(ex))
+        {
+            /* The session is already present + running. On Azure SQL DB the XE existence catalogs are
+               visibility-scoped per principal (sys.database_event_sessions needs VIEW DATABASE PERFORMANCE
+               STATE, sys.dm_xe_database_sessions needs VIEW DATABASE STATE), so a pre-check can come back
+               empty even when the session exists -- the CREATE/START path then reports "already exists"
+               (25631) / "already started" (25705). That confirms the session is up; it is success, not a
+               failure to surface as an unhealthy collector or log every cycle (#1251). */
+            _logger?.LogDebug("Blocked process XE session already present on '{Server}' (benign)", server.DisplayName);
+            AppLogger.Info("XeSession", $"[{server.DisplayName}] Blocked process XE session already present (benign, #1251)");
+        }
         catch (SqlException ex)
         {
             _logger?.LogWarning("Failed to ensure blocked process XE session on '{Server}': {Message}",
@@ -261,6 +272,33 @@ ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON DATABASE STATE = START;",
 
         _logger?.LogInformation("Created and started blocked process XE session (database-scoped, Azure SQL DB)");
         AppLogger.Info("XeSession", $"[Azure SQL DB] Created and started blocked process XE session (database-scoped)");
+    }
+
+    /// <summary>
+    /// True when every error is a benign "the session is already there" extended-events error:
+    /// 25631 (event session already exists) or 25705 (already started). On Azure SQL DB the XE
+    /// existence catalogs (sys.database_event_sessions / sys.dm_xe_database_sessions) are visibility-
+    /// scoped per principal and can come back empty even when the session is present + running, so the
+    /// CREATE/START path reports these -- they confirm the session is up, not a failure to surface (#1251).
+    /// Shared by the blocked-process and deadlock ensure paths (same partial class).
+    /// </summary>
+    private static bool IsBenignXeSessionAlreadyPresent(SqlException ex)
+    {
+        if (ex.Errors.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (Microsoft.Data.SqlClient.SqlError error in ex.Errors)
+        {
+            /* 25631 = event session already exists; 25705 = already started. */
+            if (error.Number != 25631 && error.Number != 25705)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -55,6 +55,15 @@ public partial class RemoteCollectorService
                 await EnsureDeadlockXeSessionOnPremAsync(connection, server, cancellationToken);
             }
         }
+        catch (SqlException ex) when (IsBenignXeSessionAlreadyPresent(ex))
+        {
+            /* Session already present + running -- see IsBenignXeSessionAlreadyPresent. On Azure SQL DB the
+               XE existence catalogs are visibility-scoped per principal, so the pre-check can miss an
+               existing session and CREATE/START then reports "already exists" (25631) / "already started"
+               (25705). That's success, not a failure to surface as unhealthy or log every cycle (#1251). */
+            _logger?.LogDebug("Deadlock XE session already present on '{Server}' (benign)", server.DisplayName);
+            AppLogger.Info("XeSession", $"[{server.DisplayName}] Deadlock XE session already present (benign, #1251)");
+        }
         catch (SqlException ex)
         {
             _logger?.LogWarning("Failed to ensure deadlock XE session on '{Server}': {Message}",


### PR DESCRIPTION
Addresses #1251 (intentionally not auto-closing — leave open until validated on live Azure SQL DB).

On Azure SQL DB the database-scoped XE existence catalogs are visibility-scoped per principal: `sys.database_event_sessions` needs `VIEW DATABASE PERFORMANCE STATE`, `sys.dm_xe_database_sessions` needs `VIEW DATABASE STATE` (different permissions). A monitoring login missing one sees the existence pre-check come back empty even when `PerformanceMonitor_BlockedProcess` / `_Deadlock` already exist and are running, so `EnsureXeSession` falls into the CREATE/START branch and the engine returns **25631** ("already exists") / **25705** ("already started"). Since #1086 the ensure throws on any `SqlException`, so those *benign* errors marked the blocked_process + deadlock collectors **unhealthy** and spammed the collection log every cycle — even though collection was fine.

**Fix:** both ensure paths now treat 25631/25705 as success (shared `IsBenignXeSessionAlreadyPresent` helper) instead of throwing. Genuine failures still surface (the #1086 intent is preserved).

- Azure SQL DB only; **pre-existing** — the ensure path is unchanged since v1.0.0, *not* a 3.1.0 regression.
- Build clean; 618 Lite.Tests pass.
- No live Azure instance up now → to be **live-validated in the next release's cloud testing**, and the OP can confirm on the next nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)