### PR TITLE
Lite audit follow-ups: complete RootFactKey removal + 2 dead ServerTab helpers

### DIFF
--- a/Lite.Tests/LiteRecommendationsReaderTests.cs
+++ b/Lite.Tests/LiteRecommendationsReaderTests.cs
@@ -93,7 +93,6 @@ public class LiteRecommendationsReaderTests
         Assert.Equal(LiteRecommendationSeverity.Critical, item.Severity);
         Assert.Equal(1.6, item.RawSeverity);
         Assert.Equal(ServerName, item.ServerName);
-        Assert.Equal("SOS_SCHEDULER_YIELD", item.RootFactKey);
         Assert.False(string.IsNullOrEmpty(item.AdviceText));
     }
 
@@ -235,7 +234,11 @@ public class LiteRecommendationsReaderTests
 
         var items = LiteRecommendationsReader.MapFindings(findings, ServerName);
         Assert.Single(items);
-        Assert.Equal("CPU_SQL_PERCENT", items[0].RootFactKey);
+        // RootFactKey is no longer surfaced on the card; verify the newer batch (CPU_SQL_PERCENT)
+        // won via its mapped Title (same fallback MapFinding uses: advice headline, else the key).
+        var cpuAdvice = FactAdvice.GetForFactKey("CPU_SQL_PERCENT");
+        var expectedTitle = !string.IsNullOrEmpty(cpuAdvice?.Headline) ? cpuAdvice!.Headline : "CPU_SQL_PERCENT";
+        Assert.Equal(expectedTitle, items[0].Title);
     }
 
     [Fact]

--- a/Lite.Tests/LiteRecommendationsViewModelTests.cs
+++ b/Lite.Tests/LiteRecommendationsViewModelTests.cs
@@ -26,7 +26,6 @@ public class LiteRecommendationsViewModelTests
             Database = database,
             CopyPasteSql = sql,
             AdviceText = advice,
-            RootFactKey = "CPU_SQL_PERCENT",
             IncidentId = incidentId,
             ServerName = serverName,
             WindowStartUtc = new DateTime(2026, 6, 1, 10, 0, 0, DateTimeKind.Utc),

--- a/Lite/Analysis/Recommendations/LiteRecommendationItem.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationItem.cs
@@ -71,9 +71,6 @@ public sealed class LiteRecommendationItem
     /// </summary>
     public string? CopyPasteSql { get; set; }
 
-    /// <summary>The finding's root fact key — drives the advice lookup and the Ask-AI prompt.</summary>
-    public string RootFactKey { get; set; } = string.Empty;
-
     /// <summary>
     /// The finding's incident id (correlate-and-focus) — the group key the surface collapses cards
     /// under, so related findings render as one report. Empty for findings analyzed before incident_id

--- a/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
+++ b/Lite/Analysis/Recommendations/LiteRecommendationsReader.cs
@@ -150,7 +150,6 @@ public sealed class LiteRecommendationsReader
             Title = !string.IsNullOrEmpty(advice?.Headline) ? advice!.Headline : finding.RootFactKey,
             AdviceText = ComposeAdvice(advice),
             CopyPasteSql = NullIfEmpty(FactRemediation.GenerateForFinding(finding)),
-            RootFactKey = finding.RootFactKey,
             IncidentId = finding.IncidentId,
             ServerName = serverName ?? string.Empty,
             WindowStartUtc = AsUtc(finding.TimeRangeStart),

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -1360,17 +1360,6 @@ public partial class ServerTab : UserControl
         CorrelatedLanes.ReapplyTheme();
     }
 
-    private static IEnumerable<ScottPlot.WPF.WpfPlot> GetAllCharts(DependencyObject root)
-    {
-        foreach (var child in LogicalTreeHelper.GetChildren(root).OfType<DependencyObject>())
-        {
-            if (child is ScottPlot.WPF.WpfPlot plot)
-                yield return plot;
-            foreach (var nested in GetAllCharts(child))
-                yield return nested;
-        }
-    }
-
     /// <summary>
     /// Reapplies theme-appropriate axis text colors/sizes after DateTimeTicksBottom() resets them.
     /// Delegates to the shared <see cref="ChartStyle"/>.

--- a/Lite/Controls/ServerTab.TimeRange.cs
+++ b/Lite/Controls/ServerTab.TimeRange.cs
@@ -69,15 +69,6 @@ public partial class ServerTab : UserControl
         return date.AddHours(hour).AddMinutes(minute);
     }
 
-    private void SetPickersFromDateTime(DateTime serverTime, DatePicker datePicker, ComboBox hourCombo, ComboBox minuteCombo)
-    {
-        /* Convert server time to the current display mode for UI */
-        var displayTime = ServerTimeHelper.ConvertForDisplay(serverTime, ServerTimeHelper.CurrentDisplayMode);
-        datePicker.SelectedDate = displayTime.Date;
-        hourCombo.SelectedIndex = displayTime.Hour;
-        minuteCombo.SelectedIndex = displayTime.Minute / 15;
-    }
-
     /// <summary>
     /// Gets the selected time range in hours.
     /// </summary>


### PR DESCRIPTION
Completes three items the main Lite audit (#1259) left behind, surfaced by the impl agents' completion reports.

- **`LiteRecommendationItem.RootFactKey`** — production-dead (write-only; only the *finding's* `RootFactKey` is read, never the card's), but 3 `Lite.Tests` refs blocked it in the fanned-out pass. Removed the property + the `MapFinding` assignment; the two tests that asserted on the card's `RootFactKey` now assert on the mapped `Title` (same latest-batch-wins signal). *(My #1259 commit message claimed this was removed — it wasn't; this makes it true.)*
- **`ServerTab.Charts.GetAllCharts`** — recursive-only chart walker, zero external callers (superseded by reflection-based `OnThemeChanged`).
- **`ServerTab.TimeRange.SetPickersFromDateTime`** — zero-caller setter (superseded by inline picker assignment in `SetDrillDownTimeRange`).

All three are dead-code removals with no runtime behavior change. Lite builds; **Lite.Tests 618/618**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
