### PR TITLE
Add About window + version surface to the Darling viewer

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml
@@ -1,0 +1,81 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.AboutWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="About Performance Monitor Darling"
+        Height="380" Width="460"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="EDD.ico"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- Mirrors Lite's AboutWindow (Lite/Windows/AboutWindow.xaml), dark-styled via the shared
+         ViewerDarkTheme resource dictionary like the viewer's other dialogs (Manage Mute Rules).
+         The viewer ships inside the Darling service release and is not independently Velopack-managed,
+         so this drops Lite's "Check for Updates" affordance; the version is read from the viewer
+         assembly (csproj 3.1.0). -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="Hyperlink">
+                <Setter Property="Foreground" Value="#6CB6FF"/>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="SQL Server Performance Monitor Darling"
+                   FontSize="18" FontWeight="Bold" Foreground="#E4E6EB"
+                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" x:Name="VersionText" Text="Version 3.1.0"
+                   Foreground="#8B93A1" Margin="0,0,0,16"/>
+
+        <TextBlock Grid.Row="2" TextWrapping="Wrap" Foreground="#E4E6EB" Margin="0,0,0,8">
+            The desktop viewer for the Performance Monitor Darling service. Connects to the central
+            Postgres store to show per-server dashboards, recommendations, and alerts across every
+            monitored SQL Server.
+        </TextBlock>
+
+        <StackPanel Grid.Row="3" Margin="0,0,0,8">
+            <TextBlock Foreground="#E4E6EB" FontSize="12">
+                © 2026 Erik Darling, Darling Data LLC
+            </TextBlock>
+            <TextBlock Foreground="#8B93A1" FontSize="12">
+                Licensed under the MIT License
+            </TextBlock>
+        </StackPanel>
+
+        <!-- Links -->
+        <StackPanel Grid.Row="4">
+            <TextBlock FontSize="12" Margin="0,0,0,5">
+                <Hyperlink Click="GitHubLink_Click">
+                    GitHub Repository
+                </Hyperlink>
+            </TextBlock>
+            <TextBlock FontSize="12" Margin="0,0,0,5">
+                <Hyperlink Click="ReportIssueLink_Click">
+                    Report an Issue
+                </Hyperlink>
+            </TextBlock>
+            <TextBlock FontSize="12">
+                <Hyperlink Click="DarlingDataLink_Click">
+                    www.erikdarling.com
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+
+        <Button Grid.Row="5" Content="Close" Click="CloseButton_Click"
+                HorizontalAlignment="Right" Padding="16,4"/>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's About dialog — app name, version (read from the viewer assembly), copyright, and
+/// links. Mirrors Lite's <see cref="T:PerformanceMonitorLite.Windows.AboutWindow"/> minus the "Check
+/// for Updates" affordance: the viewer ships inside the Darling service release rather than as an
+/// independently Velopack-managed app, so it has no self-update path.
+/// </summary>
+public partial class AboutWindow : Window
+{
+    private const string GitHubUrl = "https://github.com/erikdarlingdata/PerformanceMonitor";
+    private const string IssuesUrl = "https://github.com/erikdarlingdata/PerformanceMonitor/issues";
+    private const string DarlingDataUrl = "https://www.erikdarling.com";
+
+    public AboutWindow()
+    {
+        InitializeComponent();
+
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        VersionText.Text = $"Version {version?.Major}.{version?.Minor}.{version?.Build}";
+    }
+
+    private void GitHubLink_Click(object sender, RoutedEventArgs e) => OpenUrl(GitHubUrl);
+
+    private void ReportIssueLink_Click(object sender, RoutedEventArgs e) => OpenUrl(IssuesUrl);
+
+    private void DarlingDataLink_Click(object sender, RoutedEventArgs e) => OpenUrl(DarlingDataUrl);
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+            MessageBox.Show($"Could not open URL: {url}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -249,6 +249,27 @@
                     <TextBlock Text="Servers" Style="{StaticResource SectionHeader}" Margin="0,0,0,2"/>
                     <TextBlock Text="Double-click to open a server tab" Foreground="#8B93A1" FontSize="11" Margin="0,0,0,6"/>
                 </StackPanel>
+
+                <!-- Sidebar footer: a small button stack pinned to the bottom of the server list. About
+                     only for now — the viewer writes no application log of its own (its diagnostics go to
+                     Debug output, and the shared store's collection log is a per-server tab), so there are
+                     no View Log / Open Log Folder buttons. Declared as the first Bottom-docked child so it
+                     sits at the very bottom, below the no-servers hint. -->
+                <Border DockPanel.Dock="Bottom"
+                        BorderBrush="#2a2d35" BorderThickness="0,1,0,0"
+                        Margin="0,8,0,0" Padding="0,8,0,0">
+                    <Button Click="AboutButton_Click"
+                            Style="{StaticResource DarkButton}"
+                            Padding="8,5"
+                            ToolTip="About Performance Monitor Darling">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE897;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="About" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </Border>
+
                 <TextBlock x:Name="ServersHintText"
                            DockPanel.Dock="Bottom"
                            Text="no servers registered — is the Darling service running?"

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -587,6 +587,15 @@ public partial class MainWindow : Window
         RecommendationsStatusText.Text = "AI prompt copied to clipboard.";
     }
 
+    // ── About ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Opens the viewer's About dialog (app name, version, copyright, links).</summary>
+    private void AboutButton_Click(object sender, RoutedEventArgs e)
+    {
+        var about = new AboutWindow { Owner = this };
+        about.ShowDialog();
+    }
+
     private void ShowMessage(string message)
     {
         MessageText.Text = message;


### PR DESCRIPTION
## What

Adds an **About window** and a version surface to the Darling viewer (`Darling/PerformanceMonitor.Darling.Viewer/`), which previously had no way to see the app version and no About dialog — unlike Lite and Dashboard.

### Added
- **`AboutWindow.xaml(.cs)`** — mirrors Lite's `AboutWindow`: app name ("SQL Server Performance Monitor Darling"), version read from the viewer assembly (`Assembly.GetExecutingAssembly()` → 3.1.0), copyright + MIT license line, and links (GitHub Repository, Report an Issue, www.erikdarling.com). Dark-styled by merging the viewer's own `ViewerDarkTheme.xaml` and setting the same `#22252b`/`#E4E6EB` palette its other dialogs (Manage Mute Rules) use, with `Icon="EDD.ico"`.
- **Sidebar footer** — a small button stack pinned to the bottom of the server list in `MainWindow.xaml` (a bordered `Border` with one `About` button using the existing `DarkButton` style + the `&#xE897;` glyph, matching Lite's About button). Wired to a new `AboutButton_Click` in `MainWindow.xaml.cs` that opens the dialog with `Owner = this`.

### Adapted / omitted vs. Lite
- **No "Check for Updates"**: the viewer ships inside the Darling service release and is not independently Velopack-managed, so it has no self-update path (and doesn't reference Velopack / `UpdateCheckService`). That row from Lite's About is dropped.
- **No "View Log" / "Open Log Folder" buttons**: I checked `App.xaml.cs` and the whole viewer project — the viewer writes **no application log of its own**. There's no `AppLogger`/file logging (the one `AppLogger` reference is a comment in the copied `CorrelatedTimelineLanesControl` noting `AppLogger -> Debug.WriteLine`); diagnostics go to `Debug` output, and the shared store's collection log is already surfaced as a per-server tab. There is no per-user viewer log file or log folder to point at (config comes from `darling.json`; the only `%ProgramData%` path is the *service's* Postgres data dir, not the viewer's). Per the task's "don't invent a log path" guidance, the log buttons are omitted.

## Scope
Only the Darling viewer project is touched (2 new files, 2 edited). Kept minimal — no full Lite/Dashboard footer.

## Testing
- `dotnet build Darling/PerformanceMonitor.Darling.Viewer -c Release` → **Build succeeded, 0 errors** (9 warnings, all pre-existing in other files; none from the new/edited files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)