### PR TITLE
Lite: add reset-path observability (init/view table counts + compaction-failure logging)

### DIFF
--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -194,6 +194,15 @@ public class DuckDbInitializer
                 await SetSchemaVersionAsync(connection, CurrentSchemaVersion);
             }
 
+            /* Table count on the init connection — makes a failed reset (schema not persisting to the
+               file for the next connection to see) diagnosable from the log alone. */
+            using (var tableCountCmd = connection.CreateCommand())
+            {
+                tableCountCmd.CommandText = "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'main'";
+                var tableCount = Convert.ToInt64(await tableCountCmd.ExecuteScalarAsync());
+                _logger?.LogInformation("Schema initialization created {Count} tables", tableCount);
+            }
+
             _logger?.LogInformation("Database initialization complete. Schema version: {Version}", CurrentSchemaVersion);
         }
 
@@ -905,6 +914,18 @@ public class DuckDbInitializer
     {
         using var connection = CreateConnection();
         await connection.OpenAsync();
+
+        /* This fresh connection must see every table InitializeAsync just created. If it sees none,
+           the reset left an empty database — surface it loudly rather than only failing per-table below. */
+        using (var tableCountCmd = connection.CreateCommand())
+        {
+            tableCountCmd.CommandText = "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'main'";
+            var tableCount = Convert.ToInt64(await tableCountCmd.ExecuteScalarAsync());
+            if (tableCount == 0)
+                _logger?.LogError("Archive-view refresh opened a database with no tables — the reset did not persist the schema; collectors will fail until restart");
+            else
+                _logger?.LogInformation("Archive-view refresh sees {Count} tables", tableCount);
+        }
 
         foreach (var table in ArchivableTables)
         {

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -675,7 +675,17 @@ COPY (
                This runs outside the write lock using an in-memory DuckDB connection
                and only touches filesystem files — no contention with collectors. */
             _logger?.LogInformation("Compacting parquet files into monthly archives");
-            CompactParquetFiles();
+            try
+            {
+                CompactParquetFiles();
+            }
+            catch (Exception compactEx)
+            {
+                /* Compaction is best-effort (merging per-cycle parquet into monthly files); a failure
+                   must not abort the archive/reset. Previously unlogged — surface it so a stuck or
+                   oversized backlog is visible instead of silently degrading. */
+                _logger?.LogError(compactEx, "Parquet compaction failed; continuing with archive and reset");
+            }
 
             /* Nuke and reinitialize outside the using-connection scope so all handles are closed */
             _logger?.LogInformation("Deleting and reinitializing database");


### PR DESCRIPTION
Turns the temporary `[reset-diag]` logging from the archival-reset investigation into permanent reset-path observability. The **64 MB test threshold stays local-only** — this PR is instrumentation, not the knob.

If the size-based archive/reset ever again leaves the DB without its tables (the intermittent failure we hit under load), the log now says exactly where:
- **`InitializeAsync`** logs how many tables the init connection created.
- **`CreateArchiveViewsAsync`** logs how many tables its *fresh* connection sees, and logs an **ERROR** if that's zero — the "reset left an empty database, collectors fail until restart" mode — instead of only emitting 28 per-table view-creation warnings.
- **`CompactParquetFiles`** is now wrapped in try/catch: a compaction failure is logged (it was silent) and no longer aborts the archive/reset, since compaction is best-effort.

Observability only — no schema change; the sole behavior change is making a compaction failure non-fatal to the reset. **Lite build clean, Lite.Tests 619/619.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)