### PR TITLE
Standardize Lite collectors on AppLogger; drop duplicate log lines (C2)

### DIFF
--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using DuckDB.NET.Data;
 using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Logging;
 using PerformanceMonitorLite.Models;
 
 namespace PerformanceMonitorLite.Services;
@@ -63,13 +62,10 @@ public partial class RemoteCollectorService
                empty even when the session exists -- the CREATE/START path then reports "already exists"
                (25631) / "already started" (25705). That confirms the session is up; it is success, not a
                failure to surface as an unhealthy collector or log every cycle (#1251). */
-            _logger?.LogDebug("Blocked process XE session already present on '{Server}' (benign)", server.DisplayName);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Blocked process XE session already present (benign, #1251)");
         }
         catch (SqlException ex)
         {
-            _logger?.LogWarning("Failed to ensure blocked process XE session on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure blocked process XE session: {ex.Message}");
 
             /* Propagate so RunCollectorAsync marks the collector unhealthy instead
@@ -120,7 +116,6 @@ SELECT @threshold;", connection);
 
             if (threshold == 0)
             {
-                _logger?.LogInformation("Configured blocked process threshold to 5 seconds on '{Server}'", server.DisplayName);
                 AppLogger.Info("XeSession", $"[{server.DisplayName}] Configured blocked process threshold to 5 seconds");
             }
         }
@@ -156,20 +151,17 @@ WHERE ses.name = @session_name;", connection))
                             $"ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON SERVER STATE = START;", connection);
                         startCmd.CommandTimeout = CommandTimeoutSeconds;
                         await startCmd.ExecuteNonQueryAsync(cancellationToken);
-                        _logger?.LogInformation("Started blocked process XE session on '{Server}'", server.DisplayName);
                         AppLogger.Info("XeSession", $"[{server.DisplayName}] Started blocked process XE session");
                     }
                     catch (SqlException ex)
                     {
-                        _logger?.LogWarning("Failed to start blocked process XE session on '{Server}': {Message}",
-                            server.DisplayName, ex.Message);
                         AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to start blocked process XE session: {ex.Message}");
                         throw;
                     }
                 }
                 else
                 {
-                    _logger?.LogDebug("Blocked process XE session is running on '{Server}'", server.DisplayName);
+                    AppLogger.Debug("XeSession", $"Blocked process XE session is running on '{server.DisplayName}'");
                 }
                 return;
             }
@@ -195,13 +187,10 @@ WITH
 ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON SERVER STATE = START;", connection);
             createCmd.CommandTimeout = CommandTimeoutSeconds;
             await createCmd.ExecuteNonQueryAsync(cancellationToken);
-            _logger?.LogInformation("Created and started blocked process XE session on '{Server}'", server.DisplayName);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Created and started blocked process XE session");
         }
         catch (SqlException ex)
         {
-            _logger?.LogWarning("Failed to create blocked process XE session on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create blocked process XE session: {ex.Message}");
             throw;
         }
@@ -243,7 +232,6 @@ END;", connection);
                 startCmd.CommandTimeout = CommandTimeoutSeconds;
                 await startCmd.ExecuteNonQueryAsync(cancellationToken);
 
-                _logger?.LogDebug("Blocked process XE session already exists (database-scoped, Azure SQL DB)");
                 AppLogger.Info("XeSession", $"[Azure SQL DB] Blocked process XE session verified (database-scoped)");
                 return;
             }
@@ -270,7 +258,6 @@ ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON DATABASE STATE = START;",
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        _logger?.LogInformation("Created and started blocked process XE session (database-scoped, Azure SQL DB)");
         AppLogger.Info("XeSession", $"[Azure SQL DB] Created and started blocked process XE session (database-scoped)");
     }
 
@@ -748,13 +735,11 @@ OPTION(RECOMPILE);";
         catch (SqlException ex) when (ex.Number == 297 || ex.Number == 15151 || ex.Message.Contains("XE session"))
         {
             /* XE session not found or not accessible */
-            _logger?.LogDebug("Blocked process XE session not available on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Blocked process XE session not available: {ex.Message}");
             return 0;
         }
 
-        _logger?.LogDebug("Collected {RowCount} blocked process reports for server '{Server}'", rowsCollected, server.DisplayName);
+        AppLogger.Debug("Collector", $"Collected {rowsCollected} blocked process reports for server '{server.DisplayName}'");
         return rowsCollected;
     }
 

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -14,7 +14,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Logging;
 using PerformanceMonitorLite.Models;
 
 namespace PerformanceMonitorLite.Services;
@@ -61,13 +60,10 @@ public partial class RemoteCollectorService
                XE existence catalogs are visibility-scoped per principal, so the pre-check can miss an
                existing session and CREATE/START then reports "already exists" (25631) / "already started"
                (25705). That's success, not a failure to surface as unhealthy or log every cycle (#1251). */
-            _logger?.LogDebug("Deadlock XE session already present on '{Server}' (benign)", server.DisplayName);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Deadlock XE session already present (benign, #1251)");
         }
         catch (SqlException ex)
         {
-            _logger?.LogWarning("Failed to ensure deadlock XE session on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure deadlock XE session: {ex.Message}");
 
             /* Propagate so RunCollectorAsync marks the collector unhealthy instead
@@ -107,20 +103,17 @@ WHERE ses.name = @session_name;", connection))
                             $"ALTER EVENT SESSION [{DeadlockXeSessionName}] ON SERVER STATE = START;", connection);
                         startCmd.CommandTimeout = CommandTimeoutSeconds;
                         await startCmd.ExecuteNonQueryAsync(cancellationToken);
-                        _logger?.LogInformation("Started deadlock XE session on '{Server}'", server.DisplayName);
                         AppLogger.Info("XeSession", $"[{server.DisplayName}] Started deadlock XE session");
                     }
                     catch (SqlException ex)
                     {
-                        _logger?.LogWarning("Failed to start deadlock XE session on '{Server}': {Message}",
-                            server.DisplayName, ex.Message);
                         AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to start deadlock XE session: {ex.Message}");
                         throw;
                     }
                 }
                 else
                 {
-                    _logger?.LogDebug("Deadlock XE session is running on '{Server}'", server.DisplayName);
+                    AppLogger.Debug("XeSession", $"Deadlock XE session is running on '{server.DisplayName}'");
                 }
                 return;
             }
@@ -149,13 +142,10 @@ WITH
 ALTER EVENT SESSION [{DeadlockXeSessionName}] ON SERVER STATE = START;", connection);
             createCmd.CommandTimeout = CommandTimeoutSeconds;
             await createCmd.ExecuteNonQueryAsync(cancellationToken);
-            _logger?.LogInformation("Created and started deadlock XE session on '{Server}'", server.DisplayName);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Created and started deadlock XE session");
         }
         catch (SqlException ex)
         {
-            _logger?.LogWarning("Failed to create deadlock XE session on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create deadlock XE session: {ex.Message}");
             throw;
         }
@@ -234,7 +224,6 @@ END;", connection);
                     startCmd.CommandTimeout = CommandTimeoutSeconds;
                     await startCmd.ExecuteNonQueryAsync(cancellationToken);
 
-                    _logger?.LogDebug("Deadlock XE session already exists (database-scoped, Azure SQL DB)");
                     AppLogger.Info("XeSession", $"[Azure SQL DB] Deadlock XE session verified (database-scoped)");
                     return;
                 }
@@ -264,7 +253,6 @@ ALTER EVENT SESSION [{DeadlockXeSessionName}] ON DATABASE STATE = START;", conne
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        _logger?.LogInformation("Created and started deadlock XE session (database-scoped, Azure SQL DB)");
         AppLogger.Info("XeSession", $"[Azure SQL DB] Created and started deadlock XE session (database-scoped)");
     }
 
@@ -435,13 +423,11 @@ OPTION(RECOMPILE);";
         catch (SqlException ex) when (ex.Number == 297 || ex.Number == 15151 || ex.Message.Contains("XE session"))
         {
             /* XE session not found or not accessible */
-            _logger?.LogDebug("Deadlock XE session not available on '{Server}': {Message}",
-                server.DisplayName, ex.Message);
             AppLogger.Info("XeSession", $"[{server.DisplayName}] Deadlock XE session not available: {ex.Message}");
             return 0;
         }
 
-        _logger?.LogDebug("Collected {RowCount} deadlocks for server '{Server}'", rowsCollected, server.DisplayName);
+        AppLogger.Debug("Collector", $"Collected {rowsCollected} deadlocks for server '{server.DisplayName}'");
         return rowsCollected;
     }
 

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -319,7 +319,7 @@ public partial class RemoteCollectorService
             if (serverStatus.IsOnline == false)
             {
                 skippedOffline++;
-                _logger?.LogDebug("Skipping offline server '{Server}'", server.DisplayName);
+                AppLogger.Debug("Scheduler", $"Skipping offline server '{server.DisplayName}'");
                 continue;
             }
             onlineServers.Add(server);
@@ -330,8 +330,7 @@ public partial class RemoteCollectorService
             return;
         }
 
-        _logger?.LogInformation("Checking per-server schedules for {OnlineCount}/{TotalCount} servers ({SkippedCount} offline, skipped)",
-            onlineServers.Count, enabledServers.Count, skippedOffline);
+        AppLogger.Info("Scheduler", $"Checking per-server schedules for {onlineServers.Count}/{enabledServers.Count} servers ({skippedOffline} offline, skipped)");
 
         /* Run servers in parallel, but collectors within each server sequentially.
            DuckDB is single-writer; running all collectors in parallel causes spin-wait
@@ -363,7 +362,7 @@ public partial class RemoteCollectorService
         }
         catch (Exception ex)
         {
-            _logger?.LogDebug(ex, "Post-collection checkpoint failed (non-critical)");
+            AppLogger.Debug("Collector", $"Post-collection checkpoint failed (non-critical): {ex.Message}");
         }
     }
 
@@ -384,9 +383,7 @@ public partial class RemoteCollectorService
         /* Persist edition/version to DuckDB for the analysis engine */
         await PersistServerMetadataAsync(server, serverStatus);
 
-        AppLogger.Info("Collector", $"Running {enabledSchedules.Count} collectors for '{server.DisplayName}' (serverId={GetServerId(server)})");
-        _logger?.LogInformation("Running {Count} collectors for server '{Server}' (initial load)",
-            enabledSchedules.Count, server.DisplayName);
+        AppLogger.Info("Collector", $"Running {enabledSchedules.Count} collectors for '{server.DisplayName}' (serverId={GetServerId(server)}, initial load)");
 
         foreach (var schedule in enabledSchedules)
         {
@@ -396,8 +393,7 @@ public partial class RemoteCollectorService
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Initial collector '{Collector}' failed for server '{Server}'",
-                    schedule.Name, server.DisplayName);
+                AppLogger.Error("Collector", $"Initial collector '{schedule.Name}' failed for server '{server.DisplayName}'", ex);
             }
         }
     }
@@ -433,8 +429,6 @@ public partial class RemoteCollectorService
             if (server.AuthenticationType == AuthenticationTypes.EntraMFA && serverStatus.UserCancelledMfa)
             {
                 AppLogger.Info("Collector", $"  [{server.DisplayName}] {collectorName} SKIPPED - MFA authentication cancelled by user");
-                _logger?.LogDebug("Skipping collector '{Collector}' for server '{Server}' - user cancelled MFA",
-                    collectorName, server.DisplayName);
                 return;
             }
 
@@ -442,13 +436,11 @@ public partial class RemoteCollectorService
             // this session. Flag is in-memory — next app start retries once (see #857).
             if (IsCollectorPermissionRestricted(GetServerId(server), collectorName))
             {
-                _logger?.LogDebug("Skipping collector '{Collector}' for server '{Server}' - permission denied this session",
-                    collectorName, server.DisplayName);
+                AppLogger.Debug("Collector", $"Skipping collector '{collectorName}' for server '{server.DisplayName}' - permission denied this session");
                 return;
             }
 
-            _logger?.LogDebug("Running collector '{Collector}' for server '{Server}'",
-                collectorName, server.DisplayName);
+            AppLogger.Debug("Collector", $"Running collector '{collectorName}' for server '{server.DisplayName}'");
 
             /* Ensure the backing XE session exists before reading its ring buffer.
                Runs on every cycle (cheap existence check when already present) so a
@@ -512,8 +504,6 @@ public partial class RemoteCollectorService
                 : "ERROR";
             xeSessionUnavailable = true;
             AppLogger.Error("Collector", $"  [{server.DisplayName}] {collectorName} {ex.Message}");
-            _logger?.LogWarning("Collector '{Collector}' XE session unavailable for server '{Server}': {Message}",
-                collectorName, server.DisplayName, ex.Message);
         }
         catch (SqlException ex)
         {
@@ -523,24 +513,20 @@ public partial class RemoteCollectorService
 
             if (RetryHelper.IsTransient(ex))
             {
-                _logger?.LogWarning("Collector '{Collector}' transient SQL error #{ErrorNumber} for server '{Server}': {Message}",
-                    collectorName, ex.Number, server.DisplayName, ex.Message);
+                AppLogger.Warn("Collector", $"Collector '{collectorName}' transient SQL error #{ex.Number} for server '{server.DisplayName}': {ex.Message}");
             }
             else if (ex.Number == 207) /* Invalid column name - likely version incompatibility */
             {
-                _logger?.LogWarning("Collector '{Collector}' column not found for server '{Server}' (possible version incompatibility): {Message}",
-                    collectorName, server.DisplayName, ex.Message);
+                AppLogger.Warn("Collector", $"Collector '{collectorName}' column not found for server '{server.DisplayName}' (possible version incompatibility): {ex.Message}");
             }
             else if (ex.Number == 229 || ex.Number == 297 || ex.Number == 300)
             {
                 status = "PERMISSIONS";
-                _logger?.LogWarning("Collector '{Collector}' permission denied for server '{Server}': {Message}",
-                    collectorName, server.DisplayName, ex.Message);
+                AppLogger.Warn("Collector", $"Collector '{collectorName}' permission denied for server '{server.DisplayName}': {ex.Message}");
             }
             else
             {
-                _logger?.LogError(ex, "Collector '{Collector}' SQL error #{ErrorNumber} for server '{Server}'",
-                    collectorName, ex.Number, server.DisplayName);
+                AppLogger.Error("Collector", $"Collector '{collectorName}' SQL error #{ex.Number} for server '{server.DisplayName}'", ex);
             }
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("MFA authentication cancelled"))
@@ -554,15 +540,14 @@ public partial class RemoteCollectorService
         {
             status = "CANCELLED";
             errorMessage = "Collection cancelled";
-            _logger?.LogDebug("Collector '{Collector}' cancelled for server '{Server}'", collectorName, server.DisplayName);
+            AppLogger.Debug("Collector", $"Collector '{collectorName}' cancelled for server '{server.DisplayName}'");
         }
         catch (Exception ex)
         {
             status = "ERROR";
             errorMessage = ex.Message;
             AppLogger.Error("Collector", $"  [{server.DisplayName}] {collectorName} {ex.GetType().Name}: {ex.Message}");
-            _logger?.LogError(ex, "Collector '{Collector}' failed for server '{Server}'",
-                collectorName, server.DisplayName);
+            AppLogger.Error("Collector", $"Collector '{collectorName}' failed for server '{server.DisplayName}'", ex);
         }
 
         // Track collector health
@@ -652,7 +637,7 @@ WHERE server_id = $3";
             {
                 /* First few failures: log at Error level with full detail */
                 AppLogger.Error("Collector", $"COLLECTION LOGGING FAILED ({_logInsertFailures}x): {ex.GetType().Name}: {ex.Message}");
-                _logger?.LogError(ex, "Failed to log collection for {Collector} (failure #{Count})", collectorName, _logInsertFailures);
+                AppLogger.Error("Collector", $"Failed to log collection for {collectorName} (failure #{_logInsertFailures})", ex);
             }
             else if (_logInsertFailures % 100 == 0)
             {
@@ -880,8 +865,7 @@ WHERE server_id = $3";
                         {
                             var serverStatus = _serverManager.GetConnectionStatus(server.Id);
                             serverStatus.UserCancelledMfa = true;
-                            AppLogger.Info("Collector", $"  [{server.DisplayName}] MFA authentication cancelled by user");
-                            _logger?.LogInformation("MFA authentication cancelled by user for server '{DisplayName}' - flagging to abort other pending connections", server.DisplayName);
+                            AppLogger.Info("Collector", $"  [{server.DisplayName}] MFA authentication cancelled by user - flagging to abort other pending connections");
                         }
                         throw;
                     }


### PR DESCRIPTION
Architecture-review cleanup **C2** (Erik chose: standardize on AppLogger).

`RemoteCollectorService` + its `.Deadlocks`/`.BlockedProcessReport` partials logged many events via **both** the injected `_logger` and static `AppLogger`. In production the DI container injects `AppLoggerAdapter<RemoteCollectorService>`, which routes `_logger` to the **same** `lite_*.log` — so every paired event wrote two differently-worded lines.

- **Dropped** the redundant `_logger` calls where an adjacent `AppLogger` call already logs the event.
- **Converted** the `_logger`-only calls (branch-specific SQL error subtypes, debug traces) to `AppLogger`, preserving message + stack trace (`AppLogger.Error(..., ex)`).
- **Folded** unique detail that lived only in a `_logger` line (`"initial load"`, `"flagging to abort other pending connections"`) into the kept `AppLogger` message rather than dropping it.
- **Untouched:** the `_logger` field, ctor param, and the connection retry-helper argument (the field is still used by that helper); `AppLogger`/`AppLoggerAdapter`.

Zero `_logger?.Log` calls remain in any of the three files. **Lite.Tests 619/619**, build clean.

**Note:** the two schedule-dispatch lines (`Skipping offline server`, `Checking per-server schedules`) use a new `"Scheduler"` source tag (not used elsewhere — was `_logger`-only before). Say the word if you'd rather fold them under `"Collector"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)