### PR TITLE
Add shared session_summary_stats collector (Dashboard->Darling parity)

### DIFF
--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -241,7 +241,7 @@ public sealed class DarlingAnalysisStoreTests
 
         using (var versions = new NpgsqlCommand("SELECT COUNT(*) FROM darling_schema_version", connection))
         {
-            Assert.Equal(11L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(12L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
         }
 
         /* Clear leftovers from an earlier aborted run so the assertions below are deterministic. */

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -32,9 +32,9 @@ public sealed class DarlingObservabilityTests
     private const int TestServerId = -424242;
 
     [Fact]
-    public void MigrationScripts_ElevenVersions_V9InventoryCost_V10LatchSpinlock_V11CpuSchedulerPlanCache()
+    public void MigrationScripts_TwelveVersions_V10LatchSpinlock_V11CpuSchedulerPlanCache_V12SessionSummary()
     {
-        Assert.Equal(11, PgMigrations.Scripts.Count);
+        Assert.Equal(12, PgMigrations.Scripts.Count);
         Assert.Equal(1, PgMigrations.Scripts[0].Version);
         Assert.Equal(2, PgMigrations.Scripts[1].Version);
         Assert.Equal(3, PgMigrations.Scripts[2].Version);
@@ -46,7 +46,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(9, PgMigrations.Scripts[8].Version);
         Assert.Equal(10, PgMigrations.Scripts[9].Version);
         Assert.Equal(11, PgMigrations.Scripts[10].Version);
-        Assert.Equal(11, StorageVersion.SchemaVersion);
+        Assert.Equal(12, PgMigrations.Scripts[11].Version);
+        Assert.Equal(12, StorageVersion.SchemaVersion);
 
         /* V5 completes the v_* twin of Lite's DuckDB view layer -- the copy-parity tail tabs
            (Running Jobs, Configuration, Daily Summary, Collection Health) read these five, so
@@ -139,6 +140,20 @@ public sealed class DarlingObservabilityTests
         Assert.Contains("CREATE OR REPLACE VIEW v_cpu_scheduler_stats AS SELECT * FROM cpu_scheduler_stats;", v11, StringComparison.Ordinal);
         Assert.Contains("CREATE OR REPLACE VIEW v_plan_cache_stats AS SELECT * FROM plan_cache_stats;", v11, StringComparison.Ordinal);
 
+        /* V12 adds the session_summary_stats collector table (server-wide session SUMMARY: the
+           connection-leak / idle signal) and its v_* passthrough view (Dashboard->Darling parity,
+           #1262). Generated from the collector definition so the table matches the fresh V1 shape;
+           CREATE TABLE IF NOT EXISTS no-ops on a fresh store and really creates it on a store built
+           before this collector existed. Distinct from the per-application session_stats table. */
+        var v12 = PgMigrations.Scripts[11].Sql;
+        Assert.Equal("session-summary-collector", PgMigrations.Scripts[11].Name);
+        Assert.Contains("CREATE TABLE IF NOT EXISTS session_summary_stats (", v12, StringComparison.Ordinal);
+        Assert.Contains("idle_sessions_over_30min integer", v12, StringComparison.Ordinal);
+        Assert.Contains("sessions_waiting_for_memory integer", v12, StringComparison.Ordinal);
+        Assert.Contains("top_application_name text", v12, StringComparison.Ordinal);
+        Assert.Contains("CREATE INDEX IF NOT EXISTS idx_session_summary_stats_time ON session_summary_stats(server_id, collection_time);", v12, StringComparison.Ordinal);
+        Assert.Contains("CREATE OR REPLACE VIEW v_session_summary_stats AS SELECT * FROM session_summary_stats;", v12, StringComparison.Ordinal);
+
         var v2 = PgMigrations.Scripts[1].Sql;
         Assert.Contains("CREATE TABLE IF NOT EXISTS servers (", v2, StringComparison.Ordinal);
         Assert.Contains("CREATE TABLE IF NOT EXISTS collection_log (", v2, StringComparison.Ordinal);
@@ -161,7 +176,7 @@ public sealed class DarlingObservabilityTests
 
         using (var versions = new NpgsqlCommand("SELECT COUNT(*) FROM darling_schema_version", connection))
         {
-            Assert.Equal(11L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(12L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
         }
 
         /* Clear leftovers from an earlier aborted run so the assertions below are deterministic. */

--- a/Darling/Darling.Tests/PgSchemaGeneratorTests.cs
+++ b/Darling/Darling.Tests/PgSchemaGeneratorTests.cs
@@ -16,18 +16,18 @@ namespace Darling.Tests;
 
 /// <summary>
 /// Pins Darling's generated Postgres schema against the collector definitions: the catalog covers
-/// all 30 collectors, the type map mirrors Lite's DuckDB types (per-column numeric(p,s) included),
+/// all 31 collectors, the type map mirrors Lite's DuckDB types (per-column numeric(p,s) included),
 /// the prefix names vary exactly where Lite's schema varies (deadlock_id / blocked_report_id /
 /// config_id+capture_time / running_jobs' no-id), and the index shapes mirror Lite's columns.
 /// </summary>
 public sealed class PgSchemaGeneratorTests
 {
     [Fact]
-    public void Catalog_CoversAll30Collectors_WithUniqueTablesAndNames()
+    public void Catalog_CoversAll31Collectors_WithUniqueTablesAndNames()
     {
-        Assert.Equal(30, CollectorCatalog.All.Count);
-        Assert.Equal(30, CollectorCatalog.All.Select(s => s.TargetTable).Distinct().Count());
-        Assert.Equal(30, CollectorCatalog.All.Select(s => s.Name).Distinct().Count());
+        Assert.Equal(31, CollectorCatalog.All.Count);
+        Assert.Equal(31, CollectorCatalog.All.Select(s => s.TargetTable).Distinct().Count());
+        Assert.Equal(31, CollectorCatalog.All.Select(s => s.Name).Distinct().Count());
     }
 
     [Fact]
@@ -243,6 +243,33 @@ public sealed class PgSchemaGeneratorTests
     }
 
     [Fact]
+    public void CreateTable_SessionSummaryStats_MapsCountsToInteger_AndTopColumns()
+    {
+        var ddl = PgSchemaGenerator.CreateTable(SessionSummaryStatsCollector.Instance);
+
+        Assert.Equal(
+            "CREATE TABLE IF NOT EXISTS session_summary_stats (\n" +
+            "    collection_id bigint NOT NULL,\n" +
+            "    collection_time timestamp NOT NULL,\n" +
+            "    server_id integer NOT NULL,\n" +
+            "    server_name text NOT NULL,\n" +
+            "    total_sessions integer,\n" +
+            "    running_sessions integer,\n" +
+            "    sleeping_sessions integer,\n" +
+            "    background_sessions integer,\n" +
+            "    dormant_sessions integer,\n" +
+            "    idle_sessions_over_30min integer,\n" +
+            "    sessions_waiting_for_memory integer,\n" +
+            "    databases_with_connections integer,\n" +
+            "    top_application_name text,\n" +
+            "    top_application_connections integer,\n" +
+            "    top_host_name text,\n" +
+            "    top_host_connections integer\n" +
+            ");",
+            ddl);
+    }
+
+    [Fact]
     public void CreateIndex_MirrorsLiteIndexColumns()
     {
         Assert.Equal(
@@ -267,11 +294,11 @@ public sealed class PgSchemaGeneratorTests
         var script = PgSchemaGenerator.GenerateFullSchema();
 
         var tableCount = CollectorCatalog.All.Count(s => script.Contains($"CREATE TABLE IF NOT EXISTS {s.TargetTable} (", StringComparison.Ordinal));
-        Assert.Equal(30, tableCount);
+        Assert.Equal(31, tableCount);
 
-        /* 30 tables minus the two index-less config tables = 28 indexes. */
+        /* 31 tables minus the two index-less config tables = 29 indexes. */
         var indexCount = script.Split("CREATE INDEX IF NOT EXISTS").Length - 1;
-        Assert.Equal(28, indexCount);
+        Assert.Equal(29, indexCount);
 
         /* The precision guard can never regress silently. */
         Assert.DoesNotContain("numeric(0,0)", script, StringComparison.Ordinal);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -762,6 +762,7 @@ LIMIT 1", connection);
         ["trace_flags"] = RunTraceFlagsTolerantAsync,
         ["database_scoped_config"] = (r, s, ct) => r.RunAsync(DatabaseScopedConfigCollector.Instance, s, ct),
         ["session_stats"] = (r, s, ct) => r.RunAsync(SessionStatsCollector.Instance, s, ct),
+        ["session_summary_stats"] = (r, s, ct) => r.RunAsync(SessionSummaryStatsCollector.Instance, s, ct),
         ["waiting_tasks"] = (r, s, ct) => r.RunAsync(WaitingTasksCollector.Instance, s, ct),
         ["procedure_stats"] = (r, s, ct) => r.RunAsync(ProcedureStatsCollector.Instance, s, ct),
         ["running_jobs"] = (r, s, ct) => r.RunAsync(RunningJobsCollector.Instance, s, ct),

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -55,6 +55,7 @@ public static class PgMigrations
         new Migration(9, "server-inventory-cost-fields", V9Sql),
         new Migration(10, "latch-spinlock-collectors", PgSchemaGenerator.GenerateV10AddLatchSpinlock()),
         new Migration(11, "cpu-scheduler-plan-cache-collectors", PgSchemaGenerator.GenerateV11AddCpuSchedulerPlanCache()),
+        new Migration(12, "session-summary-collector", PgSchemaGenerator.GenerateV12AddSessionSummary()),
     };
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/PgSchemaGenerator.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgSchemaGenerator.cs
@@ -336,4 +336,41 @@ public static class PgSchemaGenerator
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// The V12 migration body — adds the session_summary_stats collector table (server-wide session
+    /// SUMMARY: the connection-leak / idle signal from sys.dm_exec_sessions + sys.dm_exec_requests)
+    /// plus its <c>v_*</c> passthrough view. Generated from the collector definition (not hand-listed)
+    /// so the table is column-for-column identical to the fresh-store V1 shape. <c>CREATE TABLE IF NOT
+    /// EXISTS</c> makes this a harmless no-op on a fresh store (V1 already created it from the current
+    /// catalog and V8 moved it to <c>collect</c>) and the real create on a store built before this
+    /// collector existed; the view is created directly in <c>collect</c> because V12 runs after V8,
+    /// resolving the bare names through <c>search_path = collect, config, public</c>. Distinct from the
+    /// per-application session_stats table (V1), which this does not touch.
+    /// </summary>
+    public static string GenerateV12AddSessionSummary()
+    {
+        var sb = new StringBuilder();
+        sb.Append("/* V12: session_summary_stats collector (Dashboard->Darling connection-leak / idle parity, #1262).\n");
+        sb.Append("   Generated from the collector definition so the table matches the fresh V1 shape. */\n");
+
+        foreach (ICollectorSchemaInfo schema in new ICollectorSchemaInfo[]
+        {
+            SessionSummaryStatsCollector.Instance,
+        })
+        {
+            sb.Append('\n').Append(CreateTable(schema)).Append('\n');
+
+            var index = CreateIndex(schema);
+            if (index is not null)
+            {
+                sb.Append(index).Append('\n');
+            }
+
+            sb.Append("CREATE OR REPLACE VIEW v_").Append(schema.TargetTable)
+              .Append(" AS SELECT * FROM ").Append(schema.TargetTable).Append(";\n");
+        }
+
+        return sb.ToString();
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 11;
+    public const int SchemaVersion = 12;
 }

--- a/Lite.Tests/DuckDbSchemaTests.cs
+++ b/Lite.Tests/DuckDbSchemaTests.cs
@@ -142,11 +142,11 @@ public class DuckDbSchemaTests : IDisposable
         foreach (var _ in Schema.GetAllTableStatements())
             tableCount++;
 
-        /* 37 tables from Schema (schema_version is created separately by DuckDbInitializer).
+        /* 38 tables from Schema (schema_version is created separately by DuckDbInitializer).
            Includes config_edge_trigger_watermarks (#1145), dmv_blocking_snapshots (always-on
-           blocking fallback), latch_stats/spinlock_stats, and cpu_scheduler_stats/plan_cache_stats
-           (#1262 shared DMV collectors). */
-        Assert.Equal(37, tableCount);
+           blocking fallback), latch_stats/spinlock_stats, cpu_scheduler_stats/plan_cache_stats, and
+           session_summary_stats (#1262 shared DMV collectors). */
+        Assert.Equal(38, tableCount);
     }
 
     [Fact]

--- a/Lite.Tests/SessionSummaryStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/SessionSummaryStatsCollectorDefinitionTests.cs
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lite.Tests.Helpers;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Pins the cross-SKU parity contract of the shared session_summary_stats collector definition (the
+/// Dashboard-parity port of install/36_collect_session_stats.sql — the server-wide session SUMMARY /
+/// connection-leak / idle signal): verbatim query text, the collect-everywhere AppliesTo (the DMVs
+/// exist on all platforms; Azure SQL DB merely scopes the counts), payload column order, ReadAsync
+/// mapping (including the nullable top-application/host columns), and the point-in-time no-delta
+/// WritePayload. An intentional change to any of these must consciously update these tests. Distinct
+/// from the per-application session_stats collector.
+/// </summary>
+public sealed class SessionSummaryStatsCollectorDefinitionTests
+{
+    private const string ExpectedQuery = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    total_sessions = CONVERT(integer, COUNT_BIG(*)),
+    running_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'running'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    sleeping_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'sleeping'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    background_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.is_user_process = 0
+                THEN 1
+                ELSE 0
+            END
+        ),
+    dormant_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'dormant'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    idle_sessions_over_30min =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'sleeping'
+                AND des.last_request_end_time < DATEADD(MINUTE, -30, SYSDATETIME())
+                AND des.is_user_process = 1
+                THEN 1
+                ELSE 0
+            END
+        ),
+    sessions_waiting_for_memory =
+        SUM
+        (
+            CASE
+                WHEN der.wait_type LIKE N'%MEMORY%'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    databases_with_connections = CONVERT(integer, COUNT_BIG(DISTINCT des.database_id)),
+    top_application_name = MAX(top_app.program_name),
+    top_application_connections = CONVERT(integer, MAX(top_app.connection_count)),
+    top_host_name = MAX(top_host.host_name),
+    top_host_connections = CONVERT(integer, MAX(top_host.connection_count))
+FROM sys.dm_exec_sessions AS des
+LEFT JOIN sys.dm_exec_requests AS der
+  ON der.session_id = des.session_id
+OUTER APPLY
+(
+    SELECT TOP (1)
+        program_name = des2.program_name,
+        connection_count = COUNT_BIG(*)
+    FROM sys.dm_exec_sessions AS des2
+    WHERE des2.session_id > 50
+    AND   des2.is_user_process = 1
+    AND   des2.program_name IS NOT NULL
+    GROUP BY
+        des2.program_name
+    ORDER BY
+        COUNT_BIG(*) DESC
+) AS top_app
+OUTER APPLY
+(
+    SELECT TOP (1)
+        host_name = des3.host_name,
+        connection_count = COUNT_BIG(*)
+    FROM sys.dm_exec_sessions AS des3
+    WHERE des3.session_id > 50
+    AND   des3.is_user_process = 1
+    AND   des3.host_name IS NOT NULL
+    GROUP BY
+        des3.host_name
+    ORDER BY
+        COUNT_BIG(*) DESC
+) AS top_host
+WHERE des.session_id > 50
+OPTION(RECOMPILE);";
+
+    [Fact]
+    public void Query_IsTheVerbatimParityContract()
+    {
+        var context = CollectorTestContext.Make(new RecordingCollectorDeltaCalculator());
+        Assert.Equal(ExpectedQuery, SessionSummaryStatsCollector.Instance.BuildQuery(context).Text);
+        Assert.Empty(SessionSummaryStatsCollector.Instance.BuildQuery(context).Parameters);
+        Assert.Null(SessionSummaryStatsCollector.Instance.WatermarkColumn);
+        Assert.Equal("session_summary_stats", SessionSummaryStatsCollector.Instance.Name);
+        Assert.Equal("session_summary_stats", SessionSummaryStatsCollector.Instance.TargetTable);
+    }
+
+    [Fact]
+    public void AppliesTo_CollectsEverywhere_IncludingAzureSqlDb()
+    {
+        /* Both DMVs exist on SQL Server, Azure SQL DB, and Managed Instance (MS Learn-verified) and
+           the query never fails — Azure SQL DB just scopes the counts. Mirrors SessionStatsCollector. */
+        Assert.True(SessionSummaryStatsCollector.Instance.AppliesTo(new CollectorTargetInfo { IsAzureSqlDb = true }));
+        Assert.True(SessionSummaryStatsCollector.Instance.AppliesTo(new CollectorTargetInfo { IsAzureManagedInstance = true }));
+        Assert.True(SessionSummaryStatsCollector.Instance.AppliesTo(new CollectorTargetInfo()));
+    }
+
+    [Fact]
+    public void PayloadColumns_AreInAppendOrder()
+    {
+        var names = SessionSummaryStatsCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                "total_sessions",
+                "running_sessions",
+                "sleeping_sessions",
+                "background_sessions",
+                "dormant_sessions",
+                "idle_sessions_over_30min",
+                "sessions_waiting_for_memory",
+                "databases_with_connections",
+                "top_application_name",
+                "top_application_connections",
+                "top_host_name",
+                "top_host_connections",
+            },
+            names);
+
+        /* All counts are integer; the two top_* names are varchar (nullable), matching the Dashboard. */
+        Assert.Equal(CollectorColumnType.Integer, SessionSummaryStatsCollector.Instance.PayloadColumns.Single(c => c.Name == "idle_sessions_over_30min").Type);
+        Assert.Equal(CollectorColumnType.Varchar, SessionSummaryStatsCollector.Instance.PayloadColumns.Single(c => c.Name == "top_application_name").Type);
+        Assert.Equal(CollectorColumnType.Integer, SessionSummaryStatsCollector.Instance.PayloadColumns.Single(c => c.Name == "top_host_connections").Type);
+    }
+
+    [Fact]
+    public async Task ReadAsync_MapsColumns_IncludingNullableTopAppHostColumns()
+    {
+        using var reader = new FakeCollectorDataReader(
+            /* A busy row: a top application and host both present. */
+            new object[]
+            {
+                42, 3, 30, 5, 1, 8, 0, 4, "MyApp", 20, "WEB01", 15,
+            },
+            /* A quiet row (no qualifying user session for the top-app/host APPLYs): the three top_*
+               columns come back NULL. */
+            new object[]
+            {
+                1, 1, 0, 0, 0, 0, 0, 1, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+            });
+
+        var context = CollectorTestContext.Make(new RecordingCollectorDeltaCalculator());
+
+        var rows = await SessionSummaryStatsCollector.Instance.ReadAsync(reader, context, CancellationToken.None);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(
+            new SessionSummaryStatsCollector.Row(42, 3, 30, 5, 1, 8, 0, 4, "MyApp", 20, "WEB01", 15),
+            rows[0]);
+        Assert.Equal(
+            new SessionSummaryStatsCollector.Row(1, 1, 0, 0, 0, 0, 0, 1, null, null, null, null),
+            rows[1]);
+    }
+
+    [Fact]
+    public void WritePayload_EmitsPayloadOrder_PointInTime_NoDeltas()
+    {
+        var deltas = new RecordingCollectorDeltaCalculator();
+        var context = CollectorTestContext.Make(deltas);
+        var writer = new RecordingCollectorRowWriter();
+        var row = new SessionSummaryStatsCollector.Row(42, 3, 30, 5, 1, 8, 0, 4, "MyApp", 20, "WEB01", 15);
+
+        SessionSummaryStatsCollector.Instance.WritePayload(row, writer, context);
+
+        Assert.Equal(
+            new object?[]
+            {
+                42, 3, 30, 5, 1, 8, 0, 4, "MyApp", 20, "WEB01", 15,
+            },
+            writer.Values);
+
+        /* Point-in-time snapshot — no delta calculator interaction at all. */
+        Assert.Empty(deltas.Calls);
+    }
+}

--- a/Lite.Tests/SessionSummaryStatsRoundTripTests.cs
+++ b/Lite.Tests/SessionSummaryStatsRoundTripTests.cs
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using Lite.Tests.Helpers;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Real-DuckDB round-trip pin for the #1262 session_summary_stats collector. The definition test pins
+/// PayloadColumns/WritePayload against a recording writer, but nothing else proves the Lite DuckDB
+/// table's physical column layout stays aligned with WritePayload — the appender writes BY POSITION,
+/// so a table whose column count/order drifts from (4 prefix + WritePayload) fails at EndRow(). This
+/// exercises the exact append path RemoteCollectorService.RunCollectorDefinitionAsync uses
+/// (CreateAppender -> prefix -> WritePayload -> EndRow) against a freshly initialized schema, then
+/// reads representative columns back, including the nullable top_* columns left NULL.
+/// </summary>
+public sealed class SessionSummaryStatsRoundTripTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SessionSummaryStatsRoundTripTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LiteSessSumRt_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            /* Best-effort cleanup */
+        }
+    }
+
+    [Fact]
+    public async Task SessionSummaryStats_AppendRoundTrips_Counts_AndNullableTopColumns()
+    {
+        /* top_application_name / top_application_connections / top_host_name / top_host_connections
+           left NULL (a quiet server with no qualifying user session) to prove the nullable appends
+           round-trip too. */
+        var row = new SessionSummaryStatsCollector.Row(42, 3, 30, 5, 1, 8, 2, 4, null, null, null, null);
+
+        using var connection = await AppendOneRowAsync(SessionSummaryStatsCollector.Instance, row);
+
+        Assert.Equal(42, (int)await ScalarAsync(connection, "session_summary_stats", "total_sessions"));
+        Assert.Equal(8, (int)await ScalarAsync(connection, "session_summary_stats", "idle_sessions_over_30min"));
+        Assert.Equal(2, (int)await ScalarAsync(connection, "session_summary_stats", "sessions_waiting_for_memory"));
+        Assert.Equal(4, (int)await ScalarAsync(connection, "session_summary_stats", "databases_with_connections"));
+        Assert.Equal(DBNull.Value, await ScalarAsync(connection, "session_summary_stats", "top_application_name"));
+        Assert.Equal(DBNull.Value, await ScalarAsync(connection, "session_summary_stats", "top_host_connections"));
+    }
+
+    [Fact]
+    public async Task SessionSummaryStats_AppendRoundTrips_PopulatedTopColumns()
+    {
+        var row = new SessionSummaryStatsCollector.Row(100, 5, 90, 3, 2, 12, 0, 6, "MyApp", 20, "WEB01", 15);
+
+        using var connection = await AppendOneRowAsync(SessionSummaryStatsCollector.Instance, row);
+
+        Assert.Equal("MyApp", (string)await ScalarAsync(connection, "session_summary_stats", "top_application_name"));
+        Assert.Equal(20, (int)await ScalarAsync(connection, "session_summary_stats", "top_application_connections"));
+        Assert.Equal("WEB01", (string)await ScalarAsync(connection, "session_summary_stats", "top_host_name"));
+        Assert.Equal(15, (int)await ScalarAsync(connection, "session_summary_stats", "top_host_connections"));
+    }
+
+    /// <summary>
+    /// Appends one row through the exact runner path (prefix columns + WritePayload + EndRow) against a
+    /// freshly initialized DuckDB and returns the open connection. EndRow throwing here would mean the
+    /// Schema.cs table column count/order drifted from WritePayload.
+    /// </summary>
+    private async Task<DuckDBConnection> AppendOneRowAsync<TRow>(ICollectorDefinition<TRow> definition, TRow row)
+    {
+        var dbPath = Path.Combine(_tempDir, $"{definition.TargetTable}.duckdb");
+        await new DuckDbInitializer(dbPath).InitializeAsync();
+
+        var context = CollectorTestContext.Make(new RecordingCollectorDeltaCalculator());
+
+        var connection = new DuckDBConnection($"Data Source={dbPath}");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        using (var appender = connection.CreateAppender(definition.TargetTable))
+        {
+            var appenderRow = appender.CreateRow();
+            if (definition.IncludesCollectionId)
+            {
+                appenderRow.AppendValue(1L);
+            }
+            appenderRow.AppendValue(context.CollectionTime).AppendValue(42).AppendValue("s");
+
+            var writer = new AppenderCollectorRowWriter { CurrentRow = appenderRow };
+            definition.WritePayload(row, writer, context);
+            appenderRow.EndRow();   /* throws if the appended column count != table column count */
+        }
+
+        return connection;
+    }
+
+    private static async Task<object> ScalarAsync(DuckDBConnection connection, string table, string column)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT {column} FROM {table} LIMIT 1";
+        return (await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+}

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 38;
+    internal const int CurrentSchemaVersion = 39;
 
     private readonly string _archivePath;
 
@@ -119,7 +119,7 @@ public class DuckDbInitializer
         "deadlocks", "blocked_process_reports", "memory_grant_stats", "waiting_tasks",
         "dmv_blocking_snapshots",
         "running_jobs", "database_size_stats", "index_object_stats", "server_properties",
-        "session_stats", "server_config", "database_config",
+        "session_stats", "session_summary_stats", "server_config", "database_config",
         "database_scoped_config", "trace_flags", "config_alert_log",
         "collection_log"
     ];
@@ -929,6 +929,17 @@ public class DuckDbInitializer
                     GetAllTableStatements() below; the v_ views come from CreateArchiveViewsAsync via
                     ArchivableTables. */
             _logger?.LogInformation("Running migration to v38: adding cpu_scheduler_stats and plan_cache_stats tables");
+        }
+
+        if (fromVersion < 39)
+        {
+            /* v39: added session_summary_stats (server-wide session SUMMARY from sys.dm_exec_sessions
+                    + sys.dm_exec_requests: total/running/sleeping/background/dormant sessions, idle
+                    sessions over 30 min, memory-wait count, top application/host) — the Dashboard->
+                    Darling connection-leak / idle parity collector. Distinct from the per-application
+                    session_stats table. New table only — created by GetAllTableStatements() below; the
+                    v_ view comes from CreateArchiveViewsAsync via ArchivableTables. */
+            _logger?.LogInformation("Running migration to v39: adding session_summary_stats table");
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -903,6 +903,29 @@ CREATE TABLE IF NOT EXISTS session_stats (
     public const string CreateSessionStatsIndex = @"
 CREATE INDEX IF NOT EXISTS idx_session_stats_time ON session_stats(server_id, collection_time)";
 
+    public const string CreateSessionSummaryStatsTable = @"
+CREATE TABLE IF NOT EXISTS session_summary_stats (
+    collection_id BIGINT PRIMARY KEY,
+    collection_time TIMESTAMP NOT NULL,
+    server_id INTEGER NOT NULL,
+    server_name VARCHAR NOT NULL,
+    total_sessions INTEGER NOT NULL,
+    running_sessions INTEGER NOT NULL,
+    sleeping_sessions INTEGER NOT NULL,
+    background_sessions INTEGER NOT NULL,
+    dormant_sessions INTEGER NOT NULL,
+    idle_sessions_over_30min INTEGER NOT NULL,
+    sessions_waiting_for_memory INTEGER NOT NULL,
+    databases_with_connections INTEGER NOT NULL,
+    top_application_name VARCHAR,
+    top_application_connections INTEGER,
+    top_host_name VARCHAR,
+    top_host_connections INTEGER
+)";
+
+    public const string CreateSessionSummaryStatsIndex = @"
+CREATE INDEX IF NOT EXISTS idx_session_summary_stats_time ON session_summary_stats(server_id, collection_time)";
+
     public const string CreateAlertLogTable = @"
 CREATE TABLE IF NOT EXISTS config_alert_log (
     alert_time TIMESTAMP NOT NULL,
@@ -1003,6 +1026,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateIndexObjectStatsTable;
         yield return CreateServerPropertiesTable;
         yield return CreateSessionStatsTable;
+        yield return CreateSessionSummaryStatsTable;
         yield return CreateAlertLogTable;
         yield return CreateEdgeTriggerWatermarksTable;
         yield return CreateMuteRulesTable;
@@ -1043,6 +1067,7 @@ ON dismissed_archive_alerts (alert_time, server_id, metric_name)";
         yield return CreateIndexObjectStatsIndex;
         yield return CreateServerPropertiesIndex;
         yield return CreateSessionStatsIndex;
+        yield return CreateSessionSummaryStatsIndex;
         yield return CreateDismissedArchiveAlertsIndex;
     }
 }

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -83,6 +83,7 @@ public class ArchiveService
         ("index_object_stats", "collection_time"),
         ("server_properties", "collection_time"),
         ("session_stats", "collection_time"),
+        ("session_summary_stats", "collection_time"),
         ("server_config", "capture_time"),
         ("database_config", "capture_time"),
         ("database_scoped_config", "capture_time"),

--- a/Lite/Services/RemoteCollectorService.SessionStats.cs
+++ b/Lite/Services/RemoteCollectorService.SessionStats.cs
@@ -21,4 +21,12 @@ public partial class RemoteCollectorService
     /// </summary>
     private Task<int> CollectSessionStatsAsync(ServerConnection server, CancellationToken cancellationToken)
         => RunCollectorDefinitionAsync(SessionStatsCollector.Instance, server, cancellationToken);
+
+    /// <summary>
+    /// Collects the server-wide session SUMMARY (connection-leak / idle signal) via the shared
+    /// <see cref="SessionSummaryStatsCollector"/> definition (query text and payload order live there —
+    /// the cross-SKU parity contract). Distinct from the per-application session_stats collector.
+    /// </summary>
+    private Task<int> CollectSessionSummaryStatsAsync(ServerConnection server, CancellationToken cancellationToken)
+        => RunCollectorDefinitionAsync(SessionSummaryStatsCollector.Instance, server, cancellationToken);
 }

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -487,6 +487,7 @@ public partial class RemoteCollectorService
                 "index_object_stats" => await CollectIndexObjectStatsAsync(server, cancellationToken),
                 "server_properties" => await CollectServerPropertiesAsync(server, cancellationToken),
                 "session_stats" => await CollectSessionStatsAsync(server, cancellationToken),
+                "session_summary_stats" => await CollectSessionSummaryStatsAsync(server, cancellationToken),
                 _ => throw new ArgumentException($"Unknown collector: {collectorName}")
             };
 

--- a/Lite/Services/ScheduleManager.cs
+++ b/Lite/Services/ScheduleManager.cs
@@ -42,7 +42,8 @@ public class ScheduleManager
             ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
             ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
             ["dmv_blocking_snapshot"] = 1,
-            ["blocked_process_report"] = 1, ["running_jobs"] = 2
+            ["blocked_process_report"] = 1, ["running_jobs"] = 2,
+            ["session_summary_stats"] = 2
         },
         ["Balanced"] = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -55,7 +56,8 @@ public class ScheduleManager
             ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
             ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
             ["dmv_blocking_snapshot"] = 1,
-            ["blocked_process_report"] = 1, ["running_jobs"] = 5
+            ["blocked_process_report"] = 1, ["running_jobs"] = 5,
+            ["session_summary_stats"] = 5
         },
         ["Low-Impact"] = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -68,7 +70,8 @@ public class ScheduleManager
             ["tempdb_stats"] = 5, ["perfmon_stats"] = 5, ["deadlocks"] = 5,
             ["memory_grant_stats"] = 5, ["waiting_tasks"] = 5,
             ["dmv_blocking_snapshot"] = 5,
-            ["blocked_process_report"] = 5, ["running_jobs"] = 30
+            ["blocked_process_report"] = 5, ["running_jobs"] = 30,
+            ["session_summary_stats"] = 15
         }
     };
 
@@ -594,7 +597,8 @@ public class ScheduleManager
             new() { Name = "database_size_stats", Enabled = true, FrequencyMinutes = 60, RetentionDays = 90, Description = "Database file sizes for growth trending and capacity planning" },
             new() { Name = "index_object_stats", Enabled = true, FrequencyMinutes = 1440, RetentionDays = 90, Description = "Per-object table/index size, usage, and locking stats for growth, unused-index, and contention analysis (daily collection)" },
             new() { Name = "server_properties", Enabled = true, FrequencyMinutes = 0, RetentionDays = 365, Description = "Server edition, licensing, CPU/memory hardware metadata (on-load only)" },
-            new() { Name = "session_stats", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Per-application session counts from sys.dm_exec_sessions" }
+            new() { Name = "session_stats", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Per-application session counts from sys.dm_exec_sessions" },
+            new() { Name = "session_summary_stats", Enabled = true, FrequencyMinutes = 5, RetentionDays = 30, Description = "Server-wide session summary (idle/leak signal): total/running/sleeping/idle-over-30min counts, memory waits, top app/host from sys.dm_exec_sessions + sys.dm_exec_requests" }
         };
     }
 

--- a/PerformanceMonitor.Collectors/CollectorCatalog.cs
+++ b/PerformanceMonitor.Collectors/CollectorCatalog.cs
@@ -37,6 +37,7 @@ public static class CollectorCatalog
         TraceFlagsCollector.Instance,
         DatabaseScopedConfigCollector.Instance,
         SessionStatsCollector.Instance,
+        SessionSummaryStatsCollector.Instance,
         WaitingTasksCollector.Instance,
         ProcedureStatsCollector.Instance,
         RunningJobsCollector.Instance,

--- a/PerformanceMonitor.Collectors/CollectorScheduleDefaults.cs
+++ b/PerformanceMonitor.Collectors/CollectorScheduleDefaults.cs
@@ -55,5 +55,6 @@ public static class CollectorScheduleDefaults
         ["index_object_stats"] = new(1440, 90),
         ["server_properties"] = new(0, 365),
         ["session_stats"] = new(5, 30),
+        ["session_summary_stats"] = new(5, 30),
     };
 }

--- a/PerformanceMonitor.Collectors/SessionSummaryStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/SessionSummaryStatsCollector.cs
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// Server-wide session SUMMARY snapshot from sys.dm_exec_sessions (+ sys.dm_exec_requests for the
+/// memory-wait count) — the connection-leak / idle-session signal that is the Dashboard-parity port
+/// of install/36_collect_session_stats.sql. A POINT-IN-TIME snapshot, not a cumulative-counter delta
+/// collector: it reports the current session-status breakdown directly, ONE aggregate row per
+/// collection — no delta groups (mirrors <see cref="MemoryStatsCollector"/> /
+/// <see cref="CpuSchedulerStatsCollector"/>). Counts total/running/sleeping/background/dormant
+/// sessions, idle sessions over 30 minutes (the leak signal), sessions waiting on memory, distinct
+/// databases with connections, and the top application/host by connection count. The Dashboard proc's
+/// collection_log logging and RAISERROR idle-percent debug output are the collector framework's job
+/// and are intentionally dropped.
+///
+/// <para>Distinct from the existing <see cref="SessionStatsCollector"/> (table session_stats), which
+/// emits ONE ROW PER program_name for per-application resource use — a different shape from a
+/// different Dashboard source. This collector's server-wide summary is deliberately named
+/// session_summary_stats so the two never collide.</para>
+///
+/// <para>Available on SQL Server, Azure SQL Database, and Azure SQL Managed Instance — both DMVs are
+/// verified against MS Learn ("Applies to" lists all three) and the query never fails on any of them,
+/// so <see cref="AppliesTo"/> is unconditionally true (mirroring the sibling
+/// <see cref="SessionStatsCollector"/>, which reads the same sys.dm_exec_sessions everywhere, and the
+/// Dashboard proc, which has no platform guard). On Azure SQL Database the counts are inherently
+/// SCOPED, not absent: sys.dm_exec_sessions with VIEW DATABASE STATE sees only sessions in the
+/// current database, and sys.dm_exec_requests is always limited to the current connection there
+/// (VIEW SERVER STATE cannot be granted on Azure SQL DB), so sessions_waiting_for_memory reflects
+/// only this connection. That is a documented platform property of the DMVs — a narrower view, not a
+/// collection gap — exactly the kind of Azure scoping <see cref="PlanCacheStatsCollector"/> notes and
+/// keeps collecting through.</para>
+/// </summary>
+public sealed class SessionSummaryStatsCollector : CollectorDefinitionBase<SessionSummaryStatsCollector.Row>
+{
+    public static SessionSummaryStatsCollector Instance { get; } = new();
+
+    private SessionSummaryStatsCollector()
+    {
+    }
+
+    public readonly record struct Row(
+        int TotalSessions,
+        int RunningSessions,
+        int SleepingSessions,
+        int BackgroundSessions,
+        int DormantSessions,
+        int IdleSessionsOver30Min,
+        int SessionsWaitingForMemory,
+        int DatabasesWithConnections,
+        string? TopApplicationName,
+        int? TopApplicationConnections,
+        string? TopHostName,
+        int? TopHostConnections);
+
+    /* Ported verbatim from install/36_collect_session_stats.sql's SELECT (the point-in-time
+       aggregate — one row, no GROUP BY). The only additions over the proc body are explicit
+       CONVERT(integer, ...) wrappers the proc relied on the INSERT into its integer columns to do
+       implicitly (COUNT_BIG for total_sessions / databases_with_connections, and MAX-of-COUNT_BIG
+       for the two top_*_connections) so the positional reader gets clean int32s — mirroring the
+       CONVERT(integer, COUNT_BIG(*)) the plan_cache_stats port added. Values stored are identical to
+       the Dashboard table (all counts integer NOT NULL; the four top_* columns nullable). */
+    private const string QueryText = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    total_sessions = CONVERT(integer, COUNT_BIG(*)),
+    running_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'running'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    sleeping_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'sleeping'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    background_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.is_user_process = 0
+                THEN 1
+                ELSE 0
+            END
+        ),
+    dormant_sessions =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'dormant'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    idle_sessions_over_30min =
+        SUM
+        (
+            CASE
+                WHEN des.status = N'sleeping'
+                AND des.last_request_end_time < DATEADD(MINUTE, -30, SYSDATETIME())
+                AND des.is_user_process = 1
+                THEN 1
+                ELSE 0
+            END
+        ),
+    sessions_waiting_for_memory =
+        SUM
+        (
+            CASE
+                WHEN der.wait_type LIKE N'%MEMORY%'
+                THEN 1
+                ELSE 0
+            END
+        ),
+    databases_with_connections = CONVERT(integer, COUNT_BIG(DISTINCT des.database_id)),
+    top_application_name = MAX(top_app.program_name),
+    top_application_connections = CONVERT(integer, MAX(top_app.connection_count)),
+    top_host_name = MAX(top_host.host_name),
+    top_host_connections = CONVERT(integer, MAX(top_host.connection_count))
+FROM sys.dm_exec_sessions AS des
+LEFT JOIN sys.dm_exec_requests AS der
+  ON der.session_id = des.session_id
+OUTER APPLY
+(
+    SELECT TOP (1)
+        program_name = des2.program_name,
+        connection_count = COUNT_BIG(*)
+    FROM sys.dm_exec_sessions AS des2
+    WHERE des2.session_id > 50
+    AND   des2.is_user_process = 1
+    AND   des2.program_name IS NOT NULL
+    GROUP BY
+        des2.program_name
+    ORDER BY
+        COUNT_BIG(*) DESC
+) AS top_app
+OUTER APPLY
+(
+    SELECT TOP (1)
+        host_name = des3.host_name,
+        connection_count = COUNT_BIG(*)
+    FROM sys.dm_exec_sessions AS des3
+    WHERE des3.session_id > 50
+    AND   des3.is_user_process = 1
+    AND   des3.host_name IS NOT NULL
+    GROUP BY
+        des3.host_name
+    ORDER BY
+        COUNT_BIG(*) DESC
+) AS top_host
+WHERE des.session_id > 50
+OPTION(RECOMPILE);";
+
+    public override string Name => "session_summary_stats";
+
+    public override string TargetTable => "session_summary_stats";
+
+    public override string? WatermarkColumn => null;
+
+    /// <summary>
+    /// Collects everywhere: sys.dm_exec_sessions and sys.dm_exec_requests exist on SQL Server, Azure
+    /// SQL Database, and Azure SQL Managed Instance (MS Learn-verified) and the query never fails.
+    /// On Azure SQL DB the counts are scoped (sessions to the current database, the memory-wait count
+    /// to the current connection) — a platform property, not a gap. Mirrors SessionStatsCollector.
+    /// </summary>
+    public override bool AppliesTo(CollectorTargetInfo target) => true;
+
+    public override bool RunsPerDatabase(CollectorTargetInfo target) => false;
+
+    public override CollectorQuery BuildQuery(CollectorContext context) => new(QueryText);
+
+    public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } = new[]
+    {
+        new CollectorColumn("total_sessions", CollectorColumnType.Integer),
+        new CollectorColumn("running_sessions", CollectorColumnType.Integer),
+        new CollectorColumn("sleeping_sessions", CollectorColumnType.Integer),
+        new CollectorColumn("background_sessions", CollectorColumnType.Integer),
+        new CollectorColumn("dormant_sessions", CollectorColumnType.Integer),
+        new CollectorColumn("idle_sessions_over_30min", CollectorColumnType.Integer),
+        new CollectorColumn("sessions_waiting_for_memory", CollectorColumnType.Integer),
+        new CollectorColumn("databases_with_connections", CollectorColumnType.Integer),
+        new CollectorColumn("top_application_name", CollectorColumnType.Varchar),
+        new CollectorColumn("top_application_connections", CollectorColumnType.Integer),
+        new CollectorColumn("top_host_name", CollectorColumnType.Varchar),
+        new CollectorColumn("top_host_connections", CollectorColumnType.Integer),
+    };
+
+    public override async ValueTask<List<Row>> ReadAsync(DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
+    {
+        var rows = new List<Row>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new Row(
+                TotalSessions: reader.GetInt32(0),
+                RunningSessions: reader.GetInt32(1),
+                SleepingSessions: reader.GetInt32(2),
+                BackgroundSessions: reader.GetInt32(3),
+                DormantSessions: reader.GetInt32(4),
+                IdleSessionsOver30Min: reader.GetInt32(5),
+                SessionsWaitingForMemory: reader.GetInt32(6),
+                DatabasesWithConnections: reader.GetInt32(7),
+                /* The three top_* OUTER APPLYs yield NULL when no user session qualifies (no program /
+                   host); the name and its count are nullable, matching the Dashboard columns. */
+                TopApplicationName: reader.IsDBNull(8) ? null : reader.GetString(8),
+                TopApplicationConnections: reader.IsDBNull(9) ? null : reader.GetInt32(9),
+                TopHostName: reader.IsDBNull(10) ? null : reader.GetString(10),
+                TopHostConnections: reader.IsDBNull(11) ? null : reader.GetInt32(11)));
+        }
+
+        return rows;
+    }
+
+    public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
+    {
+        writer
+            .Value(row.TotalSessions)             /* total_sessions INTEGER */
+            .Value(row.RunningSessions)           /* running_sessions INTEGER */
+            .Value(row.SleepingSessions)          /* sleeping_sessions INTEGER */
+            .Value(row.BackgroundSessions)        /* background_sessions INTEGER */
+            .Value(row.DormantSessions)           /* dormant_sessions INTEGER */
+            .Value(row.IdleSessionsOver30Min)     /* idle_sessions_over_30min INTEGER */
+            .Value(row.SessionsWaitingForMemory)  /* sessions_waiting_for_memory INTEGER */
+            .Value(row.DatabasesWithConnections)  /* databases_with_connections INTEGER */
+            .Value(row.TopApplicationName)        /* top_application_name VARCHAR (nullable) */
+            .Value(row.TopApplicationConnections) /* top_application_connections INTEGER (nullable) */
+            .Value(row.TopHostName)               /* top_host_name VARCHAR (nullable) */
+            .Value(row.TopHostConnections);       /* top_host_connections INTEGER (nullable) */
+    }
+}


### PR DESCRIPTION
## What

Adds **one net-new shared collector** — `SessionSummaryStatsCollector` (table `session_summary_stats`) — closing the Dashboard→Darling parity gap for the **connection-leak / idle-session signal**. It ports the server-wide session SUMMARY from `install/36_collect_session_stats.sql` into the shared `PerformanceMonitor.Collectors`, so **both Lite (DuckDB) and Darling (Postgres)** now collect it.

Columns (one aggregate row per collection): `total/running/sleeping/background/dormant_sessions`, `idle_sessions_over_30min`, `sessions_waiting_for_memory`, `databases_with_connections`, `top_application_name`/`top_application_connections`, `top_host_name`/`top_host_connections` — from `sys.dm_exec_sessions` (+ `sys.dm_exec_requests` for the memory-wait count).

Point-in-time snapshot (no deltas), mirroring the just-merged `CpuSchedulerStats` / `PlanCacheStats` collectors end-to-end.

**Distinct from** the existing per-application `SessionStatsCollector` (table `session_stats`, one row per `program_name`) — deliberately named `session_summary_stats` so the two never collide.

## Wiring
- **Shared**: `CollectorCatalog` (30→31), `CollectorScheduleDefaults` (5 min / 30 days)
- **Lite**: `Schema.cs` (table + index), `DuckDbInitializer` (CurrentSchemaVersion 38→39 + `ArchivableTables` + v39 migration), `ArchiveService.ArchivableTables`, `RemoteCollectorService` dispatch + partial, `ScheduleManager` defaults + presets (2/5/15). The `v_session_summary_stats` view is auto-created via `ArchivableTables`.
- **Darling**: `PgSchemaGenerator.GenerateV12AddSessionSummary` (table + index + `v_` view), `PgMigrations` V12, `StorageVersion` 11→12, `DarlingWorker` dispatch.

## Tests
- New `SessionSummaryStatsCollectorDefinitionTests` (verbatim query pin, AppliesTo, payload order, ReadAsync incl. nullable top_* columns, point-in-time WritePayload) + `SessionSummaryStatsRoundTripTests` (real-DuckDB append-by-position round-trip).
- Updated pins: Lite table-count 37→38; Darling catalog 30→31, `Scripts.Count` 11→12, `StorageVersion`, schema-version `11L`→`12L` (both gated pins), + a generated-DDL pin.
- **Lite.Tests: 893 passed / 0 failed.** **Darling.Tests: 529 passed / 80 skipped (live-Postgres) / 0 failed.**

## Azure (verified vs MS Learn, surfaced not cut)
Both DMVs exist on Azure SQL Database and Managed Instance and the query never fails, so `AppliesTo` is unconditionally **true** (mirrors `SessionStatsCollector` and the guardless Dashboard proc). On Azure SQL DB the counts are **scoped** — `sys.dm_exec_sessions` sees only the current database (VIEW DATABASE STATE), and `sys.dm_exec_requests` is limited to the current connection (VIEW SERVER STATE can't be granted), so `sessions_waiting_for_memory` reflects only that connection. This is a documented platform property of the DMVs, not a collection gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)