### PR TITLE
Fix two verified metric-drift bugs: RDS blocking fallback + high-CPU view definition (architecture review B1, B2)

### DIFF
--- a/Lite/Analysis/AnomalyDetector.cs
+++ b/Lite/Analysis/AnomalyDetector.cs
@@ -447,10 +447,16 @@ LIMIT 10";
             await connection.OpenAsync();
 
             using var cmd = connection.CreateCommand();
+            /* current_blocking: prefer the blocked-process-report; fall back to the always-on DMV
+               snapshot so RDS (where the BPR session is empty) still counts blocking. Mirrors the
+               overview/alert path (LocalDataService.Overview.cs / LocalDataService.Blocking.cs). */
             cmd.CommandText = @"
 SELECT
-    (SELECT COUNT(*) FROM v_blocked_process_reports
-     WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3) AS current_blocking,
+    COALESCE(NULLIF(
+        (SELECT COUNT(*) FROM v_blocked_process_reports
+         WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3), 0),
+        (SELECT COUNT(*) FROM v_dmv_blocking_snapshots
+         WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3)) AS current_blocking,
     (SELECT COUNT(*) FROM v_deadlocks
      WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3) AS current_deadlocks";
 

--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -521,7 +521,9 @@ WITH
                 COUNT_BIG(*)
             FROM collect.cpu_utilization_stats AS cus
             CROSS JOIN yesterday_boundary AS yb
-            WHERE cus.sqlserver_cpu_utilization >= 80
+            /* Linux: total_cpu_utilization is NULL (#1048); fall back to the SQL-only figure.
+               Matches report.daily_summary.high_cpu_events so both surfaces agree. */
+            WHERE ISNULL(cus.total_cpu_utilization, cus.sqlserver_cpu_utilization) >= 80
             AND   cus.collection_time >= yb.start_time
             AND   cus.collection_time < yb.end_time
         )
@@ -556,7 +558,9 @@ WITH
                 COUNT_BIG(*)
             FROM collect.cpu_utilization_stats AS cus
             CROSS JOIN today_boundary AS tb
-            WHERE cus.sqlserver_cpu_utilization >= 80
+            /* Linux: total_cpu_utilization is NULL (#1048); fall back to the SQL-only figure.
+               Matches report.daily_summary.high_cpu_events so both surfaces agree. */
+            WHERE ISNULL(cus.total_cpu_utilization, cus.sqlserver_cpu_utilization) >= 80
             AND   cus.collection_time >= tb.start_time
         ),
         memory_pressure_count =


### PR DESCRIPTION
Two **verified latent bugs** the architecture-altitude review surfaced (`plans/architecture-review.md`, B1 + B2). Both confirmed against source before and after the fix.

## B1 — blocking disappears for the anomaly engine on AWS RDS
`Lite/Analysis/AnomalyDetector.cs` counted blocking from `v_blocked_process_reports` **only**, while the alert/overview path (`LocalDataService.Overview.cs`) uses a `COALESCE` fallback to the always-on `v_dmv_blocking_snapshots` — which is the blocking source on AWS RDS, where the blocked-process-report XE session is empty. So **on RDS the alert fired while the anomaly engine saw zero.**
- Fix: `current_blocking` now uses the same `NULLIF/COALESCE` fallback over both views (same `collection_time` window; `current_deadlocks` untouched).
- **Backward-compatible** — the fallback only engages when the BPR count is 0, so existing behavior (and all 618 Lite tests) is unchanged.
- **Parity:** Dashboard has *no* equivalent gap — its blocking alert computes a live `sys.sysprocesses` count (not collected BPR), so there's nothing to mirror. Left unchanged (verified).

## B2 — "high CPU events" defined two different ways
`report.daily_summary.high_cpu_events` used `ISNULL(total_cpu_utilization, sqlserver_cpu_utilization) >= 80` (**total** CPU, Linux-safe), but `report.daily_summary_v2.high_cpu_count` (the today-vs-yesterday tab) used `sqlserver_cpu_utilization >= 80` (**SQL-only**) — the two views disagreed for the same metric.
- Fix: both `daily_summary_v2` occurrences now use the same `ISNULL(total, sqlserver)` definition (comments cite #1048). `CREATE OR ALTER VIEW`, reruns on upgrade — no `upgrades/` script needed.
- **Parity:** Lite has a single high-CPU definition and its `cpu_utilization_stats` table has no `total_cpu_utilization` column, so there's no internal split to reconcile. (Whether Lite's SQL-only definition *should* become total-CPU is a real semantic question — flagged in the review, not changed here.)

## Verification
B1: **Lite.Tests 618/618**, build green. B2: SQL view change, verified by inspection (not run against SQL2022 per the no-touch-the-test-server rule).

Held for review per the overnight batch — not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
