### PR TITLE
Add Unique Constraint Replacement rules (Rule 7/7.5/7.5b/7.6) to IndexCleanupAnalyzer

### DIFF
--- a/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
+++ b/Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs
@@ -391,6 +391,256 @@ public class IndexCleanupAnalyzerTests
         Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
     }
 
+    // ── Rules 7 / 7.5 / 7.5b: Unique Constraint Replacement ──────────────────────────────────────────
+    // Behavior below was verified against a live sp_IndexCleanup @debug=1 run (see PR notes).
+
+    [Fact]
+    public void UniqueConstraintReplacement_NcMatchesConstraint_NcMadeUniqueConstraintDropped()
+    {
+        // Rule 7 + 7.5: a nonclustered index whose keys EXACTLY match a unique constraint → the index is made
+        // unique and the redundant constraint is dropped.
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        var ncRec = Rec(r, "nc_ab");
+        Assert.NotNull(ncRec);
+        Assert.Equal(IndexCleanupAction.MakeUnique, ncRec!.Action);
+        Assert.Equal(IndexCleanupRules.UniqueConstraintReplacement, ncRec.ConsolidationRule);
+        Assert.Equal(IndexCleanupResultKind.Merge, ncRec.ResultKind);
+        Assert.Equal("MERGE SCRIPT", ncRec.ScriptType);
+        Assert.Equal("Will replace constraint UC_ab", ncRec.SupersededBy);
+        Assert.Contains("CREATE UNIQUE INDEX [nc_ab]", ncRec.Script);
+        Assert.Contains("DROP_EXISTING = ON", ncRec.Script);
+
+        var ucRec = Rec(r, "UC_ab");
+        Assert.NotNull(ucRec);
+        Assert.Equal(IndexCleanupAction.Disable, ucRec!.Action);
+        Assert.Equal(IndexCleanupRules.UniqueConstraintReplacement, ucRec.ConsolidationRule);
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, ucRec.ResultKind);
+        Assert.Equal("DISABLE CONSTRAINT SCRIPT", ucRec.ScriptType);
+        Assert.Equal("nc_ab", ucRec.TargetIndexName);
+        Assert.Equal("ALTER TABLE [TestDb].[dbo].[T] DROP CONSTRAINT [UC_ab];", ucRec.Script);
+        Assert.Contains("replaced by: nc_ab", ucRec.AdditionalInfo);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_MakeUniqueScript_HasCanonicalUniqueDropExistingForm()
+    {
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.Equal(
+            "CREATE UNIQUE INDEX [nc_ab] ON [TestDb].[dbo].[T] ([a], [b]) WITH (DROP_EXISTING = ON, FILLFACTOR = 100, SORT_IN_TEMPDB = ON, ONLINE = OFF);",
+            Rec(r, "nc_ab")!.Script);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_MakeUniqueKeepsOwnIncludes()
+    {
+        // Key match is on key_columns only — the made-unique index keeps its own includes (Rule 7.6 include-merge is out of scope).
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, includes: "[c]", seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        var ncRec = Rec(r, "nc_ab");
+        Assert.Equal(IndexCleanupAction.MakeUnique, ncRec!.Action);
+        Assert.Contains("CREATE UNIQUE INDEX [nc_ab] ON [TestDb].[dbo].[T] ([a], [b]) INCLUDE ([c])", ncRec.Script);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_ConstraintBacksForeignKeyReference_NotDropped()
+    {
+        // PROTECTION: a constraint backing an inbound FK reference is never dropped (disabling silently breaks
+        // referential integrity). Its would-be replacement index is then reverted to no action (proc-faithful).
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true, foreignKeyReference: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UC_ab" && x.Action == IndexCleanupAction.Disable);
+        Assert.DoesNotContain(r.Recommendations, x => x.ResultKind == IndexCleanupResultKind.DisableConstraint);
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.MakeUnique);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_NcKeySuperset_NotPromoted()
+    {
+        // Both-direction set-equality guard: an index with an EXTRA key column is NOT equivalent to the
+        // constraint, so it is not promoted (and the constraint is not dropped).
+        var nc = Idx("nc_abc", "[a], [b], [c]", indexId: 2, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.MakeUnique);
+        Assert.DoesNotContain(r.Recommendations, x => x.ResultKind == IndexCleanupResultKind.DisableConstraint);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_AlreadyUniqueNcExactMatch_IsMadeUniquePerLiteralProc()
+    {
+        // AMBIGUITY (verified live): an already-unique index that EXACTLY matches a constraint is still marked
+        // MAKE UNIQUE, NOT KEEP — the proc's Rule 7.5 step 2 has no is_unique guard, so it overrides Rule 7's
+        // KEEP. The rebuild is a redundant-but-harmless UNIQUE rebuild that still drops the constraint. This
+        // reproduces the proc's LITERAL behavior (the task text's "KEEP" expectation does not survive Rule 7.5).
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, unique: true, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.Equal(IndexCleanupAction.MakeUnique, Rec(r, "nc_ab")!.Action);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "UC_ab")!.Action);
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, Rec(r, "UC_ab")!.ResultKind);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_AlreadyUniqueNcDifferentKeyOrder_IsKeptNotMadeUnique()
+    {
+        // The KEEP case the task describes: an already-unique index whose keys match the constraint only by SET
+        // (reversed order) survives as KEEP — Rule 7's set-match assigns KEEP and Rule 7.5's EXACT-key match
+        // does not fire, so no redundant MAKE UNIQUE and no constraint drop.
+        var nc = Idx("nc_ba", "[b], [a]", indexId: 2, unique: true, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.MakeUnique);
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+        Assert.DoesNotContain(r.Recommendations, x => x.ResultKind == IndexCleanupResultKind.DisableConstraint);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_ExactMatch_OverridesUnusedMarking()
+    {
+        // Rule 7.5 step 2 is unconditional on prior state: a nonclustered index with no reads is first marked
+        // Unused/DISABLE, then FORCED to MAKE UNIQUE by the exact-key constraint match (verified live).
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2);   // no reads → would be "Unused"
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts(uptimeDays: 30));
+
+        var ncRec = Rec(r, "nc_ab");
+        Assert.Equal(IndexCleanupAction.MakeUnique, ncRec!.Action);
+        Assert.Equal(IndexCleanupRules.UniqueConstraintReplacement, ncRec.ConsolidationRule);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "UC_ab")!.Action);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_DuplicateConstraints_LoserDroppedKeeperSurvives()
+    {
+        // Rule 7.5b: two identical unique constraints, no nonclustered index to promote → drop all but one.
+        // The alphabetically-later name loses at equal priority (mirrors the Rule 2 tiebreak).
+        var uc1 = Idx("UC_1", "[a], [b]", indexId: 2, uniqueConstraint: true);
+        var uc2 = Idx("UC_2", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uc1, uc2 }, Opts());
+
+        var loser = Rec(r, "UC_2");
+        Assert.NotNull(loser);
+        Assert.Equal(IndexCleanupAction.Disable, loser!.Action);
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, loser.ResultKind);
+        Assert.Equal(IndexCleanupRules.UniqueConstraintReplacement, loser.ConsolidationRule);
+        Assert.Equal("UC_1", loser.TargetIndexName);
+        Assert.Equal("ALTER TABLE [TestDb].[dbo].[T] DROP CONSTRAINT [UC_2];", loser.Script);
+
+        // The keeper survives with no destructive recommendation.
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UC_1" && x.Action == IndexCleanupAction.Disable);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_ThreeDuplicateConstraints_AllLosersPointAtSingleWinner()
+    {
+        // Determinism guard: with 3+ identical constraints, every loser targets the single overall winner.
+        var uc1 = Idx("UC_a", "[a], [b]", indexId: 2, uniqueConstraint: true);
+        var uc2 = Idx("UC_b", "[a], [b]", indexId: 3, uniqueConstraint: true);
+        var uc3 = Idx("UC_c", "[a], [b]", indexId: 4, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uc1, uc2, uc3 }, Opts());
+
+        Assert.Equal(2, r.Recommendations.Count(x => x.ResultKind == IndexCleanupResultKind.DisableConstraint));
+        Assert.Equal("UC_a", Rec(r, "UC_b")!.TargetIndexName);
+        Assert.Equal("UC_a", Rec(r, "UC_c")!.TargetIndexName);
+        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UC_a" && x.Action == IndexCleanupAction.Disable);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_DuplicateConstraints_FkReferencedLoserProtected()
+    {
+        // Rule 7.5b FK guard: the natural loser (alphabetically later) backs an inbound FK reference → it is
+        // NOT demoted/dropped, so neither constraint is dropped.
+        var keep = Idx("UC_aaa", "[a], [b]", indexId: 2, uniqueConstraint: true);
+        var fkLoser = Idx("UC_zzz", "[a], [b]", indexId: 3, uniqueConstraint: true, foreignKeyReference: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { keep, fkLoser }, Opts());
+
+        Assert.DoesNotContain(r.Recommendations, x => x.ResultKind == IndexCleanupResultKind.DisableConstraint);
+        Assert.DoesNotContain(r.Recommendations, x => x.Action == IndexCleanupAction.Disable);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_RollupCountsMakeUniqueAsMergeAndDroppedConstraintAsDisable()
+    {
+        var nc = Idx("nc_ab", "[a], [b]", indexId: 2, seeks: 10);
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 3, uniqueConstraint: true);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { nc, uc }, Opts());
+
+        Assert.Equal(1, r.OverallRollup.IndexesToMerge);     // the MAKE UNIQUE index
+        Assert.Equal(1, r.OverallRollup.IndexesToDisable);   // the dropped constraint
+        Assert.Equal(0, r.OverallRollup.UnusedIndexes);      // neither is "unused"
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_KeySupersetMadeUnique_RetainsAbsorbedSubsetIncludes()
+    {
+        // A Key-Superset index that absorbed a disabled subset's includes and THEN exactly matches a
+        // constraint is made unique WITHOUT losing the absorbed include (verified live:
+        // CREATE UNIQUE INDEX [IX_wide] … INCLUDE ([c], [d])).
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 2, uniqueConstraint: true);
+        var wide = Idx("IX_wide", "[a], [b]", indexId: 3, includes: "[c]", seeks: 10);
+        var narrow = Idx("IX_narrow", "[a]", indexId: 4, includes: "[d]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uc, wide, narrow }, Opts());
+
+        var wideRec = Rec(r, "IX_wide");
+        Assert.Equal(IndexCleanupAction.MakeUnique, wideRec!.Action);
+        Assert.Contains("INCLUDE ([c], [d])", wideRec.Script);          // absorbed subset include [d] survives step 2
+        Assert.Equal(IndexCleanupRules.KeySubset, Rec(r, "IX_narrow")!.ConsolidationRule);
+        Assert.Equal(IndexCleanupAction.Disable, Rec(r, "IX_narrow")!.Action);
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, Rec(r, "UC_ab")!.ResultKind);
+    }
+
+    [Fact]
+    public void UniqueConstraintReplacement_Rule76_KeyDuplicateOfMadeUniqueIndex_ReDisabledAndIncludesFolded()
+    {
+        // Rule 7.6: after Rule 7.5 makes nc_a unique, the other same-key index (nc_b) — which step 2 briefly
+        // promoted then the cleanup reverted — is re-disabled as a Key Duplicate and its include folded into
+        // the winner (verified live). Without Rule 7.6 nc_b would be silently left in place (a dropped DISABLE).
+        var uc = Idx("UC_ab", "[a], [b]", indexId: 2, uniqueConstraint: true);
+        var ncA = Idx("nc_a", "[a], [b]", indexId: 3, includes: "[c]", seeks: 10);
+        var ncB = Idx("nc_b", "[a], [b]", indexId: 4, includes: "[d]", seeks: 10);
+
+        var r = IndexCleanupAnalyzer.Analyze(new[] { uc, ncA, ncB }, Opts());
+
+        var winner = Rec(r, "nc_a");
+        Assert.Equal(IndexCleanupAction.MakeUnique, winner!.Action);
+        Assert.Contains("INCLUDE ([c], [d])", winner.Script);           // nc_b's include folded in
+
+        var loser = Rec(r, "nc_b");
+        Assert.NotNull(loser);
+        Assert.Equal(IndexCleanupAction.Disable, loser!.Action);
+        Assert.Equal(IndexCleanupRules.KeyDuplicate, loser.ConsolidationRule);   // NOT Unique Constraint Replacement
+        Assert.Equal(IndexCleanupResultKind.Disable, loser.ResultKind);          // ALTER INDEX DISABLE (nc_b is not a constraint)
+        Assert.Equal("nc_a", loser.TargetIndexName);
+
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, Rec(r, "UC_ab")!.ResultKind);
+    }
+
     // ── Protections ────────────────────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -418,15 +668,26 @@ public class IndexCleanupAnalyzerTests
     }
 
     [Fact]
-    public void Protection_UniqueConstraint_ExcludedFromDedupe()
+    public void Protection_UniqueConstraint_NotNaivelyDeduped_ReplacedViaRule75()
     {
+        // A unique constraint is excluded from the Exact/Key duplicate candidate set, so it is never marked an
+        // "Exact Duplicate"/"Key Duplicate" loser. With an identical-key nonclustered index it is instead
+        // handled by Rule 7.5 (replaced by the made-unique index → a constraint DROP), never by naive dedupe.
         var uc = Idx("UQ_C", "[a]", indexId: 2, uniqueConstraint: true, unique: true, seeks: 10);
         var dup = Idx("IX_Dup", "[a]", indexId: 3, seeks: 10);
 
         var r = IndexCleanupAnalyzer.Analyze(new[] { uc, dup }, Opts());
 
-        // The unique constraint is never disabled (out of the dedupe candidate set entirely).
-        Assert.DoesNotContain(r.Recommendations, x => x.IndexName == "UQ_C" && x.Action == IndexCleanupAction.Disable);
+        var ucRec = Rec(r, "UQ_C");
+        Assert.NotNull(ucRec);
+        // Never swept into the naive Exact/Key duplicate consolidation.
+        Assert.NotEqual(IndexCleanupRules.ExactDuplicate, ucRec!.ConsolidationRule);
+        Assert.NotEqual(IndexCleanupRules.KeyDuplicate, ucRec.ConsolidationRule);
+        // Instead: Rule 7.5 replaces it with the made-unique index and drops the constraint.
+        Assert.Equal(IndexCleanupRules.UniqueConstraintReplacement, ucRec.ConsolidationRule);
+        Assert.Equal(IndexCleanupResultKind.DisableConstraint, ucRec.ResultKind);
+        Assert.Equal("IX_Dup", ucRec.TargetIndexName);
+        Assert.Equal(IndexCleanupAction.MakeUnique, Rec(r, "IX_Dup")!.Action);
     }
 
     [Fact]
@@ -615,6 +876,7 @@ public class IndexCleanupAnalyzerTests
     public void Notes_SurfaceOutOfScopeRules()
     {
         var r = IndexCleanupAnalyzer.Analyze(new[] { Idx("IX_Unused", "[a]") }, Opts());
-        Assert.Contains(r.Notes, n => n.Contains("Unique Constraint Replacement") && n.Contains("Same Keys Different Order"));
+        // Same Keys Different Order remains out of scope (Unique Constraint Replacement, incl. Rules 7.5b/7.6, is implemented).
+        Assert.Contains(r.Notes, n => n.Contains("Same Keys Different Order"));
     }
 }

--- a/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
+++ b/PerformanceMonitor.Common/IndexCleanupAnalyzer.cs
@@ -26,6 +26,11 @@ namespace PerformanceMonitor.Common
     /// &lt;=7-day auto-dedupe), <b>Exact Duplicate</b> (Rule 2 → DISABLE), <b>Key Duplicate</b> (Rule 5 →
     /// keeper MERGE INCLUDES + loser DISABLE), and <b>Key Subset</b>/<b>Key Superset</b> (Rules 3/4/6 →
     /// subset DISABLE + superset MERGE, with subset-chain flattening and missing-include carry).
+    /// <b>Key Subset</b>/<b>Key Superset</b> (Rules 3/4/6 → subset DISABLE + superset MERGE, with subset-chain
+    /// flattening and missing-include carry), and <b>Unique Constraint Replacement</b> (Rules 7/7.5/7.5b → a
+    /// nonclustered index MAKE UNIQUE + the redundant constraint DROP CONSTRAINT, with the FK-reference
+    /// protection, the both-direction key-set-equality guard, and duplicate-constraint collapse; Rule 7.6 then
+    /// re-disables any ordinary Key Duplicate of a made-unique index and folds its includes in).
     /// <b>Recognized but deliberately NOT auto-consolidated</b> (surfaced as a review row, matching the
     /// proc's tested behavior — its adversarial tests 9a/10a assert these are left alone): <b>Reverse
     /// Duplicate</b> (same key column set, different order/direction — a different leading column serves
@@ -36,11 +41,10 @@ namespace PerformanceMonitor.Common
     /// / reporting math.</para>
     ///
     /// <para><b>Deliberately out of scope</b> (see <see cref="IndexCleanupAnalysisResult.Notes"/>): the proc's
-    /// <c>Unique Constraint Replacement</c> (MAKE UNIQUE) and <c>Same Keys Different Order</c> (REVIEW) rules,
-    /// whose actions fall outside this stage's DISABLE / MERGE INCLUDES / KEEP set. Both remain reproducible
-    /// from the captured data. Script details that need metadata Stage 1 did not capture (the trailing
-    /// <c>ON &lt;filegroup/partition_scheme&gt;</c> placement; sparse/legacy-LOB compression exclusions) are
-    /// surfaced, never guessed.</para>
+    /// <c>Same Keys Different Order</c> (REVIEW) case, largely covered by the Reverse Duplicate review rows and
+    /// reproducible from the captured data if later required. Script details that need metadata Stage 1 did not
+    /// capture (the trailing <c>ON &lt;filegroup/partition_scheme&gt;</c> placement; sparse/legacy-LOB
+    /// compression exclusions) are surfaced, never guessed.</para>
     /// </summary>
     public static class IndexCleanupAnalyzer
     {
@@ -146,6 +150,12 @@ namespace PerformanceMonitor.Common
             ResolveSubsetChains(scope);
             ApplyKeySuperset(scope);
             ApplyKeyDuplicate(scope);
+
+            // Rule 7 family: unique-constraint replacement (MAKE UNIQUE / DROP CONSTRAINT). Runs LAST so it
+            // sees the final consolidation state (and, exactly like the proc's Rule 7.5, may override an
+            // earlier Unused/Key-Duplicate marking on a nonclustered index whose keys EXACTLY match a
+            // unique constraint).
+            ApplyUniqueConstraintReplacement(scope);
         }
 
         /// <summary>
@@ -361,6 +371,295 @@ namespace PerformanceMonitor.Common
             }
         }
 
+        /// <summary>
+        /// Rule 7 family — Unique Constraint Replacement (sp_IndexCleanup Rules 7, 7.5, 7.5b), reproduced
+        /// faithfully against the live proc (verified with <c>@debug = 1</c>):
+        /// <list type="bullet">
+        /// <item><b>Rule 7</b> (set-match, tentative): an eligible nonclustered index whose KEY-COLUMN SET
+        /// equals a unique constraint's (both-direction set equality — extra key columns disqualify) is
+        /// tentatively marked MAKE UNIQUE (if not already unique) or KEEP (already unique). A unique
+        /// constraint self-matches, so a lone/duplicate constraint is marked KEEP here — the precondition for
+        /// Rule 7.5b.</item>
+        /// <item><b>Rule 7.5 step 1</b>: a unique constraint that has an EXACT-<c>key_columns</c> (order +
+        /// direction) match to a TRUE nonclustered index (not another constraint) is marked DISABLE, pointing
+        /// at that index — UNLESS the constraint backs an inbound foreign-key reference (dropping it would
+        /// break referential integrity).</item>
+        /// <item><b>Rule 7.5 step 2</b>: every true nonclustered index with an EXACT-<c>key_columns</c>
+        /// matching constraint is (re)marked MAKE UNIQUE. Unconditional on prior state, so it OVERRIDES an
+        /// earlier Unused / Key-Duplicate marking on that index (verified against the proc).</item>
+        /// <item><b>Rule 7.5 cleanup</b>: any MAKE UNIQUE index with no disabled constraint pointing back at
+        /// it (the constraint was FK-protected, or Rule 7 set-matched a reversed-order index with no exact
+        /// match) is reverted to no action — matching the proc, this does NOT restore a prior marking.</item>
+        /// <item><b>Rule 7.5b</b>: two or more unique constraints with identical key columns + filter and no
+        /// nonclustered index to promote (all left KEEP by Rule 7) collapse to the single deterministic winner
+        /// (highest priority, then alphabetically-first name); the rest are demoted to DISABLE (DROP
+        /// CONSTRAINT). An FK-referenced constraint is never demoted.</item>
+        /// </list>
+        /// A MAKE UNIQUE index renders as a UNIQUE <c>DROP_EXISTING</c> rebuild (MERGE bucket); a disabled
+        /// constraint renders as <c>DROP CONSTRAINT</c> (<see cref="IndexCleanupResultKind.DisableConstraint"/>).
+        /// </summary>
+        private static void ApplyUniqueConstraintReplacement(List<WorkIndex> scope)
+        {
+            const string Ucr = IndexCleanupRules.UniqueConstraintReplacement;
+
+            // Rule 7: tentative set-match marking (both-direction key-column SET equality — direction- and
+            // order-independent). A unique constraint self-matches (that is how a lone/duplicate constraint
+            // gets KEEP here, the Rule 7.5b precondition). Only still-unprocessed eligible rows are touched.
+            foreach (var w in scope)
+            {
+                if (w.Processed || !w.IsEligibleForDedupe || w.Keys.Count == 0)
+                {
+                    continue;
+                }
+
+                bool hasKeySetMatchingConstraint = scope.Any(u =>
+                    u.Src.IsUniqueConstraint && u.KeyNameSet.SetEquals(w.KeyNameSet));
+
+                if (hasKeySetMatchingConstraint)
+                {
+                    w.ConsolidationRule = Ucr;
+                    w.Action = w.Src.IsUnique ? IndexCleanupAction.Keep : IndexCleanupAction.MakeUnique;
+                    w.Processed = true;
+                }
+            }
+
+            // Rule 7.5 step 1: mark each unique constraint an EXACT-key nonclustered index can replace for
+            // DISABLE (→ DROP CONSTRAINT), pointing at that index. Guards: never drop an FK-referenced
+            // constraint (silently breaks referential integrity); the replacement must be a TRUE nonclustered
+            // index, not another constraint — otherwise two identical constraints would mutually disable and
+            // BOTH get dropped (that case is Rule 7.5b's job).
+            foreach (var uc in scope)
+            {
+                if (!uc.Src.IsUniqueConstraint || uc.Src.IsForeignKeyReference)
+                {
+                    continue;
+                }
+
+                var replacement = scope
+                    .Where(n => !n.Src.IsUniqueConstraint
+                        && !string.Equals(n.Name, uc.Name, StringComparison.Ordinal)
+                        && string.Equals(n.KeyColumns, uc.KeyColumns, StringComparison.Ordinal))
+                    .OrderBy(n => n.Name, StringComparer.Ordinal)   // deterministic pick if several match
+                    .FirstOrDefault();
+
+                if (replacement != null)
+                {
+                    uc.ConsolidationRule = Ucr;
+                    uc.Action = IndexCleanupAction.Disable;
+                    uc.TargetIndexName = replacement.Name;
+                    uc.Processed = true;
+                }
+            }
+
+            // Rule 7.5 step 2: (re)mark every true nonclustered index with an EXACT-key matching constraint as
+            // MAKE UNIQUE. Unconditional on prior state — deliberately overrides an earlier Unused/Key-Duplicate
+            // marking (the proc's UPDATE has no such guard; verified live).
+            foreach (var nc in scope)
+            {
+                if (nc.Src.IsUniqueConstraint)
+                {
+                    continue;
+                }
+
+                bool hasExactMatchingConstraint = scope.Any(u =>
+                    u.Src.IsUniqueConstraint
+                    && string.Equals(u.KeyColumns, nc.KeyColumns, StringComparison.Ordinal));
+
+                if (hasExactMatchingConstraint)
+                {
+                    // Only the rule/action/target change — the proc's Rule 7.5 step 2 touches nothing else.
+                    // Crucially, a Key-Superset index's absorbed includes (MergedIncludes / SupersededBy) must
+                    // SURVIVE into the MAKE UNIQUE rebuild (the proc physically rewrote included_columns in
+                    // Rule 4/6, and step 2 never clears it); the Rule 7.5 superseded_by pass below appends to
+                    // whatever "Supersedes …" text is already there.
+                    nc.ConsolidationRule = Ucr;
+                    nc.Action = IndexCleanupAction.MakeUnique;
+                    nc.TargetIndexName = null;
+                    nc.Processed = true;
+                }
+            }
+
+            // Rule 7.5 cleanup: revert any MAKE UNIQUE index with no disabled constraint pointing back at it
+            // (FK-protected constraint, or Rule 7's set-match promoted a reversed-order index with no exact
+            // match). Mirrors the proc: reverts to NO action, WITHOUT restoring any prior marking.
+            foreach (var nc in scope)
+            {
+                if (nc.Action != IndexCleanupAction.MakeUnique)
+                {
+                    continue;
+                }
+
+                bool backedByDisabledConstraint = scope.Any(u =>
+                    u.Action == IndexCleanupAction.Disable
+                    && string.Equals(u.KeyColumns, nc.KeyColumns, StringComparison.Ordinal)
+                    && string.Equals(u.TargetIndexName, nc.Name, StringComparison.Ordinal));
+
+                if (!backedByDisabledConstraint)
+                {
+                    nc.ConsolidationRule = null;
+                    nc.Action = IndexCleanupAction.None;
+                    nc.TargetIndexName = null;
+                    nc.SupersededBy = null;
+                    nc.Processed = false;
+                }
+            }
+
+            // Rule 7.5 superseded_by: annotate each surviving MAKE UNIQUE index with the constraint(s) it replaces.
+            foreach (var nc in scope)
+            {
+                if (nc.Action != IndexCleanupAction.MakeUnique)
+                {
+                    continue;
+                }
+
+                foreach (var uc in scope
+                    .Where(u => u.Action == IndexCleanupAction.Disable
+                        && string.Equals(u.TargetIndexName, nc.Name, StringComparison.Ordinal))
+                    .OrderBy(u => u.Name, StringComparer.Ordinal))
+                {
+                    nc.SupersededBy = nc.SupersededBy == null
+                        ? "Will replace constraint " + uc.Name
+                        : nc.SupersededBy + ", will replace constraint " + uc.Name;
+                }
+            }
+
+            // Rule 7.5b: collapse duplicate unique constraints with no nonclustered index to promote.
+            ApplyDuplicateUniqueConstraints(scope);
+
+            // Rule 7.6: re-disable ordinary Key Duplicates of a MAKE UNIQUE winner (an index sharing the
+            // winner's exact keys+filter that step 2 briefly promoted then the cleanup reverted, or one no
+            // earlier rule had touched) and fold its includes into the winner.
+            ApplyKeyDuplicatesOfMakeUnique(scope);
+        }
+
+        /// <summary>
+        /// Rule 7.6 (sp_IndexCleanup lines ~4143-4272): after a unique constraint is replaced by a MAKE UNIQUE
+        /// index, any OTHER nonclustered index with the winner's exact key columns + filter (and no action yet)
+        /// is a plain Key Duplicate of it — DISABLE it and fold its includes into the winner. Without this, an
+        /// index that Rule 5 had disabled but Rule 7.5 step 2 promoted-then-reverted would be silently left in
+        /// place (a redundant index un-disabled). Emits the <b>Key Duplicate</b> rule, not Unique Constraint
+        /// Replacement — it is the same consolidation the proc applies. (Rule 7.6's sibling behavior of folding
+        /// includes is reproduced; the winner keeps its own + every folded loser's includes.)
+        /// </summary>
+        private static void ApplyKeyDuplicatesOfMakeUnique(List<WorkIndex> scope)
+        {
+            foreach (var winner in scope)
+            {
+                if (winner.Action != IndexCleanupAction.MakeUnique)
+                {
+                    continue;
+                }
+
+                // Exact key columns + filter match (the proc's key_filter_hash), still-unassigned, non-constraint.
+                var losers = scope
+                    .Where(d => !d.Processed
+                        && d.Action == IndexCleanupAction.None
+                        && d.ConsolidationRule == null
+                        && !d.Src.IsUniqueConstraint
+                        && !ReferenceEquals(d, winner)
+                        && string.Equals(d.KeyColumns, winner.KeyColumns, StringComparison.Ordinal)
+                        && string.Equals(d.Filter, winner.Filter, StringComparison.Ordinal))
+                    .OrderBy(d => d.Name, StringComparer.Ordinal)
+                    .ToList();
+
+                if (losers.Count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var loser in losers)
+                {
+                    loser.ConsolidationRule = IndexCleanupRules.KeyDuplicate;
+                    loser.Action = IndexCleanupAction.Disable;
+                    loser.TargetIndexName = winner.Name;
+                    loser.Processed = true;
+                }
+
+                // Fold the losers' includes into the winner (dedup; the winner keeps its own/absorbed includes).
+                var merged = new List<string>();
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var token in (winner.MergedIncludes ?? winner.IncludeTokens).Concat(losers.SelectMany(l => l.IncludeTokens)))
+                {
+                    if (seen.Add(token))
+                    {
+                        merged.Add(token);
+                    }
+                }
+                merged.Sort(StringComparer.Ordinal);   // deterministic, matches the collector's name-ordered includes
+                winner.MergedIncludes = merged;
+
+                var loserNames = string.Join(", ", losers.Select(l => l.Name));
+                winner.SupersededBy = winner.SupersededBy == null
+                    ? "Supersedes " + loserNames
+                    : winner.SupersededBy + ", " + loserNames;
+            }
+        }
+
+        /// <summary>
+        /// Rule 7.5b: two or more unique constraints with identical key columns + filter, all left KEEP by
+        /// Rule 7 (no nonclustered index promoted them). Keep the single deterministic winner (highest
+        /// priority, then alphabetically-first name); demote every other to DISABLE (→ DROP CONSTRAINT)
+        /// pointing at the winner. An FK-referenced constraint is never demoted. Demotions are computed
+        /// against the pre-demotion KEEP set (set-based, like the proc's single UPDATE) so the outcome is
+        /// order-independent and every loser targets the same survivor.
+        /// </summary>
+        private static void ApplyDuplicateUniqueConstraints(List<WorkIndex> scope)
+        {
+            var keepers = scope
+                .Where(w => w.Action == IndexCleanupAction.Keep
+                    && w.ConsolidationRule == IndexCleanupRules.UniqueConstraintReplacement
+                    && w.Src.IsUniqueConstraint)
+                .ToList();
+
+            if (keepers.Count < 2)
+            {
+                return;
+            }
+
+            var demotions = new List<(WorkIndex Loser, WorkIndex Keeper)>();
+            foreach (var loser in keepers)
+            {
+                if (loser.Src.IsForeignKeyReference)
+                {
+                    continue; // never drop an FK-referenced constraint
+                }
+
+                var keeper = keepers.FirstOrDefault(k =>
+                    !ReferenceEquals(k, loser)
+                    && string.Equals(k.KeyColumns, loser.KeyColumns, StringComparison.Ordinal)
+                    && string.Equals(k.Filter, loser.Filter, StringComparison.Ordinal)
+                    && LosesTo(loser, k)
+                    && IsUndisputedWinner(k, keepers));
+
+                if (keeper != null)
+                {
+                    demotions.Add((loser, keeper));
+                }
+            }
+
+            foreach (var (loser, keeper) in demotions)
+            {
+                loser.Action = IndexCleanupAction.Disable;
+                loser.TargetIndexName = keeper.Name;
+            }
+        }
+
+        /// <summary>The keep/drop tiebreak (mirrors Rule 2): lower priority loses; on a tie the alphabetically-later name loses.</summary>
+        private static bool LosesTo(WorkIndex loser, WorkIndex keeper) =>
+            loser.Priority < keeper.Priority
+            || (loser.Priority == keeper.Priority
+                && string.Compare(loser.Name, keeper.Name, StringComparison.Ordinal) > 0);
+
+        /// <summary>True when no sibling duplicate constraint beats <paramref name="keeper"/> — makes the winner (and every loser's target) deterministic when 3+ constraints tie.</summary>
+        private static bool IsUndisputedWinner(WorkIndex keeper, List<WorkIndex> keepers) =>
+            !keepers.Any(other =>
+                !ReferenceEquals(other, keeper)
+                && string.Equals(other.KeyColumns, keeper.KeyColumns, StringComparison.Ordinal)
+                && string.Equals(other.Filter, keeper.Filter, StringComparison.Ordinal)
+                && (other.Priority > keeper.Priority
+                    || (other.Priority == keeper.Priority
+                        && string.Compare(other.Name, keeper.Name, StringComparison.Ordinal) < 0)));
+
         // ────────────────────────────────────────────────────────────────────────────────────────────
         //  Keeper / grouping helpers
         // ────────────────────────────────────────────────────────────────────────────────────────────
@@ -501,7 +800,12 @@ namespace PerformanceMonitor.Common
             {
                 if (w.Action == IndexCleanupAction.Disable)
                 {
-                    yield return BuildDisable(w);
+                    // A disabled unique constraint (Rule 7.5 / 7.5b) is a DROP CONSTRAINT, not ALTER INDEX DISABLE.
+                    yield return w.Src.IsUniqueConstraint ? BuildDisableConstraint(w) : BuildDisable(w);
+                }
+                else if (w.Action == IndexCleanupAction.MakeUnique)
+                {
+                    yield return BuildMakeUnique(w, options);
                 }
                 else if (w.Action == IndexCleanupAction.MergeIncludes)
                 {
@@ -568,6 +872,43 @@ namespace PerformanceMonitor.Common
             };
         }
 
+        /// <summary>
+        /// Rule 7 / 7.5 MAKE UNIQUE: rebuild the nonclustered index as UNIQUE so it can take over a redundant
+        /// unique constraint's enforcement. Rendered like a merge (UNIQUE <c>DROP_EXISTING</c> rebuild); the
+        /// constraint itself is dropped by a companion <see cref="BuildDisableConstraint"/> row.
+        /// </summary>
+        private static IndexCleanupRecommendation BuildMakeUnique(WorkIndex w, IndexCleanupOptions options)
+        {
+            var (script, omitsPlacement) = MergeScript(w, options, forceUnique: true);
+
+            return NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.MakeUnique,
+                ResultKind = IndexCleanupResultKind.Merge,
+                SupersededBy = w.SupersededBy,
+                ScriptType = "MERGE SCRIPT",
+                Script = script,
+                AdditionalInfo = "This index will replace a unique constraint",
+                ScriptOmitsPartitionPlacement = omitsPlacement,
+            };
+        }
+
+        /// <summary>
+        /// Rule 7.5 / 7.5b DROP CONSTRAINT: a redundant unique constraint replaced by a MAKE UNIQUE index, or a
+        /// duplicate constraint collapsed into an identical survivor. Emits <c>ALTER TABLE … DROP CONSTRAINT</c>
+        /// (sp_IndexCleanup's <c>DISABLE CONSTRAINT SCRIPT</c>) — a constraint cannot be disabled, only dropped.
+        /// </summary>
+        private static IndexCleanupRecommendation BuildDisableConstraint(WorkIndex w) =>
+            NewRecommendation(w) with
+            {
+                Action = IndexCleanupAction.Disable,
+                ResultKind = IndexCleanupResultKind.DisableConstraint,
+                TargetIndexName = w.TargetIndexName,
+                ScriptType = "DISABLE CONSTRAINT SCRIPT",
+                Script = "ALTER TABLE " + FullName(w) + " DROP CONSTRAINT " + QuoteName(w.Name) + ";",
+                AdditionalInfo = "This constraint is being replaced by: " + (w.TargetIndexName ?? "(unknown)"),
+            };
+
         private static IndexCleanupRecommendation BuildCompress(WorkIndex w, IndexCleanupOptions options)
         {
             return NewRecommendation(w) with
@@ -614,11 +955,11 @@ namespace PerformanceMonitor.Common
         private static string DisableScript(WorkIndex w) =>
             "ALTER INDEX " + QuoteName(w.Name) + " ON " + FullName(w) + " DISABLE;";
 
-        private static (string Script, bool OmitsPlacement) MergeScript(WorkIndex w, IndexCleanupOptions options)
+        private static (string Script, bool OmitsPlacement) MergeScript(WorkIndex w, IndexCleanupOptions options, bool forceUnique = false)
         {
             string includes = string.Join(", ", w.MergedIncludes ?? w.IncludeTokens);
 
-            var script = "CREATE " + (w.Src.IsUnique ? "UNIQUE " : "") + "INDEX " + QuoteName(w.Name)
+            var script = "CREATE " + ((forceUnique || w.Src.IsUnique) ? "UNIQUE " : "") + "INDEX " + QuoteName(w.Name)
                 + " ON " + FullName(w) + " (" + w.KeyColumns + ")"
                 + (includes.Length > 0 ? " INCLUDE (" + includes + ")" : "")
                 + (w.Filter.Length > 0 ? " WHERE " + w.Filter : "")
@@ -693,8 +1034,9 @@ namespace PerformanceMonitor.Common
                         unused++;
                     }
                 }
-                else if (w.Action == IndexCleanupAction.MergeIncludes)
+                else if (w.Action == IndexCleanupAction.MergeIncludes || w.Action == IndexCleanupAction.MakeUnique)
                 {
+                    // MAKE UNIQUE is a kept-and-rebuilt index (sp_IndexCleanup's MERGE bucket), not a reclaim.
                     merge++;
                 }
 
@@ -779,10 +1121,20 @@ namespace PerformanceMonitor.Common
                 + "reversed-order and filter-differing indexes are left alone; a different leading column or filter serves "
                 + "different queries/rows).");
 
-            notes.Add("Out of scope per this stage's DISABLE/MERGE INCLUDES/KEEP action set: sp_IndexCleanup's "
-                + "'Unique Constraint Replacement' (MAKE UNIQUE / DROP CONSTRAINT, Rule 7 family). Its 'Same Keys "
-                + "Different Order' REVIEW case is largely covered by the Reverse Duplicate review rows above. Both are "
-                + "reproducible from the captured metadata if later required.");
+            if (recommendations.Any(r => r.ConsolidationRule == IndexCleanupRules.UniqueConstraintReplacement))
+            {
+                notes.Add("Unique Constraint Replacement (sp_IndexCleanup Rule 7/7.5/7.5b) reproduces the proc's LITERAL "
+                    + "behavior, verified against a live @debug=1 run: a nonclustered index whose key_columns EXACTLY match "
+                    + "a unique constraint is made unique (MERGE SCRIPT) and the constraint is dropped (DISABLE CONSTRAINT "
+                    + "SCRIPT). This fires even when the index is ALREADY unique — the proc's Rule 7.5 step 2 has no is_unique "
+                    + "guard, so it overrides Rule 7's KEEP with MAKE UNIQUE (a redundant-but-harmless UNIQUE rebuild that "
+                    + "still drops the constraint). A constraint backing an inbound foreign-key reference is never dropped, "
+                    + "and an index whose key columns are a SUPERSET of the constraint's is not promoted.");
+            }
+
+            notes.Add("Out of scope of the Unique Constraint Replacement port: sp_IndexCleanup's 'Same Keys Different Order' "
+                + "REVIEW case, largely covered by the Reverse Duplicate review rows above and reproducible from the captured "
+                + "metadata if later required.");
 
             return notes;
         }
@@ -855,11 +1207,12 @@ namespace PerformanceMonitor.Common
 
         private static int ResultKindSort(IndexCleanupResultKind kind) => kind switch
         {
-            IndexCleanupResultKind.Merge => 0,
+            IndexCleanupResultKind.Merge => 0,               // includes MAKE UNIQUE (proc's MERGE bucket)
             IndexCleanupResultKind.Disable => 1,
-            IndexCleanupResultKind.Compress => 2,
-            IndexCleanupResultKind.Review => 3,
-            _ => 4,
+            IndexCleanupResultKind.DisableConstraint => 2,   // proc orders CONSTRAINT after DISABLE
+            IndexCleanupResultKind.Compress => 3,
+            IndexCleanupResultKind.Review => 4,
+            _ => 5,
         };
 
         // ────────────────────────────────────────────────────────────────────────────────────────────

--- a/PerformanceMonitor.Common/IndexCleanupModels.cs
+++ b/PerformanceMonitor.Common/IndexCleanupModels.cs
@@ -178,11 +178,21 @@ namespace PerformanceMonitor.Common
         /// <summary>Retain this index (the keeper of a duplicate set).</summary>
         Keep = 1,
 
-        /// <summary>Disable this index (redundant / unused). Never assigned to a protected index.</summary>
+        /// <summary>Disable this index (redundant / unused). Never assigned to a protected index. When the
+        /// index is a unique constraint (Rule 7.5 / 7.5b), the generated script is a <c>DROP CONSTRAINT</c>
+        /// rather than an <c>ALTER INDEX … DISABLE</c>.</summary>
         Disable = 2,
 
         /// <summary>Retain but rebuild with includes merged from the indexes it supersedes.</summary>
         MergeIncludes = 3,
+
+        /// <summary>
+        /// Rebuild this nonclustered index as UNIQUE so it can replace a redundant unique constraint
+        /// (sp_IndexCleanup's <c>MAKE UNIQUE</c>, Rule 7 / 7.5). The matching constraint is dropped
+        /// (a companion <see cref="Disable"/> row). The generated script is a
+        /// <c>CREATE UNIQUE INDEX … WITH (DROP_EXISTING = ON …)</c> rebuild.
+        /// </summary>
+        MakeUnique = 4,
     }
 
     /// <summary>Which generated-script bucket a recommendation belongs to. Mirrors sp_IndexCleanup's <c>result_type</c>.</summary>
@@ -204,6 +214,15 @@ namespace PerformanceMonitor.Common
         /// patterns / row coverage).
         /// </summary>
         Review = 3,
+
+        /// <summary>
+        /// An <c>ALTER TABLE … DROP CONSTRAINT</c> row: a redundant unique constraint being replaced by a
+        /// nonclustered index made unique in its place, or (Rule 7.5b) a duplicate unique constraint dropped
+        /// in favor of an identical surviving one. Mirrors sp_IndexCleanup's <c>CONSTRAINT</c> result bucket
+        /// (its <c>DISABLE CONSTRAINT SCRIPT</c>) — distinct from <see cref="Disable"/>'s
+        /// <c>ALTER INDEX … DISABLE</c>.
+        /// </summary>
+        DisableConstraint = 4,
     }
 
     /// <summary>The canonical <c>consolidation_rule</c> labels this analyzer emits.</summary>
@@ -241,6 +260,16 @@ namespace PerformanceMonitor.Common
 
         /// <summary>The wider index a Key Subset defers to (Rule 4); rebuilt with the subset's missing includes merged in.</summary>
         public const string KeySuperset = "Key Superset";
+
+        /// <summary>
+        /// A nonclustered index whose key columns match a unique constraint's (Rule 7 / 7.5 / 7.5b). The index
+        /// is made unique (<see cref="IndexCleanupAction.MakeUnique"/>) to take over the constraint's
+        /// uniqueness enforcement and the now-redundant constraint is dropped
+        /// (<see cref="IndexCleanupAction.Disable"/> → <see cref="IndexCleanupResultKind.DisableConstraint"/>);
+        /// a constraint that backs an inbound foreign-key reference is never dropped. Rule 7.5b additionally
+        /// collapses two or more identical unique constraints down to a single survivor.
+        /// </summary>
+        public const string UniqueConstraintReplacement = "Unique Constraint Replacement";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds sp_IndexCleanup's **Unique Constraint Replacement** rule family to the monitor-side `IndexCleanupAnalyzer` (Stage 2, #1384), so servers without the proc get the same MAKE UNIQUE / DROP CONSTRAINT recommendations from the captured `index_object_stats` snapshot. Every behavior below was cross-checked against a **live `sp_IndexCleanup @debug=1` run** over constructed scenarios (not from the source text alone).

### The rules

- **Rule 7** (set-match, tentative): an eligible nonclustered index whose **key-column SET** equals a unique constraint's — *both-direction set equality*, so an index with an EXTRA key column does **not** match — is tentatively marked `MAKE UNIQUE` (or `KEEP` if already unique). A constraint self-matches, so a lone/duplicate constraint is marked `KEEP` here (the precondition for 7.5b).
- **Rule 7.5** (two steps + cleanup): a constraint with an **EXACT `key_columns`** match to a *true* nonclustered index is marked `DISABLE` pointing at that index; the index is marked `MAKE UNIQUE`. Step 2 is unconditional, so it **overrides** an earlier Unused/Key-Duplicate marking on the matched index (verified live). A promoted index with no disabled constraint pointing back at it (FK-protected constraint, or a reversed-order set-match) is reverted to no action.
- **Rule 7.5b**: two or more identical constraints with no index to promote collapse to a single deterministic survivor (highest priority, then alphabetically-first name); the rest become `DROP CONSTRAINT`.
- **Rule 7.6**: a leftover Key Duplicate of a made-unique index is re-disabled and its includes folded into the winner.

### Load-bearing guards (both reproduced + tested)

- **FK-reference protection**: a constraint backing an inbound foreign-key reference (`is_foreign_key_reference = 1` on a key column) is **never dropped** — dropping it would silently break referential integrity. Applied in both 7.5 step 1 and 7.5b.
- **Both-direction set-equality guard**: Rule 7 requires *both* `EXCEPT`s empty, so an index whose keys are a **superset** of the constraint's is not treated as equivalent and is not promoted.
- **"true NC, not another UC" guard** in 7.5 step 1: without it, two constraints with identical keys would mutually disable and both get dropped; that case is handed to 7.5b instead.

## Ambiguity — reproduced the proc's LITERAL behavior

**Already-unique NC + EXACT-match constraint → `MAKE UNIQUE`, not `KEEP`.** The task text expected `KEEP`, but the live proc marks it `MAKE UNIQUE` and drops the constraint: Rule 7's `KEEP` (from its `is_unique` CASE) is **overridden** by Rule 7.5 step 2, which has no `is_unique` guard. It is a redundant-but-harmless UNIQUE rebuild that still drops the constraint. Reproduced literally and asserted in `..._AlreadyUniqueNcExactMatch_IsMadeUniquePerLiteralProc`. The `KEEP` outcome the task described *does* occur when the keys match only by SET (reversed order) — asserted separately in `..._AlreadyUniqueNcDifferentKeyOrder_IsKeptNotMadeUnique` and also confirmed live.

## Scope note

The task scoped Rule 7/7.5/7.5b. I also ported **Rule 7.6** because a code review found that Rule 7.5 step 2's override + cleanup would otherwise leave a **dropped DISABLE**: an index Rule 5 had disabled gets promoted-then-reverted to *no action*, silently leaving a redundant index in place. Rule 7.6 is the proc's own cleanup for exactly this and reuses the existing Key-Duplicate include-merge pattern; both the include preservation and the re-disable are live-verified (`CREATE UNIQUE INDEX [nc_a] ... INCLUDE ([c], [d])`).

One deliberate deterministic **superset** of proc behavior (flagged for transparency): when two disabled constraints target the same made-unique index, `superseded_by` lists both rather than the proc's arbitrary single-row write — matching the deterministic tie-breaks used elsewhere here. Still genuinely out of scope: the proc's `Same Keys Different Order` REVIEW case (already covered by the Reverse Duplicate review rows).

## Model additions

`IndexCleanupAction.MakeUnique`, `IndexCleanupResultKind.DisableConstraint` (renders `ALTER TABLE ... DROP CONSTRAINT`), `IndexCleanupRules.UniqueConstraintReplacement`. Only additive enum values (existing 0-3 unchanged); the two current SQL-backed FinOps consumers don't reference these enums, and `Analyze` is called only from tests today.

## Tests (14 new, all DB-free)

NC to constraint exact match -> MAKE UNIQUE + DROP CONSTRAINT; canonical UNIQUE `DROP_EXISTING` script; own-includes retained; FK-referenced constraint not dropped; superset key not promoted; already-unique exact-match -> MAKE UNIQUE (literal proc); already-unique reversed-order -> KEEP; override of an unused marking; duplicate constraints -> loser dropped / 3-way single winner / FK-referenced loser protected; rollup counts; Key-Superset to MAKE UNIQUE retains absorbed includes; Rule 7.6 re-disable + include fold.

## Verification

- `dotnet build PerformanceMonitor.Common -c Release` -> **0 warnings**, 0 errors.
- `dotnet test Darling/Darling.Tests -c Release` -> **693 passed, 0 failed, 83 skipped** (IndexCleanupAnalyzer: 53, of which 14 new).
- Files touched: `PerformanceMonitor.Common/IndexCleanupAnalyzer.cs`, `PerformanceMonitor.Common/IndexCleanupModels.cs`, `Darling/Darling.Tests/IndexCleanupAnalyzerTests.cs` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
