### PR TITLE
Lite: fix query-stats delta key to match Full (per-statement, not per-plan)

### DIFF
--- a/Lite/Services/RemoteCollectorService.QueryStats.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStats.cs
@@ -92,7 +92,9 @@ SELECT /* PerformanceMonitorLite */ TOP (200)
                     ) / 2 + 1
                 )
         END,
-    plan_generation_num = qs.plan_generation_num
+    plan_generation_num = qs.plan_generation_num,
+    statement_start_offset = qs.statement_start_offset,
+    statement_end_offset = qs.statement_end_offset
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
 CROSS APPLY
@@ -177,7 +179,9 @@ SELECT /* PerformanceMonitorLite */ TOP (200)
                     ) / 2 + 1
                 )
         END,
-    plan_generation_num = qs.plan_generation_num
+    plan_generation_num = qs.plan_generation_num,
+    statement_start_offset = qs.statement_start_offset,
+    statement_end_offset = qs.statement_end_offset
 FROM sys.dm_exec_query_stats AS qs
 OUTER APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
 WHERE st.text NOT LIKE N'%PerformanceMonitorLite%'
@@ -258,7 +262,8 @@ OPTION(RECOMPILE);";
                        28=min_ideal_grant_kb, 29=max_ideal_grant_kb,
                        30=min_reserved_threads, 31=max_reserved_threads, 32=min_used_threads, 33=max_used_threads,
                        34=min_spills, 35=max_spills,
-                       36=sql_handle, 37=plan_handle, 38=query_text, 39=plan_generation_num */
+                       36=sql_handle, 37=plan_handle, 38=query_text, 39=plan_generation_num,
+                       40=statement_start_offset, 41=statement_end_offset */
                     var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
                     var creationTime = reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3);
                     var lastExecTime = reader.IsDBNull(4) ? (DateTime?)null : reader.GetDateTime(4);
@@ -274,10 +279,17 @@ OPTION(RECOMPILE);";
                     var sqlHandle = reader.IsDBNull(36) ? (string?)null : reader.GetString(36);
                     var planHandle = reader.IsDBNull(37) ? (string?)null : reader.GetString(37);
                     var planGenerationNum = reader.IsDBNull(39) ? 0L : reader.GetInt64(39);
+                    var statementStartOffset = reader.IsDBNull(40) ? 0 : reader.GetInt32(40);
+                    var statementEndOffset = reader.IsDBNull(41) ? 0 : reader.GetInt32(41);
 
-                    /* Delta calculations keyed by plan_handle to prevent cross-contamination
-                       when multiple plans exist for the same query_hash */
-                    var deltaKey = planHandle ?? queryHash;
+                    /* Delta key = the dm_exec_query_stats row identity, matching the Dashboard's delta framework
+                       (sql_handle + statement_start_offset + statement_end_offset + plan_handle). Keying on
+                       plan_handle alone cross-contaminated the multiple statements that share one plan (a proc or
+                       multi-statement batch is ONE plan_handle with MANY statements at different offsets): within a
+                       collection the calculator got called repeatedly with the same key but each statement's
+                       cumulative value, so one statement's total became another's "previous" — yielding garbage
+                       resource-deltas (large CPU/reads deltas with zero execution delta) that inflated the totals. */
+                    var deltaKey = $"{sqlHandle}:{statementStartOffset}:{statementEndOffset}:{planHandle}";
                     var deltaExecCount = _deltaCalculator.CalculateDelta(serverId, "query_stats_exec", deltaKey, executionCount, collectionTime: collectionTime, maxGapSeconds: 300);
                     /* Capture the collection interval alongside the CPU delta so the display can derive
                        worker_time_per_second (peak CPU-ms per wall-clock second) over the window. */


### PR DESCRIPTION
Fixes the inflated Total/Avg columns on **Top Queries by Duration** (and the other query-stats grids) that you spotted — totals in the billions of ms for ~40 executions, wildly out of line with the per-query drilldown.

## Root cause (Lite-only, pre-existing)
`sys.dm_exec_query_stats` returns **one row per statement** (`sql_handle` + `statement_start_offset` + `statement_end_offset` + `plan_handle`). A stored proc or multi-statement batch is **one `plan_handle` with many statements**. The Lite query collector keyed deltas on `plan_handle` alone, so within a single collection the `DeltaCalculator` was called repeatedly with the *same key* but each statement's cumulative counters — statement A's total became statement B's "previous." The heavy statement's baseline got clobbered by a lighter one every cycle, emitting the same **~3.59M ms CPU / 138M reads delta with 0 executions**, collection after collection. The grid does `SUM(delta_*)` across the window, so those bogus zero-exec deltas piled into the billions (`67B` total reads ≈ 138M × ~480 rows). A delta with **zero executions but millions of ms of CPU is impossible** — that's the tell.

## Fix
Key the deltas on the actual `dm_exec_query_stats` row identity — **`sql_handle + statement_start_offset + statement_end_offset + plan_handle`** — exactly what the Dashboard's delta framework joins on. Both collector SELECTs (standard + Azure) now emit the two statement offsets at the end (reader ordinals 40/41, read for the key only — not persisted); `deltaKey` rebuilt accordingly. Matching Full keeps the two apps consistent so this can't drift again.

We discussed the alternatives — `sql_handle`/`plan_hash` are batch/plan-shape level (same collision); `(database_id, query_hash, query_plan_hash)` is a nice *stable* identity but merges literal-only-different statements (query_hash is parameterized) and needs `database_id` since the hashes are DB-agnostic. Offsets are exact and `plan_handle` bakes in the DB, so this is the collision-proof choice.

## Verification
Lite build clean; **Lite.Tests 619/619**.

## Note on already-collected data
This corrects deltas **going forward**. The bogus rows already collected on that client server stay in DuckDB until retention ages them out, so the grid there will keep showing inflation for that historical window. If you want immediate relief we can either purge the offending rows or add a display-side guard (only count resource deltas where `delta_execution_count > 0`, since zero executions can't produce real CPU/reads) — say the word and I'll follow up.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)