### PR TITLE
Extract shared CredentialStore to PerformanceMonitor.Common (architecture review W1)

### DIFF
--- a/Dashboard/Services/CredentialService.cs
+++ b/Dashboard/Services/CredentialService.cs
@@ -6,9 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System;
-using System.Security;
-using CredentialManagement;
+using PerformanceMonitor.Common;
 using PerformanceMonitorDashboard.Helpers;
 using PerformanceMonitorDashboard.Interfaces;
 
@@ -18,174 +16,40 @@ namespace PerformanceMonitorDashboard.Services
     /// Secure credential storage service using Windows Credential Manager.
     /// Credentials are encrypted by Windows using DPAPI and stored per-user.
     /// NEVER stores passwords in plain text.
+    ///
+    /// Thin adapter over the shared <see cref="CredentialStore"/>. The
+    /// <c>"PerformanceMonitor_"</c> prefix keeps Dashboard credentials isolated from
+    /// Lite's (<c>"PerformanceMonitorLite_"</c>) in Windows Credential Manager — it MUST
+    /// stay distinct. Warnings are routed to the app's static logger via
+    /// <see cref="LoggerAdapter{T}"/>.
     /// </summary>
     public class CredentialService : ICredentialService
     {
         private const string CredentialPrefix = "PerformanceMonitor_";
 
-        /// <summary>
-        /// Saves SQL Server credentials to Windows Credential Manager.
-        /// Credentials are encrypted automatically by Windows.
-        /// </summary>
-        /// <param name="serverId">Unique server identifier</param>
-        /// <param name="username">SQL Server username</param>
-        /// <param name="password">SQL Server password (will be encrypted)</param>
-        /// <returns>True if successful, false otherwise</returns>
+        private readonly CredentialStore _store = new CredentialStore(
+            CredentialPrefix,
+            "SQL Server credentials for Performance Monitor Dashboard",
+            new LoggerAdapter<CredentialService>());
+
+        /// <inheritdoc />
         public bool SaveCredential(string serverId, string username, string password)
-        {
-            if (string.IsNullOrWhiteSpace(serverId))
-            {
-                throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-            }
+            => _store.SaveCredential(serverId, username, password);
 
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                throw new ArgumentException("Username cannot be null or empty", nameof(username));
-            }
-
-            if (password == null)
-            {
-                throw new ArgumentNullException(nameof(password));
-            }
-
-            try
-            {
-                using (var credential = new Credential
-                {
-                    Target = GetCredentialTarget(serverId),
-                    Username = username,
-                    Password = password,
-                    Type = CredentialType.Generic,
-                    PersistanceType = PersistanceType.LocalComputer,
-                    Description = "SQL Server credentials for Performance Monitor Dashboard"
-                })
-                {
-                    return credential.Save();
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warning($"Failed to save credential for server {serverId}: {ex.Message}");
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Retrieves SQL Server credentials from Windows Credential Manager.
-        /// </summary>
-        /// <param name="serverId">Unique server identifier</param>
-        /// <returns>Tuple of (username, password) or null if not found</returns>
+        /// <inheritdoc />
         public (string Username, string Password)? GetCredential(string serverId)
-        {
-            if (string.IsNullOrWhiteSpace(serverId))
-            {
-                throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-            }
+            => _store.GetCredential(serverId);
 
-            try
-            {
-                using (var credential = new Credential
-                {
-                    Target = GetCredentialTarget(serverId),
-                    Type = CredentialType.Generic
-                })
-                {
-                    if (credential.Load())
-                    {
-                        return (credential.Username, credential.Password);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warning($"Failed to load credential for server {serverId}: {ex.Message}");
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Deletes SQL Server credentials from Windows Credential Manager.
-        /// Should be called when a server is removed.
-        /// </summary>
-        /// <param name="serverId">Unique server identifier</param>
-        /// <returns>True if deleted or didn't exist, false on error</returns>
+        /// <inheritdoc />
         public bool DeleteCredential(string serverId)
-        {
-            if (string.IsNullOrWhiteSpace(serverId))
-            {
-                throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-            }
+            => _store.DeleteCredential(serverId);
 
-            try
-            {
-                using (var credential = new Credential
-                {
-                    Target = GetCredentialTarget(serverId),
-                    Type = CredentialType.Generic
-                })
-                {
-                    return credential.Delete();
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warning($"Failed to delete credential for server {serverId}: {ex.Message}");
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Checks if credentials exist for a server.
-        /// </summary>
-        /// <param name="serverId">Unique server identifier</param>
-        /// <returns>True if credentials exist in Credential Manager</returns>
+        /// <inheritdoc />
         public bool CredentialExists(string serverId)
-        {
-            if (string.IsNullOrWhiteSpace(serverId))
-            {
-                return false;
-            }
+            => _store.CredentialExists(serverId);
 
-            try
-            {
-                using (var credential = new Credential
-                {
-                    Target = GetCredentialTarget(serverId),
-                    Type = CredentialType.Generic
-                })
-                {
-                    return credential.Exists();
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warning($"Failed to check credential existence for server {serverId}: {ex.Message}");
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Updates existing credentials. If credentials don't exist, creates them.
-        /// </summary>
-        /// <param name="serverId">Unique server identifier</param>
-        /// <param name="username">SQL Server username</param>
-        /// <param name="password">SQL Server password (will be encrypted)</param>
-        /// <returns>True if successful, false otherwise</returns>
+        /// <inheritdoc />
         public bool UpdateCredential(string serverId, string username, string password)
-        {
-            DeleteCredential(serverId);
-            return SaveCredential(serverId, username, password);
-        }
-
-        /// <summary>
-        /// Generates the credential target name for Windows Credential Manager.
-        /// Format: PerformanceMonitor_{serverId}
-        /// </summary>
-        private string GetCredentialTarget(string serverId)
-        {
-            return $"{CredentialPrefix}{serverId}";
-        }
-
+            => _store.UpdateCredential(serverId, username, password);
     }
 }

--- a/Dashboard/packages.lock.json
+++ b/Dashboard/packages.lock.json
@@ -736,6 +736,8 @@
       "performancemonitor.common": {
         "type": "Project",
         "dependencies": {
+          "CredentialManagement": "[1.0.2, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
           "ModelContextProtocol": "[1.4.0, )"
         }
       },

--- a/Lite.Tests/packages.lock.json
+++ b/Lite.Tests/packages.lock.json
@@ -892,6 +892,8 @@
       "performancemonitor.common": {
         "type": "Project",
         "dependencies": {
+          "CredentialManagement": "[1.0.2, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
           "ModelContextProtocol": "[1.4.0, )"
         }
       },

--- a/Lite/Services/CredentialService.cs
+++ b/Lite/Services/CredentialService.cs
@@ -6,9 +6,8 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using System;
-using CredentialManagement;
 using Microsoft.Extensions.Logging;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -16,15 +15,24 @@ namespace PerformanceMonitorLite.Services;
 /// Secure credential storage service using Windows Credential Manager.
 /// Credentials are encrypted by Windows using DPAPI and stored per-user.
 /// NEVER stores passwords in plain text.
+///
+/// Thin adapter over the shared <see cref="CredentialStore"/>. The
+/// <c>"PerformanceMonitorLite_"</c> prefix keeps Lite credentials isolated from
+/// Dashboard's (<c>"PerformanceMonitor_"</c>) in Windows Credential Manager — it MUST
+/// stay distinct.
 /// </summary>
 public class CredentialService
 {
     private const string CredentialPrefix = "PerformanceMonitorLite_";
-    private readonly ILogger<CredentialService>? _logger;
+
+    private readonly CredentialStore _store;
 
     public CredentialService(ILogger<CredentialService>? logger = null)
     {
-        _logger = logger;
+        _store = new CredentialStore(
+            CredentialPrefix,
+            "SQL Server credentials for Performance Monitor Lite",
+            logger);
     }
 
     /// <summary>
@@ -32,143 +40,30 @@ public class CredentialService
     /// Credentials are encrypted automatically by Windows.
     /// </summary>
     public bool SaveCredential(string serverId, string username, string password)
-    {
-        if (string.IsNullOrWhiteSpace(serverId))
-        {
-            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-        }
-
-        if (string.IsNullOrWhiteSpace(username))
-        {
-            throw new ArgumentException("Username cannot be null or empty", nameof(username));
-        }
-
-        if (password == null)
-        {
-            throw new ArgumentNullException(nameof(password));
-        }
-
-        try
-        {
-            using var credential = new Credential
-            {
-                Target = GetCredentialTarget(serverId),
-                Username = username,
-                Password = password,
-                Type = CredentialType.Generic,
-                PersistanceType = PersistanceType.LocalComputer,
-                Description = "SQL Server credentials for Performance Monitor Lite"
-            };
-
-            return credential.Save();
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Failed to save credential for server {ServerId}", serverId);
-            return false;
-        }
-    }
+        => _store.SaveCredential(serverId, username, password);
 
     /// <summary>
     /// Retrieves SQL Server credentials from Windows Credential Manager.
     /// </summary>
     public (string Username, string Password)? GetCredential(string serverId)
-    {
-        if (string.IsNullOrWhiteSpace(serverId))
-        {
-            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-        }
-
-        try
-        {
-            using var credential = new Credential
-            {
-                Target = GetCredentialTarget(serverId),
-                Type = CredentialType.Generic
-            };
-
-            if (credential.Load())
-            {
-                return (credential.Username, credential.Password);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Failed to load credential for server {ServerId}", serverId);
-        }
-
-        return null;
-    }
+        => _store.GetCredential(serverId);
 
     /// <summary>
     /// Deletes SQL Server credentials from Windows Credential Manager.
     /// Should be called when a server is removed.
     /// </summary>
     public bool DeleteCredential(string serverId)
-    {
-        if (string.IsNullOrWhiteSpace(serverId))
-        {
-            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
-        }
-
-        try
-        {
-            using var credential = new Credential
-            {
-                Target = GetCredentialTarget(serverId),
-                Type = CredentialType.Generic
-            };
-
-            return credential.Delete();
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Failed to delete credential for server {ServerId}", serverId);
-            return false;
-        }
-    }
+        => _store.DeleteCredential(serverId);
 
     /// <summary>
     /// Checks if credentials exist for a server.
     /// </summary>
     public bool CredentialExists(string serverId)
-    {
-        if (string.IsNullOrWhiteSpace(serverId))
-        {
-            return false;
-        }
-
-        try
-        {
-            using var credential = new Credential
-            {
-                Target = GetCredentialTarget(serverId),
-                Type = CredentialType.Generic
-            };
-
-            return credential.Exists();
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Failed to check credential existence for server {ServerId}", serverId);
-            return false;
-        }
-    }
+        => _store.CredentialExists(serverId);
 
     /// <summary>
     /// Updates existing credentials. If credentials don't exist, creates them.
     /// </summary>
     public bool UpdateCredential(string serverId, string username, string password)
-    {
-        DeleteCredential(serverId);
-        return SaveCredential(serverId, username, password);
-    }
-
-    /// <summary>
-    /// Generates the credential target name for Windows Credential Manager.
-    /// </summary>
-    private static string GetCredentialTarget(string serverId)
-    {
-        return $"{CredentialPrefix}{serverId}";
-    }
+        => _store.UpdateCredential(serverId, username, password);
 }

--- a/Lite/packages.lock.json
+++ b/Lite/packages.lock.json
@@ -748,6 +748,8 @@
       "performancemonitor.common": {
         "type": "Project",
         "dependencies": {
+          "CredentialManagement": "[1.0.2, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
           "ModelContextProtocol": "[1.4.0, )"
         }
       },

--- a/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
+++ b/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
@@ -9,7 +9,8 @@
     <Copyright>Copyright © 2026 Darling Data, LLC</Copyright>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806;CA2254</NoWarn>
+    <!-- NU1701: CredentialManagement package has no .NET 10 build (matches Dashboard/Lite suppression). -->
+    <NoWarn>CA1849;CA2007;CA1508;CA1822;CA1805;CA1510;CA1816;CA1861;CA1845;CA2201;CA1848;CA1852;CA1305;CA1860;CA1707;CA1507;CA1806;CA2254;NU1701</NoWarn>
     <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
 
@@ -17,6 +18,10 @@
     <!-- MCP SDK: required by Mcp/McpSchemaCompat.cs (Gemini-compatible tool registration, issue #1074).
          Brings ModelContextProtocol.Core + Microsoft.Extensions.AI.Abstractions transitively. -->
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <!-- Windows Credential Manager (DPAPI) for the shared CredentialStore; version matches Dashboard/Lite. -->
+    <PackageReference Include="CredentialManagement" Version="1.0.2" />
+    <!-- ILogger abstraction used by CredentialStore; version matches the apps' logging stack. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PerformanceMonitor.Common/Services/CredentialStore.cs
+++ b/PerformanceMonitor.Common/Services/CredentialStore.cs
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using CredentialManagement;
+using Microsoft.Extensions.Logging;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// Secure credential storage backed by Windows Credential Manager. Credentials are
+/// encrypted by Windows using DPAPI and stored per-user. NEVER stores passwords in plain text.
+///
+/// <para>
+/// Shared by Dashboard and Lite. The <c>credentialPrefix</c> namespaces each app's stored
+/// secrets so they never collide in Windows Credential Manager: Dashboard uses
+/// <c>"PerformanceMonitor_"</c>, Lite uses <c>"PerformanceMonitorLite_"</c>. Those prefixes
+/// are LOAD-BEARING and must stay distinct — unifying them would let one app read the other's
+/// credentials. Each app wraps this type in a thin adapter that supplies its own prefix.
+/// </para>
+/// </summary>
+public class CredentialStore
+{
+    private const string DefaultDescription = "SQL Server credentials for Performance Monitor";
+
+    private readonly string _credentialPrefix;
+    private readonly string _description;
+    private readonly ILogger? _logger;
+
+    /// <summary>
+    /// Creates a credential store for the given prefix using the default credential description.
+    /// </summary>
+    /// <param name="credentialPrefix">
+    /// Per-app prefix prepended to every credential target (e.g. <c>"PerformanceMonitor_"</c>).
+    /// Must be non-empty and distinct per app.
+    /// </param>
+    /// <param name="logger">Optional logger; failures are logged as warnings.</param>
+    public CredentialStore(string credentialPrefix, ILogger? logger = null)
+        : this(credentialPrefix, DefaultDescription, logger)
+    {
+    }
+
+    /// <summary>
+    /// Creates a credential store for the given prefix and credential description.
+    /// </summary>
+    /// <param name="credentialPrefix">
+    /// Per-app prefix prepended to every credential target (e.g. <c>"PerformanceMonitor_"</c>).
+    /// Must be non-empty and distinct per app.
+    /// </param>
+    /// <param name="description">Description stored on each credential entry in Credential Manager.</param>
+    /// <param name="logger">Optional logger; failures are logged as warnings.</param>
+    public CredentialStore(string credentialPrefix, string description, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(credentialPrefix))
+        {
+            throw new ArgumentException("Credential prefix cannot be null or empty", nameof(credentialPrefix));
+        }
+
+        _credentialPrefix = credentialPrefix;
+        _description = description;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Saves SQL Server credentials to Windows Credential Manager.
+    /// Credentials are encrypted automatically by Windows.
+    /// </summary>
+    /// <param name="serverId">Unique server identifier</param>
+    /// <param name="username">SQL Server username</param>
+    /// <param name="password">SQL Server password (will be encrypted)</param>
+    /// <returns>True if successful, false otherwise</returns>
+    public bool SaveCredential(string serverId, string username, string password)
+    {
+        if (string.IsNullOrWhiteSpace(serverId))
+        {
+            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
+        }
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            throw new ArgumentException("Username cannot be null or empty", nameof(username));
+        }
+
+        if (password == null)
+        {
+            throw new ArgumentNullException(nameof(password));
+        }
+
+        try
+        {
+            using var credential = new Credential
+            {
+                Target = GetCredentialTarget(serverId),
+                Username = username,
+                Password = password,
+                Type = CredentialType.Generic,
+                PersistanceType = PersistanceType.LocalComputer,
+                Description = _description
+            };
+
+            return credential.Save();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to save credential for server {ServerId}: {Error}", serverId, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves SQL Server credentials from Windows Credential Manager.
+    /// </summary>
+    /// <param name="serverId">Unique server identifier</param>
+    /// <returns>Tuple of (username, password) or null if not found</returns>
+    public (string Username, string Password)? GetCredential(string serverId)
+    {
+        if (string.IsNullOrWhiteSpace(serverId))
+        {
+            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
+        }
+
+        try
+        {
+            using var credential = new Credential
+            {
+                Target = GetCredentialTarget(serverId),
+                Type = CredentialType.Generic
+            };
+
+            if (credential.Load())
+            {
+                return (credential.Username, credential.Password);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to load credential for server {ServerId}: {Error}", serverId, ex.Message);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Deletes SQL Server credentials from Windows Credential Manager.
+    /// Should be called when a server is removed.
+    /// </summary>
+    /// <param name="serverId">Unique server identifier</param>
+    /// <returns>True if deleted or didn't exist, false on error</returns>
+    public bool DeleteCredential(string serverId)
+    {
+        if (string.IsNullOrWhiteSpace(serverId))
+        {
+            throw new ArgumentException("Server ID cannot be null or empty", nameof(serverId));
+        }
+
+        try
+        {
+            using var credential = new Credential
+            {
+                Target = GetCredentialTarget(serverId),
+                Type = CredentialType.Generic
+            };
+
+            return credential.Delete();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to delete credential for server {ServerId}: {Error}", serverId, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if credentials exist for a server.
+    /// </summary>
+    /// <param name="serverId">Unique server identifier</param>
+    /// <returns>True if credentials exist in Credential Manager</returns>
+    public bool CredentialExists(string serverId)
+    {
+        if (string.IsNullOrWhiteSpace(serverId))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var credential = new Credential
+            {
+                Target = GetCredentialTarget(serverId),
+                Type = CredentialType.Generic
+            };
+
+            return credential.Exists();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to check credential existence for server {ServerId}: {Error}", serverId, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Updates existing credentials. If credentials don't exist, creates them.
+    /// </summary>
+    /// <param name="serverId">Unique server identifier</param>
+    /// <param name="username">SQL Server username</param>
+    /// <param name="password">SQL Server password (will be encrypted)</param>
+    /// <returns>True if successful, false otherwise</returns>
+    public bool UpdateCredential(string serverId, string username, string password)
+    {
+        DeleteCredential(serverId);
+        return SaveCredential(serverId, username, password);
+    }
+
+    /// <summary>
+    /// Generates the credential target name for Windows Credential Manager.
+    /// Format: {credentialPrefix}{serverId}
+    /// </summary>
+    private string GetCredentialTarget(string serverId)
+    {
+        return $"{_credentialPrefix}{serverId}";
+    }
+}


### PR DESCRIPTION
From the architecture-altitude review (`plans/architecture-review.md`, finding **W1** — the top clean consolidation win, flagged by two independent agents and self-verified).

## Why
Dashboard's and Lite's `CredentialService` were functionally **identical** — same 5 methods, same Windows Credential Manager / DPAPI calls via the `CredentialManagement` package. The only real differences were the credential prefix, the `ICredentialService` interface, and the logger seam. This is security-sensitive code that had to be patched twice and could silently drift.

## What
- **New `PerformanceMonitor.Common/Services/CredentialStore.cs`** — the shared store, parameterized by credential prefix (validated non-empty) + description + optional `ILogger`. Method bodies unchanged from the originals.
- Both apps' `CredentialService` become **thin adapters preserving their exact public surface** (no caller changes): Dashboard keeps `ICredentialService` and bridges its static `Logger` via the existing `LoggerAdapter`; Lite passes its injected `ILogger`.
- **The two prefixes stay distinct** — `PerformanceMonitor_` (Dashboard) vs `PerformanceMonitorLite_` (Lite) — so the apps never read each other's stored secrets. (Unifying them would be a security bug; explicitly preserved + documented.)
- `Common` gains `CredentialManagement` 1.0.2 + `Microsoft.Extensions.Logging.Abstractions` 10.0.9 (versions match the apps) + `NU1701` suppression; the 3 dependent `packages.lock.json` files are updated accordingly.
- The store embeds `ex.Message` in its warning templates so Dashboard (whose `LoggerAdapter` renders only the message) keeps the failure detail it logged before — no diagnostic regression, and the shared `LoggerAdapter` is untouched.

## Verification
Both apps + Common build clean; credential tests pass (**Lite 15/15, Dashboard 1/1**). The actual Save/Get methods hit Windows DPAPI so aren't unit-tested, but the public surface is byte-for-byte preserved and the prefixes are confirmed distinct.

Held for review per the overnight batch — not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
