### PR TITLE
Wire View Plan onto Darling viewer Procedures, Blocking, and Deadlock grids

### DIFF
--- a/Darling/Darling.Tests/ViewerBlockingDepthTests.cs
+++ b/Darling/Darling.Tests/ViewerBlockingDepthTests.cs
@@ -22,19 +22,31 @@ namespace Darling.Tests;
 /// <summary>
 /// Pins the W1e Blocking-depth reads (widened Blocked Process Reports grid, the block-chain pair-row fetch,
 /// the Deadlocks grid, and the two slicer bucket reads) against the Darling store contract, no live Postgres.
-/// All mirror Lite's <c>LocalDataService.Blocking.cs</c> queries: the 37-column BPR read (including
-/// <c>blocked_process_report_xml</c>) over <c>v_blocked_process_reports</c> with the 19-column DMV fallback;
+/// All mirror Lite's <c>LocalDataService.Blocking.cs</c> queries: the BPR grid read (including
+/// <c>blocked_process_report_xml</c> + the best-effort plan columns) with the 19-column DMV fallback;
 /// the pair-row read built from the shared <c>PgBlockingPairRowQuery</c> fragments (so the apex + column
-/// order can't drift); the deadlock read over <c>v_deadlocks</c>; and the hourly slicer buckets (blocking
-/// XE-preferred with the DMV fallback exclusion, deadlocks by collection_time).
+/// order can't drift); the deadlock grid read (including the victim plan); and the hourly slicer buckets
+/// (blocking XE-preferred with the DMV fallback exclusion, deadlocks by collection_time). The two
+/// plan-carrying grid reads source the BASE tables, not the v_ views: the #1368 / V7 plan columns are
+/// projected reliably only by the base table (Postgres pins a view's <c>SELECT *</c> at creation — V4,
+/// before V7 — and V8 only <c>ALTER VIEW … SET SCHEMA</c>s it, never re-creating it), so a view read would
+/// fail on an upgraded store. The plan columns are Darling-only, so those reads were never Lite-twinnable
+/// once they carry a plan; every OTHER blocking/deadlock read (pair-row, slicers, trends, summaries) still
+/// twins over the v_ views.
 /// </summary>
 public sealed class ViewerBlockingDepthSqlTests
 {
     [Fact]
-    public void BlockedProcessReportsSql_FullColumnSet_IncludesReportXml_OverBprView()
+    public void BlockedProcessReportsSql_FullColumnSet_IncludesReportXml_AndBestEffortPlans_OverBaseTable()
     {
-        Assert.Contains("FROM v_blocked_process_reports", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
+        /* Base table, not v_blocked_process_reports: the V7 best-effort plan columns are projected reliably
+           only by the base table (pinned SELECT * view; see the class remarks). */
+        Assert.Contains("FROM blocked_process_reports", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("FROM v_blocked_process_reports", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
         Assert.Contains("blocked_process_report_xml", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
+        /* The two best-effort plan columns the grid's "View Plan" items open in-row (#1368 / V7). */
+        Assert.Contains("blocked_query_plan_xml", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
+        Assert.Contains("blocking_query_plan_xml", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY event_time DESC", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
         Assert.Contains("LIMIT 200", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
         Assert.Contains("collection_time >= $2", ViewerDataService.BlockedProcessReportsSql, StringComparison.Ordinal);
@@ -80,11 +92,16 @@ public sealed class ViewerBlockingDepthSqlTests
     }
 
     [Fact]
-    public void RecentDeadlocksSql_CarriesGraphXml_OrdersByDeadlockTime()
+    public void RecentDeadlocksSql_CarriesGraphXml_AndVictimPlan_OverBaseTable_OrdersByDeadlockTime()
     {
-        Assert.Contains("FROM v_deadlocks", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
+        /* Base deadlocks table, not v_deadlocks: the V7 victim_query_plan_xml is projected reliably only by
+           the base table (pinned SELECT * view; see the class remarks). */
+        Assert.Contains("FROM deadlocks", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("FROM v_deadlocks", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
         Assert.Contains("deadlock_graph_xml", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
         Assert.Contains("victim_process_id", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
+        /* The best-effort victim plan the grid's "View Victim Plan" item opens in-row (#1368 / V7). */
+        Assert.Contains("victim_query_plan_xml", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY deadlock_time DESC", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
         Assert.Contains("LIMIT 50", ViewerDataService.RecentDeadlocksSql, StringComparison.Ordinal);
     }
@@ -149,6 +166,8 @@ public sealed class ViewerBlockingDepthSqlTests
             "blocking_client_app", "blocking_host_name", "blocking_login_name", "blocking_sql_text",
             "blocked_process_report_xml", "blocked_transaction_name", "blocking_transaction_name",
             "blocked_priority", "blocking_priority", "contentious_object", "monitor_loop",
+            /* the best-effort plan columns the grid read carries in-row (#1368 / V7) */
+            "blocked_query_plan_xml", "blocking_query_plan_xml",
         })
         {
             Assert.Contains(column, ddl, StringComparison.Ordinal);
@@ -161,7 +180,12 @@ public sealed class ViewerBlockingDepthSqlTests
         Assert.Equal("deadlocks", DeadlocksCollector.Instance.TargetTable);
 
         var ddl = PgSchemaGenerator.CreateTable(DeadlocksCollector.Instance);
-        foreach (var column in new[] { "collection_time", "deadlock_time", "victim_process_id", "victim_sql_text", "deadlock_graph_xml" })
+        foreach (var column in new[]
+        {
+            "collection_time", "deadlock_time", "victim_process_id", "victim_sql_text", "deadlock_graph_xml",
+            /* the best-effort victim plan the grid read carries in-row (#1368 / V7) */
+            "victim_query_plan_xml",
+        })
         {
             Assert.Contains(column, ddl, StringComparison.Ordinal);
         }
@@ -239,6 +263,45 @@ public sealed class DeadlockProcessDetailParseTests
     }
 
     [Fact]
+    public void ParseFromRows_ThreadsVictimPlanOntoEveryProcessRow_GatingFlagFollows()
+    {
+        /* One deadlock, one best-effort victim plan (#1368 / V7) — it must ride on EVERY process row so the
+           per-row-gated "View Victim Plan" reaches the same plan from any process. */
+        var rows = new List<ViewerDeadlockRow>
+        {
+            new()
+            {
+                DeadlockTime = new DateTime(2026, 7, 1, 10, 0, 5, DateTimeKind.Unspecified),
+                VictimProcessId = "process1",
+                DeadlockGraphXml = TwoProcessDeadlockXml,
+                VictimQueryPlanXml = "<ShowPlanXML>victim</ShowPlanXML>",
+            },
+        };
+
+        var details = DeadlockProcessDetail.ParseFromRows(rows);
+
+        Assert.Equal(2, details.Count);
+        Assert.All(details, d => Assert.True(d.HasVictimQueryPlan));
+        Assert.All(details, d => Assert.Equal("<ShowPlanXML>victim</ShowPlanXML>", d.VictimQueryPlanXml));
+    }
+
+    [Fact]
+    public void ParseFromRows_NullVictimPlan_LeavesGatingFlagFalse()
+    {
+        /* The common best-effort case: no victim plan captured → every row's flag is false → the item disables. */
+        var rows = new List<ViewerDeadlockRow>
+        {
+            new() { DeadlockTime = DateTime.UnixEpoch, VictimProcessId = "process1", DeadlockGraphXml = TwoProcessDeadlockXml },
+        };
+
+        var details = DeadlockProcessDetail.ParseFromRows(rows);
+
+        Assert.NotEmpty(details);
+        Assert.All(details, d => Assert.False(d.HasVictimQueryPlan));
+        Assert.All(details, d => Assert.Null(d.VictimQueryPlanXml));
+    }
+
+    [Fact]
     public void ParseFromRows_MalformedXml_YieldsSingleVictimFallbackRow()
     {
         var rows = new List<ViewerDeadlockRow>
@@ -281,6 +344,8 @@ public sealed class ViewerBlockingDepthLivePostgresTests
     private const int DeadlockServerId = -972003;
     private const int BlockingSlicerServerId = -972004;
     private const int DeadlockSlicerServerId = -972005;
+    private const int BprPlanServerId = -972006;
+    private const int DeadlockPlanServerId = -972007;
 
     private const string ServerName = "viewer-w1e-e2e";
 
@@ -424,6 +489,105 @@ public sealed class ViewerBlockingDepthLivePostgresTests
     }
 
     [Fact]
+    public async Task BprRead_CarriesBestEffortPlans_InRow_GatesPerRow_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live BPR-plan test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "blocked_process_reports", BprPlanServerId);
+        await DeleteRowsAsync(connection, "dmv_blocking_snapshots", BprPlanServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            /* Both plans captured (1000 ms), only the blocked plan (2000), neither (3000) — best-effort, so
+               each side is independently NULL-able and the Has* flags gate the two "View Plan" items per row. */
+            await InsertBlockedProcessReportAsync(connection, BprPlanServerId, t, t.AddSeconds(1),
+                waitTimeMs: 1000, reportXml: "", monitorLoop: 1,
+                blockedPlanXml: "<ShowPlanXML>blocked</ShowPlanXML>", blockingPlanXml: "<ShowPlanXML>blocking</ShowPlanXML>");
+            await InsertBlockedProcessReportAsync(connection, BprPlanServerId, t, t.AddSeconds(2),
+                waitTimeMs: 2000, reportXml: "", monitorLoop: 1,
+                blockedPlanXml: "<ShowPlanXML>blocked-only</ShowPlanXML>", blockingPlanXml: null);
+            await InsertBlockedProcessReportAsync(connection, BprPlanServerId, t, t.AddSeconds(3),
+                waitTimeMs: 3000, reportXml: "", monitorLoop: 1);
+
+            var rows = await viewer.GetRecentBlockedProcessReportsAsync(BprPlanServerId, t.AddMinutes(-1), t.AddMinutes(1));
+
+            var both = rows.Single(r => r.WaitTimeMs == 1000);
+            Assert.True(both.HasBlockedQueryPlan);
+            Assert.True(both.HasBlockingQueryPlan);
+            Assert.Equal("<ShowPlanXML>blocked</ShowPlanXML>", both.BlockedQueryPlanXml);
+            Assert.Equal("<ShowPlanXML>blocking</ShowPlanXML>", both.BlockingQueryPlanXml);
+
+            var blockedOnly = rows.Single(r => r.WaitTimeMs == 2000);
+            Assert.True(blockedOnly.HasBlockedQueryPlan);
+            Assert.False(blockedOnly.HasBlockingQueryPlan);   // best-effort: the blocking side stayed NULL
+
+            var neither = rows.Single(r => r.WaitTimeMs == 3000);
+            Assert.False(neither.HasBlockedQueryPlan);
+            Assert.False(neither.HasBlockingQueryPlan);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "blocked_process_reports", BprPlanServerId);
+            await DeleteRowsAsync(connection, "dmv_blocking_snapshots", BprPlanServerId);
+        }
+    }
+
+    [Fact]
+    public async Task DeadlockRead_CarriesVictimPlan_ThreadedOntoEveryProcessRow_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live victim-plan test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "deadlocks", DeadlockPlanServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            const string graph = """
+                <deadlock>
+                  <victim-list><victimProcess id="p1" /></victim-list>
+                  <process-list>
+                    <process id="p1" spid="55" currentdbname="AppDb" lockMode="X"><inputbuf>UPDATE dbo.t SET c = 1</inputbuf></process>
+                    <process id="p2" spid="60" currentdbname="AppDb" lockMode="X"><inputbuf>UPDATE dbo.t SET c = 2</inputbuf></process>
+                  </process-list>
+                  <resource-list></resource-list>
+                </deadlock>
+                """;
+            await InsertDeadlockAsync(connection, DeadlockPlanServerId, t, t.AddSeconds(1), "p1", graph,
+                victimPlanXml: "<ShowPlanXML>victim</ShowPlanXML>");
+
+            var rows = await viewer.GetRecentDeadlocksAsync(DeadlockPlanServerId, t.AddMinutes(-1), t.AddMinutes(1));
+            var row = Assert.Single(rows);
+            Assert.Equal("<ShowPlanXML>victim</ShowPlanXML>", row.VictimQueryPlanXml);
+
+            /* The single victim plan rides on EVERY parsed process row so "View Victim Plan" is reachable from
+               any of them (gated on presence, not IsVictim). */
+            var details = DeadlockProcessDetail.ParseFromRows(rows);
+            Assert.Equal(2, details.Count);
+            Assert.All(details, d => Assert.True(d.HasVictimQueryPlan));
+            Assert.All(details, d => Assert.Equal("<ShowPlanXML>victim</ShowPlanXML>", d.VictimQueryPlanXml));
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "deadlocks", DeadlockPlanServerId);
+        }
+    }
+
+    [Fact]
     public async Task BlockingSlicer_HourlyBuckets_XePreferredDmvExcluded_AgainstDevPostgres()
     {
         var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
@@ -498,7 +662,8 @@ public sealed class ViewerBlockingDepthLivePostgresTests
 
     private static async Task InsertBlockedProcessReportAsync(
         NpgsqlConnection connection, int serverId, DateTime collectionTimeUtc, DateTime eventTimeUtc,
-        long waitTimeMs, string reportXml, int monitorLoop)
+        long waitTimeMs, string reportXml, int monitorLoop,
+        string? blockedPlanXml = null, string? blockingPlanXml = null)
     {
         using var command = new NpgsqlCommand(@"
 INSERT INTO blocked_process_reports
@@ -508,9 +673,10 @@ INSERT INTO blocked_process_reports
      blocked_client_app, blocked_host_name, blocked_login_name, blocked_sql_text,
      blocking_status, blocking_isolation_level, blocking_client_app, blocking_host_name, blocking_login_name,
      blocking_sql_text, blocked_process_report_xml, blocked_transaction_name, blocking_transaction_name,
-     blocked_priority, blocking_priority, contentious_object, monitor_loop)
+     blocked_priority, blocking_priority, contentious_object, monitor_loop,
+     blocked_query_plan_xml, blocking_query_plan_xml)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
-        $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34)", connection);
+        $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)", connection);
         command.Parameters.AddWithValue(1L);
         command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
         command.Parameters.AddWithValue(serverId);
@@ -545,6 +711,8 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
         command.Parameters.AddWithValue(0);
         command.Parameters.AddWithValue("dbo.t");
         command.Parameters.AddWithValue(monitorLoop);
+        command.Parameters.AddWithValue((object?)blockedPlanXml ?? DBNull.Value);
+        command.Parameters.AddWithValue((object?)blockingPlanXml ?? DBNull.Value);
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 
@@ -577,13 +745,13 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)", connectio
 
     private static async Task InsertDeadlockAsync(
         NpgsqlConnection connection, int serverId, DateTime collectionTimeUtc, DateTime deadlockTimeUtc,
-        string victimProcessId, string graphXml)
+        string victimProcessId, string graphXml, string? victimPlanXml = null)
     {
         using var command = new NpgsqlCommand(@"
 INSERT INTO deadlocks
     (deadlock_id, collection_time, server_id, server_name, deadlock_time,
-     victim_process_id, victim_sql_text, deadlock_graph_xml)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", connection);
+     victim_process_id, victim_sql_text, deadlock_graph_xml, victim_query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)", connection);
         command.Parameters.AddWithValue(1L);
         command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
         command.Parameters.AddWithValue(serverId);
@@ -592,6 +760,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", connection);
         command.Parameters.AddWithValue(victimProcessId);
         command.Parameters.AddWithValue("UPDATE dbo.t SET c = 1");
         command.Parameters.AddWithValue(graphXml);
+        command.Parameters.AddWithValue((object?)victimPlanXml ?? DBNull.Value);
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 

--- a/Darling/Darling.Tests/ViewerPlanHostTests.cs
+++ b/Darling/Darling.Tests/ViewerPlanHostTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
@@ -54,6 +55,31 @@ public sealed class ViewerPlanHostSqlTests
     }
 
     [Fact]
+    public void ProcedureStatsPlanXmlSql_ReadsStoredXml_KeyedByDatabaseSchemaObject_LatestNonNull()
+    {
+        var sql = ViewerDataService.ProcedureStatsPlanXmlSql;
+        Assert.Contains("SELECT query_plan_xml", sql, StringComparison.Ordinal);
+        /* The base procedure_stats table (there is no v_procedure_stats view; the plan column is on the table). */
+        Assert.Contains("FROM procedure_stats", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_procedure_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("database_name = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("schema_name = $3", sql, StringComparison.Ordinal);
+        Assert.Contains("object_name = $4", sql, StringComparison.Ordinal); /* (database, schema, object) = the grid's group key */
+        Assert.Contains("query_plan_xml IS NOT NULL", sql, StringComparison.Ordinal); /* skip rows the collector left NULL */
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal); /* most-recent plan for the key */
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProcedureStatsPlanColumn_ExistsInTheGeneratedProcedureStatsTable()
+    {
+        /* The keyed fetch reads procedure_stats.query_plan_xml — pin that the collector-generated table has it. */
+        Assert.Equal("procedure_stats", ProcedureStatsCollector.Instance.TargetTable);
+        Assert.Contains("query_plan_xml", PgSchemaGenerator.CreateTable(ProcedureStatsCollector.Instance), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TopQueriesSql_CarriesCheapHasPlanFlag_NotThePlanItself()
     {
         /* The grid gates its Query Plan column on a group-level presence flag; the multi-KB plan XML is
@@ -66,11 +92,15 @@ public sealed class ViewerPlanHostSqlTests
     [Theory]
     [InlineData(nameof(ViewerDataService.QueryStatsPlanXmlSql))]
     [InlineData(nameof(ViewerDataService.QueryStorePlanTextSql))]
+    [InlineData(nameof(ViewerDataService.ProcedureStatsPlanXmlSql))]
     public void PlanReads_ArePostgresDialect_PositionalParams_NoTsqlIsms(string sqlName)
     {
-        var sql = sqlName == nameof(ViewerDataService.QueryStatsPlanXmlSql)
-            ? ViewerDataService.QueryStatsPlanXmlSql
-            : ViewerDataService.QueryStorePlanTextSql;
+        var sql = sqlName switch
+        {
+            nameof(ViewerDataService.QueryStatsPlanXmlSql) => ViewerDataService.QueryStatsPlanXmlSql,
+            nameof(ViewerDataService.QueryStorePlanTextSql) => ViewerDataService.QueryStorePlanTextSql,
+            _ => ViewerDataService.ProcedureStatsPlanXmlSql,
+        };
         Assert.DoesNotContain("getdate", sql.ToLowerInvariant());
         Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
         Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
@@ -86,6 +116,34 @@ public sealed class ViewerPlanHostGatingTests
     {
         Assert.False(new ViewerQueryStatsRow().HasQueryPlan);
         Assert.True(new ViewerQueryStatsRow { HasQueryPlan = true }.HasQueryPlan);
+    }
+
+    [Fact]
+    public void BlockedProcessRow_PlanFlags_DefaultFalse_GateBlockedAndBlockingIndependently()
+    {
+        var empty = new ViewerBlockedProcessRow();
+        Assert.False(empty.HasBlockedQueryPlan);
+        Assert.False(empty.HasBlockingQueryPlan);
+
+        var both = new ViewerBlockedProcessRow
+        {
+            BlockedQueryPlanXml = "<ShowPlanXML/>",
+            BlockingQueryPlanXml = "<ShowPlanXML/>",
+        };
+        Assert.True(both.HasBlockedQueryPlan);
+        Assert.True(both.HasBlockingQueryPlan);
+
+        /* Best-effort: one side can be captured while the other is NULL — the two "View Plan" items gate apart. */
+        var blockedOnly = new ViewerBlockedProcessRow { BlockedQueryPlanXml = "<ShowPlanXML/>" };
+        Assert.True(blockedOnly.HasBlockedQueryPlan);
+        Assert.False(blockedOnly.HasBlockingQueryPlan);
+    }
+
+    [Fact]
+    public void DeadlockProcessDetail_VictimPlanFlag_DefaultsFalse_ReflectsPresence()
+    {
+        Assert.False(new DeadlockProcessDetail().HasVictimQueryPlan);
+        Assert.True(new DeadlockProcessDetail { VictimQueryPlanXml = "<ShowPlanXML/>" }.HasVictimQueryPlan);
     }
 }
 

--- a/Darling/Darling.Tests/ViewerQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesTests.cs
@@ -294,6 +294,7 @@ public sealed class ViewerQueriesLivePostgresTests
     private const int QueryStoreServerId = -970803;
     private const int ComparisonServerId = -970804;
     private const int SlicerServerId = -970805;
+    private const int ProcedureStatsPlanServerId = -970806;
 
     private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
 
@@ -381,6 +382,43 @@ public sealed class ViewerQueriesLivePostgresTests
         finally
         {
             await DeleteRowsAsync(connection, "procedure_stats", ProcedureStatsServerId);
+        }
+    }
+
+    [Fact]
+    public async Task ProcedureStatsPlan_FetchesNewestStoredXml_KeyedByObject_NullWhenUncaptured_AgainstDevPostgres()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs), "Set DARLING_TEST_PG to a Postgres connection string to run the live procedure-plan test.");
+
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "procedure_stats", ProcedureStatsPlanServerId);
+
+        await using var viewer = new ViewerDataService(cs!);
+        var t = TruncateToSeconds(DateTime.UtcNow).AddHours(-2);
+
+        try
+        {
+            /* Same (db, schema, object) captured twice — the newer plan wins (ORDER BY collection_time DESC). */
+            await InsertProcedureStatsAsync(connection, ProcedureStatsPlanServerId, t, "StackOverflow", "dbo", "usp_WithPlan", "PROC",
+                deltaExec: 1, deltaWorker: 10_000, deltaElapsed: 20_000, deltaReads: 100, planXml: "<ShowPlanXML>older</ShowPlanXML>");
+            await InsertProcedureStatsAsync(connection, ProcedureStatsPlanServerId, t.AddMinutes(30), "StackOverflow", "dbo", "usp_WithPlan", "PROC",
+                deltaExec: 1, deltaWorker: 10_000, deltaElapsed: 20_000, deltaReads: 100, planXml: "<ShowPlanXML>newer</ShowPlanXML>");
+            /* A procedure with activity but no captured plan (query_plan_xml NULL). */
+            await InsertProcedureStatsAsync(connection, ProcedureStatsPlanServerId, t, "StackOverflow", "dbo", "usp_NoPlan", "PROC",
+                deltaExec: 1, deltaWorker: 10_000, deltaElapsed: 20_000, deltaReads: 100);
+
+            Assert.Equal("<ShowPlanXML>newer</ShowPlanXML>",
+                await viewer.GetProcedureStatsPlanXmlAsync(ProcedureStatsPlanServerId, "StackOverflow", "dbo", "usp_WithPlan"));
+            /* No plan captured, and an absent object, both fetch null. */
+            Assert.Null(await viewer.GetProcedureStatsPlanXmlAsync(ProcedureStatsPlanServerId, "StackOverflow", "dbo", "usp_NoPlan"));
+            Assert.Null(await viewer.GetProcedureStatsPlanXmlAsync(ProcedureStatsPlanServerId, "StackOverflow", "dbo", "usp_Absent"));
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "procedure_stats", ProcedureStatsPlanServerId);
         }
     }
 
@@ -549,7 +587,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
     private static async Task InsertProcedureStatsAsync(
         NpgsqlConnection connection, int serverId, DateTime collectionTimeUtc,
         string databaseName, string schemaName, string objectName, string objectType,
-        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads)
+        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, string? planXml = null)
     {
         using var command = new NpgsqlCommand(@"
 INSERT INTO procedure_stats
@@ -557,8 +595,8 @@ INSERT INTO procedure_stats
      database_name, schema_name, object_name, object_type,
      cached_time, last_execution_time, sql_handle, plan_handle,
      delta_execution_count, delta_worker_time, delta_elapsed_time, delta_logical_reads,
-     delta_logical_writes, delta_physical_reads, delta_spills)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)", connection);
+     delta_logical_writes, delta_physical_reads, delta_spills, query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)", connection);
         command.Parameters.AddWithValue(1L);
         command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
         command.Parameters.AddWithValue(serverId);
@@ -578,6 +616,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
         command.Parameters.AddWithValue(0L);
         command.Parameters.AddWithValue(0L);
         command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue((object?)planXml ?? DBNull.Value);
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 

--- a/Darling/Darling.Tests/ViewerWave2Tests.cs
+++ b/Darling/Darling.Tests/ViewerWave2Tests.cs
@@ -27,7 +27,10 @@ namespace Darling.Tests;
 public sealed class ViewerWave2SqlTests
 {
     [Theory]
-    [InlineData(ViewerDataService.BlockedProcessReportsSql, "FROM v_blocked_process_reports")]
+    /* The BPR read sources the BASE table (not v_blocked_process_reports) so its #1368 / V7 best-effort plan
+       columns are projected on every store — the pinned SELECT * view would omit them on an upgraded store.
+       This also matches DarlingAlertReadAdapter, which already reads the base blocked_process_reports. */
+    [InlineData(ViewerDataService.BlockedProcessReportsSql, "FROM blocked_process_reports")]
     [InlineData(ViewerDataService.DmvBlockingSnapshotsSql, "FROM v_dmv_blocking_snapshots")]
     public void BlockingSql_WindowsOnCollectionTime_NewestEventsFirst_Cap200(string sql, string fromClause)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -69,6 +69,20 @@ public sealed class ViewerBlockedProcessRow : BlockedProcessAlertRow
 
     /// <summary>Lite's long-block tint threshold: over 30 seconds waiting.</summary>
     public bool IsLongBlock => WaitTimeMs > 30000;
+
+    /// <summary>
+    /// The blocked / blocking query plans the Darling collector resolved BEST-EFFORT alongside the report
+    /// (blocked_process_reports.blocked_query_plan_xml / blocking_query_plan_xml, #1368 / V7 — from the
+    /// report's sql_handle via dm_exec_query_stats → dm_exec_text_query_plan, only when the host sets
+    /// CapturePlanXml; often NULL, and always NULL on the DMV-snapshot fallback rows and under Lite). The
+    /// Has* flags gate the two "View Plan" context items per row so a plan-less row shows them disabled
+    /// rather than shown-and-failed. The XML rides in-row (like blocked_process_report_xml already does),
+    /// so "View Plan" opens it with no second fetch.
+    /// </summary>
+    public string? BlockedQueryPlanXml { get; set; }
+    public string? BlockingQueryPlanXml { get; set; }
+    public bool HasBlockedQueryPlan => !string.IsNullOrEmpty(BlockedQueryPlanXml);
+    public bool HasBlockingQueryPlan => !string.IsNullOrEmpty(BlockingQueryPlanXml);
 }
 
 public sealed partial class ViewerDataService
@@ -76,7 +90,17 @@ public sealed partial class ViewerDataService
     /// <summary>
     /// The XE blocked-process-report read — Lite's <c>GetRecentBlockedProcessReportsAsync</c> full
     /// 37-column SELECT ported to Postgres, including <c>blocked_process_report_xml</c> (the block-chain /
-    /// XML-save surface needs it). Same WHERE / ORDER BY event_time DESC / LIMIT 200 semantics.
+    /// XML-save surface needs it) and the two BEST-EFFORT plan columns (#1368 / V7) the grid's "View Plan"
+    /// items open. Same WHERE / ORDER BY event_time DESC / LIMIT 200 semantics.
+    ///
+    /// <para>Reads the BASE <c>blocked_process_reports</c> table, not <c>v_blocked_process_reports</c>
+    /// (deliberate divergence from the other blocking reads' v_-view twinning): the V7 plan columns are
+    /// projected reliably only by the base table. Postgres pins <c>SELECT *</c> in a view to the column
+    /// list at view-creation time (V4, before V7 added the plan columns), and V8 only <c>ALTER VIEW … SET
+    /// SCHEMA</c>s the view (it never re-creates it) — so on a store upgraded across the V7 boundary the
+    /// view would not expose the plan columns and this read would fail. The plan columns are Darling-only
+    /// (Lite's DuckDB view has no such column), so a plan-carrying read was never twinnable with Lite
+    /// anyway. The shared alert read (<c>DarlingAlertReadAdapter</c>) already reads this base table.</para>
     /// $1 server_id, $2 window start, $3 window end (naive UTC).
     /// </summary>
     public const string BlockedProcessReportsSql = """
@@ -117,8 +141,10 @@ public sealed partial class ViewerDataService
             blocked_priority,
             blocking_priority,
             contentious_object,
-            monitor_loop
-        FROM v_blocked_process_reports
+            monitor_loop,
+            blocked_query_plan_xml,
+            blocking_query_plan_xml
+        FROM blocked_process_reports
         WHERE server_id = $1
         AND   collection_time >= $2
         AND   collection_time <= $3
@@ -250,6 +276,8 @@ public sealed partial class ViewerDataService
                 BlockingPriority = reader.IsDBNull(34) ? 0 : reader.GetInt32(34),
                 ContentiousObject = reader.IsDBNull(35) ? "" : reader.GetString(35),
                 MonitorLoop = reader.IsDBNull(36) ? null : reader.GetInt32(36),
+                BlockedQueryPlanXml = reader.IsDBNull(37) ? null : reader.GetString(37),
+                BlockingQueryPlanXml = reader.IsDBNull(38) ? null : reader.GetString(38),
                 Source = BlockedProcessAlertRow.XeReportSource,
             });
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -26,6 +26,13 @@ public sealed class ViewerDeadlockRow : DeadlockAlertRow
 {
     public DateTime CollectionTime { get; set; }
     public DateTime? DeadlockTime { get; set; }
+
+    /// <summary>
+    /// The deadlock's BEST-EFFORT victim plan (deadlocks.victim_query_plan_xml, #1368 / V7 — resolved at
+    /// collection time from the victim's sql_handle, only when the host sets CapturePlanXml; often NULL,
+    /// always NULL under Lite). Threaded onto every <see cref="DeadlockProcessDetail"/> parsed from this row.
+    /// </summary>
+    public string? VictimQueryPlanXml { get; set; }
 }
 
 /// <summary>
@@ -58,6 +65,15 @@ public sealed class DeadlockProcessDetail
     public string Status { get; set; } = "";
     public string DeadlockGraphXml { get; set; } = "";
     public bool HasDeadlockXml => !string.IsNullOrEmpty(DeadlockGraphXml);
+
+    /// <summary>
+    /// The BEST-EFFORT victim plan for this deadlock (deadlocks.victim_query_plan_xml, #1368 / V7) — one
+    /// plan per deadlock, copied onto every process row parsed from the same graph. The "View Victim Plan"
+    /// context item is gated per row on <see cref="HasVictimQueryPlan"/> so a plan-less deadlock (NULL, the
+    /// common case, and always so under Lite) shows it disabled rather than shown-and-failed.
+    /// </summary>
+    public string? VictimQueryPlanXml { get; set; }
+    public bool HasVictimQueryPlan => !string.IsNullOrEmpty(VictimQueryPlanXml);
 
     /* New fields from sp_BlitzLock analysis */
     public string DeadlockType { get; set; } = "";
@@ -198,6 +214,7 @@ public sealed class DeadlockProcessDetail
                         LoginName = proc.Attribute("loginname")?.Value ?? "",
                         Status = proc.Attribute("status")?.Value ?? "",
                         DeadlockGraphXml = row.DeadlockGraphXml,
+                        VictimQueryPlanXml = row.VictimQueryPlanXml,
                         DeadlockType = deadlockType,
                         ProcName = procName,
                         TransactionName = proc.Attribute("transactionname")?.Value ?? "",
@@ -219,7 +236,8 @@ public sealed class DeadlockProcessDetail
                     DeadlockTime = row.DeadlockTime,
                     SqlText = row.VictimSqlText,
                     IsVictim = true,
-                    DeadlockGraphXml = row.DeadlockGraphXml
+                    DeadlockGraphXml = row.DeadlockGraphXml,
+                    VictimQueryPlanXml = row.VictimQueryPlanXml
                 });
             }
         }
@@ -233,7 +251,17 @@ public sealed partial class ViewerDataService
     /// Recent deadlock events for one server — Lite's <c>GetRecentDeadlocksAsync</c> ported to Postgres.
     /// Windows on the collection prefix, orders newest deadlock first, caps at 50 (Lite's cap). Carries the
     /// graph XML so <see cref="DeadlockProcessDetail.ParseFromRows"/> and the deadlock-graph viewer work
-    /// without a second fetch. $1 server_id, $2 window start, $3 window end (naive UTC).
+    /// without a second fetch, and the BEST-EFFORT victim plan (#1368 / V7) the grid's "View Victim Plan"
+    /// item opens.
+    ///
+    /// <para>Reads the BASE <c>deadlocks</c> table, not <c>v_deadlocks</c> (deliberate divergence from the
+    /// other deadlock reads' v_-view twinning): the V7 <c>victim_query_plan_xml</c> column is projected
+    /// reliably only by the base table. Postgres pins <c>SELECT *</c> in a view to the columns present at
+    /// view-creation (V4, before V7), and V8 only <c>ALTER VIEW … SET SCHEMA</c>s it (never re-creates it),
+    /// so an upgraded store's view would not expose the plan column and this read would fail. The column is
+    /// Darling-only (Lite's DuckDB view has none), so this read was never twinnable with Lite once it
+    /// carries the plan.</para>
+    /// $1 server_id, $2 window start, $3 window end (naive UTC).
     /// </summary>
     public const string RecentDeadlocksSql = """
         SELECT
@@ -241,8 +269,9 @@ public sealed partial class ViewerDataService
             deadlock_time,
             victim_process_id,
             victim_sql_text,
-            deadlock_graph_xml
-        FROM v_deadlocks
+            deadlock_graph_xml,
+            victim_query_plan_xml
+        FROM deadlocks
         WHERE server_id = $1
         AND   collection_time >= $2
         AND   collection_time <= $3
@@ -268,6 +297,7 @@ public sealed partial class ViewerDataService
                 VictimProcessId = reader.IsDBNull(2) ? "" : reader.GetString(2),
                 VictimSqlText = reader.IsDBNull(3) ? "" : reader.GetString(3),
                 DeadlockGraphXml = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                VictimQueryPlanXml = reader.IsDBNull(5) ? null : reader.GetString(5),
             });
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Plans.cs
@@ -15,15 +15,18 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// On-demand execution-plan reads for the Plan Viewer host (headless-plan wave): the plan XML the
-/// Darling service captures alongside the query/query-store stats (PR #1349, gated on
-/// <c>CollectorContext.CapturePlanXml</c> — Darling sets it true, TOAST compresses the text). Unlike
-/// Lite — which fetches plans live from the monitored server's plan cache — the viewer never touches
-/// SQL Server, so it reads the stored plan text straight out of Postgres by the grid row's key columns.
-/// The grid reads carry only a cheap <c>has_query_plan</c> presence flag (no multi-KB XML per row); the
-/// full plan is fetched here on click. These lookups are keyed (server + object identity), not windowed,
-/// so there is no timestamp parameter and no naive-UTC concern — <c>ORDER BY collection_time DESC LIMIT 1</c>
-/// returns the most recently captured plan for that key. Plans can be large; they are read as text with no
-/// size games (the task's rule: TOAST handles storage, reading is fine).
+/// Darling service captures alongside the query/query-store/procedure stats (PR #1349 for query &amp;
+/// query-store, #1368 / V7 for procedure_stats, gated on <c>CollectorContext.CapturePlanXml</c> — Darling
+/// sets it true, TOAST compresses the text). Unlike Lite — which fetches plans live from the monitored
+/// server's plan cache — the viewer never touches SQL Server, so it reads the stored plan text straight out
+/// of Postgres by the grid row's key columns. The keyed grids (Top Queries / Query Store / Top Procedures)
+/// carry only a cheap presence flag or fetch on click (no multi-KB XML per row); the blocked-process /
+/// deadlock grids instead carry their best-effort plan XML in-row (see ViewerDataService.Blocking.cs /
+/// .Deadlock.cs), like they already carry the report / graph XML. These keyed lookups are keyed (server +
+/// object identity), not windowed, so there is no timestamp parameter and no naive-UTC concern —
+/// <c>ORDER BY collection_time DESC LIMIT 1</c> returns the most recently captured plan for that key. Plans
+/// can be large; they are read as text with no size games (the task's rule: TOAST handles storage, reading
+/// is fine).
 /// </summary>
 public sealed partial class ViewerDataService
 {
@@ -92,6 +95,50 @@ public sealed partial class ViewerDataService
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = planId });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is string s ? s : null;
+    }
+
+    /// <summary>
+    /// The latest captured procedure_stats plan for a Top-Procedures row, keyed by (server, database,
+    /// schema, object) — the grid groups by (database_name, schema_name, object_name, object_type), so the
+    /// same object identity fetches the plan the row represents (Top Queries' keyed-fetch pattern, not the
+    /// in-row carry the aggregate grid can't do). procedure_stats.query_plan_xml is captured CLEANLY from the
+    /// cached plan (dm_exec_procedure_stats.plan_handle → dm_exec_text_query_plan) whenever the host sets
+    /// CapturePlanXml — Darling does, Lite always writes NULL. Read from the base <c>procedure_stats</c>
+    /// table (there is no v_procedure_stats view; TopProceduresSql already reads the base table), which also
+    /// avoids the V7-column / pinned-view issue the blocked/deadlock reads sidestep. $1 server_id, $2
+    /// database_name, $3 schema_name, $4 object_name.
+    /// </summary>
+    public const string ProcedureStatsPlanXmlSql = """
+        SELECT query_plan_xml
+        FROM procedure_stats
+        WHERE server_id = $1
+        AND   database_name = $2
+        AND   schema_name = $3
+        AND   object_name = $4
+        AND   query_plan_xml IS NOT NULL
+        ORDER BY collection_time DESC
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// The stored execution plan for a Top-Procedures grid row, or null when no plan was captured for that
+    /// (database, schema, object). Read as text — no length cap (the collector stored the whole plan).
+    /// </summary>
+    public async Task<string?> GetProcedureStatsPlanXmlAsync(
+        int serverId, string databaseName, string schemaName, string objectName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(objectName))
+        {
+            return null;
+        }
+
+        await using var command = _dataSource.CreateCommand(ProcedureStatsPlanXmlSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = objectName });
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is string s ? s : null;
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -252,6 +252,30 @@ public partial class ViewerServerTab
     private static Task<List<DeadlockProcessDetail>> ParseDeadlocksOffUiThreadAsync(List<ViewerDeadlockRow> rows)
         => Task.Run(() => DeadlockProcessDetail.ParseFromRows(rows));
 
+    /// <summary>
+    /// "View Blocked Query Plan" / "View Blocking Query Plan" for a blocked-process report row: opens the
+    /// BEST-EFFORT plan the row already carries (blocked_process_reports.blocked_query_plan_xml /
+    /// blocking_query_plan_xml, #1368 / V7) in the shared Plan Viewer host — NO live SQL, the same
+    /// stored-plan surface Top Queries uses. The context items are gated per row on Has*QueryPlan (a NULL
+    /// plan shows them disabled), so these only fire with a captured plan; the guard here is belt-and-braces
+    /// (and covers the DMV-snapshot fallback rows, which never carry a plan). Lite recovered these plans
+    /// live from the monitored server's cache — the headless viewer can't, so only the stored plan shows,
+    /// and Lite's "Get Actual Plan" has no viewer equivalent (omitted everywhere).
+    /// </summary>
+    private void ViewBlockedQueryPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        if (FindParentDataGrid(menuItem)?.CurrentItem is not ViewerBlockedProcessRow row || !row.HasBlockedQueryPlan) return;
+        OpenPlanTab(row.BlockedQueryPlanXml!, $"Blocked Plan - SPID {row.BlockedSpid}", row.BlockedSqlText);
+    }
+
+    private void ViewBlockingQueryPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        if (FindParentDataGrid(menuItem)?.CurrentItem is not ViewerBlockedProcessRow row || !row.HasBlockingQueryPlan) return;
+        OpenPlanTab(row.BlockingQueryPlanXml!, $"Blocking Plan - SPID {row.BlockingSpid}", row.BlockingSqlText);
+    }
+
     private void RenderLockWaitTrendChart(List<LockWaitTrendPoint> data)
     {
         ClearChart(LockWaitTrendChart);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Deadlock.cs
@@ -33,6 +33,26 @@ public partial class ViewerServerTab
         await OpenDeadlockGraphAsync(row);
     }
 
+    /// <summary>
+    /// "View Victim Plan" on a deadlock row: opens the BEST-EFFORT victim plan the deadlock carries
+    /// (deadlocks.victim_query_plan_xml, #1368 / V7 — one plan per deadlock, threaded onto every process
+    /// row) in the shared Plan Viewer host — NO live SQL, the same stored-plan surface Top Queries uses.
+    /// The context item is gated per row on <see cref="DeadlockProcessDetail.HasVictimQueryPlan"/> (a NULL
+    /// plan — the common case, and always so under Lite — shows it disabled), so this only fires with a
+    /// captured plan; the guard here is belt-and-braces. Lite's "Get Actual Plan" (live) has no viewer
+    /// equivalent and is omitted everywhere.
+    /// </summary>
+    private void ViewVictimQueryPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        if (FindParentDataGrid(menuItem)?.CurrentItem is not DeadlockProcessDetail row || !row.HasVictimQueryPlan) return;
+        /* queryText is null, not row.SqlText: the victim plan rides on every process row of the deadlock, so
+           the right-clicked row's own statement text would mis-pair on a non-victim row. The plan XML carries
+           its own statement text; the side panel simply stays empty (unlike the blocking rows, which each own
+           their blocked/blocking SQL+plan pair and so pass it). */
+        OpenPlanTab(row.VictimQueryPlanXml!, "Victim Plan", null);
+    }
+
     /// <summary>Double-clicking a deadlock row opens the same graph viewer.</summary>
     private async void DeadlockGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
@@ -27,10 +27,11 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// / <see cref="ViewerDataService.GetQueryStorePlanTextAsync"/>). Consequently Lite's "Get Actual Plan"
 /// (live execution) has no viewer equivalent and is omitted everywhere; only stored plans are shown.
 ///
-/// <para><see cref="OpenPlanTab"/> is the shared entry point every "View Plan" surface calls (the Top
-/// Queries / Query Store context menus here, and — across the parallel Queries wave — the Active Queries
-/// snapshot grid, which already carries its plan XML). It parses the plan off the UI thread, adds a
-/// closable sub-tab, and focuses the host.</para>
+/// <para><see cref="OpenPlanTab"/> is the shared entry point every "View Plan" surface calls: the keyed
+/// Top Queries / Query Store / Top Procedures context menus here (fetched on click by
+/// <see cref="ViewPlan_Click"/>), the FinOps High Impact / Expensive Queries menus, the Active Queries
+/// snapshot grid, and the blocked-process / deadlock grids — the last three already carry their plan XML
+/// in-row. It parses the plan off the UI thread, adds a closable sub-tab, and focuses the host.</para>
 /// </summary>
 public partial class ViewerServerTab
 {
@@ -133,10 +134,13 @@ public partial class ViewerServerTab
     private void CancelPlanButton_Click(object sender, RoutedEventArgs e) => _planLoadCts?.Cancel();
 
     /// <summary>
-    /// The "View Plan" context-menu handler for the Top Queries + Query Store grids: fetches the stored
-    /// plan by the row's key columns (behind the loading overlay), then opens it via <see cref="OpenPlanTab"/>.
-    /// Top Procedures rows never reach here — the procedure_stats collector stores no plan (only a
-    /// plan_handle, which needs a live server to resolve), so those grids keep the plan-less context menu.
+    /// The "View Plan" context-menu handler for the Top Queries + Query Store + Top Procedures grids:
+    /// fetches the stored plan by the row's key columns (behind the loading overlay), then opens it via
+    /// <see cref="OpenPlanTab"/>. Top Procedures now reaches here too — the procedure_stats collector DOES
+    /// store the plan (query_plan_xml, cleanly captured from the cached plan since #1368 / migration V7,
+    /// gated on the host's CapturePlanXml — Darling sets it, Lite writes NULL); it is fetched by object
+    /// identity, exactly like the query-stats key. Comparison grids stay plan-less (a current-vs-baseline
+    /// aggregate has no single stored plan keyed on the row).
     /// </summary>
     private async void ViewPlan_Click(object sender, RoutedEventArgs e)
     {
@@ -160,6 +164,12 @@ public partial class ViewerServerTab
                 label = $"Plan - QS {qs.QueryId}";
                 queryText = qs.QueryText;
                 fetch = ct => _dataService.GetQueryStorePlanTextAsync(_server.ServerId, qs.DatabaseName, qs.QueryId, qs.PlanId, ct);
+                break;
+            case ViewerProcedureStatsRow proc:
+                if (string.IsNullOrEmpty(proc.ObjectName)) return;
+                label = $"Plan - {proc.FullName}";
+                queryText = null; /* the procedure grid carries no statement text; the plan XML holds its own */
+                fetch = ct => _dataService.GetProcedureStatsPlanXmlAsync(_server.ServerId, proc.DatabaseName, proc.SchemaName, proc.ObjectName, ct);
                 break;
             default:
                 /* Comparison items / anything else: no stored plan keyed on the row — deferred. */

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -87,13 +87,16 @@
             <Setter Property="CellStyle" Value="{StaticResource DarkGridCell}"/>
         </Style>
 
-        <!-- Blocking-tab context menus (W1e), copied from Lite's ServerTab.xaml with the two View-Plan
-             items dropped. These stay deferred even now that the Plan Viewer host exists — for a structural
-             reason, not a missing host: blocked-process reports and deadlock graphs carry statement text +
-             a sql_handle, not plan XML. Lite recovers the plan by re-querying the live server's plan cache
-             from that handle, which the viewer (Postgres-only, no live SQL connection) can't do. Copy/Export
-             delegate to the shared PerformanceMonitor.Ui DataGridExport; the graph actions open the shared
-             .Ui BlockingChainControl / DeadlockGraphControl in a GraphViewerWindow. -->
+        <!-- Blocking-tab context menus (W1e), copied from Lite's ServerTab.xaml. The stored-plan "View Plan"
+             items ARE wired now (#1368 / V7): the Darling collector captures the blocked / blocking / victim
+             query plans BEST-EFFORT alongside the report and deadlock graph (blocked_process_reports.
+             blocked_query_plan_xml / blocking_query_plan_xml, deadlocks.victim_query_plan_xml), so these open
+             the stored plan in the Plan Viewer host — NO live SQL. The plans are often NULL (best-effort, and
+             always NULL on the DMV-snapshot fallback rows / under Lite), so each item is gated per row on its
+             Has*QueryPlan flag and shows disabled rather than shown-and-failed. Lite's "Get Actual Plan" (a
+             LIVE re-execution the headless viewer can't run) stays omitted everywhere. Copy/Export delegate
+             to the shared PerformanceMonitor.Ui DataGridExport; the graph actions open the shared .Ui
+             BlockingChainControl / DeadlockGraphControl in a GraphViewerWindow. -->
         <ContextMenu x:Key="BlockedProcessContextMenu">
             <MenuItem Header="Copy Cell" Click="CopyCell_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
@@ -109,6 +112,17 @@
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
             <Separator/>
+            <!-- Stored blocked / blocking query plans (#1368 / V7), gated per row on the row's Has*QueryPlan
+                 flag via the ContextMenu's PlacementTarget so a plan-less row (best-effort NULL, or a DMV
+                 fallback row) shows the item disabled instead of shown-and-failed. -->
+            <MenuItem Header="View Blocked Query Plan" Click="ViewBlockedQueryPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasBlockedQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="View Blocking Query Plan" Click="ViewBlockingQueryPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasBlockingQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
             <MenuItem Header="View Block Chain" Click="ViewBlockChain_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F517;"/></MenuItem.Icon>
             </MenuItem>
@@ -129,6 +143,13 @@
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
             <Separator/>
+            <!-- Stored victim query plan (#1368 / V7), gated per row on HasVictimQueryPlan via the
+                 ContextMenu's PlacementTarget so a plan-less deadlock (best-effort NULL, the common case)
+                 shows the item disabled instead of shown-and-failed. -->
+            <MenuItem Header="View Victim Plan" Click="ViewVictimQueryPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasVictimQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
             <MenuItem Header="View Deadlock Graph" Click="ViewDeadlockGraph_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F578;"/></MenuItem.Icon>
             </MenuItem>
@@ -151,11 +172,12 @@
         </Style>
 
         <!-- Queries-tab grid context menu (W1f-1), copied from Lite's ServerTab.xaml DataGridContextMenu.
-             This is the PLAN-LESS variant used by Top Procedures + the comparison grids: procedure plans
-             are never stored (procedure_stats has only plan_handle, no query_plan column — Lite fetches
-             them live from the plan cache, which the viewer can't do), so "View Plan" is honestly omitted
-             here rather than shown-and-failed. Lite's "Get Actual Plan" (needs a live execution) and "Copy
-             Repro Script" (needs a live connection string) stay deferred everywhere.
+             This is the PLAN-LESS variant used by the comparison grids + the Active Queries snapshot grid:
+             a comparison row is a current-vs-baseline aggregate with no single stored plan keyed on it, and
+             the snapshot grid has its own dedicated Estimated / Actual plan buttons — so neither needs a
+             "View Plan" context item. (Top Procedures moved OFF this menu to the plan-enabled variant below:
+             procedure_stats DOES store the plan since #1368 / V7.) Lite's "Get Actual Plan" (needs a live
+             execution) and "Copy Repro Script" (needs a live connection string) stay deferred everywhere.
              Copy/Export delegate to the shared PerformanceMonitor.Ui DataGridExport (ViewerServerTab.CopyExport.cs). -->
         <ContextMenu x:Key="QueryGridContextMenu">
             <MenuItem Header="Copy Cell" Click="CopyCell_Click">
@@ -173,9 +195,10 @@
             </MenuItem>
         </ContextMenu>
 
-        <!-- PLAN-enabled variant for Top Queries + Query Store, whose plans the collector stores
-             (query_stats.query_plan_xml / query_store_stats.query_plan_text, PR #1349). "View Plan" opens
-             the stored plan in the Plan Viewer tab via ViewPlan_Click (ViewerServerTab.Plans.cs). -->
+        <!-- PLAN-enabled variant for Top Queries + Query Store + Top Procedures, whose plans the collector
+             stores (query_stats.query_plan_xml / query_store_stats.query_plan_text, PR #1349;
+             procedure_stats.query_plan_xml, #1368 / V7). "View Plan" opens the stored plan in the Plan
+             Viewer tab via ViewPlan_Click (ViewerServerTab.Plans.cs), which fetches by the row's key. -->
         <ContextMenu x:Key="QueryPlanGridContextMenu">
             <MenuItem Header="Copy Cell" Click="CopyCell_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
@@ -196,21 +219,22 @@
             </MenuItem>
         </ContextMenu>
 
-        <!-- Row style for Top Procedures + the comparison grids: the plan-less copy/export menu on the DarkGridRow hover chrome. -->
+        <!-- Row style for the comparison grids + the Active Queries snapshot grid: the plan-less copy/export menu on the DarkGridRow hover chrome. -->
         <Style x:Key="QueryGridRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource DarkGridRow}">
             <Setter Property="ContextMenu" Value="{StaticResource QueryGridContextMenu}"/>
         </Style>
 
-        <!-- Row style for Top Queries + Query Store: adds "View Plan" (their plans are stored). -->
+        <!-- Row style for Top Queries + Query Store + Top Procedures: adds "View Plan" (their plans are stored). -->
         <Style x:Key="QueryPlanGridRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource DarkGridRow}">
             <Setter Property="ContextMenu" Value="{StaticResource QueryPlanGridContextMenu}"/>
         </Style>
 
         <!-- FinOps tab (copy-parity program). The four *_wait_in_ms cells in the Locking grid are shaded by
              this shared .Ui converter; the copy/export context menus reuse the shell's DataGridExport
-             handlers. Lite's FinOps plan-navigation context items (High Impact / Expensive Queries "View
-             Plan" / "Get Actual Plan") are intentionally NOT ported — the viewer has no live SQL connection
-             to fetch a plan from a query_hash, matching the Blocking/Procedures grids' plan-less menus. -->
+             handlers. Lite's FinOps "View Plan" IS ported for the High Impact / Expensive Queries grids (their
+             rows carry the stored query_stats.query_plan_xml — see FinOpsQueryPlanContextMenu below); only
+             Lite's "Get Actual Plan" (a LIVE re-execution) has no headless-viewer equivalent and stays omitted
+             everywhere, as on every other viewer grid. -->
         <ui:HeatIntensityToBrushConverter x:Key="FinOpsHeatBrush"/>
 
         <ContextMenu x:Key="FinOpsGridContextMenu">
@@ -345,12 +369,12 @@
              derivatives). Reads rewired to Postgres over the fixed 24-hour window, which supplies the
              slicer range. Performance Trends / Active Queries / Query Heatmap sub-tabs are deferred to
              W1f-2, so their slots are ABSENT. Now wired (headless-plan wave): Top Queries' "Query Plan"
-             download column + a "View Plan" context item on Top Queries and Query Store, which open the
-             stored query_stats.query_plan_xml / query_store_stats.query_plan_text in the Plan Viewer tab.
-             Still deferred: Top Procedures' plan actions (procedure plans aren't stored — resolving the
-             plan_handle needs a live server), Lite's "Get Actual Plan" (needs a live execution), the
-             per-row double-click history windows, and the slicer overlay-on-select — only the
-             slicer's drag-to-narrow re-read and its sort-driven metric re-labeling are wired here. -->
+             download column + a "View Plan" context item on Top Queries, Query Store, AND Top Procedures,
+             which open the stored query_stats.query_plan_xml / query_store_stats.query_plan_text /
+             procedure_stats.query_plan_xml (procedure plans ARE stored since #1368 / V7) in the Plan Viewer
+             tab. Still deferred: Lite's "Get Actual Plan" (needs a live execution), the per-row double-click
+             history windows, and the slicer overlay-on-select — only the slicer's drag-to-narrow re-read and
+             its sort-driven metric re-labeling are wired here. -->
         <TabItem Header="Queries">
             <Grid Margin="0,8,0,0">
                 <Grid.RowDefinitions>
@@ -824,7 +848,7 @@
                                        Foreground="{DynamicResource ForegroundBrush}"
                                        Background="#2244AAFF"/>
                             <DataGrid Grid.Row="2" x:Name="ProcedureStatsGrid" Style="{StaticResource DarkGrid}"
-                                      RowStyle="{StaticResource QueryGridRowStyle}"
+                                      RowStyle="{StaticResource QueryPlanGridRowStyle}"
                                       HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
                                       Sorting="ProcedureStatsGrid_Sorting">
                                 <DataGrid.Columns>
@@ -1548,9 +1572,10 @@
              rate, blocking incidents, deadlocks), "Current Waits" (waiting-task duration by wait type,
              blocked sessions by database), "Blocked Process Reports" (W1e widened ~25-column filterable
              grid + UTC slicer + block-chain viewer), and "Deadlocks" (W1e per-process grid + UTC slicer +
-             deadlock-graph viewer). Reads rewired to Postgres; the two View-Plan context-menu items stay
-             deferred even with the Plan Viewer host live — the reports carry statement text + a sql_handle
-             (not plan XML), which only a live server could resolve to a plan. -->
+             deadlock-graph viewer). Reads rewired to Postgres; the blocked / blocking / victim "View Plan"
+             context items ARE wired now (#1368 / V7 store the plans BEST-EFFORT alongside the report /
+             deadlock graph, gated per row on presence), opening the stored plan in the Plan Viewer host —
+             NO live SQL. Only Lite's "Get Actual Plan" (a live re-execution) stays omitted. -->
         <TabItem Header="Blocking">
             <Grid Margin="8">
                 <TabControl x:Name="BlockingSubTabs"


### PR DESCRIPTION
## What

The execution plans for the viewer's **Procedures**, **Blocking**, and **Deadlock** grids ARE stored (added in #1368 / migration V7), but the viewer omitted the "View Plan" menus behind stale "plans aren't stored" comments — a store-backed capability going unused. This wires them onto the existing plan-enabled Plan Viewer host pattern (the same one Top Queries / Query Store / FinOps use). Darling-viewer-only: no collector, no Lite, no migration.

- **Procedures** → "View Plan" fetches `procedure_stats.query_plan_xml` keyed by (server, db, schema, object) via `ViewPlan_Click` (repointed the grid to the existing `QueryPlanGridRowStyle`; mirrors Top Queries' keyed fetch, message-on-null since it's cleanly captured).
- **Blocking** → two clearly-labeled per-row-gated items open the best-effort blocked/blocking plans (`blocked_process_reports.blocked_query_plan_xml` / `blocking_query_plan_xml`), carried in-row like the report XML already is. DMV-fallback rows never carry a plan → item disabled.
- **Deadlock** → "View Victim Plan" opens `victim_query_plan_xml`, threaded onto every parsed process row, gated per row on presence.

Best-effort plans are frequently NULL, so the blocking/deadlock items gate **per row** (disabled, never shown-and-failed) via the ContextMenu `PlacementTarget` binding with `FallbackValue=False`. "Get Actual Plan" (live execution) stays omitted everywhere — architectural, the established headless pattern. Stale XAML/handler comments asserting these plans aren't stored / are plan-less were corrected.

## Columns verified stored (base tables + Darling collectors)

| Column | Capture | Collector |
|---|---|---|
| `procedure_stats.query_plan_xml` | clean (dm_exec_text_query_plan) | ProcedureStatsCollector |
| `blocked_process_reports.blocked_query_plan_xml` / `blocking_query_plan_xml` | best-effort (can be NULL) | BlockedProcessReportCollector |
| `deadlocks.victim_query_plan_xml` | best-effort (can be NULL) | DeadlocksCollector |

All gated on `CollectorContext.CapturePlanXml` — Darling sets it true; Lite always writes NULL.

## Surfaced finding — blocking/deadlock grid reads now source BASE tables, not the `v_` views

The two plan-carrying grid reads (`BlockedProcessReportsSql`, `RecentDeadlocksSql`) were switched from `v_blocked_process_reports` / `v_deadlocks` to the base tables. **Reason (verified in the migration code):** Postgres pins a view's `SELECT *` to the column list at creation time. These views are created in **V4** (before **V7** added the plan columns), and **V8** only `ALTER VIEW ... SET SCHEMA`s them — it never re-creates them. So on a store **upgraded** across the V7 boundary, the views do not project the plan columns and a view-based read would fail the *entire* grid (a fresh store is fine because V1 already carries the columns). The base tables always have the columns, the `viewer` role has `SELECT ON ALL TABLES IN SCHEMA collect`, and the plan columns are Darling-only (never Lite-twinnable), so those two reads were never byte-twinnable with Lite once they carry a plan. `DarlingAlertReadAdapter` already reads these base tables; the pair-row/slicer/trend/summary reads still twin over the `v_` views. The 3 twinning assertions were updated with justification. (An alternative fix — a tiny V11 view-refresh migration — was **not** taken because the task scoped out migrations and this keeps the change viewer-only.)

## Tests

`Darling.Tests`: **533 passed, 0 failed, 83 skipped** (the 83 are `DARLING_TEST_PG` live round-trips — env unset here). Added/extended:
- SQL: `ProcedureStatsPlanXmlSql` shape + `procedure_stats.query_plan_xml` schema-existence + dialect theory; base-table + plan-column assertions on the two grid reads; the two schema-existence loops now include the plan columns.
- Gating: `HasBlockedQueryPlan` / `HasBlockingQueryPlan` (independent) + `HasVictimQueryPlan` default-false/presence.
- Parse: victim plan threaded onto every process row (present) + left false (NULL).
- Live (gated): in-row blocking plans (both / blocked-only / neither), victim plan threaded onto every row, keyed procedure fetch (newest wins / NULL when uncaptured).

Builds clean: viewer + service + tests, 0 errors.

Do **not** merge — for lead validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)