### PR TITLE
Add column filtering + chart hover to Lite query/proc drilldowns

### DIFF
--- a/Lite/Windows/ProcedureHistoryWindow.xaml.cs
+++ b/Lite/Windows/ProcedureHistoryWindow.xaml.cs
@@ -13,7 +13,9 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorLite.Controls;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
 using PerformanceMonitor.Common;
@@ -32,6 +34,10 @@ public partial class ProcedureHistoryWindow : Window
     private readonly string? _connectionString;
     private readonly PlanNavigationController _planActions;
     private List<ProcedureStatsHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private DataGridFilterManager<ProcedureStatsHistoryRow>? _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
 
     public ProcedureHistoryWindow(LocalDataService dataService, int serverId, string databaseName, string schemaName, string objectName, int hoursBack, string? connectionString = null)
     {
@@ -51,6 +57,10 @@ public partial class ProcedureHistoryWindow : Window
                 _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
             "the monitored server");
 
+        _filterManager = new DataGridFilterManager<ProcedureStatsHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
         var fullName = string.IsNullOrEmpty(schemaName) ? objectName : $"{schemaName}.{objectName}";
         ProcIdentifierText.Text = $"Procedure History: {fullName} in [{databaseName}]";
         Loaded += async (_, _) => await LoadHistoryAsync();
@@ -63,7 +73,7 @@ public partial class ProcedureHistoryWindow : Window
         try
         {
             _historyData = await _dataService.GetProcedureStatsHistoryAsync(_serverId, _databaseName, _schemaName, _objectName, _hoursBack);
-            HistoryDataGrid.ItemsSource = _historyData;
+            _filterManager!.UpdateData(_historyData);
 
             if (_historyData.Count > 0)
             {
@@ -110,6 +120,14 @@ public partial class ProcedureHistoryWindow : Window
         ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
 
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+        _chartHover.Add(scatter, label);
+
         HistoryChart.Plot.Axes.DateTimeTicksBottom();
         ApplyTheme(HistoryChart);
 
@@ -135,7 +153,59 @@ public partial class ProcedureHistoryWindow : Window
     {
         ApplyTheme(HistoryChart);
         HistoryChart.Refresh();
+        _filterManager?.UpdateFilterButtonStyles();
     }
+
+    #region Column Filter Popup
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+        if (_filterManager == null) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+        _filterManager?.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+    }
+
+    #endregion
 
     private async void DownloadPlan_Click(object sender, RoutedEventArgs e)
     {

--- a/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStatsHistoryWindow.xaml.cs
@@ -13,7 +13,9 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorLite.Controls;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
 using PerformanceMonitor.Common;
@@ -32,6 +34,10 @@ public partial class QueryStatsHistoryWindow : Window
     private readonly string? _queryText;
     private readonly PlanNavigationController _planActions;
     private List<QueryStatsHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private DataGridFilterManager<QueryStatsHistoryRow>? _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
 
     public QueryStatsHistoryWindow(LocalDataService dataService, int serverId, string databaseName, string queryHash, int hoursBack, string? queryText = null, string? connectionString = null)
     {
@@ -51,6 +57,10 @@ public partial class QueryStatsHistoryWindow : Window
                 _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
             "the monitored server");
 
+        _filterManager = new DataGridFilterManager<QueryStatsHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
         QueryIdentifierText.Text = $"Query Stats History: {queryHash} in [{databaseName}]";
         Loaded += async (_, _) => await LoadHistoryAsync();
         ThemeManager.ThemeChanged += OnThemeChanged;
@@ -62,7 +72,7 @@ public partial class QueryStatsHistoryWindow : Window
         try
         {
             _historyData = await _dataService.GetQueryStatsHistoryAsync(_serverId, _databaseName, _queryHash, _hoursBack);
-            HistoryDataGrid.ItemsSource = _historyData;
+            _filterManager!.UpdateData(_historyData);
 
             if (_historyData.Count > 0)
             {
@@ -108,6 +118,14 @@ public partial class QueryStatsHistoryWindow : Window
         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
         ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
+
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+        _chartHover.Add(scatter, label);
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();
         ApplyTheme(HistoryChart);
@@ -194,7 +212,59 @@ public partial class QueryStatsHistoryWindow : Window
     {
         ApplyTheme(HistoryChart);
         HistoryChart.Refresh();
+        _filterManager?.UpdateFilterButtonStyles();
     }
+
+    #region Column Filter Popup
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+        if (_filterManager == null) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+        _filterManager?.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+    }
+
+    #endregion
 
     private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
     private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);

--- a/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
+++ b/Lite/Windows/QueryStoreHistoryWindow.xaml.cs
@@ -13,7 +13,9 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Microsoft.Win32;
+using PerformanceMonitorLite.Controls;
 using PerformanceMonitorLite.Services;
 using ScottPlot;
 using PerformanceMonitor.Common;
@@ -33,6 +35,10 @@ public partial class QueryStoreHistoryWindow : Window
     private readonly string _queryText;
     private readonly PlanNavigationController _planActions;
     private List<QueryStoreHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private DataGridFilterManager<QueryStoreHistoryRow>? _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
 
     public QueryStoreHistoryWindow(LocalDataService dataService, int serverId, string databaseName, long queryId, long planId, string queryText, int hoursBack, string? connectionString = null)
     {
@@ -53,6 +59,10 @@ public partial class QueryStoreHistoryWindow : Window
                 _connectionString ?? "", db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
             "the monitored server");
 
+        _filterManager = new DataGridFilterManager<QueryStoreHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
         var displayText = queryText.Length > 120 ? queryText[..120] + "..." : queryText;
         QueryIdentifierText.Text = $"Query Store History: Query {queryId}, Plan {planId} in [{databaseName}]";
         SummaryText.Text = displayText;
@@ -66,7 +76,7 @@ public partial class QueryStoreHistoryWindow : Window
         try
         {
             _historyData = await _dataService.GetQueryStoreHistoryAsync(_serverId, _databaseName, _queryId, _planId, _hoursBack);
-            HistoryDataGrid.ItemsSource = _historyData;
+            _filterManager!.UpdateData(_historyData);
 
             if (_historyData.Count > 0)
             {
@@ -111,6 +121,14 @@ public partial class QueryStoreHistoryWindow : Window
         scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
         ChartStyle.StyleScatter(scatter);
         scatter.LegendText = label;
+
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+        _chartHover.Add(scatter, label);
 
         HistoryChart.Plot.Axes.DateTimeTicksBottom();
         ApplyTheme(HistoryChart);
@@ -175,7 +193,59 @@ public partial class QueryStoreHistoryWindow : Window
     {
         ApplyTheme(HistoryChart);
         HistoryChart.Refresh();
+        _filterManager?.UpdateFilterButtonStyles();
     }
+
+    #region Column Filter Popup
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+        if (_filterManager == null) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+        _filterManager?.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null)
+            _filterPopup.IsOpen = false;
+    }
+
+    #endregion
 
     private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
     private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);

--- a/PerformanceMonitor.Ui/DataGridFilterColumns.cs
+++ b/PerformanceMonitor.Ui/DataGridFilterColumns.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace PerformanceMonitor.Ui;
+
+/// <summary>
+/// Decorates a DataGrid's bound columns with per-column filter buttons at runtime, so a grid
+/// authored with plain-string headers gains the same filter affordance as hand-built
+/// StackPanel headers — without repeating the StackPanel+Button markup on every column.
+/// Pair with <see cref="DataGridFilterManager{T}"/>: each button's Tag is the column's binding
+/// path, which is the property name the manager filters on and looks up when styling the icons.
+/// </summary>
+public static class DataGridFilterColumns
+{
+    /// <summary>
+    /// Wraps each bound column's plain-string header in a horizontal StackPanel containing a
+    /// filter button (styled via the "ColumnFilterButtonStyle" resource, Tag = binding path) and
+    /// the original header text. Template columns, unbound columns, and columns whose header is
+    /// already a StackPanel are left untouched, so the call is idempotent.
+    /// </summary>
+    public static void AddFilterButtons(DataGrid grid, RoutedEventHandler onFilterClick)
+    {
+        foreach (var column in grid.Columns)
+        {
+            if (column is not DataGridBoundColumn bound) continue;
+            if (bound.Binding is not Binding binding) continue;
+            var path = binding.Path?.Path;
+            if (string.IsNullOrEmpty(path)) continue;
+            if (column.Header is not string headerText) continue; // skip already-decorated / non-text headers
+
+            var filterButton = new Button
+            {
+                Tag = path,
+                Margin = new Thickness(0, 0, 4, 0)
+            };
+            filterButton.SetResourceReference(FrameworkElement.StyleProperty, "ColumnFilterButtonStyle");
+            filterButton.Click += onFilterClick;
+
+            var header = new StackPanel { Orientation = Orientation.Horizontal };
+            header.Children.Add(filterButton);
+            header.Children.Add(new TextBlock
+            {
+                Text = headerText,
+                FontWeight = FontWeights.Bold,
+                VerticalAlignment = VerticalAlignment.Center
+            });
+
+            column.Header = header;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the two gaps spotted while showing off Lite: the query drilldowns had **no column filtering** and the trend graph emitted **no hover tooltips**. Both are Lite-vs-Dashboard parity gaps — Dashboard's `QueryStatsHistoryWindow` already has both; Lite's three query/proc drilldowns had neither.

## What
Wired the *already-existing* Lite infrastructure into `QueryStatsHistoryWindow`, `ProcedureHistoryWindow`, and `QueryStoreHistoryWindow`:

- **Column filtering** — each grid gets a `DataGridFilterManager<T>` (shared `.Ui`) and routes rows through `UpdateData()`. A new shared helper **`PerformanceMonitor.Ui.DataGridFilterColumns.AddFilterButtons`** decorates every bound column's plain-string header with a filter button at runtime (`Tag` = binding path), so there's **no ~40-per-window XAML header churn** and the affordance stays identical across grids. Filter icons re-theme on theme change.
- **Chart hover** — `UpdateChart` registers the trend scatter with a `ChartHoverHelper`, matching the Dashboard drilldowns: value/time tooltip on hover, plus the shared click-to-isolate mechanic for free.

## Verification
Lite build clean; **Lite.Tests 619/619**; Dashboard builds unaffected by the shared `.Ui` addition. Runtime behavior mirrors `WaitDrillDownWindow` (filtering) and the Dashboard drilldowns (hover), both already proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)