### PR TITLE
Move Common-type unit tests to CI-run Darling.Tests

### DIFF
--- a/Darling/Darling.Tests/AlertMetricClassifierTests.cs
+++ b/Darling/Darling.Tests/AlertMetricClassifierTests.cs
@@ -1,7 +1,15 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
 using PerformanceMonitor.Common;
 using Xunit;
 
-namespace PerformanceMonitorDashboard.Tests;
+namespace Darling.Tests;
 
 /// <summary>
 /// #1225: the shared metric-name classifier that both apps' Alert History grids and the Dashboard

--- a/Darling/Darling.Tests/BlockingChainLayoutTests.cs
+++ b/Darling/Darling.Tests/BlockingChainLayoutTests.cs
@@ -1,10 +1,18 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using PerformanceMonitor.Common;
 using Xunit;
 
-namespace PerformanceMonitorDashboard.Tests;
+namespace Darling.Tests;
 
 /// <summary>
 /// Pure unit tests for the shared <see cref="BlockingChainLayout"/> — determinism and no-overlap of the

--- a/Darling/Darling.Tests/BlockingChainTreeBuilderTests.cs
+++ b/Darling/Darling.Tests/BlockingChainTreeBuilderTests.cs
@@ -1,10 +1,18 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using PerformanceMonitor.Common;
 using Xunit;
 
-namespace PerformanceMonitorDashboard.Tests;
+namespace Darling.Tests;
 
 /// <summary>
 /// Pure unit tests for the shared <see cref="BlockingChainTreeBuilder"/> — the DAG -> tree logic that


### PR DESCRIPTION
## What

Moves three unit-test files from the **non-CI** `Dashboard.Tests` project into `Darling/Darling.Tests` (a CI-run suite), so their assertions actually execute in the pipeline:

- `AlertMetricClassifierTests.cs` — tests `PerformanceMonitor.Common/AlertMetricClassifier.cs`
- `BlockingChainLayoutTests.cs` — tests `PerformanceMonitor.Common/BlockingChainLayout.cs`
- `BlockingChainTreeBuilderTests.cs` — tests `PerformanceMonitor.Common/BlockingChainTreeBuilder.cs`

## Why

`.github/workflows/build.yml` builds/runs **Lite.Tests, Installer.Tests, and Darling.Tests — not Dashboard.Tests**. These three files test **shared `PerformanceMonitor.Common` types** but sat in `Dashboard.Tests`, so CI never ran them — 42 test cases were effectively unverified in the pipeline. Moving them into a CI-run project that already references Common gets them executing.

This follows the exact precedent set by **#1380** (SystemHealthParser tests) and **#1382** (DeadlockGraphParser tests).

## How

- `git mv` each file (history preserved — rename detected).
- `namespace PerformanceMonitorDashboard.Tests` -> `namespace Darling.Tests`, plus the standard MIT copyright header to match the destination suite (all 46 sibling files carry it).
- No `.csproj` edits: both test projects are SDK glob-style (zero explicit `<Compile Include>` items), so the files drop out of Dashboard.Tests and are picked up by Darling.Tests automatically.
- Each moved test references **only** `PerformanceMonitor.Common` (+ xunit) — no Dashboard-only dependencies.

## Verification

- `dotnet build Darling/Darling.Tests -c Release` — succeeds (0 errors).
- `dotnet test Darling/Darling.Tests -c Release` — **679 -> 721 passing (+42), 83 skipped, 0 failed.** The +42 are the moved cases (27 AlertMetricClassifier + 5 BlockingChainLayout + 10 BlockingChainTreeBuilder), all green.
- `dotnet build Dashboard.Tests -c Release` — still succeeds (0 errors) with the files removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
