### PR TITLE
Add monitor-side Index Analysis tab to the Darling viewer (#1262)

### DIFF
--- a/Darling/Darling.Tests/ViewerIndexAnalysisTests.cs
+++ b/Darling/Darling.Tests/ViewerIndexAnalysisTests.cs
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the FinOps Index Analysis sub-tab's Darling-specific read/map/derive/project layer (Stage 3) against
+/// the store contract, no live Postgres. The Common <see cref="IndexCleanupAnalyzer"/> itself is already
+/// covered (53 tests); these cover ONLY the viewer glue Stage 3 adds: (1) the two reads — the load-bearing
+/// SQL clauses + column parity against the generated collector DDL; (2) the <c>v_index_object_stats</c> row →
+/// <see cref="IndexCleanupIndexInput"/> mapping (incl. NULL flag → false); (3) the
+/// <see cref="IndexCleanupOptions"/> derivation from the collected <c>server_properties</c> facts
+/// (edition → compression/online, start-time → uptime); and (4) the analyzer-result → grid-row projections
+/// (the six-value action label, the "ALL DATABASES"-first rollup).
+/// </summary>
+public sealed class ViewerIndexAnalysisTests
+{
+    // ── Reads: SQL clause pins ──
+
+    [Fact]
+    public void IndexObjectStatsLatestSql_LatestPerIndex_ViaDistinctOn()
+    {
+        var sql = ViewerDataService.IndexObjectStatsLatestSql;
+
+        Assert.Contains("FROM v_index_object_stats", sql, StringComparison.Ordinal);
+        /* Latest snapshot per index identity — never the whole history, and keyed on the index (not a single
+           server-wide MAX(collection_time)) so per-database cycles with different times still dedupe right. */
+        Assert.Contains("DISTINCT ON (database_id, object_id, index_id)", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY database_id, object_id, index_id, collection_time DESC", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ServerCompressionInfoSql_ReadsServerPropertiesBaseTable_LatestRow()
+    {
+        var sql = ViewerDataService.ServerCompressionInfoSql;
+
+        /* Darling has no v_server_properties view — the base table, bare-name resolved via the Search Path. */
+        Assert.Contains("FROM server_properties", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_server_properties", sql, StringComparison.Ordinal);
+        Assert.Contains("engine_edition", sql, StringComparison.Ordinal);
+        Assert.Contains("product_version", sql, StringComparison.Ordinal);
+        Assert.Contains("sqlserver_start_time", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(ViewerDataService.IndexObjectStatsLatestSql))]
+    [InlineData(nameof(ViewerDataService.ServerCompressionInfoSql))]
+    public void IndexAnalysisReads_PgDialect_PositionalParams_NoTSqlNamedParams(string sqlName)
+    {
+        var sql = (string)typeof(ViewerDataService).GetField(sqlName)!.GetValue(null)!;
+
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+    }
+
+    // ── Reads: column parity against the generated collector DDL ──
+
+    [Fact]
+    public void IndexObjectStatsLatestSql_ReferencesColumnsThatExistInTheGeneratedTable()
+    {
+        var ddl = PgSchemaGenerator.CreateTable(IndexObjectStatsCollector.Instance);
+        Assert.Equal("index_object_stats", IndexObjectStatsCollector.Instance.TargetTable);
+
+        foreach (var col in new[]
+        {
+            "database_name", "database_id", "schema_name", "object_id", "table_name", "index_id", "index_name",
+            "index_type_desc", "key_columns", "included_columns", "filter_definition", "is_unique",
+            "is_unique_constraint", "is_primary_key", "is_foreign_key", "is_foreign_key_reference", "is_disabled",
+            "is_indexed_view", "data_compression_desc", "optimize_for_sequential_key", "fill_factor", "is_padded",
+            "allow_page_locks", "allow_row_locks", "user_seeks", "user_scans", "user_lookups", "user_updates",
+            "reserved_mb", "total_rows", "partition_count", "sqlserver_start_time", "collection_time", "server_id",
+        })
+        {
+            Assert.Contains(col, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ServerCompressionInfoRead_ReferencesColumnsThatExistInTheGeneratedTable()
+    {
+        var ddl = PgSchemaGenerator.CreateTable(ServerPropertiesCollector.Instance);
+        Assert.Equal("server_properties", ServerPropertiesCollector.Instance.TargetTable);
+
+        foreach (var col in new[] { "engine_edition", "product_version", "sqlserver_start_time", "collection_time", "server_id" })
+        {
+            Assert.Contains(col, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    // ── Row → IndexCleanupIndexInput mapping ──
+
+    private static ViewerDataService.IndexObjectStatsRow FullRow() => new()
+    {
+        DatabaseName = "AdventureWorks",
+        DatabaseId = 7,
+        SchemaName = "Sales",
+        ObjectId = 12345,
+        TableName = "Orders",
+        IndexId = 3,
+        IndexName = "IX_Orders_CustomerId",
+        IndexTypeDesc = "NONCLUSTERED",
+        KeyColumns = "[CustomerId], [OrderDate] DESC",
+        IncludedColumns = "[Total]",
+        FilterDefinition = "([Status]=(1))",
+        IsUnique = true,
+        IsUniqueConstraint = true,
+        IsPrimaryKey = true,
+        IsForeignKey = true,
+        IsForeignKeyReference = true,
+        IsDisabled = false,
+        IsIndexedView = true,
+        DataCompressionDesc = "NONE",
+        OptimizeForSequentialKey = true,
+        FillFactor = 90,
+        IsPadded = true,
+        AllowPageLocks = true,
+        AllowRowLocks = true,
+        UserSeeks = 10,
+        UserScans = 20,
+        UserLookups = 30,
+        UserUpdates = 40,
+        ReservedMb = 512.50m,
+        TotalRows = 1_000_000,
+        PartitionCount = 4,
+        SqlServerStartTime = new DateTime(2026, 7, 1, 8, 0, 0),
+    };
+
+    [Fact]
+    public void MapToIndexInput_CarriesEveryField()
+    {
+        var input = ViewerDataService.MapToIndexInput(FullRow());
+
+        Assert.Equal("AdventureWorks", input.DatabaseName);
+        Assert.Equal(7, input.DatabaseId);
+        Assert.Equal("Sales", input.SchemaName);
+        Assert.Equal(12345, input.ObjectId);
+        Assert.Equal("Orders", input.TableName);
+        Assert.Equal(3, input.IndexId);
+        Assert.Equal("IX_Orders_CustomerId", input.IndexName);
+        Assert.Equal("NONCLUSTERED", input.IndexTypeDesc);
+        Assert.Equal("[CustomerId], [OrderDate] DESC", input.KeyColumns);
+        Assert.Equal("[Total]", input.IncludedColumns);
+        Assert.Equal("([Status]=(1))", input.FilterDefinition);
+        Assert.True(input.IsUnique);
+        Assert.True(input.IsUniqueConstraint);
+        Assert.True(input.IsPrimaryKey);
+        Assert.True(input.IsForeignKey);
+        Assert.True(input.IsForeignKeyReference);
+        Assert.False(input.IsDisabled);
+        Assert.True(input.IsIndexedView);
+        Assert.Equal("NONE", input.DataCompressionDesc);
+        Assert.True(input.OptimizeForSequentialKey);
+        Assert.Equal((short)90, input.FillFactor);
+        Assert.True(input.IsPadded);
+        Assert.True(input.AllowPageLocks);
+        Assert.True(input.AllowRowLocks);
+        Assert.Equal(10, input.UserSeeks);
+        Assert.Equal(20, input.UserScans);
+        Assert.Equal(30, input.UserLookups);
+        Assert.Equal(40, input.UserUpdates);
+        Assert.Equal(512.50m, input.ReservedMb);
+        Assert.Equal(1_000_000, input.TotalRows);
+        Assert.Equal(4, input.PartitionCount);
+        Assert.Equal(new DateTime(2026, 7, 1, 8, 0, 0), input.SqlServerStartTime);
+    }
+
+    [Fact]
+    public void MapToIndexInput_NullFlags_CollapseToFalse_AbsentGuardIsNotAGuard()
+    {
+        // A minimal row: every boolean flag NULL (the Postgres columns are nullable), counters NULL, sizes NULL.
+        var input = ViewerDataService.MapToIndexInput(new ViewerDataService.IndexObjectStatsRow
+        {
+            DatabaseName = "db",
+            SchemaName = "dbo",
+            TableName = "t",
+            IndexId = 2,
+        });
+
+        Assert.False(input.IsUnique);
+        Assert.False(input.IsUniqueConstraint);
+        Assert.False(input.IsPrimaryKey);
+        Assert.False(input.IsForeignKey);
+        Assert.False(input.IsForeignKeyReference);
+        Assert.False(input.IsDisabled);
+        Assert.False(input.IsIndexedView);
+        Assert.False(input.OptimizeForSequentialKey);
+        Assert.False(input.IsPadded);
+        Assert.False(input.AllowPageLocks);
+        Assert.False(input.AllowRowLocks);
+        Assert.Equal(0, input.UserSeeks);
+        Assert.Equal(0, input.UserScans);
+        Assert.Equal(0, input.UserLookups);
+        Assert.Equal(0, input.UserUpdates);
+        // The genuinely-nullable sizing fields stay null (distinct from "collected as 0").
+        Assert.Null(input.ReservedMb);
+        Assert.Null(input.TotalRows);
+        Assert.Null(input.PartitionCount);
+        Assert.Null(input.FillFactor);
+    }
+
+    // ── Options derivation: compression / online by edition ──
+
+    private static readonly DateTime Ref = new(2026, 7, 5, 12, 0, 0);
+
+    [Theory]
+    [InlineData(3, "16.0.1000.6", true, true)]   // Enterprise (also Developer/Evaluation) — both
+    [InlineData(5, "12.0.2000.8", true, true)]   // Azure SQL Database — both (version irrelevant)
+    [InlineData(8, "12.0.2000.8", true, true)]   // Azure SQL Managed Instance — both
+    [InlineData(2, "16.0.1000.6", true, false)]  // Standard 2016+ — compression yes, online no
+    [InlineData(2, "13.0.5026.0", true, false)]  // Standard 2016 RTM (major 13) — compression yes
+    [InlineData(4, "15.0.4300.1", true, false)]  // Express 2019 — compression yes, online no
+    [InlineData(2, "12.0.6024.0", false, false)] // Standard 2014 (pre-2016) — no compression, no online
+    [InlineData(4, "11.0.7001.0", false, false)] // Express 2012 — neither
+    public void DeriveOptions_CompressionAndOnline_ByEditionAndVersion(
+        int engineEdition, string productVersion, bool expectCompression, bool expectOnline)
+    {
+        var options = ViewerDataService.DeriveIndexCleanupOptions(engineEdition, productVersion, null, Ref);
+
+        Assert.Equal(expectCompression, options.ServerSupportsCompression);
+        Assert.Equal(expectOnline, options.ServerSupportsOnline);
+    }
+
+    [Fact]
+    public void DeriveOptions_UnknownEdition_NoCollectedRow_SafeDefaults()
+    {
+        // No server_properties row collected yet: assume compression available (2016+ product minimum), online off.
+        var options = ViewerDataService.DeriveIndexCleanupOptions(null, null, null, Ref);
+
+        Assert.True(options.ServerSupportsCompression);
+        Assert.False(options.ServerSupportsOnline);
+    }
+
+    // ── Options derivation: uptime days from start time ──
+
+    [Fact]
+    public void DeriveOptions_UptimeDays_FromServerLocalStartVsReferenceNow()
+    {
+        var start = Ref.AddDays(-30);
+        var options = ViewerDataService.DeriveIndexCleanupOptions(3, "16.0.1000.6", start, Ref);
+
+        Assert.NotNull(options.ServerUptimeDays);
+        Assert.Equal(30.0, options.ServerUptimeDays!.Value, precision: 3);
+    }
+
+    [Fact]
+    public void DeriveOptions_UptimeUnderSevenDays_DrivesAnalyzerDedupeAndWarning()
+    {
+        // Uptime derivation feeds the analyzer's <=7-day auto-dedupe and <14-day caveat: prove the wiring end to end.
+        var options = ViewerDataService.DeriveIndexCleanupOptions(3, "16.0.1000.6", Ref.AddDays(-3), Ref);
+        Assert.Equal(3.0, options.ServerUptimeDays!.Value, precision: 3);
+
+        var result = IndexCleanupAnalyzer.Analyze(Array.Empty<IndexCleanupIndexInput>(), options);
+        Assert.True(result.DedupeOnlyApplied);
+        Assert.True(result.UptimeWarning);
+    }
+
+    [Fact]
+    public void DeriveOptions_NullStart_NoUptime_AndFutureStartIgnored()
+    {
+        Assert.Null(ViewerDataService.DeriveIndexCleanupOptions(3, "16.0", null, Ref).ServerUptimeDays);
+        // A start clock ahead of the viewer's (timezone skew) yields a negative age — discarded, not applied.
+        Assert.Null(ViewerDataService.DeriveIndexCleanupOptions(3, "16.0", Ref.AddDays(2), Ref).ServerUptimeDays);
+    }
+
+    [Fact]
+    public void DeriveOptions_MinimumsAndFactors_MatchSpIndexCleanupParameterDefaults()
+    {
+        var options = ViewerDataService.DeriveIndexCleanupOptions(3, "16.0.1000.6", Ref.AddDays(-30), Ref);
+
+        // sp_IndexCleanup @min_reads / @min_writes / @min_size_gb / @min_rows / @dedupe_only defaults (0 / off).
+        Assert.False(options.DedupeOnly);
+        Assert.Equal(0m, options.MinSizeGb);
+        Assert.Equal(0, options.MinReads);
+        Assert.Equal(0, options.MinWrites);
+        Assert.Equal(0, options.MinRows);
+        // The 0.20–0.60 general compression savings band (record defaults, unchanged).
+        Assert.Equal(0.20m, options.CompressionMinSavingsFactor);
+        Assert.Equal(0.60m, options.CompressionMaxSavingsFactor);
+    }
+
+    // ── ParseMajorVersion ──
+
+    [Theory]
+    [InlineData("16.0.1000.6", 16)]
+    [InlineData("13.0.5026.0", 13)]
+    [InlineData("9.00.5000.00", 9)]
+    [InlineData("11.0.7001.0", 11)]
+    [InlineData(null, 0)]
+    [InlineData("", 0)]
+    [InlineData("   ", 0)]
+    [InlineData("garbage", 0)]
+    public void ParseMajorVersion_LeadingInteger(string? productVersion, int expected) =>
+        Assert.Equal(expected, ViewerDataService.ParseMajorVersion(productVersion));
+
+    // ── Recommendation-row action label (the six-value filter set) ──
+
+    [Theory]
+    [InlineData(IndexCleanupAction.MakeUnique, IndexCleanupResultKind.Merge, "MAKE UNIQUE")]
+    [InlineData(IndexCleanupAction.MakeUnique, IndexCleanupResultKind.Disable, "MAKE UNIQUE")] // Action wins over its bucket
+    [InlineData(IndexCleanupAction.Disable, IndexCleanupResultKind.Disable, "DISABLE")]
+    [InlineData(IndexCleanupAction.MergeIncludes, IndexCleanupResultKind.Merge, "MERGE")]
+    [InlineData(IndexCleanupAction.Keep, IndexCleanupResultKind.Compress, "COMPRESS")]
+    [InlineData(IndexCleanupAction.Keep, IndexCleanupResultKind.Review, "REVIEW")]
+    [InlineData(IndexCleanupAction.Disable, IndexCleanupResultKind.DisableConstraint, "DROP CONSTRAINT")]
+    public void ActionLabelFor_MapsToTheSixOperationLabels(
+        IndexCleanupAction action, IndexCleanupResultKind resultKind, string expected) =>
+        Assert.Equal(expected, IndexCleanupRecommendationRow.ActionLabelFor(action, resultKind));
+
+    [Fact]
+    public void RecommendationRow_ReviewRow_CarriesNoDestructiveScript()
+    {
+        var row = new IndexCleanupRecommendationRow(new IndexCleanupRecommendation
+        {
+            DatabaseName = "db",
+            SchemaName = "dbo",
+            TableName = "t",
+            IndexName = "IX_review",
+            Action = IndexCleanupAction.Keep,
+            ResultKind = IndexCleanupResultKind.Review,
+            ConsolidationRule = IndexCleanupRules.ReverseDuplicate,
+            SupersededBy = "Related to IX_other",
+            Script = "",
+        });
+
+        Assert.Equal("REVIEW", row.ActionDisplay);
+        Assert.Equal("REVIEW", row.ResultKindDisplay);
+        Assert.Equal(IndexCleanupRules.ReverseDuplicate, row.ConsolidationRule);
+        Assert.Equal("", row.Script);
+        Assert.Equal("Related to IX_other", row.SupersededBy);
+    }
+
+    // ── Rollup projection ──
+
+    [Fact]
+    public void ProjectRollups_OverallFirst_ThenPerDatabase()
+    {
+        var result = new IndexCleanupAnalysisResult
+        {
+            OverallRollup = new IndexCleanupRollup { DatabaseName = null, IndexCount = 42, TotalMaxSavingsGb = 9.5m },
+            DatabaseRollups = new[]
+            {
+                new IndexCleanupRollup { DatabaseName = "Alpha", IndexCount = 20 },
+                new IndexCleanupRollup { DatabaseName = "Beta", IndexCount = 22 },
+            },
+        };
+
+        var rows = ViewerDataService.ProjectRollups(result);
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal("ALL DATABASES", rows[0].Scope);
+        Assert.Equal(42, rows[0].IndexCount);
+        Assert.Equal(9.5m, rows[0].TotalMaxSavingsGb);
+        Assert.Equal("Alpha", rows[1].Scope);
+        Assert.Equal("Beta", rows[2].Scope);
+    }
+
+    // ── End-to-end glue: map → analyze → project (NOT re-testing analyzer rules; just the Stage-3 wiring) ──
+
+    [Fact]
+    public void EndToEnd_MapAnalyzeProject_ExactDuplicate_YieldsADisableRecommendation()
+    {
+        // Two identical nonclustered indexes on one table = an Exact Duplicate; the analyzer disables the loser.
+        ViewerDataService.IndexObjectStatsRow Idx(int indexId, string name) => new()
+        {
+            DatabaseName = "AdventureWorks",
+            DatabaseId = 7,
+            SchemaName = "Sales",
+            ObjectId = 100,
+            TableName = "Orders",
+            IndexId = indexId,
+            IndexName = name,
+            IndexTypeDesc = "NONCLUSTERED",
+            KeyColumns = "[CustomerId]",
+            IncludedColumns = "[Total]",
+            IsUnique = false,
+            ReservedMb = 100m,
+            TotalRows = 500_000,
+            UserSeeks = 5,
+        };
+
+        var clustered = new ViewerDataService.IndexObjectStatsRow
+        {
+            DatabaseName = "AdventureWorks",
+            DatabaseId = 7,
+            SchemaName = "Sales",
+            ObjectId = 100,
+            TableName = "Orders",
+            IndexId = 1,
+            IndexName = "PK_Orders",
+            IndexTypeDesc = "CLUSTERED",
+            KeyColumns = "[OrderId]",
+            IsUnique = true,
+            IsPrimaryKey = true,
+            ReservedMb = 400m,
+            TotalRows = 500_000,
+        };
+
+        var inputs = new[] { clustered, Idx(2, "IX_A"), Idx(3, "IX_B") }
+            .Select(ViewerDataService.MapToIndexInput)
+            .ToList();
+
+        var options = ViewerDataService.DeriveIndexCleanupOptions(3, "16.0.1000.6", Ref.AddDays(-60), Ref);
+        var result = IndexCleanupAnalyzer.Analyze(inputs, options);
+
+        var recRows = ViewerDataService.ProjectRecommendations(result);
+        var rollupRows = ViewerDataService.ProjectRollups(result);
+
+        // The Stage-3 glue produced rows the grids can bind: at least one DISABLE recommendation for the duplicate.
+        Assert.Contains(recRows, r => r.ActionDisplay == "DISABLE" && r.ConsolidationRule == IndexCleanupRules.ExactDuplicate);
+        // The rollup carries the overall row and reflects the disable.
+        Assert.Equal("ALL DATABASES", rollupRows[0].Scope);
+        Assert.True(rollupRows[0].IndexesToDisable >= 1);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.IndexAnalysis.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.IndexAnalysis.cs
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/*
+ * FinOps Index Analysis sub-tab reads (Stage 3, deferred from the #1372 FinOps port). Lite runs the LIVE
+ * dbo.sp_IndexCleanup proc against the target; the headless viewer cannot reach targets, so it reproduces the
+ * analysis MONITOR-SIDE: it reads the latest collected per-index snapshot from v_index_object_stats (Stage 1),
+ * maps each row into the Common IndexCleanupIndexInput contract, derives the server-fact options
+ * (edition -> compression/online support, start time -> uptime days) from the collected server_properties, and
+ * runs the pure Common IndexCleanupAnalyzer (Stage 2, 53 tests, incl. the Rule 7 Unique Constraint Replacement
+ * family). No live proc, no "install sp_IndexCleanup" prompt, no server-side work — parse-on-read, mirroring the
+ * System Events tab. The analysis is string-comparison-heavy so it runs off the UI thread (Task.Run), like the
+ * deadlock-graph / system_health shreds. SQL kept in public const so tests pin it.
+ */
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The latest collected snapshot of EVERY index for one server: DISTINCT ON keeps the newest row per
+    /// (database_id, object_id, index_id) so the analyzer sees each index exactly once (never the whole
+    /// history). Per-database collection cycles can carry different collection_times, so the dedupe keys on the
+    /// index identity, not a single server-wide MAX(collection_time). $1 server_id. Column order is the read
+    /// contract for <see cref="ReadIndexObjectStatsRow"/>.
+    /// </summary>
+    public const string IndexObjectStatsLatestSql = @"
+SELECT DISTINCT ON (database_id, object_id, index_id)
+    database_name,
+    database_id,
+    schema_name,
+    object_id,
+    table_name,
+    index_id,
+    index_name,
+    index_type_desc,
+    key_columns,
+    included_columns,
+    filter_definition,
+    is_unique,
+    is_unique_constraint,
+    is_primary_key,
+    is_foreign_key,
+    is_foreign_key_reference,
+    is_disabled,
+    is_indexed_view,
+    data_compression_desc,
+    optimize_for_sequential_key,
+    fill_factor,
+    is_padded,
+    allow_page_locks,
+    allow_row_locks,
+    user_seeks,
+    user_scans,
+    user_lookups,
+    user_updates,
+    reserved_mb,
+    total_rows,
+    partition_count,
+    sqlserver_start_time
+FROM v_index_object_stats
+WHERE server_id = $1
+ORDER BY database_id, object_id, index_id, collection_time DESC";
+
+    /// <summary>
+    /// The server's latest edition / version / start-time facts for the analyzer options — the same three
+    /// SERVERPROPERTY-derived values sp_IndexCleanup reads at runtime, sourced from the collected
+    /// server_properties (Darling has no v_server_properties view; the base table is bare-name resolved via the
+    /// connection Search Path, exactly like the Utilization/Inventory reads). $1 server_id.
+    /// </summary>
+    public const string ServerCompressionInfoSql = @"
+SELECT
+    engine_edition,
+    product_version,
+    sqlserver_start_time
+FROM server_properties
+WHERE server_id = $1
+ORDER BY collection_time DESC
+LIMIT 1";
+
+    /// <summary>
+    /// The analysis-relevant projection of one <c>v_index_object_stats</c> row — the viewer's own read-layer
+    /// shape (NOT the collector Row: the Common contract is deliberately collector-free), mapped into
+    /// <see cref="IndexCleanupIndexInput"/> by <see cref="MapToIndexInput"/>. Booleans are nullable because the
+    /// Postgres columns are; the mapper collapses a NULL flag to <c>false</c> (an absent guard is not a guard).
+    /// </summary>
+    public sealed record IndexObjectStatsRow
+    {
+        public string DatabaseName { get; init; } = "";
+        public int DatabaseId { get; init; }
+        public string SchemaName { get; init; } = "";
+        public int ObjectId { get; init; }
+        public string TableName { get; init; } = "";
+        public int IndexId { get; init; }
+        public string? IndexName { get; init; }
+        public string? IndexTypeDesc { get; init; }
+        public string? KeyColumns { get; init; }
+        public string? IncludedColumns { get; init; }
+        public string? FilterDefinition { get; init; }
+        public bool? IsUnique { get; init; }
+        public bool? IsUniqueConstraint { get; init; }
+        public bool? IsPrimaryKey { get; init; }
+        public bool? IsForeignKey { get; init; }
+        public bool? IsForeignKeyReference { get; init; }
+        public bool? IsDisabled { get; init; }
+        public bool? IsIndexedView { get; init; }
+        public string? DataCompressionDesc { get; init; }
+        public bool? OptimizeForSequentialKey { get; init; }
+        public short? FillFactor { get; init; }
+        public bool? IsPadded { get; init; }
+        public bool? AllowPageLocks { get; init; }
+        public bool? AllowRowLocks { get; init; }
+        public long? UserSeeks { get; init; }
+        public long? UserScans { get; init; }
+        public long? UserLookups { get; init; }
+        public long? UserUpdates { get; init; }
+        public decimal? ReservedMb { get; init; }
+        public long? TotalRows { get; init; }
+        public int? PartitionCount { get; init; }
+        public DateTime? SqlServerStartTime { get; init; }
+    }
+
+    /// <summary>Maps a collected snapshot row into the analyzer's per-index input contract (nullable flag -&gt; false).</summary>
+    public static IndexCleanupIndexInput MapToIndexInput(IndexObjectStatsRow row) => new()
+    {
+        DatabaseName = row.DatabaseName,
+        DatabaseId = row.DatabaseId,
+        SchemaName = row.SchemaName,
+        ObjectId = row.ObjectId,
+        TableName = row.TableName,
+        IndexId = row.IndexId,
+        IndexName = row.IndexName,
+        IndexTypeDesc = row.IndexTypeDesc,
+        KeyColumns = row.KeyColumns,
+        IncludedColumns = row.IncludedColumns,
+        FilterDefinition = row.FilterDefinition,
+        IsUnique = row.IsUnique ?? false,
+        IsUniqueConstraint = row.IsUniqueConstraint ?? false,
+        IsPrimaryKey = row.IsPrimaryKey ?? false,
+        IsForeignKey = row.IsForeignKey ?? false,
+        IsForeignKeyReference = row.IsForeignKeyReference ?? false,
+        IsDisabled = row.IsDisabled ?? false,
+        IsIndexedView = row.IsIndexedView ?? false,
+        DataCompressionDesc = row.DataCompressionDesc,
+        OptimizeForSequentialKey = row.OptimizeForSequentialKey ?? false,
+        FillFactor = row.FillFactor,
+        IsPadded = row.IsPadded ?? false,
+        AllowPageLocks = row.AllowPageLocks ?? false,
+        AllowRowLocks = row.AllowRowLocks ?? false,
+        UserSeeks = row.UserSeeks ?? 0,
+        UserScans = row.UserScans ?? 0,
+        UserLookups = row.UserLookups ?? 0,
+        UserUpdates = row.UserUpdates ?? 0,
+        ReservedMb = row.ReservedMb,
+        TotalRows = row.TotalRows,
+        PartitionCount = row.PartitionCount,
+        SqlServerStartTime = row.SqlServerStartTime,
+    };
+
+    /// <summary>
+    /// Derives the analyzer options from the collected server facts, reproducing sp_IndexCleanup's runtime
+    /// gates: <c>@can_compress</c> = EngineEdition IN (3,5,8) [Enterprise / Azure SQL DB / Managed Instance] OR
+    /// (EngineEdition IN (2,4) [Standard / Express family] AND ProductVersion major &gt;= 13 [SQL 2016+]);
+    /// <c>@online</c> = EngineEdition IN (3,5,8). The size/read/write/row minimums and dedupe-only match the
+    /// proc's parameter DEFAULTS (all 0 / off) — no speculative settings knobs. Uptime days is computed from the
+    /// server-LOCAL <c>sqlserver_start_time</c> vs the viewer's local now (both wall-clock, mirroring the proc's
+    /// <c>DATEDIFF(DAY, sqlserver_start_time, SYSDATETIME())</c>); it drives the analyzer's &lt;14-day
+    /// unused caveat and &lt;=7-day auto-dedupe. When no server_properties row is collected yet, edition is
+    /// unknown: fall back to the safe defaults (compression assumed available — 2016+ is the product minimum —
+    /// and ONLINE off).
+    /// </summary>
+    public static IndexCleanupOptions DeriveIndexCleanupOptions(
+        int? engineEdition,
+        string? productVersion,
+        DateTime? sqlServerStartTime,
+        DateTime referenceLocalTime)
+    {
+        bool supportsOnline;
+        bool supportsCompression;
+
+        if (engineEdition is { } edition)
+        {
+            bool isEnterpriseOrAzure = edition is 3 or 5 or 8;
+            bool isStandardFamily = edition is 2 or 4;
+            supportsOnline = isEnterpriseOrAzure;
+            supportsCompression =
+                isEnterpriseOrAzure
+                || (isStandardFamily && ParseMajorVersion(productVersion) >= 13);
+        }
+        else
+        {
+            /* No collected properties row: assume compression is available (SQL 2016+ is the product minimum)
+               and keep ONLINE off (the safe default the generated scripts also default to). */
+            supportsOnline = false;
+            supportsCompression = true;
+        }
+
+        double? uptimeDays = null;
+        if (sqlServerStartTime is { } start)
+        {
+            var days = (referenceLocalTime - start).TotalDays;
+            if (days >= 0)
+            {
+                uptimeDays = days;
+            }
+        }
+
+        return new IndexCleanupOptions
+        {
+            DedupeOnly = false,
+            MinSizeGb = 0m,
+            MinReads = 0,
+            MinWrites = 0,
+            MinRows = 0,
+            ServerSupportsCompression = supportsCompression,
+            ServerSupportsOnline = supportsOnline,
+            ServerUptimeDays = uptimeDays,
+            /* CompressionMin/MaxSavingsFactor keep the record defaults (0.20 / 0.60 — sp_IndexCleanup's band). */
+        };
+    }
+
+    /// <summary>Parses the leading major-version integer from a ProductVersion string (e.g. "16.0.1000.6" -&gt; 16); 0 when unparseable.</summary>
+    public static int ParseMajorVersion(string? productVersion)
+    {
+        if (string.IsNullOrWhiteSpace(productVersion))
+        {
+            return 0;
+        }
+
+        var head = productVersion.Split('.', 2)[0].Trim();
+        return int.TryParse(head, NumberStyles.Integer, CultureInfo.InvariantCulture, out var major) ? major : 0;
+    }
+
+    /// <summary>Reads one <c>v_index_object_stats</c> row at the <see cref="IndexObjectStatsLatestSql"/> column ordinals.</summary>
+    private static IndexObjectStatsRow ReadIndexObjectStatsRow(NpgsqlDataReader reader)
+    {
+        long? L(int i) => reader.IsDBNull(i) ? null : Convert.ToInt64(reader.GetValue(i), CultureInfo.InvariantCulture);
+        int? I(int i) => reader.IsDBNull(i) ? null : Convert.ToInt32(reader.GetValue(i), CultureInfo.InvariantCulture);
+        short? Sh(int i) => reader.IsDBNull(i) ? null : Convert.ToInt16(reader.GetValue(i), CultureInfo.InvariantCulture);
+        decimal? D(int i) => reader.IsDBNull(i) ? null : Convert.ToDecimal(reader.GetValue(i), CultureInfo.InvariantCulture);
+        bool? B(int i) => reader.IsDBNull(i) ? null : reader.GetBoolean(i);
+        string? S(int i) => reader.IsDBNull(i) ? null : reader.GetString(i);
+
+        return new IndexObjectStatsRow
+        {
+            DatabaseName = reader.IsDBNull(0) ? "" : reader.GetString(0),
+            DatabaseId = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture),
+            SchemaName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+            ObjectId = reader.IsDBNull(3) ? 0 : Convert.ToInt32(reader.GetValue(3), CultureInfo.InvariantCulture),
+            TableName = reader.IsDBNull(4) ? "" : reader.GetString(4),
+            IndexId = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5), CultureInfo.InvariantCulture),
+            IndexName = S(6),
+            IndexTypeDesc = S(7),
+            KeyColumns = S(8),
+            IncludedColumns = S(9),
+            FilterDefinition = S(10),
+            IsUnique = B(11),
+            IsUniqueConstraint = B(12),
+            IsPrimaryKey = B(13),
+            IsForeignKey = B(14),
+            IsForeignKeyReference = B(15),
+            IsDisabled = B(16),
+            IsIndexedView = B(17),
+            DataCompressionDesc = S(18),
+            OptimizeForSequentialKey = B(19),
+            FillFactor = Sh(20),
+            IsPadded = B(21),
+            AllowPageLocks = B(22),
+            AllowRowLocks = B(23),
+            UserSeeks = L(24),
+            UserScans = L(25),
+            UserLookups = L(26),
+            UserUpdates = L(27),
+            ReservedMb = D(28),
+            TotalRows = L(29),
+            PartitionCount = I(30),
+            SqlServerStartTime = reader.IsDBNull(31) ? null : reader.GetDateTime(31),
+        };
+    }
+
+    /// <summary>Reads the latest per-index snapshot for the server and maps each row to the analyzer input contract.</summary>
+    public async Task<List<IndexCleanupIndexInput>> GetIndexCleanupInputsAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        var inputs = new List<IndexCleanupIndexInput>();
+
+        await using var command = _dataSource.CreateCommand(IndexObjectStatsLatestSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            inputs.Add(MapToIndexInput(ReadIndexObjectStatsRow(reader)));
+        }
+
+        return inputs;
+    }
+
+    /// <summary>Reads the server's latest collected edition/version/start-time facts and derives the analyzer options.</summary>
+    public async Task<IndexCleanupOptions> GetIndexCleanupOptionsAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        int? engineEdition = null;
+        string? productVersion = null;
+        DateTime? startTime = null;
+
+        await using var command = _dataSource.CreateCommand(ServerCompressionInfoSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (await reader.ReadAsync(cancellationToken))
+        {
+            engineEdition = reader.IsDBNull(0) ? null : Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture);
+            productVersion = reader.IsDBNull(1) ? null : reader.GetString(1);
+            startTime = reader.IsDBNull(2) ? null : reader.GetDateTime(2);
+        }
+
+        /* sqlserver_start_time is the server's LOCAL wall clock, compared to the viewer's local now — mirrors
+           the proc's SYSDATETIME() derivation (both wall-clock; the coarse days measure tolerates any offset). */
+        return DeriveIndexCleanupOptions(engineEdition, productVersion, startTime, DateTime.Now);
+    }
+
+    /// <summary>
+    /// The full monitor-side index-cleanup analysis for one server: reads the latest collected snapshot, derives
+    /// the server-fact options, and runs the pure Common analyzer off the UI thread (the dedupe is
+    /// string-comparison-heavy). Returns the analyzer result verbatim — the tab projects it into the grids +
+    /// rollup + banners.
+    /// </summary>
+    public async Task<IndexCleanupAnalysisResult> GetIndexAnalysisAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        var inputs = await GetIndexCleanupInputsAsync(serverId, cancellationToken);
+        var options = await GetIndexCleanupOptionsAsync(serverId, cancellationToken);
+        return await Task.Run(() => IndexCleanupAnalyzer.Analyze(inputs, options), cancellationToken);
+    }
+
+    /// <summary>Projects the analyzer recommendations into the detail-grid view-models.</summary>
+    public static List<IndexCleanupRecommendationRow> ProjectRecommendations(IndexCleanupAnalysisResult result) =>
+        result.Recommendations.Select(r => new IndexCleanupRecommendationRow(r)).ToList();
+
+    /// <summary>
+    /// Projects the analyzer rollups into the summary-grid view-models: the overall "ALL DATABASES" total first,
+    /// then one row per database.
+    /// </summary>
+    public static List<IndexCleanupRollupRow> ProjectRollups(IndexCleanupAnalysisResult result)
+    {
+        var rows = new List<IndexCleanupRollupRow>
+        {
+            new(result.OverallRollup, "ALL DATABASES"),
+        };
+        rows.AddRange(result.DatabaseRollups.Select(r => new IndexCleanupRollupRow(r, r.DatabaseName ?? "")));
+        return rows;
+    }
+}
+
+/// <summary>
+/// One recommendation row for the Index Analysis detail grid — a flat, display-formatted projection of the
+/// Common <see cref="IndexCleanupRecommendation"/>. <see cref="ActionDisplay"/> collapses (Action, ResultKind)
+/// into the single operation label the tab filters by (DISABLE / MAKE UNIQUE / MERGE / DROP CONSTRAINT /
+/// COMPRESS / REVIEW); REVIEW rows carry an empty <see cref="Script"/> (informational only — a recognized-but-
+/// not-consolidated Reverse Duplicate / Equal-Except-Filter relationship).
+/// </summary>
+public sealed class IndexCleanupRecommendationRow
+{
+    private readonly IndexCleanupRecommendation _rec;
+
+    public IndexCleanupRecommendationRow(IndexCleanupRecommendation rec)
+    {
+        _rec = rec;
+    }
+
+    public string DatabaseName => _rec.DatabaseName;
+    public string SchemaName => _rec.SchemaName;
+    public string TableName => _rec.TableName;
+    public string IndexName => _rec.IndexName;
+    public string ConsolidationRule => _rec.ConsolidationRule ?? "";
+    public string ActionDisplay => ActionLabelFor(_rec.Action, _rec.ResultKind);
+    public string ResultKindDisplay => ResultKindLabelFor(_rec.ResultKind);
+    public string TargetIndexName => _rec.TargetIndexName ?? "";
+    public string SupersededBy => _rec.SupersededBy ?? "";
+    public string AdditionalInfo => _rec.AdditionalInfo ?? "";
+    public decimal IndexSizeGb => _rec.IndexSizeGb;
+    public long IndexRows => _rec.IndexRows;
+    public long IndexReads => _rec.IndexReads;
+    public long IndexWrites => _rec.IndexWrites;
+    public bool CanCompress => _rec.CanCompress;
+    public string OriginalIndexDefinition => _rec.OriginalIndexDefinition;
+    public string Script => _rec.Script;
+
+    /// <summary>The single filterable operation label mirroring sp_IndexCleanup's script buckets: MAKE UNIQUE wins over its MERGE bucket; otherwise the result kind names the bucket.</summary>
+    public static string ActionLabelFor(IndexCleanupAction action, IndexCleanupResultKind resultKind)
+    {
+        if (action == IndexCleanupAction.MakeUnique)
+        {
+            return "MAKE UNIQUE";
+        }
+
+        return ResultKindLabelFor(resultKind);
+    }
+
+    /// <summary>The display label for a script bucket.</summary>
+    public static string ResultKindLabelFor(IndexCleanupResultKind resultKind) => resultKind switch
+    {
+        IndexCleanupResultKind.Disable => "DISABLE",
+        IndexCleanupResultKind.Merge => "MERGE",
+        IndexCleanupResultKind.Compress => "COMPRESS",
+        IndexCleanupResultKind.Review => "REVIEW",
+        IndexCleanupResultKind.DisableConstraint => "DROP CONSTRAINT",
+        _ => resultKind.ToString().ToUpperInvariant(),
+    };
+}
+
+/// <summary>
+/// One reclaimable-space rollup row for the Index Analysis summary grid — a flat projection of the Common
+/// <see cref="IndexCleanupRollup"/> plus its scope label (a database name, or "ALL DATABASES" for the overall
+/// total). Mirrors sp_IndexCleanup's <c>#index_reporting_stats</c> DATABASE row.
+/// </summary>
+public sealed class IndexCleanupRollupRow
+{
+    private readonly IndexCleanupRollup _rollup;
+
+    public IndexCleanupRollupRow(IndexCleanupRollup rollup, string scope)
+    {
+        _rollup = rollup;
+        Scope = scope;
+    }
+
+    /// <summary>Database name, or "ALL DATABASES" for the overall total.</summary>
+    public string Scope { get; }
+
+    public int TablesAnalyzed => _rollup.TablesAnalyzed;
+    public int IndexCount => _rollup.IndexCount;
+    public decimal TotalSizeGb => _rollup.TotalSizeGb;
+    public long TotalRows => _rollup.TotalRows;
+    public int IndexesToDisable => _rollup.IndexesToDisable;
+    public int IndexesToMerge => _rollup.IndexesToMerge;
+    public int CompressableIndexes => _rollup.CompressableIndexes;
+    public int UnusedIndexes => _rollup.UnusedIndexes;
+    public decimal UnusedSizeGb => _rollup.UnusedSizeGb;
+    public decimal CompressionMinSavingsGb => _rollup.CompressionMinSavingsGb;
+    public decimal CompressionMaxSavingsGb => _rollup.CompressionMaxSavingsGb;
+    public decimal TotalMinSavingsGb => _rollup.TotalMinSavingsGb;
+    public decimal TotalMaxSavingsGb => _rollup.TotalMaxSavingsGb;
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.IndexAnalysis.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.IndexAnalysis.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// FinOps Index Analysis sub-tab (Stage 3) — the monitor-side reproduction of Erik's sp_IndexCleanup, run in
+/// the viewer over the latest collected <c>v_index_object_stats</c> snapshot (parse-on-read, like the System
+/// Events tab; NO live proc, NO "install the proc" prompt). <see cref="ViewerDataService.GetIndexAnalysisAsync"/>
+/// reads + maps the snapshot, derives the edition/uptime options from <c>server_properties</c>, and runs the
+/// pure Common <c>IndexCleanupAnalyzer</c> off the UI thread. This partial projects the result into the
+/// reclaimable-space rollup grid (overall + per database) and the recommendations detail grid (DISABLE / MAKE
+/// UNIQUE / MERGE / DROP CONSTRAINT / COMPRESS / REVIEW — REVIEW rows carry no destructive script), and surfaces
+/// the analyzer's <c>UptimeWarning</c> / <c>DedupeOnlyApplied</c> flags + <c>Notes</c> (its stated limitations)
+/// as banners. Load-on-view + a Refresh button, mirroring the other FinOps sub-tabs.
+/// </summary>
+public partial class ViewerServerTab
+{
+    /// <summary>
+    /// Runs the analysis over the latest collected snapshot and repaints the rollup + detail grids and the
+    /// banners. When no index statistics have been collected yet (no rollups), shows the empty hint and clears
+    /// the grids/banners.
+    /// </summary>
+    private async Task LoadFinOpsIndexAnalysisAsync()
+    {
+        var result = await _dataService.GetIndexAnalysisAsync(_server.ServerId);
+
+        var nothingCollected = result.DatabaseRollups.Count == 0;
+
+        if (nothingCollected)
+        {
+            _finopsIndexAnalysisRollupFilterMgr!.UpdateData(new List<IndexCleanupRollupRow>());
+            _finopsIndexAnalysisFilterMgr!.UpdateData(new List<IndexCleanupRecommendationRow>());
+            FinOpsIndexAnalysisBannerPanel.Children.Clear();
+            FinOpsIndexAnalysisBannerPanel.Visibility = Visibility.Collapsed;
+            FinOpsIndexAnalysisNoDataMessage.Visibility = Visibility.Visible;
+            FinOpsIndexAnalysisCountIndicator.Text = "";
+            return;
+        }
+
+        var recs = ViewerDataService.ProjectRecommendations(result);
+        var rollups = ViewerDataService.ProjectRollups(result);
+
+        _finopsIndexAnalysisRollupFilterMgr!.UpdateData(rollups);
+        _finopsIndexAnalysisFilterMgr!.UpdateData(recs);
+
+        BuildIndexAnalysisBanners(result);
+
+        FinOpsIndexAnalysisNoDataMessage.Visibility = Visibility.Collapsed;
+        FinOpsIndexAnalysisCountIndicator.Text = recs.Count > 0
+            ? $"{recs.Count} recommendation(s)"
+            : "no cleanup recommendations — indexes look clean";
+    }
+
+    /// <summary>Rebuilds the banner strip: the &lt;14-day uptime caveat, the dedupe-only notice, and every analyzer Note (its stated limitations).</summary>
+    private void BuildIndexAnalysisBanners(IndexCleanupAnalysisResult result)
+    {
+        FinOpsIndexAnalysisBannerPanel.Children.Clear();
+
+        if (result.UptimeWarning)
+        {
+            AddIndexAnalysisBanner(
+                "Server uptime is under 14 days — index usage data may be incomplete, so some \"Unused Index\" findings could be premature.",
+                "#F39C12", "#33290F");
+        }
+
+        if (result.DedupeOnlyApplied)
+        {
+            AddIndexAnalysisBanner(
+                "Dedupe-only mode is in effect — unused indexes were NOT flagged (server uptime is 7 days or less). Only duplicate/consolidation and compression findings are shown.",
+                "#3498DB", "#0F2433");
+        }
+
+        foreach (var note in result.Notes)
+        {
+            AddIndexAnalysisBanner(note, "#7F8C8D", "#202628");
+        }
+
+        FinOpsIndexAnalysisBannerPanel.Visibility =
+            FinOpsIndexAnalysisBannerPanel.Children.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    /// <summary>Adds one left-accented banner row to the Index Analysis banner strip.</summary>
+    private void AddIndexAnalysisBanner(string text, string accentHex, string backgroundHex)
+    {
+        var border = new Border
+        {
+            Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString(backgroundHex)),
+            BorderBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(accentHex)),
+            BorderThickness = new Thickness(3, 0, 0, 0),
+            CornerRadius = new CornerRadius(2),
+            Margin = new Thickness(0, 0, 0, 4),
+            Padding = new Thickness(8, 5, 8, 5),
+            Child = new TextBlock
+            {
+                Text = text,
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 12,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xE0, 0xE0, 0xE0)),
+            },
+        };
+
+        FinOpsIndexAnalysisBannerPanel.Children.Add(border);
+    }
+
+    /// <summary>Refresh button — re-runs the analysis over the latest snapshot with the shell's status-bar error surfacing.</summary>
+    private async void FinOpsRefreshIndexAnalysis_Click(object sender, RoutedEventArgs e)
+        => await RunFinOpsLoad(LoadFinOpsIndexAnalysisAsync);
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.cs
@@ -42,6 +42,7 @@ public partial class ViewerServerTab
     private const int FinOpsHighImpactSubTabIndex = 6;
     private const int FinOpsApplicationConnectionsSubTabIndex = 7;
     private const int FinOpsServerInventorySubTabIndex = 8;
+    private const int FinOpsIndexAnalysisSubTabIndex = 9;
 
     private DataGridFilterManager<DatabaseResourceUsageRow>? _finopsDbResourcesFilterMgr;
     private DataGridFilterManager<StorageGrowthRow>? _finopsStorageGrowthFilterMgr;
@@ -55,6 +56,8 @@ public partial class ViewerServerTab
     private DataGridFilterManager<ExpensiveQueryRow>? _finopsExpensiveQueriesFilterMgr;
     private DataGridFilterManager<MemoryGrantEfficiencyRow>? _finopsMemoryGrantFilterMgr;
     private DataGridFilterManager<IndexLockingRow>? _finopsIndexLockingFilterMgr;
+    private DataGridFilterManager<IndexCleanupRollupRow>? _finopsIndexAnalysisRollupFilterMgr;
+    private DataGridFilterManager<IndexCleanupRecommendationRow>? _finopsIndexAnalysisFilterMgr;
 
     /// <summary>
     /// Registers the FinOps grids' column-filter managers into the shared <c>_filterManagers</c> map
@@ -75,6 +78,8 @@ public partial class ViewerServerTab
         _finopsExpensiveQueriesFilterMgr = new DataGridFilterManager<ExpensiveQueryRow>(FinOpsExpensiveQueriesDataGrid);
         _finopsMemoryGrantFilterMgr = new DataGridFilterManager<MemoryGrantEfficiencyRow>(FinOpsMemoryGrantEfficiencyDataGrid);
         _finopsIndexLockingFilterMgr = new DataGridFilterManager<IndexLockingRow>(FinOpsIndexLockingDataGrid);
+        _finopsIndexAnalysisRollupFilterMgr = new DataGridFilterManager<IndexCleanupRollupRow>(FinOpsIndexAnalysisRollupGrid);
+        _finopsIndexAnalysisFilterMgr = new DataGridFilterManager<IndexCleanupRecommendationRow>(FinOpsIndexAnalysisDetailGrid);
 
         _filterManagers[FinOpsDatabaseResourcesDataGrid] = _finopsDbResourcesFilterMgr;
         _filterManagers[FinOpsStorageGrowthDataGrid] = _finopsStorageGrowthFilterMgr;
@@ -88,6 +93,8 @@ public partial class ViewerServerTab
         _filterManagers[FinOpsExpensiveQueriesDataGrid] = _finopsExpensiveQueriesFilterMgr;
         _filterManagers[FinOpsMemoryGrantEfficiencyDataGrid] = _finopsMemoryGrantFilterMgr;
         _filterManagers[FinOpsIndexLockingDataGrid] = _finopsIndexLockingFilterMgr;
+        _filterManagers[FinOpsIndexAnalysisRollupGrid] = _finopsIndexAnalysisRollupFilterMgr;
+        _filterManagers[FinOpsIndexAnalysisDetailGrid] = _finopsIndexAnalysisFilterMgr;
     }
 
     /// <summary>
@@ -137,6 +144,9 @@ public partial class ViewerServerTab
                 break;
             case FinOpsServerInventorySubTabIndex:
                 await LoadFinOpsServerInventoryAsync();
+                break;
+            case FinOpsIndexAnalysisSubTabIndex:
+                await LoadFinOpsIndexAnalysisAsync();
                 break;
             case FinOpsUtilizationSubTabIndex:
             default:

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2914,6 +2914,94 @@
                         </Grid>
                     </Grid>
                 </TabItem>
+
+                <!-- Index Analysis Sub-Tab (Stage 3): monitor-side sp_IndexCleanup reproduction over the LATEST
+                     collected v_index_object_stats snapshot via the Common IndexCleanupAnalyzer. Parse-on-read —
+                     NO live proc, NO "install the proc" prompt. A reclaimable-space rollup (overall + per db)
+                     over the recommendations grid (DISABLE / MAKE UNIQUE / MERGE / DROP CONSTRAINT / COMPRESS /
+                     REVIEW; REVIEW rows carry no destructive script) with the analyzer's uptime/dedupe/Notes
+                     banners. -->
+                <TabItem Header="Index Analysis">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                            <TextBlock Text="Index Analysis" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <Button Content="Refresh" Click="FinOpsRefreshIndexAnalysis_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                            <TextBlock x:Name="FinOpsIndexAnalysisCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                            <TextBlock Text="Analyzed from the latest collected snapshot (no live proc)." Margin="16,0,0,0" VerticalAlignment="Center" FontStyle="Italic" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                        </StackPanel>
+
+                        <StackPanel x:Name="FinOpsIndexAnalysisBannerPanel" Grid.Row="1" Margin="10,0,10,4" Visibility="Collapsed"/>
+
+                        <Grid Grid.Row="2" Margin="10,0,10,10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Grid.Row="0" Text="Reclaimable Space (overall + per database)" FontWeight="SemiBold" FontSize="12" Margin="0,0,0,4" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+
+                            <DataGrid x:Name="FinOpsIndexAnalysisRollupGrid" Grid.Row="1" Style="{StaticResource DarkGrid}" RowStyle="{StaticResource FinOpsRowStyle}" MaxHeight="220" HorizontalScrollBarVisibility="Auto" AutoGenerateColumns="False" IsReadOnly="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding Scope}" Width="180"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Scope" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Header="Tables" Binding="{Binding TablesAnalyzed, StringFormat=N0}" Width="70" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Indexes" Binding="{Binding IndexCount, StringFormat=N0}" Width="75" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Size GB" Binding="{Binding TotalSizeGb, StringFormat=N2}" Width="80" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Rows" Binding="{Binding TotalRows, StringFormat=N0}" Width="110" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="To Disable" Binding="{Binding IndexesToDisable, StringFormat=N0}" Width="80" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="To Merge" Binding="{Binding IndexesToMerge, StringFormat=N0}" Width="80" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Compressable" Binding="{Binding CompressableIndexes, StringFormat=N0}" Width="100" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Unused" Binding="{Binding UnusedIndexes, StringFormat=N0}" Width="70" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Disable GB" Binding="{Binding UnusedSizeGb, StringFormat=N2}" Width="90" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Compress Min GB" Binding="{Binding CompressionMinSavingsGb, StringFormat=N2}" Width="120" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Compress Max GB" Binding="{Binding CompressionMaxSavingsGb, StringFormat=N2}" Width="120" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Total Min GB" Binding="{Binding TotalMinSavingsGb, StringFormat=N2}" Width="100" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Total Max GB" Binding="{Binding TotalMaxSavingsGb, StringFormat=N2}" Width="100" ElementStyle="{StaticResource NumericCell}"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+
+                            <TextBlock Grid.Row="2" Text="Recommendations" FontWeight="SemiBold" FontSize="12" Margin="0,8,0,4" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+
+                            <DataGrid x:Name="FinOpsIndexAnalysisDetailGrid" Grid.Row="3" Style="{StaticResource DarkGrid}" RowStyle="{StaticResource FinOpsRowStyle}" HorizontalScrollBarVisibility="Auto" AutoGenerateColumns="False" IsReadOnly="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding ActionDisplay}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ActionDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Action" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ResultKindDisplay}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ResultKindDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Result Kind" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ConsolidationRule}" Width="170"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ConsolidationRule" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Rule" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="140"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding SchemaName}" Width="90"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SchemaName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Schema" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TableName}" Width="170"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TableName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Table" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding IndexName}" Width="200"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IndexName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Header="Size GB" Binding="{Binding IndexSizeGb, StringFormat=N3}" Width="80" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Rows" Binding="{Binding IndexRows, StringFormat=N0}" Width="100" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Reads" Binding="{Binding IndexReads, StringFormat=N0}" Width="90" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Header="Writes" Binding="{Binding IndexWrites, StringFormat=N0}" Width="90" ElementStyle="{StaticResource NumericCell}"/>
+                                    <DataGridTextColumn Binding="{Binding TargetIndexName}" Width="180"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TargetIndexName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Target Index" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Header="Superseded / Related" Binding="{Binding SupersededBy}" Width="220">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding SupersededBy}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Info" Binding="{Binding AdditionalInfo}" Width="220">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding AdditionalInfo}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Original Definition" Binding="{Binding OriginalIndexDefinition}" Width="320">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding OriginalIndexDefinition}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Script" Binding="{Binding Script}" Width="320">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding Script}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+
+                            <TextBlock x:Name="FinOpsIndexAnalysisNoDataMessage" Grid.Row="0" Grid.RowSpan="4" Style="{StaticResource EmptyHint}" Text="No analyzable index statistics collected yet for this server."/>
+                        </Grid>
+                    </Grid>
+                </TabItem>
             </TabControl>
         </TabItem>
 


### PR DESCRIPTION
## Index Analysis tab for the Darling viewer (Stage 3, #1262)

Adds the **Index Analysis** FinOps sub-tab to the Darling viewer — the tab deferred from the #1372 FinOps port. It surfaces Erik's `sp_IndexCleanup` recommendations, computed **monitor-side** in the viewer process rather than by a live proc call.

Stages 1 (capture) and 2 (the `IndexCleanupAnalyzer`, incl. the full Rule 7 Unique Constraint Replacement family) are already merged; this is the UI + data-read layer that consumes them.

### Parse-on-read, no proc
Mirrors the System Events tab: the viewer reads the **latest collected snapshot** from the Postgres view `v_index_object_stats` (`DISTINCT ON (database_id, object_id, index_id)` ordered by `collection_time DESC` — the newest row per index, never the whole history), maps each row into the Common `IndexCleanupIndexInput` contract, and runs the pure `IndexCleanupAnalyzer.Analyze(...)` off the UI thread (`Task.Run`). No live `sp_IndexCleanup` call, no "install the proc" prompt (unlike Lite's live-target tab), no server-side work.

### Options derived from collected server facts
`DeriveIndexCleanupOptions` reproduces the proc's runtime gates from the collected `server_properties`:
- **Compression support** (`@can_compress`): `EngineEdition IN (3,5,8)` (Enterprise / Azure SQL DB / Managed Instance) OR (`IN (2,4)` Standard/Express family AND ProductVersion major >= 13, i.e. SQL 2016+).
- **Online rebuild support** (`@online`): `EngineEdition IN (3,5,8)`.
- **Uptime days** from `sqlserver_start_time` (server-local) vs the viewer's local now — drives the analyzer's <14-day "usage may be incomplete" caveat and <=7-day auto-dedupe.
- Size/read/write/row minimums and dedupe-only use `sp_IndexCleanup`'s **parameter defaults** (all 0 / off) — no speculative settings knobs. The 0.20-0.60 compression savings band is the analyzer default.
- No collected `server_properties` row yet -> safe fallback (compression assumed available since 2016+ is the product minimum; ONLINE off).

### The tab
- **Reclaimable-space rollup grid**: the overall "ALL DATABASES" total first, then one row per database — tables/indexes analyzed, size GB, rows, indexes to disable/merge, compressable, unused count + disable-reclaim GB, compression savings band (min/max GB), and total min/max reclaim.
- **Recommendations grid**: database / schema / table / index / rule / **action** / result-kind / size GB / rows / reads / writes / target index / superseded-or-related / info, plus the copyable **Original Definition** and **Script** (shared FinOps copy/export context menu, tooltips). The single **Action** column is filterable across the six operation labels: `DISABLE` / `MAKE UNIQUE` / `MERGE` / `DROP CONSTRAINT` / `COMPRESS` / `REVIEW`. `REVIEW` rows carry **no destructive script** — they are the recognized-but-not-consolidated Reverse Duplicate / Equal-Except-Filter relationships.
- **Banners**: the analyzer's `UptimeWarning` and `DedupeOnlyApplied` flags plus every `Notes` entry (its stated limitations — e.g. omitted `ON <filegroup>` placement, the 0.20-0.60 savings band proxy).
- Analyze on tab-load (parse-on-read) + a Refresh button; the 60-second inner-tab timer keeps it fresh.

### Tests
`ViewerIndexAnalysisTests` (39 tests) covers the Darling-specific glue Stage 3 adds — the analyzer itself is already covered (53 tests) and is not re-tested:
- SQL clause pins + column parity of both reads against the generated collector DDL (PG dialect, positional params).
- `v_index_object_stats` row -> `IndexCleanupIndexInput` mapping (every field; NULL flag -> false).
- `DeriveIndexCleanupOptions` edition matrix (Enterprise/Azure/MI/Standard/Express x version), unknown-edition fallback, uptime derivation (incl. the <=7-day -> analyzer dedupe+warning wiring), and the min/factor defaults.
- `ParseMajorVersion`, the six-value action label, the "ALL DATABASES"-first rollup projection, and a map->analyze->project end-to-end.

### Verification
- Darling viewer builds clean in Release.
- `Darling.Tests` (Release): **774 passed, 83 skipped** (the skips are the `*LivePostgresTests` that need a live dev Postgres), **0 failed**.

### Scope
Viewer + viewer-tests only. The analyzer, collector, migrations, and Lite are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
