### PR TITLE
Add Azure Service Principal + Managed Identity auth to Dashboard (parity with Lite)

### DIFF
--- a/Dashboard.Tests/AzureAuthConnectionStringTests.cs
+++ b/Dashboard.Tests/AzureAuthConnectionStringTests.cs
@@ -1,0 +1,321 @@
+/*
+ * Performance Monitor Dashboard
+ * Copyright (c) 2026 Darling Data, LLC
+ * Licensed under the MIT License - see LICENSE file for details
+ */
+
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Common;
+using PerformanceMonitorDashboard.Interfaces;
+using PerformanceMonitorDashboard.Models;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Connection-string SHAPE tests for the non-interactive Azure auth modes: service principal and
+/// managed identity. Mirrors Lite.Tests/AzureAuthConnectionStringTests so the two apps' SP/MI keyword
+/// mapping can never silently drift apart. The testable surface is the keywords emitted by
+/// ServerConnection.ApplyAuthentication (shared by the production GetConnectionString builder and the
+/// Add/Edit dialog's Test-Connection builder). Real Azure auth (token acquisition) is a maintainer
+/// E2E step and is NOT exercised here.
+/// </summary>
+public class AzureAuthConnectionStringTests
+{
+    /// <summary>In-memory ICredentialService so the credential-fetch paths can be exercised without
+    /// touching the real Windows Credential Manager.</summary>
+    private sealed class FakeCredentialService : ICredentialService
+    {
+        private readonly Dictionary<string, (string Username, string Password)> _store = new();
+
+        public bool SaveCredential(string serverId, string username, string password)
+        {
+            _store[serverId] = (username, password);
+            return true;
+        }
+
+        public (string Username, string Password)? GetCredential(string serverId)
+            => _store.TryGetValue(serverId, out var c) ? c : null;
+
+        public bool DeleteCredential(string serverId)
+        {
+            _store.Remove(serverId);
+            return true;
+        }
+
+        public bool CredentialExists(string serverId) => _store.ContainsKey(serverId);
+
+        public bool UpdateCredential(string serverId, string username, string password)
+        {
+            _store[serverId] = (username, password);
+            return true;
+        }
+    }
+
+    // ---- ApplyAuthentication keyword mapping ----------------------------------------------
+    // Tests the shared helper directly (internal, visible via InternalsVisibleTo=Dashboard.Tests).
+
+    private static (SqlAuthenticationMethod Auth, string? User, string? Pwd, bool Integrated) AuthShape(
+        string authType, string? user, string? pwd, string? azureClientId, string? miClientId)
+    {
+        var b = new SqlConnectionStringBuilder();
+        ServerConnection.ApplyAuthentication(b, authType, user, pwd, azureClientId, miClientId);
+        return (b.Authentication, b.UserID, b.Password, b.IntegratedSecurity);
+    }
+
+    [Fact]
+    public void ServicePrincipal_SetsActiveDirectoryServicePrincipal_WithClientIdAndSecret()
+    {
+        var shape = AuthShape(AuthenticationTypes.ServicePrincipal, "client-id-123", "the-secret",
+            azureClientId: null, miClientId: null);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, shape.Auth);
+        Assert.Equal("client-id-123", shape.User);
+        Assert.Equal("the-secret", shape.Pwd);
+        Assert.False(shape.Integrated);
+    }
+
+    [Fact]
+    public void ServicePrincipal_FallsBackToAzureClientId_WhenUsernameNull()
+    {
+        var shape = AuthShape(AuthenticationTypes.ServicePrincipal, null, "secret",
+            azureClientId: "model-client-id", miClientId: null);
+
+        Assert.Equal("model-client-id", shape.User);
+        Assert.Equal("secret", shape.Pwd);
+    }
+
+    [Fact]
+    public void ManagedIdentity_SystemAssigned_NoUserIdNoPassword()
+    {
+        var shape = AuthShape(AuthenticationTypes.ManagedIdentity, null, null,
+            azureClientId: null, miClientId: null);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, shape.Auth);
+        Assert.True(string.IsNullOrEmpty(shape.User));
+        Assert.True(string.IsNullOrEmpty(shape.Pwd));
+        Assert.False(shape.Integrated);
+    }
+
+    [Fact]
+    public void ManagedIdentity_UserAssigned_SetsUserIdToClientId()
+    {
+        var shape = AuthShape(AuthenticationTypes.ManagedIdentity, null, null,
+            azureClientId: null, miClientId: "uami-client-id");
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, shape.Auth);
+        Assert.Equal("uami-client-id", shape.User);
+        Assert.True(string.IsNullOrEmpty(shape.Pwd));
+    }
+
+    // ---- Regression: existing modes unchanged ---------------------------------------------
+
+    [Fact]
+    public void Windows_UsesIntegratedSecurity_NoAuthenticationKeyword()
+    {
+        var shape = AuthShape(AuthenticationTypes.Windows, null, null, null, null);
+
+        Assert.True(shape.Integrated);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, shape.Auth);
+    }
+
+    [Fact]
+    public void SqlServer_SetsUserIdAndPassword_NoAuthenticationKeyword()
+    {
+        var shape = AuthShape(AuthenticationTypes.SqlServer, "sa", "pw", null, null);
+
+        Assert.False(shape.Integrated);
+        Assert.Equal("sa", shape.User);
+        Assert.Equal("pw", shape.Pwd);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, shape.Auth);
+    }
+
+    [Fact]
+    public void EntraMfa_SetsActiveDirectoryInteractive()
+    {
+        var shape = AuthShape(AuthenticationTypes.EntraMFA, "user@tenant.com", null, null, null);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryInteractive, shape.Auth);
+        Assert.Equal("user@tenant.com", shape.User);
+    }
+
+    // ---- AuthenticationDisplay switch (label parity with Lite) ----------------------------
+
+    [Theory]
+    [InlineData(AuthenticationTypes.ServicePrincipal, "Azure — Service Principal")]
+    [InlineData(AuthenticationTypes.ManagedIdentity, "Azure — Managed Identity")]
+    [InlineData(AuthenticationTypes.EntraMFA, "Microsoft Entra MFA")]
+    [InlineData(AuthenticationTypes.SqlServer, "SQL Server")]
+    [InlineData(AuthenticationTypes.Windows, "Windows")]
+    public void AuthenticationDisplay_MapsEachMode(string authType, string expected)
+    {
+        var server = new ServerConnection { AuthenticationType = authType };
+        Assert.Equal(expected, server.AuthenticationDisplay);
+    }
+
+    // ---- Full GetConnectionString path (unified builder + credential resolution) ----------
+
+    private static SqlConnectionStringBuilder Build(ServerConnection server, ICredentialService cs)
+        => new(server.GetConnectionString(cs));
+
+    [Fact]
+    public void GetConnectionString_ServicePrincipal_FetchesStoredSecret()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.ServicePrincipal };
+        cs.SaveCredential(server.Id, "stored-client-id", "stored-secret");
+
+        var conn = Build(server, cs);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+        Assert.Equal("stored-client-id", conn.UserID);
+        Assert.Equal("stored-secret", conn.Password);
+        // Dashboard always targets the PerformanceMonitor database.
+        Assert.Equal("PerformanceMonitor", conn.InitialCatalog);
+    }
+
+    [Fact]
+    public void GetConnectionString_ServicePrincipal_FallsBackToAzureClientId_WhenNoStoredUsername()
+    {
+        // No stored credential — the model's AzureClientId supplies the UserID.
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.ServicePrincipal,
+            AzureClientId = "model-client-id"
+        };
+
+        var conn = Build(server, cs);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, conn.Authentication);
+        Assert.Equal("model-client-id", conn.UserID);
+    }
+
+    [Fact]
+    public void GetConnectionString_ManagedIdentity_FetchesNoSecret()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.ManagedIdentity };
+        // Even if a stale credential somehow existed, MI must not pull it into the string.
+        cs.SaveCredential(server.Id, "leftover", "leftover-secret");
+
+        var conn = Build(server, cs);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, conn.Authentication);
+        Assert.True(string.IsNullOrEmpty(conn.Password));
+        Assert.NotEqual("leftover", conn.UserID);
+    }
+
+    [Fact]
+    public void GetConnectionString_ManagedIdentity_UserAssigned_SetsUserId()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection
+        {
+            ServerName = "s",
+            AuthenticationType = AuthenticationTypes.ManagedIdentity,
+            ManagedIdentityClientId = "uami-client-id"
+        };
+
+        var conn = Build(server, cs);
+
+        Assert.Equal("uami-client-id", conn.UserID);
+        Assert.True(string.IsNullOrEmpty(conn.Password));
+    }
+
+    [Fact]
+    public void GetConnectionString_Windows_UsesIntegratedSecurity()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.Windows };
+
+        var conn = Build(server, cs);
+
+        Assert.True(conn.IntegratedSecurity);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, conn.Authentication);
+    }
+
+    [Fact]
+    public void GetConnectionString_SqlServer_FetchesStoredUsernameAndPassword()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.SqlServer };
+        cs.SaveCredential(server.Id, "sa", "pw");
+
+        var conn = Build(server, cs);
+
+        Assert.False(conn.IntegratedSecurity);
+        Assert.Equal("sa", conn.UserID);
+        Assert.Equal("pw", conn.Password);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, conn.Authentication);
+    }
+
+    [Fact]
+    public void GetConnectionString_EntraMfa_SetsInteractive_AndUsernameHint()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { ServerName = "s", AuthenticationType = AuthenticationTypes.EntraMFA };
+        cs.SaveCredential(server.Id, "user@tenant.com", string.Empty);
+
+        var conn = Build(server, cs);
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryInteractive, conn.Authentication);
+        Assert.Equal("user@tenant.com", conn.UserID);
+    }
+
+    // ---- HasStoredCredentials --------------------------------------------------------------
+
+    [Fact]
+    public void HasStoredCredentials_ManagedIdentity_IsTrue_WithoutCredential()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { AuthenticationType = AuthenticationTypes.ManagedIdentity };
+
+        Assert.True(server.HasStoredCredentials(cs));
+    }
+
+    [Fact]
+    public void HasStoredCredentials_ServicePrincipal_ReflectsCredentialStore()
+    {
+        var cs = new FakeCredentialService();
+        var server = new ServerConnection { AuthenticationType = AuthenticationTypes.ServicePrincipal };
+
+        Assert.False(server.HasStoredCredentials(cs));
+
+        cs.SaveCredential(server.Id, "client", "secret");
+        Assert.True(server.HasStoredCredentials(cs));
+    }
+
+    // ---- Two-build-site PARITY ------------------------------------------------------------
+    // The dialog's Test-Connection builder and ServerConnection's production builder both route
+    // their auth keywords through the shared ServerConnection.ApplyAuthentication helper, so they
+    // emit identical Authentication / UserID / Password / IntegratedSecurity for each mode.
+
+    [Theory]
+    [InlineData(AuthenticationTypes.Windows)]
+    [InlineData(AuthenticationTypes.SqlServer)]
+    [InlineData(AuthenticationTypes.EntraMFA)]
+    [InlineData(AuthenticationTypes.ServicePrincipal)]
+    [InlineData(AuthenticationTypes.ManagedIdentity)]
+    public void BuildSites_ProduceIdenticalAuthShape_PerMode(string authType)
+    {
+        string? user = authType switch
+        {
+            AuthenticationTypes.SqlServer => "sa",
+            AuthenticationTypes.EntraMFA => "user@tenant.com",
+            AuthenticationTypes.ServicePrincipal => "client-id",
+            _ => null
+        };
+        string? pwd = authType is AuthenticationTypes.SqlServer or AuthenticationTypes.ServicePrincipal ? "secret" : null;
+        string? mi = authType == AuthenticationTypes.ManagedIdentity ? "uami-id" : null;
+
+        // Production builder passes the model's AzureClientId; the dialog builder passes null (it
+        // surfaces the SP client id as the username). Both must reduce to the same auth shape.
+        var production = AuthShape(authType, user, pwd, azureClientId: "client-id", miClientId: mi);
+        var dialog = AuthShape(authType, user, pwd, azureClientId: null, miClientId: mi);
+
+        Assert.Equal(production, dialog);
+    }
+}

--- a/Dashboard/AddServerDialog.xaml
+++ b/Dashboard/AddServerDialog.xaml
@@ -59,6 +59,16 @@
                                  Foreground="{DynamicResource ForegroundBrush}"
                                  Checked="AuthType_Changed"
                                  ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
+                    <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal"
+                                 GroupName="Auth"
+                                 Foreground="{DynamicResource ForegroundBrush}"
+                                 Checked="AuthType_Changed" Margin="0,4,0,0"
+                                 ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+                    <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity"
+                                 GroupName="Auth"
+                                 Foreground="{DynamicResource ForegroundBrush}"
+                                 Checked="AuthType_Changed" Margin="0,4,0,0"
+                                 ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running the Dashboard."/>
                 </StackPanel>
 
                 <!-- SQL Authentication Fields -->
@@ -78,6 +88,31 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="EntraMfaUsernameBox"
                              ToolTip="Optional: Pre-populate the authentication dialog with this email address"/>
+                </StackPanel>
+
+                <!-- Azure Service Principal Fields -->
+                <StackPanel x:Name="ServicePrincipalPanel" Visibility="Collapsed" Margin="0,0,0,12">
+                    <TextBlock Text="Application (Client) ID:" Margin="0,0,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="ServicePrincipalClientIdBox" Margin="0,0,0,8"
+                             ToolTip="The Application (client) ID of the Entra app registration / service principal."/>
+                    <TextBlock Text="Client Secret:" Margin="0,0,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <PasswordBox x:Name="ServicePrincipalSecretBox" Margin="0,0,0,4"/>
+                    <TextBlock TextWrapping="Wrap" FontSize="11"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"
+                               Text="The client secret is stored securely in Windows Credential Manager, never in servers.json."/>
+                </StackPanel>
+
+                <!-- Azure Managed Identity Fields -->
+                <StackPanel x:Name="ManagedIdentityPanel" Visibility="Collapsed" Margin="0,0,0,12">
+                    <TextBlock Text="User-Assigned Identity Client ID (optional):" Margin="0,0,0,4"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="ManagedIdentityClientIdBox" Margin="0,0,0,4"
+                             ToolTip="Leave blank for the system-assigned identity. Set to a client id to use a specific user-assigned identity."/>
+                    <TextBlock TextWrapping="Wrap" FontSize="11"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"
+                               Text="Leave blank for the system-assigned identity. Managed Identity only works when the Dashboard runs on an Azure resource that has a managed identity assigned."/>
                 </StackPanel>
 
                 <!-- Connection Options -->

--- a/Dashboard/AddServerDialog.xaml.cs
+++ b/Dashboard/AddServerDialog.xaml.cs
@@ -114,6 +114,32 @@ namespace PerformanceMonitorDashboard
                     PasswordBox.Password = cred.Value.Password;
                 }
             }
+            else if (existingServer.AuthenticationType == AuthenticationTypes.ServicePrincipal)
+            {
+                ServicePrincipalAuthRadio.IsChecked = true;
+                ServicePrincipalClientIdBox.Text = existingServer.AzureClientId ?? string.Empty;
+
+                // Pre-fill the client id and the client secret from Credential Manager, matching how SQL
+                // Server auth pre-fills its password above (and how Lite pre-fills the SP secret). The
+                // model's AzureClientId takes precedence for the client id, falling back to the stored
+                // credential username. The user can leave the secret untouched to keep it, or overwrite to
+                // rotate it — the save path re-persists whatever is in the box.
+                var credentialService = new CredentialService();
+                var cred = credentialService.GetCredential(existingServer.Id);
+                if (cred.HasValue)
+                {
+                    if (string.IsNullOrEmpty(ServicePrincipalClientIdBox.Text) && !string.IsNullOrEmpty(cred.Value.Username))
+                    {
+                        ServicePrincipalClientIdBox.Text = cred.Value.Username;
+                    }
+                    ServicePrincipalSecretBox.Password = cred.Value.Password;
+                }
+            }
+            else if (existingServer.AuthenticationType == AuthenticationTypes.ManagedIdentity)
+            {
+                ManagedIdentityAuthRadio.IsChecked = true;
+                ManagedIdentityClientIdBox.Text = existingServer.ManagedIdentityClientId ?? string.Empty;
+            }
             else
             {
                 WindowsAuthRadio.IsChecked = true;
@@ -130,13 +156,22 @@ namespace PerformanceMonitorDashboard
 
         private void AuthType_Changed(object sender, RoutedEventArgs e)
         {
-            if (SqlAuthPanel != null && EntraMfaPanel != null)
+            if (SqlAuthPanel != null && EntraMfaPanel != null &&
+                ServicePrincipalPanel != null && ManagedIdentityPanel != null)
             {
                 SqlAuthPanel.Visibility = SqlAuthRadio.IsChecked == true
                     ? System.Windows.Visibility.Visible
                     : System.Windows.Visibility.Collapsed;
 
                 EntraMfaPanel.Visibility = EntraMfaAuthRadio.IsChecked == true
+                    ? System.Windows.Visibility.Visible
+                    : System.Windows.Visibility.Collapsed;
+
+                ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true
+                    ? System.Windows.Visibility.Visible
+                    : System.Windows.Visibility.Collapsed;
+
+                ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true
                     ? System.Windows.Visibility.Visible
                     : System.Windows.Visibility.Collapsed;
             }
@@ -185,24 +220,46 @@ namespace PerformanceMonitorDashboard
                 MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true
             };
 
+            // Resolve auth type + per-mode credentials from the live controls, then apply via the SHARED
+            // helper so this Test-Connection builder can never diverge from ServerConnection's production
+            // builder (the two-bodies trap). See ServerConnection.ApplyAuthentication.
+            string authType;
+            string? userId = null;
+            string? secret = null;
+            string? managedIdentityClientId = null;
+
             if (WindowsAuthRadio.IsChecked == true)
             {
-                builder.IntegratedSecurity = true;
+                authType = AuthenticationTypes.Windows;
             }
             else if (SqlAuthRadio.IsChecked == true)
             {
-                builder.IntegratedSecurity = false;
-                builder.UserID = UsernameTextBox.Text.Trim();
-                builder.Password = PasswordBox.Password;
+                authType = AuthenticationTypes.SqlServer;
+                userId = UsernameTextBox.Text.Trim();
+                secret = PasswordBox.Password;
             }
             else if (EntraMfaAuthRadio.IsChecked == true)
             {
-                builder.IntegratedSecurity = false;
-                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
-                var mfaUsername = EntraMfaUsernameBox.Text.Trim();
-                if (!string.IsNullOrEmpty(mfaUsername))
-                    builder.UserID = mfaUsername;
+                authType = AuthenticationTypes.EntraMFA;
+                userId = EntraMfaUsernameBox.Text.Trim();
             }
+            else if (ServicePrincipalAuthRadio.IsChecked == true)
+            {
+                authType = AuthenticationTypes.ServicePrincipal;
+                userId = ServicePrincipalClientIdBox.Text.Trim();
+                secret = ServicePrincipalSecretBox.Password;
+            }
+            else if (ManagedIdentityAuthRadio.IsChecked == true)
+            {
+                authType = AuthenticationTypes.ManagedIdentity;
+                managedIdentityClientId = ManagedIdentityClientIdBox.Text.Trim();
+            }
+            else
+            {
+                authType = AuthenticationTypes.Windows;
+            }
+
+            ServerConnection.ApplyAuthentication(builder, authType, userId, secret, azureClientId: null, managedIdentityClientId);
 
             return builder;
         }
@@ -214,6 +271,9 @@ namespace PerformanceMonitorDashboard
             bool useEntraAuth = EntraMfaAuthRadio.IsChecked == true;
             string? username = null;
             string? password = null;
+            string? authenticationType = null;
+            string? azureClientId = null;
+            string? managedIdentityClientId = null;
 
             if (SqlAuthRadio.IsChecked == true)
             {
@@ -224,6 +284,18 @@ namespace PerformanceMonitorDashboard
             {
                 username = EntraMfaUsernameBox.Text.Trim();
             }
+            else if (ServicePrincipalAuthRadio.IsChecked == true)
+            {
+                authenticationType = AuthenticationTypes.ServicePrincipal;
+                azureClientId = ServicePrincipalClientIdBox.Text.Trim();
+                username = azureClientId;
+                password = ServicePrincipalSecretBox.Password;
+            }
+            else if (ManagedIdentityAuthRadio.IsChecked == true)
+            {
+                authenticationType = AuthenticationTypes.ManagedIdentity;
+                managedIdentityClientId = ManagedIdentityClientIdBox.Text.Trim();
+            }
 
             return InstallationService.BuildConnectionString(
                 server,
@@ -232,7 +304,10 @@ namespace PerformanceMonitorDashboard
                 password,
                 GetSelectedEncryptMode(),
                 TrustServerCertificateCheckBox.IsChecked == true,
-                useEntraAuth);
+                useEntraAuth,
+                authenticationType,
+                azureClientId,
+                managedIdentityClientId);
         }
 
         private static string GetAppVersion()
@@ -290,6 +365,31 @@ namespace PerformanceMonitorDashboard
                     MessageBoxImage.Warning
                 );
                 return false;
+            }
+
+            if (ServicePrincipalAuthRadio.IsChecked == true)
+            {
+                if (string.IsNullOrWhiteSpace(ServicePrincipalClientIdBox.Text))
+                {
+                    MessageBox.Show(
+                        "Please enter the Application (Client) ID for service principal authentication.",
+                        "Validation Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(ServicePrincipalSecretBox.Password))
+                {
+                    MessageBox.Show(
+                        "Please enter the client secret for service principal authentication.",
+                        "Validation Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
+                    return false;
+                }
             }
 
             return true;
@@ -852,9 +952,14 @@ namespace PerformanceMonitorDashboard
             WindowsAuthRadio.IsEnabled = enabled;
             SqlAuthRadio.IsEnabled = enabled;
             EntraMfaAuthRadio.IsEnabled = enabled;
+            ServicePrincipalAuthRadio.IsEnabled = enabled;
+            ManagedIdentityAuthRadio.IsEnabled = enabled;
             UsernameTextBox.IsEnabled = enabled;
             PasswordBox.IsEnabled = enabled;
             EntraMfaUsernameBox.IsEnabled = enabled;
+            ServicePrincipalClientIdBox.IsEnabled = enabled;
+            ServicePrincipalSecretBox.IsEnabled = enabled;
+            ManagedIdentityClientIdBox.IsEnabled = enabled;
             EncryptModeComboBox.IsEnabled = enabled;
             TrustServerCertificateCheckBox.IsEnabled = enabled;
             ReadOnlyIntentCheckBox.IsEnabled = enabled;
@@ -908,6 +1013,8 @@ namespace PerformanceMonitorDashboard
 
             // Determine authentication type and credentials
             string authenticationType;
+            string? azureClientId = null;
+            string? managedIdentityClientId = null;
             if (WindowsAuthRadio.IsChecked == true)
             {
                 authenticationType = AuthenticationTypes.Windows;
@@ -918,6 +1025,25 @@ namespace PerformanceMonitorDashboard
             {
                 authenticationType = AuthenticationTypes.EntraMFA;
                 Username = EntraMfaUsernameBox.Text.Trim();
+                Password = null;
+            }
+            else if (ServicePrincipalAuthRadio.IsChecked == true)
+            {
+                authenticationType = AuthenticationTypes.ServicePrincipal;
+                // Surface the client id as the Username and the secret as the Password so the existing
+                // ServerManager credential-save path persists them (client id + client secret).
+                azureClientId = ServicePrincipalClientIdBox.Text.Trim();
+                Username = azureClientId;
+                Password = ServicePrincipalSecretBox.Password;
+            }
+            else if (ManagedIdentityAuthRadio.IsChecked == true)
+            {
+                authenticationType = AuthenticationTypes.ManagedIdentity;
+                managedIdentityClientId = string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text)
+                    ? null
+                    : ManagedIdentityClientIdBox.Text.Trim();
+                // No credential to store for managed identity.
+                Username = null;
                 Password = null;
             }
             else
@@ -949,6 +1075,8 @@ namespace PerformanceMonitorDashboard
                 ServerConnection.DisplayName = displayName;
                 ServerConnection.ServerName = ServerNameTextBox.Text.Trim();
                 ServerConnection.AuthenticationType = authenticationType;
+                ServerConnection.AzureClientId = azureClientId;
+                ServerConnection.ManagedIdentityClientId = managedIdentityClientId;
                 ServerConnection.Description = DescriptionTextBox.Text.Trim();
                 ServerConnection.IsFavorite = IsFavoriteCheckBox.IsChecked == true;
                 ServerConnection.EncryptMode = GetSelectedEncryptMode();
@@ -970,6 +1098,8 @@ namespace PerformanceMonitorDashboard
                     DisplayName = displayName,
                     ServerName = ServerNameTextBox.Text.Trim(),
                     AuthenticationType = authenticationType,
+                    AzureClientId = azureClientId,
+                    ManagedIdentityClientId = managedIdentityClientId,
                     Description = DescriptionTextBox.Text.Trim(),
                     IsFavorite = IsFavoriteCheckBox.IsChecked == true,
                     CreatedDate = DateTime.Now,

--- a/Dashboard/Models/ServerConnection.cs
+++ b/Dashboard/Models/ServerConnection.cs
@@ -45,9 +45,23 @@ namespace PerformanceMonitorDashboard.Models
         }
 
         /// <summary>
-        /// Authentication type: Windows, SqlServer, or EntraMFA.
+        /// Authentication type: Windows, SqlServer, EntraMFA, ServicePrincipal, or ManagedIdentity.
         /// </summary>
         public string AuthenticationType { get; set; } = AuthenticationTypes.Windows;
+
+        /// <summary>
+        /// Service-principal application/client id (used as UserID for ServicePrincipal auth).
+        /// Non-secret; safe to persist in servers.json. The SP secret is NEVER stored here —
+        /// it lives only in Windows Credential Manager (DPAPI) via CredentialService.
+        /// </summary>
+        public string? AzureClientId { get; set; }
+
+        /// <summary>
+        /// Optional user-assigned managed identity client id. Blank = system-assigned identity.
+        /// Non-secret; safe to persist in servers.json.
+        /// </summary>
+        public string? ManagedIdentityClientId { get; set; }
+
         public string? Description { get; set; }
         public DateTime CreatedDate { get; set; } = DateTime.Now;
         public DateTime LastConnected { get; set; } = DateTime.Now;
@@ -129,6 +143,8 @@ namespace PerformanceMonitorDashboard.Models
         {
             AuthenticationTypes.EntraMFA => "Microsoft Entra MFA",
             AuthenticationTypes.SqlServer => "SQL Server",
+            AuthenticationTypes.ServicePrincipal => "Azure — Service Principal",
+            AuthenticationTypes.ManagedIdentity => "Azure — Managed Identity",
             _ => "Windows"
         };
 
@@ -141,40 +157,36 @@ namespace PerformanceMonitorDashboard.Models
         /// <returns>Connection string for SQL Server</returns>
         public string GetConnectionString(ICredentialService credentialService)
         {
-            if (AuthenticationType == AuthenticationTypes.EntraMFA)
+            // Single builder for every auth mode; the auth-specific keywords are applied by the shared
+            // ApplyAuthentication helper so this production path can never drift from the Add/Edit
+            // dialog's Test-Connection builder. These non-auth settings match the prior EntraMFA builder.
+            var builder = new SqlConnectionStringBuilder
             {
-                // Build MFA connection string with ActiveDirectoryInteractive
-                var mfaBuilder = new SqlConnectionStringBuilder
+                DataSource = ServerName,
+                InitialCatalog = "PerformanceMonitor",
+                ApplicationName = "PerformanceMonitorDashboard",
+                ConnectTimeout = 15,
+                MultipleActiveResultSets = true,
+                TrustServerCertificate = TrustServerCertificate,
+                Encrypt = EncryptMode switch
                 {
-                    DataSource = ServerName,
-                    InitialCatalog = "PerformanceMonitor",
-                    ApplicationName = "PerformanceMonitorDashboard",
-                    ConnectTimeout = 15,
-                    MultipleActiveResultSets = true,
-                    TrustServerCertificate = TrustServerCertificate,
-                    Encrypt = EncryptMode switch
-                    {
-                        "Optional" => SqlConnectionEncryptOption.Optional,
-                        "Strict" => SqlConnectionEncryptOption.Strict,
-                        _ => SqlConnectionEncryptOption.Mandatory
-                    },
-                    ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
-                    MultiSubnetFailover = MultiSubnetFailover,
-                    Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive
-                };
+                    "Optional" => SqlConnectionEncryptOption.Optional,
+                    "Strict" => SqlConnectionEncryptOption.Strict,
+                    _ => SqlConnectionEncryptOption.Mandatory
+                },
+                ApplicationIntent = ReadOnlyIntent ? ApplicationIntent.ReadOnly : ApplicationIntent.ReadWrite,
+                MultiSubnetFailover = MultiSubnetFailover
+            };
 
-                // Optionally pre-populate username from credential store
-                var mfaCred = credentialService.GetCredential(Id);
-                if (mfaCred.HasValue && !string.IsNullOrEmpty(mfaCred.Value.Username))
-                    mfaBuilder.UserID = mfaCred.Value.Username;
-
-                return mfaBuilder.ConnectionString;
-            }
-
+            // Resolve credentials from secure storage per auth mode (mirrors Lite's inline resolution):
+            //   SqlServer / ServicePrincipal -> stored username + password (SP: client id + client secret)
+            //   EntraMFA                     -> stored username hint only (pre-populates the interactive prompt)
+            //   ManagedIdentity / Windows    -> no stored secret
             string? username = null;
             string? password = null;
 
-            if (AuthenticationType == AuthenticationTypes.SqlServer)
+            if (AuthenticationType == AuthenticationTypes.SqlServer ||
+                AuthenticationType == AuthenticationTypes.ServicePrincipal)
             {
                 var cred = credentialService.GetCredential(Id);
                 if (cred.HasValue)
@@ -183,17 +195,81 @@ namespace PerformanceMonitorDashboard.Models
                     password = cred.Value.Password;
                 }
             }
+            else if (AuthenticationType == AuthenticationTypes.EntraMFA)
+            {
+                // Preserve the existing behavior: pre-populate UserID from the stored username hint.
+                var cred = credentialService.GetCredential(Id);
+                if (cred.HasValue && !string.IsNullOrEmpty(cred.Value.Username))
+                {
+                    username = cred.Value.Username;
+                }
+            }
 
-            return DatabaseService.BuildConnectionString(
-                ServerName,
-                UseWindowsAuth,
-                username,
-                password,
-                EncryptMode,
-                TrustServerCertificate,
-                ReadOnlyIntent,
-                MultiSubnetFailover
-            ).ConnectionString;
+            ApplyAuthentication(builder, AuthenticationType, username, password, AzureClientId, ManagedIdentityClientId);
+
+            return builder.ConnectionString;
+        }
+
+        // SYNC: verbatim mirror of Lite ServerConnection.ApplyAuthentication — keep the two in lockstep.
+        // Guarded by Dashboard.Tests/AzureAuthConnectionStringTests + Lite.Tests/AzureAuthConnectionStringTests.
+        /// <summary>
+        /// Applies the authentication-mode keywords (IntegratedSecurity / Authentication / UserID /
+        /// Password) to a connection-string builder. Shared by <see cref="GetConnectionString"/> and
+        /// the Add/Edit dialog's Test-Connection builder so the two build sites never diverge.
+        /// </summary>
+        /// <param name="builder">The builder to mutate.</param>
+        /// <param name="authenticationType">One of the <see cref="AuthenticationTypes"/> constants.</param>
+        /// <param name="username">SQL username, Entra UPN, or SP client id (depending on mode).</param>
+        /// <param name="password">SQL password or SP client secret (depending on mode). Never logged.</param>
+        /// <param name="azureClientId">SP client id fallback when <paramref name="username"/> is null.</param>
+        /// <param name="managedIdentityClientId">User-assigned MI client id; blank = system-assigned.</param>
+        internal static void ApplyAuthentication(
+            SqlConnectionStringBuilder builder,
+            string authenticationType,
+            string? username,
+            string? password,
+            string? azureClientId,
+            string? managedIdentityClientId)
+        {
+            if (authenticationType == AuthenticationTypes.Windows)
+            {
+                builder.IntegratedSecurity = true;
+            }
+            else if (authenticationType == AuthenticationTypes.SqlServer)
+            {
+                builder.IntegratedSecurity = false;
+                builder.UserID = username ?? string.Empty;
+                builder.Password = password ?? string.Empty;
+            }
+            else if (authenticationType == AuthenticationTypes.EntraMFA)
+            {
+                // Microsoft Entra MFA (Azure AD Interactive)
+                builder.IntegratedSecurity = false;
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
+                // Optionally set UserID (email/UPN)
+                if (!string.IsNullOrWhiteSpace(username))
+                {
+                    builder.UserID = username;
+                }
+            }
+            else if (authenticationType == AuthenticationTypes.ServicePrincipal)
+            {
+                // Microsoft Entra service principal (non-interactive): client id + secret.
+                builder.IntegratedSecurity = false;
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryServicePrincipal;
+                builder.UserID = username ?? azureClientId ?? string.Empty;   // client/app id
+                builder.Password = password ?? string.Empty;                  // client secret (from Credential Manager)
+            }
+            else if (authenticationType == AuthenticationTypes.ManagedIdentity)
+            {
+                // Azure managed identity (non-interactive): no secret.
+                builder.IntegratedSecurity = false;
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
+                if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
+                {
+                    builder.UserID = managedIdentityClientId;   // user-assigned MI; omit for system-assigned
+                }
+            }
         }
 
         /// <summary>
@@ -201,14 +277,18 @@ namespace PerformanceMonitorDashboard.Models
         /// Used to validate that SQL auth servers have credentials available.
         /// </summary>
         /// <param name="credentialService">The credential service to use for checking credentials</param>
-        /// <returns>True if Windows auth or MFA is used, or if credentials exist in credential manager</returns>
+        /// <returns>True for zero-touch modes (Windows, MFA, Managed Identity), or if a credential exists in credential manager</returns>
         public bool HasStoredCredentials(ICredentialService credentialService)
         {
-            if (AuthenticationType == AuthenticationTypes.Windows || AuthenticationType == AuthenticationTypes.EntraMFA)
+            // Zero-touch auth modes need no stored secret.
+            if (AuthenticationType == AuthenticationTypes.Windows ||
+                AuthenticationType == AuthenticationTypes.EntraMFA ||
+                AuthenticationType == AuthenticationTypes.ManagedIdentity)
             {
                 return true;
             }
 
+            // SqlServer (password) and ServicePrincipal (client secret) require a stored credential.
             return credentialService.CredentialExists(Id);
         }
     }

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -153,9 +153,12 @@ namespace PerformanceMonitorDashboard.Services
                 SaveServersInternal();
             }
 
-            if (server.AuthenticationType == AuthenticationTypes.SqlServer && !string.IsNullOrEmpty(username) && password != null)
+            if ((server.AuthenticationType == AuthenticationTypes.SqlServer ||
+                 server.AuthenticationType == AuthenticationTypes.ServicePrincipal) &&
+                !string.IsNullOrEmpty(username) && password != null)
             {
-                // For SQL Server auth, save both username and password
+                // SQL Server auth (username + password) and Service Principal (client id + client secret)
+                // both persist a secret in Windows Credential Manager.
                 if (!_credentialService.SaveCredential(server.Id, username, password))
                 {
                     throw new InvalidOperationException("Failed to save credentials to Windows Credential Manager");
@@ -169,6 +172,7 @@ namespace PerformanceMonitorDashboard.Services
                     throw new InvalidOperationException("Failed to save username to Windows Credential Manager");
                 }
             }
+            // ManagedIdentity stores no credential.
 
             // Initialize status as unknown for new server
             _connectionStatuses[server.Id] = new ServerConnectionStatus { ServerId = server.Id };
@@ -189,9 +193,12 @@ namespace PerformanceMonitorDashboard.Services
                 SaveServersInternal();
             }
 
-            if (server.AuthenticationType == AuthenticationTypes.SqlServer && !string.IsNullOrEmpty(username) && password != null)
+            if ((server.AuthenticationType == AuthenticationTypes.SqlServer ||
+                 server.AuthenticationType == AuthenticationTypes.ServicePrincipal) &&
+                !string.IsNullOrEmpty(username) && password != null)
             {
-                // For SQL Server auth, update both username and password
+                // SQL Server auth (username + password) and Service Principal (client id + client secret)
+                // both persist a secret in Windows Credential Manager.
                 if (!_credentialService.UpdateCredential(server.Id, username, password))
                 {
                     throw new InvalidOperationException("Failed to update credentials in Windows Credential Manager");
@@ -205,9 +212,11 @@ namespace PerformanceMonitorDashboard.Services
                     throw new InvalidOperationException("Failed to update username in Windows Credential Manager");
                 }
             }
-            else if (server.AuthenticationType == AuthenticationTypes.Windows)
+            else if (server.AuthenticationType == AuthenticationTypes.Windows ||
+                     server.AuthenticationType == AuthenticationTypes.ManagedIdentity)
             {
-                // For Windows auth, remove any stored credentials
+                // Windows and Managed Identity use no stored secret — remove any credential left over
+                // from a previous auth mode so it can't linger orphaned in Credential Manager.
                 _credentialService.DeleteCredential(server.Id);
             }
         }

--- a/Dashboard/Services/ServerManager.cs
+++ b/Dashboard/Services/ServerManager.cs
@@ -204,12 +204,22 @@ namespace PerformanceMonitorDashboard.Services
                     throw new InvalidOperationException("Failed to update credentials in Windows Credential Manager");
                 }
             }
-            else if (server.AuthenticationType == AuthenticationTypes.EntraMFA && !string.IsNullOrEmpty(username))
+            else if (server.AuthenticationType == AuthenticationTypes.EntraMFA)
             {
-                // For MFA auth, update username hint only (no password needed)
-                if (!_credentialService.UpdateCredential(server.Id, username, string.Empty))
+                if (!string.IsNullOrEmpty(username))
                 {
-                    throw new InvalidOperationException("Failed to update username in Windows Credential Manager");
+                    // For MFA auth, update the username hint only (no password needed).
+                    if (!_credentialService.UpdateCredential(server.Id, username, string.Empty))
+                    {
+                        throw new InvalidOperationException("Failed to update username in Windows Credential Manager");
+                    }
+                }
+                else
+                {
+                    // No username hint to store. Remove any credential left over from a previous
+                    // secret-bearing mode (SqlServer/ServicePrincipal) so the old secret can't linger
+                    // orphaned when a server is switched to MFA with a blank username.
+                    _credentialService.DeleteCredential(server.Id);
                 }
             }
             else if (server.AuthenticationType == AuthenticationTypes.Windows ||

--- a/Installer.Core/InstallationService.cs
+++ b/Installer.Core/InstallationService.cs
@@ -54,6 +54,16 @@ public static class InstallationService
     /// <summary>
     /// Build a connection string from the provided parameters.
     /// </summary>
+    /// <param name="authenticationType">
+    /// Optional explicit auth type for the non-interactive Entra modes. When set to the
+    /// PerformanceMonitor.Common.AuthenticationTypes values "ServicePrincipal" or "ManagedIdentity"
+    /// it takes precedence over <paramref name="useWindowsAuth"/>/<paramref name="useEntraAuth"/>.
+    /// Left null by the CLI installer, which only offers Windows/SQL/Entra-interactive — those paths
+    /// are unchanged. (Installer.Core intentionally has no reference to PerformanceMonitor.Common, so
+    /// the values are matched as string literals here; they must stay in sync with that enum.)
+    /// </param>
+    /// <param name="azureClientId">Service-principal client id fallback when <paramref name="username"/> is null.</param>
+    /// <param name="managedIdentityClientId">User-assigned managed identity client id; blank = system-assigned.</param>
     public static string BuildConnectionString(
         string server,
         bool useWindowsAuth,
@@ -61,7 +71,10 @@ public static class InstallationService
         string? password = null,
         string encryption = "Mandatory",
         bool trustCertificate = false,
-        bool useEntraAuth = false)
+        bool useEntraAuth = false,
+        string? authenticationType = null,
+        string? azureClientId = null,
+        string? managedIdentityClientId = null)
     {
         var builder = new SqlConnectionStringBuilder
         {
@@ -78,7 +91,24 @@ public static class InstallationService
             _ => SqlConnectionEncryptOption.Mandatory
         };
 
-        if (useEntraAuth)
+        // Non-interactive Entra modes (service principal / managed identity) take precedence when an
+        // explicit authentication type is supplied. The useWindowsAuth/useEntraAuth path below is
+        // preserved unchanged for callers that leave authenticationType null (e.g. the CLI installer).
+        if (authenticationType == "ServicePrincipal")
+        {
+            builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryServicePrincipal;
+            builder.UserID = username ?? azureClientId ?? string.Empty;   // client/app id
+            builder.Password = password ?? string.Empty;                  // client secret
+        }
+        else if (authenticationType == "ManagedIdentity")
+        {
+            builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
+            if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
+            {
+                builder.UserID = managedIdentityClientId;   // user-assigned MI; omit for system-assigned
+            }
+        }
+        else if (useEntraAuth)
         {
             builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
             builder.UserID = username;


### PR DESCRIPTION
## What

Adds the two non-interactive Microsoft Entra auth modes — **Service Principal** and **Managed Identity** — to the Dashboard, bringing it to auth parity with Lite. `AuthenticationTypes` (incl. the `ServicePrincipal`/`ManagedIdentity` constants) was already shared in `PerformanceMonitor.Common`; Dashboard just didn't use them. (Answers the architecture-review D1 auth-gap; Erik chose "Add SP + Managed Identity".)

## Implementation

- **`ServerConnection`** — new persisted, non-secret `AzureClientId` + `ManagedIdentityClientId` fields; an `ApplyAuthentication` helper ported **verbatim** from Lite (with a `// SYNC:` lockstep comment) that is now the single auth-keyword source for both the runtime `GetConnectionString` and the dialog's Test-Connection builder; `HasStoredCredentials` treats Managed Identity as zero-touch.
- **`AddServerDialog`** — SP (client id + secret) and MI (optional user-assigned client id) radios + panels; validation; the SP secret is pre-filled from Credential Manager on edit (matching SQL-auth password + Lite); save persists the non-secret ids and stores the SP secret.
- **`ServerManager`** — SP persists a secret like SQL auth; switching to MI / Windows / MFA-with-blank-username deletes any orphaned secret. The background-refresh interactive gate still blocks only EntraMFA, so SP/MI connect unattended (their whole point).
- **`InstallationService.BuildConnectionString`** — optional SP/MI params (string literals, since Installer.Core has no `.Common` reference); existing CLI paths unchanged.
- **`Dashboard.Tests/AzureAuthConnectionStringTests`** (new) — 26 shape tests mirroring Lite's contract; a drift guard against the two apps' keyword mappings diverging.

## Verification

- **Dashboard.Tests 732/732** (incl. the 26 new). Builds clean (Dashboard + Installer CLI).
- **Security-reviewed** (subagent): secrets go only to Windows Credential Manager — never servers.json or logs; keywords correct; no injection; existing modes not weakened. It found one Low orphaned-secret edge case (switch a secret-bearing server to MFA with a blank username) — **fixed in the second commit**.

## Notes

- **Existing-mode keyword change (minor, intentional):** `GetConnectionString` now uses one unified builder, so SqlServer/Windows connections gain `Application Name=PerformanceMonitorDashboard` (previously only EntraMFA sent it) — makes the Dashboard's own connections identifiable in `program_name`, consistent with EntraMFA and Lite. `Connect Timeout=15` is the prior implicit default (inert). If you'd rather keep SqlServer/Windows byte-identical, say so and I'll gate those two keywords to the Azure modes only.
- **No `AzureTenantId` field:** Lite has one, but its own code documents it as *"display/future use only, NOT injected into the connection string"* (MDS resolves the tenant from the target server's AAD authority). Omitting it is functionally identical to Lite for SP auth.
- **`DatabaseService.BuildConnectionString`** is now unused by `ServerConnection` (its only caller); left in place as public API.

## HELD — needs live dialog testing

The connection-string logic is unit-tested, but the WPF Add/Edit Server dialog (radios, panels, load/save, Test Connection) can't be automated. Please exercise: add a server with SP (client id + secret) and with MI, Test Connection, save, re-open to edit (secret pre-filled), and switch an SP server to another mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)