### PR TITLE
Surface grant-quality, thread, and CLR columns in the Top Queries grid (both apps)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -706,6 +706,14 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding TotalClrTimeMs, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrTimeMs" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Total CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                     <DataGridTemplateColumn SortMemberPath="TotalElapsedTimeMs" Width="120">
                         <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -808,6 +816,14 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Avg Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding TotalRows, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -856,11 +872,83 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MinReservedThreads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinReservedThreads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Min Rsvd Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MaxReservedThreads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxReservedThreads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Max Rsvd Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MinUsedThreads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Min Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MaxUsedThreads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Max Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MinGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Min Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Max Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MinUsedGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Min Used Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Max Used Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MinIdealGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinIdealGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Min Ideal Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding MaxIdealGrantMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantMb" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Max Ideal Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>

--- a/Dashboard/Models/QueryStatsItem.cs
+++ b/Dashboard/Models/QueryStatsItem.cs
@@ -45,6 +45,15 @@ namespace PerformanceMonitorDashboard.Models
         public short? MaxDop { get; set; }
         public long? MinGrantKb { get; set; }
         public long? MaxGrantKb { get; set; }
+        public long? MinUsedGrantKb { get; set; }
+        public long? MaxUsedGrantKb { get; set; }
+        public long? MinIdealGrantKb { get; set; }
+        public long? MaxIdealGrantKb { get; set; }
+        public long? MinReservedThreads { get; set; }
+        public long? MaxReservedThreads { get; set; }
+        public long? MinUsedThreads { get; set; }
+        public long? MaxUsedThreads { get; set; }
+        public long TotalClrTime { get; set; }
         public long? MinSpills { get; set; }
         public long? MaxSpills { get; set; }
 
@@ -52,6 +61,13 @@ namespace PerformanceMonitorDashboard.Models
         public double TotalWorkerTimeSec => TotalWorkerTime / 1000000.0;
         public double TotalElapsedTimeSec => TotalElapsedTime / 1000000.0;
         public double? MaxGrantMb => MaxGrantKb.HasValue ? MaxGrantKb.Value / 1024.0 : null;
+        public double? MinGrantMb => MinGrantKb.HasValue ? MinGrantKb.Value / 1024.0 : null;
+        public double? MinUsedGrantMb => MinUsedGrantKb.HasValue ? MinUsedGrantKb.Value / 1024.0 : null;
+        public double? MaxUsedGrantMb => MaxUsedGrantKb.HasValue ? MaxUsedGrantKb.Value / 1024.0 : null;
+        public double? MinIdealGrantMb => MinIdealGrantKb.HasValue ? MinIdealGrantKb.Value / 1024.0 : null;
+        public double? MaxIdealGrantMb => MaxIdealGrantKb.HasValue ? MaxIdealGrantKb.Value / 1024.0 : null;
+        // total_clr_time is stored in microseconds (like worker/elapsed time)
+        public double TotalClrTimeMs => TotalClrTime / 1000.0;
 
         // CPU time aliases (Worker time = CPU time in SQL Server)
         public double TotalCpuTimeMs => TotalWorkerTime / 1000.0;

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
@@ -73,7 +73,16 @@ namespace PerformanceMonitorDashboard.Services
             max_spills = MAX(qs.max_spills),
             query_plan_hash = MAX(qs.query_plan_hash),
             sql_handle = MAX(qs.sql_handle),
-            plan_handle = MAX(qs.plan_handle)
+            plan_handle = MAX(qs.plan_handle),
+            min_used_grant_kb = MIN(qs.min_used_grant_kb),
+            max_used_grant_kb = MAX(qs.max_used_grant_kb),
+            min_ideal_grant_kb = MIN(qs.min_ideal_grant_kb),
+            max_ideal_grant_kb = MAX(qs.max_ideal_grant_kb),
+            min_reserved_threads = MIN(qs.min_reserved_threads),
+            max_reserved_threads = MAX(qs.max_reserved_threads),
+            min_used_threads = MIN(qs.min_used_threads),
+            max_used_threads = MAX(qs.max_used_threads),
+            total_clr_time = MAX(qs.total_clr_time)
         INTO #per_lifetime
         FROM collect.query_stats AS qs
         WHERE (
@@ -143,7 +152,16 @@ namespace PerformanceMonitorDashboard.Services
             max_spills = MAX(pl.max_spills),
             query_plan_hash = CONVERT(nvarchar(20), MAX(pl.query_plan_hash), 1),
             sql_handle = CONVERT(nvarchar(130), MAX(pl.sql_handle), 1),
-            plan_handle = CONVERT(nvarchar(130), MAX(pl.plan_handle), 1)
+            plan_handle = CONVERT(nvarchar(130), MAX(pl.plan_handle), 1),
+            min_used_grant_kb = MIN(pl.min_used_grant_kb),
+            max_used_grant_kb = MAX(pl.max_used_grant_kb),
+            min_ideal_grant_kb = MIN(pl.min_ideal_grant_kb),
+            max_ideal_grant_kb = MAX(pl.max_ideal_grant_kb),
+            min_reserved_threads = MIN(pl.min_reserved_threads),
+            max_reserved_threads = MAX(pl.max_reserved_threads),
+            min_used_threads = MIN(pl.min_used_threads),
+            max_used_threads = MAX(pl.max_used_threads),
+            total_clr_time = SUM(pl.total_clr_time)
         INTO #top_ranked
         FROM #per_lifetime AS pl
         GROUP BY
@@ -200,7 +218,16 @@ namespace PerformanceMonitorDashboard.Services
             query_plan_xml = CONVERT(nvarchar(max), NULL),
             tr.query_plan_hash,
             tr.sql_handle,
-            tr.plan_handle
+            tr.plan_handle,
+            tr.min_used_grant_kb,
+            tr.max_used_grant_kb,
+            tr.min_ideal_grant_kb,
+            tr.max_ideal_grant_kb,
+            tr.min_reserved_threads,
+            tr.max_reserved_threads,
+            tr.min_used_threads,
+            tr.max_used_threads,
+            tr.total_clr_time
         FROM #top_ranked AS tr
         OUTER APPLY
         (
@@ -266,7 +293,16 @@ namespace PerformanceMonitorDashboard.Services
                             QueryPlanXml = reader.IsDBNull(35) ? null : reader.GetString(35),
                             QueryPlanHash = reader.IsDBNull(36) ? null : reader.GetString(36),
                             SqlHandle = reader.IsDBNull(37) ? null : reader.GetString(37),
-                            PlanHandle = reader.IsDBNull(38) ? null : reader.GetString(38)
+                            PlanHandle = reader.IsDBNull(38) ? null : reader.GetString(38),
+                            MinUsedGrantKb = reader.IsDBNull(39) ? null : reader.GetInt64(39),
+                            MaxUsedGrantKb = reader.IsDBNull(40) ? null : reader.GetInt64(40),
+                            MinIdealGrantKb = reader.IsDBNull(41) ? null : reader.GetInt64(41),
+                            MaxIdealGrantKb = reader.IsDBNull(42) ? null : reader.GetInt64(42),
+                            MinReservedThreads = reader.IsDBNull(43) ? null : reader.GetInt64(43),
+                            MaxReservedThreads = reader.IsDBNull(44) ? null : reader.GetInt64(44),
+                            MinUsedThreads = reader.IsDBNull(45) ? null : reader.GetInt64(45),
+                            MaxUsedThreads = reader.IsDBNull(46) ? null : reader.GetInt64(46),
+                            TotalClrTime = reader.IsDBNull(47) ? 0 : reader.GetInt64(47)
                         });
                     }
 

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -450,6 +450,9 @@
                                     <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalClrMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTemplateColumn SortMemberPath="TotalElapsedMs" Width="130">
                                         <DataGridTemplateColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTemplateColumn.Header>
                                         <DataGridTemplateColumn.CellTemplate><DataTemplate>
@@ -510,6 +513,18 @@
                                     <DataGridTextColumn Binding="{Binding MaxGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Used Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Used Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinIdealGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Ideal Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Ideal Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -521,6 +536,18 @@
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinReservedThreads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Rsvd Threads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxReservedThreads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Rsvd Threads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Used Threads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Used Threads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding QueryHash}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryHash" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Query Hash" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -125,7 +125,16 @@ WITH ranked AS (
         MAX(max_spills) AS max_spills,
         MAX(query_plan_hash) AS query_plan_hash,
         MAX(sql_handle) AS sql_handle,
-        MAX(plan_handle) AS plan_handle
+        MAX(plan_handle) AS plan_handle,
+        MIN(min_used_grant_kb) AS min_used_grant_kb,
+        MAX(max_used_grant_kb) AS max_used_grant_kb,
+        MIN(min_ideal_grant_kb) AS min_ideal_grant_kb,
+        MAX(max_ideal_grant_kb) AS max_ideal_grant_kb,
+        MIN(min_reserved_threads) AS min_reserved_threads,
+        MAX(max_reserved_threads) AS max_reserved_threads,
+        MIN(min_used_threads) AS min_used_threads,
+        MAX(max_used_threads) AS max_used_threads,
+        MAX(total_clr_time) AS total_clr_time
     FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2
@@ -198,8 +207,17 @@ LIMIT $4";
                 QueryPlanHash = reader.IsDBNull(26) ? "" : reader.GetString(26),
                 SqlHandle = reader.IsDBNull(27) ? "" : reader.GetString(27),
                 PlanHandle = reader.IsDBNull(28) ? "" : reader.GetString(28),
-                QueryText = reader.IsDBNull(29) ? "" : reader.GetString(29),
-                QueryPlan = reader.IsDBNull(30) ? null : reader.GetString(30)
+                MinUsedGrantKb = reader.IsDBNull(29) ? 0 : reader.GetInt64(29),
+                MaxUsedGrantKb = reader.IsDBNull(30) ? 0 : reader.GetInt64(30),
+                MinIdealGrantKb = reader.IsDBNull(31) ? 0 : reader.GetInt64(31),
+                MaxIdealGrantKb = reader.IsDBNull(32) ? 0 : reader.GetInt64(32),
+                MinReservedThreads = reader.IsDBNull(33) ? 0 : reader.GetInt64(33),
+                MaxReservedThreads = reader.IsDBNull(34) ? 0 : reader.GetInt64(34),
+                MinUsedThreads = reader.IsDBNull(35) ? 0 : reader.GetInt64(35),
+                MaxUsedThreads = reader.IsDBNull(36) ? 0 : reader.GetInt64(36),
+                TotalClrUs = reader.IsDBNull(37) ? 0 : reader.GetInt64(37),
+                QueryText = reader.IsDBNull(38) ? "" : reader.GetString(38),
+                QueryPlan = reader.IsDBNull(39) ? null : reader.GetString(39)
             });
         }
 
@@ -1213,6 +1231,15 @@ public class QueryStatsRow
     public long MaxRows { get; set; }
     public long MinGrantKb { get; set; }
     public long MaxGrantKb { get; set; }
+    public long MinUsedGrantKb { get; set; }
+    public long MaxUsedGrantKb { get; set; }
+    public long MinIdealGrantKb { get; set; }
+    public long MaxIdealGrantKb { get; set; }
+    public long MinReservedThreads { get; set; }
+    public long MaxReservedThreads { get; set; }
+    public long MinUsedThreads { get; set; }
+    public long MaxUsedThreads { get; set; }
+    public long TotalClrUs { get; set; }
     public long MinSpills { get; set; }
     public long MaxSpills { get; set; }
     public string QueryPlanHash { get; set; } = "";
@@ -1230,6 +1257,8 @@ public class QueryStatsRow
     public double MaxCpuMs => MaxCpuUs / 1000.0;
     public double MinElapsedMs => MinElapsedUs / 1000.0;
     public double MaxElapsedMs => MaxElapsedUs / 1000.0;
+    // total_clr_time is stored in microseconds (like worker/elapsed time)
+    public double TotalClrMs => TotalClrUs / 1000.0;
 }
 
 public class ProcedureStatsRow


### PR DESCRIPTION
**Drilldown-completeness batch, item 3** — the memory-grant-quality signals.

The **Top Queries (by Duration/CPU)** grid collected these but never surfaced them. Added in both apps:
- `min/max_used_grant_kb` — grant actually **used** (over-grant detection)
- `min/max_ideal_grant_kb` — **ideal** grant (under-grant / spill signal)
- `min/max_reserved_threads`, `min/max_used_threads` — parallelism thread reservation/use
- `total_clr_time` — CLR execution time

Plus two Dashboard-only `[in model, not in grid]` wins: an **Avg Writes** column and a **Min Grant** column (the grid showed only Max).

Grants display in each grid's existing unit (Dashboard MB, Lite KB); threads as counts; CLR in ms. Reader ordinals: Dashboard appends 39–47; Lite appends to the ranked CTE so `query_text`/`query_plan` shift 29/30 → 38/39 (reader updated). Filters/sorts resolve by reflection on the property name — no per-column wiring.

## Verification
- New columns confirmed present in the live `collect.query_stats`. **Dashboard.Tests 732/732, Lite.Tests 619/619**, both apps build clean.

## Note — a small CLR parity nuance (flagging per the parity rule)
`total_clr_time` aggregates slightly differently: Dashboard reconstructs a windowed total (MAX per plan-lifetime, SUM across lifetimes, like `total_worker_time`); **Lite uses `MAX(cumulative)`** because it has no `delta_clr_time` column. Equal when a query has one plan-lifetime in the window; Lite under-reports across a mid-window recompile. Closing it fully needs a Lite `delta_clr_time` collector column — a separate follow-up if you want it. The grant/thread columns are full parity.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)