### PR TITLE
Capture per-index definition metadata for UNUSED/DUPLICATE analysis (FinOps Stage 1)

### DIFF
--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -241,7 +241,7 @@ public sealed class DarlingAnalysisStoreTests
 
         using (var versions = new NpgsqlCommand("SELECT COUNT(*) FROM darling_schema_version", connection))
         {
-            Assert.Equal(14L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(15L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
         }
 
         /* Clear leftovers from an earlier aborted run so the assertions below are deterministic. */

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -32,9 +32,9 @@ public sealed class DarlingObservabilityTests
     private const int TestServerId = -424242;
 
     [Fact]
-    public void MigrationScripts_FourteenVersions_V13SystemHealth_V14RefreshViews()
+    public void MigrationScripts_FifteenVersions_V14RefreshViews_V15IndexMetadata()
     {
-        Assert.Equal(14, PgMigrations.Scripts.Count);
+        Assert.Equal(15, PgMigrations.Scripts.Count);
         Assert.Equal(1, PgMigrations.Scripts[0].Version);
         Assert.Equal(2, PgMigrations.Scripts[1].Version);
         Assert.Equal(3, PgMigrations.Scripts[2].Version);
@@ -49,7 +49,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(12, PgMigrations.Scripts[11].Version);
         Assert.Equal(13, PgMigrations.Scripts[12].Version);
         Assert.Equal(14, PgMigrations.Scripts[13].Version);
-        Assert.Equal(14, StorageVersion.SchemaVersion);
+        Assert.Equal(15, PgMigrations.Scripts[14].Version);
+        Assert.Equal(15, StorageVersion.SchemaVersion);
 
         /* V5 completes the v_* twin of Lite's DuckDB view layer -- the copy-parity tail tabs
            (Running Jobs, Configuration, Daily Summary, Collection Health) read these five, so
@@ -207,6 +208,29 @@ public sealed class DarlingObservabilityTests
             new System.Collections.Generic.SortedSet<string>(PgSchemaGenerator.AllPassthroughViews, StringComparer.Ordinal),
             viewsCreatedByAnyMigration);
 
+        /* V15 adds the per-index definition metadata for monitor-side UNUSED/DUPLICATE analysis
+           (FinOps Index Analysis, Stage 1) additively — one ADD COLUMN IF NOT EXISTS per column so a
+           pre-metadata store comes up to shape and a fresh V1 store no-ops — then CREATE OR REPLACE
+           re-expands v_index_object_stats' SELECT * so an upgraded store's view (last refreshed by
+           V14, before these columns existed) surfaces them. */
+        var v15 = PgMigrations.Scripts[14].Sql;
+        Assert.Equal("index-metadata-columns", PgMigrations.Scripts[14].Name);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS key_columns text;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS included_columns text;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS filter_definition text;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_unique_constraint boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key_reference boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_disabled boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS data_compression_desc text;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS optimize_for_sequential_key boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS fill_factor smallint;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_padded boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_page_locks boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_row_locks boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_indexed_view boolean;", v15, StringComparison.Ordinal);
+        Assert.Contains("CREATE OR REPLACE VIEW v_index_object_stats AS SELECT * FROM index_object_stats;", v15, StringComparison.Ordinal);
+
         var v2 = PgMigrations.Scripts[1].Sql;
         Assert.Contains("CREATE TABLE IF NOT EXISTS servers (", v2, StringComparison.Ordinal);
         Assert.Contains("CREATE TABLE IF NOT EXISTS collection_log (", v2, StringComparison.Ordinal);
@@ -229,7 +253,7 @@ public sealed class DarlingObservabilityTests
 
         using (var versions = new NpgsqlCommand("SELECT COUNT(*) FROM darling_schema_version", connection))
         {
-            Assert.Equal(14L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(15L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
         }
 
         /* Clear leftovers from an earlier aborted run so the assertions below are deterministic. */

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -58,6 +58,7 @@ public static class PgMigrations
         new Migration(12, "session-summary-collector", PgSchemaGenerator.GenerateV12AddSessionSummary()),
         new Migration(13, "system-health-events-collector", PgSchemaGenerator.GenerateV13AddSystemHealthEvents()),
         new Migration(14, "refresh-passthrough-views", PgSchemaGenerator.GenerateV14RefreshViews()),
+        new Migration(15, "index-metadata-columns", V15Sql),
     };
 
     /// <summary>
@@ -281,6 +282,42 @@ ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS sqlserver_start_time time
 ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS host_os_version text;
 ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS ag_replica_role text;
 ALTER TABLE servers ADD COLUMN IF NOT EXISTS monthly_cost_usd numeric;";
+
+    /// <summary>
+    /// V15 — the per-index DEFINITION metadata monitor-side UNUSED/DUPLICATE index analysis needs
+    /// (FinOps Index Analysis, Stage 1), added additively to <c>index_object_stats</c>: the ordered
+    /// <c>key_columns</c> / <c>included_columns</c> lists (sp_IndexCleanup's delimited representation,
+    /// so the Stage-2 analyzer's string-comparison dedupe ports cleanly), <c>filter_definition</c>,
+    /// the uniqueness/constraint/FK discriminators (<c>is_unique_constraint</c>, <c>is_foreign_key</c>,
+    /// <c>is_foreign_key_reference</c>) + <c>is_disabled</c>, and the reconstruct-a-CREATE options
+    /// (<c>data_compression_desc</c>, <c>optimize_for_sequential_key</c>, <c>fill_factor</c>,
+    /// <c>is_padded</c>, <c>allow_page_locks</c>, <c>allow_row_locks</c>). Every column is nullable and
+    /// appended, so a fresh store's V1 <c>index_object_stats</c> (generated from the current collector
+    /// definition, which now includes them) already has them and <c>ADD COLUMN IF NOT EXISTS</c>
+    /// no-ops, while an upgraded store gets the real add — with an identical physical column order for
+    /// the binary COPY either way. The trailing <c>CREATE OR REPLACE VIEW</c> re-expands
+    /// <c>v_index_object_stats</c>' pinned <c>SELECT *</c> (Postgres freezes it at CREATE, so an
+    /// upgraded store's view — last refreshed by V14 before these columns existed — would otherwise
+    /// omit them; append-only ADDs keep the refresh legal). Runs after V8, so the bare names resolve
+    /// through <c>search_path = collect, config, public</c>.
+    /// </summary>
+    private const string V15Sql = @"
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS key_columns text;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS included_columns text;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS filter_definition text;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_unique_constraint boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key_reference boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_disabled boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS data_compression_desc text;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS optimize_for_sequential_key boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS fill_factor smallint;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_padded boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_page_locks boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_row_locks boolean;
+ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_indexed_view boolean;
+
+CREATE OR REPLACE VIEW v_index_object_stats AS SELECT * FROM index_object_stats;";
 
     private const string VersionTableSql = @"
 CREATE TABLE IF NOT EXISTS darling_schema_version (

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 14;
+    public const int SchemaVersion = 15;
 }

--- a/Lite.Tests/IndexObjectStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/IndexObjectStatsCollectorDefinitionTests.cs
@@ -20,7 +20,9 @@ namespace Lite.Tests;
 /// <summary>
 /// Pins the parity contract of the extracted index_object_stats definition: dual execution
 /// (Azure per-database connections; on-prem enumeration + quote-doubled [db].sys.sp_executesql
-/// body), the dedicated 300 s per-database budget (#1135), and the 44-column payload.
+/// body), the dedicated 300 s per-database budget (#1135), and the 57-column payload (44
+/// size/usage/locking counters + 13 index-definition columns for monitor-side UNUSED/DUPLICATE
+/// analysis, Stage 1).
 /// </summary>
 public sealed class IndexObjectStatsCollectorDefinitionTests
 {
@@ -66,29 +68,45 @@ public sealed class IndexObjectStatsCollectorDefinitionTests
     }
 
     [Fact]
-    public void PayloadColumns_MatchSchemaOrder_44Columns()
+    public void PayloadColumns_MatchSchemaOrder_58Columns()
     {
         var names = IndexObjectStatsCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray();
-        Assert.Equal(44, names.Length);
+        Assert.Equal(58, names.Length);
         Assert.Equal("sqlserver_start_time", names[0]);
         Assert.Equal("page_io_latch_wait_in_ms", names[43]);
+        /* The Stage-1 index-definition metadata is appended after the counters (ordinals 44..57). */
+        Assert.Equal("key_columns", names[44]);
+        Assert.Equal("included_columns", names[45]);
+        Assert.Equal("filter_definition", names[46]);
+        Assert.Equal("is_foreign_key", names[48]);
+        Assert.Equal("is_foreign_key_reference", names[49]);
+        Assert.Equal("data_compression_desc", names[51]);
+        Assert.Equal("optimize_for_sequential_key", names[52]);
+        Assert.Equal("fill_factor", names[53]);
+        Assert.Equal("allow_row_locks", names[56]);
+        Assert.Equal("is_indexed_view", names[57]);
     }
 
     [Fact]
     public async Task ReadItem_AndWrite_RoundTrip_WithBitConversions()
     {
         var start = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
-        var row44 = new object[44];
-        row44[0] = start; row44[1] = "SO"; row44[2] = 7; row44[3] = "dbo"; row44[4] = 12345;
-        row44[5] = "Posts"; row44[6] = 1; row44[7] = "PK_Posts"; row44[8] = "CLUSTERED";
-        row44[9] = 1; row44[10] = 1; row44[11] = 0; row44[12] = 4;
-        row44[13] = 1024.50m; row44[14] = 1000.25m; row44[15] = 900.00m; row44[16] = 50.00m; row44[17] = 25.00m;
-        for (int i = 18; i < 44; i++) row44[i] = (long)(i * 10);
+        var input = new object[58];
+        input[0] = start; input[1] = "SO"; input[2] = 7; input[3] = "dbo"; input[4] = 12345;
+        input[5] = "Posts"; input[6] = 1; input[7] = "PK_Posts"; input[8] = "CLUSTERED";
+        input[9] = 1; input[10] = 1; input[11] = 0; input[12] = 4;
+        input[13] = 1024.50m; input[14] = 1000.25m; input[15] = 900.00m; input[16] = 50.00m; input[17] = 25.00m;
+        for (int i = 18; i < 44; i++) input[i] = (long)(i * 10);
         /* last_user_* are timestamps at 23..26 */
-        row44[23] = start; row44[24] = DBNull.Value; row44[25] = start; row44[26] = DBNull.Value;
+        input[23] = start; input[24] = DBNull.Value; input[25] = start; input[26] = DBNull.Value;
+        /* Stage-1 index-definition metadata (ordinals 44..57): key/include lists, filter, the
+           uniqueness/FK/disabled discriminators, the reconstruct-a-CREATE options, and is_indexed_view. */
+        input[44] = "[OwnerUserId], [CreationDate] DESC"; input[45] = "[Score]"; input[46] = DBNull.Value;
+        input[47] = 0; input[48] = 1; input[49] = 0; input[50] = 0;
+        input[51] = "PAGE"; input[52] = 1; input[53] = 90; input[54] = 0; input[55] = 1; input[56] = 1; input[57] = 0;
 
         var rows = new List<IndexObjectStatsCollector.Row>();
-        using (var reader = new FakeCollectorDataReader(row44))
+        using (var reader = new FakeCollectorDataReader(input))
         {
             await IndexObjectStatsCollector.Instance.ReadItemAsync("SO", reader, rows, CollectorTestContext.Make(s_deltas), CancellationToken.None);
         }
@@ -97,12 +115,31 @@ public sealed class IndexObjectStatsCollectorDefinitionTests
         Assert.True(row.IsUnique);
         Assert.False(row.IsFiltered);
         Assert.Null(row.LastUserScan);
+        /* Index-definition metadata round-trips (incl. the FK-protection + option flags). */
+        Assert.Equal("[OwnerUserId], [CreationDate] DESC", row.KeyColumns);
+        Assert.Equal("[Score]", row.IncludedColumns);
+        Assert.Null(row.FilterDefinition);
+        Assert.False(row.IsUniqueConstraint);
+        Assert.True(row.IsForeignKey);
+        Assert.False(row.IsForeignKeyReference);
+        Assert.False(row.IsDisabled);
+        Assert.Equal("PAGE", row.DataCompressionDesc);
+        Assert.True(row.OptimizeForSequentialKey);
+        Assert.Equal((short)90, row.FillFactor);
+        Assert.False(row.IsPadded);
+        Assert.True(row.AllowPageLocks);
+        Assert.True(row.AllowRowLocks);
+        Assert.False(row.IsIndexedView);
 
         var writer = new RecordingCollectorRowWriter();
         IndexObjectStatsCollector.Instance.WritePayload(row, writer, CollectorTestContext.Make(s_deltas));
-        Assert.Equal(44, writer.Values.Count);
+        Assert.Equal(58, writer.Values.Count);
         Assert.Equal(start, writer.Values[0]);
         Assert.Equal(true, writer.Values[9]);
         Assert.Equal(430L, writer.Values[43]);
+        Assert.Equal("[OwnerUserId], [CreationDate] DESC", writer.Values[44]);
+        Assert.Equal((short)90, writer.Values[53]);
+        Assert.Equal(true, writer.Values[56]);
+        Assert.Equal(false, writer.Values[57]);
     }
 }

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 40;
+    internal const int CurrentSchemaVersion = 41;
 
     private readonly string _archivePath;
 
@@ -949,6 +949,41 @@ public class DuckDbInitializer
                     parity. New table only — created by GetAllTableStatements() below; the v_ view comes
                     from CreateArchiveViewsAsync via ArchivableTables. */
             _logger?.LogInformation("Running migration to v40: adding system_health_events table");
+        }
+
+        if (fromVersion < 41)
+        {
+            /* v41: index_object_stats gains the per-index DEFINITION metadata monitor-side
+                    UNUSED/DUPLICATE analysis needs (FinOps Index Analysis, Stage 1): the ordered
+                    key_columns / included_columns lists (sp_IndexCleanup's delimited representation),
+                    filter_definition, the uniqueness/constraint/FK discriminators + is_disabled, and
+                    the reconstruct-a-CREATE options (data_compression_desc, optimize_for_sequential_key,
+                    fill_factor, is_padded, allow_page_locks, allow_row_locks). All appended at the end
+                    to keep the positional appender aligned; the collector now writes them, so an
+                    un-migrated DB would mis-align on the next append — these ALTERs are required. The
+                    v_ view (SELECT *) surfaces them and old parquet reads back NULL (union BY NAME). */
+            _logger?.LogInformation("Running migration to v41: adding index_object_stats index-definition columns");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS key_columns VARCHAR");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS included_columns VARCHAR");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS filter_definition VARCHAR");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_unique_constraint BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_foreign_key_reference BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_disabled BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS data_compression_desc VARCHAR");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS optimize_for_sequential_key BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS fill_factor SMALLINT");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_padded BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_page_locks BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_row_locks BOOLEAN");
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_indexed_view BOOLEAN");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v41 encountered an error (non-fatal): {Error}", ex.Message);
+            }
         }
     }
 

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -794,8 +794,10 @@ CREATE INDEX IF NOT EXISTS idx_database_size_stats_time ON database_size_stats(s
 
     // Per-table/per-index size, usage, and locking stats. Sizes are point-in-time;
     // usage/locking counters are cumulative (reset boundary in sqlserver_start_time).
-    // Column order MUST match the appender in RemoteCollectorService.IndexObjectStats.cs
-    // and the data columns in install/02_create_tables.sql (Dashboard parity).
+    // Column order MUST match the shared IndexObjectStatsCollector.PayloadColumns (the appender
+    // and Darling's binary COPY both write in that order) and the data columns in
+    // install/02_create_tables.sql (Dashboard parity). The trailing index-definition columns
+    // (key_columns .. allow_row_locks) back monitor-side UNUSED/DUPLICATE analysis (Stage 1).
     public const string CreateIndexObjectStatsTable = @"
 CREATE TABLE IF NOT EXISTS index_object_stats (
     collection_id BIGINT PRIMARY KEY,
@@ -845,7 +847,21 @@ CREATE TABLE IF NOT EXISTS index_object_stats (
     page_latch_wait_count BIGINT,
     page_latch_wait_in_ms BIGINT,
     page_io_latch_wait_count BIGINT,
-    page_io_latch_wait_in_ms BIGINT
+    page_io_latch_wait_in_ms BIGINT,
+    key_columns VARCHAR,
+    included_columns VARCHAR,
+    filter_definition VARCHAR,
+    is_unique_constraint BOOLEAN,
+    is_foreign_key BOOLEAN,
+    is_foreign_key_reference BOOLEAN,
+    is_disabled BOOLEAN,
+    data_compression_desc VARCHAR,
+    optimize_for_sequential_key BOOLEAN,
+    fill_factor SMALLINT,
+    is_padded BOOLEAN,
+    allow_page_locks BOOLEAN,
+    allow_row_locks BOOLEAN,
+    is_indexed_view BOOLEAN
 )";
 
     public const string CreateIndexObjectStatsIndex = @"

--- a/PerformanceMonitor.Collectors/IndexObjectStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/IndexObjectStatsCollector.cs
@@ -25,6 +25,19 @@ namespace PerformanceMonitor.Collectors;
 /// then join — the sp_IndexCleanup technique that fixed the #1135 monolithic-join timeouts —
 /// under a dedicated 300 s per-database budget (CommandTimeoutSecondsOverride; the enumeration
 /// keeps the default). sqlserver_start_time flags restart-class counter resets for the read layer.
+///
+/// <para>Also captures the per-index DEFINITION metadata that monitor-side UNUSED/DUPLICATE index
+/// analysis needs (FinOps Index Analysis, Stage 1): the ordered KEY column list (with sort
+/// direction), the INCLUDE column set, the filter predicate, the uniqueness/constraint/PK/FK and
+/// table-vs-indexed-view discriminators, disabled state, and the reconstruct-a-CREATE options
+/// (compression, sequential key, fill factor, padding, lock granularity). key_columns/included_columns
+/// use sp_IndexCleanup's
+/// exact delimited STUFF/FOR XML representation so a Stage-2 analyzer's string-comparison dedupe
+/// (Exact/Reverse Duplicate, Equal-Except-Filter, Key Subset/Superset) ports cleanly, and the FK
+/// flags reproduce its "never drop an FK-supporting or FK-referenced index" protection. These come
+/// from sys.indexes/sys.index_columns/sys.columns/sys.foreign_key_columns/sys.partitions — catalog
+/// views present on every platform incl. Azure SQL DB — so they share the collector's existing
+/// per-database execution unchanged.</para>
 /// </summary>
 public sealed class IndexObjectStatsCollector : CollectorDefinitionBase<IndexObjectStatsCollector.Row>
 {
@@ -80,10 +93,38 @@ public sealed class IndexObjectStatsCollector : CollectorDefinitionBase<IndexObj
         public long? PageLatchWaitInMs { get; set; }
         public long? PageIoLatchWaitCount { get; set; }
         public long? PageIoLatchWaitInMs { get; set; }
+        public string? KeyColumns { get; set; }
+        public string? IncludedColumns { get; set; }
+        public string? FilterDefinition { get; set; }
+        public bool? IsUniqueConstraint { get; set; }
+        public bool? IsForeignKey { get; set; }
+        public bool? IsForeignKeyReference { get; set; }
+        public bool? IsDisabled { get; set; }
+        public string? DataCompressionDesc { get; set; }
+        public bool? OptimizeForSequentialKey { get; set; }
+        public short? FillFactor { get; set; }
+        public bool? IsPadded { get; set; }
+        public bool? AllowPageLocks { get; set; }
+        public bool? AllowRowLocks { get; set; }
+        public bool? IsIndexedView { get; set; }
     }
 
-    /// <summary>The per-database staged body — the ordinals of its final SELECT are the read contract.</summary>
-    internal const string PerDatabaseStatsBody = @"
+    /// <summary>
+    /// The per-database staged body — the ordinals of its final SELECT are the read contract.
+    /// <paramref name="supportsOptimizeForSequentialKey"/> gates the SQL 2019+/Azure-only
+    /// optimize_for_sequential_key column: a typed NULL is emitted on older engines, where the
+    /// column does not exist and referencing it would fail the whole batch (mirrors
+    /// sp_IndexCleanup's @supports_optimize_for_sequential_key gate). Everything else is
+    /// engine-version-invariant.
+    /// </summary>
+    internal static string BuildPerDatabaseStatsBody(bool supportsOptimizeForSequentialKey)
+    {
+        string optimizeForSequentialKey =
+            supportsOptimizeForSequentialKey
+                ? "i.optimize_for_sequential_key"
+                : "CONVERT(bit, NULL)";
+
+        return @"
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -194,7 +235,146 @@ SELECT
     page_latch_wait_count = os.page_latch_wait_count,
     page_latch_wait_in_ms = os.page_latch_wait_in_ms,
     page_io_latch_wait_count = os.page_io_latch_wait_count,
-    page_io_latch_wait_in_ms = os.page_io_latch_wait_in_ms
+    page_io_latch_wait_in_ms = os.page_io_latch_wait_in_ms,
+    /* Per-index DEFINITION metadata for monitor-side UNUSED/DUPLICATE analysis (sp_IndexCleanup
+       parity, Stage 1). key_columns/included_columns reproduce sp_IndexCleanup's delimited
+       STUFF/FOR XML representation EXACTLY (QUOTENAME + ' DESC', key order for keys, name order
+       for the include set) so Stage-2 string-comparison dedupe ports cleanly. */
+    key_columns =
+        STUFF
+        (
+          (
+            SELECT
+                N', ' +
+                QUOTENAME(c.name) +
+                CASE
+                    WHEN ic.is_descending_key = 1
+                    THEN N' DESC'
+                    ELSE N''
+                END
+            FROM sys.index_columns AS ic
+            JOIN sys.columns AS c
+              ON  c.object_id = ic.object_id
+              AND c.column_id = ic.column_id
+            WHERE ic.object_id = i.object_id
+            AND   ic.index_id = i.index_id
+            AND   ic.is_included_column = 0
+            ORDER BY
+                ic.key_ordinal
+            FOR
+                XML
+                PATH(''),
+                TYPE
+          ).value('text()[1]', 'nvarchar(max)'),
+          1,
+          2,
+          ''
+        ),
+    included_columns =
+        STUFF
+        (
+          (
+            SELECT
+                N', ' +
+                QUOTENAME(c.name)
+            FROM sys.index_columns AS ic
+            JOIN sys.columns AS c
+              ON  c.object_id = ic.object_id
+              AND c.column_id = ic.column_id
+            WHERE ic.object_id = i.object_id
+            AND   ic.index_id = i.index_id
+            AND   ic.is_included_column = 1
+            ORDER BY
+                c.name
+            FOR
+                XML
+                PATH(''),
+                TYPE
+          ).value('text()[1]', 'nvarchar(max)'),
+          1,
+          2,
+          ''
+        ),
+    filter_definition = i.filter_definition,
+    is_unique_constraint = i.is_unique_constraint,
+    /* FK protections (sp_IndexCleanup guards on is_foreign_key_reference): aggregated to the index
+       grain over KEY columns (is_included_column = 0), matching its per-column derivation from
+       sys.foreign_key_columns. is_foreign_key = a key column backs an outgoing FK (supporting
+       index); is_foreign_key_reference = a key column is referenced by an incoming FK. */
+    is_foreign_key =
+        CONVERT
+        (
+            bit,
+            CASE
+                WHEN EXISTS
+                     (
+                         SELECT
+                             1/0
+                         FROM sys.index_columns AS ic
+                         JOIN sys.foreign_key_columns AS fkc
+                           ON  fkc.parent_object_id = ic.object_id
+                           AND fkc.parent_column_id = ic.column_id
+                         WHERE ic.object_id = i.object_id
+                         AND   ic.index_id = i.index_id
+                         AND   ic.is_included_column = 0
+                     )
+                THEN 1
+                ELSE 0
+            END
+        ),
+    is_foreign_key_reference =
+        CONVERT
+        (
+            bit,
+            CASE
+                WHEN EXISTS
+                     (
+                         SELECT
+                             1/0
+                         FROM sys.index_columns AS ic
+                         JOIN sys.foreign_key_columns AS fkc
+                           ON  fkc.referenced_object_id = ic.object_id
+                           AND fkc.referenced_column_id = ic.column_id
+                         WHERE ic.object_id = i.object_id
+                         AND   ic.index_id = i.index_id
+                         AND   ic.is_included_column = 0
+                     )
+                THEN 1
+                ELSE 0
+            END
+        ),
+    is_disabled = i.is_disabled,
+    /* Compression state aggregated to the index grain: the lowest level across partitions, so an
+       index with ANY uncompressed partition surfaces as NONE (sp_IndexCleanup's compressibility
+       signal). */
+    data_compression_desc =
+    (
+        SELECT TOP (1)
+            p.data_compression_desc
+        FROM sys.partitions AS p
+        WHERE p.object_id = i.object_id
+        AND   p.index_id = i.index_id
+        ORDER BY
+            p.data_compression
+    ),
+    optimize_for_sequential_key = " + optimizeForSequentialKey + @",
+    fill_factor = i.fill_factor,
+    is_padded = i.is_padded,
+    allow_page_locks = i.allow_page_locks,
+    allow_row_locks = i.allow_row_locks,
+    /* Table (U) vs indexed-view (V) index — the one table-vs-view discriminator index_type_desc
+       cannot express (a view's clustered index is also CLUSTERED); mirrors sp_IndexCleanup's
+       is_indexed_view so Stage 2 never dedupes across the two. */
+    is_indexed_view =
+        CONVERT
+        (
+            bit,
+            CASE
+                WHEN o.type = N'V'
+                THEN 1
+                ELSE 0
+            END
+        )
 FROM sys.indexes AS i
 JOIN sys.objects AS o
   ON o.object_id = i.object_id
@@ -212,6 +392,18 @@ LEFT JOIN #ops AS os
 WHERE o.is_ms_shipped = 0
 AND   o.type IN (N'U', N'V')
 OPTION(RECOMPILE);";
+    }
+
+    /// <summary>
+    /// optimize_for_sequential_key exists only on SQL Server 2019+ (major >= 15), Azure SQL DB, and
+    /// Azure SQL Managed Instance (mirrors sp_IndexCleanup's engine-edition/version gate). Unknown
+    /// version (0) fails safe to unsupported — a typed NULL is emitted rather than risk a hard bind
+    /// error against a column that may not exist on the target.
+    /// </summary>
+    private static bool SupportsOptimizeForSequentialKey(CollectorTargetInfo target) =>
+        target.IsAzureSqlDb
+        || target.IsAzureManagedInstance
+        || target.SqlMajorVersion >= 15;
 
     public override string Name => "index_object_stats";
 
@@ -224,7 +416,8 @@ OPTION(RECOMPILE);";
     public override bool RunsPerDatabase(CollectorTargetInfo target) => target.IsAzureSqlDb;
 
     /// <summary>Azure per-database connections run the staged body directly.</summary>
-    public override CollectorQuery BuildQuery(CollectorContext context) => new(PerDatabaseStatsBody);
+    public override CollectorQuery BuildQuery(CollectorContext context) =>
+        new(BuildPerDatabaseStatsBody(SupportsOptimizeForSequentialKey(context.Target)));
 
     /// <summary>On-prem: enumerate accessible online databases (with exclusions), then per-item.</summary>
     public override CollectorQuery? BuildEnumerationQuery(CollectorContext context)
@@ -253,7 +446,8 @@ ORDER BY
     public override CollectorQuery BuildPerItemQuery(string item, CollectorContext context)
     {
         /* Double single quotes so the body survives nesting inside [db].sys.sp_executesql N'...' */
-        var escapedBody = PerDatabaseStatsBody.Replace("'", "''", StringComparison.Ordinal);
+        var escapedBody = BuildPerDatabaseStatsBody(SupportsOptimizeForSequentialKey(context.Target))
+            .Replace("'", "''", StringComparison.Ordinal);
         var escapedDbName = item.Replace("]", "]]", StringComparison.Ordinal);
         return new CollectorQuery($"EXECUTE [{escapedDbName}].sys.sp_executesql N'{escapedBody}';");
     }
@@ -272,9 +466,11 @@ ORDER BY
     {
         long? L(int i) => reader.IsDBNull(i) ? null : Convert.ToInt64(reader.GetValue(i), CultureInfo.InvariantCulture);
         int? I(int i) => reader.IsDBNull(i) ? null : Convert.ToInt32(reader.GetValue(i), CultureInfo.InvariantCulture);
+        short? Sh(int i) => reader.IsDBNull(i) ? null : Convert.ToInt16(reader.GetValue(i), CultureInfo.InvariantCulture);
         decimal? D(int i) => reader.IsDBNull(i) ? null : reader.GetDecimal(i);
         DateTime? T(int i) => reader.IsDBNull(i) ? null : reader.GetDateTime(i);
         bool? B(int i) => reader.IsDBNull(i) ? null : (bool?)(Convert.ToInt32(reader.GetValue(i), CultureInfo.InvariantCulture) == 1);
+        string? S(int i) => reader.IsDBNull(i) ? null : reader.GetString(i);
 
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -324,6 +520,20 @@ ORDER BY
                 PageLatchWaitInMs = L(41),
                 PageIoLatchWaitCount = L(42),
                 PageIoLatchWaitInMs = L(43),
+                KeyColumns = S(44),
+                IncludedColumns = S(45),
+                FilterDefinition = S(46),
+                IsUniqueConstraint = B(47),
+                IsForeignKey = B(48),
+                IsForeignKeyReference = B(49),
+                IsDisabled = B(50),
+                DataCompressionDesc = S(51),
+                OptimizeForSequentialKey = B(52),
+                FillFactor = Sh(53),
+                IsPadded = B(54),
+                AllowPageLocks = B(55),
+                AllowRowLocks = B(56),
+                IsIndexedView = B(57),
             });
         }
     }
@@ -374,6 +584,20 @@ ORDER BY
         new CollectorColumn("page_latch_wait_in_ms", CollectorColumnType.BigInt),
         new CollectorColumn("page_io_latch_wait_count", CollectorColumnType.BigInt),
         new CollectorColumn("page_io_latch_wait_in_ms", CollectorColumnType.BigInt),
+        new CollectorColumn("key_columns", CollectorColumnType.Varchar),
+        new CollectorColumn("included_columns", CollectorColumnType.Varchar),
+        new CollectorColumn("filter_definition", CollectorColumnType.Varchar),
+        new CollectorColumn("is_unique_constraint", CollectorColumnType.Boolean),
+        new CollectorColumn("is_foreign_key", CollectorColumnType.Boolean),
+        new CollectorColumn("is_foreign_key_reference", CollectorColumnType.Boolean),
+        new CollectorColumn("is_disabled", CollectorColumnType.Boolean),
+        new CollectorColumn("data_compression_desc", CollectorColumnType.Varchar),
+        new CollectorColumn("optimize_for_sequential_key", CollectorColumnType.Boolean),
+        new CollectorColumn("fill_factor", CollectorColumnType.SmallInt),
+        new CollectorColumn("is_padded", CollectorColumnType.Boolean),
+        new CollectorColumn("allow_page_locks", CollectorColumnType.Boolean),
+        new CollectorColumn("allow_row_locks", CollectorColumnType.Boolean),
+        new CollectorColumn("is_indexed_view", CollectorColumnType.Boolean),
     };
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
@@ -422,6 +646,20 @@ ORDER BY
             .Value(row.PageLatchWaitCount)
             .Value(row.PageLatchWaitInMs)
             .Value(row.PageIoLatchWaitCount)
-            .Value(row.PageIoLatchWaitInMs);
+            .Value(row.PageIoLatchWaitInMs)
+            .Value(row.KeyColumns)
+            .Value(row.IncludedColumns)
+            .Value(row.FilterDefinition)
+            .Value(row.IsUniqueConstraint)
+            .Value(row.IsForeignKey)
+            .Value(row.IsForeignKeyReference)
+            .Value(row.IsDisabled)
+            .Value(row.DataCompressionDesc)
+            .Value(row.OptimizeForSequentialKey)
+            .Value(row.FillFactor)
+            .Value(row.IsPadded)
+            .Value(row.AllowPageLocks)
+            .Value(row.AllowRowLocks)
+            .Value(row.IsIndexedView);
     }
 }


### PR DESCRIPTION
## Summary

**FinOps Index Analysis, Stage 1 of 3.** Extends the shared `IndexObjectStatsCollector` to capture the per-index *definition* metadata that monitor-side **UNUSED + DUPLICATE** index analysis needs — the prescriptive "which indexes to drop/merge" capability the current (observational) FinOps tabs lack. Stage 2 (analyzer) and Stage 3 (viewer tab) land in later PRs; this PR is **capture only**.

The capture matches the raw staged surface of Erik's `sp_IndexCleanup` so a Stage-2 analyzer can reproduce its recommendations (Exact Duplicate, Reverse Duplicate, Equal-Except-Filter, Key Subset/Superset, Unused) **and** its FK/constraint/uniqueness drop/merge protections exactly.

## New columns (14 appended to `index_object_stats`, 44 → 58)

| Column | Purpose |
|---|---|
| `key_columns` | Ordered KEY list, `QUOTENAME` + ` DESC`, key-ordinal order — sp_IndexCleanup's exact delimited STUFF/FOR XML form so string-comparison dedupe ports cleanly |
| `included_columns` | INCLUDE set, name-ordered |
| `filter_definition` | Raw filtered-index predicate |
| `is_unique_constraint`, `is_disabled`, `is_indexed_view` | Discriminators (`is_indexed_view` = the table-vs-indexed-view signal `index_type_desc` can't express) |
| `is_foreign_key`, `is_foreign_key_reference` | FK **protections** — aggregated to the index grain over KEY columns, mirroring sp_IndexCleanup's `is_foreign_key_reference = 1` guards (never drop an FK-supporting/referenced index) |
| `data_compression_desc`, `optimize_for_sequential_key`, `fill_factor`, `is_padded`, `allow_page_locks`, `allow_row_locks` | Reconstruct-a-CREATE options |

All sourced from `sys.indexes` / `sys.index_columns` / `sys.columns` / `sys.foreign_key_columns` / `sys.partitions` — catalog views present on every platform incl. Azure SQL DB — reusing the collector's existing per-database execution. `optimize_for_sequential_key` (SQL 2019+/Azure only) is version-gated (typed NULL on older engines; the collector body is otherwise version-invariant).

## Wiring
- `IndexObjectStatsCollector.cs`: query + payload (appended, positional-write aligned)
- Lite `Schema.cs` + `DuckDbInitializer` (CurrentSchemaVersion 40 → 41 ALTER)
- Darling migration **V15** (ALTER + `v_index_object_stats` SELECT * refresh) + `StorageVersion` 14 → 15 + both gated `14L → 15L` pins + `Scripts.Count`/`StorageVersion`/V15 asserts; `PgSchemaGenerator` auto-derives fresh V1 from `PayloadColumns`

## Testing
- **Lite.Tests: 902 passed / 0 failed**
- **Darling.Tests: 601 passed / 0 failed / 83 skipped** (live-Postgres gated)
- Generated T-SQL validated live on **SQL 2022**: key/include/DESC/filter format matches sp_IndexCleanup byte-for-byte; FK-supporting/referenced detection correct (TSQLV5: 10/8); compression/fill_factor/OFSK/is_indexed_view all correct

## Surfaced (not silently scoped)
- **`is_max_length`** — sp_IndexCleanup stages it but (verified across the whole proc) no rule/protection/output consumes it, and it's per-column (doesn't fit the per-index grain). Excluded; add later if a stage needs per-column type detail.
- **Dashboard SQL Server path** (`install/55_collect_index_object_stats.sql` + `install/02` table) is a **separate T-SQL implementation** not wired here — it has no Stage-2/3 consumer (headless-only) and is the deprecated path. Flagged for a decision rather than extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)