### PR TITLE
Default DataGrid column-click sort to descending (both apps)

### DIFF
--- a/Dashboard/Themes/CoolBreezeTheme.xaml
+++ b/Dashboard/Themes/CoolBreezeTheme.xaml
@@ -719,6 +719,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/Dashboard/Themes/DarkTheme.xaml
+++ b/Dashboard/Themes/DarkTheme.xaml
@@ -718,6 +718,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/Dashboard/Themes/LightTheme.xaml
+++ b/Dashboard/Themes/LightTheme.xaml
@@ -719,6 +719,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/Lite/Themes/CoolBreezeTheme.xaml
+++ b/Lite/Themes/CoolBreezeTheme.xaml
@@ -645,6 +645,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -645,6 +645,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/Lite/Themes/LightTheme.xaml
+++ b/Lite/Themes/LightTheme.xaml
@@ -645,6 +645,7 @@
     <!-- ============================================ -->
     <Style TargetType="DataGrid">
         <Setter Property="helpers:DataGridClipboardBehavior.FixHeaderCopy" Value="True"/>
+        <Setter Property="helpers:DataGridSortBehavior.SortDescendingFirst" Value="True"/>
         <Setter Property="helpers:ScrollPanBehavior.EnableMiddleClickPanning" Value="True"/>
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/PerformanceMonitor.Ui/DataGridSortBehavior.cs
+++ b/PerformanceMonitor.Ui/DataGridSortBehavior.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Attached behavior that makes the FIRST click on a DataGrid column header sort
+/// DESCENDING instead of the WPF default (ascending). When diagnosing performance you
+/// almost always want the largest values — highest CPU / duration / reads — on top
+/// first; clicking the same column again toggles to ascending as usual. Applied app-wide
+/// via the implicit DataGrid style in the theme dictionaries.
+/// </summary>
+public static class DataGridSortBehavior
+{
+    public static readonly DependencyProperty SortDescendingFirstProperty =
+        DependencyProperty.RegisterAttached(
+            "SortDescendingFirst",
+            typeof(bool),
+            typeof(DataGridSortBehavior),
+            new PropertyMetadata(false, OnSortDescendingFirstChanged));
+
+    public static bool GetSortDescendingFirst(DependencyObject obj) => (bool)obj.GetValue(SortDescendingFirstProperty);
+    public static void SetSortDescendingFirst(DependencyObject obj, bool value) => obj.SetValue(SortDescendingFirstProperty, value);
+
+    private static void OnSortDescendingFirstChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not DataGrid grid)
+        {
+            return;
+        }
+
+        /* Idempotent — detach first so re-applying the style doesn't double-subscribe. */
+        grid.Sorting -= OnSorting;
+        if ((bool)e.NewValue)
+        {
+            grid.Sorting += OnSorting;
+        }
+    }
+
+    private static void OnSorting(object? sender, DataGridSortingEventArgs e)
+    {
+        if (sender is not DataGrid grid)
+        {
+            return;
+        }
+
+        var sortPath = e.Column.SortMemberPath;
+        if (string.IsNullOrEmpty(sortPath))
+        {
+            /* Template column with no SortMemberPath — nothing to sort on; leave the default alone. */
+            return;
+        }
+
+        var view = CollectionViewSource.GetDefaultView(grid.ItemsSource);
+        if (view == null)
+        {
+            return;
+        }
+
+        /* First click on an unsorted column starts DESCENDING; subsequent clicks on the same
+           column toggle. (Default WPF is Ascending first, which is backwards for perf triage.) */
+        var direction = e.Column.SortDirection == ListSortDirection.Descending
+            ? ListSortDirection.Ascending
+            : ListSortDirection.Descending;
+
+        foreach (var column in grid.Columns)
+        {
+            column.SortDirection = column == e.Column ? direction : null;
+        }
+
+        view.SortDescriptions.Clear();
+        view.SortDescriptions.Add(new SortDescription(sortPath, direction));
+        e.Handled = true;
+    }
+}


### PR DESCRIPTION
Flips the default column-header sort from ascending to **descending** on first click, across every grid in both apps — because for perf triage you want the biggest offender (highest CPU / duration / reads) on top first, not last.

## How
New shared attached behavior **`PerformanceMonitor.Ui.DataGridSortBehavior.SortDescendingFirst`**:
- First click on an unsorted column → **Descending**; clicking the same column again toggles to Ascending (normal behavior thereafter).
- Applied app-wide via the implicit `<Style TargetType="DataGrid">` in all **six** theme dictionaries (Dashboard + Lite × Dark / Light / CoolBreeze), right next to the existing `DataGridClipboardBehavior` setter — so every grid picks it up with **zero per-grid wiring**.
- Template columns with no `SortMemberPath` are left to the WPF default (they're generally unsortable anyway).

## Verification
Both apps build clean; **Dashboard.Tests 732/732, Lite.Tests 619/619**. The behavior itself is UI, so it's held for your visual click-test — click a CPU/duration column in each app and confirm first click puts the largest on top.

Held for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)