### PR TITLE
Add 'Show Active Queries at This Time' drill-down to Performance Trends charts (both apps)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml.cs
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml.cs
@@ -61,6 +61,9 @@ namespace PerformanceMonitorDashboard.Controls
         /// <summary>Fired when the Queries sub-tab changes, so the global Compare dropdown can update.</summary>
         public event Action? SubTabChanged;
 
+        /// <summary>Raised when user drills down on a chart point. Args: (chartType, serverLocalTime)</summary>
+        public event Action<string, DateTime>? ChartDrillDownRequested;
+
         private CancellationTokenSource? _actualPlanCts;
 
         /// <summary>Cancels the in-flight actual plan execution, if any.</summary>
@@ -873,12 +876,41 @@ namespace PerformanceMonitorDashboard.Controls
             }
         }
 
+        private void AddDrillDown(ScottPlot.WPF.WpfPlot chart, ContextMenu menu,
+            Func<ChartHoverHelper?> hoverGetter, string label, string chartType)
+        {
+            menu.Items.Insert(0, new Separator());
+            var item = new MenuItem { Header = label };
+            menu.Items.Insert(0, item);
+
+            menu.Opened += (s, _) =>
+            {
+                var pos = System.Windows.Input.Mouse.GetPosition(chart);
+                var nearest = hoverGetter()?.GetNearestSeries(pos);
+                item.Tag = nearest?.Time;
+                item.IsEnabled = nearest.HasValue;
+            };
+
+            item.Click += (s, _) =>
+            {
+                if (item.Tag is DateTime time)
+                    ChartDrillDownRequested?.Invoke(chartType, time);
+            };
+        }
+
         private void SetupChartSaveMenus()
         {
-            TabHelpers.SetupChartContextMenu(QueryPerfTrendsQueryChart, "Query_Durations", "report.query_stats_summary");
-            TabHelpers.SetupChartContextMenu(QueryPerfTrendsProcChart, "Procedure_Durations", "report.procedure_stats_summary");
-            TabHelpers.SetupChartContextMenu(QueryPerfTrendsQsChart, "QueryStore_Durations", "report.query_store_summary");
-            TabHelpers.SetupChartContextMenu(QueryPerfTrendsExecChart, "Execution_Counts", "collect.query_stats");
+            var queryMenu = TabHelpers.SetupChartContextMenu(QueryPerfTrendsQueryChart, "Query_Durations", "report.query_stats_summary");
+            AddDrillDown(QueryPerfTrendsQueryChart, queryMenu, () => _queryDurationHover, "Show Active Queries at This Time", "QueryPerfTrendsQuery");
+
+            var procMenu = TabHelpers.SetupChartContextMenu(QueryPerfTrendsProcChart, "Procedure_Durations", "report.procedure_stats_summary");
+            AddDrillDown(QueryPerfTrendsProcChart, procMenu, () => _procDurationHover, "Show Active Queries at This Time", "QueryPerfTrendsProc");
+
+            var qsMenu = TabHelpers.SetupChartContextMenu(QueryPerfTrendsQsChart, "QueryStore_Durations", "report.query_store_summary");
+            AddDrillDown(QueryPerfTrendsQsChart, qsMenu, () => _qsDurationHover, "Show Active Queries at This Time", "QueryPerfTrendsQs");
+
+            var execMenu = TabHelpers.SetupChartContextMenu(QueryPerfTrendsExecChart, "Execution_Counts", "collect.query_stats");
+            AddDrillDown(QueryPerfTrendsExecChart, execMenu, () => _execTrendsHover, "Show Active Queries at This Time", "QueryPerfTrendsExec");
         }
 
         // ── Active Queries refresh ──

--- a/Dashboard/ServerTab.xaml.cs
+++ b/Dashboard/ServerTab.xaml.cs
@@ -130,6 +130,7 @@ namespace PerformanceMonitorDashboard
             PerformanceTab.ActualPlanFinished += _actualPlanFinishedHandler;
             PerformanceTab.DrillDownTimeRangeRequested += _drillDownTimeRangeHandler;
             PerformanceTab.SubTabChanged += _subTabChangedHandler;
+            PerformanceTab.ChartDrillDownRequested += OnChildChartDrillDown;
             SystemEventsContent.Initialize(_databaseService);
             _baselineProvider = new Analysis.SqlServerBaselineProvider(_databaseService.ConnectionString);
             ResourceMetricsContent.Initialize(_databaseService, _baselineProvider);
@@ -251,6 +252,7 @@ namespace PerformanceMonitorDashboard
 
             MemoryTab.ChartDrillDownRequested -= OnChildChartDrillDown;
             ResourceMetricsContent.ChartDrillDownRequested -= OnChildChartDrillDown;
+            PerformanceTab.ChartDrillDownRequested -= OnChildChartDrillDown;
 
             if (_viewPlanHandler != null) PerformanceTab.ViewPlanRequested -= _viewPlanHandler;
             if (_actualPlanStartedHandler != null) PerformanceTab.ActualPlanStarted -= _actualPlanStartedHandler;

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -317,10 +317,14 @@ public partial class ServerTab : UserControl
         /* Chart context menus (right-click save/export) */
         var waitStatsMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(WaitStatsChart, "Wait_Stats");
         AddWaitDrillDownMenuItem(WaitStatsChart, waitStatsMenu);
-        Helpers.ContextMenuHelper.SetupChartContextMenu(QueryDurationTrendChart, "Query_Duration_Trends");
-        Helpers.ContextMenuHelper.SetupChartContextMenu(ProcDurationTrendChart, "Procedure_Duration_Trends");
-        Helpers.ContextMenuHelper.SetupChartContextMenu(QueryStoreDurationTrendChart, "QueryStore_Duration_Trends");
-        Helpers.ContextMenuHelper.SetupChartContextMenu(ExecutionCountTrendChart, "Execution_Count_Trends");
+        var queryDurationTrendMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(QueryDurationTrendChart, "Query_Duration_Trends");
+        AddChartDrillDownMenuItem(QueryDurationTrendChart, queryDurationTrendMenu, _queryDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        var procDurationTrendMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(ProcDurationTrendChart, "Procedure_Duration_Trends");
+        AddChartDrillDownMenuItem(ProcDurationTrendChart, procDurationTrendMenu, _procDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        var queryStoreDurationTrendMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(QueryStoreDurationTrendChart, "QueryStore_Duration_Trends");
+        AddChartDrillDownMenuItem(QueryStoreDurationTrendChart, queryStoreDurationTrendMenu, _queryStoreDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        var executionCountTrendMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(ExecutionCountTrendChart, "Execution_Count_Trends");
+        AddChartDrillDownMenuItem(ExecutionCountTrendChart, executionCountTrendMenu, _executionCountTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
         var cpuMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(CpuChart, "CPU_Usage");
         AddChartDrillDownMenuItem(CpuChart, cpuMenu, _cpuHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
         var memoryMenu = Helpers.ContextMenuHelper.SetupChartContextMenu(MemoryChart, "Memory_Usage");


### PR DESCRIPTION
Closes the gap you flagged: the **Queries > Performance Trends** charts were the only time-series charts in either app missing the right-click **"Show Active Queries at This Time"** drill-down that every other chart has. Pure additive wiring — no existing handler or chart behavior changed.

**Dashboard** — the 4 charts live in the `QueryPerformanceContent` child control, which never got the `ChartDrillDownRequested` event bridge that `MemoryContent` and `ResourceMetricsContent` already use. Added the event + the `AddDrillDown` helper (copied verbatim from `ResourceMetricsContent`), wired the 4 trend charts' existing context menus + hover helpers to it, and subscribed it in `ServerTab` to the existing `OnChildChartDrillDown` handler (subscribe + unsubscribe, next to the other child controls).

**Lite** — the 4 trend charts already had hover helpers, but their `SetupChartContextMenu` return was discarded, so no drill-down item was added. Captured each menu and added `AddChartDrillDownMenuItem -> OnActiveQueriesDrillDown`, mirroring the `CpuChart` pattern right below.

Both apps build clean. There are no unit tests for chart context menus.

## HELD — needs a quick live check

Right-click each of the 4 Performance Trends charts in both apps, confirm the "Show Active Queries at This Time" item appears, and that clicking it jumps to Active Queries around that time (±30 min) — same as the other charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)