### PR TITLE
Surface 6 dropped column groups + split by exec type in the QS history drilldown (both apps)

### DIFF
--- a/Dashboard/Models/QueryExecutionHistoryItem.cs
+++ b/Dashboard/Models/QueryExecutionHistoryItem.cs
@@ -17,6 +17,16 @@ namespace PerformanceMonitorDashboard.Models
         public long PlanId { get; set; }
         public long CountExecutions { get; set; }
 
+        // Execution type (Regular / Aborted / Exception) - group key
+        public string? ExecutionTypeDesc { get; set; }
+
+        // First/last execution time in the interval (server local time)
+        public DateTime? ServerFirstExecutionTime { get; set; }
+        public DateTime? ServerLastExecutionTime { get; set; }
+
+        // Module (proc/function) the query came from
+        public string? ModuleName { get; set; }
+
         // Duration metrics (microseconds stored, convert to ms for display)
         public long AvgDuration { get; set; }
         public long MinDuration { get; set; }
@@ -26,6 +36,11 @@ namespace PerformanceMonitorDashboard.Models
         public long AvgCpuTime { get; set; }
         public long MinCpuTime { get; set; }
         public long MaxCpuTime { get; set; }
+
+        // CLR time metrics (microseconds stored)
+        public long AvgClrTime { get; set; }
+        public long MinClrTime { get; set; }
+        public long MaxClrTime { get; set; }
 
         // Logical IO Reads
         public long AvgLogicalReads { get; set; }
@@ -41,6 +56,11 @@ namespace PerformanceMonitorDashboard.Models
         public long AvgPhysicalReads { get; set; }
         public long MinPhysicalReads { get; set; }
         public long MaxPhysicalReads { get; set; }
+
+        // Number of physical IO reads - nullable (NULL on SQL 2016)
+        public long? AvgNumPhysicalReads { get; set; }
+        public long? MinNumPhysicalReads { get; set; }
+        public long? MaxNumPhysicalReads { get; set; }
 
         // DOP (degree of parallelism)
         public long MinDop { get; set; }
@@ -60,6 +80,11 @@ namespace PerformanceMonitorDashboard.Models
         public long? AvgTempdbSpaceUsed { get; set; }
         public long? MinTempdbSpaceUsed { get; set; }
         public long? MaxTempdbSpaceUsed { get; set; }
+
+        // Log bytes used - nullable for SQL 2016
+        public long? AvgLogBytesUsed { get; set; }
+        public long? MinLogBytesUsed { get; set; }
+        public long? MaxLogBytesUsed { get; set; }
 
         // Query identifiers (hex strings from binary columns)
         public string? QueryHash { get; set; }
@@ -81,6 +106,9 @@ namespace PerformanceMonitorDashboard.Models
         public double AvgCpuTimeMs => AvgCpuTime / 1000.0;
         public double MinCpuTimeMs => MinCpuTime / 1000.0;
         public double MaxCpuTimeMs => MaxCpuTime / 1000.0;
+        public double AvgClrTimeMs => AvgClrTime / 1000.0;
+        public double MinClrTimeMs => MinClrTime / 1000.0;
+        public double MaxClrTimeMs => MaxClrTime / 1000.0;
 
         // Memory in MB (8KB pages * 8 / 1024)
         public double AvgMemoryMb => AvgMemoryPages * 8.0 / 1024.0;
@@ -91,5 +119,10 @@ namespace PerformanceMonitorDashboard.Models
         public double? AvgTempdbMb => AvgTempdbSpaceUsed.HasValue ? AvgTempdbSpaceUsed.Value * 8.0 / 1024.0 : null;
         public double? MinTempdbMb => MinTempdbSpaceUsed.HasValue ? MinTempdbSpaceUsed.Value * 8.0 / 1024.0 : null;
         public double? MaxTempdbMb => MaxTempdbSpaceUsed.HasValue ? MaxTempdbSpaceUsed.Value * 8.0 / 1024.0 : null;
+
+        // Log bytes in MB (1 MB = 1,048,576 bytes)
+        public double? AvgLogMb => AvgLogBytesUsed.HasValue ? AvgLogBytesUsed.Value / 1048576.0 : null;
+        public double? MinLogMb => MinLogBytesUsed.HasValue ? MinLogBytesUsed.Value / 1048576.0 : null;
+        public double? MaxLogMb => MaxLogBytesUsed.HasValue ? MaxLogBytesUsed.Value / 1048576.0 : null;
     }
 }

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -111,6 +111,39 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
+                <!-- Execution Type / First & Last Exec / Module -->
+                <DataGridTextColumn Binding="{Binding ExecutionTypeDesc}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionTypeDesc" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Exec Type" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ServerFirstExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerFirstExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="First Exec" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ServerLastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerLastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Last Exec" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ModuleName}" Width="160">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ModuleName" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Module" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding CountExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
@@ -172,6 +205,32 @@
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
 
+                <!-- CLR (ms) -->
+                <DataGridTextColumn Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+
                 <!-- Logical Reads -->
                 <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
                     <DataGridTextColumn.Header>
@@ -224,6 +283,32 @@
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
 
+                <!-- Log (MB) -->
+                <DataGridTextColumn Binding="{Binding AvgLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+
                 <!-- Physical Reads -->
                 <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                     <DataGridTextColumn.Header>
@@ -246,6 +331,32 @@
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
                             <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+
+                <!-- Num Physical Reads -->
+                <DataGridTextColumn Binding="{Binding AvgNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Avg Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>

--- a/Dashboard/Services/DatabaseService.QueryPerformance.History.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.History.cs
@@ -75,14 +75,28 @@ namespace PerformanceMonitorDashboard.Services
             force_failure_count = MAX(qsd.force_failure_count),
             last_force_failure_reason_desc = MAX(qsd.last_force_failure_reason_desc),
             plan_forcing_type = MAX(qsd.plan_forcing_type),
-            compatibility_level = MAX(qsd.compatibility_level)
+            compatibility_level = MAX(qsd.compatibility_level),
+            qsd.execution_type_desc,
+            server_first_execution_time = MIN(qsd.server_first_execution_time),
+            server_last_execution_time = MAX(qsd.server_last_execution_time),
+            module_name = MAX(qsd.module_name),
+            avg_num_physical_io_reads = SUM(qsd.avg_num_physical_io_reads * qsd.count_executions) / NULLIF(SUM(qsd.count_executions), 0),
+            min_num_physical_io_reads = MIN(qsd.min_num_physical_io_reads),
+            max_num_physical_io_reads = MAX(qsd.max_num_physical_io_reads),
+            avg_clr_time = SUM(qsd.avg_clr_time * qsd.count_executions) / NULLIF(SUM(qsd.count_executions), 0),
+            min_clr_time = MIN(qsd.min_clr_time),
+            max_clr_time = MAX(qsd.max_clr_time),
+            avg_log_bytes_used = SUM(qsd.avg_log_bytes_used * qsd.count_executions) / NULLIF(SUM(qsd.count_executions), 0),
+            min_log_bytes_used = MIN(qsd.min_log_bytes_used),
+            max_log_bytes_used = MAX(qsd.max_log_bytes_used)
         FROM collect.query_store_data AS qsd
         WHERE qsd.database_name = @database_name
         AND   qsd.query_id = @query_id
         {timeFilter}
         GROUP BY
             qsd.collection_time,
-            qsd.plan_id
+            qsd.plan_id,
+            qsd.execution_type_desc
         ORDER BY
             qsd.collection_time DESC;";
 
@@ -144,7 +158,20 @@ namespace PerformanceMonitorDashboard.Services
                             ForceFailureCount = reader.IsDBNull(34) ? null : reader.GetInt64(34),
                             LastForceFailureReasonDesc = reader.IsDBNull(35) ? null : reader.GetString(35),
                             PlanForcingType = reader.IsDBNull(36) ? null : reader.GetString(36),
-                            CompatibilityLevel = reader.IsDBNull(37) ? null : reader.GetInt16(37)
+                            CompatibilityLevel = reader.IsDBNull(37) ? null : reader.GetInt16(37),
+                            ExecutionTypeDesc = reader.IsDBNull(38) ? null : reader.GetString(38),
+                            ServerFirstExecutionTime = reader.IsDBNull(39) ? null : reader.GetDateTime(39),
+                            ServerLastExecutionTime = reader.IsDBNull(40) ? null : reader.GetDateTime(40),
+                            ModuleName = reader.IsDBNull(41) ? null : reader.GetString(41),
+                            AvgNumPhysicalReads = reader.IsDBNull(42) ? null : reader.GetInt64(42),
+                            MinNumPhysicalReads = reader.IsDBNull(43) ? null : reader.GetInt64(43),
+                            MaxNumPhysicalReads = reader.IsDBNull(44) ? null : reader.GetInt64(44),
+                            AvgClrTime = reader.GetInt64(45),
+                            MinClrTime = reader.GetInt64(46),
+                            MaxClrTime = reader.GetInt64(47),
+                            AvgLogBytesUsed = reader.IsDBNull(48) ? null : reader.GetInt64(48),
+                            MinLogBytesUsed = reader.IsDBNull(49) ? null : reader.GetInt64(49),
+                            MaxLogBytesUsed = reader.IsDBNull(50) ? null : reader.GetInt64(50)
                         });
                     }
 

--- a/Lite/Services/LocalDataService.QueryStore.cs
+++ b/Lite/Services/LocalDataService.QueryStore.cs
@@ -344,7 +344,19 @@ SELECT
     CAST(avg_rowcount AS DOUBLE) AS avg_rowcount,
     last_execution_time,
     min_dop,
-    max_dop
+    max_dop,
+    execution_type_desc,
+    first_execution_time,
+    module_name,
+    CAST(avg_num_physical_io_reads AS DOUBLE) AS avg_num_physical_reads,
+    CAST(min_num_physical_io_reads AS DOUBLE) AS min_num_physical_reads,
+    CAST(max_num_physical_io_reads AS DOUBLE) AS max_num_physical_reads,
+    avg_clr_time_us / 1000.0 AS avg_clr_time_ms,
+    min_clr_time_us / 1000.0 AS min_clr_time_ms,
+    max_clr_time_us / 1000.0 AS max_clr_time_ms,
+    CAST(avg_log_bytes_used AS DOUBLE) / 1048576.0 AS avg_log_mb,
+    CAST(min_log_bytes_used AS DOUBLE) / 1048576.0 AS min_log_mb,
+    CAST(max_log_bytes_used AS DOUBLE) / 1048576.0 AS max_log_mb
 FROM v_query_store_stats
 WHERE server_id = $1
 AND   database_name = $2
@@ -377,7 +389,19 @@ ORDER BY collection_time";
                 AvgRowcount = reader.IsDBNull(7) ? 0 : ToDouble(reader.GetValue(7)),
                 LastExecutionTime = reader.IsDBNull(8) ? (DateTime?)null : reader.GetDateTime(8),
                 MinDop = reader.IsDBNull(9) ? 0 : Convert.ToInt64(reader.GetValue(9)),
-                MaxDop = reader.IsDBNull(10) ? 0 : Convert.ToInt64(reader.GetValue(10))
+                MaxDop = reader.IsDBNull(10) ? 0 : Convert.ToInt64(reader.GetValue(10)),
+                ExecutionTypeDesc = reader.IsDBNull(11) ? "" : reader.GetString(11),
+                FirstExecutionTime = reader.IsDBNull(12) ? (DateTime?)null : reader.GetDateTime(12),
+                ModuleName = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                AvgNumPhysicalReads = reader.IsDBNull(14) ? 0 : ToDouble(reader.GetValue(14)),
+                MinNumPhysicalReads = reader.IsDBNull(15) ? 0 : ToDouble(reader.GetValue(15)),
+                MaxNumPhysicalReads = reader.IsDBNull(16) ? 0 : ToDouble(reader.GetValue(16)),
+                AvgClrTimeMs = reader.IsDBNull(17) ? 0 : ToDouble(reader.GetValue(17)),
+                MinClrTimeMs = reader.IsDBNull(18) ? 0 : ToDouble(reader.GetValue(18)),
+                MaxClrTimeMs = reader.IsDBNull(19) ? 0 : ToDouble(reader.GetValue(19)),
+                AvgLogMb = reader.IsDBNull(20) ? 0 : ToDouble(reader.GetValue(20)),
+                MinLogMb = reader.IsDBNull(21) ? 0 : ToDouble(reader.GetValue(21)),
+                MaxLogMb = reader.IsDBNull(22) ? 0 : ToDouble(reader.GetValue(22))
             });
         }
 
@@ -525,8 +549,34 @@ public class QueryStoreHistoryRow
     public DateTime? LastExecutionTime { get; set; }
     public long MinDop { get; set; }
     public long MaxDop { get; set; }
+
+    // Execution type (Regular / Aborted / Exception)
+    public string ExecutionTypeDesc { get; set; } = "";
+
+    // First execution time in the interval
+    public DateTime? FirstExecutionTime { get; set; }
+
+    // Module (proc/function) the query came from
+    public string ModuleName { get; set; } = "";
+
+    // Number of physical IO reads (avg/min/max)
+    public double AvgNumPhysicalReads { get; set; }
+    public double MinNumPhysicalReads { get; set; }
+    public double MaxNumPhysicalReads { get; set; }
+
+    // CLR time, already converted to ms in SQL (avg/min/max)
+    public double AvgClrTimeMs { get; set; }
+    public double MinClrTimeMs { get; set; }
+    public double MaxClrTimeMs { get; set; }
+
+    // Log bytes used, already converted to MB in SQL (avg/min/max)
+    public double AvgLogMb { get; set; }
+    public double MinLogMb { get; set; }
+    public double MaxLogMb { get; set; }
+
     public double TotalDurationMs => ExecutionCount * AvgDurationMs;
     public double TotalCpuMs => ExecutionCount * AvgCpuTimeMs;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
+    public string FirstExecutionTimeLocal => ServerTimeHelper.FormatServerTime(FirstExecutionTime);
     public string LastExecutionTimeLocal => ServerTimeHelper.FormatServerTime(LastExecutionTime);
 }

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml
@@ -78,16 +78,28 @@
                   ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Exec Type" Binding="{Binding ExecutionTypeDesc}" Width="90"/>
+                <DataGridTextColumn Header="First Execution" Binding="{Binding FirstExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Module" Binding="{Binding ModuleName}" Width="160"/>
                 <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
                 <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
                 <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
                 <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
                 <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg CLR (ms)" Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CLR (ms)" Binding="{Binding MinClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CLR (ms)" Binding="{Binding MaxClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
                 <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgLogicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
                 <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Log (MB)" Binding="{Binding AvgLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Log (MB)" Binding="{Binding MinLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Log (MB)" Binding="{Binding MaxLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
                 <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Avg Num Physical Reads" Binding="{Binding AvgNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Min Num Physical Reads" Binding="{Binding MinNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Max Num Physical Reads" Binding="{Binding MaxNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
                 <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
-                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
                 <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" Width="70"/>
                 <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" Width="70"/>
                 <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">


### PR DESCRIPTION
**Drilldown-completeness batch, item 1 of the QS surfaces.**

The per-query **Query Store history drilldown** (the executions-over-time window) collected far more than it showed. This surfaces the six collected-but-dropped metric groups and splits rows by execution type, in both apps:

- `execution_type_desc` (Regular / Aborted / Exception) — **split into distinct rows** so aborted/excepted executions are visible
- `server_first_execution_time` / `server_last_execution_time`
- `module_name` (the proc/function a query came from)
- `num_physical_io_reads` (avg/min/max)
- `clr_time` (avg/min/max)
- `log_bytes_used` (avg/min/max)

No collector or schema change — the data was already collected. Dashboard adds `execution_type_desc` to the `GROUP BY` (grain-checked live: `Aborted` is captured, and no `(query, plan, interval)` carries >1 type, so the split adds **no extra rows in practice**, it just attributes each row's type). Lite's history query is already per-snapshot grain, so it just surfaces the column.

Reader ordinals: Dashboard appends SELECT cols 38–50 + matching reads; Lite appends 11–22; existing ordinals untouched.

## Verification
- **New query validated live on SQL2022** — the appended aggregates + `GROUP BY execution_type_desc` run clean and return the new columns (execution_type_desc, first/last exec, module, num-physical/clr/log).
- **Dashboard.Tests 732/732.** **Lite.Tests 618 pass + 1 known-flaky** (`CredentialProfileTests.SwitchToProfile_DeletesOrphanedPerServerSecret` — hits the real Windows Credential Manager, leaks state across the suite, **passes in isolation**, touches none of this code).
- Both apps build clean; rebased onto current dev (merged cleanly with the tempdb header lowercasing in the same window).

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)