### PR TITLE
Lite snapshot collector: memory-grant, tempdb, and transaction triage columns

### DIFF
--- a/Dashboard/Controls/QueryPerformanceContent.xaml
+++ b/Dashboard/Controls/QueryPerformanceContent.xaml
@@ -247,7 +247,7 @@
                         <DataGridTextColumn.Header>
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocations" Click="ActiveQueriesFilter_Click" Margin="0,0,4,0"/>
-                                <TextBlock Text="tempdb Alloc (pages)" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <TextBlock Text="tempdb Alloc (MB)" FontWeight="Bold" VerticalAlignment="Center"/>
                             </StackPanel>
                         </DataGridTextColumn.Header>
                     </DataGridTextColumn>

--- a/Dashboard/Services/DatabaseService.QueryPerformance.Snapshots.cs
+++ b/Dashboard/Services/DatabaseService.QueryPerformance.Snapshots.cs
@@ -176,8 +176,9 @@ namespace PerformanceMonitorDashboard.Services
                             PhysicalReads = SafeToInt64(reader.GetValue(16), "physical_reads"),
                             ContextSwitches = SafeToInt64(reader.GetValue(17), "context_switches"),
                             UsedMemoryMb = SafeToDecimal(reader.GetValue(18), "used_memory") / 128m,
-                            TempdbCurrentMb = SafeToDecimal(reader.GetValue(19), "tempdb_current"),
-                            TempdbAllocations = SafeToDecimal(reader.GetValue(20), "tempdb_allocations"),
+                            /* sp_WhoIsActive tempdb counters are 8KB-page counts — /128 to MB (same fix as the memory columns, #1274) */
+                            TempdbCurrentMb = SafeToDecimal(reader.GetValue(19), "tempdb_current") / 128m,
+                            TempdbAllocations = SafeToDecimal(reader.GetValue(20), "tempdb_allocations") / 128m,
                             TranLogWrites = reader.IsDBNull(21) ? null : reader.GetValue(21)?.ToString(),
                             OpenTranCount = SafeToInt16(reader.GetValue(22), "open_tran_count"),
                             PercentComplete = SafeToDecimal(reader.GetValue(23), "percent_complete"),
@@ -382,8 +383,9 @@ namespace PerformanceMonitorDashboard.Services
                             PhysicalReads = SafeToInt64(reader.GetValue(16), "physical_reads"),
                             ContextSwitches = SafeToInt64(reader.GetValue(17), "context_switches"),
                             UsedMemoryMb = SafeToDecimal(reader.GetValue(18), "used_memory") / 128m,
-                            TempdbCurrentMb = SafeToDecimal(reader.GetValue(19), "tempdb_current"),
-                            TempdbAllocations = SafeToDecimal(reader.GetValue(20), "tempdb_allocations"),
+                            /* sp_WhoIsActive tempdb counters are 8KB-page counts — /128 to MB (same fix as the memory columns, #1274) */
+                            TempdbCurrentMb = SafeToDecimal(reader.GetValue(19), "tempdb_current") / 128m,
+                            TempdbAllocations = SafeToDecimal(reader.GetValue(20), "tempdb_allocations") / 128m,
                             TranLogWrites = reader.IsDBNull(21) ? null : reader.GetValue(21)?.ToString(),
                             OpenTranCount = SafeToInt16(reader.GetValue(22), "open_tran_count"),
                             PercentComplete = SafeToDecimal(reader.GetValue(23), "percent_complete"),

--- a/Dashboard/WaitDrillDownWindow.xaml
+++ b/Dashboard/WaitDrillDownWindow.xaml
@@ -90,7 +90,7 @@
                 <DataGridTextColumn Header="Granted Mem (MB)" Binding="{Binding GrantedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
                 <DataGridTextColumn Header="Max Used Mem (MB)" Binding="{Binding MaxUsedMemoryMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
                 <DataGridTextColumn Header="tempdb Cur (MB)" Binding="{Binding TempdbCurrentMb, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
-                <DataGridTextColumn Header="tempdb Alloc" Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="tempdb Alloc (MB)" Binding="{Binding TempdbAllocations, StringFormat='{}{0:N2}'}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
                 <DataGridTextColumn Header="Tran Log" Binding="{Binding TranLogWrites}" ElementStyle="{StaticResource NumericCell}" Width="100" SortMemberPath="TranLogWritesSort"/>
                 <DataGridTextColumn Header="Open Tran" Binding="{Binding OpenTranCount}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
                 <DataGridTextColumn Header="Isolation" Binding="{Binding IsolationLevel}" Width="110"/>

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 33;
+    internal const int CurrentSchemaVersion = 34;
 
     private readonly string _archivePath;
 
@@ -839,6 +839,32 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v33 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 34)
+        {
+            /* v34: query_snapshots gains the wait-drilldown triage columns Dashboard collects via
+               sp_WhoIsActive — memory-grant requested/used/max-used (MB), tempdb current/allocations
+               (MB), transaction log used (MB) + transaction start time, and request_id. All appended
+               at the end to keep the positional appender aligned; the v_ view (SELECT *) surfaces
+               them and old parquet reads back NULL (union BY NAME). The snapshot collector writes
+               these columns, so an un-migrated DB would mis-align — these ALTERs are required. */
+            _logger?.LogInformation("Running migration to v34: query_snapshots memory-grant/tempdb/transaction columns");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS requested_memory_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS used_memory_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS max_used_memory_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS tempdb_current_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS tempdb_allocations_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS tran_log_used_mb DOUBLE");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS tran_start_time TIMESTAMP");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE query_snapshots ADD COLUMN IF NOT EXISTS request_id INTEGER");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v34 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -351,7 +351,15 @@ CREATE TABLE IF NOT EXISTS query_snapshots (
     open_transaction_count INTEGER,
     percent_complete DECIMAL(5,2),
     is_cdc_capture BOOLEAN DEFAULT false,
-    query_hash VARCHAR
+    query_hash VARCHAR,
+    requested_memory_mb DOUBLE,
+    used_memory_mb DOUBLE,
+    max_used_memory_mb DOUBLE,
+    tempdb_current_mb DOUBLE,
+    tempdb_allocations_mb DOUBLE,
+    tran_log_used_mb DOUBLE,
+    tran_start_time TIMESTAMP,
+    request_id INTEGER
 )";
 
     public const string CreateTempdbStatsTable = @"

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -1087,6 +1087,18 @@ public class QuerySnapshotRow
     // snapshot queries; Chain mode overwrites it with the chain walker's transitive count)
     public int BlockedSessionCount { get; set; }
 
+    // Wait-drilldown triage columns collected from dm_exec_query_memory_grants,
+    // session/task tempdb space usage, and dm_tran_* (schema v34)
+    public double RequestedMemoryMb { get; set; }
+    public double UsedMemoryMb { get; set; }
+    public double MaxUsedMemoryMb { get; set; }
+    public double TempdbCurrentMb { get; set; }
+    public double TempdbAllocationsMb { get; set; }
+    public double TranLogUsedMb { get; set; }
+    public DateTime? TranStartTime { get; set; }
+    public int RequestId { get; set; }
+    public string TranStartTimeLocal => ServerTimeHelper.FormatServerTime(TranStartTime);
+
     // Chain mode — set by WaitDrillDownWindow when showing head blockers
     public string ChainBlockingPath { get; set; } = "";
 }

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -374,7 +374,15 @@ SELECT
     q.open_transaction_count,
     q.percent_complete,
     q.query_hash,
-    COALESCE(bc.blocked_session_count, 0) AS blocked_session_count
+    COALESCE(bc.blocked_session_count, 0) AS blocked_session_count,
+    q.requested_memory_mb,
+    q.used_memory_mb,
+    q.max_used_memory_mb,
+    q.tempdb_current_mb,
+    q.tempdb_allocations_mb,
+    q.tran_log_used_mb,
+    q.tran_start_time,
+    q.request_id
 FROM v_query_snapshots q
 LEFT JOIN blocked_counts bc
   ON  bc.collection_time = q.collection_time
@@ -424,7 +432,15 @@ LIMIT 500";
                 OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
                 PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25)),
                 QueryHash = reader.IsDBNull(26) ? "" : reader.GetString(26),
-                BlockedSessionCount = reader.IsDBNull(27) ? 0 : Convert.ToInt32(reader.GetValue(27))
+                BlockedSessionCount = reader.IsDBNull(27) ? 0 : Convert.ToInt32(reader.GetValue(27)),
+                RequestedMemoryMb = reader.IsDBNull(28) ? 0 : ToDouble(reader.GetValue(28)),
+                UsedMemoryMb = reader.IsDBNull(29) ? 0 : ToDouble(reader.GetValue(29)),
+                MaxUsedMemoryMb = reader.IsDBNull(30) ? 0 : ToDouble(reader.GetValue(30)),
+                TempdbCurrentMb = reader.IsDBNull(31) ? 0 : ToDouble(reader.GetValue(31)),
+                TempdbAllocationsMb = reader.IsDBNull(32) ? 0 : ToDouble(reader.GetValue(32)),
+                TranLogUsedMb = reader.IsDBNull(33) ? 0 : ToDouble(reader.GetValue(33)),
+                TranStartTime = reader.IsDBNull(34) ? (DateTime?)null : reader.GetDateTime(34),
+                RequestId = reader.IsDBNull(35) ? 0 : reader.GetInt32(35)
             });
         }
 
@@ -482,7 +498,15 @@ SELECT
     q.open_transaction_count,
     q.percent_complete,
     q.query_hash,
-    COALESCE(bc.blocked_session_count, 0) AS blocked_session_count
+    COALESCE(bc.blocked_session_count, 0) AS blocked_session_count,
+    q.requested_memory_mb,
+    q.used_memory_mb,
+    q.max_used_memory_mb,
+    q.tempdb_current_mb,
+    q.tempdb_allocations_mb,
+    q.tran_log_used_mb,
+    q.tran_start_time,
+    q.request_id
 FROM v_query_snapshots q
 LEFT JOIN blocked_counts bc
   ON  bc.collection_time = q.collection_time
@@ -530,7 +554,15 @@ LIMIT 2000";
                 OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
                 PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25)),
                 QueryHash = reader.IsDBNull(26) ? "" : reader.GetString(26),
-                BlockedSessionCount = reader.IsDBNull(27) ? 0 : Convert.ToInt32(reader.GetValue(27))
+                BlockedSessionCount = reader.IsDBNull(27) ? 0 : Convert.ToInt32(reader.GetValue(27)),
+                RequestedMemoryMb = reader.IsDBNull(28) ? 0 : ToDouble(reader.GetValue(28)),
+                UsedMemoryMb = reader.IsDBNull(29) ? 0 : ToDouble(reader.GetValue(29)),
+                MaxUsedMemoryMb = reader.IsDBNull(30) ? 0 : ToDouble(reader.GetValue(30)),
+                TempdbCurrentMb = reader.IsDBNull(31) ? 0 : ToDouble(reader.GetValue(31)),
+                TempdbAllocationsMb = reader.IsDBNull(32) ? 0 : ToDouble(reader.GetValue(32)),
+                TranLogUsedMb = reader.IsDBNull(33) ? 0 : ToDouble(reader.GetValue(33)),
+                TranStartTime = reader.IsDBNull(34) ? (DateTime?)null : reader.GetDateTime(34),
+                RequestId = reader.IsDBNull(35) ? 0 : reader.GetInt32(35)
             });
         }
 

--- a/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
+++ b/Lite/Services/RemoteCollectorService.QuerySnapshots.cs
@@ -94,7 +94,15 @@ SELECT /* PerformanceMonitorLite */
                 THEN 1
                 ELSE 0
             END),
-    query_hash = CONVERT(varchar(18), der.query_hash, 1) /* #1140 long-running-query dedup key */
+    query_hash = CONVERT(varchar(18), der.query_hash, 1), /* #1140 long-running-query dedup key */
+    requested_memory_mb = CONVERT(decimal(38, 2), deqmg.requested_memory_kb / 1024.),
+    used_memory_mb = CONVERT(decimal(38, 2), deqmg.used_memory_kb / 1024.),
+    max_used_memory_mb = CONVERT(decimal(38, 2), deqmg.max_used_memory_kb / 1024.),
+    tempdb_current_mb = tsu.tempdb_current_mb,
+    tempdb_allocations_mb = tsu.tempdb_allocations_mb,
+    tran_log_used_mb = trn.tran_log_used_mb,
+    tran_start_time = trn.tran_start_time,
+    der.request_id
 FROM sys.dm_exec_requests AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -102,6 +110,50 @@ OUTER APPLY sys.dm_exec_sql_text(COALESCE(der.sql_handle, der.plan_handle)) AS d
 OUTER APPLY sys.dm_exec_text_query_plan(der.plan_handle, der.statement_start_offset, der.statement_end_offset) AS deqp
 LEFT JOIN sys.databases AS d
   ON d.database_id = der.database_id
+LEFT JOIN sys.dm_exec_query_memory_grants AS deqmg
+  ON  deqmg.session_id = der.session_id
+  AND deqmg.request_id = der.request_id
+OUTER APPLY
+(
+    SELECT
+        tempdb_current_mb =
+            CONVERT(decimal(38, 2),
+                CASE
+                    WHEN SUM(x.alloc) - SUM(x.dealloc) < 0
+                    THEN 0.
+                    ELSE (SUM(x.alloc) - SUM(x.dealloc)) * 8. / 1024.
+                END),
+        tempdb_allocations_mb = CONVERT(decimal(38, 2), SUM(x.alloc) * 8. / 1024.)
+    FROM
+    (
+        SELECT
+            alloc = dssu.user_objects_alloc_page_count + dssu.internal_objects_alloc_page_count,
+            dealloc = dssu.user_objects_dealloc_page_count + dssu.internal_objects_dealloc_page_count
+        FROM sys.dm_db_session_space_usage AS dssu
+        WHERE dssu.session_id = der.session_id
+
+        UNION ALL
+
+        SELECT
+            dtsu.user_objects_alloc_page_count + dtsu.internal_objects_alloc_page_count,
+            dtsu.user_objects_dealloc_page_count + dtsu.internal_objects_dealloc_page_count
+        FROM sys.dm_db_task_space_usage AS dtsu
+        WHERE dtsu.session_id = der.session_id
+        AND   dtsu.request_id = der.request_id
+    ) AS x
+) AS tsu
+OUTER APPLY
+(
+    SELECT
+        tran_log_used_mb = CONVERT(decimal(38, 2), SUM(ddt.database_transaction_log_bytes_used) / 1048576.),
+        tran_start_time = MIN(dat.transaction_begin_time)
+    FROM sys.dm_tran_session_transactions AS dst
+    JOIN sys.dm_tran_active_transactions AS dat
+      ON dat.transaction_id = dst.transaction_id
+    LEFT JOIN sys.dm_tran_database_transactions AS ddt
+      ON ddt.transaction_id = dst.transaction_id
+    WHERE dst.session_id = der.session_id
+) AS trn
 {1}
 WHERE der.session_id <> @@SPID
 AND   der.session_id >= 50
@@ -150,7 +202,8 @@ SELECT
     der.dop,
     der.parallel_worker_count,
     der.percent_complete,
-    der.query_hash
+    der.query_hash,
+    der.request_id
 INTO #req
 FROM sys.dm_exec_requests AS der
 WHERE der.session_id <> @@SPID
@@ -204,7 +257,15 @@ SELECT /* PerformanceMonitorLite */
     der.percent_complete,
     /* Azure SQL Database has no SQL Agent / msdb.dbo.cdc_jobs (CDC there is scheduler-based), so no capture job to exclude. */
     is_cdc_capture = CONVERT(bit, 0),
-    query_hash = CONVERT(varchar(18), der.query_hash, 1) /* #1140 long-running-query dedup key */
+    query_hash = CONVERT(varchar(18), der.query_hash, 1), /* #1140 long-running-query dedup key */
+    requested_memory_mb = CONVERT(decimal(38, 2), deqmg.requested_memory_kb / 1024.),
+    used_memory_mb = CONVERT(decimal(38, 2), deqmg.used_memory_kb / 1024.),
+    max_used_memory_mb = CONVERT(decimal(38, 2), deqmg.max_used_memory_kb / 1024.),
+    tempdb_current_mb = tsu.tempdb_current_mb,
+    tempdb_allocations_mb = tsu.tempdb_allocations_mb,
+    tran_log_used_mb = trn.tran_log_used_mb,
+    tran_start_time = trn.tran_start_time,
+    der.request_id
 FROM #req AS der
 JOIN sys.dm_exec_sessions AS des
     ON des.session_id = der.session_id
@@ -212,6 +273,50 @@ OUTER APPLY sys.dm_exec_sql_text(COALESCE(der.sql_handle, der.plan_handle)) AS d
 OUTER APPLY sys.dm_exec_text_query_plan(der.plan_handle, der.statement_start_offset, der.statement_end_offset) AS deqp
 LEFT JOIN sys.databases AS d
   ON d.database_id = der.database_id
+LEFT JOIN sys.dm_exec_query_memory_grants AS deqmg
+  ON  deqmg.session_id = der.session_id
+  AND deqmg.request_id = der.request_id
+OUTER APPLY
+(
+    SELECT
+        tempdb_current_mb =
+            CONVERT(decimal(38, 2),
+                CASE
+                    WHEN SUM(x.alloc) - SUM(x.dealloc) < 0
+                    THEN 0.
+                    ELSE (SUM(x.alloc) - SUM(x.dealloc)) * 8. / 1024.
+                END),
+        tempdb_allocations_mb = CONVERT(decimal(38, 2), SUM(x.alloc) * 8. / 1024.)
+    FROM
+    (
+        SELECT
+            alloc = dssu.user_objects_alloc_page_count + dssu.internal_objects_alloc_page_count,
+            dealloc = dssu.user_objects_dealloc_page_count + dssu.internal_objects_dealloc_page_count
+        FROM sys.dm_db_session_space_usage AS dssu
+        WHERE dssu.session_id = der.session_id
+
+        UNION ALL
+
+        SELECT
+            dtsu.user_objects_alloc_page_count + dtsu.internal_objects_alloc_page_count,
+            dtsu.user_objects_dealloc_page_count + dtsu.internal_objects_dealloc_page_count
+        FROM sys.dm_db_task_space_usage AS dtsu
+        WHERE dtsu.session_id = der.session_id
+        AND   dtsu.request_id = der.request_id
+    ) AS x
+) AS tsu
+OUTER APPLY
+(
+    SELECT
+        tran_log_used_mb = CONVERT(decimal(38, 2), SUM(ddt.database_transaction_log_bytes_used) / 1048576.),
+        tran_start_time = MIN(dat.transaction_begin_time)
+    FROM sys.dm_tran_session_transactions AS dst
+    JOIN sys.dm_tran_active_transactions AS dat
+      ON dat.transaction_id = dst.transaction_id
+    LEFT JOIN sys.dm_tran_database_transactions AS ddt
+      ON ddt.transaction_id = dst.transaction_id
+    WHERE dst.session_id = der.session_id
+) AS trn
 {1}
 WHERE dest.text IS NOT NULL
 ORDER BY der.cpu_time DESC, der.parallel_worker_count DESC
@@ -332,6 +437,14 @@ DROP TABLE #req;
                    .AppendValue(reader.IsDBNull(24) ? 0m : Convert.ToDecimal(reader.GetValue(24)))        /* percent_complete */
                    .AppendValue(!reader.IsDBNull(25) && Convert.ToBoolean(reader.GetValue(25)))           /* is_cdc_capture */
                    .AppendValue(reader.IsDBNull(26) ? (string?)null : reader.GetString(26))                /* query_hash (#1140) */
+                   .AppendValue(reader.IsDBNull(27) ? (double?)null : Convert.ToDouble(reader.GetValue(27))) /* requested_memory_mb */
+                   .AppendValue(reader.IsDBNull(28) ? (double?)null : Convert.ToDouble(reader.GetValue(28))) /* used_memory_mb */
+                   .AppendValue(reader.IsDBNull(29) ? (double?)null : Convert.ToDouble(reader.GetValue(29))) /* max_used_memory_mb */
+                   .AppendValue(reader.IsDBNull(30) ? (double?)null : Convert.ToDouble(reader.GetValue(30))) /* tempdb_current_mb */
+                   .AppendValue(reader.IsDBNull(31) ? (double?)null : Convert.ToDouble(reader.GetValue(31))) /* tempdb_allocations_mb */
+                   .AppendValue(reader.IsDBNull(32) ? (double?)null : Convert.ToDouble(reader.GetValue(32))) /* tran_log_used_mb */
+                   .AppendValue(reader.IsDBNull(33) ? (DateTime?)null : reader.GetDateTime(33))            /* tran_start_time */
+                   .AppendValue(reader.IsDBNull(34) ? 0 : Convert.ToInt32(reader.GetValue(34)))            /* request_id */
                    .EndRow();
 
                 rowsCollected++;

--- a/Lite/Windows/WaitDrillDownWindow.xaml
+++ b/Lite/Windows/WaitDrillDownWindow.xaml
@@ -126,6 +126,30 @@
                 <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat=F2}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedQueryMemoryGb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Memory (GB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                 </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RequestedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Req Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="UsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxUsedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="130">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Max Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbCurrentMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="tempdb Cur (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbAllocationsMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocationsMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="tempdb Alloc (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranLogUsedMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogUsedMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranStartTimeLocal}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranStartTimeLocal" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Start" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestId" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Req ID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
                     <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionIsolationLevel" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Isolation" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                 </DataGridTextColumn>


### PR DESCRIPTION
The approved class-B slice from the drilldown parity audit: Lite's wait drilldown now collects and shows the triage columns Dashboard gets from sp_WhoIsActive.

## Collector (boxed + Azure variants)
Appended at the SELECT tail (existing reader ordinals untouched):
- **Req/Used/Max Used memory grant (MB)** — `sys.dm_exec_query_memory_grants` (RESOURCE_SEMAPHORE triage)
- **tempdb Current / Allocations (MB)** — session+task space usage, pages→MB (tempdb PAGELATCH/spill triage)
- **Tran Log (MB) / Tran Start** — `sys.dm_tran_*` ("who's held a transaction open since when")
- **Request ID** — MARS disambiguation
Azure `#req` staging carries `request_id` for the joins. T-SQL validated live on SQL2022 before wiring.

## Storage
`query_snapshots` +8 columns, **schema v34** migration (`ALTER ADD COLUMN IF NOT EXISTS`, appended last — verified **39 schema columns == 39 appender values**). Old parquet returns NULL via the v_ view's union BY NAME.

## Dashboard units bugfix (found while mirroring headers)
sp_WhoIsActive's tempdb counters are **8KB-page counts**, but Dashboard's snapshot readers stored them raw — "tempdb Cur (MB)" in the wait drilldown and Active Queries grid was showing **pages as MB (128× overstated)**, and the same value was labeled "(MB)" in one grid and "(pages)" in another. Readers now `/128` (the same fix the memory columns got in #1274); labels unified to "tempdb Alloc (MB)".

## Skipped, with receipts
- `query_stats.object_type`: Dashboard's column is filled by a table **DEFAULT of 'STATEMENT'** (112,318 of 112,348 live rows) — mirroring a constant isn't parity.
- Dashboard query_hash/DOP/Isolation-coverage: waved off (sql_handle + session options already ride `additional_info`).

## Verification
Both apps build clean; **Lite.Tests 619/619, Dashboard.Tests 732/732**. Post-merge I'll relaunch Lite, confirm the v34 migration runs, and verify the first collection cycle populates the new columns via read-only DuckDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)