### PR TITLE
Consolidate DataGrid copy/export into shared DataGridExport (both apps)

### DIFF
--- a/Dashboard.Tests/DataGridExportTests.cs
+++ b/Dashboard.Tests/DataGridExportTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Data;
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace Dashboard.Tests;
+
+/// <summary>
+/// Tests for the shared DataGridExport (PerformanceMonitor.Ui) used by every copy/export
+/// context menu in both apps. Because all ~29 sites delegate here, these cover their behavior.
+/// The pure formatter/escaper tests run anywhere; the grid tests run on an STA thread because
+/// WPF objects require it.
+/// </summary>
+public class DataGridExportTests
+{
+    private sealed class Row
+    {
+        public string Name { get; set; } = "";
+        public int Value { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    private static T RunSta<T>(Func<T> body)
+    {
+        T result = default!;
+        Exception? error = null;
+        var thread = new Thread(() =>
+        {
+            try { result = body(); }
+            catch (Exception ex) { error = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (error != null) throw error;
+        return result;
+    }
+
+    private static DataGrid BuildGrid()
+    {
+        var grid = new DataGrid();
+        grid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = new Binding(nameof(Row.Name)) });
+        grid.Columns.Add(new DataGridTextColumn { Header = "Value", Binding = new Binding(nameof(Row.Value)) });
+
+        // A template column with a TextBlock bound to Note -- the case the old Dashboard
+        // handlers mishandled (header filtered out, value kept).
+        var template = new System.Windows.DataTemplate();
+        var tb = new System.Windows.FrameworkElementFactory(typeof(TextBlock));
+        tb.SetBinding(TextBlock.TextProperty, new Binding(nameof(Row.Note)));
+        template.VisualTree = tb;
+        template.Seal();
+        grid.Columns.Add(new DataGridTemplateColumn { Header = "Note", CellTemplate = template });
+
+        grid.ItemsSource = new[]
+        {
+            new Row { Name = "a,b", Value = 42, Note = "hi" },
+            new Row { Name = "plain", Value = 7, Note = "there" }
+        };
+        return grid;
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("text", "text")]
+    public void FormatForExport_HandlesStringsAndNull(string? input, string expected)
+    {
+        Assert.Equal(expected, DataGridExport.FormatForExport(input));
+    }
+
+    [Fact]
+    public void FormatForExport_UsesInvariantCultureForNumbers()
+    {
+        var prior = CultureInfo.CurrentCulture;
+        try
+        {
+            // A culture whose decimal separator is a comma -- proves we don't emit "1,5".
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            Assert.Equal("1.5", DataGridExport.FormatForExport(1.5));
+            Assert.Equal("42", DataGridExport.FormatForExport(42));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prior;
+        }
+    }
+
+    [Theory]
+    [InlineData("plain", "plain")]
+    [InlineData("", "")]
+    [InlineData("a,b", "\"a,b\"")]
+    [InlineData("a\"b", "\"a\"\"b\"")]
+    [InlineData("a\nb", "\"a\nb\"")]
+    public void CsvEscape_QuotesWhenNeeded(string input, string expected)
+    {
+        Assert.Equal(expected, DataGridExport.CsvEscape(input, ","));
+    }
+
+    [Fact]
+    public void CsvEscape_QuotesWhenValueContainsSeparator()
+    {
+        // With a semicolon separator a comma is NOT special, but a semicolon is.
+        Assert.Equal("a,b", DataGridExport.CsvEscape("a,b", ";"));
+        Assert.Equal("\"a;b\"", DataGridExport.CsvEscape("a;b", ";"));
+    }
+
+    [Fact]
+    public void GetRowValues_ReturnsOneValuePerColumn_IncludingTemplate()
+    {
+        var values = RunSta(() =>
+        {
+            var grid = BuildGrid();
+            var item = grid.Items.Cast<object>().First();
+            return DataGridExport.GetRowValues(grid, item);
+        });
+
+        // Bound, bound, template -> three values, in column order.
+        Assert.Equal(new[] { "a,b", "42", "hi" }, values);
+    }
+
+    [Fact]
+    public void BuildClipboardText_KeepsHeadersAndRowsAligned()
+    {
+        var (headerFields, rowFieldCounts, columnCount) = RunSta(() =>
+        {
+            var grid = BuildGrid();
+            var text = DataGridExport.BuildClipboardText(grid);
+            var lines = text.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+            var headers = lines[0].Split('\t');
+            var counts = lines.Skip(1).Select(l => l.Split('\t').Length).ToArray();
+            return (headers, counts, grid.Columns.Count);
+        });
+
+        Assert.Equal(new[] { "Name", "Value", "Note" }, headerFields);
+        Assert.Equal(3, columnCount);
+        // The regression guard: every row has exactly as many fields as there are columns/headers.
+        Assert.All(rowFieldCounts, count => Assert.Equal(columnCount, count));
+    }
+
+    [Fact]
+    public void BuildCsv_EscapesAndIncludesAllColumns()
+    {
+        var csv = RunSta(() =>
+        {
+            var grid = BuildGrid();
+            return DataGridExport.BuildCsv(grid, ",").Replace("\r\n", "\n");
+        });
+
+        var lines = csv.TrimEnd('\n').Split('\n');
+        Assert.Equal("Name,Value,Note", lines[0]);
+        Assert.Equal("\"a,b\",42,hi", lines[1]);   // comma value quoted, number invariant, template value present
+        Assert.Equal("plain,7,there", lines[2]);
+    }
+}

--- a/Dashboard/CollectionLogWindow.xaml.cs
+++ b/Dashboard/CollectionLogWindow.xaml.cs
@@ -191,79 +191,14 @@ namespace PerformanceMonitorDashboard
             }
         }
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = Helpers.TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(Helpers.TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(Helpers.TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var dialog = new Microsoft.Win32.SaveFileDialog
-                    {
-                        FileName = $"collection_log_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        var headers = new List<string>();
-                        foreach (var column in dataGrid.Columns)
-                            headers.Add(Helpers.TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = Helpers.TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => Helpers.TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "collection_log", Helpers.TabHelpers.CsvSeparator);
 
         private void Close_Click(object sender, RoutedEventArgs e)
         {

--- a/Dashboard/CollectorScheduleWindow.xaml.cs
+++ b/Dashboard/CollectorScheduleWindow.xaml.cs
@@ -325,79 +325,14 @@ namespace PerformanceMonitorDashboard
             await LoadSchedulesAsync();
         }
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is System.Windows.Controls.MenuItem menuItem && menuItem.Parent is System.Windows.Controls.ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = Helpers.TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is System.Windows.Controls.MenuItem menuItem && menuItem.Parent is System.Windows.Controls.ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(Helpers.TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is System.Windows.Controls.MenuItem menuItem && menuItem.Parent is System.Windows.Controls.ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(Helpers.TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is System.Windows.Controls.MenuItem menuItem && menuItem.Parent is System.Windows.Controls.ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var dialog = new Microsoft.Win32.SaveFileDialog
-                    {
-                        FileName = $"collector_schedules_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        var headers = new List<string>();
-                        foreach (var column in dataGrid.Columns)
-                            headers.Add(Helpers.TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = Helpers.TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => Helpers.TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "collector_schedules", Helpers.TabHelpers.CsvSeparator);
 
         private void Close_Click(object sender, RoutedEventArgs e)
         {

--- a/Dashboard/Controls/AlertsHistoryContent.xaml.cs
+++ b/Dashboard/Controls/AlertsHistoryContent.xaml.cs
@@ -400,97 +400,14 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    var headers = dataGrid.Columns
-                        .OfType<DataGridBoundColumn>()
-                        .Select(c => DataGridClipboardBehavior.GetHeaderText(c))
-                        .ToList();
-                    sb.AppendLine(string.Join("\t", headers));
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"alert_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-                            var sep = TabHelpers.CsvSeparator;
-                            var headers = dataGrid.Columns
-                                .OfType<DataGridBoundColumn>()
-                                .Select(c => TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(c), sep))
-                                .ToList();
-                            sb.AppendLine(string.Join(sep, headers));
-
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(sep, values.Select(v => TabHelpers.EscapeCsvField(v, sep))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}",
-                                "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}",
-                                "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "alert_history", TabHelpers.CsvSeparator);
 
         #endregion
 

--- a/Dashboard/Controls/ConfigChangesContent.xaml.cs
+++ b/Dashboard/Controls/ConfigChangesContent.xaml.cs
@@ -385,79 +385,14 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var dialog = new Microsoft.Win32.SaveFileDialog
-                    {
-                        FileName = $"config_changes_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        var headers = new List<string>();
-                        foreach (var column in dataGrid.Columns)
-                            headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "config_changes", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/CriticalIssuesContent.xaml.cs
+++ b/Dashboard/Controls/CriticalIssuesContent.xaml.cs
@@ -280,118 +280,14 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem);
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(rowText, false);
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    // Add headers
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                        {
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                        }
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    // Add all rows
-                    foreach (var item in dataGrid.Items)
-                    {
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    }
-
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"critical_issues_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Add headers
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                {
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
-                                }
-                            }
-                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
-
-                            // Add all rows
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "critical_issues", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/CurrentConfigContent.xaml.cs
+++ b/Dashboard/Controls/CurrentConfigContent.xaml.cs
@@ -283,79 +283,14 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var dialog = new Microsoft.Win32.SaveFileDialog
-                    {
-                        FileName = $"config_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        var headers = new List<string>();
-                        foreach (var column in dataGrid.Columns)
-                            headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "config", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/DailySummaryContent.xaml.cs
+++ b/Dashboard/Controls/DailySummaryContent.xaml.cs
@@ -333,118 +333,14 @@ namespace PerformanceMonitorDashboard.Controls
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem);
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(rowText, false);
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    // Add headers
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                        {
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                        }
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    // Add all rows
-                    foreach (var item in dataGrid.Items)
-                    {
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    }
-
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"daily_summary_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Add headers
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                {
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
-                                }
-                            }
-                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
-
-                            // Add all rows
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "daily_summary", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/FinOpsContent.CopyExport.cs
+++ b/Dashboard/Controls/FinOpsContent.CopyExport.cs
@@ -33,141 +33,14 @@ namespace PerformanceMonitorDashboard.Controls
         // Copy / Export Context Menu Handlers
         // ============================================
 
-        private static DataGrid? FindParentDataGrid(DependencyObject? element)
-        {
-            while (element != null)
-            {
-                if (element is DataGrid dg) return dg;
-                element = VisualTreeHelper.GetParent(element);
-            }
-            return null;
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var grid = FindParentDataGrid(contextMenu.PlacementTarget);
-                if (grid != null && grid.CurrentCell.Column != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(grid, grid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var grid = FindParentDataGrid(contextMenu.PlacementTarget);
-                if (grid != null && grid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(grid, grid.SelectedItem);
-                    if (!string.IsNullOrEmpty(rowText))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(rowText, false);
-                    }
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var grid = FindParentDataGrid(contextMenu.PlacementTarget);
-                if (grid != null)
-                {
-                    var sb = new StringBuilder();
-
-                    // Header row
-                    var headers = grid.Columns.Select(c => DataGridClipboardBehavior.GetHeaderText(c));
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    // Data rows
-                    foreach (var item in grid.Items)
-                    {
-                        var values = new List<string>();
-                        foreach (var column in grid.Columns)
-                        {
-                            var binding = (column as DataGridBoundColumn)?.Binding as Binding;
-                            if (binding != null)
-                            {
-                                var prop = item.GetType().GetProperty(binding.Path.Path);
-                                var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
-                                values.Add(value);
-                            }
-                        }
-                        sb.AppendLine(string.Join("\t", values));
-                    }
-
-                    if (sb.Length > 0)
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(sb.ToString(), false);
-                    }
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var grid = FindParentDataGrid(contextMenu.PlacementTarget);
-                if (grid != null)
-                {
-                    var dialog = new SaveFileDialog
-                    {
-                        Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-                        DefaultExt = ".csv",
-                        FileName = $"FinOps_Export_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-                    };
-
-                    if (dialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Header row
-                            var sep = TabHelpers.CsvSeparator;
-                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(c), sep));
-                            sb.AppendLine(string.Join(sep, headers));
-
-                            // Data rows
-                            foreach (var item in grid.Items)
-                            {
-                                var values = new List<string>();
-                                foreach (var column in grid.Columns)
-                                {
-                                    var binding = (column as DataGridBoundColumn)?.Binding as Binding;
-                                    if (binding != null)
-                                    {
-                                        var prop = item.GetType().GetProperty(binding.Path.Path);
-                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
-                                    }
-                                }
-                                sb.AppendLine(string.Join(sep, values));
-                            }
-
-                            File.WriteAllText(dialog.FileName, sb.ToString());
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Error($"Error exporting to CSV: {ex.Message}", ex);
-                            MessageBox.Show($"Error exporting to CSV: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "FinOps_Export", TabHelpers.CsvSeparator);
 
     }
 }

--- a/Dashboard/Controls/MemoryContent.CopyExport.cs
+++ b/Dashboard/Controls/MemoryContent.CopyExport.cs
@@ -29,121 +29,14 @@ namespace PerformanceMonitorDashboard.Controls
     {
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem);
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(rowText, false);
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    // Add headers
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                        {
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                        }
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    // Add all rows
-                    foreach (var item in dataGrid.Items)
-                    {
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    }
-
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    string prefix = "memory";
-
-
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"{prefix}_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Add headers
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                {
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
-                                }
-                            }
-                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
-
-                            // Add all rows
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "memory", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/QueryPerformanceContent.CopyExport.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.CopyExport.cs
@@ -24,63 +24,11 @@ namespace PerformanceMonitorDashboard.Controls
 {
     public partial class QueryPerformanceContent : UserControl
     {
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem);
-                    Clipboard.SetDataObject(rowText, false);
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                        {
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                        }
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    foreach (var item in dataGrid.Items)
-                    {
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    }
-
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
         private void CopyReproScript_Click(object sender, RoutedEventArgs e)
         {
@@ -145,52 +93,7 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"query_performance_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                {
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column), TabHelpers.CsvSeparator));
-                                }
-                            }
-                            sb.AppendLine(string.Join(TabHelpers.CsvSeparator, headers));
-
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(TabHelpers.CsvSeparator, values.Select(v => TabHelpers.EscapeCsvField(v, TabHelpers.CsvSeparator))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "query_performance", TabHelpers.CsvSeparator);
     }
 }

--- a/Dashboard/Controls/ResourceMetricsContent.CopyExport.cs
+++ b/Dashboard/Controls/ResourceMetricsContent.CopyExport.cs
@@ -32,123 +32,14 @@ namespace PerformanceMonitorDashboard.Controls
     {
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid && grid.CurrentCell.Column != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(grid, grid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid && grid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(grid, grid.SelectedItem);
-                    if (!string.IsNullOrEmpty(rowText))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(rowText, false);
-                    }
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    var headers = grid.Columns.Select(c => DataGridClipboardBehavior.GetHeaderText(c));
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    foreach (var item in grid.Items)
-                    {
-                        var values = new List<string>();
-                        foreach (var column in grid.Columns)
-                        {
-                            var binding = (column as DataGridBoundColumn)?.Binding as System.Windows.Data.Binding;
-                            if (binding != null)
-                            {
-                                var prop = item.GetType().GetProperty(binding.Path.Path);
-                                var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
-                                values.Add(value);
-                            }
-                        }
-                        sb.AppendLine(string.Join("\t", values));
-                    }
-
-                    if (sb.Length > 0)
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(sb.ToString(), false);
-                    }
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid)
-                {
-                    var dialog = new SaveFileDialog
-                    {
-                        Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-                        DefaultExt = ".csv",
-                        FileName = $"ResourceMetrics_Export_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-                    };
-
-                    if (dialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            var sep = TabHelpers.CsvSeparator;
-                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(c), sep));
-                            sb.AppendLine(string.Join(sep, headers));
-
-                            foreach (var item in grid.Items)
-                            {
-                                var values = new List<string>();
-                                foreach (var column in grid.Columns)
-                                {
-                                    var binding = (column as DataGridBoundColumn)?.Binding as System.Windows.Data.Binding;
-                                    if (binding != null)
-                                    {
-                                        var prop = item.GetType().GetProperty(binding.Path.Path);
-                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
-                                    }
-                                }
-                                sb.AppendLine(string.Join(sep, values));
-                            }
-
-                            File.WriteAllText(dialog.FileName, sb.ToString());
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Error($"Error exporting to CSV: {ex.Message}", ex);
-                            MessageBox.Show($"Error exporting to CSV: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "ResourceMetrics_Export", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/Controls/SystemEventsContent.CopyExport.cs
+++ b/Dashboard/Controls/SystemEventsContent.CopyExport.cs
@@ -30,127 +30,14 @@ namespace PerformanceMonitorDashboard.Controls
     {
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid && grid.CurrentCell.Column != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(grid, grid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid && grid.SelectedItem != null)
-                {
-                    var rowText = TabHelpers.GetRowAsText(grid, grid.SelectedItem);
-                    if (!string.IsNullOrEmpty(rowText))
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(rowText, false);
-                    }
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    // Header row
-                    var headers = grid.Columns.Select(c => DataGridClipboardBehavior.GetHeaderText(c));
-                    sb.AppendLine(string.Join("\t", headers));
-
-                    // Data rows
-                    foreach (var item in grid.Items)
-                    {
-                        var values = new List<string>();
-                        foreach (var column in grid.Columns)
-                        {
-                            var binding = (column as DataGridBoundColumn)?.Binding as System.Windows.Data.Binding;
-                            if (binding != null)
-                            {
-                                var prop = item.GetType().GetProperty(binding.Path.Path);
-                                var value = prop?.GetValue(item)?.ToString() ?? string.Empty;
-                                values.Add(value);
-                            }
-                        }
-                        sb.AppendLine(string.Join("\t", values));
-                    }
-
-                    if (sb.Length > 0)
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(sb.ToString(), false);
-                    }
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                if (contextMenu.PlacementTarget is DataGrid grid)
-                {
-                    var dialog = new SaveFileDialog
-                    {
-                        Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-                        DefaultExt = ".csv",
-                        FileName = $"SystemEvents_Export_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-                    };
-
-                    if (dialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Header row
-                            var sep = TabHelpers.CsvSeparator;
-                            var headers = grid.Columns.Select(c => TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(c), sep));
-                            sb.AppendLine(string.Join(sep, headers));
-
-                            // Data rows
-                            foreach (var item in grid.Items)
-                            {
-                                var values = new List<string>();
-                                foreach (var column in grid.Columns)
-                                {
-                                    var binding = (column as DataGridBoundColumn)?.Binding as System.Windows.Data.Binding;
-                                    if (binding != null)
-                                    {
-                                        var prop = item.GetType().GetProperty(binding.Path.Path);
-                                        values.Add(TabHelpers.EscapeCsvField(TabHelpers.FormatForExport(prop?.GetValue(item)), sep));
-                                    }
-                                }
-                                sb.AppendLine(string.Join(sep, values));
-                            }
-
-                            File.WriteAllText(dialog.FileName, sb.ToString());
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Error($"Error exporting to CSV: {ex.Message}", ex);
-                            MessageBox.Show($"Error exporting to CSV: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "SystemEvents_Export", TabHelpers.CsvSeparator);
 
         #endregion
     }

--- a/Dashboard/ManageServersWindow.xaml.cs
+++ b/Dashboard/ManageServersWindow.xaml.cs
@@ -419,79 +419,14 @@ namespace PerformanceMonitorDashboard
             }
         }
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = Helpers.TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(Helpers.TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    var headers = new System.Collections.Generic.List<string>();
-                    foreach (var column in dataGrid.Columns)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(Helpers.TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = Helpers.TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var dialog = new Microsoft.Win32.SaveFileDialog
-                    {
-                        FileName = $"servers_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-                    if (dialog.ShowDialog() == true)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        var headers = new System.Collections.Generic.List<string>();
-                        foreach (var column in dataGrid.Columns)
-                            headers.Add(Helpers.TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = Helpers.TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => Helpers.TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "servers", Helpers.TabHelpers.CsvSeparator);
 
         private void Close_Click(object sender, RoutedEventArgs e)
         {

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -391,94 +391,14 @@ namespace PerformanceMonitorDashboard
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"procedure_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                            }
-                            sb.AppendLine(string.Join(",", headers));
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                            }
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "procedure_history", TabHelpers.CsvSeparator);
 
         #endregion
 

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -407,94 +407,14 @@ namespace PerformanceMonitorDashboard
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"query_execution_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                            }
-                            sb.AppendLine(string.Join(",", headers));
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                            }
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "query_execution_history", TabHelpers.CsvSeparator);
 
         #endregion
 

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -386,94 +386,14 @@ namespace PerformanceMonitorDashboard
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"query_stats_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                            }
-                            sb.AppendLine(string.Join(",", headers));
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                            }
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "query_stats_history", TabHelpers.CsvSeparator);
 
         #endregion
 

--- a/Dashboard/ServerTab.CopyExport.cs
+++ b/Dashboard/ServerTab.CopyExport.cs
@@ -26,118 +26,14 @@ namespace PerformanceMonitorDashboard
         // Context Menu Event Handlers
         // ====================================================================
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (cellContent != null)
-                    {
-                        /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                        Clipboard.SetDataObject(cellContent, false);
-                    }
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.SelectedItem != null)
-                {
-                    var rowText = GetRowAsText(dataGrid, dataGrid.SelectedItem);
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(rowText, false);
-                }
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-                    // Add headers
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn boundColumn)
-                        {
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                        }
-                    }
-                    sb.AppendLine(string.Join("	", headers));
-
-                    // Add all rows
-                    foreach (var item in dataGrid.Items)
-                    {
-                        sb.AppendLine(GetRowAsText(dataGrid, item));
-                    }
-
-                    /* Use SetDataObject with copy=false to avoid WPF's problematic Clipboard.Flush() */
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
-
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"export_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-
-                            // Add headers
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                {
-                                    headers.Add(EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                                }
-                            }
-                            sb.AppendLine(string.Join(",", headers));
-
-                            // Add all rows
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => EscapeCsvField(v))));
-                            }
-
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "export", TabHelpers.CsvSeparator);
 
         private DataGrid? FindDataGridFromContextMenu(ContextMenu contextMenu)
         {
@@ -151,52 +47,6 @@ namespace PerformanceMonitorDashboard
         private T? FindParent<T>(DependencyObject child) where T : DependencyObject
         {
             return TabHelpers.FindParent<T>(child);
-        }
-
-        private string GetCellContent(DataGrid dataGrid, DataGridCellInfo cellInfo)
-        {
-            var column = cellInfo.Column as DataGridBoundColumn;
-            if (column?.Binding is Binding binding && binding.Path != null)
-            {
-                var propertyName = binding.Path.Path;
-                var property = cellInfo.Item.GetType().GetProperty(propertyName);
-                if (property != null)
-                {
-                    var value = property.GetValue(cellInfo.Item);
-                    return value?.ToString() ?? string.Empty;
-                }
-            }
-            return string.Empty;
-        }
-
-        private string GetRowAsText(DataGrid dataGrid, object item)
-        {
-            var values = GetRowValues(dataGrid, item);
-            return string.Join("	", values);
-        }
-
-        private List<string> GetRowValues(DataGrid dataGrid, object item)
-        {
-            var values = new List<string>();
-            foreach (var column in dataGrid.Columns)
-            {
-                if (column is DataGridBoundColumn boundColumn && boundColumn.Binding is Binding binding)
-                {
-                    var propertyName = binding.Path.Path;
-                    var property = item.GetType().GetProperty(propertyName);
-                    if (property != null)
-                    {
-                        var value = property.GetValue(item);
-                        values.Add(value?.ToString() ?? string.Empty);
-                    }
-                }
-            }
-            return values;
-        }
-
-        private string EscapeCsvField(string field)
-        {
-            return TabHelpers.EscapeCsvField(field);
         }
     }
 }

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -316,94 +316,14 @@ namespace PerformanceMonitorDashboard
 
         #region Context Menu Handlers
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-                {
-                    var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                    if (!string.IsNullOrEmpty(cellContent))
-                        Clipboard.SetDataObject(cellContent, false);
-                }
-            }
-        }
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        private void CopyRow_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid?.SelectedItem != null)
-                    Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-            }
-        }
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    var headers = new List<string>();
-                    foreach (var column in dataGrid.Columns)
-                    {
-                        if (column is DataGridBoundColumn)
-                            headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                    }
-                    sb.AppendLine(string.Join("\t", headers));
-                    foreach (var item in dataGrid.Items)
-                        sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                    Clipboard.SetDataObject(sb.ToString(), false);
-                }
-            }
-        }
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-            {
-                var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-                if (dataGrid != null && dataGrid.Items.Count > 0)
-                {
-                    var saveFileDialog = new SaveFileDialog
-                    {
-                        FileName = $"trace_pattern_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                        DefaultExt = ".csv",
-                        Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                    };
-
-                    if (saveFileDialog.ShowDialog() == true)
-                    {
-                        try
-                        {
-                            var sb = new StringBuilder();
-                            var headers = new List<string>();
-                            foreach (var column in dataGrid.Columns)
-                            {
-                                if (column is DataGridBoundColumn)
-                                    headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                            }
-                            sb.AppendLine(string.Join(",", headers));
-                            foreach (var item in dataGrid.Items)
-                            {
-                                var values = TabHelpers.GetRowValues(dataGrid, item);
-                                sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                            }
-                            File.WriteAllText(saveFileDialog.FileName, sb.ToString());
-                            MessageBox.Show($"Data exported successfully to:\n{saveFileDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                        }
-                    }
-                }
-            }
-        }
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+            DataGridExport.ExportToCsv(sender, "trace_pattern_history", TabHelpers.CsvSeparator);
 
         [System.Text.RegularExpressions.GeneratedRegex(@"\s+")]
         private static partial System.Text.RegularExpressions.Regex MultipleSpacesRegExp();

--- a/Dashboard/WaitDrillDownWindow.xaml.cs
+++ b/Dashboard/WaitDrillDownWindow.xaml.cs
@@ -437,93 +437,14 @@ public partial class WaitDrillDownWindow : Window
 
     #region Context Menu Handlers
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-        {
-            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-            if (dataGrid != null && dataGrid.CurrentCell.Item != null)
-            {
-                var cellContent = TabHelpers.GetCellContent(dataGrid, dataGrid.CurrentCell);
-                if (!string.IsNullOrEmpty(cellContent))
-                    Clipboard.SetDataObject(cellContent, false);
-            }
-        }
-    }
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-    private void CopyRow_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-        {
-            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-            if (dataGrid?.SelectedItem != null)
-                Clipboard.SetDataObject(TabHelpers.GetRowAsText(dataGrid, dataGrid.SelectedItem), false);
-        }
-    }
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-        {
-            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-            if (dataGrid != null && dataGrid.Items.Count > 0)
-            {
-                var sb = new StringBuilder();
-                var headers = new List<string>();
-                foreach (var column in dataGrid.Columns)
-                {
-                    if (column is DataGridBoundColumn)
-                        headers.Add(DataGridClipboardBehavior.GetHeaderText(column));
-                }
-                sb.AppendLine(string.Join("\t", headers));
-                foreach (var item in dataGrid.Items)
-                    sb.AppendLine(TabHelpers.GetRowAsText(dataGrid, item));
-                Clipboard.SetDataObject(sb.ToString(), false);
-            }
-        }
-    }
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem menuItem && menuItem.Parent is ContextMenu contextMenu)
-        {
-            var dataGrid = TabHelpers.FindDataGridFromContextMenu(contextMenu);
-            if (dataGrid != null && dataGrid.Items.Count > 0)
-            {
-                var dialog = new SaveFileDialog
-                {
-                    FileName = $"wait_drill_down_{_waitType}_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
-                    DefaultExt = ".csv",
-                    Filter = "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*"
-                };
-
-                if (dialog.ShowDialog() == true)
-                {
-                    try
-                    {
-                        var sb = new StringBuilder();
-                        var headers = new List<string>();
-                        foreach (var column in dataGrid.Columns)
-                        {
-                            if (column is DataGridBoundColumn)
-                                headers.Add(TabHelpers.EscapeCsvField(DataGridClipboardBehavior.GetHeaderText(column)));
-                        }
-                        sb.AppendLine(string.Join(",", headers));
-                        foreach (var item in dataGrid.Items)
-                        {
-                            var values = TabHelpers.GetRowValues(dataGrid, item);
-                            sb.AppendLine(string.Join(",", values.Select(v => TabHelpers.EscapeCsvField(v))));
-                        }
-                        System.IO.File.WriteAllText(dialog.FileName, sb.ToString());
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show($"Export failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
-                }
-            }
-        }
-    }
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+        DataGridExport.ExportToCsv(sender, $"wait_drill_down_{_waitType}", TabHelpers.CsvSeparator);
 
     #endregion
 

--- a/Lite/Controls/AlertsHistoryTab.xaml.cs
+++ b/Lite/Controls/AlertsHistoryTab.xaml.cs
@@ -404,99 +404,14 @@ public partial class AlertsHistoryTab : UserControl
 
     #region Context Menu Handlers
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
-        if (value.Length > 0) Clipboard.SetDataObject(value, false);
-    }
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-    private void CopyRow_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentItem == null) return;
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
-        var sb = new StringBuilder();
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(GetCellValue(col, grid.CurrentItem));
-            sb.Append('\t');
-        }
-        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
-    }
-
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null) return;
-
-        var sb = new StringBuilder();
-
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
-            sb.Append('\t');
-        }
-        sb.AppendLine();
-
-        foreach (var item in grid.Items)
-        {
-            foreach (var col in grid.Columns)
-            {
-                sb.Append(GetCellValue(col, item));
-                sb.Append('\t');
-            }
-            sb.AppendLine();
-        }
-
-        Clipboard.SetDataObject(sb.ToString(), false);
-    }
-
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null || grid.Items.Count == 0) return;
-
-        var dialog = new SaveFileDialog
-        {
-            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-            DefaultExt = ".csv",
-            FileName = $"alert_history_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-        };
-
-        if (dialog.ShowDialog() != true) return;
-
-        var sb = new StringBuilder();
-
-        var headers = new List<string>();
-        foreach (var col in grid.Columns)
-            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col)));
-        sb.AppendLine(string.Join(",", headers));
-
-        foreach (var item in grid.Items)
-        {
-            var values = new List<string>();
-            foreach (var col in grid.Columns)
-                values.Add(CsvEscape(GetCellValue(col, item)));
-            sb.AppendLine(string.Join(",", values));
-        }
-
-        try
-        {
-            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error",
-                MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-    }
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+        DataGridExport.ExportToCsv(sender, "alert_history", App.CsvSeparator);
 
     #endregion
 
@@ -509,23 +424,6 @@ public partial class AlertsHistoryTab : UserControl
         while (target != null && target is not DataGrid)
             target = System.Windows.Media.VisualTreeHelper.GetParent(target) as FrameworkElement;
         return target as DataGrid;
-    }
-
-    private static string GetCellValue(DataGridColumn col, object item)
-    {
-        if (col is DataGridBoundColumn boundCol && boundCol.Binding is Binding binding)
-        {
-            var prop = item.GetType().GetProperty(binding.Path.Path);
-            return prop?.GetValue(item)?.ToString() ?? "";
-        }
-        return "";
-    }
-
-    private static string CsvEscape(string value)
-    {
-        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
-            return "\"" + value.Replace("\"", "\"\"") + "\"";
-        return value;
     }
 
     #endregion

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -948,66 +948,18 @@ public partial class FinOpsTab : UserControl
 
     #region Context Menu Handlers
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
-        if (value.Length > 0) Clipboard.SetDataObject(value, false);
-    }
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-    private void CopyRow_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentItem == null) return;
-
-        var sb = new StringBuilder();
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(GetCellValue(col, grid.CurrentItem));
-            sb.Append('\t');
-        }
-        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
-    }
-
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null) return;
-
-        var sb = new StringBuilder();
-
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
-            sb.Append('\t');
-        }
-        sb.AppendLine();
-
-        foreach (var item in grid.Items)
-        {
-            foreach (var col in grid.Columns)
-            {
-                sb.Append(GetCellValue(col, item));
-                sb.Append('\t');
-            }
-            sb.AppendLine();
-        }
-
-        Clipboard.SetDataObject(sb.ToString(), false);
-    }
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
     private void ExportToCsv_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null || grid.Items.Count == 0) return;
-
-        var prefix = grid.Name switch
+        // FinOps shares one handler across several grids, so the file-name prefix is chosen
+        // from the originating grid's name (resolved the same way the shared exporter does).
+        var grid = sender is MenuItem menuItem ? FindParentDataGrid(menuItem) : null;
+        var prefix = grid?.Name switch
         {
             nameof(DatabaseSizesDataGrid) => "database_sizes",
             nameof(ServerInventoryDataGrid) => "server_inventory",
@@ -1015,40 +967,7 @@ public partial class FinOpsTab : UserControl
             nameof(ApplicationConnectionsDataGrid) => "application_connections",
             _ => "finops_export"
         };
-
-        var dialog = new SaveFileDialog
-        {
-            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-            DefaultExt = ".csv",
-            FileName = $"{prefix}_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-        };
-
-        if (dialog.ShowDialog() != true) return;
-
-        var sb = new StringBuilder();
-
-        var headers = new List<string>();
-        foreach (var col in grid.Columns)
-            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col)));
-        sb.AppendLine(string.Join(",", headers));
-
-        foreach (var item in grid.Items)
-        {
-            var values = new List<string>();
-            foreach (var col in grid.Columns)
-                values.Add(CsvEscape(GetCellValue(col, item)));
-            sb.AppendLine(string.Join(",", values));
-        }
-
-        try
-        {
-            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error",
-                MessageBoxButton.OK, MessageBoxImage.Error);
-        }
+        DataGridExport.ExportToCsv(sender, prefix, App.CsvSeparator);
     }
 
     #endregion
@@ -1166,23 +1085,6 @@ public partial class FinOpsTab : UserControl
         while (target != null && target is not DataGrid)
             target = VisualTreeHelper.GetParent(target) as FrameworkElement;
         return target as DataGrid;
-    }
-
-    private static string GetCellValue(DataGridColumn col, object item)
-    {
-        if (col is DataGridBoundColumn boundCol && boundCol.Binding is Binding binding)
-        {
-            var prop = item.GetType().GetProperty(binding.Path.Path);
-            return prop?.GetValue(item)?.ToString() ?? "";
-        }
-        return "";
-    }
-
-    private static string CsvEscape(string value)
-    {
-        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
-            return "\"" + value.Replace("\"", "\"\"") + "\"";
-        return value;
     }
 
     #endregion

--- a/Lite/Controls/ServerTab.CopyExport.cs
+++ b/Lite/Controls/ServerTab.CopyExport.cs
@@ -38,100 +38,11 @@ public partial class ServerTab : UserControl
         return target as DataGrid;
     }
 
-    /// <summary>
-    /// Gets a cell value from a row item for any column type (bound or template).
-    /// Template columns are inspected for a TextBlock binding in their CellTemplate.
-    /// </summary>
-    private static string GetCellValue(DataGridColumn col, object item)
-    {
-        /* DataGridBoundColumn — binding is directly accessible */
-        if (col is DataGridBoundColumn boundCol
-            && boundCol.Binding is System.Windows.Data.Binding binding)
-        {
-            var prop = item.GetType().GetProperty(binding.Path.Path);
-            return FormatForExport(prop?.GetValue(item));
-        }
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
 
-        /* DataGridTemplateColumn — instantiate the template and find a TextBlock binding */
-        if (col is DataGridTemplateColumn templateCol && templateCol.CellTemplate != null)
-        {
-            var content = templateCol.CellTemplate.LoadContent();
-            if (content is TextBlock textBlock)
-            {
-                var textBinding = System.Windows.Data.BindingOperations.GetBinding(textBlock, TextBlock.TextProperty);
-                if (textBinding != null)
-                {
-                    var prop = item.GetType().GetProperty(textBinding.Path.Path);
-                    return FormatForExport(prop?.GetValue(item));
-                }
-            }
-        }
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
 
-        return "";
-    }
-
-    private static string FormatForExport(object? value)
-    {
-        if (value == null) return "";
-        if (value is IFormattable formattable)
-            return formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
-        return value.ToString() ?? "";
-    }
-
-    private void CopyCell_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentCell.Column == null || grid.CurrentItem == null) return;
-
-        var value = GetCellValue(grid.CurrentCell.Column, grid.CurrentItem);
-        if (value.Length > 0) Clipboard.SetDataObject(value, false);
-    }
-
-    private void CopyRow_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.CurrentItem == null) return;
-
-        var sb = new StringBuilder();
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(GetCellValue(col, grid.CurrentItem));
-            sb.Append('\t');
-        }
-        Clipboard.SetDataObject(sb.ToString().TrimEnd('\t'), false);
-    }
-
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null) return;
-
-        var sb = new StringBuilder();
-
-        /* Header */
-        foreach (var col in grid.Columns)
-        {
-            sb.Append(DataGridClipboardBehavior.GetHeaderText(col));
-            sb.Append('\t');
-        }
-        sb.AppendLine();
-
-        /* Rows */
-        foreach (var item in grid.Items)
-        {
-            foreach (var col in grid.Columns)
-            {
-                sb.Append(GetCellValue(col, item));
-                sb.Append('\t');
-            }
-            sb.AppendLine();
-        }
-
-        Clipboard.SetDataObject(sb.ToString(), false);
-    }
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
     private async void CopyReproScript_Click(object sender, RoutedEventArgs e)
     {
@@ -212,59 +123,6 @@ public partial class ServerTab : UserControl
         Clipboard.SetDataObject(script, false);
     }
 
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem menuItem) return;
-        var grid = FindParentDataGrid(menuItem);
-        if (grid?.Items == null || grid.Items.Count == 0) return;
-
-        var dialog = new SaveFileDialog
-        {
-            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-            DefaultExt = ".csv",
-            FileName = $"{_server.DisplayName}_{DateTime.Now:yyyyMMdd_HHmmss}.csv"
-        };
-
-        if (dialog.ShowDialog() != true) return;
-
-        var sb = new StringBuilder();
-        var sep = App.CsvSeparator;
-
-        /* Header */
-        var headers = new List<string>();
-        foreach (var col in grid.Columns)
-        {
-            headers.Add(CsvEscape(DataGridClipboardBehavior.GetHeaderText(col), sep));
-        }
-        sb.AppendLine(string.Join(sep, headers));
-
-        /* Rows */
-        foreach (var item in grid.Items)
-        {
-            var values = new List<string>();
-            foreach (var col in grid.Columns)
-            {
-                values.Add(CsvEscape(GetCellValue(col, item), sep));
-            }
-            sb.AppendLine(string.Join(sep, values));
-        }
-
-        try
-        {
-            File.WriteAllText(dialog.FileName, sb.ToString(), Encoding.UTF8);
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Failed to export: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-    }
-
-    private static string CsvEscape(string value, string separator)
-    {
-        if (value.Contains(separator, StringComparison.Ordinal) || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
-        {
-            return "\"" + value.Replace("\"", "\"\"") + "\"";
-        }
-        return value;
-    }
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
+        DataGridExport.ExportToCsv(sender, _server.DisplayName, App.CsvSeparator);
 }

--- a/Lite/Windows/CollectionLogWindow.xaml.cs
+++ b/Lite/Windows/CollectionLogWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Windows
 {
@@ -72,10 +73,10 @@ namespace PerformanceMonitorLite.Windows
             }
         }
 
-        private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-        private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "collection_log");
+        private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+        private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+        private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "collection_log", App.CsvSeparator);
 
         private void Close_Click(object sender, RoutedEventArgs e)
         {

--- a/Lite/Windows/ManageServersWindow.xaml.cs
+++ b/Lite/Windows/ManageServersWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Input;
 using PerformanceMonitorLite.Models;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Windows;
 
@@ -144,10 +145,10 @@ public partial class ManageServersWindow : Window
         }
     }
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "servers");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "servers", App.CsvSeparator);
 
     private void CloseButton_Click(object sender, RoutedEventArgs e)
     {

--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -174,10 +174,10 @@ public partial class ProcedureHistoryWindow : Window
         }
     }
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "procedure_history");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "procedure_history", App.CsvSeparator);
 
     // Procedures are View Plan only — re-executing a proc without parameter values is unsafe,
     // matching the main Procedure grid (no Get Actual case in its switch).

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -196,10 +196,10 @@ public partial class QueryStatsHistoryWindow : Window
         HistoryChart.Refresh();
     }
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_stats_history");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "query_stats_history", App.CsvSeparator);
 
     private async System.Threading.Tasks.Task<string?> FetchPlanAsync()
     {

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -177,10 +177,10 @@ public partial class QueryStoreHistoryWindow : Window
         HistoryChart.Refresh();
     }
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "query_store_history");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "query_store_history", App.CsvSeparator);
 
     private async System.Threading.Tasks.Task<string?> FetchPlanAsync()
     {

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -1198,10 +1198,10 @@ public partial class SettingsWindow : Window
         e.Handled = true;
     }
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => Helpers.ContextMenuHelper.ExportToCsv(sender, "schedules");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "schedules", App.CsvSeparator);
 
     private void CloseButton_Click(object sender, RoutedEventArgs e)
     {

--- a/Lite/Windows/WaitDrillDownWindow.xaml.cs
+++ b/Lite/Windows/WaitDrillDownWindow.xaml.cs
@@ -419,10 +419,10 @@ public partial class WaitDrillDownWindow : Window
 
     #endregion
 
-    private void CopyCell_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyCell(sender);
-    private void CopyRow_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyRow(sender);
-    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.CopyAllRows(sender);
-    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => ContextMenuHelper.ExportToCsv(sender, "wait_drill_down");
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "wait_drill_down", App.CsvSeparator);
 
     private async void ViewPlan_Click(object sender, RoutedEventArgs e)
     {

--- a/PerformanceMonitor.Ui/DataGridExport.cs
+++ b/PerformanceMonitor.Ui/DataGridExport.cs
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Microsoft.Win32;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Shared copy/export operations for DataGrid context menus, used by both Dashboard and Lite.
+/// The four context-menu handlers (Copy Cell / Copy Row / Copy All Rows / Export to CSV) are
+/// identical across ~29 sites apart from the CSV file-name prefix and the user's separator
+/// preference, so they live here once.
+///
+/// Headers and rows both iterate <see cref="DataGrid.Columns"/> in lock-step (bound AND template
+/// columns), so the two never misalign -- a bug the older Dashboard handlers had, where headers
+/// were filtered to bound columns but rows emitted every column.
+///
+/// Each operation is split into a pure builder (returns the string -- unit-testable headlessly)
+/// and a thin wrapper that performs the clipboard / SaveFileDialog / file side effect.
+/// </summary>
+public static class DataGridExport
+{
+    /* ---- side-effecting wrappers (wired to the context-menu MenuItem handlers) ---- */
+
+    /// <summary>Copies the current cell's value to the clipboard.</summary>
+    public static void CopyCell(object sender)
+    {
+        var grid = FindDataGrid(sender);
+        if (grid == null) return;
+
+        var cell = grid.CurrentCell;
+        if (cell.Column == null || cell.Item == null) return;
+
+        var value = GetCellValue(cell.Column, cell.Item);
+        if (value.Length > 0) Clipboard.SetDataObject(value, false);
+    }
+
+    /// <summary>Copies the current row (all columns, tab-delimited) to the clipboard.</summary>
+    public static void CopyRow(object sender)
+    {
+        var grid = FindDataGrid(sender);
+        if (grid?.CurrentItem == null) return;
+
+        Clipboard.SetDataObject(string.Join("\t", GetRowValues(grid, grid.CurrentItem)), false);
+    }
+
+    /// <summary>Copies the whole grid (header + all rows, tab-delimited) to the clipboard.</summary>
+    public static void CopyAllRows(object sender)
+    {
+        var grid = FindDataGrid(sender);
+        if (grid == null || grid.Items.Count == 0) return;
+
+        Clipboard.SetDataObject(BuildClipboardText(grid), false);
+    }
+
+    /// <summary>
+    /// Prompts for a file and exports the whole grid to CSV. <paramref name="fileNamePrefix"/>
+    /// seeds the suggested file name; <paramref name="separator"/> is the user's CSV separator
+    /// preference (each app passes its own).
+    /// </summary>
+    public static void ExportToCsv(object sender, string fileNamePrefix, string separator)
+    {
+        var grid = FindDataGrid(sender);
+        if (grid == null || grid.Items.Count == 0) return;
+
+        var dialog = new SaveFileDialog
+        {
+            FileName = $"{fileNamePrefix}_{DateTime.Now:yyyyMMdd_HHmmss}.csv",
+            DefaultExt = ".csv",
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, BuildCsv(grid, separator), Encoding.UTF8);
+            MessageBox.Show($"Data exported successfully to:\n{dialog.FileName}", "Export Complete",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    /* ---- pure builders (unit-testable) ---- */
+
+    /// <summary>Builds the tab-delimited header+rows text used by Copy All Rows.</summary>
+    public static string BuildClipboardText(DataGrid grid)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(string.Join("\t", grid.Columns.Select(DataGridClipboardBehavior.GetHeaderText)));
+        foreach (var item in grid.Items)
+        {
+            sb.AppendLine(string.Join("\t", GetRowValues(grid, item)));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Builds the CSV text (header + rows, escaped) for the given separator.</summary>
+    public static string BuildCsv(DataGrid grid, string separator)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(string.Join(separator,
+            grid.Columns.Select(c => CsvEscape(DataGridClipboardBehavior.GetHeaderText(c), separator))));
+        foreach (var item in grid.Items)
+        {
+            sb.AppendLine(string.Join(separator,
+                GetRowValues(grid, item).Select(v => CsvEscape(v, separator))));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Gets one string per column for a row, in column order (empty for columns with no extractable value).</summary>
+    public static List<string> GetRowValues(DataGrid grid, object item)
+    {
+        var values = new List<string>(grid.Columns.Count);
+        foreach (var column in grid.Columns)
+        {
+            values.Add(GetCellValue(column, item));
+        }
+        return values;
+    }
+
+    /// <summary>
+    /// Extracts a cell value for any column type. Bound columns read their binding path directly;
+    /// template columns are instantiated and inspected for a TextBlock binding. Unhandled column
+    /// types yield an empty string so the value count always matches the column count.
+    /// </summary>
+    public static string GetCellValue(DataGridColumn column, object item)
+    {
+        if (column is DataGridBoundColumn boundColumn
+            && boundColumn.Binding is Binding binding
+            && binding.Path != null)
+        {
+            var property = item.GetType().GetProperty(binding.Path.Path);
+            return FormatForExport(property?.GetValue(item));
+        }
+
+        if (column is DataGridTemplateColumn templateColumn && templateColumn.CellTemplate != null)
+        {
+            var content = templateColumn.CellTemplate.LoadContent();
+            if (content is TextBlock textBlock)
+            {
+                var textBinding = BindingOperations.GetBinding(textBlock, TextBlock.TextProperty);
+                if (textBinding != null && textBinding.Path != null)
+                {
+                    var property = item.GetType().GetProperty(textBinding.Path.Path);
+                    return FormatForExport(property?.GetValue(item));
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>Formats a value for export: invariant culture for IFormattable, else ToString.</summary>
+    public static string FormatForExport(object? value)
+    {
+        if (value == null) return string.Empty;
+        if (value is IFormattable formattable) return formattable.ToString(null, CultureInfo.InvariantCulture);
+        return value.ToString() ?? string.Empty;
+    }
+
+    /// <summary>Escapes a value for CSV: quote when it contains the separator, a quote, or a newline.</summary>
+    public static string CsvEscape(string value, string separator)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        if (value.Contains(separator, StringComparison.Ordinal)
+            || value.Contains('"')
+            || value.Contains('\n')
+            || value.Contains('\r'))
+        {
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    /* ---- internals ---- */
+
+    /// <summary>Resolves the DataGrid that owns the context menu the handler fired from.</summary>
+    private static DataGrid? FindDataGrid(object sender)
+    {
+        if (sender is not MenuItem menuItem || menuItem.Parent is not ContextMenu contextMenu)
+            return null;
+
+        if (contextMenu.PlacementTarget is DataGrid grid)
+            return grid;
+
+        DependencyObject? target = contextMenu.PlacementTarget;
+        while (target != null && target is not DataGrid)
+        {
+            target = VisualTreeHelper.GetParent(target);
+        }
+        return target as DataGrid;
+    }
+}


### PR DESCRIPTION
Follow-up **(a)** -- the big one. The DataGrid copy/export context-menu handlers (Copy Cell / Copy Row / Copy All Rows / Export to CSV) were copy-pasted across **29 files in both apps**; this lifts them into one shared `PerformanceMonitor.Ui.DataGridExport`. **31 files, +514 / -2201 (net ~1,700 lines removed).**

## What changed
- **New shared `DataGridExport`** (`.Ui`): the four operations plus their generic leaves, used by both apps. Each op is a **pure builder** (`BuildCsv` / `BuildClipboardText` / `GetRowValues` / `GetCellValue` / `CsvEscape` / `FormatForExport`) plus a thin clipboard / SaveFileDialog / file wrapper.
- **All 29 sites** (Dashboard 19 + Lite 10) delegate -- 116 one-line handlers. Inline leaf helpers that became unused were removed; ones still used elsewhere (`CopyReproScript`, cross-partial `FindDataGridFromContextMenu`) were kept.
- **Canonical behavior**: all-columns-aligned + template-aware + culture-aware separator + success dialog. This **fixes a latent bug** -- the older Dashboard handlers built headers from bound columns only but emitted rows from all columns, so any grid with a template column exported with headers and values misaligned. Headers and rows now iterate columns in lock-step.

## Tested
- **12 `DataGridExport` unit tests** (`Dashboard.Tests`), including an **alignment regression test** on a real `DataGrid` with a template column (small STA harness), plus formatter / escaper / template-extraction coverage. Because every site routes through this one class, the tests cover all 29 -- no 29-way manual click-through.
- Both apps green: **Dashboard.Tests 703, Lite.Tests 618**; build 0 errors.

## One residual (live)
A unit test can't drive the context-menu -> SaveFileDialog -> file UI. That hop is identical at every site, so a **single Export per app** confirms it -- a 2-click spot-check.

## How it was built
Phase 1 (keystone + tests + 2 proof sites) was hand-built and committed first; Phase 2 fanned out one agent per remaining site via a workflow, then verified centrally (build + both test suites + a dead-leaf sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
