### PR TITLE
Sign the Velopack (Setup.exe) build output -- currently ships unsigned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,56 @@ jobs:
           Remove-Item "releases/PerformanceMonitorInstaller-$version.zip" -ErrorAction SilentlyContinue
           Compress-Archive -Path 'signed/Installer/*' -DestinationPath "releases/PerformanceMonitorInstaller-$version.zip" -Force
 
+      # The Velopack (Setup.exe) path publishes a SEPARATE self-contained build
+      # (publish/Dashboard-velopack, publish/Lite-velopack -- see the "self-contained
+      # for Velopack" steps above) that previously went straight into `vpk pack`
+      # without ever being uploaded to SignPath. Only the framework-dependent trees
+      # used for the legacy ZIPs were signed, so every Setup.exe shipped unsigned
+      # since Velopack packaging was introduced. These steps close that gap by
+      # mirroring the exact upload/sign pattern used for Dashboard/Lite/Installer
+      # above, and vpk pack below now reads from the signed output.
+      - name: Upload Dashboard (Velopack) for signing
+        if: github.event_name == 'release'
+        id: upload-dashboard-velopack
+        uses: actions/upload-artifact@v6
+        with:
+          name: Dashboard-Velopack-unsigned
+          path: publish/Dashboard-velopack/
+
+      - name: Upload Lite (Velopack) for signing
+        if: github.event_name == 'release'
+        id: upload-lite-velopack
+        uses: actions/upload-artifact@v6
+        with:
+          name: Lite-Velopack-unsigned
+          path: publish/Lite-velopack/
+
+      - name: Sign Dashboard (Velopack)
+        if: github.event_name == 'release'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
+          project-slug: 'PerformanceMonitor'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'Dashboard'
+          github-artifact-id: '${{ steps.upload-dashboard-velopack.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'signed/Dashboard-Velopack'
+
+      - name: Sign Lite (Velopack)
+        if: github.event_name == 'release'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'
+          project-slug: 'PerformanceMonitor'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'Lite'
+          github-artifact-id: '${{ steps.upload-lite-velopack.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'signed/Lite-Velopack'
+
       - name: Create Velopack release (Dashboard)
         if: github.event_name == 'release'
         shell: pwsh
@@ -248,13 +298,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path releases/velopack-dashboard
           New-Item -ItemType Directory -Force -Path releases/velopack-lite
 
-          # Dashboard: download previous + pack
+          # Dashboard: download previous + pack (from the SIGNED velopack output, not the raw publish dir)
           vpk download github --repoUrl https://github.com/${{ github.repository }} --channel dashboard -o releases/velopack-dashboard --token $env:GH_TOKEN
-          vpk pack -u PerformanceMonitorDashboard -v $env:VERSION -p publish/Dashboard-velopack -e PerformanceMonitorDashboard.exe -o releases/velopack-dashboard --channel dashboard
+          vpk pack -u PerformanceMonitorDashboard -v $env:VERSION -p signed/Dashboard-Velopack -e PerformanceMonitorDashboard.exe -o releases/velopack-dashboard --channel dashboard
 
-          # Lite: download previous + pack
+          # Lite: download previous + pack (from the SIGNED velopack output, not the raw publish dir)
           vpk download github --repoUrl https://github.com/${{ github.repository }} --channel lite -o releases/velopack-lite --token $env:GH_TOKEN
-          vpk pack -u PerformanceMonitorLite -v $env:VERSION -p publish/Lite-velopack -e PerformanceMonitorLite.exe -o releases/velopack-lite --channel lite
+          vpk pack -u PerformanceMonitorLite -v $env:VERSION -p signed/Lite-Velopack -e PerformanceMonitorLite.exe -o releases/velopack-lite --channel lite
 
       - name: Generate checksums
         if: github.event_name == 'release'


### PR DESCRIPTION
## The problem

**Setup.exe -- the install method the README recommends first -- ships completely unsigned**, and has since Velopack packaging was introduced (v2.4.0, 2026-03-23), including every release since Setup.exe became the *recommended* path (v2.11.0, 2026-05-19). Verified directly against the live v3.1.0 release, not just by reading the workflow:

```
PS> Get-AuthenticodeSignature .\PerformanceMonitorDashboard-dashboard-Setup.exe | fl Status
Status : NotSigned

PS> Get-AuthenticodeSignature .\explicit-zip\PerformanceMonitorDashboard.exe | fl Status
Status : Valid   (chains to CN=SignPath Foundation, issued by GlobalSign)
```

`PerformanceMonitorDashboard-dashboard-Portable.zip` (Velopack's own portable-zip output) and its bundled `Update.exe` are also unsigned. Only the legacy `PerformanceMonitorDashboard-3.1.0.zip` / `PerformanceMonitorLite-3.1.0.zip` / `PerformanceMonitorInstaller-3.1.0.zip` -- built and signed via the workflow's own explicit `Compress-Archive` + SignPath steps -- are actually signed.

**Root cause:** the Velopack path publishes a separate self-contained build (`publish/Dashboard-velopack`, `publish/Lite-velopack`) that `vpk pack` consumed directly. Only the framework-dependent `publish/Dashboard` / `publish/Lite` / `publish/Installer` trees (used for the ZIPs) were ever uploaded to SignPath. SignPath signing was wired up in v2.6.0, when the ZIP was still the primary artifact; when Setup.exe was promoted to primary in v2.11.0, signing was never extended to cover it.

This means every "unsafe/flagged" download report against Setup.exe (see #1321) has a real, mundane cause -- not just SmartScreen reputation lag, an actually-missing signature that no amount of resubmitting to Microsoft's feedback portal will fix.

## The fix

Mirrors the exact upload/sign pattern already used 3x in this file for Dashboard/Lite/Installer: upload the two velopack publish trees for signing right after they're built, submit to SignPath, then point `vpk pack -p ...` at the signed output (`signed/Dashboard-Velopack`, `signed/Lite-Velopack`) instead of the raw `publish/*-velopack` directory.

## Open questions before merging -- please review carefully

1. **SignPath artifact-configuration may need adjustment.** The self-contained publish is a much larger tree (bundled .NET runtime DLLs) than anything the existing `Dashboard`/`Lite` artifact-configuration slugs have signed before (which only ever saw the framework-dependent tree). I reused the same slugs as a first attempt, but I can't verify from the repo whether their file-matching glob correctly targets just `PerformanceMonitor*.exe` (what actually needs a fresh signature) versus trying to touch bundled runtime DLLs (already Microsoft-signed, don't need it, and might not even be glob-matched the same way). You may need to check/adjust this in the SignPath web dashboard, or this PR's first real run will surface it.
2. **This doubles SignPath signing requests per release** (3 -> 5: Dashboard, Lite, Installer, Dashboard-Velopack, Lite-Velopack). If SignPath's approval flow is manual per request, this means more manual clicks per release, not just more CI time.
3. **Cannot be verified outside a real `release` event.** `pull_request`-triggered runs skip every step in this diff (all gated on `github.event_name == 'release'`), so this PR's own CI run will build/test green but prove nothing about signing. The only way to validate this is a real tag/release (or a throwaway pre-release) that actually calls SignPath with real credentials.
4. **Possible cleaner alternative for later, out of scope here:** unify the ZIP and Velopack publishes into one self-contained build so both derive from the same signed tree instead of building (and now signing) two separate trees per app. That's a bigger change with real tradeoffs (ZIP size, air-gapped-user runtime assumptions) and a product decision, not a quick fix -- flagging it, not doing it here.

Given the above, this is a **draft PR** -- recommend testing on a patch release before merging to dev, not merging straight through.

## Test plan

- [x] YAML validated (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Diff mirrors the existing signing pattern exactly (same action, same secrets, same `wait-for-completion`/`output-artifact-directory` shape)
- [ ] Real `release` event run confirms SignPath accepts the Velopack artifact-configuration and returns a validly signed `PerformanceMonitorDashboard.exe`/`PerformanceMonitorLite.exe` inside Setup.exe
- [ ] `Get-AuthenticodeSignature` on the resulting Setup.exe from that test release comes back `Valid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)