### PR TITLE
Name the failing step in failed-job alerts (both apps)

### DIFF
--- a/Dashboard/MainWindow.AlertEngine.cs
+++ b/Dashboard/MainWindow.AlertEngine.cs
@@ -1172,6 +1172,8 @@ namespace PerformanceMonitorDashboard
                 var item = new AlertDetailItem { Heading = j.JobName, Fields = new() };
                 item.Fields.Add(("Job", j.JobName));
                 item.Fields.Add(("Failed At", j.RunDateTimeFormatted));
+                if (j.StepId > 0 && !string.IsNullOrEmpty(j.StepName))
+                    item.Fields.Add(("Step", $"{j.StepId} — {j.StepName}"));
                 if (!string.IsNullOrEmpty(j.Message))
                     item.Fields.Add(("Message", Truncate(j.Message, 300)));
                 context.Details.Add(item);

--- a/Dashboard/Models/FailedJobInfo.cs
+++ b/Dashboard/Models/FailedJobInfo.cs
@@ -9,9 +9,11 @@ using System;
 namespace PerformanceMonitorDashboard.Models
 {
     /// <summary>
-    /// A SQL Agent job run (step_id = 0 outcome row) that FAILED within the alert
-    /// lookback window. Sourced from a live msdb.dbo.sysjobhistory query at alert-check
-    /// time — failure outcomes are not part of the collected running_jobs snapshot.
+    /// A SQL Agent job run that FAILED within the alert lookback window. Sourced from a live
+    /// msdb.dbo.sysjobhistory query at alert-check time (failure outcomes are not part of the
+    /// collected running_jobs snapshot). StepId/StepName/Message describe the actual failing step
+    /// (correlated from the run's step rows), falling back to the job-outcome row when a job-level
+    /// failure has no failed step.
     /// </summary>
     public class FailedJobInfo
     {

--- a/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -1064,8 +1064,11 @@ namespace PerformanceMonitorDashboard.Services
         }
 
         /// <summary>
-        /// Live query against the monitored server's msdb for SQL Agent job runs (step_id = 0
-        /// outcome row, run_status = 0 = Failed) that failed within the lookback window.
+        /// Live query against the monitored server's msdb for SQL Agent job runs that FAILED within
+        /// the lookback window (the step_id = 0 outcome row, run_status = 0). For each failure it
+        /// correlates the actual failing step (step_id > 0, run_status = 0) from that run via
+        /// instance_id, so step_id/step_name/message describe the failing step rather than the
+        /// generic "(Job outcome)" row.
         /// run_date/run_time integers are converted to a server-local datetime and filtered to the
         /// last N minutes. Degrades gracefully: a login without msdb / SQLAgentReaderRole access
         /// raises a catchable SqlException (916/229/297/300) that returns an empty list rather than
@@ -1089,12 +1092,37 @@ namespace PerformanceMonitorDashboard.Services
                             (jh.run_time % 100),
                             CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
                         ),
-                    step_id = jh.step_id,
-                    step_name = jh.step_name,
-                    message = jh.message
+                    step_id = ISNULL(fs.step_id, jh.step_id),
+                    step_name = ISNULL(fs.step_name, jh.step_name),
+                    message = ISNULL(fs.message, jh.message)
                 FROM msdb.dbo.sysjobhistory AS jh
                 JOIN msdb.dbo.sysjobs AS j
                   ON j.job_id = jh.job_id
+                OUTER APPLY
+                (
+                    /* The actual failing step (step_id > 0, run_status = 0) from THIS run, correlated by
+                       instance_id and bounded to be after this job's previous outcome row, so the alert
+                       names the failing step instead of the generic job-outcome row. Falls back to the
+                       outcome row for a rare job-level failure with no failed step row. */
+                    SELECT TOP (1)
+                        s.step_id,
+                        s.step_name,
+                        s.message
+                    FROM msdb.dbo.sysjobhistory AS s
+                    WHERE s.job_id = jh.job_id
+                    AND   s.step_id > 0
+                    AND   s.run_status = 0
+                    AND   s.instance_id < jh.instance_id
+                    AND   s.instance_id >
+                          (
+                              SELECT ISNULL(MAX(p.instance_id), 0)
+                              FROM msdb.dbo.sysjobhistory AS p
+                              WHERE p.job_id = jh.job_id
+                              AND   p.step_id = 0
+                              AND   p.instance_id < jh.instance_id
+                          )
+                    ORDER BY s.instance_id DESC
+                ) AS fs
                 WHERE jh.step_id = 0
                 AND   jh.run_status = 0
                 AND   jh.run_date >= CONVERT(integer, CONVERT(varchar(8), DATEADD(MINUTE, -@lookback_minutes, GETDATE()), 112))

--- a/Lite/MainWindow.AlertEngine.cs
+++ b/Lite/MainWindow.AlertEngine.cs
@@ -1131,6 +1131,8 @@ public partial class MainWindow : Window
                 var item = new AlertDetailItem { Heading = j.JobName, Fields = new() };
                 item.Fields.Add(("Job", j.JobName));
                 item.Fields.Add(("Failed At", j.RunDateTimeFormatted));
+                if (j.StepId > 0 && !string.IsNullOrEmpty(j.StepName))
+                    item.Fields.Add(("Step", $"{j.StepId} — {j.StepName}"));
                 if (!string.IsNullOrEmpty(j.Message))
                     item.Fields.Add(("Message", TruncateText(j.Message, 300)));
                 context.Details.Add(item);

--- a/Lite/Services/RemoteCollectorService.RunningJobs.cs
+++ b/Lite/Services/RemoteCollectorService.RunningJobs.cs
@@ -191,8 +191,10 @@ OPTION(RECOMPILE);";
     }
 
     /// <summary>
-    /// Live query against the monitored server's msdb for SQL Agent job runs (step_id = 0 outcome
-    /// row, run_status = 0 = Failed) that failed within the lookback window.
+    /// Live query against the monitored server's msdb for SQL Agent job runs that FAILED within the
+    /// lookback window (the step_id = 0 outcome row, run_status = 0), also correlating the actual
+    /// failing step (step_id > 0, run_status = 0) from that run via instance_id so step_id/step_name/
+    /// message describe the failing step rather than the generic "(Job outcome)" row.
     /// Runs at alert-check time — failure outcomes are not part of the collected running_jobs
     /// snapshot. run_date/run_time integers are converted to a server-local datetime and filtered
     /// to the last N minutes. Reuses the collector's connection path (MFA serialization, throttle,
@@ -220,12 +222,37 @@ SELECT TOP (50)
             (jh.run_time % 100),
             CONVERT(datetime, CONVERT(varchar(8), jh.run_date))
         ),
-    step_id = jh.step_id,
-    step_name = jh.step_name,
-    message = jh.message
+    step_id = ISNULL(fs.step_id, jh.step_id),
+    step_name = ISNULL(fs.step_name, jh.step_name),
+    message = ISNULL(fs.message, jh.message)
 FROM msdb.dbo.sysjobhistory AS jh
 JOIN msdb.dbo.sysjobs AS j
   ON j.job_id = jh.job_id
+OUTER APPLY
+(
+    /* The actual failing step (step_id > 0, run_status = 0) from THIS run, correlated by
+       instance_id and bounded to be after this job's previous outcome row, so the alert names
+       the failing step instead of the generic job-outcome row. Falls back to the outcome row
+       for a rare job-level failure with no failed step row. */
+    SELECT TOP (1)
+        s.step_id,
+        s.step_name,
+        s.message
+    FROM msdb.dbo.sysjobhistory AS s
+    WHERE s.job_id = jh.job_id
+    AND   s.step_id > 0
+    AND   s.run_status = 0
+    AND   s.instance_id < jh.instance_id
+    AND   s.instance_id >
+          (
+              SELECT ISNULL(MAX(p.instance_id), 0)
+              FROM msdb.dbo.sysjobhistory AS p
+              WHERE p.job_id = jh.job_id
+              AND   p.step_id = 0
+              AND   p.instance_id < jh.instance_id
+          )
+    ORDER BY s.instance_id DESC
+) AS fs
 WHERE jh.step_id = 0
 AND   jh.run_status = 0
 AND   jh.run_date >= CONVERT(integer, CONVERT(varchar(8), DATEADD(MINUTE, -@lookback_minutes, GETDATE()), 112))


### PR DESCRIPTION
Queued enhancement (you confirmed: "we should get job step yes").

**Before:** the failed-job alert queried `msdb.dbo.sysjobhistory WHERE step_id = 0` (the job-outcome row), so it named the job but `step_name` was SQL Agent's generic `(Job outcome)` — it never told you **which step** failed; the only hint was the truncated outcome message.

**After:** the query correlates the actual failing step (`step_id > 0, run_status = 0`) from the same run via `instance_id`, bounded to be after that job's previous outcome row. `FailedJobInfo.StepId/StepName/Message` now carry the failing step and **its own error**. The alert detail gains a **Step** field (e.g. `3 — LoadStaging`), and **Message** now shows the step's actual error instead of the generic "The job failed" text. Falls back to the outcome row for the rare job-level failure with no failed step.

Both apps (identical msdb query + mirrored `BuildFailedJobContext`). `FailedJobInfo` already had the fields.

## Verification
- **Correlation validated against a live msdb:** spun up an isolated throwaway 2-step Agent job (step 2 deliberately fails) on SQL2022 → the query resolved it to `step_id=2, "Step Two FAILS"` with the step's RAISERROR error; job cleaned up afterward.
- **Production query parses + runs on SQL2022** (valid T-SQL).
- **Dashboard.Tests 732, Lite.Tests 619**, both apps build clean.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)