### PR TITLE
Migrate Dashboard drilldown windows to shared filter manager + runtime headers

### DIFF
--- a/Dashboard/ProcedureHistoryWindow.xaml
+++ b/Dashboard/ProcedureHistoryWindow.xaml
@@ -90,336 +90,63 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CachedTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CachedTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Cached Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ObjectType}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Object Type" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TypeDesc}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TypeDesc" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Type Desc" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Cached Time" Binding="{Binding CachedTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Object Type" Binding="{Binding ObjectType}" Width="90"/>
+                <DataGridTextColumn Header="Type Desc" Binding="{Binding TypeDesc}" Width="120"/>
 
                 <!-- Execution Count (per-interval, computed from cumulative counter) -->
-                <DataGridTextColumn Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IntervalExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Exec Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Exec Count" Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Worker Time (CPU) -->
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="CPU Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
 
                 <!-- Elapsed Time -->
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Duration Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Logical Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Logical Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Reads Delta" Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Phys Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Physical Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Phys Reads Delta" Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Writes Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Logical Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Logical Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Logical Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Writes Delta" Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
 
                 <!-- Spills -->
-                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgSpills, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Spills" Binding="{Binding AvgSpills, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Interval (sec)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Query Identifiers -->
-                <DataGridTextColumn Binding="{Binding SqlHandle}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlHandle" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="SQL Handle" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PlanHandle}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanHandle" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Plan Handle" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="SQL Handle" Binding="{Binding SqlHandle}" Width="160"/>
+                <DataGridTextColumn Header="Plan Handle" Binding="{Binding PlanHandle}" Width="160"/>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/ProcedureHistoryWindow.xaml.cs
+++ b/Dashboard/ProcedureHistoryWindow.xaml.cs
@@ -42,8 +42,7 @@ namespace PerformanceMonitorDashboard
         private ChartHoverHelper? _chartHover;
 
         // Filter state
-        private Dictionary<string, ColumnFilterState> _filters = new();
-        private List<ProcedureExecutionHistoryItem>? _unfilteredData;
+        private readonly DataGridFilterManager<ProcedureExecutionHistoryItem> _filterManager;
         private Popup? _filterPopup;
         private ColumnFilterPopup? _filterPopupContent;
 
@@ -76,6 +75,10 @@ namespace PerformanceMonitorDashboard
                 (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
                     _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
                 "the monitored server");
+
+            _filterManager = new DataGridFilterManager<ProcedureExecutionHistoryItem>(HistoryDataGrid);
+            DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+            _filterManager.UpdateFilterButtonStyles();
 
             ProcedureIdentifierText.Text = $"Procedure Execution History: {objectName} in [{databaseName}]";
 
@@ -145,10 +148,7 @@ namespace PerformanceMonitorDashboard
                     }
                 }
 
-                _unfilteredData = _historyData;
-                _filters.Clear();
-                HistoryDataGrid.ItemsSource = _historyData;
-                UpdateFilterButtonStyles();
+                _filterManager.UpdateData(_historyData);
 
                 if (_historyData.Count > 0)
                 {
@@ -313,7 +313,7 @@ namespace PerformanceMonitorDashboard
                 };
             }
 
-            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
             _filterPopupContent!.Initialize(columnName, existingFilter);
 
             _filterPopup.PlacementTarget = button;
@@ -323,68 +323,12 @@ namespace PerformanceMonitorDashboard
         private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-
-            if (e.FilterState.IsActive)
-                _filters[e.FilterState.ColumnName] = e.FilterState;
-            else
-                _filters.Remove(e.FilterState.ColumnName);
-
-            ApplyFilters();
-            UpdateFilterButtonStyles();
+            _filterManager.SetFilter(e.FilterState);
         }
 
         private void FilterPopup_FilterCleared(object? sender, EventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-        }
-
-        private void ApplyFilters()
-        {
-            if (_unfilteredData == null) return;
-
-            if (_filters.Count == 0)
-            {
-                HistoryDataGrid.ItemsSource = _unfilteredData;
-                return;
-            }
-
-            var filtered = _unfilteredData.Where(item =>
-            {
-                foreach (var filter in _filters.Values)
-                {
-                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
-                        return false;
-                }
-                return true;
-            }).ToList();
-
-            HistoryDataGrid.ItemsSource = filtered;
-        }
-
-        private void UpdateFilterButtonStyles()
-        {
-            foreach (var column in HistoryDataGrid.Columns)
-            {
-                if (column.Header is StackPanel stackPanel)
-                {
-                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
-                    if (filterButton?.Tag is string columnName)
-                    {
-                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
-                        filterButton.Content = new System.Windows.Controls.TextBlock
-                        {
-                            Text = "\uE71C",
-                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
-                            Foreground = hasActive
-                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
-                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
-                        };
-                        filterButton.ToolTip = hasActive && filter != null
-                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
-                            : "Click to filter";
-                    }
-                }
-            }
         }
 
         #endregion

--- a/Dashboard/QueryExecutionHistoryWindow.xaml
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml
@@ -95,435 +95,85 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanId" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Plan ID" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Plan ID" Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
                 <!-- Execution Type / First & Last Exec / Module -->
-                <DataGridTextColumn Binding="{Binding ExecutionTypeDesc}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionTypeDesc" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Exec Type" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ServerFirstExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerFirstExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="First Exec" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ServerLastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ServerLastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Last Exec" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ModuleName}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ModuleName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Module" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CountExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CountExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Exec Type" Binding="{Binding ExecutionTypeDesc}" Width="100"/>
+                <DataGridTextColumn Header="First Exec" Binding="{Binding ServerFirstExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Last Exec" Binding="{Binding ServerLastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Module" Binding="{Binding ModuleName}" Width="160"/>
+                <DataGridTextColumn Header="Executions" Binding="{Binding CountExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
 
                 <!-- Duration (ms) -->
-                <DataGridTextColumn Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- CPU (ms) -->
-                <DataGridTextColumn Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxCpuTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
 
                 <!-- CLR (ms) -->
-                <DataGridTextColumn Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxClrTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max CLR (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg CLR (ms)" Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CLR (ms)" Binding="{Binding MinClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CLR (ms)" Binding="{Binding MaxClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Logical Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Logical Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Logical Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Logical Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Log (MB) -->
-                <DataGridTextColumn Binding="{Binding AvgLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxLogMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Log (MB)" Binding="{Binding AvgLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Log (MB)" Binding="{Binding MinLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Log (MB)" Binding="{Binding MaxLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
 
                 <!-- Num Physical Reads -->
-                <DataGridTextColumn Binding="{Binding AvgNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxNumPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Num Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Num Physical Reads" Binding="{Binding AvgNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Min Num Physical Reads" Binding="{Binding MinNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Max Num Physical Reads" Binding="{Binding MaxNumPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
 
                 <!-- DOP -->
-                <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
 
                 <!-- Memory (MB) -->
-                <DataGridTextColumn Binding="{Binding AvgMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Memory (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Memory (MB)" Binding="{Binding AvgMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Memory (MB)" Binding="{Binding MinMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Memory (MB)" Binding="{Binding MaxMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Row Count -->
-                <DataGridTextColumn Binding="{Binding AvgRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRowcount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
 
                 <!-- tempdb (MB) -->
-                <DataGridTextColumn Binding="{Binding AvgTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg tempdb (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min tempdb (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxTempdbMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max tempdb (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Avg tempdb (MB)" Binding="{Binding AvgTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min tempdb (MB)" Binding="{Binding MinTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max tempdb (MB)" Binding="{Binding MaxTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Plan Info -->
-                <DataGridTextColumn Binding="{Binding PlanType}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanType" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Plan Type" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridCheckBoxColumn Binding="{Binding IsForcedPlan}" Width="60">
-                    <DataGridCheckBoxColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsForcedPlan" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Forced" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridCheckBoxColumn.Header>
-                </DataGridCheckBoxColumn>
-                <DataGridTextColumn Binding="{Binding ForceFailureCount}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ForceFailureCount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Force Failures" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LastForceFailureReasonDesc}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastForceFailureReasonDesc" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Last Failure Reason" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PlanForcingType}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanForcingType" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Forcing Type" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CompatibilityLevel" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Compat Level" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Plan Type" Binding="{Binding PlanType}" Width="100"/>
+                <DataGridCheckBoxColumn Header="Forced" Binding="{Binding IsForcedPlan}" Width="60"/>
+                <DataGridTextColumn Header="Force Failures" Binding="{Binding ForceFailureCount}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Last Failure Reason" Binding="{Binding LastForceFailureReasonDesc}" Width="150"/>
+                <DataGridTextColumn Header="Forcing Type" Binding="{Binding PlanForcingType}" Width="100"/>
+                <DataGridTextColumn Header="Compat Level" Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
 
                 <!-- Query Identifiers -->
-                <DataGridTextColumn Binding="{Binding QueryHash}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryHash" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Query Hash" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding QueryPlanHash}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryPlanHash" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Query Plan Hash" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Query Hash" Binding="{Binding QueryHash}" Width="160"/>
+                <DataGridTextColumn Header="Query Plan Hash" Binding="{Binding QueryPlanHash}" Width="160"/>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/QueryExecutionHistoryWindow.xaml.cs
+++ b/Dashboard/QueryExecutionHistoryWindow.xaml.cs
@@ -42,8 +42,7 @@ namespace PerformanceMonitorDashboard
         private ChartHoverHelper? _chartHover;
 
         // Filter state
-        private Dictionary<string, ColumnFilterState> _filters = new();
-        private List<QueryExecutionHistoryItem>? _unfilteredData;
+        private readonly DataGridFilterManager<QueryExecutionHistoryItem> _filterManager;
         private Popup? _filterPopup;
         private ColumnFilterPopup? _filterPopupContent;
 
@@ -74,6 +73,10 @@ namespace PerformanceMonitorDashboard
                 (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
                     _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
                 "the monitored server");
+
+            _filterManager = new DataGridFilterManager<QueryExecutionHistoryItem>(HistoryDataGrid);
+            DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+            _filterManager.UpdateFilterButtonStyles();
 
             QueryIdentifierText.Text = $"Query Execution History: Query {queryId} in [{databaseName}]";
 
@@ -124,10 +127,7 @@ namespace PerformanceMonitorDashboard
                     _historyData = new List<QueryExecutionHistoryItem>();
                 }
 
-                _unfilteredData = _historyData;
-                _filters.Clear();
-                HistoryDataGrid.ItemsSource = _historyData;
-                UpdateFilterButtonStyles();
+                _filterManager.UpdateData(_historyData);
 
                 if (_historyData.Count > 0)
                 {
@@ -329,7 +329,7 @@ namespace PerformanceMonitorDashboard
                 };
             }
 
-            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
             _filterPopupContent!.Initialize(columnName, existingFilter);
 
             _filterPopup.PlacementTarget = button;
@@ -339,68 +339,12 @@ namespace PerformanceMonitorDashboard
         private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-
-            if (e.FilterState.IsActive)
-                _filters[e.FilterState.ColumnName] = e.FilterState;
-            else
-                _filters.Remove(e.FilterState.ColumnName);
-
-            ApplyFilters();
-            UpdateFilterButtonStyles();
+            _filterManager.SetFilter(e.FilterState);
         }
 
         private void FilterPopup_FilterCleared(object? sender, EventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-        }
-
-        private void ApplyFilters()
-        {
-            if (_unfilteredData == null) return;
-
-            if (_filters.Count == 0)
-            {
-                HistoryDataGrid.ItemsSource = _unfilteredData;
-                return;
-            }
-
-            var filtered = _unfilteredData.Where(item =>
-            {
-                foreach (var filter in _filters.Values)
-                {
-                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
-                        return false;
-                }
-                return true;
-            }).ToList();
-
-            HistoryDataGrid.ItemsSource = filtered;
-        }
-
-        private void UpdateFilterButtonStyles()
-        {
-            foreach (var column in HistoryDataGrid.Columns)
-            {
-                if (column.Header is StackPanel stackPanel)
-                {
-                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
-                    if (filterButton?.Tag is string columnName)
-                    {
-                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
-                        filterButton.Content = new System.Windows.Controls.TextBlock
-                        {
-                            Text = "\uE71C",
-                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
-                            Foreground = hasActive
-                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
-                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
-                        };
-                        filterButton.ToolTip = hasActive && filter != null
-                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
-                            : "Click to filter";
-                    }
-                }
-            }
         }
 
         #endregion

--- a/Dashboard/QueryStatsHistoryWindow.xaml
+++ b/Dashboard/QueryStatsHistoryWindow.xaml
@@ -93,450 +93,86 @@
                   Margin="10">
             <DataGrid.Columns>
                 <!-- Collection Info -->
-                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CreationTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CreationTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Creation Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ObjectType}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectType" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Object Type" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Creation Time" Binding="{Binding CreationTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Object Type" Binding="{Binding ObjectType}" Width="90"/>
 
                 <!-- Execution Count (per-interval, computed from cumulative counter) -->
-                <DataGridTextColumn Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IntervalExecutions" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Exec Count" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCountDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Exec Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Exec Count" Binding="{Binding IntervalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding ExecutionCountDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Worker Time (CPU) - Total/Avg/Min/Max -->
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxWorkerTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="CPU Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding TotalWorkerTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
 
                 <!-- Elapsed Time - Total/Avg/Min/Max -->
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxElapsedTimeMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeDeltaMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Duration Delta (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding TotalElapsedTimeDeltaMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
 
                 <!-- Logical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Logical Reads" Binding="{Binding AvgLogicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Reads Delta" Binding="{Binding TotalLogicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
 
                 <!-- Physical Reads -->
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxPhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReadsDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Phys Reads Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Physical Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Phys Reads Delta" Binding="{Binding TotalPhysicalReadsDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
 
                 <!-- Logical Writes -->
-                <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Logical Writes" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWritesDelta" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Writes Delta" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Logical Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Avg Logical Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Writes Delta" Binding="{Binding TotalLogicalWritesDelta, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
 
                 <!-- Rows -->
-                <DataGridTextColumn Binding="{Binding TotalRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRows" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding AvgRows, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgRows" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Avg Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinRows" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxRows" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Rows" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Rows" Binding="{Binding TotalRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRows, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Parallelism -->
-                <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
 
                 <!-- Memory Grants -->
-                <DataGridTextColumn Binding="{Binding MinGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Used (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Used (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinIdealGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Ideal (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Ideal (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Min Grant (MB)" Binding="{Binding MinGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                <DataGridTextColumn Header="Max Grant (MB)" Binding="{Binding MaxGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                <DataGridTextColumn Header="Min Used (MB)" Binding="{Binding MinUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                <DataGridTextColumn Header="Max Used (MB)" Binding="{Binding MaxUsedGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                <DataGridTextColumn Header="Min Ideal (MB)" Binding="{Binding MinIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                <DataGridTextColumn Header="Max Ideal (MB)" Binding="{Binding MaxIdealGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
 
                 <!-- Thread Usage -->
-                <DataGridTextColumn Binding="{Binding MinReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinReservedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Reserved Threads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxReservedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Reserved Threads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedThreads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Used Threads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Min Reserved Threads" Binding="{Binding MinReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Max Reserved Threads" Binding="{Binding MaxReservedThreads}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Min Used Threads" Binding="{Binding MinUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Max Used Threads" Binding="{Binding MaxUsedThreads}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
 
                 <!-- Spills -->
-                <DataGridTextColumn Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- CLR Time -->
-                <DataGridTextColumn Binding="{Binding TotalClrTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalClrTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Total CLR Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total CLR Time" Binding="{Binding TotalClrTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
 
                 <!-- Sample Interval -->
-                <DataGridTextColumn Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SampleIntervalSeconds" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Interval (sec)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
 
                 <!-- Query Identifiers -->
-                <DataGridTextColumn Binding="{Binding SqlHandle}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlHandle" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="SQL Handle" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PlanHandle}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanHandle" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Plan Handle" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding QueryHash}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryHash" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Query Hash" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding QueryPlanHash}" Width="160">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="QueryPlanHash" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Query Plan Hash" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="SQL Handle" Binding="{Binding SqlHandle}" Width="160"/>
+                <DataGridTextColumn Header="Plan Handle" Binding="{Binding PlanHandle}" Width="160"/>
+                <DataGridTextColumn Header="Query Hash" Binding="{Binding QueryHash}" Width="160"/>
+                <DataGridTextColumn Header="Query Plan Hash" Binding="{Binding QueryPlanHash}" Width="160"/>
 
                 <!-- Download Plan Button -->
                 <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">

--- a/Dashboard/QueryStatsHistoryWindow.xaml.cs
+++ b/Dashboard/QueryStatsHistoryWindow.xaml.cs
@@ -40,8 +40,7 @@ namespace PerformanceMonitorDashboard
         private ChartHoverHelper? _chartHover;
 
         // Filter state
-        private Dictionary<string, ColumnFilterState> _filters = new();
-        private List<QueryStatsHistoryItem>? _unfilteredData;
+        private readonly DataGridFilterManager<QueryStatsHistoryItem> _filterManager;
         private Popup? _filterPopup;
         private ColumnFilterPopup? _filterPopupContent;
 
@@ -70,6 +69,10 @@ namespace PerformanceMonitorDashboard
                 (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
                     _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
                 "the monitored server");
+
+            _filterManager = new DataGridFilterManager<QueryStatsHistoryItem>(HistoryDataGrid);
+            DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+            _filterManager.UpdateFilterButtonStyles();
 
             QueryIdentifierText.Text = $"Query Stats History: {queryHash} in [{databaseName}]";
 
@@ -140,10 +143,7 @@ namespace PerformanceMonitorDashboard
                     }
                 }
 
-                _unfilteredData = _historyData;
-                _filters.Clear();
-                HistoryDataGrid.ItemsSource = _historyData;
-                UpdateFilterButtonStyles();
+                _filterManager.UpdateData(_historyData);
 
                 if (_historyData.Count > 0)
                 {
@@ -308,7 +308,7 @@ namespace PerformanceMonitorDashboard
                 };
             }
 
-            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
             _filterPopupContent!.Initialize(columnName, existingFilter);
 
             _filterPopup.PlacementTarget = button;
@@ -318,68 +318,12 @@ namespace PerformanceMonitorDashboard
         private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-
-            if (e.FilterState.IsActive)
-                _filters[e.FilterState.ColumnName] = e.FilterState;
-            else
-                _filters.Remove(e.FilterState.ColumnName);
-
-            ApplyFilters();
-            UpdateFilterButtonStyles();
+            _filterManager.SetFilter(e.FilterState);
         }
 
         private void FilterPopup_FilterCleared(object? sender, EventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-        }
-
-        private void ApplyFilters()
-        {
-            if (_unfilteredData == null) return;
-
-            if (_filters.Count == 0)
-            {
-                HistoryDataGrid.ItemsSource = _unfilteredData;
-                return;
-            }
-
-            var filtered = _unfilteredData.Where(item =>
-            {
-                foreach (var filter in _filters.Values)
-                {
-                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
-                        return false;
-                }
-                return true;
-            }).ToList();
-
-            HistoryDataGrid.ItemsSource = filtered;
-        }
-
-        private void UpdateFilterButtonStyles()
-        {
-            foreach (var column in HistoryDataGrid.Columns)
-            {
-                if (column.Header is StackPanel stackPanel)
-                {
-                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
-                    if (filterButton?.Tag is string columnName)
-                    {
-                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
-                        filterButton.Content = new System.Windows.Controls.TextBlock
-                        {
-                            Text = "\uE71C",
-                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
-                            Foreground = hasActive
-                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
-                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
-                        };
-                        filterButton.ToolTip = hasActive && filter != null
-                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
-                            : "Click to filter";
-                    }
-                }
-            }
         }
 
         #endregion

--- a/Dashboard/TracePatternHistoryWindow.xaml
+++ b/Dashboard/TracePatternHistoryWindow.xaml
@@ -83,134 +83,22 @@
                   ContextMenu="{DynamicResource DataGridContextMenu}"
                   Margin="10">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding EndTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EndTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="End Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Collection Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding StartTime, Converter={StaticResource ServerTimeConverter}}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Start Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding EventName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Event" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding CpuMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CpuMs" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding RowCounts, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowCounts" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Row Counts" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding NtUserName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NtUserName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="NT User" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ApplicationName}" Width="150">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ApplicationName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Application" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding HostName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Spid}" ElementStyle="{StaticResource NumericCell}" Width="60">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Spid" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ObjectId}" ElementStyle="{StaticResource NumericCell}" Width="90">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectId" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Object ID" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="End Time" Binding="{Binding EndTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Start Time" Binding="{Binding StartTime, Converter={StaticResource ServerTimeConverter}}" Width="150"/>
+                <DataGridTextColumn Header="Event" Binding="{Binding EventName}" Width="120"/>
+                <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="120"/>
+                <DataGridTextColumn Header="Duration (ms)" Binding="{Binding DurationMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="CPU (ms)" Binding="{Binding CpuMs, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Reads (pages)" Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Writes (pages)" Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Row Counts" Binding="{Binding RowCounts, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Login" Binding="{Binding LoginName}" Width="120"/>
+                <DataGridTextColumn Header="NT User" Binding="{Binding NtUserName}" Width="120"/>
+                <DataGridTextColumn Header="Application" Binding="{Binding ApplicationName}" Width="150"/>
+                <DataGridTextColumn Header="Host" Binding="{Binding HostName}" Width="120"/>
+                <DataGridTextColumn Header="SPID" Binding="{Binding Spid}" ElementStyle="{StaticResource NumericCell}" Width="60"/>
+                <DataGridTextColumn Header="Object ID" Binding="{Binding ObjectId}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
                 <DataGridTemplateColumn Width="*" MinWidth="300">
                     <DataGridTemplateColumn.Header>
                         <StackPanel Orientation="Horizontal">

--- a/Dashboard/TracePatternHistoryWindow.xaml.cs
+++ b/Dashboard/TracePatternHistoryWindow.xaml.cs
@@ -39,8 +39,7 @@ namespace PerformanceMonitorDashboard
         private ChartHoverHelper? _chartHover;
 
         // Filter state
-        private Dictionary<string, ColumnFilterState> _filters = new();
-        private List<TracePatternDetailItem>? _unfilteredData;
+        private readonly DataGridFilterManager<TracePatternDetailItem> _filterManager;
         private Popup? _filterPopup;
         private ColumnFilterPopup? _filterPopupContent;
 
@@ -73,6 +72,10 @@ namespace PerformanceMonitorDashboard
             if (displayPattern.Length > 120)
                 displayPattern = displayPattern.Substring(0, 120) + "...";
             QueryIdentifierText.Text = $"Trace Pattern History: [{databaseName}] — {displayPattern}";
+
+            _filterManager = new DataGridFilterManager<TracePatternDetailItem>(HistoryDataGrid);
+            DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+            _filterManager.UpdateFilterButtonStyles();
 
             ApplyThemeToChart();
             Loaded += TracePatternHistoryWindow_Loaded;
@@ -114,10 +117,7 @@ namespace PerformanceMonitorDashboard
             {
                 _historyData = await _databaseService.GetTracePatternHistoryAsync(_databaseName, _queryPattern, _hoursBack, _fromDate, _toDate);
 
-                _unfilteredData = _historyData;
-                _filters.Clear();
-                HistoryDataGrid.ItemsSource = _historyData;
-                UpdateFilterButtonStyles();
+                _filterManager.UpdateData(_historyData);
 
                 if (_historyData.Count > 0)
                 {
@@ -238,7 +238,7 @@ namespace PerformanceMonitorDashboard
                 };
             }
 
-            _filters.TryGetValue(columnName, out var existingFilter);
+            _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
             _filterPopupContent!.Initialize(columnName, existingFilter);
 
             _filterPopup.PlacementTarget = button;
@@ -248,68 +248,12 @@ namespace PerformanceMonitorDashboard
         private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-
-            if (e.FilterState.IsActive)
-                _filters[e.FilterState.ColumnName] = e.FilterState;
-            else
-                _filters.Remove(e.FilterState.ColumnName);
-
-            ApplyFilters();
-            UpdateFilterButtonStyles();
+            _filterManager.SetFilter(e.FilterState);
         }
 
         private void FilterPopup_FilterCleared(object? sender, EventArgs e)
         {
             if (_filterPopup != null) _filterPopup.IsOpen = false;
-        }
-
-        private void ApplyFilters()
-        {
-            if (_unfilteredData == null) return;
-
-            if (_filters.Count == 0)
-            {
-                HistoryDataGrid.ItemsSource = _unfilteredData;
-                return;
-            }
-
-            var filtered = _unfilteredData.Where(item =>
-            {
-                foreach (var filter in _filters.Values)
-                {
-                    if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
-                        return false;
-                }
-                return true;
-            }).ToList();
-
-            HistoryDataGrid.ItemsSource = filtered;
-        }
-
-        private void UpdateFilterButtonStyles()
-        {
-            foreach (var column in HistoryDataGrid.Columns)
-            {
-                if (column.Header is StackPanel stackPanel)
-                {
-                    var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
-                    if (filterButton?.Tag is string columnName)
-                    {
-                        bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
-                        filterButton.Content = new System.Windows.Controls.TextBlock
-                        {
-                            Text = "\uE71C",
-                            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
-                            Foreground = hasActive
-                                ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
-                                : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
-                        };
-                        filterButton.ToolTip = hasActive && filter != null
-                            ? $"Filter: {filter.DisplayText}\n(Click to modify)"
-                            : "Click to filter";
-                    }
-                }
-            }
         }
 
         #endregion

--- a/Dashboard/WaitDrillDownWindow.xaml
+++ b/Dashboard/WaitDrillDownWindow.xaml
@@ -71,246 +71,36 @@
                   RowStyle="{DynamicResource DefaultRowStyle}"
                   ContextMenu="{StaticResource DataGridContextMenu}">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding CollectionTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Collected" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="60">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionId" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="SPID" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Duration}" Width="100" SortMemberPath="DurationSort">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Duration" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Duration" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Status}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding WaitInfo}" Width="180">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="WaitInfo" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Wait Info" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockingSessionId" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding BlockedSessionCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="BlockedSessionCount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Blocked" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Cpu}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Cpu" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Reads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Reads (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Writes" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Writes (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PhysicalReads}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PhysicalReads" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PhysicalIo, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PhysicalIo" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Physical I/O" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ContextSwitches}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ContextSwitches" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Ctx Switches" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding Tasks, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Tasks" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Tasks" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="UsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding RequestedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Req Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding GrantedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Granted Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding MaxUsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Max Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbCurrentMb" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="tempdb Cur (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocations" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="tempdb Alloc" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="TranLogWritesSort">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogWrites" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Tran Log" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding OpenTranCount}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OpenTranCount" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Open Tran" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding PercentComplete, StringFormat='{}{0:N1}%'}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PercentComplete" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="% Complete" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding StartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="StartTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Start Time" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding TranStartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranStartTime" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Tran Start" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestId" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Req ID" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding DatabaseName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding LoginName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LoginName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Login" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding HostName}" Width="120">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HostName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Host" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
-                <DataGridTextColumn Binding="{Binding ProgramName}" Width="140">
-                    <DataGridTextColumn.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ProgramName" Click="Filter_Click" Margin="0,0,4,0"/>
-                            <TextBlock Text="Program" FontWeight="Bold" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </DataGridTextColumn.Header>
-                </DataGridTextColumn>
+                <DataGridTextColumn Header="Collected" Binding="{Binding CollectionTime, StringFormat='MM/dd HH:mm:ss'}" Width="140"/>
+                <DataGridTextColumn Header="SPID" Binding="{Binding SessionId}" ElementStyle="{StaticResource NumericCell}" Width="60"/>
+                <DataGridTextColumn Header="Duration" Binding="{Binding Duration}" Width="100" SortMemberPath="DurationSort"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="80"/>
+                <DataGridTextColumn Header="Wait Info" Binding="{Binding WaitInfo}" Width="180"/>
+                <DataGridTextColumn Header="Blocking" Binding="{Binding BlockingSessionId}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Blocked" Binding="{Binding BlockedSessionCount}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="CPU (ms)" Binding="{Binding Cpu}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Reads (pages)" Binding="{Binding Reads, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Writes (pages)" Binding="{Binding Writes, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Physical Reads" Binding="{Binding PhysicalReads}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Physical I/O" Binding="{Binding PhysicalIo, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Ctx Switches" Binding="{Binding ContextSwitches}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Tasks" Binding="{Binding Tasks, StringFormat='{}{0:N0}'}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Used Mem (MB)" Binding="{Binding UsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Req Mem (MB)" Binding="{Binding RequestedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Granted Mem (MB)" Binding="{Binding GrantedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Used Mem (MB)" Binding="{Binding MaxUsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="tempdb Cur (MB)" Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="tempdb Alloc" Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Tran Log" Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="TranLogWritesSort"/>
+                <DataGridTextColumn Header="Open Tran" Binding="{Binding OpenTranCount}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="% Complete" Binding="{Binding PercentComplete, StringFormat='{}{0:N1}%'}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Start Time" Binding="{Binding StartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140"/>
+                <DataGridTextColumn Header="Tran Start" Binding="{Binding TranStartTime, StringFormat='MM/dd HH:mm:ss'}" Width="140"/>
+                <DataGridTextColumn Header="Req ID" Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Database" Binding="{Binding DatabaseName}" Width="120"/>
+                <DataGridTextColumn Header="Login" Binding="{Binding LoginName}" Width="120"/>
+                <DataGridTextColumn Header="Host" Binding="{Binding HostName}" Width="120"/>
+                <DataGridTextColumn Header="Program" Binding="{Binding ProgramName}" Width="140"/>
                 <DataGridTemplateColumn Width="500">
                     <DataGridTemplateColumn.Header>
                         <StackPanel Orientation="Horizontal">

--- a/Dashboard/WaitDrillDownWindow.xaml.cs
+++ b/Dashboard/WaitDrillDownWindow.xaml.cs
@@ -33,8 +33,7 @@ public partial class WaitDrillDownWindow : Window
     private readonly DateTime? _toDate;
 
     // Filter state
-    private Dictionary<string, ColumnFilterState> _filters = new();
-    private List<QuerySnapshotItem>? _unfilteredData;
+    private readonly DataGridFilterManager<QuerySnapshotItem> _filterManager;
     private Popup? _filterPopup;
     private ColumnFilterPopup? _filterPopupContent;
     private readonly PlanNavigationController _planActions;
@@ -59,6 +58,10 @@ public partial class WaitDrillDownWindow : Window
             (db, qt, est, iso, ct) => ActualPlanExecutor.ExecuteForActualPlanAsync(
                 _databaseService.ConnectionString, db, qt, est, iso, isAzureSqlDb: false, timeoutSeconds: 0, ct),
             "the monitored server");
+
+        _filterManager = new DataGridFilterManager<QuerySnapshotItem>(ResultsDataGrid);
+        DataGridFilterColumns.AddFilterButtons(ResultsDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
 
         Title = $"Wait Drill-Down: {waitType}";
 
@@ -119,10 +122,7 @@ public partial class WaitDrillDownWindow : Window
     private void LoadDirectData(List<QuerySnapshotItem> data, WaitClassification classification)
     {
         data = SortByProperty(data, classification.SortProperty);
-        _unfilteredData = data;
-        _filters.Clear();
-        ResultsDataGrid.ItemsSource = data;
-        UpdateFilterButtonStyles();
+        _filterManager.UpdateData(data);
 
         var timeRange = GetTimeRangeDescription(data);
         var truncated = data.Count >= 500 ? " (limited to 500 rows)" : "";
@@ -143,10 +143,7 @@ public partial class WaitDrillDownWindow : Window
         if (headBlockerInfos.Count == 0)
         {
             // No chain found — fall back to showing direct data
-            _unfilteredData = data;
-            _filters.Clear();
-            ResultsDataGrid.ItemsSource = data;
-            UpdateFilterButtonStyles();
+            _filterManager.UpdateData(data);
             var timeRange = GetTimeRangeDescription(data);
             SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange} | No blocking chains found, showing waiters";
             return;
@@ -172,10 +169,7 @@ public partial class WaitDrillDownWindow : Window
         if (headBlockerRows.Count == 0)
         {
             // Head blockers not in data — show original data
-            _unfilteredData = data;
-            _filters.Clear();
-            ResultsDataGrid.ItemsSource = data;
-            UpdateFilterButtonStyles();
+            _filterManager.UpdateData(data);
             var timeRange = GetTimeRangeDescription(data);
             SummaryText.Text = $"{data.Count} snapshot(s) | {classification.Description} | {timeRange} | Head blockers not in snapshots, showing waiters";
             return;
@@ -183,11 +177,10 @@ public partial class WaitDrillDownWindow : Window
 
         // Insert chain-specific columns into the existing XAML columns
         InsertChainColumns();
+        // The inserted column's filter button gets its glyph from UpdateFilterButtonStyles
+        _filterManager.UpdateFilterButtonStyles();
 
-        _unfilteredData = headBlockerRows;
-        _filters.Clear();
-        ResultsDataGrid.ItemsSource = headBlockerRows;
-        UpdateFilterButtonStyles();
+        _filterManager.UpdateData(headBlockerRows);
 
         var timeRangeDesc = GetTimeRangeDescription(headBlockerRows);
         SummaryText.Text = $"{headBlockerRows.Count} head blocker(s) from {data.Count} waiting session(s) | " +
@@ -335,7 +328,7 @@ public partial class WaitDrillDownWindow : Window
 
     private void OnThemeChanged(string _)
     {
-        UpdateFilterButtonStyles();
+        _filterManager.UpdateFilterButtonStyles();
     }
 
     #region Column Filter Popup
@@ -359,7 +352,7 @@ public partial class WaitDrillDownWindow : Window
             };
         }
 
-        _filters.TryGetValue(columnName, out var existingFilter);
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
         _filterPopupContent!.Initialize(columnName, existingFilter);
 
         _filterPopup.PlacementTarget = button;
@@ -369,68 +362,12 @@ public partial class WaitDrillDownWindow : Window
     private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
     {
         if (_filterPopup != null) _filterPopup.IsOpen = false;
-
-        if (e.FilterState.IsActive)
-            _filters[e.FilterState.ColumnName] = e.FilterState;
-        else
-            _filters.Remove(e.FilterState.ColumnName);
-
-        ApplyFilters();
-        UpdateFilterButtonStyles();
+        _filterManager.SetFilter(e.FilterState);
     }
 
     private void FilterPopup_FilterCleared(object? sender, EventArgs e)
     {
         if (_filterPopup != null) _filterPopup.IsOpen = false;
-    }
-
-    private void ApplyFilters()
-    {
-        if (_unfilteredData == null) return;
-
-        if (_filters.Count == 0)
-        {
-            ResultsDataGrid.ItemsSource = _unfilteredData;
-            return;
-        }
-
-        var filtered = _unfilteredData.Where(item =>
-        {
-            foreach (var filter in _filters.Values)
-            {
-                if (filter.IsActive && !DataGridFilterService.MatchesFilter(item, filter))
-                    return false;
-            }
-            return true;
-        }).ToList();
-
-        ResultsDataGrid.ItemsSource = filtered;
-    }
-
-    private void UpdateFilterButtonStyles()
-    {
-        foreach (var column in ResultsDataGrid.Columns)
-        {
-            if (column.Header is StackPanel stackPanel)
-            {
-                var filterButton = stackPanel.Children.OfType<Button>().FirstOrDefault();
-                if (filterButton?.Tag is string columnName)
-                {
-                    bool hasActive = _filters.TryGetValue(columnName, out var filter) && filter.IsActive;
-                    filterButton.Content = new System.Windows.Controls.TextBlock
-                    {
-                        Text = "\uE71C",
-                        FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
-                        Foreground = hasActive
-                            ? new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xD7, 0x00))
-                            : new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0xFF, 0xFF))
-                    };
-                    filterButton.ToolTip = hasActive && filter != null
-                        ? $"Filter: {filter.DisplayText}\n(Click to modify)"
-                        : "Click to filter";
-                }
-            }
-        }
     }
 
     #endregion


### PR DESCRIPTION
DRY cleanup Erik greenlit: the five Dashboard drilldown windows each hand-rolled the same column-filter machinery — ~7 lines of StackPanel+Button header XAML **per column** (186 columns) plus ~95 duplicated lines of `_filters`/`ApplyFilters`/`UpdateFilterButtonStyles` per window. Lite already does the same thing through the shared `DataGridFilterManager<T>` + runtime `DataGridFilterColumns.AddFilterButtons` (from #1283).

## What changed
- All five windows (`QueryStatsHistoryWindow`, `ProcedureHistoryWindow`, `QueryExecutionHistoryWindow`, `WaitDrillDownWindow`, `TracePatternHistoryWindow`) now use the shared manager; XAML columns collapse to plain one-line `Header="..."` definitions with filter buttons decorated at runtime from the binding path.
- **Behavior-identical by construction**: the transformer verified every old filter `Tag` equals its column's binding path (zero mismatches), and Dashboard's `DataGridFilterService.MatchesFilter` was already a forwarder to the same shared `ColumnFilterMatcher` the manager calls.
- Template columns with filterable text (Wait: QueryText/SqlCommand/AdditionalInfo, Trace: SqlText) keep their hand-built headers — no `Binding` to derive a tag from, and collapsing them would have *lost* their filters.
- WaitDrillDown's runtime chain column restyles through the manager after insertion; active-filter icons now re-theme (gold/dim) like Lite's.

**Net −1,596 lines.** This also makes the upcoming drilldown column-parity fixes trivial — new columns are one-line additions.

## Verification
Dashboard builds clean; **Dashboard.Tests 732/732**. Lite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)