### PR TITLE
Bring the query-stats + procedure history drilldowns to parity with their Top grids (both apps)

### DIFF
--- a/Dashboard/Models/QueryStatsHistoryItem.cs
+++ b/Dashboard/Models/QueryStatsHistoryItem.cs
@@ -112,8 +112,11 @@ namespace PerformanceMonitorDashboard.Models
         public double? AvgRows => ExecutionCount > 0 ? TotalRows / (double)ExecutionCount : null;
 
         // Memory in MB
+        public double MinGrantMb => MinGrantKb / 1024.0;
         public double MaxGrantMb => MaxGrantKb / 1024.0;
+        public double MinUsedGrantMb => MinUsedGrantKb / 1024.0;
         public double MaxUsedGrantMb => MaxUsedGrantKb / 1024.0;
+        public double MinIdealGrantMb => MinIdealGrantKb / 1024.0;
         public double MaxIdealGrantMb => MaxIdealGrantKb / 1024.0;
     }
 }

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -375,6 +375,14 @@
                 </DataGridTextColumn>
 
                 <!-- Memory Grants -->
+                <DataGridTextColumn Binding="{Binding MinGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
@@ -383,11 +391,27 @@
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Used (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
                             <TextBlock Text="Max Used (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinIdealGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Ideal (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
@@ -401,19 +425,35 @@
                 </DataGridTextColumn>
 
                 <!-- Thread Usage -->
-                <DataGridTextColumn Binding="{Binding MinUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                <DataGridTextColumn Binding="{Binding MinReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinReservedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Reserved Threads" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                <DataGridTextColumn Binding="{Binding MaxReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxReservedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Max Reserved Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MinUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95">
+                    <DataGridTextColumn.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
+                            <TextBlock Text="Min Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95">
                     <DataGridTextColumn.Header>
                         <StackPanel Orientation="Horizontal">
                             <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Threads" FontWeight="Bold" VerticalAlignment="Center"/>
+                            <TextBlock Text="Max Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
                     </DataGridTextColumn.Header>
                 </DataGridTextColumn>

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -348,7 +348,24 @@ SELECT
     min_elapsed_time,
     max_elapsed_time,
     query_plan_xml,
-    query_plan_hash
+    query_plan_hash,
+    min_grant_kb,
+    max_grant_kb,
+    min_used_grant_kb,
+    max_used_grant_kb,
+    min_ideal_grant_kb,
+    max_ideal_grant_kb,
+    min_reserved_threads,
+    max_reserved_threads,
+    min_used_threads,
+    max_used_threads,
+    min_physical_reads,
+    max_physical_reads,
+    min_rows,
+    max_rows,
+    min_spills,
+    max_spills,
+    total_clr_time
 FROM v_query_stats
 WHERE server_id = $1
 AND   database_name = $2
@@ -385,7 +402,24 @@ ORDER BY collection_time";
                 MinElapsedUs = reader.IsDBNull(13) ? 0 : reader.GetInt64(13),
                 MaxElapsedUs = reader.IsDBNull(14) ? 0 : reader.GetInt64(14),
                 QueryPlan = reader.IsDBNull(15) ? null : reader.GetString(15),
-                QueryPlanHash = reader.IsDBNull(16) ? "" : reader.GetString(16)
+                QueryPlanHash = reader.IsDBNull(16) ? "" : reader.GetString(16),
+                MinGrantKb = reader.IsDBNull(17) ? 0 : reader.GetInt64(17),
+                MaxGrantKb = reader.IsDBNull(18) ? 0 : reader.GetInt64(18),
+                MinUsedGrantKb = reader.IsDBNull(19) ? 0 : reader.GetInt64(19),
+                MaxUsedGrantKb = reader.IsDBNull(20) ? 0 : reader.GetInt64(20),
+                MinIdealGrantKb = reader.IsDBNull(21) ? 0 : reader.GetInt64(21),
+                MaxIdealGrantKb = reader.IsDBNull(22) ? 0 : reader.GetInt64(22),
+                MinReservedThreads = reader.IsDBNull(23) ? 0 : reader.GetInt64(23),
+                MaxReservedThreads = reader.IsDBNull(24) ? 0 : reader.GetInt64(24),
+                MinUsedThreads = reader.IsDBNull(25) ? 0 : reader.GetInt64(25),
+                MaxUsedThreads = reader.IsDBNull(26) ? 0 : reader.GetInt64(26),
+                MinPhysicalReads = reader.IsDBNull(27) ? 0 : reader.GetInt64(27),
+                MaxPhysicalReads = reader.IsDBNull(28) ? 0 : reader.GetInt64(28),
+                MinRows = reader.IsDBNull(29) ? 0 : reader.GetInt64(29),
+                MaxRows = reader.IsDBNull(30) ? 0 : reader.GetInt64(30),
+                MinSpills = reader.IsDBNull(31) ? 0 : reader.GetInt64(31),
+                MaxSpills = reader.IsDBNull(32) ? 0 : reader.GetInt64(32),
+                TotalClrTimeUs = reader.IsDBNull(33) ? 0 : reader.GetInt64(33)
             });
         }
 
@@ -413,7 +447,17 @@ SELECT
     max_worker_time,
     min_elapsed_time,
     max_elapsed_time,
-    total_spills
+    total_spills,
+    min_logical_reads,
+    max_logical_reads,
+    min_physical_reads,
+    max_physical_reads,
+    min_logical_writes,
+    max_logical_writes,
+    min_spills,
+    max_spills,
+    sql_handle,
+    plan_handle
 FROM v_procedure_stats
 WHERE server_id = $1
 AND   database_name = $2
@@ -447,7 +491,17 @@ ORDER BY collection_time";
                 MaxWorkerTimeUs = reader.IsDBNull(8) ? 0 : reader.GetInt64(8),
                 MinElapsedTimeUs = reader.IsDBNull(9) ? 0 : reader.GetInt64(9),
                 MaxElapsedTimeUs = reader.IsDBNull(10) ? 0 : reader.GetInt64(10),
-                TotalSpills = reader.IsDBNull(11) ? 0 : reader.GetInt64(11)
+                TotalSpills = reader.IsDBNull(11) ? 0 : reader.GetInt64(11),
+                MinLogicalReads = reader.IsDBNull(12) ? 0 : reader.GetInt64(12),
+                MaxLogicalReads = reader.IsDBNull(13) ? 0 : reader.GetInt64(13),
+                MinPhysicalReads = reader.IsDBNull(14) ? 0 : reader.GetInt64(14),
+                MaxPhysicalReads = reader.IsDBNull(15) ? 0 : reader.GetInt64(15),
+                MinLogicalWrites = reader.IsDBNull(16) ? 0 : reader.GetInt64(16),
+                MaxLogicalWrites = reader.IsDBNull(17) ? 0 : reader.GetInt64(17),
+                MinSpills = reader.IsDBNull(18) ? 0 : reader.GetInt64(18),
+                MaxSpills = reader.IsDBNull(19) ? 0 : reader.GetInt64(19),
+                SqlHandle = reader.IsDBNull(20) ? "" : reader.GetString(20),
+                PlanHandle = reader.IsDBNull(21) ? "" : reader.GetString(21)
             });
         }
 
@@ -1292,6 +1346,23 @@ public class QueryStatsHistoryRow
     public long MaxCpuUs { get; set; }
     public long MinElapsedUs { get; set; }
     public long MaxElapsedUs { get; set; }
+    public long MinGrantKb { get; set; }
+    public long MaxGrantKb { get; set; }
+    public long MinUsedGrantKb { get; set; }
+    public long MaxUsedGrantKb { get; set; }
+    public long MinIdealGrantKb { get; set; }
+    public long MaxIdealGrantKb { get; set; }
+    public long MinReservedThreads { get; set; }
+    public long MaxReservedThreads { get; set; }
+    public long MinUsedThreads { get; set; }
+    public long MaxUsedThreads { get; set; }
+    public long MinPhysicalReads { get; set; }
+    public long MaxPhysicalReads { get; set; }
+    public long MinRows { get; set; }
+    public long MaxRows { get; set; }
+    public long MinSpills { get; set; }
+    public long MaxSpills { get; set; }
+    public long TotalClrTimeUs { get; set; }
     public string? QueryPlan { get; set; }
     public string QueryPlanHash { get; set; } = "";
     public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlan);
@@ -1304,6 +1375,7 @@ public class QueryStatsHistoryRow
     public double MaxCpuMs => MaxCpuUs / 1000.0;
     public double MinElapsedMs => MinElapsedUs / 1000.0;
     public double MaxElapsedMs => MaxElapsedUs / 1000.0;
+    public double TotalClrMs => TotalClrTimeUs / 1000.0;
     public string CollectionTimeLocal => ServerTimeHelper.FormatServerTime(CollectionTime);
 }
 
@@ -1321,6 +1393,16 @@ public class ProcedureStatsHistoryRow
     public long MinElapsedTimeUs { get; set; }
     public long MaxElapsedTimeUs { get; set; }
     public long TotalSpills { get; set; }
+    public long MinLogicalReads { get; set; }
+    public long MaxLogicalReads { get; set; }
+    public long MinPhysicalReads { get; set; }
+    public long MaxPhysicalReads { get; set; }
+    public long MinLogicalWrites { get; set; }
+    public long MaxLogicalWrites { get; set; }
+    public long MinSpills { get; set; }
+    public long MaxSpills { get; set; }
+    public string SqlHandle { get; set; } = "";
+    public string PlanHandle { get; set; } = "";
     public double DeltaCpuMs => DeltaCpuUs / 1000.0;
     public double DeltaElapsedMs => DeltaElapsedUs / 1000.0;
     public double AvgCpuMs => DeltaExecutions > 0 ? DeltaCpuMs / DeltaExecutions : 0;

--- a/Lite/Windows/ProcedureHistoryWindow.xaml
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml
@@ -89,6 +89,16 @@
                 <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
                 <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
                 <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Phys Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Max Phys Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Min Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="SQL Handle" Binding="{Binding SqlHandle}" Width="140"/>
+                <DataGridTextColumn Header="Plan Handle" Binding="{Binding PlanHandle}" Width="140"/>
                 <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml
@@ -95,6 +95,23 @@
                 <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
                 <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" Width="70"/>
                 <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" Width="70"/>
+                <DataGridTextColumn Header="Min Phys Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Max Phys Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Min Grant KB" Binding="{Binding MinGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Grant KB" Binding="{Binding MaxGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Used Grant KB" Binding="{Binding MinUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Used Grant KB" Binding="{Binding MaxUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Ideal Grant KB" Binding="{Binding MinIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Ideal Grant KB" Binding="{Binding MaxIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Reserved Threads" Binding="{Binding MinReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Max Reserved Threads" Binding="{Binding MaxReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Min Used Threads" Binding="{Binding MinUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Used Threads" Binding="{Binding MaxUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Total CLR (ms)" Binding="{Binding TotalClrMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
                 <DataGridTextColumn Header="Plan Hash" Binding="{Binding QueryPlanHash}" Width="140"/>
                 <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
                     <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
**Drilldown-completeness batch, item 4** — the per-query / per-procedure **history drilldowns** were strictly poorer than the Top grid you clicked from (they dropped min/max + grant/thread columns the parent shows). Brought to parity.

**Dashboard query-stats history** — the read + model already carried used/ideal grant, threads, and `total_clr_time` (it was actually *richer* than the parent Top grid), so this is **grid-only**: added Min Grant / Used / Ideal (MB) columns and the **Reserved Threads** pair, and relabeled the existing used-threads columns to `Min/Max Used Threads` to disambiguate. Procedure history was already at parity — no change.

**Lite query-stats history** — appended 17 columns (min/max grant + used/ideal grant + reserved/used threads + physical_reads + rows + spills + `total_clr_time`) to the read SELECT + row + grid (ordinals 17–33; existing 0–16 unchanged). **Lite procedure history** — appended 10 (min/max logical_reads + physical_reads + logical_writes + spills + `sql_handle` + `plan_handle`; ordinals 12–21).

Columns mirror each grid's existing unit (Dashboard MB, Lite KB/counts); CLR in ms. Copy / Copy-All / CSV export auto-includes the new columns (generic column-driven helper — no code-behind change).

## Verification
- Lite reader ordinals verified contiguous; **Dashboard.Tests 732/732**, both apps build clean.

**One judgment call:** I relabeled the Dashboard used-threads headers `Min/Max Threads` → `Min/Max Used Threads` (to disambiguate from the new Reserved pair). One-line revert each if you'd rather keep the originals.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)