### PR TITLE
Adopt validated colorblind-safe chart palette (Dashboard + Lite)

### DIFF
--- a/PerformanceMonitor.Common/ChartPalette.cs
+++ b/PerformanceMonitor.Common/ChartPalette.cs
@@ -30,15 +30,21 @@ namespace PerformanceMonitor.Common
     /// </summary>
     public static class ChartPalette
     {
-        // ── Cycling palette (Material Design 300/200) — for arbitrary, data-driven series ──
-        // Ported from Dashboard's ChartColors so both apps share one ordering (Lite's old
-        // SeriesColors was reordered + swapped #FFD54F<->#90A4AE, which broke cross-app parity).
+        // ── Cycling palette: validated colorblind-safe categorical ramp ──
+        // Slots 1-8 are the primary ramp, chosen with the dataviz palette validator:
+        // CVD-safe (worst adjacent deltaE ~24) and >= 3:1 contrast on all three chart
+        // surfaces (dark #111217, light #F5F7FA, CoolBreeze #DAE6F0), with no gray-reading
+        // (low-chroma) hues. This is ONE theme-independent list by design (see class
+        // remarks), so the hues are mid-tone cross-theme compromises rather than the
+        // brighter per-theme optima. Slots 9-20 are a chromatic fallback tier: color stops
+        // reliably distinguishing past 8, so many-series charts lean on legends/labels.
+        // Keep the slot 1-8 order; it is the CVD-safety mechanism.
         private static readonly string[] Cycling =
         {
-            "#4FC3F7", "#81C784", "#FFB74D", "#E57373", "#BA68C8",
-            "#4DD0E1", "#FFF176", "#F06292", "#AED581", "#90A4AE",
-            "#A1887F", "#7986CB", "#FF7043", "#80DEEA", "#FFE082",
-            "#CE93D8", "#EF9A9A", "#C5E1A5", "#FFCC80", "#B0BEC5",
+            "#2A78D6", "#1BAF7A", "#EDA100", "#008300", "#6C5CE7",
+            "#E34948", "#E87BA4", "#EB6834", "#17A2B8", "#B5179E",
+            "#74B816", "#AD6B3C", "#3D5AFE", "#C2185B", "#2E7D32",
+            "#8E44AD", "#0097A7", "#D81B60", "#7CB342", "#5C6BC0",
         };
 
         /// <summary>Stable cycling color for index <paramref name="index"/> (wraps the palette).</summary>
@@ -52,60 +58,67 @@ namespace PerformanceMonitor.Common
         // Defines ONE color per named series, applied identically in both apps. This is the fix
         // for "Buffer Pool is three different colors today" (green in Lite, blue and purple in two
         // Dashboard charts). Unknown names fall back to stable cycling.
+        //
+        // Identity series draw from the validated Cycling ramp above (co-occurring series in a
+        // given chart are kept on distinct ramp slots). Severity series use reserved status hues
+        // (dataviz good/warning/serious/critical) so a "getting worse" signal never reuses an
+        // identity hue.
+        // A few series are intentional NEUTRALS (a dashed reference line, an inactive/idle state,
+        // an unallocated remainder) and stay low-chroma grey on purpose.
         private static readonly Dictionary<string, string> Series =
             new(StringComparer.OrdinalIgnoreCase)
             {
-                ["SqlCpu"]        = "#4FC3F7", // SQL Server CPU %
-                ["TotalCpu"]      = "#FF7043", // Total (non-idle) CPU %
-                ["BufferPool"]    = "#81C784", // Buffer pool MB
-                ["MemoryGrants"]  = "#FFB74D", // Granted memory MB
-                ["OtherCpu"]          = "#E57373", // Other (non-SQL) process CPU %
-                ["TotalServerMemory"] = "#4FC3F7", // Total server memory GB
+                ["SqlCpu"]        = "#2A78D6", // SQL Server CPU %
+                ["TotalCpu"]      = "#EB6834", // Total (non-idle) CPU %
+                ["BufferPool"]    = "#008300", // Buffer pool MB
+                ["MemoryGrants"]  = "#EDA100", // Granted memory MB
+                ["OtherCpu"]          = "#E34948", // Other (non-SQL) process CPU %
+                ["TotalServerMemory"] = "#2A78D6", // Total server memory GB
                 ["TargetMemory"]      = "#808080", // Target server memory (dashed grey reference line)
-                ["Blocking"]          = "#FFB74D", // blocking count / incidents
-                ["BlockingDuration"]  = "#FF7043", // total blocking duration
-                ["Deadlocks"]         = "#E57373", // deadlock count
-                ["DeadlockWaitTime"]  = "#BA68C8", // total deadlock wait time
-                ["BlockedSessions"]   = "#EF9A9A", // blocked session count
-                ["ReadLatency"]   = "#4DD0E1", // Avg read latency ms
-                ["WriteLatency"]  = "#F06292", // Avg write latency ms
-                ["Reads"]         = "#4DD0E1", // Logical/physical reads
-                ["Writes"]        = "#F06292", // Logical/physical writes
-                ["Duration"]      = "#4FC3F7", // Elapsed/duration
-                ["Executions"]    = "#BA68C8", // Execution count
+                ["Blocking"]          = "#2A78D6", // blocking count / incidents
+                ["BlockingDuration"]  = "#EDA100", // total blocking duration
+                ["Deadlocks"]         = "#E34948", // deadlock count
+                ["DeadlockWaitTime"]  = "#6C5CE7", // total deadlock wait time
+                ["BlockedSessions"]   = "#17A2B8", // blocked session count (spread off the warm cluster; tritan-safe)
+                ["ReadLatency"]   = "#17A2B8", // Avg read latency ms
+                ["WriteLatency"]  = "#E87BA4", // Avg write latency ms
+                ["Reads"]         = "#17A2B8", // Logical/physical reads
+                ["Writes"]        = "#E87BA4", // Logical/physical writes
+                ["Duration"]      = "#2A78D6", // Elapsed/duration
+                ["Executions"]    = "#6C5CE7", // Execution count
                 // Session states (co-occur in the Sessions chart)
-                ["SessionTotal"]      = "#4FC3F7",
-                ["SessionRunning"]    = "#81C784",
-                ["SessionSleeping"]   = "#FFB74D",
-                ["SessionBackground"] = "#BA68C8",
-                ["SessionDormant"]    = "#4DD0E1",
-                ["SessionIdle"]       = "#90A4AE",
-                ["SessionWaiting"]    = "#E57373",
+                ["SessionTotal"]      = "#2A78D6",
+                ["SessionRunning"]    = "#008300",
+                ["SessionSleeping"]   = "#EDA100",
+                ["SessionBackground"] = "#6C5CE7",
+                ["SessionDormant"]    = "#17A2B8",
+                ["SessionIdle"]       = "#90A4AE", // intentional neutral: inactive state
+                ["SessionWaiting"]    = "#E34948",
                 // Memory overview (total / plan cache / available)
-                ["TotalMemory"]       = "#90A4AE",
-                ["CacheMemory"]       = "#81C784",
-                ["AvailableMemory"]   = "#FFB74D",
-                // Memory pressure event severity (stacked event-count bars; SQL = orange family, OS = red family)
-                ["SqlPressureMedium"] = "#FFB74D",
-                ["SqlPressureSevere"] = "#E65100",
-                ["OsPressureMedium"]  = "#E57373",
-                ["OsPressureSevere"]  = "#B71C1C",
+                ["TotalMemory"]       = "#90A4AE", // intentional neutral: overall envelope
+                ["CacheMemory"]       = "#008300",
+                ["AvailableMemory"]   = "#EDA100",
+                // Memory pressure event severity (status palette: SQL = amber->orange, OS = salmon->red)
+                ["SqlPressureMedium"] = "#FAB219",
+                ["SqlPressureSevere"] = "#E8720C",
+                ["OsPressureMedium"]  = "#EC835A",
+                ["OsPressureSevere"]  = "#D03B3B",
                 // Plan cache size buckets
-                ["SinglePagePlans"]   = "#E57373",
-                ["MultiPagePlans"]    = "#81C784",
+                ["SinglePagePlans"]   = "#E34948",
+                ["MultiPagePlans"]    = "#008300",
                 // Tempdb object types
-                ["UserObjects"]       = "#4FC3F7",
-                ["VersionStore"]      = "#81C784",
-                ["InternalObjects"]   = "#FFB74D",
-                ["UnallocatedTempdb"] = "#90A4AE",
-                ["TopTempdbTask"]     = "#E57373",
+                ["UserObjects"]       = "#2A78D6",
+                ["VersionStore"]      = "#008300",
+                ["InternalObjects"]   = "#EDA100",
+                ["UnallocatedTempdb"] = "#90A4AE", // intentional neutral: unallocated remainder
+                ["TopTempdbTask"]     = "#E34948",
                 // Duration trend charts (history windows / per-type)
-                ["QueryDuration"]     = "#4FC3F7",
-                ["ProcedureDuration"] = "#81C784",
-                ["QueryStoreDuration"]= "#FFB74D",
-                ["MetricTrend"]       = "#4FC3F7", // generic single-metric history trend
-                ["LockWaits"]         = "#4FC3F7",
-                ["CurrentWaits"]      = "#4FC3F7",
+                ["QueryDuration"]     = "#2A78D6",
+                ["ProcedureDuration"] = "#008300",
+                ["QueryStoreDuration"]= "#EDA100",
+                ["MetricTrend"]       = "#2A78D6", // generic single-metric history trend
+                ["LockWaits"]         = "#2A78D6",
+                ["CurrentWaits"]      = "#2A78D6",
             };
 
         /// <summary>Color for a fixed-meaning series (e.g. "BufferPool"); falls back to cycling.</summary>
@@ -116,13 +129,13 @@ namespace PerformanceMonitor.Common
         private static readonly Dictionary<string, string> Accents =
             new(StringComparer.OrdinalIgnoreCase)
             {
-                ["Threshold"]      = "#FFD54F", // generic threshold / target line (yellow)
-                ["PressureMedium"] = "#FFB74D", // medium pressure zone (orange)
-                ["PressureSevere"] = "#E57373", // severe pressure zone (red)
-                ["Anomaly"]        = "#FF5252", // anomaly dot
-                ["Average"]        = "#FFD54F", // mean / average line
-                ["BaselineCpu"]      = "#4FC3F7", // CPU-lane baseline band / mean tint
-                ["BaselineBlocking"] = "#E57373", // blocking-lane baseline band / mean tint
+                ["Threshold"]      = "#E8B21E", // generic threshold / target line (gold)
+                ["PressureMedium"] = "#FAB219", // medium pressure zone (status warning)
+                ["PressureSevere"] = "#D03B3B", // severe pressure zone (status critical)
+                ["Anomaly"]        = "#E8352E", // anomaly dot (critical red)
+                ["Average"]        = "#E8B21E", // mean / average line (gold)
+                ["BaselineCpu"]      = "#2A78D6", // CPU-lane baseline band / mean tint (matches SqlCpu)
+                ["BaselineBlocking"] = "#E34948", // blocking-lane baseline band / mean tint
                 ["Crosshair"]        = "#FFFFFF", // correlated-charts crosshair vline
                 ["GhostLine"]        = "#FFFFFF", // comparison-overlay ghost line (rendered semi-transparent)
                 ["Placeholder"]      = "#888888", // no-data placeholder line


### PR DESCRIPTION
## What

Replaces the shared `ChartPalette` color system (`PerformanceMonitor.Common`) with a validated colorblind-safe palette. Both Dashboard and Lite consume `Common`, so the fix lands in both apps at once and keeps them in visual sync.

## Why

The old system failed the dataviz palette validator: the 20-color `Cycling` palette had five gray-reading hues (including a taupe indistinguishable from pink under CVD), and the Material-300 hues washed out to 1-2:1 contrast on the Light/CoolBreeze themes. The `Series` and `Accents` maps carried the same defects and had drifted out of sync with `Cycling`.

## Changes

- **`Cycling`**: 20-color Material set -> validated cross-theme ramp. Slots 1-8 are CVD-safe (worst adjacent deltaE ~24) and clear 3:1 contrast on all three chart surfaces (dark `#111217`, light `#F5F7FA`, CoolBreeze `#DAE6F0`), with no gray-readers. Slots 9-20 are a chromatic fallback tier (color stops distinguishing past 8; many-series charts lean on legends).
- **`Series` (40 metrics) + `Accents`**: reconciled onto the ramp. Identity metrics -> distinct ramp slots (co-occurring series kept apart); severity signals (memory pressure, anomaly) -> reserved status hues so a "getting worse" signal never reuses an identity color; intentional neutrals (target-memory reference line, idle sessions, unallocated tempdb) stay low-chroma grey by design.
- **Blocking chart**: spread off the warm cluster so red/orange no longer collapse under tritanopia (tritan deltaE 4.9 -> 14.9).

## Not in scope

`WaitCategoryColors` (24 semantic wait categories) is intentionally untouched: 24 categories is past the 8-color CVD ceiling (no validated palette to swap in), the hues are user-recognized meanings, and it already carries a light-theme override. Redesigning that taxonomy is a deliberate design task for a separate pass.

## Validation

- dataviz palette validator run against all three surfaces; the ramp passes lightness / chroma / contrast, with CVD in the legal floor band backed by the legends and labels the charts carry.
- Each co-occurring chart group (CPU, Blocking, Sessions, Tempdb, memory pressure) re-validated to clear the CVD gate on the common deutan/protan types.
- Full solution builds clean (0 errors). Eyeballed live in both Dashboard and Lite across themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
