### PR TITLE
Darling viewer: --open-server startup arg

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -87,16 +87,59 @@ public partial class MainWindow : Window
 
         await LoadServersAsync();
 
+        /* --open-server <name>: deep-link straight into a server's per-server tab on startup —
+           the same tab a double-click opens. Case-insensitive on the registered server name;
+           an unknown name is ignored (the window still opens normally). */
+        var openServer = OpenServerNameFromArgs();
+        if (openServer is not null && ServerList.ItemsSource is IEnumerable<DarlingServer> loaded)
+        {
+            var match = loaded.FirstOrDefault(s =>
+                string.Equals(s.ServerName, openServer, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                OpenServerTab(match);
+            }
+        }
+
         _refreshTimer = new DispatcherTimer { Interval = s_refreshInterval };
         _refreshTimer.Tick += OnRefreshTimerTick;
         _refreshTimer.Start();
     }
 
-    /// <summary>First command-line argument = explicit config path, mirroring the service.</summary>
+    /// <summary>
+    /// First non-option command-line argument = explicit config path, mirroring the service
+    /// (option pairs like --open-server &lt;name&gt; are skipped).
+    /// </summary>
     private static string? ExplicitConfigPathFromArgs()
     {
         var args = Environment.GetCommandLineArgs();
-        return args.Length > 1 ? args[1] : null;
+        for (var i = 1; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--open-server", StringComparison.OrdinalIgnoreCase))
+            {
+                i++; /* Skip the option's value too. */
+                continue;
+            }
+
+            return args[i];
+        }
+
+        return null;
+    }
+
+    /// <summary>The value following --open-server, or null when absent/dangling.</summary>
+    private static string? OpenServerNameFromArgs()
+    {
+        var args = Environment.GetCommandLineArgs();
+        for (var i = 1; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], "--open-server", StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return null;
     }
 
     private async void OnRefreshTimerTick(object? sender, EventArgs e)


### PR DESCRIPTION
Deep-links straight into a server's per-server tab on startup (same path as double-click; case-insensitive; unknown name = normal startup). The positional explicit-config-path arg now skips option pairs so both coexist. Doubles as the UIA-validation hook for the copy-parity program - WPF list double-clicks cannot be synthesized on background windows, and this removes that gap for every future tab-wave smoke.

Verified live against the fixture: --open-server SQL2022 opened the per-server tab with Overview/Queries/Blocking/Collection Health inner tabs - which also completes the W0 shell's visual validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)