### PR TITLE
Fix BYO first-start collecting nothing (search_path pool timing) + refresh Darling README

### DIFF
--- a/Darling/Darling.Tests/DarlingWorkerTests.cs
+++ b/Darling/Darling.Tests/DarlingWorkerTests.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Linq;
+using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
@@ -37,5 +38,49 @@ public sealed class DarlingWorkerTests
         }
 
         Assert.Equal(CollectorCatalog.All.Count, dispatched.Count);
+    }
+
+    /// <summary>
+    /// A bring-your-own store connection string that omits the search path must get the canonical
+    /// collect/config/public one injected BEFORE the data source is created — otherwise the Npgsql
+    /// pool's first physical connections keep a pre-migration session search_path and a fresh BYO
+    /// store silently collects nothing (42P01) until the service restarts. The injected path pins
+    /// against the managed constant so both modes carry the same schemas in the same order.
+    /// </summary>
+    [Fact]
+    public void EnsureStoreSearchPath_InjectsCanonicalPath_WhenByoStringOmitsIt()
+    {
+        const string byo = "Host=localhost;Port=5432;Username=darling;Database=darling";
+        Assert.Empty(new NpgsqlConnectionStringBuilder(byo).SearchPath ?? string.Empty);
+
+        var result = DarlingWorker.EnsureStoreSearchPath(byo);
+
+        var parsed = new NpgsqlConnectionStringBuilder(result);
+        Assert.Equal("collect,config,public", parsed.SearchPath);
+        Assert.Equal(DarlingManagedPostgres.SearchPath, parsed.SearchPath);
+
+        /* The rest of the connection string is preserved. */
+        Assert.Equal("localhost", parsed.Host);
+        Assert.Equal(5432, parsed.Port);
+        Assert.Equal("darling", parsed.Username);
+        Assert.Equal("darling", parsed.Database);
+    }
+
+    /// <summary>
+    /// A connection string that ALREADY specifies a Search Path (managed mode carries it, and a BYO
+    /// operator may set their own) is returned untouched — no double-set, and a non-default choice
+    /// is respected.
+    /// </summary>
+    [Fact]
+    public void EnsureStoreSearchPath_LeavesExistingSearchPathUnchanged()
+    {
+        /* Managed-mode shape: already carries collect,config,public. */
+        var managed = DarlingManagedPostgres.BuildConnectionString(5641, "pw123");
+        Assert.Equal(managed, DarlingWorker.EnsureStoreSearchPath(managed));
+
+        /* A BYO operator's own non-default choice is respected, not overwritten. */
+        const string custom = "Host=pg.example.com;Database=metrics;Search Path=collect,config,reporting,public";
+        var result = DarlingWorker.EnsureStoreSearchPath(custom);
+        Assert.Equal("collect,config,reporting,public", new NpgsqlConnectionStringBuilder(result).SearchPath);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -193,6 +193,15 @@ public sealed class DarlingWorker : BackgroundService
     /// </summary>
     private async Task RunCollectionLoopAsync(DarlingConfig config, string storeConnectionString, CancellationToken stoppingToken)
     {
+        /* Carry the collect/config search path on the store connection string BEFORE the data
+           source (and its pool) is created, so every pooled physical connection resolves the
+           shared SQL's bare table names to the V8 schemas from its very first use — deterministic
+           and independent of the pool's connection-open timing relative to PgMigrations'
+           best-effort ALTER DATABASE ... SET search_path. Without this a FRESH bring-your-own
+           store silently collects nothing until the service is restarted; see
+           EnsureStoreSearchPath for the pool-timing root cause. Managed mode already sets it, so
+           this is a no-op there. */
+        storeConnectionString = EnsureStoreSearchPath(storeConnectionString);
         await using var postgres = NpgsqlDataSource.Create(storeConnectionString);
         _postgres = postgres;
         try
@@ -367,6 +376,45 @@ public sealed class DarlingWorker : BackgroundService
         }
 
         _logger.LogInformation("PerformanceMonitor Darling collection loop stopped");
+    }
+
+    /// <summary>
+    /// Ensures the store connection string carries the collect/config search path (the V8 schema
+    /// split) so every pooled physical connection resolves the shared SQL's bare table names to the
+    /// <c>collect</c>/<c>config</c> schemas from its FIRST use. Managed mode already sets it
+    /// (<see cref="DarlingManagedPostgres.SearchPath"/>) — that string is returned unchanged, no
+    /// double-set. A bring-your-own connection string usually omits it and would otherwise rely on
+    /// the database-default <c>search_path</c> that
+    /// <see cref="PgMigrations.MigrateAsync(NpgsqlConnection, ILogger, CancellationToken)"/>
+    /// best-effort sets via <c>ALTER DATABASE ... SET search_path</c>.
+    ///
+    /// <para>That database default only governs the startup search_path of connections established
+    /// AFTER the ALTER commits, but the Npgsql pool's physical connections opened around it (for the
+    /// migration itself, the hypertable conversion, and the first collection sweep) keep their
+    /// pre-ALTER session search_path for their entire lifetime. On a FRESH BYO store that means the
+    /// whole first run fails — hypertable conversion, delta seeding, and every collector write hit
+    /// <c>42P01: relation "wait_stats" does not exist</c> — and collection only starts working after
+    /// a service restart hands out a fresh pool. Carrying the search path on the connection string
+    /// itself is deterministic and pool-timing-independent; any login may <c>SET</c> its own
+    /// search_path, so this is safe for least-privilege BYO logins too.</para>
+    /// </summary>
+    internal static string EnsureStoreSearchPath(string connectionString)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+        if (string.IsNullOrWhiteSpace(builder.SearchPath))
+        {
+            /* DarlingManagedPostgres is annotated [SupportedOSPlatform("windows")] for its DPAPI /
+               bundled-cluster surface, but SearchPath is a platform-neutral compile-time constant
+               with no runtime dependency, and BYO mode runs on any OS — so the CA1416 cross-platform
+               reachability flag is spurious for this const reference. Suppressed narrowly rather than
+               forking the constant, keeping managed and BYO byte-identical (a test pins them equal). */
+#pragma warning disable CA1416
+            builder.SearchPath = DarlingManagedPostgres.SearchPath;
+#pragma warning restore CA1416
+            return builder.ConnectionString;
+        }
+
+        return connectionString;
     }
 
     /// <summary>

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -4,7 +4,7 @@ Darling is the headless, centralized edition of Performance Monitor: a 24/7 Wind
 
 It runs the **same monitoring brain as the Lite edition** — one shared codebase, two storage engines:
 
-- `PerformanceMonitor.Collectors` owns all 26 collector definitions: the exact T-SQL sent to monitored servers, the result-row mappings, the delta rules, the default cadences and retention horizons, and the ignored-wait-types list. Lite writes those rows to DuckDB; Darling writes the same rows to PostgreSQL via binary COPY.
+- `PerformanceMonitor.Collectors` owns all 32 collector definitions: the exact T-SQL sent to monitored servers, the result-row mappings, the delta rules, the default cadences and retention horizons, and the ignored-wait-types list. Lite writes those rows to DuckDB; Darling writes the same rows to PostgreSQL via binary COPY.
 - `PerformanceMonitor.Alerting` owns the shared alert engine — the same thresholds, edge-trigger gates, cooldowns, and dedup fingerprints Lite uses.
 - The analysis/recommendations pipeline (the same inference engine behind both apps' Recommendations tabs and the `analyze_server` MCP tool) runs on a schedule inside the service.
 
@@ -97,7 +97,7 @@ The same executable serves interactive debugging and service installation; the W
 Darling\PerformanceMonitor.Darling.Service\bin\Release\net10.0\PerformanceMonitor.Darling.Service.exe
 ```
 
-Watch the log output: you should see the config load (`Loaded configuration from ...`), the store migrate (`Postgres store ready (schema v4, ...)`), the TimescaleDB detection result, per-server connects, and then per-collector run lines with row counts.
+Watch the log output: you should see the config load (`Loaded configuration from ...`), the store migrate (`Postgres store ready (schema v15, ...)`), the TimescaleDB detection result, per-server connects, and then per-collector run lines with row counts.
 
 ### Install as a Windows Service
 
@@ -284,14 +284,25 @@ There are deliberately **no collection-schedule or retention settings** in `darl
 
 ### The Store
 
-The service migrates the store itself at startup — plain versioned SQL scripts, each applied once inside its own transaction, tracked in `darling_schema_version`, safe under concurrent starters (advisory-locked). Current schema is **v4**:
+The service migrates the store itself at startup — plain versioned SQL scripts, each applied once inside its own transaction, tracked in `darling_schema_version`, safe under concurrent starters (advisory-locked). Current schema is **v15**:
 
 | Version | Contents |
 |---|---|
-| **V1** — collector tables | One table per collector, all 26, generated from the shared collector definitions (column-for-column identical to Lite's DuckDB schema): `wait_stats`, `query_stats`, `procedure_stats`, `query_store_stats`, `query_snapshots`, `cpu_utilization_stats`, `file_io_stats`, `memory_stats`, `memory_clerks`, `memory_pressure_events`, `tempdb_stats`, `perfmon_stats`, `deadlocks`, `blocked_process_reports`, `dmv_blocking_snapshots`, `memory_grant_stats`, `waiting_tasks`, `session_stats`, `running_jobs`, `database_size_stats`, `index_object_stats`, `server_properties`, and the four config snapshots (`server_config`, `database_config`, `database_scoped_config`, `trace_flags`) |
+| **V1** — collector tables | One table per collector, all 32, generated from the shared collector definitions (column-for-column identical to Lite's DuckDB schema): `wait_stats`, `latch_stats`, `spinlock_stats`, `query_stats`, `procedure_stats`, `query_store_stats`, `query_snapshots`, `plan_cache_stats`, `cpu_utilization_stats`, `cpu_scheduler_stats`, `file_io_stats`, `memory_stats`, `memory_clerks`, `memory_pressure_events`, `tempdb_stats`, `perfmon_stats`, `deadlocks`, `blocked_process_reports`, `dmv_blocking_snapshots`, `memory_grant_stats`, `waiting_tasks`, `session_stats`, `session_summary_stats`, `running_jobs`, `database_size_stats`, `index_object_stats`, `server_properties`, `system_health_events`, and the four config snapshots (`server_config`, `database_config`, `database_scoped_config`, `trace_flags`) |
 | **V2** — observability | `servers` (registry, upserted on every successful connect: identity, display name, engine edition, major version) and `collection_log` (one row per collector run: SUCCESS / PERMISSIONS / ERROR, row count, SQL-phase and storage-phase timings) |
 | **V3** — alerting | `config_alert_log` (one history row per fired alert), `config_edge_trigger_watermarks` (restart-surviving edge-trigger and failed-job watermarks), `config_mute_rules` (alert mute rules; starts empty) |
 | **V4** — analysis | `analysis_findings` (persisted findings incl. the stored remediation action), `analysis_muted` (muted finding patterns), and 17 `v_<table>` passthrough views so the shared analysis SQL runs verbatim against this store |
+| **V5** — viewer passthrough views | The five remaining `v_*` passthrough views (`v_running_jobs`, `v_server_config`, `v_database_scoped_config`, `v_trace_flags`, `v_collection_log`) that complete the viewer's read layer |
+| **V6** — memory passthrough views | `v_memory_clerks` and `v_memory_pressure_events`, the two views the Memory tab reads |
+| **V7** — plan-capture columns | Nullable plan-XML columns for the viewer's View Plan surfaces: `procedure_stats.query_plan_xml`, `blocked_process_reports.blocked_query_plan_xml` / `blocking_query_plan_xml`, `deadlocks.victim_query_plan_xml` |
+| **V8** — schema split (collect/config) | Moves the tables into the `collect` and `config` schemas (least-privilege security split); the shared SQL keeps using bare names, resolved via `search_path = collect, config, public` |
+| **V9** — inventory + cost fields | `server_properties` inventory columns (`sqlserver_start_time`, `host_os_version`, `ag_replica_role`) and `servers.monthly_cost_usd` (the FinOps per-server budget) |
+| **V10** — latch + spinlock collectors | `latch_stats` and `spinlock_stats` tables plus their `v_*` views |
+| **V11** — CPU scheduler + plan cache collectors | `cpu_scheduler_stats` and `plan_cache_stats` tables plus their `v_*` views |
+| **V12** — session summary collector | `session_summary_stats` (server-wide connection-leak / idle signal) table plus its `v_*` view |
+| **V13** — system health events collector | `system_health_events` (raw `system_health` Extended Events capture) table plus its `v_*` view |
+| **V14** — refresh passthrough views | `CREATE OR REPLACE` on every `v_*` view so a store upgraded across a column-adding migration picks up the new columns (Postgres freezes a view's `SELECT *` expansion at create time) |
+| **V15** — index metadata columns | Per-index definition columns on `index_object_stats` (ordered key/included column lists, filter, uniqueness/constraint/FK flags, `is_disabled`, and the reconstruct-a-CREATE options — compression, fill factor, page/row locks, etc.) for monitor-side UNUSED/DUPLICATE index analysis, and refreshes `v_index_object_stats` |
 
 All timestamps in the store are **naive-UTC** `timestamp` columns — the product-wide cross-store contract (Lite's DuckDB does the same).
 
@@ -428,7 +439,7 @@ With `postgres.managed = true` (the sample's default), the service runs its own 
 }
 ```
 
-**What first run does.** The service looks for `pg-runtime\pgsql\` beside its binary, extracting it from `pg-runtime.zip` when only the zip is present (deleting the extracted directory is therefore always safe — it self-heals). If the data directory has no cluster, it generates a 32-character random password, protects it with DPAPI LocalMachine into `pg-credential.dpapi` beside the data directory (credential first, so a crash mid-initdb never strands a cluster nobody can log into), then runs `initdb` with `scram-sha-256` auth, data checksums, and UTF8/C locale. A marker-guarded block appended to `postgresql.conf` preloads TimescaleDB, sets the port, and restricts listening to `127.0.0.1`; a second versioned block sizes background workers for the 26 per-hypertable compression jobs (`timescaledb.max_background_workers = 28`, `max_worker_processes = 40` — PostgreSQL's default of 8 workers cannot launch them). Both appends are re-checked on every start, so a crash between initdb and the append heals itself instead of silently degrading — and clusters initialized before the worker sizing existed gain it on their next start (effective at the next PostgreSQL restart). Then `pg_ctl start`, `CREATE DATABASE darling`, and the normal startup path (migrations, TimescaleDB adoption — you should see `26/26 collector table(s) are hypertables`) continues exactly as in bring-your-own mode. The connection string is derived from the stored credential; the Viewer and the MCP host on the same machine derive it the same way, so nothing needs configuring there either.
+**What first run does.** The service looks for `pg-runtime\pgsql\` beside its binary, extracting it from `pg-runtime.zip` when only the zip is present (deleting the extracted directory is therefore always safe — it self-heals). If the data directory has no cluster, it generates a 32-character random password, protects it with DPAPI LocalMachine into `pg-credential.dpapi` beside the data directory (credential first, so a crash mid-initdb never strands a cluster nobody can log into), then runs `initdb` with `scram-sha-256` auth, data checksums, and UTF8/C locale. A marker-guarded block appended to `postgresql.conf` preloads TimescaleDB, sets the port, and restricts listening to `127.0.0.1`; a second versioned block sizes background workers up for the per-hypertable compression jobs (`timescaledb.max_background_workers = 28`, `max_worker_processes = 40` — PostgreSQL's default of 8 workers cannot launch them). Both appends are re-checked on every start, so a crash between initdb and the append heals itself instead of silently degrading — and clusters initialized before the worker sizing existed gain it on their next start (effective at the next PostgreSQL restart). Then `pg_ctl start`, `CREATE DATABASE darling`, and the normal startup path (migrations, TimescaleDB adoption — you should see `32/32 collector table(s) are hypertables`) continues exactly as in bring-your-own mode. The connection string is derived from the stored credential; the Viewer and the MCP host on the same machine derive it the same way, so nothing needs configuring there either.
 
 **Why scram and not trust, even loopback-only.** Trust auth would hand superuser to any local code that can open a loopback socket — every other local user, and network-capable-but-not-filesystem-capable attack primitives like SSRF from a co-hosted app. With scram the credential travels on the wire, failed attempts are auditable, and access is confined to what can read the DPAPI-protected credential file. `listen_addresses = '127.0.0.1'` keeps the server unreachable off the machine on top.
 
@@ -442,7 +453,7 @@ With `postgres.managed = true` (the sample's default), the service runs its own 
 
 The store is split into two schemas so that no consumer connects with more privilege than it needs:
 
-- **`collect`** — the 26 collector hypertables plus the service-written, user-read metadata (`servers`, `collection_log`, `analysis_findings`, the `v_*` views). Read-only to everyone but the service.
+- **`collect`** — the 32 collector hypertables plus the service-written, user-read metadata (`servers`, `collection_log`, `analysis_findings`, the `v_*` views). Read-only to everyone but the service.
 - **`config`** — exactly the tables a human operator changes through the Viewer or MCP: `config_mute_rules`, `config_alert_log` (alert dismissals), `config_edge_trigger_watermarks`, and `analysis_muted`.
 
 Table names are unchanged — only their schema moved — and the shared SQL keeps using the bare, unqualified names, resolved through `search_path = collect, config, public` (set as the database default and carried on the managed connection strings). This is deliberate: Darling's SQL is byte-identical to Lite's DuckDB SQL, and re-qualifying it would fork that twin.


### PR DESCRIPTION
## Summary

Two fixes found during a live end-to-end validation of the Darling headless service.

### Defect 1 (real bug) — a fresh BYO Postgres store silently collects nothing until restart

**Symptom (verified live):** on a fresh bring-your-own PostgreSQL store, the entire first run fails — hypertable conversion, delta seeding, and every collector log `42P01: relation "wait_stats" does not exist` — and it only starts working after a service restart.

**Root cause — Npgsql pool timing:** `DarlingWorker.RunCollectionLoopAsync` creates the store `NpgsqlDataSource` from the connection string. The collector tables live in the `collect` schema (V8 security split) and the shared SQL uses bare names resolved via `search_path = collect, config, public`. Managed mode's connection string **carries** `Search Path` (`DarlingManagedPostgres.SearchPath`), so every pooled physical connection gets it. A BYO connection string does **not** — it relies on the database default that `PgMigrations.MigrateAsync` best-effort sets via `ALTER DATABASE ... SET search_path`. But `ALTER DATABASE` only affects the startup search_path of connections established **after** it; the pool's physical connections opened for migration, hypertable conversion, and the first sweep were established before/around it and keep their pre-ALTER session search_path for their lifetime. So the whole first run resolves the bare names against the wrong path and fails until a restart hands out a fresh pool.

**Fix:** `EnsureStoreSearchPath` injects the canonical `collect,config,public` search path onto the store connection string **before** the data source is created, for **both** modes — deterministic and pool-timing-independent. Managed mode already sets it, so the guard leaves it untouched (no double-set). Any login can `SET` its own search_path, so this is safe for least-privilege BYO logins too. A BYO operator's own non-default `Search Path` is respected, not overwritten.

Extracted as an `internal static` helper so it is unit-testable; two new `Darling.Tests` cases cover (a) injection when the path is absent and (b) leaving an existing path unchanged (managed-mode string returned byte-identical; a custom path preserved). The existing test pinning `DarlingManagedPostgres.SearchPath` order against the SQL form is untouched.

### Defect 2 (doc drift) — `Darling/README.md` was stale

The README documented schema **v4** and **26 collectors**; the store is now schema **v15** with **32 collectors** (cross-checked against `CollectorCatalog.cs`, `PgMigrations.cs`, `StorageVersion.cs`, and the `TimescaleSupport` hypertable log line):

- Schema version `v4` -> `v15` (the "Current schema is" line and the console example log line).
- V1 collector list: `all 26` -> `all 32`, added the six collectors added since (`latch_stats`, `spinlock_stats`, `cpu_scheduler_stats`, `plan_cache_stats`, `session_summary_stats`, `system_health_events`).
- Extended the migration-version table from V1-V4 through **V15**, one line each, read from `PgMigrations.Scripts` (not invented).
- `26/26` -> `32/32 collector table(s) are hypertables` (verified against `TimescaleSupport.HypertableTables => CollectorCatalog.All`); `the 26 collector hypertables` -> `32`; dropped the now-stale hard count in the worker-sizing rationale (kept the real `max_background_workers = 28` / `max_worker_processes = 40` values — see note below).

## Testing

- `dotnet build Darling/PerformanceMonitor.Darling.Service -c Release` — **0 errors, 0 net-new warnings** (the one CA1416 the const reference raised — `DarlingManagedPostgres` is `[SupportedOSPlatform("windows")]` but `SearchPath` is a platform-neutral const — is suppressed narrowly with justification; the only remaining CA1416 is pre-existing in `DarlingServerConnector.cs`).
- `dotnet test Darling/Darling.Tests -c Release` — **801 passed, 0 failed, 83 skipped** (skips are the live-Postgres-gated suites). The two new `EnsureStoreSearchPath` tests pass.

## Note (out of scope, flagged not fixed)

The managed worker-sizing block (`DarlingManagedPostgres.BuildWorkerSizingConfAppend`, `max_background_workers = 28`) was sized from a live smoke test for **26** hypertable compression jobs (`jobs + 2`). There are now **32** hypertables, so by that same formula the sizing may be low (would want ~34). This is a code+pinned-test change driven by a TimescaleDB tuning heuristic that came from live observation, so it needs a fresh managed smoke test to re-derive — deliberately left for a separate change (this PR's Defect 2 is README-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
