### PR TITLE
Lite: fix proc spills delta + surface query plan-stability + CPU-rate signals

### DIFF
--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -453,6 +453,12 @@
                                     <DataGridTextColumn Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding WorkerTimePerSecond, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WorkerTimePerSecond" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Peak CPU (ms/s)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding PlanGenerationNum, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanGenerationNum" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Gen" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding TotalClrMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -759,6 +765,9 @@
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="90">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 32;
+    internal const int CurrentSchemaVersion = 33;
 
     private readonly string _archivePath;
 
@@ -807,6 +807,29 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v32 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 33)
+        {
+            /* v33: procedure_stats gains delta_spills, and query_stats gains plan_generation_num +
+               sample_interval_seconds. All appended at the end to keep the positional appenders aligned; the
+               v_ views (SELECT *) surface them; old parquet reads back NULL (union BY NAME). The collectors now
+               write these columns, so an un-migrated DB would mis-align — these ALTERs are required.
+               - procedure_stats.delta_spills: spill-delta parity with query_stats (proc Total/Avg Spills now
+                 reflect per-window work, not summed cumulative DMV totals).
+               - query_stats.plan_generation_num: plan-stability signal.
+               - query_stats.sample_interval_seconds: lets the display derive worker_time_per_second (CPU-ms/sec). */
+            _logger?.LogInformation("Running migration to v33: proc delta_spills + query_stats signal columns");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE procedure_stats ADD COLUMN IF NOT EXISTS delta_spills BIGINT");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_stats ADD COLUMN IF NOT EXISTS plan_generation_num BIGINT");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_stats ADD COLUMN IF NOT EXISTS sample_interval_seconds INTEGER");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v33 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -117,7 +117,9 @@ CREATE TABLE IF NOT EXISTS query_stats (
     delta_logical_writes BIGINT,
     delta_physical_reads BIGINT,
     delta_rows BIGINT,
-    delta_spills BIGINT
+    delta_spills BIGINT,
+    plan_generation_num BIGINT,
+    sample_interval_seconds INTEGER
 )";
 
     public const string CreateCpuUtilizationStatsTable = @"
@@ -252,7 +254,8 @@ CREATE TABLE IF NOT EXISTS procedure_stats (
     delta_elapsed_time BIGINT,
     delta_logical_reads BIGINT,
     delta_logical_writes BIGINT,
-    delta_physical_reads BIGINT
+    delta_physical_reads BIGINT,
+    delta_spills BIGINT
 )";
 
     public const string CreateQueryStoreStatsTable = @"

--- a/Lite/Services/DeltaCalculator.cs
+++ b/Lite/Services/DeltaCalculator.cs
@@ -78,11 +78,24 @@ public class DeltaCalculator
     /// </summary>
     public long CalculateDelta(int serverId, string collectorName, string key, long currentValue,
         DateTime? collectionTime = null, int maxGapSeconds = 0)
+        => CalculateDeltaWithInterval(serverId, collectorName, key, currentValue, out _, collectionTime, maxGapSeconds);
+
+    /// <summary>
+    /// Same as <see cref="CalculateDelta"/>, but also reports the number of seconds between the
+    /// previous cached collection and the current one via <paramref name="intervalSeconds"/>.
+    /// The interval is 0 on the first sighting of a key or after a gap reset (no prior baseline to
+    /// measure against), mirroring the delta's own 0 in those cases. Callers can divide a delta by
+    /// this interval to derive a per-second rate (e.g. CPU-ms per wall-clock second).
+    /// Thread-safe via atomic AddOrUpdate.
+    /// </summary>
+    public long CalculateDeltaWithInterval(int serverId, string collectorName, string key, long currentValue,
+        out int intervalSeconds, DateTime? collectionTime = null, int maxGapSeconds = 0)
     {
         var serverCache = _cache.GetOrAdd(serverId, _ => new ConcurrentDictionary<string, ConcurrentDictionary<string, (long Value, DateTime? Timestamp)>>());
         var collectorCache = serverCache.GetOrAdd(collectorName, _ => new ConcurrentDictionary<string, (long Value, DateTime? Timestamp)>());
 
         long delta = 0;
+        int interval = 0;
 
         collectorCache.AddOrUpdate(
             key,
@@ -91,6 +104,7 @@ public class DeltaCalculator
             _ =>
             {
                 delta = 0;
+                interval = 0;
                 return (currentValue, collectionTime);
             },
             /* Update: compute delta atomically */
@@ -102,8 +116,15 @@ public class DeltaCalculator
                     && (collectionTime.Value - previous.Timestamp.Value).TotalSeconds > maxGapSeconds)
                 {
                     delta = 0;
+                    interval = 0;
                     return (currentValue, collectionTime);
                 }
+
+                /* Seconds between the previous and current collection, when both timestamps exist —
+                   the wall-clock span this delta accrued over. */
+                interval = (collectionTime.HasValue && previous.Timestamp.HasValue)
+                    ? (int)(collectionTime.Value - previous.Timestamp.Value).TotalSeconds
+                    : 0;
 
                 delta = currentValue < previous.Value
                     ? 0              /* counter reset (plan cache eviction/re-entry) — not real new work */
@@ -111,6 +132,7 @@ public class DeltaCalculator
                 return (currentValue, collectionTime);
             });
 
+        intervalSeconds = interval;
         return delta;
     }
 

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -134,7 +134,9 @@ WITH ranked AS (
         MAX(max_reserved_threads) AS max_reserved_threads,
         MIN(min_used_threads) AS min_used_threads,
         MAX(max_used_threads) AS max_used_threads,
-        MAX(total_clr_time) AS total_clr_time
+        MAX(total_clr_time) AS total_clr_time,
+        MAX(plan_generation_num) AS plan_generation_num,
+        MAX(CAST(delta_worker_time AS DOUBLE) / NULLIF(sample_interval_seconds, 0) / 1000.0) AS worker_time_per_second
     FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2
@@ -216,8 +218,10 @@ LIMIT $4";
                 MinUsedThreads = reader.IsDBNull(35) ? 0 : reader.GetInt64(35),
                 MaxUsedThreads = reader.IsDBNull(36) ? 0 : reader.GetInt64(36),
                 TotalClrUs = reader.IsDBNull(37) ? 0 : reader.GetInt64(37),
-                QueryText = reader.IsDBNull(38) ? "" : reader.GetString(38),
-                QueryPlan = reader.IsDBNull(39) ? null : reader.GetString(39)
+                PlanGenerationNum = reader.IsDBNull(38) ? 0 : reader.GetInt64(38),
+                WorkerTimePerSecond = reader.IsDBNull(39) ? 0 : ToDouble(reader.GetValue(39)),
+                QueryText = reader.IsDBNull(40) ? "" : reader.GetString(40),
+                QueryPlan = reader.IsDBNull(41) ? null : reader.GetString(41)
             });
         }
 
@@ -789,13 +793,14 @@ SELECT
     MAX(max_physical_reads) AS max_physical_reads,
     MIN(min_logical_writes) AS min_logical_writes,
     MAX(max_logical_writes) AS max_logical_writes,
-    SUM(total_spills) AS total_spills,
+    SUM(delta_spills) AS total_spills,
     MIN(min_spills) AS min_spills,
     MAX(max_spills) AS max_spills,
     MAX(cached_time) AS cached_time,
     MAX(last_execution_time) AS last_execution_time,
     MAX(sql_handle) AS sql_handle,
-    MAX(plan_handle) AS plan_handle
+    MAX(plan_handle) AS plan_handle,
+    CAST(SUM(delta_spills) AS DOUBLE) / NULLIF(SUM(delta_execution_count), 0) AS avg_spills
 FROM v_procedure_stats
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -846,7 +851,8 @@ LIMIT $4";
                 CachedTime = reader.IsDBNull(23) ? (DateTime?)null : reader.GetDateTime(23),
                 LastExecutionTime = reader.IsDBNull(24) ? (DateTime?)null : reader.GetDateTime(24),
                 SqlHandle = reader.IsDBNull(25) ? "" : reader.GetString(25),
-                PlanHandle = reader.IsDBNull(26) ? "" : reader.GetString(26)
+                PlanHandle = reader.IsDBNull(26) ? "" : reader.GetString(26),
+                AvgSpills = reader.IsDBNull(27) ? 0 : ToDouble(reader.GetValue(27))
             });
         }
 
@@ -1296,6 +1302,8 @@ public class QueryStatsRow
     public long TotalClrUs { get; set; }
     public long MinSpills { get; set; }
     public long MaxSpills { get; set; }
+    public long PlanGenerationNum { get; set; }
+    public double WorkerTimePerSecond { get; set; }
     public string QueryPlanHash { get; set; } = "";
     public string SqlHandle { get; set; } = "";
     public string PlanHandle { get; set; } = "";
@@ -1338,6 +1346,7 @@ public class ProcedureStatsRow
     public long MinLogicalWrites { get; set; }
     public long MaxLogicalWrites { get; set; }
     public long TotalSpills { get; set; }
+    public double AvgSpills { get; set; }
     public long MinSpills { get; set; }
     public long MaxSpills { get; set; }
     public DateTime? CachedTime { get; set; }

--- a/Lite/Services/RemoteCollectorService.ProcedureStats.cs
+++ b/Lite/Services/RemoteCollectorService.ProcedureStats.cs
@@ -285,6 +285,7 @@ OPTION(RECOMPILE);";
                     var logicalReads = reader.GetInt64(9);
                     var physicalReads = reader.GetInt64(10);
                     var logicalWrites = reader.GetInt64(11);
+                    var totalSpills = reader.GetInt64(22);
                     var sqlHandle = reader.IsDBNull(25) ? (string?)null : reader.GetString(25);
                     var planHandle = reader.IsDBNull(26) ? (string?)null : reader.GetString(26);
 
@@ -297,6 +298,7 @@ OPTION(RECOMPILE);";
                     var deltaReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_reads", deltaKey, logicalReads, collectionTime: collectionTime, maxGapSeconds: 300);
                     var deltaWrites = _deltaCalculator.CalculateDelta(serverId, "proc_stats_writes", deltaKey, logicalWrites, collectionTime: collectionTime, maxGapSeconds: 300);
                     var deltaPhysReads = _deltaCalculator.CalculateDelta(serverId, "proc_stats_phys_reads", deltaKey, physicalReads, collectionTime: collectionTime, maxGapSeconds: 300);
+                    var deltaSpills = _deltaCalculator.CalculateDelta(serverId, "proc_stats_spills", deltaKey, totalSpills, collectionTime: collectionTime, maxGapSeconds: 300);
 
                     /* Appender column order must match DuckDB table definition exactly */
                     var row = appender.CreateRow();
@@ -326,7 +328,7 @@ OPTION(RECOMPILE);";
                        .AppendValue(reader.IsDBNull(19) ? 0L : reader.GetInt64(19))             /* max_physical_reads */
                        .AppendValue(reader.IsDBNull(20) ? 0L : reader.GetInt64(20))             /* min_logical_writes */
                        .AppendValue(reader.IsDBNull(21) ? 0L : reader.GetInt64(21))             /* max_logical_writes */
-                       .AppendValue(reader.GetInt64(22))                                        /* total_spills */
+                       .AppendValue(totalSpills)                                                /* total_spills */
                        .AppendValue(reader.GetInt64(23))                                        /* min_spills */
                        .AppendValue(reader.GetInt64(24))                                        /* max_spills */
                        .AppendValue(sqlHandle)                                                  /* sql_handle */
@@ -337,6 +339,7 @@ OPTION(RECOMPILE);";
                        .AppendValue(deltaReads)                                                 /* delta_logical_reads */
                        .AppendValue(deltaWrites)                                                /* delta_logical_writes */
                        .AppendValue(deltaPhysReads)                                             /* delta_physical_reads */
+                       .AppendValue(deltaSpills)                                                /* delta_spills */
                        .EndRow();
 
                     rowsCollected++;

--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -91,7 +91,8 @@ SELECT /* PerformanceMonitorLite */ TOP (200)
                         END - qs.statement_start_offset
                     ) / 2 + 1
                 )
-        END
+        END,
+    plan_generation_num = qs.plan_generation_num
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
 CROSS APPLY
@@ -175,7 +176,8 @@ SELECT /* PerformanceMonitorLite */ TOP (200)
                         END - qs.statement_start_offset
                     ) / 2 + 1
                 )
-        END
+        END,
+    plan_generation_num = qs.plan_generation_num
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
 WHERE st.text NOT LIKE N'%PerformanceMonitorLite%'
@@ -256,7 +258,7 @@ OPTION(RECOMPILE);";
                        28=min_ideal_grant_kb, 29=max_ideal_grant_kb,
                        30=min_reserved_threads, 31=max_reserved_threads, 32=min_used_threads, 33=max_used_threads,
                        34=min_spills, 35=max_spills,
-                       36=sql_handle, 37=plan_handle, 38=query_text */
+                       36=sql_handle, 37=plan_handle, 38=query_text, 39=plan_generation_num */
                     var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
                     var creationTime = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3);
                     var lastExecTime = reader.IsDBNull(4) ? (DateTime?)null : reader.GetDateTime(4);
@@ -271,12 +273,15 @@ OPTION(RECOMPILE);";
                     var totalSpills = reader.IsDBNull(13) ? 0L : reader.GetInt64(13);
                     var sqlHandle = reader.IsDBNull(36) ? (string?)null : reader.GetString(36);
                     var planHandle = reader.IsDBNull(37) ? (string?)null : reader.GetString(37);
+                    var planGenerationNum = reader.IsDBNull(39) ? 0L : reader.GetInt64(39);
 
                     /* Delta calculations keyed by plan_handle to prevent cross-contamination
                        when multiple plans exist for the same query_hash */
                     var deltaKey = planHandle ?? queryHash;
                     var deltaExecCount = _deltaCalculator.CalculateDelta(serverId, "query_stats_exec", deltaKey, executionCount, collectionTime: collectionTime, maxGapSeconds: 300);
-                    var deltaWorkerTime = _deltaCalculator.CalculateDelta(serverId, "query_stats_worker", deltaKey, totalWorkerTime, collectionTime: collectionTime, maxGapSeconds: 300);
+                    /* Capture the collection interval alongside the CPU delta so the display can derive
+                       worker_time_per_second (peak CPU-ms per wall-clock second) over the window. */
+                    var deltaWorkerTime = _deltaCalculator.CalculateDeltaWithInterval(serverId, "query_stats_worker", deltaKey, totalWorkerTime, out var sampleIntervalSeconds, collectionTime: collectionTime, maxGapSeconds: 300);
                     var deltaElapsedTime = _deltaCalculator.CalculateDelta(serverId, "query_stats_elapsed", deltaKey, totalElapsedTime, collectionTime: collectionTime, maxGapSeconds: 300);
                     var deltaLogicalReads = _deltaCalculator.CalculateDelta(serverId, "query_stats_reads", deltaKey, totalLogicalReads, collectionTime: collectionTime, maxGapSeconds: 300);
                     var deltaLogicalWrites = _deltaCalculator.CalculateDelta(serverId, "query_stats_writes", deltaKey, totalLogicalWrites, collectionTime: collectionTime, maxGapSeconds: 300);
@@ -338,6 +343,8 @@ OPTION(RECOMPILE);";
                        .AppendValue(deltaPhysicalReads)                                                     /* delta_physical_reads */
                        .AppendValue(deltaRows)                                                              /* delta_rows */
                        .AppendValue(deltaSpills)                                                            /* delta_spills */
+                       .AppendValue(planGenerationNum)                                                      /* plan_generation_num */
+                       .AppendValue(sampleIntervalSeconds)                                                  /* sample_interval_seconds */
                        .EndRow();
 
                     rowsCollected++;


### PR DESCRIPTION
Closes the two real Lite follow-ups from the drilldown batch (the third, a Dashboard proc-interval "bug", turned out to be a non-issue — sparse test data, not code).

## #3 — proc spills were cumulative, now delta'd
Lite's proc collector stored `total_spills` raw from the cumulative DMV (no delta — unlike its *query* collector's `delta_spills`, and unlike proc exec/worker/etc. which go through the delta calculator). So the proc grid's **Total Spills** summed cumulative values (inflated across snapshots). Now `delta_spills` is computed via the same `_deltaCalculator` path; the proc grid's Total Spills sums the delta, and a new **Avg Spills** column shows spills/execution.

## #1 — query plan-stability + CPU-rate signals (Dashboard parity)
- **Plan Gen** (`plan_generation_num`) — plan-regeneration count, collected from `dm_exec_query_stats`.
- **Peak CPU (ms/s)** (`worker_time_per_second`) — peak CPU-ms per wall-clock second, derived from `delta_worker_time / sample_interval_seconds`. `query_stats` gains a per-row `sample_interval_seconds`; `DeltaCalculator` now exposes the sample gap via `CalculateDeltaWithInterval` (existing `CalculateDelta` delegates to it — ~30 callers untouched).

## Migration + positional safety
Schema **v32 → v33**: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for all three (appended at table end, so DuckDB's end-appending ALTER stays aligned with the positional appenders). Re-verified 1:1: `query_stats` 54 cols ↔ 54 `.AppendValue`; `procedure_stats` 38 ↔ 38. Both display reads' reader ordinals traced — the query read's `r.*, query_text, query_plan` shift handled (signals at 38/39, query_text/plan at 40/41). New columns flow through the `v_` views (`SELECT *` + union BY NAME) and parquet archive with no registration changes.

**Verify:** Lite build clean; Lite.Tests 619/619. Migration will run live on launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)