### PR TITLE
Surface query-stats signals + proc Avg Spills; drop dead Locks field (Dashboard)

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -690,6 +690,22 @@
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding WorkerTimePerSecond, StringFormat='{}{0:N1}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WorkerTimePerSecond" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Peak CPU (ms/s)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding PlanGenerationNum, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanGenerationNum" Click="QueryStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Plan Gen" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
                     <DataGridTextColumn Binding="{Binding MinWorkerTime}" ElementStyle="{StaticResource NumericCell}" Width="100">
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
@@ -1198,6 +1214,14 @@
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
                                 <TextBlock Text="Total Spills (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </DataGridTextColumn.Header>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                        <DataGridTextColumn.Header>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgSpills" Click="ProcStatsFilter_Click" Margin="0,0,4,0"/>
+                                <TextBlock Text="Avg Spills (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>

--- a/Dashboard/Models/QuerySnapshotItem.cs
+++ b/Dashboard/Models/QuerySnapshotItem.cs
@@ -41,7 +41,6 @@ namespace PerformanceMonitorDashboard.Models
         public DateTime? TranStartTime { get; set; }
         public short? RequestId { get; set; }
         public string? AdditionalInfo { get; set; }
-        public string? Locks { get; set; }
         public string? QueryPlan { get; set; }
 
         // Property alias for XAML binding compatibility

--- a/Dashboard/Models/QueryStatsItem.cs
+++ b/Dashboard/Models/QueryStatsItem.cs
@@ -48,6 +48,11 @@ namespace PerformanceMonitorDashboard.Models
         public long? MinSpills { get; set; }
         public long? MaxSpills { get; set; }
 
+        // Signals: plan stability (plan_generation_num — higher = more plan churn) and peak CPU
+        // rate (worker_time_per_second — ms of CPU per wall-clock second; 1000 ≈ one full core)
+        public long? PlanGenerationNum { get; set; }
+        public double? WorkerTimePerSecond { get; set; }
+
         // Display helpers
         public double TotalWorkerTimeSec => TotalWorkerTime / 1000000.0;
         public double TotalElapsedTimeSec => TotalElapsedTime / 1000000.0;

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Stats.cs
@@ -73,7 +73,9 @@ namespace PerformanceMonitorDashboard.Services
             max_spills = MAX(qs.max_spills),
             query_plan_hash = MAX(qs.query_plan_hash),
             sql_handle = MAX(qs.sql_handle),
-            plan_handle = MAX(qs.plan_handle)
+            plan_handle = MAX(qs.plan_handle),
+            plan_generation_num = MAX(qs.plan_generation_num),
+            worker_time_per_second = MAX(qs.worker_time_per_second)
         INTO #per_lifetime
         FROM collect.query_stats AS qs
         WHERE (
@@ -143,7 +145,9 @@ namespace PerformanceMonitorDashboard.Services
             max_spills = MAX(pl.max_spills),
             query_plan_hash = CONVERT(nvarchar(20), MAX(pl.query_plan_hash), 1),
             sql_handle = CONVERT(nvarchar(130), MAX(pl.sql_handle), 1),
-            plan_handle = CONVERT(nvarchar(130), MAX(pl.plan_handle), 1)
+            plan_handle = CONVERT(nvarchar(130), MAX(pl.plan_handle), 1),
+            plan_generation_num = MAX(pl.plan_generation_num),
+            worker_time_per_second = MAX(pl.worker_time_per_second)
         INTO #top_ranked
         FROM #per_lifetime AS pl
         GROUP BY
@@ -200,7 +204,9 @@ namespace PerformanceMonitorDashboard.Services
             query_plan_xml = CONVERT(nvarchar(max), NULL),
             tr.query_plan_hash,
             tr.sql_handle,
-            tr.plan_handle
+            tr.plan_handle,
+            tr.plan_generation_num,
+            tr.worker_time_per_second
         FROM #top_ranked AS tr
         OUTER APPLY
         (
@@ -266,7 +272,9 @@ namespace PerformanceMonitorDashboard.Services
                             QueryPlanXml = reader.IsDBNull(35) ? null : reader.GetString(35),
                             QueryPlanHash = reader.IsDBNull(36) ? null : reader.GetString(36),
                             SqlHandle = reader.IsDBNull(37) ? null : reader.GetString(37),
-                            PlanHandle = reader.IsDBNull(38) ? null : reader.GetString(38)
+                            PlanHandle = reader.IsDBNull(38) ? null : reader.GetString(38),
+                            PlanGenerationNum = reader.IsDBNull(39) ? null : reader.GetInt64(39),
+                            WorkerTimePerSecond = reader.IsDBNull(40) ? null : Convert.ToDouble(reader.GetValue(40), CultureInfo.InvariantCulture)
                         });
                     }
 


### PR DESCRIPTION
**Drilldown-completeness batch, item 5** — correlation/signals/quick-wins + the dead-field cleanup. Per your call, the two signals ship **Dashboard-only** (they're not collected in Lite), with the Lite collector add queued as a follow-up.

## Shipped (Dashboard)
**Query-stats grid — two collected-but-unsurfaced signals:**
- **Plan Gen** (`plan_generation_num`) — plan-regeneration count; a high value flags plan churn / frequent recompiles.
- **Peak CPU (ms/s)** (`worker_time_per_second`) — ms of CPU consumed per wall-clock second (1000 ≈ one full core), peak over the window.

Both thread through all three phases of `GetQueryStatsAsync` (`#per_lifetime` → `#top_ranked` → hydrate) via `MAX` and append at reader ordinals **39/40** (existing 0–38 untouched). `QueryStatsItem` gains `PlanGenerationNum` + `WorkerTimePerSecond`.

**Procedure-stats grid — Avg Spills:** `ProcedureStatsItem` already carried `AvgSpills` (the proc read computes `SUM(total_spills)/executions`, lifetime-aware) but the grid only showed Total/Min/Max. This is the audit's "in-model-not-grid" gap — a display-only column add.

**Dead field:** deleted `QuerySnapshotItem.Locks` (no reader assignment, no XAML binding, no reference).

New columns display / sort / filter with no handler changes (`DataGridFilterService` resolves the Tag by reflection). **Live-validated** the query aggregates on sql2022 (plan_gen 3–10, worker_time ~1 ms/s); **Dashboard.Tests 732/732**, build clean.

## Scoped out — three follow-ups I hit while doing this
1. **Lite signals (approved):** `plan_generation_num` / `worker_time_per_second` aren't collected in Lite's DuckDB. Needs a collector add (new columns + appender-by-position; rate computed client-side). Separate PR.
2. **Proc `worker_time_per_second` is a dead metric (both apps):** in `procedure_stats`, `sample_interval_seconds = 0` for every row, so the computed `worker_time_per_second` is **always NULL** (`NULLIF(interval,0)` nulls the division) — a proc "Peak CPU" column would ship permanently empty. So I did **not** add it to the proc grid. The proc collector isn't recording a real sample interval; worth a look.
3. **Lite proc `total_spills` is cumulative, not delta'd:** unlike the Lite *query* collector (`delta_spills`) and unlike executions/worker/etc. (which go through the delta calculator), the Lite proc collector stores raw cumulative `total_spills`. So the existing Lite proc **Total Spills** column sums cumulative values (inflated across multi-snapshot windows), and a correct Lite Avg Spills can't be computed until spills is delta-collected. That's why proc Avg Spills is Dashboard-only here.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)