### PR TITLE
Installer audit: wire up --troubleshoot, tighten interactive security defaults, remove dead code

### DIFF
--- a/Installer.Core/InstallationService.cs
+++ b/Installer.Core/InstallationService.cs
@@ -385,8 +385,6 @@ END;";
         {
             Message = "Starting installation...",
             Status = "Info",
-            CurrentStep = 0,
-            TotalSteps = scriptFiles.Count,
             ProgressPercent = 0
         });
 
@@ -413,8 +411,6 @@ END;";
             {
                 Message = $"Executing {fileName}...",
                 Status = "Info",
-                CurrentStep = i + 1,
-                TotalSteps = scriptFiles.Count,
                 ProgressPercent = (int)(((i + 1) / (double)scriptFiles.Count) * 100)
             });
 
@@ -496,8 +492,6 @@ END;";
                 {
                     Message = $"{fileName} - Success",
                     Status = "Success",
-                    CurrentStep = i + 1,
-                    TotalSteps = scriptFiles.Count,
                     ProgressPercent = (int)(((i + 1) / (double)scriptFiles.Count) * 100)
                 });
 
@@ -512,9 +506,7 @@ END;";
                 progress?.Report(new InstallationProgress
                 {
                     Message = $"{fileName} - FAILED: {ex.Message}",
-                    Status = "Error",
-                    CurrentStep = i + 1,
-                    TotalSteps = scriptFiles.Count
+                    Status = "Error"
                 });
 
                 result.FilesFailed++;
@@ -888,24 +880,6 @@ END;";
                 sb.AppendLine($"Error: {errorMsg}");
                 sb.AppendLine();
             }
-        }
-
-        if (result.LogMessages.Count > 0)
-        {
-            sb.AppendLine("DETAILED INSTALLATION LOG");
-            sb.AppendLine("--------------------------------------------------------------------------------");
-            foreach (var (message, status) in result.LogMessages)
-            {
-                string prefix = status switch
-                {
-                    "Success" => "[OK] ",
-                    "Error" => "[ERROR] ",
-                    "Warning" => "[WARN] ",
-                    _ => ""
-                };
-                sb.AppendLine($"{prefix}{message}");
-            }
-            sb.AppendLine();
         }
 
         sb.AppendLine("================================================================================");

--- a/Installer.Core/Models/InstallationProgress.cs
+++ b/Installer.Core/Models/InstallationProgress.cs
@@ -7,7 +7,5 @@ public class InstallationProgress
 {
     public string Message { get; set; } = string.Empty;
     public string Status { get; set; } = "Info"; // Info, Success, Error, Warning
-    public int? CurrentStep { get; set; }
-    public int? TotalSteps { get; set; }
     public int? ProgressPercent { get; set; }
 }

--- a/Installer.Core/Models/InstallationResult.cs
+++ b/Installer.Core/Models/InstallationResult.cs
@@ -9,8 +9,6 @@ public class InstallationResult
     public int FilesSucceeded { get; set; }
     public int FilesFailed { get; set; }
     public List<(string FileName, string ErrorMessage)> Errors { get; } = new();
-    public List<(string Message, string Status)> LogMessages { get; } = new();
     public DateTime StartTime { get; set; }
     public DateTime EndTime { get; set; }
-    public string? ReportPath { get; set; }
 }

--- a/Installer.Core/Models/InstallationResultCode.cs
+++ b/Installer.Core/Models/InstallationResultCode.cs
@@ -15,5 +15,6 @@ public enum InstallationResultCode
     SqlFilesNotFound = 6,
     UninstallFailed = 7,
     UpgradesFailed = 8,
-    CleanInstallFailed = 9
+    CleanInstallFailed = 9,
+    DiagnosticsFailed = 10
 }

--- a/Installer.Core/ScriptProvider.cs
+++ b/Installer.Core/ScriptProvider.cs
@@ -29,63 +29,9 @@ public abstract class ScriptProvider
         => new EmbeddedResourceScriptProvider(assembly ?? typeof(ScriptProvider).Assembly);
 
     /// <summary>
-    /// Auto-discover: search filesystem starting from CWD and executable directory,
-    /// walking up to 5 parent directories. Falls back to embedded resources.
-    /// </summary>
-    /// <param name="log">Optional logging callback for diagnostics.</param>
-    public static ScriptProvider AutoDiscover(Action<string>? log = null)
-    {
-        var startDirs = new[] { Directory.GetCurrentDirectory(), AppDomain.CurrentDomain.BaseDirectory }
-            .Distinct()
-            .ToList();
-
-        log?.Invoke($"AutoDiscover: searching from [{string.Join(", ", startDirs)}]");
-
-        foreach (string startDir in startDirs)
-        {
-            DirectoryInfo? searchDir = new DirectoryInfo(startDir);
-            for (int i = 0; i < 6 && searchDir != null; i++)
-            {
-                string installFolder = Path.Combine(searchDir.FullName, "install");
-                if (Directory.Exists(installFolder))
-                {
-                    var sqlFiles = Directory.GetFiles(installFolder, "*.sql")
-                        .Where(f => Patterns.SqlFilePattern().IsMatch(Path.GetFileName(f)))
-                        .ToList();
-                    if (sqlFiles.Count > 0)
-                    {
-                        log?.Invoke($"AutoDiscover: found {sqlFiles.Count} scripts in {installFolder}");
-                        return new FileSystemScriptProvider(searchDir.FullName);
-                    }
-                }
-
-                var rootFiles = Directory.GetFiles(searchDir.FullName, "*.sql")
-                    .Where(f => Patterns.SqlFilePattern().IsMatch(Path.GetFileName(f)))
-                    .ToList();
-                if (rootFiles.Count > 0)
-                {
-                    log?.Invoke($"AutoDiscover: found {rootFiles.Count} scripts in {searchDir.FullName}");
-                    return new FileSystemScriptProvider(searchDir.FullName);
-                }
-
-                log?.Invoke($"AutoDiscover: no scripts in {searchDir.FullName}, trying parent");
-                searchDir = searchDir.Parent;
-            }
-        }
-
-        log?.Invoke("AutoDiscover: no filesystem scripts found, falling back to embedded resources");
-        return FromEmbeddedResources();
-    }
-
-    /// <summary>
     /// Returns the filtered, sorted list of install scripts (excludes 00_/97_/99_).
     /// </summary>
     public abstract List<ScriptFile> GetInstallFiles();
-
-    /// <summary>
-    /// Reads the content of an install script.
-    /// </summary>
-    public abstract string ReadScript(ScriptFile file);
 
     /// <summary>
     /// Reads the content of an install script asynchronously.
@@ -224,9 +170,6 @@ internal sealed class FileSystemScriptProvider : ScriptProvider
             .ToList();
     }
 
-    public override string ReadScript(ScriptFile file) =>
-        File.ReadAllText(file.Identifier);
-
     public override Task<string> ReadScriptAsync(ScriptFile file, CancellationToken cancellationToken = default) =>
         File.ReadAllTextAsync(file.Identifier, cancellationToken);
 
@@ -316,9 +259,6 @@ internal sealed class EmbeddedResourceScriptProvider : ScriptProvider
             .OrderBy(f => f.Name, StringComparer.Ordinal)
             .ToList();
     }
-
-    public override string ReadScript(ScriptFile file) =>
-        ReadResource(file.Identifier);
 
     public override Task<string> ReadScriptAsync(ScriptFile file, CancellationToken cancellationToken = default) =>
         Task.FromResult(ReadResource(file.Identifier));

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -64,6 +64,7 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  --reinstall          Drop existing database and perform clean install");
                 Console.WriteLine("  --uninstall          Remove database, Agent jobs, and XE sessions");
                 Console.WriteLine("  --reset-schedule     Reset collection schedule to recommended defaults");
+                Console.WriteLine("  --troubleshoot       Run installation diagnostics (99_installer_troubleshooting.sql)");
                 Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                 Console.WriteLine("  --trust-cert         Trust server certificate without validation");
                 Console.WriteLine("  --entra <email>      Use Microsoft Entra ID interactive authentication (MFA)");
@@ -83,6 +84,8 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  6  SQL files not found");
                 Console.WriteLine("  7  Uninstall failed");
                 Console.WriteLine("  8  Upgrade failed");
+                Console.WriteLine("  9  Clean install failed");
+                Console.WriteLine("  10 Diagnostics found errors or failed to run");
                 return 0;
             }
 
@@ -90,6 +93,7 @@ namespace PerformanceMonitorInstaller
             bool reinstallMode = args.Any(a => a.Equals("--reinstall", StringComparison.OrdinalIgnoreCase));
             bool uninstallMode = args.Any(a => a.Equals("--uninstall", StringComparison.OrdinalIgnoreCase));
             bool resetSchedule = args.Any(a => a.Equals("--reset-schedule", StringComparison.OrdinalIgnoreCase));
+            bool troubleshootMode = args.Any(a => a.Equals("--troubleshoot", StringComparison.OrdinalIgnoreCase));
             bool trustCert = args.Any(a => a.Equals("--trust-cert", StringComparison.OrdinalIgnoreCase));
             bool entraMode = args.Any(a => a.Equals("--entra", StringComparison.OrdinalIgnoreCase));
 
@@ -295,22 +299,21 @@ namespace PerformanceMonitorInstaller
                     return (int)InstallationResultCode.InvalidArguments;
                 }
 
-                Console.Write("Trust server certificate? (Y/N, default Y): ");
+                Console.Write("Trust server certificate? (Y/N, default N): ");
                 string? trustResponse = Console.ReadLine()?.Trim();
-                trustCert = string.IsNullOrWhiteSpace(trustResponse)
-                    || trustResponse.Equals("Y", StringComparison.OrdinalIgnoreCase);
+                trustCert = trustResponse?.Equals("Y", StringComparison.OrdinalIgnoreCase) ?? false;
 
                 Console.WriteLine("Encryption level:");
-                Console.WriteLine("  [O] Optional (default)");
-                Console.WriteLine("  [M] Mandatory");
+                Console.WriteLine("  [M] Mandatory (default)");
+                Console.WriteLine("  [O] Optional");
                 Console.WriteLine("  [S] Strict");
-                Console.Write("Choice (O/M/S, default O): ");
+                Console.Write("Choice (M/O/S, default M): ");
                 string? encryptResponse = Console.ReadLine()?.Trim();
                 encryptionLevel = encryptResponse?.ToUpperInvariant() switch
                 {
-                    "M" => "Mandatory",
+                    "O" => "Optional",
                     "S" => "Strict",
-                    _ => "Optional"
+                    _ => "Mandatory"
                 };
 
                 Console.WriteLine("Authentication type:");
@@ -485,6 +488,12 @@ namespace PerformanceMonitorInstaller
             }
 
             scriptProvider = ScriptProvider.FromDirectory(monitorRootDirectory);
+
+            if (troubleshootMode)
+            {
+                return await PerformTroubleshootAsync(connectionString, scriptProvider, automatedMode);
+            }
+
             var sqlFiles = scriptProvider.GetInstallFiles();
 
             Console.WriteLine();
@@ -711,8 +720,6 @@ namespace PerformanceMonitorInstaller
                         case "Success":
                             if (p.Message.EndsWith(" - Success", StringComparison.Ordinal))
                             {
-                                /*File success: replicate the original "Executing <file>... Success" format*/
-                                string fileName = p.Message.Replace(" - Success", "", StringComparison.Ordinal);
                                 /*The "Executing..." was already printed by the Info message*/
                                 WriteSuccess("Success");
                             }
@@ -745,7 +752,7 @@ namespace PerformanceMonitorInstaller
                             if (p.Message.StartsWith("Executing ", StringComparison.Ordinal) && p.Message.EndsWith("...", StringComparison.Ordinal))
                             {
                                 /*Replicate "Executing <file>... " format (no newline yet)*/
-                                Console.Write(p.Message.Replace("Executing ", "Executing ", StringComparison.Ordinal) + " ");
+                                Console.Write(p.Message + " ");
                             }
                             else if (p.Message == "Resetting schedule to recommended defaults...")
                             {
@@ -1093,6 +1100,78 @@ namespace PerformanceMonitorInstaller
                 WaitForExit();
             }
             return (int)InstallationResultCode.Success;
+        }
+
+        /// <summary>
+        /// Runs installation diagnostics (99_installer_troubleshooting.sql) against the server and
+        /// prints the [OK]/[WARN]/[ERROR] results. Exit code 0 when no errors are found, otherwise 10.
+        /// </summary>
+        private static async Task<int> PerformTroubleshootAsync(string connectionString, ScriptProvider scriptProvider, bool automatedMode)
+        {
+            Console.WriteLine();
+            Console.WriteLine("================================================================================");
+            Console.WriteLine("TROUBLESHOOT MODE");
+            Console.WriteLine("================================================================================");
+            Console.WriteLine();
+            Console.WriteLine("Running installation diagnostics (99_installer_troubleshooting.sql)...");
+            Console.WriteLine();
+
+            bool noErrors;
+            try
+            {
+                noErrors = await InstallationService.RunTroubleshootingAsync(
+                    connectionString,
+                    scriptProvider,
+                    new Progress<InstallationProgress>(p =>
+                    {
+                        switch (p.Status)
+                        {
+                            case "Success":
+                                WriteSuccess(p.Message);
+                                break;
+                            case "Error":
+                                WriteError(p.Message);
+                                break;
+                            case "Warning":
+                                WriteWarning(p.Message);
+                                break;
+                            case "Info":
+                                Console.WriteLine(p.Message);
+                                break;
+                            case "Debug":
+                                break;
+                            default:
+                                Console.WriteLine(p.Message);
+                                break;
+                        }
+                    })).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Diagnostics failed: {ex.Message}");
+                if (!automatedMode)
+                {
+                    WaitForExit();
+                }
+                return (int)InstallationResultCode.DiagnosticsFailed;
+            }
+
+            Console.WriteLine();
+            if (noErrors)
+            {
+                WriteSuccess("Diagnostics completed: no errors found.");
+            }
+            else
+            {
+                WriteWarning("Diagnostics completed: issues were reported above ([WARN]/[ERROR]).");
+            }
+
+            if (!automatedMode)
+            {
+                WaitForExit();
+            }
+            return noErrors ? (int)InstallationResultCode.Success : (int)InstallationResultCode.DiagnosticsFailed;
         }
 
         /*


### PR DESCRIPTION
The CLI-installer counterpart to the Dashboard/Lite simplification audits. A 3-area read-only audit of `Installer/` + `Installer.Core/`, every finding verified. **CLI builds clean; 81 non-DB installer tests pass; `--troubleshoot` live-verified against sql2022.**

Unlike the Lite pass, the high-value findings here were correctness/security rather than dead code (the nature of deployment code), so this is a small but meaningful change.

## New feature — wired up a dead one (your call: "wire it up")
- **`--troubleshoot`** now runs the installation diagnostics (`99_installer_troubleshooting.sql` via `InstallationService.RunTroubleshootingAsync`) and prints the `[OK]`/`[WARN]`/`[ERROR]` results. The ~133-line runner existed but was never called from any command. New exit code `DiagnosticsFailed = 10` (0 when no errors found). Live-tested: connected, ran the script, parsed results, exited 0.

## Security — interactive defaults were laxer than automated (your call: "tighten both")
- Interactive prompts now default to **trust-cert=No** and **encryption=Mandatory**, matching the automated/scripted defaults and the `--help` text. They previously defaulted to trust-any-cert + Optional encryption — the less-secure path, contradicting the documented default.

## Correctness
- `--help` now documents exit codes **9 (`CleanInstallFailed`)** — already returned at runtime but undocumented — and **10 (`DiagnosticsFailed`)**.

## Dead code removed (~80 lines, all verified zero-caller)
- `ScriptProvider.AutoDiscover` (CLI uses `FromDirectory`, Dashboard uses `FromEmbeddedResources` directly).
- The sync `ReadScript` variant (production uses `ReadScriptAsync`).
- `InstallationResult.ReportPath` (unreferenced) + `LogMessages` (never written → the "DETAILED INSTALLATION LOG" report block was unreachable).
- `InstallationProgress.CurrentStep`/`TotalSteps` (write-only; Dashboard uses `ProgressPercent`).
- A dead local + a no-op `string.Replace` in Program.cs.

## Verified "leave it" (not changed)
- `AppendPathOverride`'s path re-validation looks redundant but is a **SQL-injection boundary** (path → dynamic `CREATE DATABASE`) — kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
