### PR TITLE
Fix right-click Copy Cell/Copy Row across all DataGrids

### DIFF
--- a/PerformanceMonitor.Ui/DataGridExport.cs
+++ b/PerformanceMonitor.Ui/DataGridExport.cs
@@ -50,13 +50,20 @@ public static class DataGridExport
         if (value.Length > 0) Clipboard.SetDataObject(value, false);
     }
 
-    /// <summary>Copies the current row (all columns, tab-delimited) to the clipboard.</summary>
+    /// <summary>
+    /// Copies a row (all columns, tab-delimited) to the clipboard -- the row the context menu was
+    /// opened on, falling back to the current or selected row. Row-attached context menus don't
+    /// select the row on right-click, so CurrentItem alone is often null here.
+    /// </summary>
     public static void CopyRow(object sender)
     {
         var grid = FindDataGrid(sender);
-        if (grid?.CurrentItem == null) return;
+        if (grid == null) return;
 
-        Clipboard.SetDataObject(string.Join("\t", GetRowValues(grid, grid.CurrentItem)), false);
+        var item = FindRowItem(sender) ?? grid.CurrentItem ?? grid.SelectedItem;
+        if (item == null) return;
+
+        Clipboard.SetDataObject(string.Join("\t", GetRowValues(grid, item)), false);
     }
 
     /// <summary>Copies the whole grid (header + all rows, tab-delimited) to the clipboard.</summary>
@@ -210,5 +217,22 @@ public static class DataGridExport
             target = VisualTreeHelper.GetParent(target);
         }
         return target as DataGrid;
+    }
+
+    /// <summary>
+    /// The data item of the DataGridRow the context menu was opened on (for row- or cell-attached
+    /// menus), or null when the menu is attached directly to the DataGrid.
+    /// </summary>
+    private static object? FindRowItem(object sender)
+    {
+        if (sender is not MenuItem menuItem || menuItem.Parent is not ContextMenu contextMenu)
+            return null;
+
+        DependencyObject? target = contextMenu.PlacementTarget;
+        while (target != null && target is not DataGridRow)
+        {
+            target = VisualTreeHelper.GetParent(target);
+        }
+        return (target as DataGridRow)?.Item;
     }
 }

--- a/PerformanceMonitor.Ui/DataGridRowSelectionBehavior.cs
+++ b/PerformanceMonitor.Ui/DataGridRowSelectionBehavior.cs
@@ -14,20 +14,22 @@ using System.Windows.Media;
 namespace PerformanceMonitor.Ui;
 
 /// <summary>
-/// Makes right-clicking a DataGrid row select it. WPF's DataGrid does not select a row on
-/// right-click by default, so context-menu actions that read <c>SelectedItem</c> (e.g. "View Plan")
-/// silently do nothing whenever the prior left-click selection was cleared — most commonly by a
-/// background auto-refresh re-binding <c>ItemsSource</c>, which also drops the row's highlight.
-/// Selecting the row under the cursor on right-click makes the menu always act on the row the user
-/// actually clicked. Call <see cref="Enable"/> once at application startup to apply this app-wide.
+/// Makes right-clicking a DataGrid select the row AND make the cell under the cursor current. WPF's
+/// DataGrid does neither on right-click by default, so context-menu actions that read
+/// <c>SelectedItem</c>/<c>CurrentItem</c> (e.g. "View Plan", "Copy Row") or <c>CurrentCell</c>
+/// (e.g. "Copy Cell") silently do nothing on a bare right-click — and any prior left-click selection
+/// is most commonly cleared by a background auto-refresh re-binding <c>ItemsSource</c>. Setting both
+/// the selected row and the current cell under the cursor makes every context-menu item act on what
+/// the user actually clicked, regardless of how the grid attaches its menu (row-level or grid-level).
+/// Call <see cref="Enable"/> once at application startup to apply this app-wide.
 /// </summary>
 public static class DataGridRowSelectionBehavior
 {
     private static bool _enabled;
 
     /// <summary>
-    /// Registers a class handler so every <see cref="DataGrid"/> in the app selects the row under
-    /// the cursor on right-click. Idempotent.
+    /// Registers a class handler so every <see cref="DataGrid"/> in the app selects the row and makes
+    /// the cell under the cursor current on right-click. Idempotent.
     /// </summary>
     public static void Enable()
     {
@@ -42,15 +44,30 @@ public static class DataGridRowSelectionBehavior
 
     private static void OnPreviewRightButtonDown(object sender, MouseButtonEventArgs e)
     {
-        // Walk up from the actual clicked element (a cell's content) to its DataGridRow.
+        if (sender is not DataGrid grid) return;
+
+        // Walk up from the actual clicked element (a cell's content), capturing the DataGridCell on
+        // the way to its DataGridRow. The cell is a descendant of the row, so it is seen first.
+        DataGridCell? cell = null;
         var dep = e.OriginalSource as DependencyObject;
         while (dep != null && dep is not DataGridRow)
+        {
+            if (cell == null && dep is DataGridCell c) cell = c;
             dep = VisualTreeHelper.GetParent(dep);
+        }
 
-        if (dep is DataGridRow row && sender is DataGrid grid)
+        if (dep is DataGridRow row)
         {
             row.IsSelected = true;
             grid.SelectedItem = row.Item;
+        }
+
+        // Also make the clicked cell current so cell-scoped items (Copy Cell) act on it. This sets
+        // CurrentItem too, which row-scoped items (Copy Row) fall back to. We do NOT mark the event
+        // handled — the context menu must still open.
+        if (cell?.Column != null)
+        {
+            grid.CurrentCell = new DataGridCellInfo(cell);
         }
     }
 }


### PR DESCRIPTION
## Problem

After the copy/export consolidation (#1257), right-click **Copy Cell** and **Copy Row** did nothing on most grids. Copy Cell reads `grid.CurrentCell` and Copy Row reads `grid.CurrentItem`, but a bare right-click sets neither -- WPF only updates them on left-click / keyboard nav. The app-wide `DataGridRowSelectionBehavior` selected the row (`SelectedItem`) on right-click (so View Plan kept working) but never set the current cell or item.

## Fix

Enhance the existing app-wide `DataGridRowSelectionBehavior` to also make the right-clicked **cell** current (which sets `CurrentItem` too). One shared mechanism, so every grid behaves identically -- both context-menu attachment patterns, row-level (`PlacementTarget = DataGridRow`) and grid-level (`PlacementTarget = DataGrid`), now feed Copy Cell and Copy Row. `CopyRow` also reads the clicked row directly via `FindRowItem` for the row-attached case, falling back to `CurrentItem` then `SelectedItem`.

No duplicate handler added -- the fix lives in the one behavior both apps already register at startup.

## Verification

- Live: Collection Health (row-level menu) + Current Configuration (grid-level menu) -- Copy Cell, Copy Row, Copy All Rows all correct, columns aligned.
- Both apps build clean; 12/12 `DataGridExport` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
