### PR TITLE
Add FinOps Recommendations sub-tab to Darling viewer (monitor-side, #1262)

### DIFF
--- a/Darling/Darling.Tests/ViewerFinOpsRecommendationsTests.cs
+++ b/Darling/Darling.Tests/ViewerFinOpsRecommendationsTests.cs
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the FinOps Recommendations sub-tab — the last deferred sub-tab, reproduced MONITOR-SIDE. Lite mixed
+/// collected reads with LIVE target queries; every check here runs over the collected Postgres store. These tests
+/// cover the three checks Lite ran "live" and now reproduces from collected data (edition/license audit, TDE from
+/// <c>database_config.is_encrypted</c>, compression from <c>index_object_stats</c>, dev/test name match), the
+/// dropped check (sp_IndexCleanup existence — superseded by native Index Analysis), the AG-nuance deferral, and the
+/// collected time-series reads' SQL contract (a representative case, per the port brief — not the ported arithmetic).
+/// </summary>
+public sealed class ViewerFinOpsRecommendationsTests
+{
+    // ── Check 1: Edition / license audit branching (reproduced from collected server_properties) ──
+
+    [Fact]
+    public void EditionAudit_NonEnterprise_ReturnsNoRecommendations()
+    {
+        var recs = ViewerDataService.BuildEditionAuditRecommendations(
+            "Standard Edition (64-bit)", majorVersion: 16, cpuCount: 8, Array.Empty<string>(), monthlyCost: 1000m);
+
+        Assert.Empty(recs);
+    }
+
+    [Fact]
+    public void EditionAudit_Enterprise2019Plus_SuggestsDowngrade_WithBudgetSavings_AndAgNote()
+    {
+        var recs = ViewerDataService.BuildEditionAuditRecommendations(
+            "Enterprise Edition (64-bit)", majorVersion: 16, cpuCount: 16, Array.Empty<string>(), monthlyCost: 1000m);
+
+        var rec = Assert.Single(recs);
+        Assert.Equal("Licensing", rec.Category);
+        Assert.Equal("High", rec.Severity);
+        /* AG state isn't collected, so the AG-driven confidence downgrade collapses to the standalone value. */
+        Assert.Equal("Medium", rec.Confidence);
+        Assert.Equal("Enterprise Edition may not be required", rec.Finding);
+        Assert.Equal(400m, rec.EstMonthlySavings); // 1000 * 0.40
+        /* The AG-nuance deferral note is present; the AG-secondary / advanced-AG caveats are NOT invented. */
+        Assert.Contains("Availability Group topology isn't evaluated", rec.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("secondary replica", rec.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Basic Availability Groups", rec.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditionAudit_EnterprisePre2019_NoTde_SuggestsDowngrade_HighConfidence()
+    {
+        var recs = ViewerDataService.BuildEditionAuditRecommendations(
+            "Enterprise Edition (64-bit)", majorVersion: 13, cpuCount: 8, Array.Empty<string>(), monthlyCost: 1000m);
+
+        var rec = Assert.Single(recs);
+        Assert.Equal("High", rec.Severity);
+        Assert.Equal("High", rec.Confidence);
+        Assert.Equal("Enterprise Edition with no Enterprise-only features detected", rec.Finding);
+        Assert.Equal(400m, rec.EstMonthlySavings);
+        Assert.Contains("Transparent Data Encryption", rec.Detail, StringComparison.Ordinal);
+        Assert.Contains("Availability Group topology isn't evaluated", rec.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditionAudit_EnterprisePre2019_WithTde_BlocksDowngrade_AndAddsLicenseCoreMath()
+    {
+        var tdeDbs = new[] { "Sales", "Payroll" };
+        var recs = ViewerDataService.BuildEditionAuditRecommendations(
+            "Enterprise Edition (64-bit)", majorVersion: 14, cpuCount: 8, tdeDbs, monthlyCost: 1000m);
+
+        Assert.Equal(2, recs.Count);
+
+        var blocker = recs[0];
+        Assert.Equal("TDE in use — Enterprise Edition downgrade blocker", blocker.Finding);
+        Assert.Equal("Low", blocker.Severity);
+        Assert.Equal("High", blocker.Confidence);
+        Assert.Null(blocker.EstMonthlySavings); // a blocker carries no savings estimate
+        Assert.Contains("Sales", blocker.Detail, StringComparison.Ordinal);
+        Assert.Contains("Payroll", blocker.Detail, StringComparison.Ordinal);
+
+        // Check 10: core-count list-price math (8 cores * $5,000/yr / 12 = $3,333/mo).
+        var licenseMath = recs[1];
+        Assert.Equal("Low", licenseMath.Confidence);
+        Assert.Contains("8 cores", licenseMath.Finding, StringComparison.Ordinal);
+        Assert.Contains("$3,333/mo", licenseMath.Finding, StringComparison.Ordinal);
+        Assert.NotNull(licenseMath.EstMonthlySavings);
+        Assert.Equal(8 * 5000m / 12m, licenseMath.EstMonthlySavings!.Value);
+    }
+
+    [Fact]
+    public void EditionAudit_ZeroBudget_OmitsSavingsEstimate()
+    {
+        var recs = ViewerDataService.BuildEditionAuditRecommendations(
+            "Enterprise Edition (64-bit)", majorVersion: 15, cpuCount: 8, Array.Empty<string>(), monthlyCost: 0m);
+
+        var rec = Assert.Single(recs);
+        Assert.Null(rec.EstMonthlySavings);
+        Assert.Equal("", rec.EstMonthlySavingsDisplay);
+    }
+
+    // ── Check 1 data: TDE detection from collected database_config.is_encrypted ──
+
+    [Fact]
+    public void SelectTdeDatabaseNames_PicksEncryptedOnlineUserDbs_ExcludesSystemOfflineAndUnencrypted()
+    {
+        var rows = new List<DatabaseConfigRow>
+        {
+            new() { DatabaseName = "Sales",  IsEncrypted = true,  StateDesc = "ONLINE" },   // TDE user db  -> in
+            new() { DatabaseName = "Reports", IsEncrypted = false, StateDesc = "ONLINE" },   // not encrypted -> out
+            new() { DatabaseName = "Archive", IsEncrypted = true,  StateDesc = "OFFLINE" },  // offline       -> out
+            new() { DatabaseName = "tempdb",  IsEncrypted = true,  StateDesc = "ONLINE" },   // system db     -> out
+            new() { DatabaseName = "Payroll", IsEncrypted = true,  StateDesc = "ONLINE" },   // TDE user db   -> in
+        };
+
+        var tde = ViewerDataService.SelectTdeDatabaseNames(rows);
+
+        Assert.Equal(new[] { "Payroll", "Sales" }, tde); // ordered by name
+    }
+
+    // ── Check 7: dev/test workload name match (reproduced from the collected database list) ──
+
+    [Fact]
+    public void MatchDevTestDatabases_MatchesPatternsCaseInsensitive_ExcludesSystemDbs()
+    {
+        var names = new[]
+        {
+            "AdventureWorks_DEV", "SalesTest", "app_staging", "MyQaDb", "master", "tempdb", "Production",
+        };
+
+        var matches = ViewerDataService.MatchDevTestDatabases(names);
+
+        Assert.Equal(new[] { "AdventureWorks_DEV", "SalesTest", "app_staging", "MyQaDb" }, matches);
+        Assert.DoesNotContain("Production", matches);
+        Assert.DoesNotContain("master", matches);
+    }
+
+    // ── Check 5: compression candidates (reproduced from collected index_object_stats) ──
+
+    [Fact]
+    public void BuildCompressionRecommendation_FlagsUncompressedRowstoreOver1Gb_WithStorageFraming()
+    {
+        var indexes = new[]
+        {
+            Index("Sales", "dbo", "Orders", "NONE", 30720m),          // 30 GB uncompressed -> candidate
+            Index("Sales", "dbo", "OrderLines", "NONE", 30720m),      // 30 GB uncompressed -> candidate
+            Index("Sales", "dbo", "Small", "NONE", 512m),             // < 1 GB             -> out
+            Index("Sales", "dbo", "Compressed", "PAGE", 40960m),      // already compressed -> out
+            Index("Sales", "dbo", "Cci", "COLUMNSTORE", 40960m),      // columnstore        -> out
+        };
+
+        var rec = ViewerDataService.BuildCompressionRecommendation(indexes);
+
+        Assert.NotNull(rec);
+        Assert.Equal("Storage", rec!.Category);
+        Assert.Equal("High", rec.Severity); // 60 GB total > 50
+        Assert.Equal("High", rec.Confidence);
+        Assert.Equal("2 uncompressed object(s) >= 1GB (60.0GB total)", rec.Finding);
+        Assert.Contains("dbo.Orders", rec.Detail, StringComparison.Ordinal);
+        Assert.Null(rec.EstMonthlySavings); // compression candidates carry no dollar estimate (mirrors Lite)
+    }
+
+    [Theory]
+    [InlineData(2048.0, "Low")]     // 2 GB total
+    [InlineData(20480.0, "Medium")] // 20 GB total
+    [InlineData(61440.0, "High")]   // 60 GB total
+    public void BuildCompressionRecommendation_SeverityBandsOnTotalGb(double reservedMb, string expectedSeverity)
+    {
+        var rec = ViewerDataService.BuildCompressionRecommendation(new[]
+        {
+            Index("Db", "dbo", "T", "NONE", (decimal)reservedMb),
+        });
+
+        Assert.NotNull(rec);
+        Assert.Equal(expectedSeverity, rec!.Severity);
+    }
+
+    [Fact]
+    public void BuildCompressionRecommendation_ReturnsNull_WhenNothingUncompressedAndLarge()
+    {
+        var rec = ViewerDataService.BuildCompressionRecommendation(new[]
+        {
+            Index("Db", "dbo", "Small", "NONE", 100m),
+            Index("Db", "dbo", "Compressed", "PAGE", 99999m),
+        });
+
+        Assert.Null(rec);
+    }
+
+    // ── RecommendationRow projection ──
+
+    [Fact]
+    public void RecommendationRow_SeveritySortAndSavingsDisplay()
+    {
+        Assert.Equal(1, new RecommendationRow { Severity = "High" }.SeveritySort);
+        Assert.Equal(2, new RecommendationRow { Severity = "Medium" }.SeveritySort);
+        Assert.Equal(3, new RecommendationRow { Severity = "Low" }.SeveritySort);
+        Assert.Equal(4, new RecommendationRow { Severity = "Whatever" }.SeveritySort);
+
+        Assert.Equal("$1,234", new RecommendationRow { EstMonthlySavings = 1234m }.EstMonthlySavingsDisplay);
+        Assert.Equal("", new RecommendationRow { EstMonthlySavings = null }.EstMonthlySavingsDisplay);
+    }
+
+    // ── Collected time-series reads: SQL contract (representative case; not the ported arithmetic) ──
+
+    [Fact]
+    public void EditionFactsSql_ReadsServerPropertiesBaseTable_WithCpuCount()
+    {
+        var sql = ViewerDataService.RecommendationsEditionFactsSql;
+        Assert.Contains("FROM server_properties", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_server_properties", sql, StringComparison.Ordinal);
+        Assert.Contains("edition", sql, StringComparison.Ordinal);
+        Assert.Contains("product_version", sql, StringComparison.Ordinal);
+        Assert.Contains("cpu_count", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemoryP95Sql_PercentileOverMemoryStats()
+    {
+        var sql = ViewerDataService.RecommendationsMemoryP95Sql;
+        Assert.Contains("FROM v_memory_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_server_memory_mb)", sql, StringComparison.Ordinal);
+        Assert.Contains("COUNT(*)", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MaintenanceWindowSql_RunningJobsThatRanLongAtLeastThreeTimes()
+    {
+        var sql = ViewerDataService.RecommendationsMaintenanceWindowSql;
+        Assert.Contains("FROM v_running_jobs", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(CASE WHEN is_running_long THEN 1 ELSE 0 END)", sql, StringComparison.Ordinal);
+        Assert.Contains(">= 3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StorageTierSql_PerDatabaseFileIoStall()
+    {
+        var sql = ViewerDataService.RecommendationsStorageTierSql;
+        Assert.Contains("FROM v_file_io_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(delta_stall_read_ms)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(delta_stall_write_ms)", sql, StringComparison.Ordinal);
+        Assert.Contains("HAVING SUM(delta_reads) > 1000", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReservedCapacitySql_CpuMeanAndStddevStability()
+    {
+        var sql = ViewerDataService.RecommendationsReservedCapacitySql;
+        Assert.Contains("FROM v_cpu_utilization_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("STDDEV(sqlserver_cpu_utilization)", sql, StringComparison.Ordinal);
+        Assert.Contains("HAVING COUNT(*) >= 24", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(ViewerDataService.RecommendationsEditionFactsSql))]
+    [InlineData(nameof(ViewerDataService.RecommendationsMemoryP95Sql))]
+    [InlineData(nameof(ViewerDataService.RecommendationsCpuP95Sql))]
+    [InlineData(nameof(ViewerDataService.RecommendationsMaintenanceWindowSql))]
+    [InlineData(nameof(ViewerDataService.RecommendationsStorageTierSql))]
+    [InlineData(nameof(ViewerDataService.RecommendationsReservedCapacitySql))]
+    public void RecommendationReads_PgDialect_PositionalParams_NoTSqlNamedParams(string sqlName)
+    {
+        var sql = (string)typeof(ViewerDataService).GetField(sqlName)!.GetValue(null)!;
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+    }
+
+    // ── Column parity: every column the reproduced checks reference exists in the generated collector DDL ──
+
+    [Fact]
+    public void RecommendationChecks_ReadColumnsThatExistInTheGeneratedTables()
+    {
+        var serverProps = PgSchemaGenerator.CreateTable(ServerPropertiesCollector.Instance);
+        Assert.Equal("server_properties", ServerPropertiesCollector.Instance.TargetTable);
+        foreach (var col in new[] { "edition", "product_version", "cpu_count" })
+            Assert.Contains(col, serverProps, StringComparison.Ordinal);
+
+        var databaseConfig = PgSchemaGenerator.CreateTable(DatabaseConfigCollector.Instance);
+        Assert.Equal("database_config", DatabaseConfigCollector.Instance.TargetTable);
+        foreach (var col in new[] { "database_name", "is_encrypted", "state_desc" })
+            Assert.Contains(col, databaseConfig, StringComparison.Ordinal);
+
+        var indexStats = PgSchemaGenerator.CreateTable(IndexObjectStatsCollector.Instance);
+        foreach (var col in new[] { "data_compression_desc", "reserved_mb", "schema_name", "table_name" })
+            Assert.Contains(col, indexStats, StringComparison.Ordinal);
+
+        var memory = PgSchemaGenerator.CreateTable(MemoryStatsCollector.Instance);
+        Assert.Contains("total_server_memory_mb", memory, StringComparison.Ordinal);
+
+        var cpu = PgSchemaGenerator.CreateTable(CpuUtilizationCollector.Instance);
+        Assert.Contains("sqlserver_cpu_utilization", cpu, StringComparison.Ordinal);
+
+        var runningJobs = PgSchemaGenerator.CreateTable(RunningJobsCollector.Instance);
+        foreach (var col in new[] { "job_name", "current_duration_seconds", "avg_duration_seconds", "is_running_long" })
+            Assert.Contains(col, runningJobs, StringComparison.Ordinal);
+
+        var fileIo = PgSchemaGenerator.CreateTable(FileIoStatsCollector.Instance);
+        foreach (var col in new[] { "delta_reads", "delta_stall_read_ms", "delta_writes", "delta_stall_write_ms" })
+            Assert.Contains(col, fileIo, StringComparison.Ordinal);
+    }
+
+    private static IndexCleanupIndexInput Index(string db, string schema, string table, string compression, decimal reservedMb) =>
+        new()
+        {
+            DatabaseName = db,
+            SchemaName = schema,
+            TableName = table,
+            DataCompressionDesc = compression,
+            ReservedMb = reservedMb,
+        };
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Recommendations.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Recommendations.cs
@@ -1,0 +1,744 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/*
+ * FinOps Recommendations sub-tab reads (the last deferred FinOps sub-tab from the #1372 port). Lite's
+ * GetRecommendationsAsync (LocalDataService.FinOps.Recommendations.cs) runs ~11 checks, MIXING collected DuckDB
+ * reads with LIVE queries against the target. The headless viewer can't reach targets, so every check here runs
+ * MONITOR-SIDE over already-collected Postgres data — NO live SQL:
+ *   - The time-series checks (CPU/memory right-sizing, dormant DBs, maintenance window, VM right-sizing, storage
+ *     tier, reserved capacity) reuse the Utilization/Storage FinOps helpers the port already created, or read the
+ *     same v_* views Lite's DuckDB versions did.
+ *   - The three checks Lite ran "live" are reproduced from collected data: the Edition/license audit reads the
+ *     collected server_properties + database_config.is_encrypted (instead of a live dm_db_persisted_sku_features
+ *     probe); Compression candidates come from the collected index_object_stats snapshot (data_compression_desc);
+ *     Dev/test detection matches the collected database name list.
+ *   - Lite's sp_IndexCleanup-existence check (check 4) is DROPPED — Darling has native monitor-side Index Analysis
+ *     (the FinOps Index Analysis sub-tab, #1387), so the "install sp_IndexCleanup" recommendation is obsolete.
+ *   - AG-topology nuance (secondary-replica branch, advanced-AG downgrade caveat) is NOT reproduced: Darling does
+ *     not collect Availability Group state, so the audit proceeds as "Standalone" (Lite's own fallback) and notes
+ *     the limitation in the finding Detail. No AG data is invented.
+ * The per-check threshold/severity/confidence logic and wording are ported VERBATIM from Lite (not re-tuned). Each
+ * check is independently try/caught (Lite's structure) so one failing read never suppresses the others. SQL kept
+ * in public const so tests pin it.
+ */
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>The four system databases (master/model/msdb/tempdb) — Lite's <c>database_id &gt; 4</c> filter by name.</summary>
+    private static readonly HashSet<string> RecommendationsSystemDatabases =
+        new(StringComparer.OrdinalIgnoreCase) { "master", "model", "msdb", "tempdb" };
+
+    /// <summary>
+    /// The note appended to the edition-downgrade guidance recs, since Darling collects no Availability Group
+    /// state: the headless audit can't tell a secondary replica or an advanced (non-Basic) AG from a standalone.
+    /// </summary>
+    private const string AvailabilityGroupNotEvaluatedNote =
+        " Note: Availability Group topology isn't evaluated in headless collection — every replica in an AG must " +
+        "run the same edition, so confirm this instance is standalone (or evaluate the whole group on its primary) " +
+        "before any edition change.";
+
+    /// <summary>The server's latest collected edition / product version / logical CPU count for the license audit. $1 server_id.</summary>
+    public const string RecommendationsEditionFactsSql = @"
+SELECT
+    edition,
+    product_version,
+    cpu_count
+FROM server_properties
+WHERE server_id = $1
+ORDER BY collection_time DESC
+LIMIT 1";
+
+    /// <summary>7-day P95 of Total Server Memory (MB) + sample count, for the memory right-sizing checks. $1 server_id, $2 cutoff (naive UTC).</summary>
+    public const string RecommendationsMemoryP95Sql = @"
+SELECT
+    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY total_server_memory_mb) AS p95_mb,
+    COUNT(*) AS sample_count
+FROM v_memory_stats
+WHERE server_id = $1
+AND   collection_time >= $2";
+
+    /// <summary>7-day P95 of SQL Server CPU utilization, for the VM right-sizing CPU prescription. $1 server_id, $2 cutoff (naive UTC).</summary>
+    public const string RecommendationsCpuP95Sql = @"
+SELECT PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY sqlserver_cpu_utilization) AS p95_cpu
+FROM v_cpu_utilization_stats
+WHERE server_id = $1
+AND   collection_time >= $2";
+
+    /// <summary>SQL Agent jobs that ran long at least 3 times in the window (maintenance-window efficiency). $1 server_id, $2 cutoff (naive UTC).</summary>
+    public const string RecommendationsMaintenanceWindowSql = @"
+SELECT
+    job_name,
+    COUNT(*) AS run_count,
+    AVG(current_duration_seconds) AS avg_duration_seconds,
+    MAX(current_duration_seconds) AS max_duration_seconds,
+    AVG(avg_duration_seconds) AS avg_historical,
+    SUM(CASE WHEN is_running_long THEN 1 ELSE 0 END) AS times_ran_long
+FROM v_running_jobs
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   avg_duration_seconds > 0
+GROUP BY job_name
+HAVING SUM(CASE WHEN is_running_long THEN 1 ELSE 0 END) >= 3
+ORDER BY times_ran_long DESC
+LIMIT 10";
+
+    /// <summary>Per-database aggregate read/write I/O + stall over the window (storage-tier optimization). $1 server_id, $2 cutoff (naive UTC).</summary>
+    public const string RecommendationsStorageTierSql = @"
+SELECT
+    database_name,
+    SUM(delta_reads) AS total_reads,
+    SUM(delta_stall_read_ms) AS total_stall_read_ms,
+    SUM(delta_writes) AS total_writes,
+    SUM(delta_stall_write_ms) AS total_stall_write_ms
+FROM v_file_io_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+AND   delta_reads > 0
+GROUP BY database_name
+HAVING SUM(delta_reads) > 1000";
+
+    /// <summary>CPU utilization mean + standard deviation + sample count (reserved-capacity stability). $1 server_id, $2 cutoff (naive UTC).</summary>
+    public const string RecommendationsReservedCapacitySql = @"
+SELECT
+    AVG(sqlserver_cpu_utilization) AS avg_cpu,
+    STDDEV(sqlserver_cpu_utilization) AS stddev_cpu,
+    COUNT(*) AS sample_count
+FROM v_cpu_utilization_stats
+WHERE server_id = $1
+AND   collection_time >= $2
+HAVING COUNT(*) >= 24";
+
+    /// <summary>The server's latest collected edition facts for the license audit (null when nothing collected yet).</summary>
+    public readonly record struct EditionFacts(string Edition, int MajorVersion, int CpuCount);
+
+    /// <summary>Reads the server's latest collected edition / product-version-major / CPU count, or null when no server_properties row exists yet.</summary>
+    public async Task<EditionFacts?> GetEditionFactsAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(RecommendationsEditionFactsSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        var edition = reader.IsDBNull(0) ? "" : reader.GetString(0);
+        var productVersion = reader.IsDBNull(1) ? null : reader.GetString(1);
+        var cpuCount = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2), CultureInfo.InvariantCulture);
+        return new EditionFacts(edition, ParseMajorVersion(productVersion), cpuCount);
+    }
+
+    /// <summary>
+    /// Selects the databases running Transparent Data Encryption from a collected database-config snapshot — the
+    /// monitor-side stand-in for Lite's live <c>dm_db_persisted_sku_features</c> probe: <c>is_encrypted = true</c>
+    /// marks a TDE database. System databases (Lite's <c>database_id &gt; 4</c>) and non-ONLINE databases are
+    /// excluded, mirroring Lite's probe. Ordered by name for stable output.
+    /// </summary>
+    public static List<string> SelectTdeDatabaseNames(IEnumerable<DatabaseConfigRow> configRows) =>
+        configRows
+            .Where(r => r.IsEncrypted
+                && string.Equals(r.StateDesc, "ONLINE", StringComparison.OrdinalIgnoreCase)
+                && !RecommendationsSystemDatabases.Contains(r.DatabaseName))
+            .Select(r => r.DatabaseName)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>
+    /// Matches the collected database names against Lite's dev/test name patterns (<c>%dev% / %test% / %staging% /
+    /// %qa%</c>, case-insensitive) excluding the system databases (Lite's <c>database_id &gt; 4</c>). Pure so the
+    /// pattern logic is unit-testable without a store.
+    /// </summary>
+    public static List<string> MatchDevTestDatabases(IEnumerable<string> databaseNames)
+    {
+        static bool IsDevTest(string name) =>
+            name.Contains("dev", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("test", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("staging", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("qa", StringComparison.OrdinalIgnoreCase);
+
+        return databaseNames
+            .Where(n => !RecommendationsSystemDatabases.Contains(n) && IsDevTest(n))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Builds the Edition / license audit recommendations from the collected facts (check 1 + Lite's check 10
+    /// license-cost math). Returns an empty list for non-Enterprise editions. The full Enterprise branching is
+    /// ported verbatim from Lite — 2019+ (TDE moved to Standard) vs pre-2019 (TDE is the last Enterprise-only
+    /// blocker, read from <paramref name="tdeDbNames"/>), the 40%-of-budget downgrade estimate, and the
+    /// $5,000/core/year list-price core math — MINUS the AG-role nuance (Darling collects no AG state): the
+    /// secondary-replica branch and advanced-AG downgrade caveat are omitted, the downgrade-guidance recs carry
+    /// the <see cref="AvailabilityGroupNotEvaluatedNote"/>, and the AG-driven confidence downgrades collapse to
+    /// their standalone values (Lite's own fallback for AG-less platforms).
+    /// </summary>
+    public static List<RecommendationRow> BuildEditionAuditRecommendations(
+        string edition,
+        int majorVersion,
+        int cpuCount,
+        IReadOnlyList<string> tdeDbNames,
+        decimal monthlyCost)
+    {
+        var recommendations = new List<RecommendationRow>();
+
+        if (!edition.Contains("Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return recommendations;
+        }
+
+        // SQL Server 2019 (major version 15) moved TDE to Standard Edition, so on 2019+ we give
+        // version-appropriate guidance rather than a TDE-specific check.
+        if (majorVersion >= 15)
+        {
+            recommendations.Add(new RecommendationRow
+            {
+                Category = "Licensing",
+                Severity = "High",
+                Confidence = "Medium",
+                Finding = "Enterprise Edition may not be required",
+                Detail = "Starting with SQL Server 2019, most previously Enterprise-only features " +
+                         "(including TDE, compression, partitioning, and columnstore) are available " +
+                         "in Standard Edition. Review whether remaining Enterprise-only features " +
+                         "(such as Always On availability groups with multiple secondaries) are in use " +
+                         "before considering a downgrade to Standard Edition." + AvailabilityGroupNotEvaluatedNote,
+                EstMonthlySavings = monthlyCost > 0 ? monthlyCost * 0.40m : null
+            });
+        }
+        else if (tdeDbNames.Count == 0)
+        {
+            // Pre-2019: TDE is the only commonly-used feature still restricted to Enterprise since 2016 SP1.
+            recommendations.Add(new RecommendationRow
+            {
+                Category = "Licensing",
+                Severity = "High",
+                Confidence = "High",
+                Finding = "Enterprise Edition with no Enterprise-only features detected",
+                Detail = "No databases use Transparent Data Encryption (TDE), the only feature " +
+                         "still restricted to Enterprise Edition since SQL Server 2016 SP1. " +
+                         "Review whether Standard Edition would meet workload requirements for potential license savings." +
+                         AvailabilityGroupNotEvaluatedNote,
+                EstMonthlySavings = monthlyCost > 0 ? monthlyCost * 0.40m : null
+            });
+        }
+        else
+        {
+            recommendations.Add(new RecommendationRow
+            {
+                Category = "Licensing",
+                Severity = "Low",
+                Confidence = "High",
+                Finding = "TDE in use — Enterprise Edition downgrade blocker",
+                Detail = $"The following databases use Transparent Data Encryption: {string.Join(", ", tdeDbNames.Take(20))}" +
+                         (tdeDbNames.Count > 20 ? $" and {tdeDbNames.Count - 20} more" : "") +
+                         ". TDE must be removed before downgrading to Standard Edition."
+            });
+
+            // Check 10: license cost impact estimate (only when features ARE in use).
+            if (cpuCount > 0)
+            {
+                var monthlySavings = cpuCount * 5000m / 12m;
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Licensing",
+                    Severity = "Low",
+                    Confidence = "Low",
+                    Finding = $"Enterprise to Standard would save ~${monthlySavings:N0}/mo at list pricing ({cpuCount} cores)",
+                    Detail = "Based on list pricing differential of ~$5,000/core/year between Enterprise and Standard. " +
+                             "Actual savings depend on your licensing agreement. See Enterprise feature audit for downgrade blockers.",
+                    EstMonthlySavings = monthlySavings
+                });
+            }
+        }
+
+        return recommendations;
+    }
+
+    /// <summary>
+    /// Builds the Compression-candidate recommendation (check 5) from the collected per-index snapshot — the
+    /// monitor-side stand-in for Lite's live <c>sys.partitions</c> scan: uncompressed
+    /// (<c>data_compression_desc = 'NONE'</c>, which excludes columnstore) rowstore indexes / heaps whose reserved
+    /// size is at least 1 GB. Returns null when none qualify. Severity/wording ported verbatim from Lite.
+    /// </summary>
+    public static RecommendationRow? BuildCompressionRecommendation(IEnumerable<IndexCleanupIndexInput> indexes)
+    {
+        var candidates = indexes
+            .Where(i => string.Equals(i.DataCompressionDesc, "NONE", StringComparison.OrdinalIgnoreCase)
+                && (i.ReservedMb ?? 0m) >= 1024m)
+            .OrderByDescending(i => i.ReservedMb ?? 0m)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var totalGb = candidates.Sum(c => c.ReservedMb ?? 0m) / 1024m;
+        var topItems = candidates.Take(5)
+            .Select(c => $"{c.SchemaName}.{c.TableName} ({(c.ReservedMb ?? 0m) / 1024m:N1}GB)")
+            .ToList();
+
+        return new RecommendationRow
+        {
+            Category = "Storage",
+            Severity = totalGb > 50 ? "High" : totalGb > 10 ? "Medium" : "Low",
+            Confidence = "High",
+            Finding = $"{candidates.Count} uncompressed object(s) >= 1GB ({totalGb:N1}GB total)",
+            Detail = $"Large uncompressed tables/indexes: {string.Join("; ", topItems)}" +
+                     (candidates.Count > 5 ? $" and {candidates.Count - 5} more" : "") +
+                     ". Consider PAGE or ROW compression to reduce storage and improve I/O."
+        };
+    }
+
+    /// <summary>
+    /// Runs every monitor-side FinOps recommendation check over the collected store and returns the consolidated
+    /// list sorted by severity. All reads are async I/O (they don't block the UI thread), and each check is
+    /// isolated in its own try/catch so a single failing read degrades to "that check absent" rather than an
+    /// empty tab. <paramref name="monthlyCost"/> is the per-server budget (0 → findings emit with no savings
+    /// estimate, mirroring Lite's <c>monthlyCost &gt; 0 ? … : null</c>).
+    /// </summary>
+    public async Task<List<RecommendationRow>> GetRecommendationsAsync(int serverId, decimal monthlyCost, CancellationToken cancellationToken = default)
+    {
+        var recommendations = new List<RecommendationRow>();
+        var memoryCutoff = DateTime.SpecifyKind(DateTime.UtcNow.AddDays(-7), DateTimeKind.Unspecified);
+
+        // 1. Enterprise feature / license audit (collected server_properties + database_config.is_encrypted).
+        try
+        {
+            var facts = await GetEditionFactsAsync(serverId, cancellationToken);
+            if (facts is { } f)
+            {
+                var isEnterprise = f.Edition.Contains("Enterprise", StringComparison.OrdinalIgnoreCase);
+
+                // TDE is only the deciding factor on pre-2019 Enterprise — read the config snapshot just then.
+                var tdeDbNames = new List<string>();
+                if (isEnterprise && f.MajorVersion < 15)
+                {
+                    var configRows = await GetLatestDatabaseConfigAsync(serverId, cancellationToken);
+                    tdeDbNames = SelectTdeDatabaseNames(configRows);
+                }
+
+                recommendations.AddRange(
+                    BuildEditionAuditRecommendations(f.Edition, f.MajorVersion, f.CpuCount, tdeDbNames, monthlyCost));
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Enterprise features): {ex.Message}");
+        }
+
+        // 2. CPU right-sizing (collected utilization efficiency).
+        try
+        {
+            var util = await GetUtilizationEfficiencyAsync(serverId, cancellationToken);
+            if (util != null && util.P95CpuPct < 30 && util.CpuCount > 4)
+            {
+                var targetCores = Math.Max(4, (int)(util.CpuCount * (util.P95CpuPct / 70m)));
+                var savingsPct = 1m - ((decimal)targetCores / util.CpuCount);
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Compute",
+                    Severity = util.P95CpuPct < 15 ? "High" : "Medium",
+                    Confidence = "Medium",
+                    Finding = $"CPU over-provisioned ({util.CpuCount} cores, P95 = {util.P95CpuPct:N1}%)",
+                    Detail = $"P95 CPU utilization is {util.P95CpuPct:N1}% (avg {util.AvgCpuPct:N1}%, max {util.MaxCpuPct}%) across {util.CpuCount} cores. " +
+                             $"Consider reducing to ~{targetCores} cores.",
+                    EstMonthlySavings = monthlyCost > 0 ? monthlyCost * savingsPct * 0.60m : null
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (CPU right-sizing): {ex.Message}");
+        }
+
+        // 3. Memory right-sizing (7-day P95 Total Server Memory vs physical RAM).
+        try
+        {
+            var util = await GetUtilizationEfficiencyAsync(serverId, cancellationToken);
+            if (util != null && util.PhysicalMemoryMb > 8192)
+            {
+                var (p95Mb, sampleCount) = await ReadMemoryP95Async(serverId, memoryCutoff, cancellationToken);
+
+                // Need ~16 samples to smooth a single-point anomaly without delaying the recommendation for hours.
+                if (sampleCount >= 16)
+                {
+                    var memRatio = (decimal)p95Mb / util.PhysicalMemoryMb;
+                    if (memRatio < 0.50m)
+                    {
+                        var targetMb = Math.Max(8192, p95Mb * 2);
+                        recommendations.Add(new RecommendationRow
+                        {
+                            Category = "Memory",
+                            Severity = memRatio < 0.30m ? "High" : "Medium",
+                            Confidence = "Medium",
+                            Finding = $"Memory over-provisioned (P95 SQL memory uses {memRatio:P0} of {util.PhysicalMemoryMb / 1024}GB RAM)",
+                            Detail = $"P95 SQL Server memory over 7 days is {p95Mb:N0} MB out of {util.PhysicalMemoryMb:N0} MB physical RAM ({memRatio:P0} utilization). " +
+                                     $"Consider reducing to ~{targetMb / 1024}GB.",
+                            EstMonthlySavings = monthlyCost > 0 ? monthlyCost * (1m - (decimal)targetMb / util.PhysicalMemoryMb) * 0.30m : null
+                        });
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Memory right-sizing): {ex.Message}");
+        }
+
+        // 5. Compression candidates (collected index_object_stats snapshot; Lite's check 4 is dropped — Darling
+        //    has native Index Analysis, so the sp_IndexCleanup-existence prompt is obsolete).
+        try
+        {
+            var indexes = await GetIndexCleanupInputsAsync(serverId, cancellationToken);
+            var rec = BuildCompressionRecommendation(indexes);
+            if (rec != null)
+            {
+                recommendations.Add(rec);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Compression): {ex.Message}");
+        }
+
+        // 6. Dormant database detection with cost impact (collected idle DBs + database sizes).
+        try
+        {
+            var idleDbs = await GetIdleDatabasesAsync(serverId, cancellationToken: cancellationToken);
+            if (idleDbs.Count > 0)
+            {
+                var totalSizeGb = idleDbs.Sum(d => d.TotalSizeMb) / 1024m;
+                var dbNames = string.Join(", ", idleDbs.Take(5).Select(d => d.DatabaseName));
+                var costShare = 0m;
+                if (monthlyCost > 0)
+                {
+                    var allDbSizes = await GetDatabaseSizeLatestAsync(serverId, cancellationToken);
+                    var totalMb = allDbSizes.Sum(d => d.TotalSizeMb);
+                    if (totalMb > 0)
+                        costShare = (idleDbs.Sum(d => d.TotalSizeMb) / totalMb) * monthlyCost;
+                }
+
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Databases",
+                    Severity = idleDbs.Count >= 3 ? "High" : "Medium",
+                    Confidence = "High",
+                    Finding = $"{idleDbs.Count} idle database(s) consuming {totalSizeGb:N1}GB",
+                    Detail = $"No query activity in 7 days: {dbNames}" +
+                             (idleDbs.Count > 5 ? $" and {idleDbs.Count - 5} more" : "") +
+                             ". Consider archiving or removing these databases.",
+                    EstMonthlySavings = costShare > 0 ? costShare : null
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Dormant databases): {ex.Message}");
+        }
+
+        // 7. Dev/test workload detection (collected database name list).
+        try
+        {
+            var configRows = await GetLatestDatabaseConfigAsync(serverId, cancellationToken);
+            var devDbs = MatchDevTestDatabases(configRows.Select(r => r.DatabaseName));
+            if (devDbs.Count > 0)
+            {
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Environment",
+                    Severity = "Medium",
+                    Confidence = "Low",
+                    Finding = $"{devDbs.Count} possible dev/test database(s) on production server",
+                    Detail = $"Databases matching dev/test patterns: {string.Join(", ", devDbs.Take(10))}" +
+                             (devDbs.Count > 10 ? $" and {devDbs.Count - 10} more" : "") +
+                             ". If these are non-production workloads, consider moving to a lower-cost tier or separate server."
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Dev/test detection): {ex.Message}");
+        }
+
+        // 11. Maintenance window efficiency — jobs running long (collected running_jobs).
+        try
+        {
+            await using var command = _dataSource.CreateCommand(RecommendationsMaintenanceWindowSql);
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var jobName = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                var avgDuration = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2), CultureInfo.InvariantCulture);
+                var maxDuration = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3), CultureInfo.InvariantCulture);
+                var avgHistorical = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4), CultureInfo.InvariantCulture);
+                var timesLong = reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5), CultureInfo.InvariantCulture);
+
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Maintenance",
+                    Severity = timesLong >= 5 ? "Medium" : "Low",
+                    Confidence = "High",
+                    Finding = $"{jobName} ran long {timesLong} times in 7 days",
+                    Detail = $"Average duration: {FormatDuration(avgDuration)}, max: {FormatDuration(maxDuration)}, " +
+                             $"historical average: {FormatDuration(avgHistorical)}. " +
+                             "Review whether this job's schedule or operations need tuning."
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Maintenance window): {ex.Message}");
+        }
+
+        // 12. VM right-sizing — prescriptive core/memory targets (collected 7-day P95 CPU + memory).
+        try
+        {
+            var vmUtil = await GetUtilizationEfficiencyAsync(serverId, cancellationToken);
+            if (vmUtil != null)
+            {
+                decimal p95Cpu7d = vmUtil.P95CpuPct;
+                int cpuCount = vmUtil.CpuCount;
+                int physMb = vmUtil.PhysicalMemoryMb;
+
+                // Prefer the 7-day P95 CPU; fall back to the 24-hour P95 already on vmUtil.
+                try
+                {
+                    await using var cpuCommand = _dataSource.CreateCommand(RecommendationsCpuP95Sql);
+                    cpuCommand.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+                    cpuCommand.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
+
+                    await using var cpuReader = await cpuCommand.ExecuteReaderAsync(cancellationToken);
+                    if (await cpuReader.ReadAsync(cancellationToken) && !cpuReader.IsDBNull(0))
+                    {
+                        p95Cpu7d = Convert.ToDecimal(cpuReader.GetValue(0), CultureInfo.InvariantCulture);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Recommendation check (VM right-sizing) 7-day CPU P95 fell back to 24h: {ex.Message}");
+                }
+
+                var (p95MemMb, memSampleCount) = await ReadMemoryP95Async(serverId, memoryCutoff, cancellationToken);
+
+                // CPU prescription: only if >= 4 cores.
+                if (cpuCount >= 4)
+                {
+                    int targetCores = 0;
+                    if (p95Cpu7d < 15)
+                        targetCores = Math.Max(2, cpuCount / 4);
+                    else if (p95Cpu7d < 30)
+                        targetCores = Math.Max(2, cpuCount / 2);
+
+                    if (targetCores > 0 && targetCores < cpuCount)
+                    {
+                        recommendations.Add(new RecommendationRow
+                        {
+                            Category = "Hardware",
+                            Severity = "Medium",
+                            Confidence = "Medium",
+                            Finding = $"CPU: reduce from {cpuCount} to {targetCores} cores (P95 CPU {p95Cpu7d:N1}%)",
+                            Detail = $"Over the last 7 days, P95 CPU utilization was {p95Cpu7d:N1}%. " +
+                                     $"Current allocation of {cpuCount} cores can safely be reduced to {targetCores} cores.",
+                            EstMonthlySavings = monthlyCost > 0
+                                ? monthlyCost * (1m - (decimal)targetCores / cpuCount) * 0.50m
+                                : null
+                        });
+                    }
+                }
+
+                // Memory prescription: needs >= 4 GB physical and a handful of samples.
+                if (physMb >= 4096 && physMb > 0 && memSampleCount >= 16)
+                {
+                    var memRatio = (decimal)p95MemMb / physMb;
+                    int targetMb = 0;
+                    if (memRatio < 0.25m)
+                        targetMb = Math.Max(4096, physMb / 4);
+                    else if (memRatio < 0.40m)
+                        targetMb = Math.Max(4096, physMb / 2);
+
+                    if (targetMb > 0 && targetMb < physMb)
+                    {
+                        recommendations.Add(new RecommendationRow
+                        {
+                            Category = "Hardware",
+                            Severity = "Medium",
+                            Confidence = "Medium",
+                            Finding = $"Memory: reduce from {physMb / 1024}GB to {targetMb / 1024}GB (P95 SQL memory uses {memRatio:P0})",
+                            Detail = $"P95 SQL Server memory over 7 days is {p95MemMb:N0} MB of {physMb:N0} MB physical RAM ({memRatio:P0}). " +
+                                     $"Reducing to {targetMb / 1024}GB would still leave headroom.",
+                            EstMonthlySavings = monthlyCost > 0
+                                ? monthlyCost * (1m - (decimal)targetMb / physMb) * 0.30m
+                                : null
+                        });
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (VM right-sizing): {ex.Message}");
+        }
+
+        // 13. Storage tier optimization — databases with low I/O latency (collected file_io_stats).
+        try
+        {
+            var lowLatencyDbs = new List<(string Name, decimal AvgReadMs, decimal AvgWriteMs)>();
+
+            await using (var command = _dataSource.CreateCommand(RecommendationsStorageTierSql))
+            {
+                command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+                command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
+
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
+                    var totalReads = reader.IsDBNull(1) ? 0L : Convert.ToInt64(reader.GetValue(1), CultureInfo.InvariantCulture);
+                    var totalStallRead = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2), CultureInfo.InvariantCulture);
+                    var totalWrites = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3), CultureInfo.InvariantCulture);
+                    var totalStallWrite = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4), CultureInfo.InvariantCulture);
+
+                    var avgReadMs = totalReads > 0 ? (decimal)totalStallRead / totalReads : 0m;
+                    var avgWriteMs = totalWrites > 0 ? (decimal)totalStallWrite / totalWrites : 0m;
+
+                    if (avgReadMs < 5m && avgWriteMs < 3m)
+                    {
+                        lowLatencyDbs.Add((dbName, avgReadMs, avgWriteMs));
+                    }
+                }
+            }
+
+            if (lowLatencyDbs.Count > 0)
+            {
+                var detail = string.Join("; ", lowLatencyDbs.Take(10)
+                    .Select(d => $"{d.Name} (read {d.AvgReadMs:N1}ms, write {d.AvgWriteMs:N1}ms)"));
+                recommendations.Add(new RecommendationRow
+                {
+                    Category = "Storage",
+                    Severity = "Low",
+                    Confidence = "Medium",
+                    Finding = $"{lowLatencyDbs.Count} database(s) with low IO latency — standard storage may suffice",
+                    Detail = $"These databases have avg read latency under 5ms and write under 3ms over 7 days: {detail}" +
+                             (lowLatencyDbs.Count > 10 ? $" and {lowLatencyDbs.Count - 10} more" : "") +
+                             ". Premium/high-performance storage may not be needed."
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Storage tier): {ex.Message}");
+        }
+
+        // 14. Reserved capacity candidates — stable CPU utilization (collected cpu_utilization_stats).
+        try
+        {
+            await using var command = _dataSource.CreateCommand(RecommendationsReservedCapacitySql);
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken) && !reader.IsDBNull(0))
+            {
+                var avgCpu = Convert.ToDecimal(reader.GetValue(0), CultureInfo.InvariantCulture);
+                var stddevCpu = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1), CultureInfo.InvariantCulture);
+
+                if (avgCpu > 20 && stddevCpu > 0)
+                {
+                    var cv = stddevCpu / avgCpu;
+                    if (cv < 0.3m)
+                    {
+                        var confidence = cv < 0.15m ? "High" : "Medium";
+                        recommendations.Add(new RecommendationRow
+                        {
+                            Category = "Cloud",
+                            Severity = "Low",
+                            Confidence = confidence,
+                            Finding = $"Stable CPU utilization (avg {avgCpu:N1}%, CV {cv:N2}) — reserved capacity candidate",
+                            Detail = $"CPU utilization is consistently {avgCpu:N1}% with low variance (±{stddevCpu:N1}%). " +
+                                     "Reserved pricing typically saves 30-40% over pay-as-you-go for predictable workloads."
+                        });
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recommendation check failed (Reserved capacity): {ex.Message}");
+        }
+
+        return recommendations.OrderBy(r => r.SeveritySort).ToList();
+    }
+
+    /// <summary>Reads the 7-day P95 Total Server Memory (MB) + sample count (shared by the memory + VM right-sizing checks).</summary>
+    private async Task<(int P95Mb, long SampleCount)> ReadMemoryP95Async(int serverId, DateTime cutoff, CancellationToken cancellationToken)
+    {
+        await using var command = _dataSource.CreateCommand(RecommendationsMemoryP95Sql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = cutoff });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (await reader.ReadAsync(cancellationToken))
+        {
+            var p95Mb = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture);
+            var sampleCount = reader.IsDBNull(1) ? 0L : Convert.ToInt64(reader.GetValue(1), CultureInfo.InvariantCulture);
+            return (p95Mb, sampleCount);
+        }
+
+        return (0, 0L);
+    }
+
+    /// <summary>Human-readable duration formatting for the maintenance-window finding (Lite's FinOps FormatDuration, verbatim).</summary>
+    private static string FormatDuration(long seconds)
+    {
+        if (seconds >= 3600)
+            return $"{seconds / 3600}h {(seconds % 3600) / 60}m {seconds % 60}s";
+        if (seconds >= 60)
+            return $"{seconds / 60}m {seconds % 60}s";
+        return $"{seconds}s";
+    }
+}
+
+/// <summary>
+/// One FinOps recommendation row — a flat projection mirroring Lite's <c>RecommendationRow</c>
+/// (LocalDataService.FinOps.cs): Category / Severity / Confidence / Finding / Detail / EstMonthlySavings, with a
+/// formatted savings string and the severity sort key the grid orders by. Copied (not promoted) so Lite stays
+/// untouched.
+/// </summary>
+public sealed class RecommendationRow
+{
+    public string Category { get; set; } = "";
+    public string Severity { get; set; } = "";
+    public string Confidence { get; set; } = "";
+    public string Finding { get; set; } = "";
+    public string Detail { get; set; } = "";
+    public decimal? EstMonthlySavings { get; set; }
+    public string EstMonthlySavingsDisplay => EstMonthlySavings.HasValue ? $"${EstMonthlySavings.Value:N0}" : "";
+    public int SeveritySort => Severity switch
+    {
+        "High" => 1,
+        "Medium" => 2,
+        "Low" => 3,
+        _ => 4
+    };
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.Recommendations.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.Recommendations.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// FinOps Recommendations sub-tab — the last deferred FinOps sub-tab, reproduced MONITOR-SIDE. Lite's
+/// Recommendations mixed collected reads with LIVE target queries; the headless viewer runs every check over the
+/// already-collected Postgres store (<see cref="ViewerDataService.GetRecommendationsAsync"/>) — NO live SQL. This
+/// partial projects the resulting rows (Category / Severity / Confidence / Finding / Detail / Est. Savings, sorted
+/// by severity in the read) into the grid; the per-server monthly budget (<c>_server.MonthlyCostUsd</c>) drives
+/// the savings estimates (0 → the Est. Savings column stays blank, mirroring Lite). Load-on-view + a Refresh
+/// button, like the other FinOps sub-tabs.
+/// </summary>
+public partial class ViewerServerTab
+{
+    /// <summary>Reads the collected recommendations for this server and repaints the grid + count indicator.</summary>
+    private async Task LoadFinOpsRecommendationsAsync()
+    {
+        var data = await _dataService.GetRecommendationsAsync(_server.ServerId, _server.MonthlyCostUsd);
+
+        _finopsRecommendationsFilterMgr!.UpdateData(data);
+        FinOpsRecommendationsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        FinOpsRecommendationsCountIndicator.Text = data.Count > 0
+            ? $"{data.Count} recommendation(s)"
+            : "no recommendations — this server looks right-sized";
+    }
+
+    /// <summary>Refresh button — re-runs the checks over the latest collected data with the shell's status-bar error surfacing.</summary>
+    private async void FinOpsRefreshRecommendations_Click(object sender, RoutedEventArgs e)
+        => await RunFinOpsLoad(LoadFinOpsRecommendationsAsync);
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FinOps.cs
@@ -19,16 +19,20 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// The FinOps inner tab — a COPY of Lite's FinOps tab (<c>Controls/FinOpsTab.xaml.cs</c>) for the
-/// copy-parity program, reads rewired to <see cref="ViewerDataService"/> Postgres. Nine store-backed
-/// sub-tabs are ported (Utilization, Database Resources, Storage Growth, Locking &amp; Contention,
-/// Database Sizes, Optimization, High Impact, Application Connections, Server Inventory); Lite's two
-/// live-target sub-tabs (Index Analysis / Recommendations) are deliberately EXCLUDED. Unlike Lite's
-/// cross-server FinOps tab, this is a per-server inner tab, so it drops Lite's server selector and scopes
-/// the per-server sub-tabs to <c>_server.ServerId</c>; only Server Inventory stays cross-server (it lists
-/// every registered server). The per-server FinOps COST attribution is dropped (the headless store has no
-/// budget); the health score is kept. This partial holds the sub-tab dispatch, the filter-manager wiring,
-/// and the simple grid loaders; Locking lives in <c>.FinOps.Locking.cs</c> and the Storage Growth drill in
-/// <c>.FinOps.ObjectHeatmap.cs</c>.
+/// copy-parity program, reads rewired to <see cref="ViewerDataService"/> Postgres. All eleven sub-tabs are
+/// ported (Utilization, Database Resources, Storage Growth, Locking &amp; Contention, Database Sizes,
+/// Optimization, High Impact, Application Connections, Server Inventory, plus Index Analysis and
+/// Recommendations); Lite's two originally live-target sub-tabs (Index Analysis / Recommendations) are
+/// reproduced MONITOR-SIDE over the collected store — Index Analysis (#1387) reruns sp_IndexCleanup via the
+/// Common analyzer, and Recommendations runs its ~10 cost checks over collected views — so neither touches a
+/// live target. Unlike Lite's cross-server FinOps tab, this is a per-server inner tab, so it drops Lite's
+/// server selector and scopes the per-server sub-tabs to <c>_server.ServerId</c>; only Server Inventory stays
+/// cross-server (it lists every registered server). The per-server FinOps COST attribution is sourced from the
+/// registry (<c>servers.monthly_cost_usd</c> → <c>_server.MonthlyCostUsd</c>; 0 hides the cost affordances);
+/// the health score is kept. This partial holds the sub-tab dispatch, the filter-manager wiring, and the
+/// simple grid loaders; Locking lives in <c>.FinOps.Locking.cs</c>, the Storage Growth drill in
+/// <c>.FinOps.ObjectHeatmap.cs</c>, Index Analysis in <c>.FinOps.IndexAnalysis.cs</c>, and Recommendations in
+/// <c>.FinOps.Recommendations.cs</c>.
 /// </summary>
 public partial class ViewerServerTab
 {
@@ -43,6 +47,7 @@ public partial class ViewerServerTab
     private const int FinOpsApplicationConnectionsSubTabIndex = 7;
     private const int FinOpsServerInventorySubTabIndex = 8;
     private const int FinOpsIndexAnalysisSubTabIndex = 9;
+    private const int FinOpsRecommendationsSubTabIndex = 10;
 
     private DataGridFilterManager<DatabaseResourceUsageRow>? _finopsDbResourcesFilterMgr;
     private DataGridFilterManager<StorageGrowthRow>? _finopsStorageGrowthFilterMgr;
@@ -58,6 +63,7 @@ public partial class ViewerServerTab
     private DataGridFilterManager<IndexLockingRow>? _finopsIndexLockingFilterMgr;
     private DataGridFilterManager<IndexCleanupRollupRow>? _finopsIndexAnalysisRollupFilterMgr;
     private DataGridFilterManager<IndexCleanupRecommendationRow>? _finopsIndexAnalysisFilterMgr;
+    private DataGridFilterManager<RecommendationRow>? _finopsRecommendationsFilterMgr;
 
     /// <summary>
     /// Registers the FinOps grids' column-filter managers into the shared <c>_filterManagers</c> map
@@ -80,6 +86,7 @@ public partial class ViewerServerTab
         _finopsIndexLockingFilterMgr = new DataGridFilterManager<IndexLockingRow>(FinOpsIndexLockingDataGrid);
         _finopsIndexAnalysisRollupFilterMgr = new DataGridFilterManager<IndexCleanupRollupRow>(FinOpsIndexAnalysisRollupGrid);
         _finopsIndexAnalysisFilterMgr = new DataGridFilterManager<IndexCleanupRecommendationRow>(FinOpsIndexAnalysisDetailGrid);
+        _finopsRecommendationsFilterMgr = new DataGridFilterManager<RecommendationRow>(FinOpsRecommendationsDataGrid);
 
         _filterManagers[FinOpsDatabaseResourcesDataGrid] = _finopsDbResourcesFilterMgr;
         _filterManagers[FinOpsStorageGrowthDataGrid] = _finopsStorageGrowthFilterMgr;
@@ -95,6 +102,7 @@ public partial class ViewerServerTab
         _filterManagers[FinOpsIndexLockingDataGrid] = _finopsIndexLockingFilterMgr;
         _filterManagers[FinOpsIndexAnalysisRollupGrid] = _finopsIndexAnalysisRollupFilterMgr;
         _filterManagers[FinOpsIndexAnalysisDetailGrid] = _finopsIndexAnalysisFilterMgr;
+        _filterManagers[FinOpsRecommendationsDataGrid] = _finopsRecommendationsFilterMgr;
     }
 
     /// <summary>
@@ -147,6 +155,9 @@ public partial class ViewerServerTab
                 break;
             case FinOpsIndexAnalysisSubTabIndex:
                 await LoadFinOpsIndexAnalysisAsync();
+                break;
+            case FinOpsRecommendationsSubTabIndex:
+                await LoadFinOpsRecommendationsAsync();
                 break;
             case FinOpsUtilizationSubTabIndex:
             default:

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -3002,6 +3002,60 @@
                         </Grid>
                     </Grid>
                 </TabItem>
+
+                <!-- Recommendations Sub-Tab (last deferred FinOps sub-tab): the ~10 cost-saving checks reproduced
+                     MONITOR-SIDE over the collected store (edition/license audit, CPU/memory right-sizing,
+                     compression candidates, dormant + dev/test DBs, maintenance window, VM right-sizing, storage
+                     tier, reserved capacity) — NO live target. Lite's sp_IndexCleanup-existence check is dropped
+                     (superseded by the native Index Analysis sub-tab). Sorted by severity; the per-server budget
+                     drives Est. Savings (0 → blank). -->
+                <TabItem Header="Recommendations">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                            <TextBlock Text="Cost-Saving Recommendations" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <Button Content="Refresh" Click="FinOpsRefreshRecommendations_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                            <TextBlock x:Name="FinOpsRecommendationsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
+                            <TextBlock Text="Analyzed from collected data (no live target)." Margin="16,0,0,0" VerticalAlignment="Center" FontStyle="Italic" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                        </StackPanel>
+
+                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                            <DataGrid x:Name="FinOpsRecommendationsDataGrid" Style="{StaticResource DarkGrid}" RowStyle="{StaticResource FinOpsRowStyle}" HorizontalScrollBarVisibility="Auto" AutoGenerateColumns="False" IsReadOnly="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding Category}" Width="120"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Category" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Category" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Severity}" Width="90" SortMemberPath="SeveritySort">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Severity" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Severity" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Severity}" Value="High"><Setter Property="Foreground" Value="#E74C3C"/></DataTrigger>
+                                                    <DataTrigger Binding="{Binding Severity}" Value="Medium"><Setter Property="Foreground" Value="#F39C12"/></DataTrigger>
+                                                    <DataTrigger Binding="{Binding Severity}" Value="Low"><Setter Property="Foreground" Value="#27AE60"/></DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Confidence}" Width="100"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Confidence" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Confidence" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Finding}" Width="360">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Finding" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Finding" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding Finding}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Detail" Binding="{Binding Detail}" Width="560">
+                                        <DataGridTextColumn.ElementStyle><Style TargetType="TextBlock"><Setter Property="ToolTip" Value="{Binding Detail}"/></Style></DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Header="Est. Savings ($/mo)" Binding="{Binding EstMonthlySavingsDisplay}" Width="130" SortMemberPath="EstMonthlySavings" ElementStyle="{StaticResource NumericCell}"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+
+                            <TextBlock x:Name="FinOpsRecommendationsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No recommendations — this server looks right-sized, or not enough has been collected yet."/>
+                        </Grid>
+                    </Grid>
+                </TabItem>
             </TabControl>
         </TabItem>
 


### PR DESCRIPTION
Ports the **last deferred FinOps sub-tab** — Recommendations — into the headless Darling viewer. Lite's `GetRecommendationsAsync` mixed collected reads with **live target queries**; this reproduces every check **monitor-side over the collected Postgres store**. **It hits NO live target — all collected-data, monitor-side.**

## 10 checks ported (thresholds / severity / confidence / wording verbatim from Lite)

| # | Check | Darling data source |
|---|-------|---------------------|
| 1 | Edition / license audit (+ core-count license math) | collected `server_properties` (edition / product_version / cpu_count) + `database_config.is_encrypted` for TDE — replaces Lite's live `dm_db_persisted_sku_features` probe |
| 2 | CPU right-sizing (P95 CPU < 30, cores > 4) | `GetUtilizationEfficiencyAsync` (`v_cpu_utilization_stats` + `v_memory_stats`) |
| 3 | Memory right-sizing (7-day P95 Total Server Memory vs physical) | `GetUtilizationEfficiencyAsync` + P95 over `v_memory_stats` |
| 5 | Compression candidates (uncompressed rowstore ≥ 1GB) | reproduced from collected `index_object_stats` (`data_compression_desc = 'NONE'`) via `GetIndexCleanupInputsAsync` — replaces Lite's live `sys.partitions` scan |
| 6 | Dormant database detection | `GetIdleDatabasesAsync` + `GetDatabaseSizeLatestAsync` |
| 7 | Dev/test detection (name patterns) | reproduced from the collected database name list (`v_database_config`) |
| 11 | Maintenance window (jobs ran long) | `v_running_jobs` |
| 12 | VM right-sizing (prescriptive core/memory targets) | `GetUtilizationEfficiencyAsync` + 7-day P95 over `v_cpu_utilization_stats` / `v_memory_stats` |
| 13 | Storage tier optimization (low-latency DBs) | `v_file_io_stats` |
| 14 | Reserved capacity candidates (stable CPU CV) | `v_cpu_utilization_stats` |

## 1 check dropped

- **Check 4 (sp_IndexCleanup existence)** — obsolete: Darling has **native monitor-side Index Analysis** (the FinOps Index Analysis sub-tab, #1387), so the "install sp_IndexCleanup to find unused/duplicate indexes" recommendation no longer applies. Not ported.

## AG-nuance deferral (edition audit)

Darling collects **no Availability Group state**, so the edition audit cannot detect a secondary replica or advanced (non-Basic) AGs. It proceeds as **"Standalone"** (Lite's own fallback for AG-less platforms), **omits** the AG-secondary branch and the advanced-AG downgrade caveat, and adds a short note in the finding Detail that **AG topology isn't evaluated headlessly**. No AG data is invented; the full Enterprise branching (2019+ vs pre-2019 TDE logic, 40%-of-budget estimate, $5,000/core/year license math) is otherwise intact.

## Cost

Per-server monthly cost is sourced from `servers.monthly_cost_usd` (`_server.MonthlyCostUsd`), the same way the other cost-showing FinOps sub-tabs do it. When cost is 0/unset, findings emit **without** an Est. Savings value (mirrors Lite's `monthlyCost > 0 ? … : null`).

## Files

- `ViewerDataService.FinOps.Recommendations.cs` — the check engine (all reads off the collected Postgres `v_*` views / tables), returning `RecommendationRow` sorted by severity; pure static helpers for the reproduced checks (edition branching, TDE-from-is_encrypted, compression scorer, dev/test matcher)
- `ViewerServerTab.FinOps.Recommendations.cs` + XAML TabItem — grid (Category / Severity / Confidence / Finding / Detail / Est. Savings), load-on-view + Refresh, mirroring the Index Analysis sub-tab
- `ViewerServerTab.FinOps.cs` — sub-tab wired at index 10 (after Index Analysis)

## Tests

25 new `Darling.Tests` covering the reproduced checks' data-mapping + threshold logic (edition-audit branching incl. AG-deferral guard, TDE-from-`is_encrypted`, compression-from-`index_object_stats` incl. severity bands, dev/test name match), the collected time-series reads' SQL contract (PG dialect + view names + column parity against the generated collector DDL), and the `RecommendationRow` projection.

- Viewer builds `-c Release`: **succeeds**
- `dotnet test Darling/Darling.Tests -c Release`: **799 passed / 0 failed / 83 skipped**

Scope: **viewer + viewer-tests only** — collectors, migrations, the analyzer, and Lite are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
