### PR TITLE
Remove dead inline-textbox-filter mechanism (Dashboard)

### DIFF
--- a/Dashboard/Controls/DailySummaryContent.xaml.cs
+++ b/Dashboard/Controls/DailySummaryContent.xaml.cs
@@ -178,16 +178,6 @@ namespace PerformanceMonitorDashboard.Controls
             return null;
         }
 
-        private void DailySummaryFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(DailySummaryDataGrid, sender as TextBox);
-        }
-
-        private void DailySummaryNumericFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(DailySummaryDataGrid, sender as TextBox);
-        }
-
         private async void DailySummary_Refresh_Click(object sender, RoutedEventArgs e)
         {
             try
@@ -457,7 +447,5 @@ namespace PerformanceMonitorDashboard.Controls
         }
 
         #endregion
-
-        // Filtering logic moved to DataGridFilterService.ApplyFilter()
     }
 }

--- a/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
+++ b/Dashboard/Controls/SystemEventsContent.MemoryBroker.cs
@@ -180,16 +180,6 @@ namespace PerformanceMonitorDashboard.Controls
             MemoryBrokerRatioChart.Plot.YLabel("Value");
         }
 
-        private void MemoryBrokerFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(MemoryBrokerDataGrid, sender as TextBox);
-        }
-
-        private void MemoryBrokerNumericFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(MemoryBrokerDataGrid, sender as TextBox);
-        }
-
         #endregion
     }
 }

--- a/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
+++ b/Dashboard/Controls/SystemEventsContent.SevereErrors.cs
@@ -161,16 +161,6 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
-        private void SevereErrorsFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(SevereErrorsDataGrid, sender as TextBox);
-        }
-
-        private void SevereErrorsNumericFilterTextBox_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DataGridFilterService.ApplyFilter(SevereErrorsDataGrid, sender as TextBox);
-        }
-
         #endregion
     }
 }

--- a/Dashboard/Services/DataGridFilterService.cs
+++ b/Dashboard/Services/DataGridFilterService.cs
@@ -6,181 +6,21 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Windows.Controls;
-using System.Windows.Data;
-using PerformanceMonitorDashboard.Helpers;
-using PerformanceMonitorDashboard.Models;
 using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorDashboard.Services
 {
     /// <summary>
-    /// Provides shared filtering functionality for DataGrid controls.
+    /// Provides operator-based filtering for DataGrid column filters. Forwards to the shared
+    /// <see cref="ColumnFilterMatcher"/> so Lite and Dashboard share one matching implementation.
     /// </summary>
     public static class DataGridFilterService
     {
-        /* Numeric types that should use NumericFilterHelper */
-        private static readonly HashSet<Type> NumericTypes = new HashSet<Type>
-        {
-            typeof(int), typeof(int?),
-            typeof(long), typeof(long?),
-            typeof(short), typeof(short?),
-            typeof(decimal), typeof(decimal?),
-            typeof(double), typeof(double?),
-            typeof(float), typeof(float?)
-        };
-
-        /* Date types that should use DateFilterHelper */
-        private static readonly HashSet<Type> DateTypes = new HashSet<Type>
-        {
-            typeof(DateTime), typeof(DateTime?)
-        };
-
-        /* Cache PropertyInfo lookups to avoid repeated reflection */
-        private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> s_propertyCache = new();
-
-        /// <summary>
-        /// Gets a cached PropertyInfo for the given type and property name.
-        /// </summary>
-        private static PropertyInfo? GetCachedProperty(Type type, string propertyName)
-        {
-            return s_propertyCache.GetOrAdd((type, propertyName), key => key.Item1.GetProperty(key.Item2));
-        }
-
-        /// <summary>
-        /// Checks if a single property value matches a filter string using type-aware filtering.
-        /// Use this in custom filter implementations that need additional logic (e.g., ComboBox filters).
-        /// </summary>
-        /// <param name="item">The data item to check</param>
-        /// <param name="propertyName">The property name to filter on</param>
-        /// <param name="filterText">The filter text (supports operators for numeric/date types)</param>
-        /// <returns>True if the value matches the filter, false otherwise</returns>
-        public static bool MatchesFilter(object item, string propertyName, string filterText)
-        {
-            if (item == null || string.IsNullOrWhiteSpace(filterText))
-                return true;
-
-            var property = GetCachedProperty(item.GetType(), propertyName);
-            if (property == null)
-                return true;
-
-            var propertyType = property.PropertyType;
-            var rawValue = property.GetValue(item);
-
-            // Use appropriate filter helper based on property type
-            if (NumericTypes.Contains(propertyType))
-            {
-                return NumericFilterHelper.MatchesFilter(rawValue, filterText);
-            }
-            else if (DateTypes.Contains(propertyType))
-            {
-                return DateFilterHelper.MatchesFilter(rawValue, filterText);
-            }
-            else
-            {
-                // String filtering: case-insensitive contains with comma-separated OR
-                var value = rawValue?.ToString()?.ToLowerInvariant() ?? string.Empty;
-                var filterLower = filterText.ToLowerInvariant();
-                var filterTerms = filterLower.Split(',').Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t));
-                return filterTerms.Any(term => value.Contains(term, StringComparison.Ordinal));
-            }
-        }
-
         /// <summary>
         /// Checks if an item matches a ColumnFilterState using operator-based filtering.
-        /// Used by the new popup-based column filter UI.
+        /// Used by the popup-based column filter UI.
         /// </summary>
-        /// <param name="item">The data item to check</param>
-        /// <param name="filter">The filter state containing operator and value</param>
-        /// <returns>True if the value matches the filter, false otherwise</returns>
         public static bool MatchesFilter(object item, ColumnFilterState filter) =>
             ColumnFilterMatcher.MatchesFilter(item, filter);
-
-        /// <summary>
-        /// Applies a column-based filter to a DataGrid.
-        /// Filter TextBoxes in column headers (inside StackPanels) with Tag set to property names
-        /// are used to filter the data. Multiple terms separated by commas are OR-combined,
-        /// while multiple columns are AND-combined.
-        /// Numeric columns support operators: >, <, >=, <=, and ranges (10-20 or 10..20).
-        /// Date columns support operators, relative dates (today, yesterday), and ranges.
-        /// </summary>
-        /// <param name="dataGrid">The DataGrid to filter</param>
-        /// <param name="filterTextBox">The TextBox that triggered the filter (can be null)</param>
-        public static void ApplyFilter(DataGrid? dataGrid, TextBox? filterTextBox)
-        {
-            if (dataGrid?.ItemsSource == null || filterTextBox == null)
-                return;
-
-            var view = CollectionViewSource.GetDefaultView(dataGrid.ItemsSource);
-            if (view == null)
-                return;
-
-            view.Filter = item =>
-            {
-                if (item == null)
-                    return false;
-
-                // Get all filter TextBoxes for this DataGrid
-                var filterBoxes = new List<(string PropertyName, string FilterText)>();
-                foreach (var column in dataGrid.Columns)
-                {
-                    if (column.Header is StackPanel stackPanel)
-                    {
-                        var textBox = stackPanel.Children.OfType<TextBox>().FirstOrDefault();
-                        if (textBox != null && !string.IsNullOrWhiteSpace(textBox.Text) && textBox.Tag is string propName)
-                        {
-                            filterBoxes.Add((propName, textBox.Text));
-                        }
-                    }
-                }
-
-                // If no filters, show all items
-                if (filterBoxes.Count == 0)
-                    return true;
-
-                // Check all filters (AND logic)
-                foreach (var (propertyName, filterText) in filterBoxes)
-                {
-                    var property = GetCachedProperty(item.GetType(), propertyName);
-                    if (property != null)
-                    {
-                        var propertyType = property.PropertyType;
-                        var rawValue = property.GetValue(item);
-
-                        // Use appropriate filter helper based on property type
-                        if (NumericTypes.Contains(propertyType))
-                        {
-                            // Numeric filtering: supports >, <, >=, <=, ranges
-                            if (!NumericFilterHelper.MatchesFilter(rawValue, filterText))
-                                return false;
-                        }
-                        else if (DateTypes.Contains(propertyType))
-                        {
-                            // Date filtering: supports operators, relative dates, ranges
-                            if (!DateFilterHelper.MatchesFilter(rawValue, filterText))
-                                return false;
-                        }
-                        else
-                        {
-                            // String filtering: case-insensitive contains with comma-separated OR
-                            var value = rawValue?.ToString()?.ToLowerInvariant() ?? string.Empty;
-                            var filterLower = filterText.ToLowerInvariant();
-                            var filterTerms = filterLower.Split(',').Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t));
-                            var matchesAnyTerm = filterTerms.Any(term => value.Contains(term, StringComparison.Ordinal));
-
-                            if (!matchesAnyTerm)
-                                return false;
-                        }
-                    }
-                }
-
-                return true;
-            };
-        }
     }
 }


### PR DESCRIPTION
Follow-up **(d)** from the code-simplification audit. **Dashboard-only**, no behavior change, verified by build + **691 Dashboard.Tests**. **+3 / -195.**

The pre-popup inline-textbox column filter was abandoned when the popup-button filter UI landed; its plumbing was left behind fully unwired (no XAML `TextChanged` bindings -- confirmed in both apps).

- Removed **6 dead handlers** -- `{MemoryBroker,SevereErrors,DailySummary}{Filter,NumericFilter}TextBox_TextChanged`, each a one-liner calling `DataGridFilterService.ApplyFilter`, none bound anywhere.
- **Collapsed `DataGridFilterService`** to its one live member -- the `ColumnFilterState` forwarder used by the popup filter UI (~25 callers). `ApplyFilter` (the textbox mechanism), the 3-arg string `MatchesFilter` overload (no callers), and their reflection cache + numeric/date type sets were all dead. Dashboard's service now matches Lite's minimal version.
- Dropped the stale `// Filtering logic moved to ApplyFilter()` comment.

**Lite needed no change** -- its `DataGridFilterService` was already the minimal forwarder and has no textbox-filter handlers, so removing Dashboard's dead bloat *converges* the two apps rather than risking parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
