### PR TITLE
Fix shared chart Y-axis floor: no negative dead-band for non-negative data

### DIFF
--- a/Dashboard.Tests/ChartStyleYLimitsTests.cs
+++ b/Dashboard.Tests/ChartStyleYLimitsTests.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace PerformanceMonitorDashboard.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="ChartStyle.ComputeYLimitsWithLegendPadding"/> — the pure Y-limit math
+/// shared by every trend chart in all three apps (Lite, Dashboard, and the Darling viewer). Pins the fix
+/// for the magnitude-scaled negative floor bug: a non-negative series (dataYMin &gt;= 0) must floor the
+/// axis at 0, NOT at -5% of the data max. The old middle branch put a big dead-band under high-value
+/// charts (e.g. Wait Stats peaking ~6000 ms/sec dropped to a -300 floor). Only genuinely-negative data
+/// keeps a below-zero margin. Mirror of Lite.Tests for parity.
+/// </summary>
+public class ChartStyleYLimitsTests
+{
+    [Fact]
+    public void ZeroDataMin_FloorsAtZero_NoNegativeDeadBand()
+    {
+        // The exact bug: callers pass an explicit dataYMin == 0, which used to hit the middle branch
+        // and produce yMin = -(range * 0.05) = -300 for a 0..6000 chart. It must now floor at 0.
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(0, 6000);
+        Assert.Equal(0.0, yMin);
+    }
+
+    [Fact]
+    public void PositiveDataMin_FloorsAtZero()
+    {
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(50, 6000);
+        Assert.Equal(0.0, yMin);
+    }
+
+    [Fact]
+    public void NegativeDataMin_KeepsTenPercentBelowZeroMargin()
+    {
+        // range = 100; genuinely-negative data keeps its 10%-of-range breathing room below the min.
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(-10, 90);
+        Assert.Equal(-20.0, yMin, 6);   // -10 - (100 * 0.10)
+    }
+
+    [Fact]
+    public void TopPadding_IsFivePercentOfRange()
+    {
+        var (_, yMax) = ChartStyle.ComputeYLimitsWithLegendPadding(0, 6000);
+        Assert.Equal(6300.0, yMax, 6);  // 6000 + (6000 * 0.05)
+    }
+
+    [Fact]
+    public void FlatData_ExpandsRangeAndStillFloorsAtZero()
+    {
+        // dataYMax <= dataYMin forces range to 1 so a flat non-negative series still gets a visible band.
+        var (yMin, yMax) = ChartStyle.ComputeYLimitsWithLegendPadding(5, 5);
+        Assert.Equal(0.0, yMin);
+        Assert.Equal(6.05, yMax, 6);    // dataYMax -> 6, + (1 * 0.05)
+    }
+}

--- a/Lite.Tests/ChartStyleYLimitsTests.cs
+++ b/Lite.Tests/ChartStyleYLimitsTests.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="ChartStyle.ComputeYLimitsWithLegendPadding"/> — the pure Y-limit math
+/// shared by every trend chart in all three apps (Lite, Dashboard, and the Darling viewer). Pins the fix
+/// for the magnitude-scaled negative floor bug: a non-negative series (dataYMin &gt;= 0) must floor the
+/// axis at 0, NOT at -5% of the data max. The old middle branch put a big dead-band under high-value
+/// charts (e.g. Wait Stats peaking ~6000 ms/sec dropped to a -300 floor). Only genuinely-negative data
+/// keeps a below-zero margin. Mirror of Dashboard.Tests for parity.
+/// </summary>
+public class ChartStyleYLimitsTests
+{
+    [Fact]
+    public void ZeroDataMin_FloorsAtZero_NoNegativeDeadBand()
+    {
+        // The exact bug: callers pass an explicit dataYMin == 0, which used to hit the middle branch
+        // and produce yMin = -(range * 0.05) = -300 for a 0..6000 chart. It must now floor at 0.
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(0, 6000);
+        Assert.Equal(0.0, yMin);
+    }
+
+    [Fact]
+    public void PositiveDataMin_FloorsAtZero()
+    {
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(50, 6000);
+        Assert.Equal(0.0, yMin);
+    }
+
+    [Fact]
+    public void NegativeDataMin_KeepsTenPercentBelowZeroMargin()
+    {
+        // range = 100; genuinely-negative data keeps its 10%-of-range breathing room below the min.
+        var (yMin, _) = ChartStyle.ComputeYLimitsWithLegendPadding(-10, 90);
+        Assert.Equal(-20.0, yMin, 6);   // -10 - (100 * 0.10)
+    }
+
+    [Fact]
+    public void TopPadding_IsFivePercentOfRange()
+    {
+        var (_, yMax) = ChartStyle.ComputeYLimitsWithLegendPadding(0, 6000);
+        Assert.Equal(6300.0, yMax, 6);  // 6000 + (6000 * 0.05)
+    }
+
+    [Fact]
+    public void FlatData_ExpandsRangeAndStillFloorsAtZero()
+    {
+        // dataYMax <= dataYMin forces range to 1 so a flat non-negative series still gets a visible band.
+        var (yMin, yMax) = ChartStyle.ComputeYLimitsWithLegendPadding(5, 5);
+        Assert.Equal(0.0, yMin);
+        Assert.Equal(6.05, yMax, 6);    // dataYMax -> 6, + (1 * 0.05)
+    }
+}

--- a/PerformanceMonitor.Ui/ChartStyle.cs
+++ b/PerformanceMonitor.Ui/ChartStyle.cs
@@ -167,9 +167,10 @@ namespace PerformanceMonitor.Ui
         }
 
         /// <summary>
-        /// Sets Y-axis limits with padding for a bottom legend and top breathing room.
-        /// Adds a small margin below a zero baseline so flat-at-zero lines stay visible above the
-        /// axis. Call this BEFORE LockChartVerticalAxis.
+        /// Sets Y-axis limits with padding for a bottom legend and top breathing room. Floors the axis
+        /// at zero for non-negative data (the common metric case) so there is no magnitude-scaled
+        /// dead-band below the lines; only genuinely-negative data gets a below-zero margin. Call this
+        /// BEFORE LockChartVerticalAxis.
         /// </summary>
         public static void SetChartYLimitsWithLegendPadding(WpfPlot chart, double dataYMin = 0, double dataYMax = 0)
         {
@@ -179,16 +180,28 @@ namespace PerformanceMonitor.Ui
                 dataYMin = limits.Bottom;
                 dataYMax = limits.Top;
             }
+
+            var (yMin, yMax) = ComputeYLimitsWithLegendPadding(dataYMin, dataYMax);
+            chart.Plot.Axes.SetLimitsY(yMin, yMax);
+        }
+
+        /// <summary>
+        /// Pure Y-limit math behind <see cref="SetChartYLimitsWithLegendPadding"/>, extracted so it can be
+        /// unit-tested without a WPF control. Floors at zero for non-negative data so high-magnitude charts
+        /// get no dead-band below the lines; only genuinely-negative data gets a 10%-of-range below-zero
+        /// margin. Adds 5%-of-range top breathing room for the bottom legend.
+        /// </summary>
+        public static (double YMin, double YMax) ComputeYLimitsWithLegendPadding(double dataYMin, double dataYMax)
+        {
             if (dataYMax <= dataYMin) dataYMax = dataYMin + 1;
 
             double range = dataYMax - dataYMin;
             double topPadding = range * 0.05;
 
-            /* Add a small bottom margin when dataYMin is zero so flat lines at Y=0 are visible above the axis */
-            double yMin = dataYMin > 0 ? 0 : dataYMin == 0 ? -(range * 0.05) : dataYMin - (range * 0.10);
+            double yMin = dataYMin >= 0 ? 0 : dataYMin - (range * 0.10);
             double yMax = dataYMax + topPadding;
 
-            chart.Plot.Axes.SetLimitsY(yMin, yMax);
+            return (yMin, yMax);
         }
 
         /// <summary>


### PR DESCRIPTION
## Root cause
`PerformanceMonitor.Ui/ChartStyle.cs` → `SetChartYLimitsWithLegendPadding` computed the axis floor as:

```csharp
double yMin = dataYMin > 0 ? 0 : dataYMin == 0 ? -(range * 0.05) : dataYMin - (range * 0.10);
```

Callers pass an **explicit** `dataYMin = 0` (e.g. `SetChartYLimitsWithLegendPadding(chart, 0, globalMax)`), which hit the middle branch → `yMin = -(range * 0.05)`: a **magnitude-scaled negative floor** equal to 5% of the data max. High-value charts got a large dead-band below the lines (Wait Stats peaking ~6000 ms/sec → a `-300` floor).

## Fix (shared helper — one behavioral line)
```csharp
double yMin = dataYMin >= 0 ? 0 : dataYMin - (range * 0.10);
```
Floors at 0 for the normal non-negative case (no dead-band); preserves the below-zero margin only for genuinely-negative data.

Because the fix is entirely in the **shared** `PerformanceMonitor.Ui` helper, all three apps inherit it with **no caller changes** — this is a shared-lib parity fix that clears **all non-negative metric charts across all three apps**: the 22 affected charts in the Darling viewer, Lite's picker charts (`ServerTab.Pickers.cs`), and Dashboard's detail charts. Surfaced in a live Darling-viewer audit; latent in Lite + Dashboard too.

The pure Y-limit math was extracted into `ComputeYLimitsWithLegendPadding(dataYMin, dataYMax)` so it is unit-testable without a WPF control (the public `SetChartYLimitsWithLegendPadding(WpfPlot, ...)` signature and behavior are unchanged). The stale `-5% margin` doc comment was updated.

## Tests
No existing test pinned the old behavior. Added a focused regression suite `ChartStyleYLimitsTests` (5 cases: `dataYMin=0 → yMin=0`; positive `dataYMin → yMin=0`; negative `dataYMin → yMin = dataYMin - range*0.10`; 5% top padding; flat-data guard). Placed in **Lite.Tests** (CI-run, already tests `PerformanceMonitor.Ui`) and **mirrored to Dashboard.Tests** per the existing `ChartClickIsolateTests` mirror convention.

## Build + test results (all Release)
- `PerformanceMonitor.Ui` build: **0 errors** (3 pre-existing warnings)
- Dashboard app build: **0 errors** (126 pre-existing warnings)
- **Lite.Tests**: Failed 0, Passed 909, Skipped 0
- **Darling.Tests**: Failed 0, Passed 801, Skipped 83 (skips = live-Postgres tests needing a dev DB)
- **Dashboard.Tests**: Failed 0, Passed 687, Skipped 0
- New `ChartStyleYLimitsTests`: 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)