### PR TITLE
FinOps Index Analysis Stage 2: monitor-side IndexCleanupAnalyzer

### DIFF
--- a/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
+++ b/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// DB-free tests for the shared <see cref="IndexCleanupAnalyzer"/> — the monitor-side reproduction of
+/// <c>sp_IndexCleanup</c>'s analysis over the captured <c>index_object_stats</c> snapshot. Every rule
+/// (Unused + uptime caveat, Exact/Reverse/Equal-Except-Filter, Key Duplicate, Key Subset/Superset, subset
+/// chains), every disable protection (PK, unique constraint, FK-reference), compression candidacy + the
+/// 0.20–0.60 savings band, the reclaimable roll-up, and the reconstructed T-SQL are asserted against
+/// synthetic index sets. No database.
+/// </summary>
+public class IndexCleanupAnalyzerTests
+{
+    // ── input builder ──────────────────────────────────────────────────────────────────────────────
+
+    private static IndexCleanupIndexInput Idx(
+        string name,
+        string? keys,
+        int indexId = 2,
+        string? includes = null,
+        string? filter = null,
+        string type = "NONCLUSTERED",
+        bool unique = false,
+        bool primaryKey = false,
+        bool uniqueConstraint = false,
+        bool foreignKeyReference = false,
+        bool foreignKey = false,
+        long seeks = 0,
+        long scans = 0,
+        long lookups = 0,
+        long updates = 0,
+        decimal reservedMb = 0m,
+        string? compression = "PAGE",   // default already-compressed so dedupe tests aren't cluttered with COMPRESS rows
+        long rows = 1000,
+        int partitionCount = 1,
+        bool optimizeSequentialKey = false,
+        int objectId = 1,
+        string database = "TestDb",
+        string schema = "dbo",
+        string table = "T") =>
+        new()
+        {
+            DatabaseName = database,
+            DatabaseId = 5,
+            SchemaName = schema,
+            ObjectId = objectId,
+            TableName = table,
+            IndexId = indexId,
+            IndexName = name,
+            IndexTypeDesc = type,
+            KeyColumns = keys,
+            IncludedColumns = includes,
+            FilterDefinition = filter,
+            IsUnique = unique || primaryKey || uniqueConstraint,
+            IsUniqueConstraint = uniqueConstraint,
+            IsPrimaryKey = primaryKey,
+            IsForeignKey = foreignKey,
+            IsForeignKeyReference = foreignKeyReference,
+            IsDisabled = false,
+            DataCompressionDesc = compression,
+            OptimizeForSequentialKey = optimizeSequentialKey,
+            UserSeeks = seeks,
+            UserScans = scans,
+            UserLookups = lookups,
+            UserUpdates = updates,
+            ReservedMb = reservedMb,
+            TotalRows = rows,
+            PartitionCount = partitionCount,
+            SqlServerStartTime = null,
+        };
+
+    private static IndexCleanupOptions Opts(
+        bool dedupeOnly = false,
+        double? uptimeDays = 30,
+        decimal minSizeGb = 0m,
+        long minRows = 0,
+        long minReads = 0,
+        long minWrites = 0,
+        bool supportsCompression = true,
+        bool supportsOnline = false) =>
+        new()
+        {
+            DedupeOnly = dedupeOnly,
+            ServerUptimeDays = uptimeDays,
+            MinSizeGb = minSizeGb,
+            MinRows = minRows,
+            MinReads = minReads,
+            MinWrites = minWrites,
+            ServerSupportsCompression = supportsCompression,
+            ServerSupportsOnline = supportsOnline,
+        };
+
+    private static IndexCleanupRecommendation? Rec(IndexCleanupAnalysisResult r, string indexName) =>
+        r.Recommendations.FirstOrDefault(x => x.IndexName == indexName);
+
+    // ── Rule 1: Unused ─────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Unused_NonclusteredWithNoReads_IsDisabled()
+    {
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("IX_Unused", rec.IndexName);
+        Assert.Equal(IndexCleanupAction.Disable, rec.Action);
+        Assert.Equal(IndexCleanupRules.UnusedIndex, rec.ConsolidationRule);
+        Assert.Equal("ALTER INDEX [IX_Unused] ON [TestDb].[dbo].[T] DISABLE;", rec.Script);
+        Assert.False(r.UptimeWarning);
+    }
+
+    [Fact]
+    public void Unused_UptimeUnder14Days_CarriesWarningLabel()
+    {
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts(uptimeDays: 10));
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal(IndexCleanupRules.UnusedIndexUptimeWarning, rec.ConsolidationRule);
+        Assert.Contains("uptime < 14 days", rec.ConsolidationRule);
+        Assert.True(r.UptimeWarning);
+        Assert.False(r.DedupeOnlyApplied);
+    }
+
+    [Fact]
+    public void Unused_UptimeUnder7Days_AutoDedupeSkipsUnused()
+    {
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts(uptimeDays: 5));
+
+        Assert.Empty(r.Recommendations);          // unused not flagged under auto-dedupe
+        Assert.True(r.DedupeOnlyApplied);
+    }
+
+    [Fact]
+    public void Unused_DedupeOnlyOption_SkipsUnused()
+    {
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts(dedupeOnly: true));
+        Assert.Empty(r.Recommendations);
+    }
+
+    [Fact]
+    public void Unused_ClusteredIndex_NeverFlagged()
+    {
+        // A clustered index with no reads must never be "unused".
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("PK_T", "[a]", indexId: 1, type: "CLUSTERED", primaryKey: true) }, Opts());
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+    }
+
+    // ── Rule 2: Exact Duplicate ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExactDuplicate_DisablesLowerPriorityKeepsHigher()
+    {
+        var keeper = Idx("IX_Keep", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10, scans: 5);
+        var loser = Idx("IX_Drop", "[a], [b]", indexId: 3, includes: "[c]", seeks: 5);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { keeper, loser }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("IX_Drop", rec.IndexName);
+        Assert.Equal(IndexCleanupAction.Disable, rec.Action);
+        Assert.Equal(IndexCleanupRules.ExactDuplicate, rec.ConsolidationRule);
+        Assert.Equal("IX_Keep", rec.TargetIndexName);
+        Assert.Contains("exact duplicate", rec.AdditionalInfo);
+    }
+
+    [Fact]
+    public void ExactDuplicate_TieBreaksOnIndexName()
+    {
+        // Identical priority (both seeks + includes) → the alphabetically-first name is the keeper.
+        var a = Idx("IX_AAA", "[a]", indexId: 2, includes: "[c]", seeks: 10);
+        var b = Idx("IX_BBB", "[a]", indexId: 3, includes: "[c]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { b, a }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("IX_BBB", rec.IndexName);   // BBB disabled, AAA kept
+        Assert.Equal("IX_AAA", rec.TargetIndexName);
+    }
+
+    // ── Reverse Duplicate ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ReverseDuplicate_InvertedDirections_IsFlagged()
+    {
+        var asc = Idx("IX_Asc", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10, scans: 5);
+        var desc = Idx("IX_Desc", "[a] DESC, [b] DESC", indexId: 3, includes: "[c]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { asc, desc }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("IX_Desc", rec.IndexName);
+        Assert.Equal(IndexCleanupRules.ReverseDuplicate, rec.ConsolidationRule);
+        Assert.Equal("IX_Asc", rec.TargetIndexName);
+    }
+
+    [Fact]
+    public void ReverseDuplicate_PartialDirectionDifference_NotFlagged()
+    {
+        // Only ONE of two key columns flipped → not a functional reverse duplicate, and not an exact one.
+        var a = Idx("IX_A", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10);
+        var b = Idx("IX_B", "[a], [b] DESC", indexId: 3, includes: "[c]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { a, b }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+    }
+
+    // ── Equal Except For Filter ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EqualExceptForFilter_DifferentFilters_IsFlaggedWithCaveat()
+    {
+        var a = Idx("IX_A", "[a]", indexId: 2, includes: "[b]", filter: "([a]>(0))", seeks: 10, scans: 5);
+        var b = Idx("IX_B", "[a]", indexId: 3, includes: "[b]", filter: "([a]>(100))", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { a, b }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("IX_B", rec.IndexName);
+        Assert.Equal(IndexCleanupRules.EqualExceptForFilter, rec.ConsolidationRule);
+        Assert.Contains("filter", rec.AdditionalInfo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Rule 5: Key Duplicate ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void KeyDuplicate_SameKeysDifferentIncludes_MergesIntoKeeper()
+    {
+        var keeper = Idx("IX_Keep", "[a]", indexId: 2, includes: "[b]", seeks: 10, scans: 5);
+        var loser = Idx("IX_Drop", "[a]", indexId: 3, includes: "[c]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { keeper, loser }, Opts());
+
+        var keep = Rec(r, "IX_Keep");
+        var drop = Rec(r, "IX_Drop");
+        Assert.NotNull(keep);
+        Assert.NotNull(drop);
+
+        Assert.Equal(IndexCleanupAction.MergeIncludes, keep!.Action);
+        Assert.Equal(IndexCleanupRules.KeyDuplicate, keep.ConsolidationRule);
+        Assert.Contains("INCLUDE ([b], [c])", keep.Script);        // absorbed the loser's include
+        Assert.Contains("DROP_EXISTING = ON", keep.Script);
+        Assert.Equal("Supersedes IX_Drop", keep.SupersededBy);
+
+        Assert.Equal(IndexCleanupAction.Disable, drop!.Action);
+        Assert.Equal("IX_Keep", drop.TargetIndexName);
+    }
+
+    [Fact]
+    public void KeyDuplicate_PrefersUniqueAsKeeper()
+    {
+        // Non-unique has higher usage priority, but the unique index must win.
+        var uniqueIx = Idx("IX_Unique", "[a]", indexId: 2, includes: "[b]", unique: true, seeks: 1);
+        var busyIx = Idx("IX_Busy", "[a]", indexId: 3, includes: "[c]", seeks: 99, scans: 99);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { busyIx, uniqueIx }, Opts());
+
+        Assert.Equal(IndexCleanupAction.MergeIncludes, Rec(r, "IX_Unique")!.Action);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "IX_Busy")!.Action);
+    }
+
+    // ── Rules 3/4/6: Key Subset / Superset ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void KeySubset_NarrowerPrefix_DisabledInFavorOfSuperset()
+    {
+        var narrow = Idx("IX_Narrow", "[a]", indexId: 2, includes: "[z]", seeks: 10);
+        var wide = Idx("IX_Wide", "[a], [b]", indexId: 3, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { narrow, wide }, Opts());
+
+        var sub = Rec(r, "IX_Narrow");
+        var sup = Rec(r, "IX_Wide");
+        Assert.NotNull(sub);
+        Assert.NotNull(sup);
+
+        Assert.Equal(IndexCleanupAction.Disable, sub!.Action);
+        Assert.Equal(IndexCleanupRules.KeySubset, sub.ConsolidationRule);
+        Assert.Equal("IX_Wide", sub.TargetIndexName);
+
+        Assert.Equal(IndexCleanupAction.MergeIncludes, sup!.Action);
+        Assert.Equal(IndexCleanupRules.KeySuperset, sup.ConsolidationRule);
+        Assert.Equal("[z]", sup.MissingIncludedColumns);          // subset's include merged into the superset
+        Assert.Contains("INCLUDE ([z])", sup.Script);
+        Assert.Equal("Supersedes IX_Narrow", sup.SupersededBy);
+    }
+
+    [Fact]
+    public void KeySubset_UniqueNarrower_IsNotDisabled()
+    {
+        // A unique index on (A) enforces uniqueness a wider (A,B) index does not — never disable it.
+        var uniqueNarrow = Idx("IX_UQ", "[a]", indexId: 2, unique: true, seeks: 10);
+        var wide = Idx("IX_Wide", "[a], [b]", indexId: 3, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uniqueNarrow, wide }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "IX_UQ" && x.Action == IndexCleanupAction.Disable);
+    }
+
+    [Fact]
+    public void KeySubset_ChooseClosestSuperset()
+    {
+        // Two supersets that are NOT nested in each other (different 2nd key), so neither is itself
+        // disabled — the narrow index must defer to the one with the fewest extra key columns.
+        var narrow = Idx("IX_N", "[a]", indexId: 2, seeks: 10);
+        var near = Idx("IX_Near", "[a], [b]", indexId: 3, seeks: 10);
+        var far = Idx("IX_Far", "[a], [c], [d]", indexId: 4, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { narrow, near, far }, Opts());
+
+        Assert.Equal("IX_Near", Rec(r, "IX_N")!.TargetIndexName);  // fewest extra key columns
+    }
+
+    [Fact]
+    public void KeySubset_ChainIsFlattenedToFinalSuperset()
+    {
+        var a = Idx("IX_A", "[a]", indexId: 2, seeks: 10);
+        var b = Idx("IX_B", "[a], [b]", indexId: 3, seeks: 10);
+        var c = Idx("IX_C", "[a], [b], [c]", indexId: 4, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { a, b, c }, Opts());
+
+        Assert.Equal("IX_C", Rec(r, "IX_A")!.TargetIndexName);   // A → B → C flattened to A → C
+        Assert.Equal("IX_C", Rec(r, "IX_B")!.TargetIndexName);
+        Assert.Equal(IndexCleanupAction.MergeIncludes, Rec(r, "IX_C")!.Action);
+        Assert.Equal(IndexCleanupRules.KeySuperset, Rec(r, "IX_C")!.ConsolidationRule);
+    }
+
+    // ── Protections ────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Protection_PrimaryKey_IsKeptNotDisabled()
+    {
+        var pk = Idx("PK_T", "[a]", indexId: 2, primaryKey: true, unique: true, seeks: 1);
+        var dup = Idx("IX_Dup", "[a]", indexId: 3, seeks: 99, scans: 99);   // higher usage, but must not win
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { pk, dup }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "PK_T" && x.Action == IndexCleanupAction.Disable);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "IX_Dup")!.Action);
+    }
+
+    [Fact]
+    public void Protection_ForeignKeyReference_IsKeptNotDisabled()
+    {
+        var fkRef = Idx("UQ_Ref", "[a]", indexId: 2, unique: true, foreignKeyReference: true, seeks: 1);
+        var dup = Idx("IX_Dup", "[a]", indexId: 3, seeks: 99, scans: 99);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { fkRef, dup }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UQ_Ref" && x.Action == IndexCleanupAction.Disable);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "IX_Dup")!.Action);
+    }
+
+    [Fact]
+    public void Protection_UniqueConstraint_ExcludedFromDedupe()
+    {
+        var uc = Idx("UQ_C", "[a]", indexId: 2, uniqueConstraint: true, unique: true, seeks: 10);
+        var dup = Idx("IX_Dup", "[a]", indexId: 3, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uc, dup }, Opts());
+
+        // The unique constraint is never disabled (out of the dedupe candidate set entirely).
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UQ_C" && x.Action == IndexCleanupAction.Disable);
+    }
+
+    [Fact]
+    public void Protection_ForeignKeyReferencedUnused_IsNotDisabled()
+    {
+        // FK-referenced index with zero reads: must not be flagged unused (it backs referential integrity).
+        var fkRef = Idx("UQ_Ref", "[a]", indexId: 2, unique: true, foreignKeyReference: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { fkRef }, Opts());
+        Assert.Empty(r.Recommendations);
+    }
+
+    // ── Compression ────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Compression_UncompressedLargeIndex_IsCandidateWithSavingsBand()
+    {
+        var clustered = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 10240m, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { clustered }, Opts());
+
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal(IndexCleanupResultKind.Compress, rec.ResultKind);
+        Assert.True(rec.CanCompress);
+        Assert.Equal("ALTER INDEX [CX_T] ON [TestDb].[dbo].[T] REBUILD WITH (FILLFACTOR = 100, SORT_IN_TEMPDB = ON, ONLINE = OFF, DATA_COMPRESSION = PAGE);", rec.Script);
+
+        Assert.Equal(1, r.OverallRollup.CompressableIndexes);
+        Assert.Equal(2m, Math.Round(r.OverallRollup.CompressionMinSavingsGb, 4));   // 10 GB * 0.20
+        Assert.Equal(6m, Math.Round(r.OverallRollup.CompressionMaxSavingsGb, 4));   // 10 GB * 0.60
+    }
+
+    [Fact]
+    public void Compression_AlreadyPageCompressed_NotCandidate()
+    {
+        var ix = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "PAGE", reservedMb: 10240m, seeks: 10);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts());
+        Assert.Empty(r.Recommendations);
+        Assert.Equal(0, r.OverallRollup.CompressableIndexes);
+    }
+
+    [Fact]
+    public void Compression_BelowMinSize_Excluded()
+    {
+        var ix = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 512m, seeks: 10);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts(minSizeGb: 1m));   // 0.5 GB < 1 GB
+        Assert.Empty(r.Recommendations);
+    }
+
+    [Fact]
+    public void Compression_EditionUnsupported_Excluded()
+    {
+        var ix = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 10240m, seeks: 10);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts(supportsCompression: false));
+        Assert.Empty(r.Recommendations);
+    }
+
+    [Fact]
+    public void Compression_PartitionedIndex_UsesPartitionAll()
+    {
+        var ix = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 10240m, partitionCount: 4, seeks: 10);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts());
+        Assert.Contains("REBUILD PARTITION = ALL", Assert.Single(r.Recommendations).Script);
+    }
+
+    [Fact]
+    public void Compression_OnlineSupported_EmitsOnlineOn()
+    {
+        var ix = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 10240m, optimizeSequentialKey: true, seeks: 10);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts(supportsOnline: true));
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Contains("ONLINE = ON", rec.Script);
+        Assert.Contains("OPTIMIZE_FOR_SEQUENTIAL_KEY = ON", rec.Script);
+    }
+
+    // ── Reclaimable roll-up ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Rollup_CombinesDisabledFullSizeAndCompressionBand()
+    {
+        var unused = Idx("IX_Unused", "[b]", indexId: 2, compression: "PAGE", reservedMb: 5120m);          // 5 GB, disabled → full reclaim
+        var keptCompressible = Idx("CX_T", "[a]", indexId: 1, type: "CLUSTERED", compression: "NONE", reservedMb: 10240m, seeks: 10); // 10 GB kept → 2-6 GB
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { unused, keptCompressible }, Opts());
+
+        var roll = r.OverallRollup;
+        Assert.Equal(1, roll.UnusedIndexes);
+        Assert.Equal(1, roll.IndexesToDisable);
+        Assert.Equal(5m, Math.Round(roll.UnusedSizeGb, 4));
+        Assert.Equal(1, roll.CompressableIndexes);
+        Assert.Equal(2m, Math.Round(roll.CompressionMinSavingsGb, 4));
+        Assert.Equal(6m, Math.Round(roll.CompressionMaxSavingsGb, 4));
+        Assert.Equal(7m, Math.Round(roll.TotalMinSavingsGb, 4));   // 5 + 2
+        Assert.Equal(11m, Math.Round(roll.TotalMaxSavingsGb, 4));  // 5 + 6
+    }
+
+    // ── Reconstructed T-SQL ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OriginalDefinition_ReconstructsCreateFromCapturedStrings()
+    {
+        var ix = Idx("IX_x", "[a], [b] DESC", indexId: 2, includes: "[c], [d]", filter: "([a]>(0))");
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts());
+        var rec = Assert.Single(r.Recommendations);
+
+        Assert.Equal(
+            "CREATE NONCLUSTERED INDEX [IX_x] ON [TestDb].[dbo].[T] ([a], [b] DESC) INCLUDE ([c], [d]) WHERE ([a]>(0));",
+            rec.OriginalIndexDefinition);
+    }
+
+    [Fact]
+    public void MergeScript_HasCanonicalDropExistingForm()
+    {
+        var keeper = Idx("IX_Keep", "[a]", indexId: 2, includes: "[b]", seeks: 10, scans: 5);
+        var loser = Idx("IX_Drop", "[a]", indexId: 3, includes: "[c]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { keeper, loser }, Opts());
+
+        Assert.Equal(
+            "CREATE INDEX [IX_Keep] ON [TestDb].[dbo].[T] ([a]) INCLUDE ([b], [c]) WITH (DROP_EXISTING = ON, FILLFACTOR = 100, SORT_IN_TEMPDB = ON, ONLINE = OFF);",
+            Rec(r, "IX_Keep")!.Script);
+    }
+
+    [Fact]
+    public void QuoteName_EscapesClosingBracketsInObjectNames()
+    {
+        var ix = Idx("IX]evil", "[a]", indexId: 2, table: "Weird]Table");
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts());
+        var rec = Assert.Single(r.Recommendations);
+        Assert.Equal("ALTER INDEX [IX]]evil] ON [TestDb].[dbo].[Weird]]Table] DISABLE;", rec.Script);
+    }
+
+    // ── Input shaping ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NonRowstoreAndDisabled_AreExcludedFromAnalysis()
+    {
+        var heap = Idx("Heap", null, indexId: 0, type: "HEAP");
+        var columnstore = Idx("CS", "[a]", indexId: 2, type: "NONCLUSTERED COLUMNSTORE", compression: "COLUMNSTORE");
+        var disabled = new IndexCleanupIndexInput
+        {
+            DatabaseName = "TestDb", SchemaName = "dbo", TableName = "T", ObjectId = 1, IndexId = 4,
+            IndexName = "IX_Disabled", IndexTypeDesc = "NONCLUSTERED", KeyColumns = "[a]", IsDisabled = true,
+        };
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { heap, columnstore, disabled }, Opts());
+
+        Assert.Empty(r.Recommendations);
+        Assert.Equal(0, r.OverallRollup.IndexCount);
+    }
+
+    [Fact]
+    public void MultipleDatabases_ProduceSeparateRollups()
+    {
+        var db1 = Idx("IX_1", "[a]", indexId: 2, database: "DbOne", objectId: 1);
+        var db2 = Idx("IX_2", "[a]", indexId: 2, database: "DbTwo", objectId: 2);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { db1 with { DatabaseId = 1 }, db2 with { DatabaseId = 2 } }, Opts());
+
+        Assert.Equal(2, r.DatabaseRollups.Count);
+        Assert.Contains(r.DatabaseRollups, x => x.DatabaseName == "DbOne");
+        Assert.Contains(r.DatabaseRollups, x => x.DatabaseName == "DbTwo");
+        Assert.Equal(2, r.OverallRollup.IndexesToDisable);
+    }
+
+    [Fact]
+    public void MinRows_SmallTableIsSkipped()
+    {
+        var ix = Idx("IX_Small", "[a]", indexId: 2, rows: 50);
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ix }, Opts(minRows: 1000));
+        Assert.Empty(r.Recommendations);
+    }
+
+    [Fact]
+    public void Notes_SurfaceOutOfScopeRules()
+    {
+        var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts());
+        Assert.Contains(r.Notes, n => n.Contains("Unique Constraint Replacement") && n.Contains("Same Keys Different Order"));
+    }
+}

--- a/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
+++ b/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
@@ -189,48 +189,76 @@ public class IndexCleanupAnalyzerTests
         Assert.Equal("IX_AAA", rec.TargetIndexName);
     }
 
-    // ── Reverse Duplicate ──────────────────────────────────────────────────────────────────────────
+    // ── Reverse Duplicate (review only — never auto-disabled; mirrors adversarial test 9a) ──────────
 
     [Fact]
-    public void ReverseDuplicate_InvertedDirections_IsFlagged()
+    public void ReverseDuplicate_ReversedColumnOrder_IsReviewNotDisabled()
     {
-        var asc = Idx("IX_Asc", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10, scans: 5);
-        var desc = Idx("IX_Desc", "[a] DESC, [b] DESC", indexId: 3, includes: "[c]", seeks: 10);
+        // (a, b) vs (b, a): same column set, different leading column → serve different queries.
+        var ab = Idx("IX_ab", "[a], [b]", indexId: 2, seeks: 10);
+        var ba = Idx("IX_ba", "[b], [a]", indexId: 3, seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { ab, ba }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+
+        var review = r.Recommendations.First(x => x.IndexName == "IX_ab");
+        Assert.Equal(IndexCleanupResultKind.Review, review.ResultKind);
+        Assert.Equal(IndexCleanupRules.ReverseDuplicate, review.ConsolidationRule);
+        Assert.Equal(IndexCleanupAction.Keep, review.Action);
+        Assert.Equal("", review.Script);   // informational — no destructive script
+    }
+
+    [Fact]
+    public void ReverseDuplicate_InvertedDirection_IsReviewNotDisabled()
+    {
+        // (a ASC) vs (a DESC): functionally scannable both ways, but sp_IndexCleanup does not auto-drop them.
+        var asc = Idx("IX_asc", "[a]", indexId: 2, seeks: 10);
+        var desc = Idx("IX_desc", "[a] DESC", indexId: 3, seeks: 10);
 
         var r = IndexCleanupAnalyzer.Analyze(new[] { asc, desc }, Opts());
 
-        var rec = Assert.Single(r.Recommendations);
-        Assert.Equal("IX_Desc", rec.IndexName);
-        Assert.Equal(IndexCleanupRules.ReverseDuplicate, rec.ConsolidationRule);
-        Assert.Equal("IX_Asc", rec.TargetIndexName);
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+        Assert.Contains(r.Recommendations, x => x.ResultKind == IndexCleanupResultKind.Review && x.ConsolidationRule == IndexCleanupRules.ReverseDuplicate);
     }
 
     [Fact]
-    public void ReverseDuplicate_PartialDirectionDifference_NotFlagged()
+    public void ExactDuplicate_SameDescendingKeys_IsDisabled()
     {
-        // Only ONE of two key columns flipped → not a functional reverse duplicate, and not an exact one.
-        var a = Idx("IX_A", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10);
-        var b = Idx("IX_B", "[a], [b] DESC", indexId: 3, includes: "[c]", seeks: 10);
+        // Two byte-identical DESC indexes ARE exact duplicates (mirrors adversarial test 2a).
+        var d1 = Idx("IX_d1", "[a] DESC", indexId: 2, seeks: 10, scans: 5);
+        var d2 = Idx("IX_d2", "[a] DESC", indexId: 3, seeks: 10);
 
-        var r = IndexCleanupAnalyzer.Analyze(new[] { a, b }, Opts());
+        var r = IndexCleanupAnalyzer.Analyze(new[] { d1, d2 }, Opts());
+        Assert.Contains(r.Recommendations, x => x.Action == IndexCleanupAction.Disable && x.ConsolidationRule == IndexCleanupRules.ExactDuplicate);
+    }
+
+    // ── Equal Except For Filter (review only — never auto-disabled; mirrors adversarial test 10a) ───
+
+    [Fact]
+    public void EqualExceptForFilter_FilteredVsUnfiltered_IsReviewNotDisabled()
+    {
+        var unfiltered = Idx("IX_a", "[a]", indexId: 2, seeks: 10);
+        var filtered = Idx("IX_a_filt", "[a]", indexId: 3, filter: "([status_code]=(1))", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { unfiltered, filtered }, Opts());
 
         Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+        var review = r.Recommendations.First(x => x.IndexName == "IX_a_filt" && x.ResultKind == IndexCleanupResultKind.Review);
+        Assert.Equal(IndexCleanupRules.EqualExceptForFilter, review.ConsolidationRule);
+        Assert.Contains("filter", review.AdditionalInfo, StringComparison.OrdinalIgnoreCase);
     }
 
-    // ── Equal Except For Filter ────────────────────────────────────────────────────────────────────
-
     [Fact]
-    public void EqualExceptForFilter_DifferentFilters_IsFlaggedWithCaveat()
+    public void EqualExceptForFilter_DifferentFilters_AreReviewNotDisabled()
     {
-        var a = Idx("IX_A", "[a]", indexId: 2, includes: "[b]", filter: "([a]>(0))", seeks: 10, scans: 5);
+        var a = Idx("IX_A", "[a]", indexId: 2, includes: "[b]", filter: "([a]>(0))", seeks: 10);
         var b = Idx("IX_B", "[a]", indexId: 3, includes: "[b]", filter: "([a]>(100))", seeks: 10);
 
         var r = IndexCleanupAnalyzer.Analyze(new[] { a, b }, Opts());
 
-        var rec = Assert.Single(r.Recommendations);
-        Assert.Equal("IX_B", rec.IndexName);
-        Assert.Equal(IndexCleanupRules.EqualExceptForFilter, rec.ConsolidationRule);
-        Assert.Contains("filter", rec.AdditionalInfo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+        Assert.Equal(2, r.Recommendations.Count(x => x.ResultKind == IndexCleanupResultKind.Review));
     }
 
     // ── Rule 5: Key Duplicate ──────────────────────────────────────────────────────────────────────
@@ -336,6 +364,31 @@ public class IndexCleanupAnalyzerTests
         Assert.Equal("IX_C", Rec(r, "IX_B")!.TargetIndexName);
         Assert.Equal(IndexCleanupAction.MergeIncludes, Rec(r, "IX_C")!.Action);
         Assert.Equal(IndexCleanupRules.KeySuperset, Rec(r, "IX_C")!.ConsolidationRule);
+    }
+
+    [Fact]
+    public void KeySubset_SameFilter_IsDisabled()
+    {
+        // Filtered subset with a MATCHING filter → disabled (mirrors adversarial test 3c).
+        var narrow = Idx("IX_n", "[a]", indexId: 2, filter: "([status_code]=(3))", seeks: 10);
+        var wide = Idx("IX_w", "[a], [b]", indexId: 3, filter: "([status_code]=(3))", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { narrow, wide }, Opts());
+
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "IX_n")!.Action);
+        Assert.Equal(IndexCleanupRules.KeySubset, Rec(r, "IX_n")!.ConsolidationRule);
+    }
+
+    [Fact]
+    public void KeySubset_DifferentFilter_IsNotSubset()
+    {
+        // Prefix key but a DIFFERENT filter → NOT a subset (mirrors adversarial test 3d).
+        var narrow = Idx("IX_n", "[a]", indexId: 2, filter: "([status_code]=(1))", seeks: 10);
+        var wide = Idx("IX_w", "[a], [b]", indexId: 3, filter: "([status_code]=(2))", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { narrow, wide }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
     }
 
     // ── Protections ────────────────────────────────────────────────────────────────────────────────
@@ -537,6 +590,17 @@ public class IndexCleanupAnalyzerTests
         Assert.Contains(r.DatabaseRollups, x => x.DatabaseName == "DbOne");
         Assert.Contains(r.DatabaseRollups, x => x.DatabaseName == "DbTwo");
         Assert.Equal(2, r.OverallRollup.IndexesToDisable);
+    }
+
+    [Fact]
+    public void CrossTableIsolation_IdenticalIndexesOnDifferentObjects_NotFlagged()
+    {
+        // Identical indexes on DIFFERENT tables (objects) must never dedupe each other (mirrors test 7a).
+        var t1 = Idx("IX_same", "[a]", indexId: 2, objectId: 10, table: "T1", seeks: 10);
+        var t2 = Idx("IX_same", "[a]", indexId: 2, objectId: 20, table: "T2", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { t1, t2 }, Opts());
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
     }
 
     [Fact]

--- a/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
+++ b/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
@@ -19,15 +19,18 @@ namespace PerformanceMonitor.Common
     /// and a reclaimable-space roll-up — the same analysis a live <c>sp_IndexCleanup</c> would, for servers
     /// where the proc is not (or cannot be) installed.
     ///
-    /// <para>Faithful to <c>sp_IndexCleanup</c> v2.7 (20260701). Because Stage 1 captured
-    /// <c>key_columns</c>/<c>included_columns</c> in the proc's EXACT delimited <c>QUOTENAME</c> form, the
-    /// string-comparison dedupe ports directly. Reproduced rules: <b>Unused Index</b> (Rule 1, with the
-    /// &lt;14-day-uptime caveat and &lt;=7-day auto-dedupe), <b>Exact Duplicate</b> (Rule 2),
-    /// <b>Reverse Duplicate</b> and <b>Equal Except For Filter</b> (the two exact-duplicate sub-classes the
-    /// proc documents at its <c>#index_analysis</c> definition but folds into Rule 2 — implemented here as
-    /// distinct labels, both derivable from the captured direction-bearing key strings), <b>Key Duplicate</b>
-    /// (Rule 5), and <b>Key Subset</b>/<b>Key Superset</b> (Rules 3/4/6, with subset-chain flattening and
-    /// missing-include carry). Priority scoring, <c>is_eligible_for_dedupe</c>, and the
+    /// <para>Faithful to <c>sp_IndexCleanup</c> v2.7 (20260701), cross-checked against its adversarial test
+    /// suite. Because Stage 1 captured <c>key_columns</c>/<c>included_columns</c> in the proc's EXACT
+    /// delimited <c>QUOTENAME</c> form, the string-comparison dedupe ports directly. <b>Auto-consolidated</b>
+    /// (a script is generated): <b>Unused Index</b> (Rule 1, with the &lt;14-day-uptime caveat and
+    /// &lt;=7-day auto-dedupe), <b>Exact Duplicate</b> (Rule 2 → DISABLE), <b>Key Duplicate</b> (Rule 5 →
+    /// keeper MERGE INCLUDES + loser DISABLE), and <b>Key Subset</b>/<b>Key Superset</b> (Rules 3/4/6 →
+    /// subset DISABLE + superset MERGE, with subset-chain flattening and missing-include carry).
+    /// <b>Recognized but deliberately NOT auto-consolidated</b> (surfaced as a review row, matching the
+    /// proc's tested behavior — its adversarial tests 9a/10a assert these are left alone): <b>Reverse
+    /// Duplicate</b> (same key column set, different order/direction — a different leading column serves
+    /// different queries) and <b>Equal Except For Filter</b> (same keys+includes, different filter — the
+    /// filters index different rows). Priority scoring, <c>is_eligible_for_dedupe</c>, and the
     /// PK/unique-constraint/FK-reference disable protections match the proc's guards. PAGE-compression
     /// candidacy and the 0.20–0.60 general savings band reproduce the proc's <c>#compression_eligibility</c>
     /// / reporting math.</para>
@@ -135,9 +138,10 @@ namespace PerformanceMonitor.Common
                 ApplyUnused(scope, uptimeWarning);
             }
 
+            // Auto-consolidating rules (consume-and-mark, in sp_IndexCleanup's order). Reverse Duplicate and
+            // Equal Except For Filter are intentionally NOT here — the proc recognizes but does not
+            // consolidate them; they are detected non-destructively in DetectReviewRelationships.
             ApplyExactDuplicate(scope);
-            ApplyReverseDuplicate(scope);
-            ApplyEqualExceptForFilter(scope);
             ApplyKeySubset(scope);
             ResolveSubsetChains(scope);
             ApplyKeySuperset(scope);
@@ -180,54 +184,6 @@ namespace PerformanceMonitor.Common
                 .Where(g => g.Count() > 1))
             {
                 LabelDuplicateGroup(group.ToList(), IndexCleanupRules.ExactDuplicate);
-            }
-        }
-
-        /// <summary>
-        /// Reverse Duplicate: same key columns in the same order but every sort direction inverted (a
-        /// backward scan of one serves the other), same includes and filter. Pairwise, since only the FULL
-        /// direction inverse — not a partial direction difference — is equivalent.
-        /// </summary>
-        private static void ApplyReverseDuplicate(List<WorkIndex> scope)
-        {
-            var candidates = DedupeCandidates(scope)
-                .OrderBy(w => w.Name, StringComparer.Ordinal)
-                .ToList();
-
-            for (int i = 0; i < candidates.Count; i++)
-            {
-                var a = candidates[i];
-                if (a.Processed)
-                {
-                    continue;
-                }
-
-                for (int j = i + 1; j < candidates.Count; j++)
-                {
-                    var b = candidates[j];
-                    if (b.Processed)
-                    {
-                        continue;
-                    }
-
-                    if (IsReverseDuplicate(a, b))
-                    {
-                        LabelDuplicateGroup(new List<WorkIndex> { a, b }, IndexCleanupRules.ReverseDuplicate);
-                        break; // a is now processed
-                    }
-                }
-            }
-        }
-
-        /// <summary>Equal Except For Filter: identical keys (with direction) and includes, different filter.</summary>
-        private static void ApplyEqualExceptForFilter(List<WorkIndex> scope)
-        {
-            foreach (var group in DedupeCandidates(scope)
-                .GroupBy(w => (w.KeyColumns, w.IncludedColumns), KeyIncludeComparer.Instance)
-                .Where(g => g.Count() > 1))
-            {
-                // After Exact, same keys+includes among the unprocessed necessarily differ only by filter.
-                LabelDuplicateGroup(group.ToList(), IndexCleanupRules.EqualExceptForFilter);
             }
         }
 
@@ -459,25 +415,80 @@ namespace PerformanceMonitor.Common
                 .ThenBy(m => m.Name, StringComparer.Ordinal)
                 .FirstOrDefault();
 
-        private static bool IsReverseDuplicate(WorkIndex a, WorkIndex b)
-        {
-            if (a.Keys.Count == 0 || a.Keys.Count != b.Keys.Count)
-            {
-                return false;
-            }
+        /// <summary>
+        /// Reverse Duplicate: the same key column SET but a different arrangement (reversed/reordered order
+        /// or changed sort directions), with the same includes and filter. NOT an exact duplicate (the key
+        /// strings differ). A review signal only — never a disable.
+        /// </summary>
+        private static bool IsReverseDuplicate(WorkIndex a, WorkIndex b) =>
+            a.Keys.Count > 0
+            && a.Keys.Count == b.Keys.Count
+            && !string.Equals(a.KeyColumns, b.KeyColumns, StringComparison.Ordinal)  // not an exact duplicate
+            && a.KeyNameSet.SetEquals(b.KeyNameSet)                                  // same column membership
+            && string.Equals(a.IncludedColumns, b.IncludedColumns, StringComparison.Ordinal)
+            && string.Equals(a.Filter, b.Filter, StringComparison.Ordinal);
 
-            for (int k = 0; k < a.Keys.Count; k++)
+        /// <summary>
+        /// Equal Except For Filter: byte-identical keys (with direction) and includes, but a different filter
+        /// predicate. A review signal only — never a disable (the filters index different rows).
+        /// </summary>
+        private static bool IsEqualExceptForFilter(WorkIndex a, WorkIndex b) =>
+            string.Equals(a.KeyColumns, b.KeyColumns, StringComparison.Ordinal)
+            && string.Equals(a.IncludedColumns, b.IncludedColumns, StringComparison.Ordinal)
+            && !string.Equals(a.Filter, b.Filter, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Non-destructive detection of Reverse Duplicate and Equal Except For Filter relationships among the
+        /// indexes a scope KEPT (action None/Keep). Mirrors sp_IndexCleanup's stance (adversarial tests
+        /// 9a/10a): recognize the near-duplicate, but do NOT consolidate it — emit a review row so a human can
+        /// decide. One row per participating index per relationship type.
+        /// </summary>
+        private static IEnumerable<IndexCleanupRecommendation> DetectReviewRelationships(List<WorkIndex> scope)
+        {
+            var survivors = scope
+                .Where(w => w.IsEligibleForDedupe
+                    && !w.Src.IsUniqueConstraint
+                    && (w.Action == IndexCleanupAction.None || w.Action == IndexCleanupAction.Keep))
+                .OrderBy(w => w.Name, StringComparer.Ordinal)
+                .ToList();
+
+            for (int i = 0; i < survivors.Count; i++)
             {
-                // Same column, same position, but the sort direction must be inverted on EVERY key column.
-                if (!string.Equals(a.Keys[k].Name, b.Keys[k].Name, StringComparison.Ordinal)
-                    || a.Keys[k].Descending == b.Keys[k].Descending)
+                var a = survivors[i];
+                var reverse = new List<string>();
+                var equalExceptFilter = new List<string>();
+
+                foreach (var b in survivors)
                 {
-                    return false;
+                    if (ReferenceEquals(a, b))
+                    {
+                        continue;
+                    }
+
+                    if (IsReverseDuplicate(a, b))
+                    {
+                        reverse.Add(b.Name);
+                    }
+                    else if (IsEqualExceptForFilter(a, b))
+                    {
+                        equalExceptFilter.Add(b.Name);
+                    }
+                }
+
+                if (reverse.Count > 0)
+                {
+                    yield return BuildReview(a, IndexCleanupRules.ReverseDuplicate, reverse,
+                        "Same key columns in a different order/direction as: " + string.Join(", ", reverse)
+                        + ". A different leading column serves different queries — review whether both are needed (not auto-disabled).");
+                }
+
+                if (equalExceptFilter.Count > 0)
+                {
+                    yield return BuildReview(a, IndexCleanupRules.EqualExceptForFilter, equalExceptFilter,
+                        "Identical keys and includes but a different filter than: " + string.Join(", ", equalExceptFilter)
+                        + ". The filters index different rows — review whether both are needed (not auto-disabled).");
                 }
             }
-
-            return string.Equals(a.IncludedColumns, b.IncludedColumns, StringComparison.Ordinal)
-                && string.Equals(a.Filter, b.Filter, StringComparison.Ordinal);
         }
 
         // ────────────────────────────────────────────────────────────────────────────────────────────
@@ -502,6 +513,16 @@ namespace PerformanceMonitor.Common
                     yield return BuildCompress(w, options);
                 }
             }
+
+            // Non-destructive Reverse Duplicate / Equal Except For Filter review rows, per object scope. An
+            // index may appear here AND in a compression row — the review flag is additive metadata.
+            foreach (var scope in analyzed.GroupBy(w => w.Src.ObjectId))
+            {
+                foreach (var review in DetectReviewRelationships(scope.ToList()))
+                {
+                    yield return review;
+                }
+            }
         }
 
         private static IndexCleanupRecommendation BuildDisable(WorkIndex w)
@@ -510,8 +531,6 @@ namespace PerformanceMonitor.Common
             {
                 IndexCleanupRules.KeySubset => "This index is superseded by a wider index: " + (w.TargetIndexName ?? "(unknown)"),
                 IndexCleanupRules.ExactDuplicate => "This index is an exact duplicate of: " + (w.TargetIndexName ?? "(unknown)"),
-                IndexCleanupRules.ReverseDuplicate => "This index is a reverse-order duplicate of: " + (w.TargetIndexName ?? "(unknown)"),
-                IndexCleanupRules.EqualExceptForFilter => "This index matches except for its filter: " + (w.TargetIndexName ?? "(unknown)") + " (verify the differing WHERE clauses before disabling)",
                 IndexCleanupRules.KeyDuplicate => "This index has the same keys as: " + (w.TargetIndexName ?? "(unknown)"),
                 _ when w.ConsolidationRule != null && w.ConsolidationRule.StartsWith(IndexCleanupRules.UnusedIndex, StringComparison.Ordinal) => w.ConsolidationRule,
                 _ => "This index is redundant and will be disabled",
@@ -561,6 +580,19 @@ namespace PerformanceMonitor.Common
                 AdditionalInfo = "Compression type: PAGE (All Partitions)",
             };
         }
+
+        private static IndexCleanupRecommendation BuildReview(WorkIndex w, string rule, List<string> siblings, string additionalInfo) =>
+            NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.Keep,
+                ResultKind = IndexCleanupResultKind.Review,
+                ConsolidationRule = rule,
+                TargetIndexName = siblings.Count > 0 ? siblings[0] : null,
+                SupersededBy = "Related to " + string.Join(", ", siblings),
+                ScriptType = "REVIEW",
+                Script = "",   // informational only — no destructive script
+                AdditionalInfo = additionalInfo,
+            };
 
         private static IndexCleanupRecommendation NewRecommendation(WorkIndex w) => new()
         {
@@ -742,8 +774,14 @@ namespace PerformanceMonitor.Common
                     + "capture the partition scheme name).");
             }
 
+            notes.Add("Reverse Duplicate and Equal Except For Filter are recognized and surfaced as REVIEW rows but "
+                + "never auto-disabled — matching sp_IndexCleanup's tested behavior (its adversarial tests 9a/10a assert "
+                + "reversed-order and filter-differing indexes are left alone; a different leading column or filter serves "
+                + "different queries/rows).");
+
             notes.Add("Out of scope per this stage's DISABLE/MERGE INCLUDES/KEEP action set: sp_IndexCleanup's "
-                + "'Unique Constraint Replacement' (MAKE UNIQUE) and 'Same Keys Different Order' (REVIEW) rules. Both are "
+                + "'Unique Constraint Replacement' (MAKE UNIQUE / DROP CONSTRAINT, Rule 7 family). Its 'Same Keys "
+                + "Different Order' REVIEW case is largely covered by the Reverse Duplicate review rows above. Both are "
                 + "reproducible from the captured metadata if later required.");
 
             return notes;
@@ -820,7 +858,8 @@ namespace PerformanceMonitor.Common
             IndexCleanupResultKind.Merge => 0,
             IndexCleanupResultKind.Disable => 1,
             IndexCleanupResultKind.Compress => 2,
-            _ => 3,
+            IndexCleanupResultKind.Review => 3,
+            _ => 4,
         };
 
         // ────────────────────────────────────────────────────────────────────────────────────────────
@@ -839,6 +878,7 @@ namespace PerformanceMonitor.Common
                 Filter = src.FilterDefinition ?? "";
                 Keys = ParseKeyTokens(KeyColumns);
                 KeyNames = Keys.Select(k => k.Name).ToList();
+                KeyNameSet = new HashSet<string>(KeyNames, StringComparer.Ordinal);
                 IncludeTokens = SplitDelimited(IncludedColumns);
 
                 // is_eligible_for_dedupe: nonclustered → yes; clustered → no (mirrors sp_IndexCleanup's CASE,
@@ -856,6 +896,7 @@ namespace PerformanceMonitor.Common
             public string Filter { get; }
             public List<KeyColumn> Keys { get; }
             public List<string> KeyNames { get; }
+            public HashSet<string> KeyNameSet { get; }
             public List<string> IncludeTokens { get; }
             public bool IsEligibleForDedupe { get; }
             public int Priority { get; }
@@ -1009,16 +1050,6 @@ namespace PerformanceMonitor.Common
                 && string.Equals(x.Filter, y.Filter, StringComparison.Ordinal);
             public int GetHashCode((string Key, string Include, string Filter) obj) =>
                 HashCode.Combine(obj.Key, obj.Include, obj.Filter);
-        }
-
-        private sealed class KeyIncludeComparer : IEqualityComparer<(string Key, string Include)>
-        {
-            public static readonly KeyIncludeComparer Instance = new();
-            public bool Equals((string Key, string Include) x, (string Key, string Include) y) =>
-                string.Equals(x.Key, y.Key, StringComparison.Ordinal)
-                && string.Equals(x.Include, y.Include, StringComparison.Ordinal);
-            public int GetHashCode((string Key, string Include) obj) =>
-                HashCode.Combine(obj.Key, obj.Include);
         }
 
         private sealed class KeyFilterComparer : IEqualityComparer<(string Key, string Filter)>

--- a/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
+++ b/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
@@ -1,0 +1,1034 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// Monitor-side C# reproduction of Erik's <c>sp_IndexCleanup</c> analysis, driven entirely by the
+    /// captured Stage-1 <c>index_object_stats</c> snapshot (no live proc, no database). Given the per-index
+    /// rows for one or more databases it emits DROP/MERGE/COMPRESS recommendations, the reconstructed T-SQL,
+    /// and a reclaimable-space roll-up — the same analysis a live <c>sp_IndexCleanup</c> would, for servers
+    /// where the proc is not (or cannot be) installed.
+    ///
+    /// <para>Faithful to <c>sp_IndexCleanup</c> v2.7 (20260701). Because Stage 1 captured
+    /// <c>key_columns</c>/<c>included_columns</c> in the proc's EXACT delimited <c>QUOTENAME</c> form, the
+    /// string-comparison dedupe ports directly. Reproduced rules: <b>Unused Index</b> (Rule 1, with the
+    /// &lt;14-day-uptime caveat and &lt;=7-day auto-dedupe), <b>Exact Duplicate</b> (Rule 2),
+    /// <b>Reverse Duplicate</b> and <b>Equal Except For Filter</b> (the two exact-duplicate sub-classes the
+    /// proc documents at its <c>#index_analysis</c> definition but folds into Rule 2 — implemented here as
+    /// distinct labels, both derivable from the captured direction-bearing key strings), <b>Key Duplicate</b>
+    /// (Rule 5), and <b>Key Subset</b>/<b>Key Superset</b> (Rules 3/4/6, with subset-chain flattening and
+    /// missing-include carry). Priority scoring, <c>is_eligible_for_dedupe</c>, and the
+    /// PK/unique-constraint/FK-reference disable protections match the proc's guards. PAGE-compression
+    /// candidacy and the 0.20–0.60 general savings band reproduce the proc's <c>#compression_eligibility</c>
+    /// / reporting math.</para>
+    ///
+    /// <para><b>Deliberately out of scope</b> (see <see cref="IndexCleanupAnalysisResult.Notes"/>): the proc's
+    /// <c>Unique Constraint Replacement</c> (MAKE UNIQUE) and <c>Same Keys Different Order</c> (REVIEW) rules,
+    /// whose actions fall outside this stage's DISABLE / MERGE INCLUDES / KEEP set. Both remain reproducible
+    /// from the captured data. Script details that need metadata Stage 1 did not capture (the trailing
+    /// <c>ON &lt;filegroup/partition_scheme&gt;</c> placement; sparse/legacy-LOB compression exclusions) are
+    /// surfaced, never guessed.</para>
+    /// </summary>
+    public static class IndexCleanupAnalyzer
+    {
+        private const string Clustered = "CLUSTERED";
+        private const string NonClustered = "NONCLUSTERED";
+        private const string CompressionNone = "NONE";
+
+        /// <summary>
+        /// Runs the full analysis over the captured per-index rows. Rows are grouped internally by
+        /// (database, object) scope, so a single call may span many databases. Never throws on data content;
+        /// malformed/heap/columnstore/disabled rows are simply excluded from analysis.
+        /// </summary>
+        public static IndexCleanupAnalysisResult Analyze(
+            IEnumerable<IndexCleanupIndexInput> indexes,
+            IndexCleanupOptions? options = null)
+        {
+            options ??= new IndexCleanupOptions();
+
+            var analyzable = (indexes ?? Array.Empty<IndexCleanupIndexInput>())
+                .Where(IsAnalyzable)
+                .Select(src => new WorkIndex(src))
+                .ToList();
+
+            // Uptime → the unused-index caveat (< 14 days) and sp_IndexCleanup's auto-dedupe (<= 7 days).
+            double? uptimeDays = ResolveUptimeDays(analyzable, options);
+            bool uptimeWarning = uptimeDays.HasValue && uptimeDays.Value < 14;
+            bool dedupeOnly = options.DedupeOnly || (uptimeDays.HasValue && uptimeDays.Value <= 7);
+
+            var recommendations = new List<IndexCleanupRecommendation>();
+            var databaseRollups = new List<IndexCleanupRollup>();
+
+            // Rules operate per (database_id, object_id) scope; rollups aggregate per database.
+            foreach (var dbGroup in analyzable
+                .GroupBy(w => w.Src.DatabaseId)
+                .OrderBy(g => g.First().Src.DatabaseName, StringComparer.Ordinal))
+            {
+                var perDatabaseAnalyzed = new List<WorkIndex>();
+
+                foreach (var scope in dbGroup
+                    .GroupBy(w => w.Src.ObjectId))
+                {
+                    var scopeIndexes = scope.ToList();
+
+                    // Object-level gates (mirror sp_IndexCleanup's #filtered_objects @min_rows/@min_reads/@min_writes).
+                    if (!PassesObjectFilters(scopeIndexes, options))
+                    {
+                        continue;
+                    }
+
+                    ApplyRules(scopeIndexes, options, dedupeOnly, uptimeWarning);
+                    perDatabaseAnalyzed.AddRange(scopeIndexes);
+                }
+
+                // Compression candidacy is a per-index, data-driven eligibility (independent of the dedupe action).
+                foreach (var w in perDatabaseAnalyzed)
+                {
+                    w.CanCompress =
+                        options.ServerSupportsCompression
+                        && w.Src.IndexId > 0
+                        && string.Equals(w.Src.DataCompressionDesc, CompressionNone, StringComparison.OrdinalIgnoreCase)
+                        && w.SizeGb >= options.MinSizeGb;
+                }
+
+                recommendations.AddRange(BuildRecommendations(perDatabaseAnalyzed, options));
+                databaseRollups.Add(BuildRollup(dbGroup.First().Src.DatabaseName, perDatabaseAnalyzed, options));
+            }
+
+            var ordered = recommendations
+                .OrderBy(r => r.DatabaseName, StringComparer.Ordinal)
+                .ThenBy(r => r.SchemaName, StringComparer.Ordinal)
+                .ThenBy(r => r.TableName, StringComparer.Ordinal)
+                .ThenBy(r => ResultKindSort(r.ResultKind))
+                .ThenBy(r => r.IndexName, StringComparer.Ordinal)
+                .ToList();
+
+            return new IndexCleanupAnalysisResult
+            {
+                Recommendations = ordered,
+                DatabaseRollups = databaseRollups,
+                OverallRollup = BuildOverallRollup(databaseRollups),
+                UptimeWarning = uptimeWarning,
+                DedupeOnlyApplied = dedupeOnly,
+                Notes = BuildNotes(ordered),
+            };
+        }
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Rule application (per object scope)
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        private static void ApplyRules(List<WorkIndex> scope, IndexCleanupOptions options, bool dedupeOnly, bool uptimeWarning)
+        {
+            if (!dedupeOnly)
+            {
+                ApplyUnused(scope, uptimeWarning);
+            }
+
+            ApplyExactDuplicate(scope);
+            ApplyReverseDuplicate(scope);
+            ApplyEqualExceptForFilter(scope);
+            ApplyKeySubset(scope);
+            ResolveSubsetChains(scope);
+            ApplyKeySuperset(scope);
+            ApplyKeyDuplicate(scope);
+        }
+
+        /// <summary>
+        /// Rule 1: an eligible (nonclustered, non-unique, non-PK/UC/FK-reference) index with no reads at all
+        /// is unused → DISABLE. Skipped entirely under dedupe-only. The consolidation label carries the
+        /// &lt;14-day-uptime caveat when applicable.
+        /// </summary>
+        private static void ApplyUnused(List<WorkIndex> scope, bool uptimeWarning)
+        {
+            foreach (var w in scope)
+            {
+                if (w.Processed || !w.IsEligibleForDedupe)
+                {
+                    continue;
+                }
+
+                if (w.Src.UserSeeks == 0 && w.Src.UserScans == 0 && w.Src.UserLookups == 0
+                    && !w.Src.IsPrimaryKey && !w.Src.IsUniqueConstraint && !w.Src.IsUnique
+                    && !w.Src.IsForeignKeyReference   // protection (redundant with is_unique, kept per spec item 3)
+                    && w.Src.IndexId != 1)
+                {
+                    w.ConsolidationRule = uptimeWarning
+                        ? IndexCleanupRules.UnusedIndexUptimeWarning
+                        : IndexCleanupRules.UnusedIndex;
+                    w.Action = IndexCleanupAction.Disable;
+                    w.Processed = true;
+                }
+            }
+        }
+
+        /// <summary>Rule 2: identical key string (with direction) + identical includes + identical filter.</summary>
+        private static void ApplyExactDuplicate(List<WorkIndex> scope)
+        {
+            foreach (var group in DedupeCandidates(scope)
+                .GroupBy(w => (w.KeyColumns, w.IncludedColumns, w.Filter), KeyIncludeFilterComparer.Instance)
+                .Where(g => g.Count() > 1))
+            {
+                LabelDuplicateGroup(group.ToList(), IndexCleanupRules.ExactDuplicate);
+            }
+        }
+
+        /// <summary>
+        /// Reverse Duplicate: same key columns in the same order but every sort direction inverted (a
+        /// backward scan of one serves the other), same includes and filter. Pairwise, since only the FULL
+        /// direction inverse — not a partial direction difference — is equivalent.
+        /// </summary>
+        private static void ApplyReverseDuplicate(List<WorkIndex> scope)
+        {
+            var candidates = DedupeCandidates(scope)
+                .OrderBy(w => w.Name, StringComparer.Ordinal)
+                .ToList();
+
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                var a = candidates[i];
+                if (a.Processed)
+                {
+                    continue;
+                }
+
+                for (int j = i + 1; j < candidates.Count; j++)
+                {
+                    var b = candidates[j];
+                    if (b.Processed)
+                    {
+                        continue;
+                    }
+
+                    if (IsReverseDuplicate(a, b))
+                    {
+                        LabelDuplicateGroup(new List<WorkIndex> { a, b }, IndexCleanupRules.ReverseDuplicate);
+                        break; // a is now processed
+                    }
+                }
+            }
+        }
+
+        /// <summary>Equal Except For Filter: identical keys (with direction) and includes, different filter.</summary>
+        private static void ApplyEqualExceptForFilter(List<WorkIndex> scope)
+        {
+            foreach (var group in DedupeCandidates(scope)
+                .GroupBy(w => (w.KeyColumns, w.IncludedColumns), KeyIncludeComparer.Instance)
+                .Where(g => g.Count() > 1))
+            {
+                // After Exact, same keys+includes among the unprocessed necessarily differ only by filter.
+                LabelDuplicateGroup(group.ToList(), IndexCleanupRules.EqualExceptForFilter);
+            }
+        }
+
+        /// <summary>
+        /// Rule 3: a narrower non-unique index whose key string is a leading prefix (at a ", " boundary) of a
+        /// wider index's key, with a matching filter, is disabled in favor of the closest (shortest-key)
+        /// superset. Direction consistency on the shared prefix is enforced by the string prefix itself.
+        /// </summary>
+        private static void ApplyKeySubset(List<WorkIndex> scope)
+        {
+            foreach (var narrow in DedupeCandidates(scope)
+                .Where(w => !w.Src.IsUnique)   // never disable a unique narrower via supersession
+                .OrderBy(w => w.Name, StringComparer.Ordinal))
+            {
+                if (narrow.Processed)
+                {
+                    continue;
+                }
+
+                var prefix = narrow.KeyColumns + ", ";
+                var target = scope
+                    .Where(w => !ReferenceEquals(w, narrow)
+                        && !w.Processed
+                        && w.IsEligibleForDedupe
+                        && string.Equals(w.Filter, narrow.Filter, StringComparison.Ordinal)
+                        && w.KeyColumns.StartsWith(prefix, StringComparison.Ordinal))
+                    .OrderBy(w => w.KeyColumns.Length)          // closest superset = fewest extra key columns
+                    .ThenBy(w => w.Name, StringComparer.Ordinal)
+                    .FirstOrDefault();
+
+                if (target != null)
+                {
+                    narrow.ConsolidationRule = IndexCleanupRules.KeySubset;
+                    narrow.Action = IndexCleanupAction.Disable;
+                    narrow.TargetIndexName = target.Name;
+                    narrow.Processed = true;
+                    // The superset is labelled in ApplyKeySuperset (it may absorb several subsets).
+                }
+            }
+        }
+
+        /// <summary>Flattens subset chains (A → B → C becomes A → C) so include-merge reaches the final superset.</summary>
+        private static void ResolveSubsetChains(List<WorkIndex> scope)
+        {
+            var byName = scope.Where(w => w.Name.Length > 0)
+                .GroupBy(w => w.Name, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+            bool changed = true;
+            while (changed)
+            {
+                changed = false;
+                foreach (var w in scope)
+                {
+                    if (w.ConsolidationRule == IndexCleanupRules.KeySubset
+                        && w.Action == IndexCleanupAction.Disable
+                        && w.TargetIndexName != null
+                        && byName.TryGetValue(w.TargetIndexName, out var mid)
+                        && mid.ConsolidationRule == IndexCleanupRules.KeySubset
+                        && mid.Action == IndexCleanupAction.Disable
+                        && mid.TargetIndexName != null
+                        && !string.Equals(mid.TargetIndexName, w.TargetIndexName, StringComparison.Ordinal))
+                    {
+                        w.TargetIndexName = mid.TargetIndexName;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Rule 4/6: a wider index that one or more subsets defer to becomes a Key Superset — kept but rebuilt
+        /// with the subsets' include columns merged in (excluding any already in its key). Carries the
+        /// "Supersedes …" list and the newly-merged (missing) include columns.
+        /// </summary>
+        private static void ApplyKeySuperset(List<WorkIndex> scope)
+        {
+            foreach (var superset in scope)
+            {
+                if (superset.Processed)
+                {
+                    continue;
+                }
+
+                var subsets = scope
+                    .Where(s => s.ConsolidationRule == IndexCleanupRules.KeySubset
+                        && s.Action == IndexCleanupAction.Disable
+                        && string.Equals(s.TargetIndexName, superset.Name, StringComparison.Ordinal))
+                    .OrderBy(s => s.Name, StringComparer.Ordinal)
+                    .ToList();
+
+                if (subsets.Count == 0)
+                {
+                    continue;
+                }
+
+                var keyNames = new HashSet<string>(superset.KeyNames, StringComparer.Ordinal);
+                var ownIncludes = new HashSet<string>(superset.IncludeTokens, StringComparer.Ordinal);
+
+                // Merge = superset's own includes + every subset's includes, minus anything already a key column.
+                var merged = new List<string>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var token in superset.IncludeTokens.Concat(subsets.SelectMany(s => s.IncludeTokens)))
+                {
+                    if (keyNames.Contains(token) || !seen.Add(token))
+                    {
+                        continue;
+                    }
+                    merged.Add(token);
+                }
+                merged.Sort(StringComparer.Ordinal); // deterministic, matches the collector's name-ordered includes
+
+                var missing = merged.Where(t => !ownIncludes.Contains(t)).ToList();
+
+                superset.ConsolidationRule = IndexCleanupRules.KeySuperset;
+                superset.Action = IndexCleanupAction.MergeIncludes;
+                superset.MergedIncludes = merged;
+                superset.MissingIncludedColumns = missing.Count > 0 ? string.Join(", ", missing) : null;
+                superset.SupersededBy = "Supersedes " + string.Join(", ", subsets.Select(s => s.Name));
+                superset.Processed = true;
+            }
+        }
+
+        /// <summary>
+        /// Rule 5: indexes with the same keys (and filter) but different includes. The keeper (unique first,
+        /// then priority, then name) absorbs the losers' includes (MERGE INCLUDES); the losers are disabled.
+        /// </summary>
+        private static void ApplyKeyDuplicate(List<WorkIndex> scope)
+        {
+            foreach (var group in DedupeCandidates(scope)
+                .GroupBy(w => (w.KeyColumns, w.Filter), KeyFilterComparer.Instance)
+                .Where(g => g.Count() > 1))
+            {
+                var members = group.ToList();
+                var keeper = PickKeyDuplicateKeeper(members);
+                if (keeper == null)
+                {
+                    continue;
+                }
+
+                var mergedIncludes = new List<string>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var token in members.SelectMany(m => m.IncludeTokens))
+                {
+                    if (seen.Add(token))
+                    {
+                        mergedIncludes.Add(token);
+                    }
+                }
+                mergedIncludes.Sort(StringComparer.Ordinal);
+
+                var losers = members.Where(m => !ReferenceEquals(m, keeper)).ToList();
+                var disabled = new List<WorkIndex>();
+                foreach (var loser in losers)
+                {
+                    loser.ConsolidationRule = IndexCleanupRules.KeyDuplicate;
+                    loser.Processed = true;
+                    if (loser.Protected)
+                    {
+                        continue; // never disable a protected index
+                    }
+                    loser.Action = IndexCleanupAction.Disable;
+                    loser.TargetIndexName = keeper.Name;
+                    disabled.Add(loser);
+                }
+
+                keeper.ConsolidationRule = IndexCleanupRules.KeyDuplicate;
+                keeper.Action = IndexCleanupAction.MergeIncludes;
+                keeper.MergedIncludes = mergedIncludes;
+                keeper.Processed = true;
+                if (disabled.Count > 0)
+                {
+                    keeper.SupersededBy = "Supersedes " + string.Join(", ", disabled.Select(d => d.Name).OrderBy(n => n, StringComparer.Ordinal));
+                }
+            }
+        }
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Keeper / grouping helpers
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>Indexes eligible to participate in the string-compare dedupe rules (nonclustered, not a unique constraint, still unprocessed).</summary>
+        private static IEnumerable<WorkIndex> DedupeCandidates(List<WorkIndex> scope) =>
+            scope.Where(w => !w.Processed && w.IsEligibleForDedupe && !w.Src.IsUniqueConstraint);
+
+        /// <summary>
+        /// Labels a set of equivalent duplicates: the highest-priority (then lowest-name) member is the
+        /// keeper (KEEP); the rest are disabled (unless protected, in which case the disable is skipped —
+        /// the protection is a hard guarantee). If the natural keeper is unprotected but a protected member
+        /// exists, the protected member is promoted to keeper so nothing protected is ever disabled.
+        /// </summary>
+        private static void LabelDuplicateGroup(List<WorkIndex> members, string rule)
+        {
+            var keeper = members
+                .OrderByDescending(m => m.Protected)   // never disable a protected index → make it the keeper
+                .ThenByDescending(m => m.Priority)
+                .ThenBy(m => m.Name, StringComparer.Ordinal)
+                .First();
+
+            foreach (var m in members)
+            {
+                m.ConsolidationRule = rule;
+                m.Processed = true;
+
+                if (ReferenceEquals(m, keeper))
+                {
+                    m.Action = IndexCleanupAction.Keep;
+                    continue;
+                }
+
+                if (m.Protected)
+                {
+                    // Two protected members in one duplicate set (rare): keep both, disable neither.
+                    m.Action = IndexCleanupAction.Keep;
+                    continue;
+                }
+
+                m.Action = IndexCleanupAction.Disable;
+                m.TargetIndexName = keeper.Name;
+            }
+        }
+
+        /// <summary>Rule 5 keeper: prefer a unique member, then priority, then name.</summary>
+        private static WorkIndex? PickKeyDuplicateKeeper(List<WorkIndex> members) =>
+            members
+                .OrderByDescending(m => m.Protected)
+                .ThenByDescending(m => m.Src.IsUnique)
+                .ThenByDescending(m => m.Priority)
+                .ThenBy(m => m.Name, StringComparer.Ordinal)
+                .FirstOrDefault();
+
+        private static bool IsReverseDuplicate(WorkIndex a, WorkIndex b)
+        {
+            if (a.Keys.Count == 0 || a.Keys.Count != b.Keys.Count)
+            {
+                return false;
+            }
+
+            for (int k = 0; k < a.Keys.Count; k++)
+            {
+                // Same column, same position, but the sort direction must be inverted on EVERY key column.
+                if (!string.Equals(a.Keys[k].Name, b.Keys[k].Name, StringComparison.Ordinal)
+                    || a.Keys[k].Descending == b.Keys[k].Descending)
+                {
+                    return false;
+                }
+            }
+
+            return string.Equals(a.IncludedColumns, b.IncludedColumns, StringComparison.Ordinal)
+                && string.Equals(a.Filter, b.Filter, StringComparison.Ordinal);
+        }
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Recommendation + script assembly
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        private static IEnumerable<IndexCleanupRecommendation> BuildRecommendations(List<WorkIndex> analyzed, IndexCleanupOptions options)
+        {
+            foreach (var w in analyzed)
+            {
+                if (w.Action == IndexCleanupAction.Disable)
+                {
+                    yield return BuildDisable(w);
+                }
+                else if (w.Action == IndexCleanupAction.MergeIncludes)
+                {
+                    yield return BuildMerge(w, options);
+                }
+                else if ((w.Action == IndexCleanupAction.None || w.Action == IndexCleanupAction.Keep) && w.CanCompress)
+                {
+                    // Only untouched / kept indexes get a compression row (matches sp_IndexCleanup).
+                    yield return BuildCompress(w, options);
+                }
+            }
+        }
+
+        private static IndexCleanupRecommendation BuildDisable(WorkIndex w)
+        {
+            string additionalInfo = w.ConsolidationRule switch
+            {
+                IndexCleanupRules.KeySubset => "This index is superseded by a wider index: " + (w.TargetIndexName ?? "(unknown)"),
+                IndexCleanupRules.ExactDuplicate => "This index is an exact duplicate of: " + (w.TargetIndexName ?? "(unknown)"),
+                IndexCleanupRules.ReverseDuplicate => "This index is a reverse-order duplicate of: " + (w.TargetIndexName ?? "(unknown)"),
+                IndexCleanupRules.EqualExceptForFilter => "This index matches except for its filter: " + (w.TargetIndexName ?? "(unknown)") + " (verify the differing WHERE clauses before disabling)",
+                IndexCleanupRules.KeyDuplicate => "This index has the same keys as: " + (w.TargetIndexName ?? "(unknown)"),
+                _ when w.ConsolidationRule != null && w.ConsolidationRule.StartsWith(IndexCleanupRules.UnusedIndex, StringComparison.Ordinal) => w.ConsolidationRule,
+                _ => "This index is redundant and will be disabled",
+            };
+
+            return NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.Disable,
+                ResultKind = IndexCleanupResultKind.Disable,
+                TargetIndexName = w.TargetIndexName,
+                ScriptType = "DISABLE SCRIPT",
+                Script = DisableScript(w),
+                AdditionalInfo = additionalInfo,
+            };
+        }
+
+        private static IndexCleanupRecommendation BuildMerge(WorkIndex w, IndexCleanupOptions options)
+        {
+            string additionalInfo = w.ConsolidationRule == IndexCleanupRules.KeySuperset
+                ? "This index will absorb includes from the narrower indexes it supersedes"
+                : "This index will absorb includes from duplicate indexes";
+
+            var (script, omitsPlacement) = MergeScript(w, options);
+
+            return NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.MergeIncludes,
+                ResultKind = IndexCleanupResultKind.Merge,
+                SupersededBy = w.SupersededBy,
+                MissingIncludedColumns = w.MissingIncludedColumns,
+                ScriptType = "MERGE SCRIPT",
+                Script = script,
+                AdditionalInfo = additionalInfo,
+                ScriptOmitsPartitionPlacement = omitsPlacement,
+            };
+        }
+
+        private static IndexCleanupRecommendation BuildCompress(WorkIndex w, IndexCleanupOptions options)
+        {
+            return NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.Keep,
+                ResultKind = IndexCleanupResultKind.Compress,
+                ConsolidationRule = w.ConsolidationRule,
+                ScriptType = "COMPRESSION SCRIPT",
+                Script = CompressionScript(w, options),
+                AdditionalInfo = "Compression type: PAGE (All Partitions)",
+            };
+        }
+
+        private static IndexCleanupRecommendation NewRecommendation(WorkIndex w) => new()
+        {
+            DatabaseName = w.Src.DatabaseName,
+            SchemaName = w.Src.SchemaName,
+            TableName = w.Src.TableName,
+            IndexName = w.Name,
+            IndexId = w.Src.IndexId,
+            ConsolidationRule = w.ConsolidationRule,
+            OriginalIndexDefinition = OriginalIndexDefinition(w),
+            IndexSizeGb = w.SizeGb,
+            IndexRows = w.Src.TotalRows ?? 0,
+            IndexReads = w.Reads,
+            IndexWrites = w.Src.UserUpdates,
+            CanCompress = w.CanCompress,
+            IsForeignKey = w.Src.IsForeignKey,
+        };
+
+        private static string DisableScript(WorkIndex w) =>
+            "ALTER INDEX " + QuoteName(w.Name) + " ON " + FullName(w) + " DISABLE;";
+
+        private static (string Script, bool OmitsPlacement) MergeScript(WorkIndex w, IndexCleanupOptions options)
+        {
+            string includes = string.Join(", ", w.MergedIncludes ?? w.IncludeTokens);
+
+            var script = "CREATE " + (w.Src.IsUnique ? "UNIQUE " : "") + "INDEX " + QuoteName(w.Name)
+                + " ON " + FullName(w) + " (" + w.KeyColumns + ")"
+                + (includes.Length > 0 ? " INCLUDE (" + includes + ")" : "")
+                + (w.Filter.Length > 0 ? " WHERE " + w.Filter : "")
+                + " WITH (DROP_EXISTING = ON, FILLFACTOR = 100, SORT_IN_TEMPDB = ON, ONLINE = "
+                + (options.ServerSupportsOnline ? "ON" : "OFF")
+                + (w.CanCompress ? ", DATA_COMPRESSION = PAGE" : "")
+                + (w.Src.OptimizeForSequentialKey ? ", OPTIMIZE_FOR_SEQUENTIAL_KEY = ON" : "")
+                + ");";
+
+            return (script, IsPartitioned(w));
+        }
+
+        private static string CompressionScript(WorkIndex w, IndexCleanupOptions options) =>
+            "ALTER INDEX " + QuoteName(w.Name) + " ON " + FullName(w)
+            + (IsPartitioned(w) ? " REBUILD PARTITION = ALL" : " REBUILD")
+            + " WITH (FILLFACTOR = 100, SORT_IN_TEMPDB = ON, ONLINE = "
+            + (options.ServerSupportsOnline ? "ON" : "OFF")
+            + ", DATA_COMPRESSION = PAGE"
+            + (w.Src.OptimizeForSequentialKey ? ", OPTIMIZE_FOR_SEQUENTIAL_KEY = ON" : "")
+            + ");";
+
+        /// <summary>
+        /// Reconstructs the original CREATE (or ADD CONSTRAINT) from captured metadata — the rollback /
+        /// validation reference. Uses the captured delimited key/include strings verbatim. The trailing
+        /// <c>ON &lt;filegroup/partition_scheme&gt;</c> is omitted (Stage 1 did not capture it).
+        /// </summary>
+        private static string OriginalIndexDefinition(WorkIndex w)
+        {
+            if (w.Src.IsUniqueConstraint)
+            {
+                return "ALTER TABLE " + FullName(w) + " ADD CONSTRAINT " + QuoteName(w.Name)
+                    + " UNIQUE (" + w.KeyColumns + ");";
+            }
+
+            string clustering = w.Src.IndexId == 1 ? "CLUSTERED " : "NONCLUSTERED ";
+            return "CREATE " + (w.Src.IsUnique ? "UNIQUE " : "") + clustering + "INDEX " + QuoteName(w.Name)
+                + " ON " + FullName(w) + " (" + w.KeyColumns + ")"
+                + (w.IncludedColumns.Length > 0 ? " INCLUDE (" + w.IncludedColumns + ")" : "")
+                + (w.Filter.Length > 0 ? " WHERE " + w.Filter : "")
+                + ";";
+        }
+
+        private static bool IsPartitioned(WorkIndex w) => (w.Src.PartitionCount ?? 1) > 1;
+
+        private static string FullName(WorkIndex w) =>
+            QuoteName(w.Src.DatabaseName) + "." + QuoteName(w.Src.SchemaName) + "." + QuoteName(w.Src.TableName);
+
+        /// <summary>QUOTENAME: wrap in brackets, doubling any embedded closing bracket.</summary>
+        private static string QuoteName(string name) =>
+            "[" + (name ?? "").Replace("]", "]]", StringComparison.Ordinal) + "]";
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Rollups + notes
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        private static IndexCleanupRollup BuildRollup(string databaseName, List<WorkIndex> analyzed, IndexCleanupOptions options)
+        {
+            decimal unusedSize = 0, compMin = 0, compMax = 0;
+            int disable = 0, merge = 0, compressable = 0, unused = 0;
+            decimal totalSize = 0;
+
+            foreach (var w in analyzed)
+            {
+                totalSize += w.SizeGb;
+
+                if (w.Action == IndexCleanupAction.Disable)
+                {
+                    disable++;
+                    unusedSize += w.SizeGb;
+                    if (w.ConsolidationRule != null && w.ConsolidationRule.StartsWith(IndexCleanupRules.UnusedIndex, StringComparison.Ordinal))
+                    {
+                        unused++;
+                    }
+                }
+                else if (w.Action == IndexCleanupAction.MergeIncludes)
+                {
+                    merge++;
+                }
+
+                if (w.CanCompress)
+                {
+                    compressable++;
+                    if (w.Action == IndexCleanupAction.None || w.Action == IndexCleanupAction.Keep)
+                    {
+                        compMin += w.SizeGb * options.CompressionMinSavingsFactor;
+                        compMax += w.SizeGb * options.CompressionMaxSavingsFactor;
+                    }
+                }
+            }
+
+            // Table row count = the base row (index_id 0/1) per object, summed across objects.
+            long totalRows = analyzed
+                .Where(w => w.Src.IndexId <= 1)
+                .GroupBy(w => w.Src.ObjectId)
+                .Sum(g => g.First().Src.TotalRows ?? 0);
+
+            return new IndexCleanupRollup
+            {
+                DatabaseName = databaseName,
+                TablesAnalyzed = analyzed.Select(w => w.Src.ObjectId).Distinct().Count(),
+                IndexCount = analyzed.Count,
+                TotalSizeGb = totalSize,
+                TotalRows = totalRows,
+                IndexesToDisable = disable,
+                IndexesToMerge = merge,
+                CompressableIndexes = compressable,
+                UnusedIndexes = unused,
+                UnusedSizeGb = unusedSize,
+                CompressionMinSavingsGb = compMin,
+                CompressionMaxSavingsGb = compMax,
+                TotalMinSavingsGb = unusedSize + compMin,
+                TotalMaxSavingsGb = unusedSize + compMax,
+            };
+        }
+
+        private static IndexCleanupRollup BuildOverallRollup(List<IndexCleanupRollup> perDb) => new()
+        {
+            DatabaseName = null,
+            TablesAnalyzed = perDb.Sum(r => r.TablesAnalyzed),
+            IndexCount = perDb.Sum(r => r.IndexCount),
+            TotalSizeGb = perDb.Sum(r => r.TotalSizeGb),
+            TotalRows = perDb.Sum(r => r.TotalRows),
+            IndexesToDisable = perDb.Sum(r => r.IndexesToDisable),
+            IndexesToMerge = perDb.Sum(r => r.IndexesToMerge),
+            CompressableIndexes = perDb.Sum(r => r.CompressableIndexes),
+            UnusedIndexes = perDb.Sum(r => r.UnusedIndexes),
+            UnusedSizeGb = perDb.Sum(r => r.UnusedSizeGb),
+            CompressionMinSavingsGb = perDb.Sum(r => r.CompressionMinSavingsGb),
+            CompressionMaxSavingsGb = perDb.Sum(r => r.CompressionMaxSavingsGb),
+            TotalMinSavingsGb = perDb.Sum(r => r.TotalMinSavingsGb),
+            TotalMaxSavingsGb = perDb.Sum(r => r.TotalMaxSavingsGb),
+        };
+
+        private static List<string> BuildNotes(List<IndexCleanupRecommendation> recommendations)
+        {
+            var notes = new List<string>();
+
+            if (recommendations.Any(r => r.ScriptOmitsPartitionPlacement))
+            {
+                notes.Add("Reconstructed CREATE/MERGE scripts omit the trailing ON <filegroup/partition_scheme> clause: "
+                    + "Stage 1 did not capture filegroup/partition placement. For a partitioned index the rebuild would "
+                    + "default to the table's scheme mapping; verify placement before running.");
+            }
+
+            if (recommendations.Any(r => r.ResultKind == IndexCleanupResultKind.Compress))
+            {
+                notes.Add("Compression eligibility cannot exclude tables with sparse columns or legacy LOB types "
+                    + "(text/ntext/image): Stage 1 did not capture per-column type/sparse metadata, so a small number of "
+                    + "compression candidates may be ineligible in practice (sp_IndexCleanup excludes them via a live column scan).");
+                notes.Add("Compression savings use sp_IndexCleanup's general 0.20–0.60 × size band, NOT "
+                    + "sp_estimate_data_compression_savings (a live-sampling proc, out of scope for data-driven analysis).");
+                notes.Add("COMPRESSION REBUILD uses PARTITION = ALL when partition_count > 1 (a proxy; Stage 1 did not "
+                    + "capture the partition scheme name).");
+            }
+
+            notes.Add("Out of scope per this stage's DISABLE/MERGE INCLUDES/KEEP action set: sp_IndexCleanup's "
+                + "'Unique Constraint Replacement' (MAKE UNIQUE) and 'Same Keys Different Order' (REVIEW) rules. Both are "
+                + "reproducible from the captured metadata if later required.");
+
+            return notes;
+        }
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Input shaping
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>Only rowstore CLUSTERED/NONCLUSTERED, enabled, named indexes are analyzed (mirrors <c>i.type IN (1,2) AND i.is_disabled = 0</c>).</summary>
+        private static bool IsAnalyzable(IndexCleanupIndexInput src)
+        {
+            if (src == null || src.IsDisabled || string.IsNullOrEmpty(src.IndexName))
+            {
+                return false;
+            }
+
+            return string.Equals(src.IndexTypeDesc, Clustered, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(src.IndexTypeDesc, NonClustered, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Object-level gates: @min_rows always; @min_reads/@min_writes only when the caller set them (&gt; 0), matching sp_IndexCleanup.</summary>
+        private static bool PassesObjectFilters(List<WorkIndex> scopeIndexes, IndexCleanupOptions options)
+        {
+            long objectRows = scopeIndexes
+                .Where(w => w.Src.IndexId <= 1)
+                .Select(w => w.Src.TotalRows ?? 0)
+                .DefaultIfEmpty(scopeIndexes.Max(w => w.Src.TotalRows ?? 0))
+                .First();
+
+            if (objectRows < options.MinRows)
+            {
+                return false;
+            }
+
+            if (options.MinReads > 0 || options.MinWrites > 0)
+            {
+                long reads = scopeIndexes.Sum(w => w.Reads);
+                long writes = scopeIndexes.Sum(w => w.Src.UserUpdates);
+                if (reads < options.MinReads && writes < options.MinWrites)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static double? ResolveUptimeDays(List<WorkIndex> analyzable, IndexCleanupOptions options)
+        {
+            if (options.ServerUptimeDays.HasValue)
+            {
+                return options.ServerUptimeDays;
+            }
+
+            DateTime? start = analyzable
+                .Select(w => w.Src.SqlServerStartTime)
+                .Where(t => t.HasValue)
+                .DefaultIfEmpty(null)
+                .Max();
+
+            if (!start.HasValue)
+            {
+                return null;
+            }
+
+            var reference = options.ReferenceTimeUtc ?? DateTime.UtcNow;
+            var days = (reference - start.Value).TotalDays;
+            return days < 0 ? null : days;
+        }
+
+        private static int ResultKindSort(IndexCleanupResultKind kind) => kind switch
+        {
+            IndexCleanupResultKind.Merge => 0,
+            IndexCleanupResultKind.Disable => 1,
+            IndexCleanupResultKind.Compress => 2,
+            _ => 3,
+        };
+
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+        //  Working state + delimited-string parsing
+        // ────────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>Mutable per-index state carried through the sequential rule passes.</summary>
+        private sealed class WorkIndex
+        {
+            public WorkIndex(IndexCleanupIndexInput src)
+            {
+                Src = src;
+                Name = src.IndexName ?? "";
+                KeyColumns = src.KeyColumns ?? "";
+                IncludedColumns = src.IncludedColumns ?? "";
+                Filter = src.FilterDefinition ?? "";
+                Keys = ParseKeyTokens(KeyColumns);
+                KeyNames = Keys.Select(k => k.Name).ToList();
+                IncludeTokens = SplitDelimited(IncludedColumns);
+
+                // is_eligible_for_dedupe: nonclustered → yes; clustered → no (mirrors sp_IndexCleanup's CASE,
+                // which checks type = 2 before the clustered/PK branch).
+                IsEligibleForDedupe = string.Equals(src.IndexTypeDesc, NonClustered, StringComparison.OrdinalIgnoreCase);
+
+                Priority = ComputePriority(src);
+                SizeGb = (src.ReservedMb ?? 0m) / 1024m;
+            }
+
+            public IndexCleanupIndexInput Src { get; }
+            public string Name { get; }
+            public string KeyColumns { get; }
+            public string IncludedColumns { get; }
+            public string Filter { get; }
+            public List<KeyColumn> Keys { get; }
+            public List<string> KeyNames { get; }
+            public List<string> IncludeTokens { get; }
+            public bool IsEligibleForDedupe { get; }
+            public int Priority { get; }
+            public decimal SizeGb { get; }
+
+            public long Reads => Src.UserSeeks + Src.UserScans + Src.UserLookups;
+
+            /// <summary>Hard disable protection: PK, unique constraint, or FK-referenced (matches spec item 3).</summary>
+            public bool Protected => Src.IsPrimaryKey || Src.IsUniqueConstraint || Src.IsForeignKeyReference;
+
+            // Mutable rule state
+            public bool Processed { get; set; }
+            public string? ConsolidationRule { get; set; }
+            public IndexCleanupAction Action { get; set; } = IndexCleanupAction.None;
+            public string? TargetIndexName { get; set; }
+            public string? SupersededBy { get; set; }
+            public List<string>? MergedIncludes { get; set; }
+            public string? MissingIncludedColumns { get; set; }
+            public bool CanCompress { get; set; }
+        }
+
+        private readonly record struct KeyColumn(string Name, bool Descending);
+
+        /// <summary>sp_IndexCleanup priority: clustered 1000; unique 500 (unique constraint only 50); seeks 200; scans 100; has includes 50.</summary>
+        private static int ComputePriority(IndexCleanupIndexInput src)
+        {
+            int priority = src.IndexId == 1 ? 1000 : 0;
+
+            if (src.IsUnique)
+            {
+                priority += src.IsUniqueConstraint ? 50 : 500;
+            }
+
+            if (src.UserSeeks > 0)
+            {
+                priority += 200;
+            }
+
+            if (src.UserScans > 0)
+            {
+                priority += 100;
+            }
+
+            if (!string.IsNullOrEmpty(src.IncludedColumns))
+            {
+                priority += 50;
+            }
+
+            return priority;
+        }
+
+        /// <summary>Parses a delimited key list into (bracketed-name, descending) tokens, respecting QUOTENAME bracketing.</summary>
+        private static List<KeyColumn> ParseKeyTokens(string raw)
+        {
+            var result = new List<KeyColumn>();
+            foreach (var token in SplitDelimited(raw))
+            {
+                if (token.EndsWith(" DESC", StringComparison.Ordinal))
+                {
+                    result.Add(new KeyColumn(token[..^5].TrimEnd(), true));
+                }
+                else
+                {
+                    result.Add(new KeyColumn(token, false));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Splits a QUOTENAME-delimited list on the ", " separator that sits between tokens, ignoring commas
+        /// and spaces inside <c>[ ... ]</c> (where <c>]]</c> is an escaped bracket). Robust to column names
+        /// that themselves contain commas, spaces, or brackets.
+        /// </summary>
+        private static List<string> SplitDelimited(string? raw)
+        {
+            var tokens = new List<string>();
+            if (string.IsNullOrEmpty(raw))
+            {
+                return tokens;
+            }
+
+            int n = raw.Length;
+            int start = 0;
+            int i = 0;
+            bool inBracket = false;
+
+            while (i < n)
+            {
+                char c = raw[i];
+                if (!inBracket)
+                {
+                    if (c == '[')
+                    {
+                        inBracket = true;
+                        i++;
+                    }
+                    else if (c == ',' && i + 1 < n && raw[i + 1] == ' ')
+                    {
+                        AddToken(tokens, raw, start, i);
+                        i += 2;
+                        start = i;
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+                else
+                {
+                    if (c == ']')
+                    {
+                        if (i + 1 < n && raw[i + 1] == ']')
+                        {
+                            i += 2; // escaped ]] inside a name
+                        }
+                        else
+                        {
+                            inBracket = false;
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+            }
+
+            AddToken(tokens, raw, start, n);
+            return tokens;
+        }
+
+        private static void AddToken(List<string> tokens, string raw, int start, int end)
+        {
+            var token = raw.Substring(start, end - start).Trim();
+            if (token.Length > 0)
+            {
+                tokens.Add(token);
+            }
+        }
+
+        // Composite grouping-key comparers over the raw delimited strings (byte-for-byte, ordinal).
+
+        private sealed class KeyIncludeFilterComparer : IEqualityComparer<(string Key, string Include, string Filter)>
+        {
+            public static readonly KeyIncludeFilterComparer Instance = new();
+            public bool Equals((string Key, string Include, string Filter) x, (string Key, string Include, string Filter) y) =>
+                string.Equals(x.Key, y.Key, StringComparison.Ordinal)
+                && string.Equals(x.Include, y.Include, StringComparison.Ordinal)
+                && string.Equals(x.Filter, y.Filter, StringComparison.Ordinal);
+            public int GetHashCode((string Key, string Include, string Filter) obj) =>
+                HashCode.Combine(obj.Key, obj.Include, obj.Filter);
+        }
+
+        private sealed class KeyIncludeComparer : IEqualityComparer<(string Key, string Include)>
+        {
+            public static readonly KeyIncludeComparer Instance = new();
+            public bool Equals((string Key, string Include) x, (string Key, string Include) y) =>
+                string.Equals(x.Key, y.Key, StringComparison.Ordinal)
+                && string.Equals(x.Include, y.Include, StringComparison.Ordinal);
+            public int GetHashCode((string Key, string Include) obj) =>
+                HashCode.Combine(obj.Key, obj.Include);
+        }
+
+        private sealed class KeyFilterComparer : IEqualityComparer<(string Key, string Filter)>
+        {
+            public static readonly KeyFilterComparer Instance = new();
+            public bool Equals((string Key, string Filter) x, (string Key, string Filter) y) =>
+                string.Equals(x.Key, y.Key, StringComparison.Ordinal)
+                && string.Equals(x.Filter, y.Filter, StringComparison.Ordinal);
+            public int GetHashCode((string Key, string Filter) obj) =>
+                HashCode.Combine(obj.Key, obj.Filter);
+        }
+    }
+}

--- a/PerformanceMonitor.Common/IndexCleanupModels.cs
+++ b/PerformanceMonitor.Common/IndexCleanupModels.cs
@@ -196,6 +196,14 @@ namespace PerformanceMonitor.Common
 
         /// <summary>An <c>ALTER INDEX … REBUILD … DATA_COMPRESSION = PAGE</c> row.</summary>
         Compress = 2,
+
+        /// <summary>
+        /// An informational "review these related indexes" row that carries NO destructive script — the
+        /// analyzer recognized a Reverse Duplicate or Equal Except For Filter relationship but, exactly like
+        /// sp_IndexCleanup, deliberately does NOT auto-consolidate it (the indexes serve different access
+        /// patterns / row coverage).
+        /// </summary>
+        Review = 3,
     }
 
     /// <summary>The canonical <c>consolidation_rule</c> labels this analyzer emits.</summary>
@@ -207,13 +215,22 @@ namespace PerformanceMonitor.Common
         /// <summary>The &lt;14-day-uptime variant of <see cref="UnusedIndex"/> (usage data may be incomplete).</summary>
         public const string UnusedIndexUptimeWarning = "Unused Index (WARNING: Server uptime < 14 days - usage data may be incomplete)";
 
-        /// <summary>Identical keys (with direction), includes, and filter (Rule 2).</summary>
+        /// <summary>Identical keys (with direction), includes, and filter (Rule 2) → the redundant one is disabled.</summary>
         public const string ExactDuplicate = "Exact Duplicate";
 
-        /// <summary>Same key columns in the same order but with every sort direction inverted (functionally equivalent via backward scan); same includes and filter.</summary>
+        /// <summary>
+        /// Same key column SET but a different arrangement (reversed/reordered order or changed sort
+        /// directions), with the same includes and filter. Recognized and surfaced for REVIEW but never
+        /// auto-disabled — a different leading column serves different query patterns (sp_IndexCleanup's
+        /// adversarial test 9a asserts these are not consolidated).
+        /// </summary>
         public const string ReverseDuplicate = "Reverse Duplicate";
 
-        /// <summary>Identical keys (with direction) and includes but a different filter predicate.</summary>
+        /// <summary>
+        /// Identical keys (with direction) and includes but a DIFFERENT filter predicate. Recognized and
+        /// surfaced for REVIEW but never auto-disabled — the filters index different row sets
+        /// (sp_IndexCleanup's adversarial test 10a asserts these are not consolidated).
+        /// </summary>
         public const string EqualExceptForFilter = "Equal Except For Filter";
 
         /// <summary>Same keys (with direction) and filter but different includes (Rule 5); the keeper absorbs the includes.</summary>

--- a/PerformanceMonitor.Common/IndexCleanupModels.cs
+++ b/PerformanceMonitor.Common/IndexCleanupModels.cs
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// One captured per-index row consumed by <see cref="IndexCleanupAnalyzer"/> — the analysis-relevant
+    /// subset of the Stage-1 <c>index_object_stats</c> snapshot (the shared
+    /// <c>IndexObjectStatsCollector.Row</c>). Kept as a Common-local contract (like
+    /// <see cref="SystemHealthParser"/>'s tuple input) so the analyzer has NO dependency on the collector
+    /// assembly; the caller maps its read-layer rows into this shape.
+    ///
+    /// <para><see cref="KeyColumns"/> / <see cref="IncludedColumns"/> arrive in sp_IndexCleanup's EXACT
+    /// delimited <c>QUOTENAME</c> form — keys are <c>[a], [b] DESC</c> in key-ordinal order (with a
+    /// <c> DESC</c> suffix on descending columns), includes are <c>[c], [d]</c> in column-name order — so
+    /// the string-comparison dedupe (Exact/Reverse/Equal-Except-Filter, Key Duplicate, Key
+    /// Subset/Superset) ports byte-for-byte and the reconstructed CREATE/MERGE scripts can drop the strings
+    /// in verbatim.</para>
+    /// </summary>
+    public sealed record IndexCleanupIndexInput
+    {
+        /// <summary>Owning database name (used for scope grouping and script qualification).</summary>
+        public string DatabaseName { get; init; } = "";
+
+        /// <summary>Owning database id; with <see cref="ObjectId"/> forms the per-object dedupe scope.</summary>
+        public int DatabaseId { get; init; }
+
+        /// <summary>Schema name.</summary>
+        public string SchemaName { get; init; } = "";
+
+        /// <summary>Object (table/view) id; the dedupe scope is (<see cref="DatabaseId"/>, <see cref="ObjectId"/>).</summary>
+        public int ObjectId { get; init; }
+
+        /// <summary>Table (or indexed-view) name.</summary>
+        public string TableName { get; init; } = "";
+
+        /// <summary>Index id. 1 = clustered; &gt;1 = nonclustered; 0 = heap (heaps are not analyzed).</summary>
+        public int IndexId { get; init; }
+
+        /// <summary>Index name (null only for a heap, which is excluded from analysis).</summary>
+        public string? IndexName { get; init; }
+
+        /// <summary>e.g. <c>CLUSTERED</c>, <c>NONCLUSTERED</c>. Only CLUSTERED/NONCLUSTERED rowstore indexes are analyzed.</summary>
+        public string? IndexTypeDesc { get; init; }
+
+        /// <summary>Delimited key list <c>[a], [b] DESC</c> (key-ordinal order, DESC suffix on descending keys).</summary>
+        public string? KeyColumns { get; init; }
+
+        /// <summary>Delimited include list <c>[c], [d]</c> (column-name order).</summary>
+        public string? IncludedColumns { get; init; }
+
+        /// <summary>Raw filter predicate text (null for a non-filtered index).</summary>
+        public string? FilterDefinition { get; init; }
+
+        /// <summary><c>sys.indexes.is_unique</c>.</summary>
+        public bool IsUnique { get; init; }
+
+        /// <summary><c>sys.indexes.is_unique_constraint</c> — a hard drop/disable protection.</summary>
+        public bool IsUniqueConstraint { get; init; }
+
+        /// <summary><c>sys.indexes.is_primary_key</c> — a hard drop/disable protection.</summary>
+        public bool IsPrimaryKey { get; init; }
+
+        /// <summary>A key column backs an OUTGOING foreign key (this is a supporting index). Informational — sp_IndexCleanup does not hard-guard disable on it.</summary>
+        public bool IsForeignKey { get; init; }
+
+        /// <summary>A key column is REFERENCED by an incoming foreign key — a hard drop/disable protection (matches sp_IndexCleanup's <c>is_foreign_key_reference</c> guard).</summary>
+        public bool IsForeignKeyReference { get; init; }
+
+        /// <summary>Already disabled — excluded from analysis (mirrors sp_IndexCleanup's <c>i.is_disabled = 0</c> filter).</summary>
+        public bool IsDisabled { get; init; }
+
+        /// <summary>Index belongs to an indexed view (object type V) rather than a table. Informational; scope is per-object so table and view indexes never compare.</summary>
+        public bool IsIndexedView { get; init; }
+
+        /// <summary>Lowest <c>data_compression_desc</c> across the index's partitions (<c>NONE</c> ⇒ at least one uncompressed partition ⇒ a PAGE-compression candidate).</summary>
+        public string? DataCompressionDesc { get; init; }
+
+        /// <summary><c>optimize_for_sequential_key</c> (SQL 2019+/Azure). When set, the reconstructed rebuild carries <c>OPTIMIZE_FOR_SEQUENTIAL_KEY = ON</c>.</summary>
+        public bool OptimizeForSequentialKey { get; init; }
+
+        /// <summary><c>fill_factor</c> (0 = engine default). Captured for reference; sp_IndexCleanup's generated rebuilds hardcode <c>FILLFACTOR = 100</c>.</summary>
+        public short? FillFactor { get; init; }
+
+        /// <summary><c>is_padded</c>. Captured for reference.</summary>
+        public bool IsPadded { get; init; }
+
+        /// <summary><c>allow_page_locks</c>. Captured for reference.</summary>
+        public bool AllowPageLocks { get; init; }
+
+        /// <summary><c>allow_row_locks</c>. Captured for reference.</summary>
+        public bool AllowRowLocks { get; init; }
+
+        /// <summary>Cumulative <c>user_seeks</c> since the last usage-stats reset.</summary>
+        public long UserSeeks { get; init; }
+
+        /// <summary>Cumulative <c>user_scans</c>.</summary>
+        public long UserScans { get; init; }
+
+        /// <summary>Cumulative <c>user_lookups</c>.</summary>
+        public long UserLookups { get; init; }
+
+        /// <summary>Cumulative <c>user_updates</c> (write maintenance cost).</summary>
+        public long UserUpdates { get; init; }
+
+        /// <summary>Reserved footprint in MB (summed across partitions). Divided by 1024 for the GB figures.</summary>
+        public decimal? ReservedMb { get; init; }
+
+        /// <summary>Row count (per partition sum). The base row (index_id 0/1) drives the object's <c>@min_rows</c> gate.</summary>
+        public long? TotalRows { get; init; }
+
+        /// <summary>Partition count; &gt;1 drives <c>REBUILD PARTITION = ALL</c> in the compression script (a proxy — the scheme name is not captured).</summary>
+        public int? PartitionCount { get; init; }
+
+        /// <summary>SQL Server start time (for the &lt;14-day uptime caveat / &lt;=7-day auto-dedupe, when the caller does not pass <see cref="IndexCleanupOptions.ServerUptimeDays"/> directly).</summary>
+        public DateTime? SqlServerStartTime { get; init; }
+    }
+
+    /// <summary>
+    /// Analyzer inputs that mirror sp_IndexCleanup's parameters and server-derived flags. Because the
+    /// analyzer is database-free, the edition/uptime facts SQL Server derives at runtime are passed in.
+    /// </summary>
+    public sealed record IndexCleanupOptions
+    {
+        /// <summary>Only run the consolidation rules; do NOT flag unused indexes (sp_IndexCleanup's <c>@dedupe_only</c>).</summary>
+        public bool DedupeOnly { get; init; }
+
+        /// <summary>Minimum index size (GB) for a PAGE-compression candidate (sp_IndexCleanup's <c>@min_size_gb</c>, applied per index here).</summary>
+        public decimal MinSizeGb { get; init; }
+
+        /// <summary>Minimum object read count to analyze a table (applied only when &gt; 0; mirrors <c>@min_reads</c>).</summary>
+        public long MinReads { get; init; }
+
+        /// <summary>Minimum object write count to analyze a table (applied only when &gt; 0; mirrors <c>@min_writes</c>).</summary>
+        public long MinWrites { get; init; }
+
+        /// <summary>Minimum object row count to analyze a table (mirrors <c>@min_rows</c>).</summary>
+        public long MinRows { get; init; }
+
+        /// <summary>
+        /// Server uptime in days. Drives the "usage data may be incomplete" caveat on unused indexes
+        /// (&lt; 14 days) and sp_IndexCleanup's auto-enable of dedupe-only (&lt;= 7 days). When null, the
+        /// analyzer derives it from the max <see cref="IndexCleanupIndexInput.SqlServerStartTime"/> and
+        /// <see cref="ReferenceTimeUtc"/>; if that is also indeterminable, no caveat is applied.
+        /// </summary>
+        public double? ServerUptimeDays { get; init; }
+
+        /// <summary>Reference "now" for deriving uptime from server start time. Defaults to <see cref="DateTime.UtcNow"/>.</summary>
+        public DateTime? ReferenceTimeUtc { get; init; }
+
+        /// <summary>Target engine supports data compression (Enterprise / Standard 2016+ / Azure). When false, nothing is a compression candidate (mirrors <c>@can_compress</c>).</summary>
+        public bool ServerSupportsCompression { get; init; } = true;
+
+        /// <summary>Target engine supports <c>ONLINE = ON</c> rebuilds (Enterprise / Azure). Controls the ONLINE token in generated scripts; defaults to OFF (safe).</summary>
+        public bool ServerSupportsOnline { get; init; }
+
+        /// <summary>Low end of the general PAGE-compression savings band (sp_IndexCleanup: 0.20 × size).</summary>
+        public decimal CompressionMinSavingsFactor { get; init; } = 0.20m;
+
+        /// <summary>High end of the general PAGE-compression savings band (sp_IndexCleanup: 0.60 × size).</summary>
+        public decimal CompressionMaxSavingsFactor { get; init; } = 0.60m;
+    }
+
+    /// <summary>What to do with an index. Mirrors sp_IndexCleanup's <c>action</c> for the in-scope dedupe rules.</summary>
+    public enum IndexCleanupAction
+    {
+        /// <summary>No action.</summary>
+        None = 0,
+
+        /// <summary>Retain this index (the keeper of a duplicate set).</summary>
+        Keep = 1,
+
+        /// <summary>Disable this index (redundant / unused). Never assigned to a protected index.</summary>
+        Disable = 2,
+
+        /// <summary>Retain but rebuild with includes merged from the indexes it supersedes.</summary>
+        MergeIncludes = 3,
+    }
+
+    /// <summary>Which generated-script bucket a recommendation belongs to. Mirrors sp_IndexCleanup's <c>result_type</c>.</summary>
+    public enum IndexCleanupResultKind
+    {
+        /// <summary>An <c>ALTER INDEX … DISABLE</c> row.</summary>
+        Disable = 0,
+
+        /// <summary>A <c>CREATE INDEX … WITH (DROP_EXISTING = ON …)</c> merge row (the keeper/superset).</summary>
+        Merge = 1,
+
+        /// <summary>An <c>ALTER INDEX … REBUILD … DATA_COMPRESSION = PAGE</c> row.</summary>
+        Compress = 2,
+    }
+
+    /// <summary>The canonical <c>consolidation_rule</c> labels this analyzer emits.</summary>
+    public static class IndexCleanupRules
+    {
+        /// <summary>No reads at all (Rule 1). Never-clustered, non-unique, non-PK/UC nonclustered indexes only.</summary>
+        public const string UnusedIndex = "Unused Index";
+
+        /// <summary>The &lt;14-day-uptime variant of <see cref="UnusedIndex"/> (usage data may be incomplete).</summary>
+        public const string UnusedIndexUptimeWarning = "Unused Index (WARNING: Server uptime < 14 days - usage data may be incomplete)";
+
+        /// <summary>Identical keys (with direction), includes, and filter (Rule 2).</summary>
+        public const string ExactDuplicate = "Exact Duplicate";
+
+        /// <summary>Same key columns in the same order but with every sort direction inverted (functionally equivalent via backward scan); same includes and filter.</summary>
+        public const string ReverseDuplicate = "Reverse Duplicate";
+
+        /// <summary>Identical keys (with direction) and includes but a different filter predicate.</summary>
+        public const string EqualExceptForFilter = "Equal Except For Filter";
+
+        /// <summary>Same keys (with direction) and filter but different includes (Rule 5); the keeper absorbs the includes.</summary>
+        public const string KeyDuplicate = "Key Duplicate";
+
+        /// <summary>The narrower index whose key is a leading prefix of a wider index's key (Rule 3); disabled in favor of the superset.</summary>
+        public const string KeySubset = "Key Subset";
+
+        /// <summary>The wider index a Key Subset defers to (Rule 4); rebuilt with the subset's missing includes merged in.</summary>
+        public const string KeySuperset = "Key Superset";
+    }
+
+    /// <summary>
+    /// One actionable finding for a single index — the C# analog of a row in sp_IndexCleanup's script result
+    /// set. Carries the matched rule, the action, the target/superseded linkage, the reconstructed T-SQL, and
+    /// the size/usage figures the rollup sums.
+    /// </summary>
+    public sealed record IndexCleanupRecommendation
+    {
+        /// <summary>Database name.</summary>
+        public string DatabaseName { get; init; } = "";
+
+        /// <summary>Schema name.</summary>
+        public string SchemaName { get; init; } = "";
+
+        /// <summary>Table (or indexed-view) name.</summary>
+        public string TableName { get; init; } = "";
+
+        /// <summary>The index this finding is about.</summary>
+        public string IndexName { get; init; } = "";
+
+        /// <summary>Index id (1 = clustered).</summary>
+        public int IndexId { get; init; }
+
+        /// <summary>The matched <see cref="IndexCleanupRules"/> label (null for a pure compression row).</summary>
+        public string? ConsolidationRule { get; init; }
+
+        /// <summary>The recommended action.</summary>
+        public IndexCleanupAction Action { get; init; }
+
+        /// <summary>Which script bucket this row belongs to.</summary>
+        public IndexCleanupResultKind ResultKind { get; init; }
+
+        /// <summary>The keeper/superset this index defers to (on a DISABLE row), or null.</summary>
+        public string? TargetIndexName { get; init; }
+
+        /// <summary>On a keeper/superset row, the "Supersedes …" list of indexes it absorbs.</summary>
+        public string? SupersededBy { get; init; }
+
+        /// <summary>On a Key Superset row, the subset include columns merged in that were not already present (sp_IndexCleanup's <c>missing_included_columns</c>).</summary>
+        public string? MissingIncludedColumns { get; init; }
+
+        /// <summary>Human label for the script bucket: <c>DISABLE SCRIPT</c> / <c>MERGE SCRIPT</c> / <c>COMPRESSION SCRIPT</c>.</summary>
+        public string ScriptType { get; init; } = "";
+
+        /// <summary>The reconstructed T-SQL to run.</summary>
+        public string Script { get; init; } = "";
+
+        /// <summary>A short explanation of what the script does / why.</summary>
+        public string? AdditionalInfo { get; init; }
+
+        /// <summary>The reconstructed original CREATE/ADD CONSTRAINT statement (rollback + validation reference).</summary>
+        public string OriginalIndexDefinition { get; init; } = "";
+
+        /// <summary>Reserved size in GB.</summary>
+        public decimal IndexSizeGb { get; init; }
+
+        /// <summary>Row count.</summary>
+        public long IndexRows { get; init; }
+
+        /// <summary>seeks + scans + lookups.</summary>
+        public long IndexReads { get; init; }
+
+        /// <summary>user_updates.</summary>
+        public long IndexWrites { get; init; }
+
+        /// <summary>This index is (also) a PAGE-compression candidate.</summary>
+        public bool CanCompress { get; init; }
+
+        /// <summary>This index supports an outgoing foreign key (informational; not a disable guard).</summary>
+        public bool IsForeignKey { get; init; }
+
+        /// <summary>The generated script omits the trailing <c>ON &lt;filegroup/partition_scheme&gt;</c> placement clause because Stage 1 did not capture it.</summary>
+        public bool ScriptOmitsPartitionPlacement { get; init; }
+    }
+
+    /// <summary>
+    /// The reclaimable-space roll-up for a scope (a database, or the whole snapshot) — the C# analog of
+    /// sp_IndexCleanup's <c>#index_reporting_stats</c> DATABASE row.
+    /// </summary>
+    public sealed record IndexCleanupRollup
+    {
+        /// <summary>Database this rollup covers; null for the overall (all-databases) rollup.</summary>
+        public string? DatabaseName { get; init; }
+
+        /// <summary>Distinct tables analyzed.</summary>
+        public int TablesAnalyzed { get; init; }
+
+        /// <summary>Indexes analyzed (rowstore CLUSTERED/NONCLUSTERED).</summary>
+        public int IndexCount { get; init; }
+
+        /// <summary>Total reserved size of analyzed indexes (GB).</summary>
+        public decimal TotalSizeGb { get; init; }
+
+        /// <summary>Total rows across analyzed tables' base row (index_id 0/1).</summary>
+        public long TotalRows { get; init; }
+
+        /// <summary>Indexes recommended for DISABLE (redundant + unused).</summary>
+        public int IndexesToDisable { get; init; }
+
+        /// <summary>Indexes recommended for MERGE INCLUDES (keepers/supersets).</summary>
+        public int IndexesToMerge { get; init; }
+
+        /// <summary>Indexes eligible for PAGE compression.</summary>
+        public int CompressableIndexes { get; init; }
+
+        /// <summary>Indexes flagged specifically as unused (subset of <see cref="IndexesToDisable"/>).</summary>
+        public int UnusedIndexes { get; init; }
+
+        /// <summary>Reclaimable size (GB) from disabling redundant/unused indexes (their full size).</summary>
+        public decimal UnusedSizeGb { get; init; }
+
+        /// <summary>Low-band compression savings (GB) over kept, compressible indexes (0.20 × size).</summary>
+        public decimal CompressionMinSavingsGb { get; init; }
+
+        /// <summary>High-band compression savings (GB) over kept, compressible indexes (0.60 × size).</summary>
+        public decimal CompressionMaxSavingsGb { get; init; }
+
+        /// <summary>Combined low-band reclaim (disabled full size + compression min).</summary>
+        public decimal TotalMinSavingsGb { get; init; }
+
+        /// <summary>Combined high-band reclaim (disabled full size + compression max).</summary>
+        public decimal TotalMaxSavingsGb { get; init; }
+    }
+
+    /// <summary>The full result of one analysis pass.</summary>
+    public sealed record IndexCleanupAnalysisResult
+    {
+        /// <summary>Every actionable finding (DISABLE / MERGE / COMPRESS), ordered by database, schema, table, then keepers before losers.</summary>
+        public IReadOnlyList<IndexCleanupRecommendation> Recommendations { get; init; } = Array.Empty<IndexCleanupRecommendation>();
+
+        /// <summary>One rollup per database.</summary>
+        public IReadOnlyList<IndexCleanupRollup> DatabaseRollups { get; init; } = Array.Empty<IndexCleanupRollup>();
+
+        /// <summary>The all-databases rollup.</summary>
+        public IndexCleanupRollup OverallRollup { get; init; } = new();
+
+        /// <summary>Server uptime was under 14 days, so unused-index usage data may be incomplete.</summary>
+        public bool UptimeWarning { get; init; }
+
+        /// <summary>Dedupe-only was in effect (either requested, or auto-enabled because uptime &lt;= 7 days), so unused indexes were not flagged.</summary>
+        public bool DedupeOnlyApplied { get; init; }
+
+        /// <summary>Precisely-surfaced limitations of this data-driven reproduction (e.g. omitted filegroup placement, compression exclusions not reproducible, out-of-scope rules).</summary>
+        public IReadOnlyList<string> Notes { get; init; } = Array.Empty<string>();
+    }
+}


### PR DESCRIPTION
## Summary

**Stage 2 of 3** of the FinOps Index Analysis feature (#1262). A shared, **database-free** C# reproduction of Erik's `sp_IndexCleanup` analysis that runs entirely off the Stage-1 `index_object_stats` snapshot — no live proc required on the monitored server. Given the captured per-index rows it emits drop/merge/compress recommendations, the reconstructed T-SQL, and a reclaimable-space roll-up.

- New: `PerformanceMonitor.Common/IndexCleanupAnalyzer.cs` + `IndexCleanupModels.cs` (reusable, in Common like `SystemHealthParser`).
- **No** target proc, **no** viewer tab — those are Stage 3.

Faithful to `sp_IndexCleanup` **v2.7 (20260701)**, cross-checked against the proc's own **adversarial test suite** (`tests/run_tests.py`) — the authoritative behavior spec. Because Stage 1 captured `key_columns`/`included_columns` in the proc's exact delimited `QUOTENAME` form (`[a], [b] DESC` / `[c], [d]`), the string-comparison dedupe ports directly.

## Rules ported

**Auto-consolidated (a script is generated):**

| Rule | Source | Action |
|------|--------|--------|
| **Unused Index** (+ `<14d` uptime caveat, `<=7d` auto-dedupe, `@dedupe_only`) | Rule 1 | DISABLE |
| **Exact Duplicate** (identical keys incl. direction + includes + filter) | Rule 2 | DISABLE loser |
| **Key Duplicate** (same keys+filter, different includes; winner absorbs all losers' includes) | Rule 5 + merge L4646-4705 | MERGE + DISABLE |
| **Key Subset / Key Superset** (prefix; subset-chain flattening; missing-include carry) | Rules 3/4/6 | DISABLE + MERGE |

**Recognized but deliberately NOT auto-consolidated (non-destructive REVIEW row, action KEEP):**

| Rule | Why kept | Proof |
|------|----------|-------|
| **Reverse Duplicate** (same key column *set*, different order/direction) | a different leading column serves different queries | adversarial test **9a** asserts 0 disables |
| **Equal Except For Filter** (same keys+includes, different filter) | the filters index different rows | adversarial test **10a** asserts 0 disables |

> ⚠️ A first pass wrongly auto-*disabled* these two; corrected to review-only per the proc's tests (`match its rules exactly, don't approximate`). They run as a *non-consuming* detection, so a subset/key-duplicate that legitimately overlaps a reverse/filter sibling is still consolidated as the proc does.

Priority scoring, `is_eligible_for_dedupe`, and the **PK / unique-constraint / FK-reference** disable protections match the proc's guards (the FK-reference guard applied universally per the spec, stricter than v2.7's Rule 2). PAGE-compression candidacy (`data_compression_desc = NONE`, rowstore, `>= @min_size_gb`) and the **0.20–0.60** general savings band reproduce the proc's `#compression_eligibility` / reporting math. Scripts: `ALTER INDEX … DISABLE` (the proc's reversible removal form), `CREATE INDEX … WITH (DROP_EXISTING = ON …)` merge, `ALTER INDEX … REBUILD … DATA_COMPRESSION = PAGE`, plus the original-CREATE reconstruction.

## Surfaced precisely (not guessed / not silently cut) — also emitted in `Notes`

- Reconstructed CREATE/MERGE omit the trailing `ON <filegroup/partition_scheme>` — Stage 1 did not capture placement.
- Compression cannot exclude sparse-column / legacy-LOB (`text`/`ntext`/`image`) tables — needs a live column scan Stage 1 didn't capture.
- `REBUILD PARTITION = ALL` gated on `partition_count > 1` (proxy for the scheme name).
- **Out of scope** per this stage's DISABLE/MERGE INCLUDES/KEEP action set: the proc's `Unique Constraint Replacement` (MAKE UNIQUE / DROP CONSTRAINT, Rule 7 family). Its `Same Keys Different Order` REVIEW case is largely covered by the Reverse Duplicate review rows. Both reproducible from captured data if later required.

## Tests

39 DB-free tests in **Darling.Tests** (the CI-run project) covering every rule, each protection (PK/UQ/FK-ref), the uptime caveat + auto-dedupe, compression candidacy/exclusions/savings band, the roll-up, and the reconstructed T-SQL byte-for-byte — including scenarios mirrored from the proc's adversarial suite (2a exact-DESC, 3c/3d filter subset, 7a cross-table isolation, 9a reverse, 10a equal-except-filter, 12a multi-level subset chain).

Full `Darling.Tests` suite green: **678 passed / 83 skipped / 0 failed**.

Do **not** merge — opening for review per the Stage-2 task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)