### PR TITLE
Add standalone Plan Viewer to the Darling viewer

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.PlanViewer.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.PlanViewer.cs
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The standalone Plan Viewer surface for the Darling viewer's top tab strip (<c>MainTabs</c>), ported
+/// from Lite's <c>MainWindow.PlanViewer.cs</c>: a hidden-until-used, closable "Plan Viewer" aggregate tab
+/// (<c>MainWindowPlanViewerTab</c>) that hosts the SHARED <see cref="PlanViewerControl"/> as closable
+/// sub-tabs. Unlike the per-server Plan Viewer (<see cref="ViewerServerTab"/>'s <c>OpenPlanTab</c>, which
+/// fetches a STORED plan from Postgres), this surface reads no store data and needs no server connection —
+/// the user supplies the plan by opening a .sqlplan / plan-XML file, pasting plan XML, or dragging a file
+/// in. Opened / focused from the sidebar's "Open Plan Viewer" button.
+/// </summary>
+public partial class MainWindow
+{
+    private void OpenPlanViewerButton_Click(object sender, RoutedEventArgs e)
+    {
+        EnsurePlanTabControlInitialized();
+        /* The Plan Viewer is server-independent: show it even when no servers are registered (in which
+           case the no-servers empty state otherwise owns the content column with MainTabs collapsed). */
+        EmptyStatePanel.Visibility = Visibility.Collapsed;
+        MainTabs.Visibility = Visibility.Visible;
+        MainWindowPlanViewerTab.Visibility = Visibility.Visible;
+        if (MainWindowPlanViewerTab.IsSelected)
+        {
+            // Already on Plan Viewer — just add a new empty sub-tab
+            AddNewEmptyPlanSubTab();
+        }
+        else
+        {
+            MainWindowPlanViewerTab.IsSelected = true;
+            AddNewEmptyPlanSubTab();
+        }
+        Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() => MainWindowPlanTabControl.Focus()));
+    }
+
+    private void MainWindowPlanViewerClose_Click(object sender, RoutedEventArgs e)
+    {
+        // Each plan sub-tab's viewer is rooted by the static ThemeChanged event —
+        // Cleanup() each before clearing the tab control so none leak.
+        foreach (var item in MainWindowPlanTabControl.Items)
+            if (item is TabItem { Content: Grid g } && g.Children.Count > 1
+                && g.Children[1] is PlanViewerControl pv)
+                pv.Cleanup();
+        // Reset inner tab control so next open starts fresh
+        MainWindowPlanTabControl.Items.Clear();
+        _planTabControlInitialized = false;
+        MainWindowPlanViewerTab.Visibility = Visibility.Collapsed;
+
+        /* Return the content column to the state it was in before the Plan Viewer opened: if no servers
+           are registered, restore the no-servers empty state (MainTabs collapsed, mirroring
+           LoadServersAsync's no-servers branch); otherwise select the first visible non-plan tab. */
+        if (ServerList.ItemsSource is IEnumerable<DarlingServer> servers && servers.Any())
+        {
+            foreach (TabItem item in MainTabs.Items)
+            {
+                if (item.Visibility == Visibility.Visible && item != MainWindowPlanViewerTab)
+                {
+                    item.IsSelected = true;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            MainTabs.Visibility = Visibility.Collapsed;
+            EmptyStatePanel.Visibility = Visibility.Visible;
+        }
+    }
+
+    #region Standalone Plan Viewer
+
+    private const string DarlingPlanAddTabId = "__PLAN_ADD_TAB__";
+    private bool _planTabControlInitialized;
+
+    private void EnsurePlanTabControlInitialized()
+    {
+        if (_planTabControlInitialized) return;
+        _planTabControlInitialized = true;
+
+        // "+" tab at the end
+        var addTabHeader = new TextBlock
+        {
+            Text = "+",
+            FontSize = 14,
+            FontWeight = FontWeights.Bold,
+            VerticalAlignment = VerticalAlignment.Center,
+            ToolTip = "Open a new plan sub-tab"
+        };
+        var addTab = new TabItem
+        {
+            Header = addTabHeader,
+            Tag = DarlingPlanAddTabId,
+            Content = new Grid()
+        };
+        MainWindowPlanTabControl.Items.Add(addTab);
+
+        MainWindowPlanTabControl.SelectionChanged += (_, _) =>
+        {
+            if (MainWindowPlanTabControl.SelectedItem is TabItem { Tag: string t } && t == DarlingPlanAddTabId)
+            {
+                var newSub = AddNewEmptyPlanSubTab();
+                MainWindowPlanTabControl.SelectedItem = newSub;
+            }
+        };
+    }
+
+    /// <summary>
+    /// Adds a new empty "New Plan" sub-tab to the inner plan TabControl and selects it.
+    /// Returns the newly created sub-tab.
+    /// </summary>
+    private TabItem AddNewEmptyPlanSubTab()
+    {
+        EnsurePlanTabControlInitialized();
+
+        // --- Empty state layer ---
+        var emptyState = new Grid();
+        var dashedRect = new System.Windows.Shapes.Rectangle
+        {
+            Margin = new Thickness(24),
+            Stroke = (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+            StrokeThickness = 1.5,
+            StrokeDashArray = new System.Windows.Media.DoubleCollection { 6, 4 },
+            RadiusX = 10, RadiusY = 10,
+            Opacity = 0.25
+        };
+        var emptyStack = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        emptyStack.Children.Add(new TextBlock
+        {
+            Text = "",
+            FontFamily = new System.Windows.Media.FontFamily("Segoe MDL2 Assets"),
+            FontSize = 52,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Foreground = (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+            Opacity = 0.45,
+            Margin = new Thickness(0, 0, 0, 12)
+        });
+        emptyStack.Children.Add(new TextBlock
+        {
+            Text = "New Plan",
+            FontSize = 20,
+            FontWeight = FontWeights.Light,
+            Foreground = (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+            HorizontalAlignment = HorizontalAlignment.Center
+        });
+        emptyStack.Children.Add(new TextBlock
+        {
+            Text = "Open or paste execution plan XML to render it",
+            FontSize = 13,
+            Foreground = (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 8, 0, 0)
+        });
+        var btnPanel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Center, Margin = new Thickness(0, 20, 0, 0) };
+        var openBtn = new Button { Content = "Open .sqlplan File", Height = 28, Padding = new Thickness(12, 0, 12, 0), ToolTip = "Open a .sqlplan or .xml file from disk" };
+        var pasteBtn = new Button { Content = "Paste XML", Height = 28, Padding = new Thickness(12, 0, 12, 0), Margin = new Thickness(8, 0, 0, 0), ToolTip = "Paste execution plan XML to render it (or use Ctrl+V)" };
+        btnPanel.Children.Add(openBtn);
+        btnPanel.Children.Add(pasteBtn);
+        emptyStack.Children.Add(btnPanel);
+        emptyStack.Children.Add(new TextBlock
+        {
+            Text = "or drag & drop a .sqlplan file anywhere in this area",
+            FontSize = 11,
+            Foreground = (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 12, 0, 0)
+        });
+        emptyState.Children.Add(dashedRect);
+        emptyState.Children.Add(emptyStack);
+
+        // --- Viewer layer (hidden until a plan is loaded) ---
+        var viewer = new PlanViewerControl
+        {
+            Visibility = Visibility.Collapsed
+        };
+
+        // Sub-tab content grid: index 0 = emptyState, index 1 = viewer
+        var subTabContent = new Grid();
+        subTabContent.Children.Add(emptyState);
+        subTabContent.Children.Add(viewer);
+
+        // --- Sub-tab header: label + close button ---
+        var initialLabel = GetUniqueSubTabLabel("New Plan");
+        var labelBlock = new TextBlock
+        {
+            Text = initialLabel,
+            VerticalAlignment = VerticalAlignment.Center,
+            ToolTip = initialLabel
+        };
+        var subCloseBtn = new Button { Style = (Style)FindResource("TabCloseButton") };
+        var subTabHeader = new StackPanel { Orientation = Orientation.Horizontal };
+        subTabHeader.Children.Add(labelBlock);
+        subTabHeader.Children.Add(subCloseBtn);
+
+        var subTab = new TabItem { Header = subTabHeader, Content = subTabContent };
+
+        subCloseBtn.Tag = subTab;
+        subCloseBtn.Click += (_, _) =>
+        {
+            (subTabContent.Children[1] as PlanViewerControl)?.Cleanup();
+            MainWindowPlanTabControl.Items.Remove(subTab);
+            // If only the "+" tab remains, open a fresh empty sub-tab
+            if (MainWindowPlanTabControl.Items.Count == 1 &&
+                MainWindowPlanTabControl.Items[0] is TabItem { Tag: string t2 } && t2 == DarlingPlanAddTabId)
+            {
+                AddNewEmptyPlanSubTab();
+            }
+        };
+
+        // Wire per-sub-tab buttons
+        openBtn.Click += (_, _) =>
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = "SQL Plan Files (*.sqlplan)|*.sqlplan|XML Files (*.xml)|*.xml|All Files (*.*)|*.*",
+                DefaultExt = ".sqlplan",
+                Multiselect = true
+            };
+            if (dialog.ShowDialog() != true) return;
+            var isFirst = true;
+            foreach (var fileName in dialog.FileNames)
+            {
+                try
+                {
+                    var xml = System.IO.File.ReadAllText(fileName);
+                    var targetTab = isFirst ? subTab : AddNewEmptyPlanSubTab();
+                    LoadPlanIntoSubTab(targetTab, xml, System.IO.Path.GetFileName(fileName));
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Failed to open file:\n\n{ex.Message}", "Error",
+                        MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+                isFirst = false;
+            }
+        };
+
+        pasteBtn.Click += (_, _) =>
+        {
+            var xml = Clipboard.GetText();
+            if (!string.IsNullOrWhiteSpace(xml))
+            {
+                LoadPlanIntoSubTab(subTab, xml, "Pasted Plan");
+                return;
+            }
+            MessageBox.Show("The clipboard does not contain any text.", "Paste Plan XML",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        };
+
+        // Insert before "+" tab
+        var addTabIndex = -1;
+        for (var i = 0; i < MainWindowPlanTabControl.Items.Count; i++)
+        {
+            if (MainWindowPlanTabControl.Items[i] is TabItem { Tag: string t3 } && t3 == DarlingPlanAddTabId)
+            {
+                addTabIndex = i;
+                break;
+            }
+        }
+        if (addTabIndex >= 0)
+            MainWindowPlanTabControl.Items.Insert(addTabIndex, subTab);
+        else
+            MainWindowPlanTabControl.Items.Add(subTab);
+
+        MainWindowPlanTabControl.SelectedItem = subTab;
+        return subTab;
+    }
+
+    /// <summary>
+    /// Loads plan XML into an existing sub-tab (replacing whatever was there before).
+    /// </summary>
+    private async void LoadPlanIntoSubTab(TabItem subTab, string planXml, string label, string? queryText = null)
+    {
+        if (subTab.Content is not Grid subTabContent) return;
+        if (subTabContent.Children.Count < 2) return;
+
+        var emptyState = subTabContent.Children[0] as FrameworkElement;
+        var viewer = subTabContent.Children[1] as PlanViewerControl;
+        if (viewer == null) return;
+
+        try
+        {
+            /* LoadPlan parses+analyzes off the UI thread; XmlException replaces the redundant
+               up-front XDocument.Parse validation. */
+            await viewer.LoadPlan(planXml, label, queryText);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            MessageBox.Show(
+                $"The plan XML is not valid:\n\n{ex.Message}",
+                "Invalid Plan XML",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            return;
+        }
+        emptyState!.Visibility = Visibility.Collapsed;
+        viewer.Visibility = Visibility.Visible;
+
+        var uniqueLabel = GetUniqueSubTabLabel(label);
+        if (subTab.Header is StackPanel headerPanel &&
+            headerPanel.Children[0] is TextBlock headerLabel)
+        {
+            headerLabel.Text = uniqueLabel.Length > 30 ? uniqueLabel[..30] + "…" : uniqueLabel;
+            headerLabel.ToolTip = uniqueLabel;
+        }
+    }
+
+    /// <summary>
+    /// Returns a label that is unique among current inner plan sub-tab headers.
+    /// If <paramref name="baseLabel"/> is already taken, appends " (1)", " (2)", …
+    /// </summary>
+    private string GetUniqueSubTabLabel(string baseLabel)
+    {
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in MainWindowPlanTabControl.Items)
+        {
+            if (item is TabItem { Tag: string t } && t == DarlingPlanAddTabId) continue;
+            if (item is TabItem subTab &&
+                subTab.Header is StackPanel sp &&
+                sp.Children[0] is TextBlock tb)
+                existing.Add(tb.ToolTip as string ?? tb.Text);
+        }
+        if (!existing.Contains(baseLabel)) return baseLabel;
+        var counter = 1;
+        string candidate;
+        do { candidate = $"{baseLabel} ({counter++})"; }
+        while (existing.Contains(candidate));
+        return candidate;
+    }
+
+    /// <summary>
+    /// Returns the currently active real plan sub-tab (skips the "+" tab).
+    /// </summary>
+    private TabItem? GetActivePlanSubTab()
+    {
+        if (MainWindowPlanTabControl.SelectedItem is TabItem { Tag: string t } && t == DarlingPlanAddTabId)
+            return null;
+        return MainWindowPlanTabControl.SelectedItem as TabItem;
+    }
+
+    private void MainWindowPlanViewer_DragOver(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.FileDrop))
+        {
+            var files = e.Data.GetData(DataFormats.FileDrop) as string[];
+            if (files?.Any(IsPlanFile) == true)
+            {
+                e.Effects = DragDropEffects.Copy;
+                e.Handled = true;
+                return;
+            }
+        }
+        e.Effects = DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private void MainWindowPlanViewer_Drop(object sender, DragEventArgs e)
+    {
+        if (!e.Data.GetDataPresent(DataFormats.FileDrop)) return;
+        var planFiles = (e.Data.GetData(DataFormats.FileDrop) as string[])
+            ?.Where(IsPlanFile).ToArray();
+        if (planFiles == null || planFiles.Length == 0) return;
+        LoadMainWindowPlanFromFileIntoActiveTab(planFiles[0]);
+        for (var i = 1; i < planFiles.Length; i++)
+        {
+            var newTab = AddNewEmptyPlanSubTab();
+            try
+            {
+                var xml = System.IO.File.ReadAllText(planFiles[i]);
+                LoadPlanIntoSubTab(newTab, xml, System.IO.Path.GetFileName(planFiles[i]));
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to load plan file:\n{ex.Message}", "Load Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+    }
+
+    private void MainWindowPlanViewer_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key == System.Windows.Input.Key.V &&
+            System.Windows.Input.Keyboard.Modifiers == System.Windows.Input.ModifierKeys.Control &&
+            e.OriginalSource is not System.Windows.Controls.TextBox)
+        {
+            var xml = Clipboard.GetText();
+            if (!string.IsNullOrWhiteSpace(xml))
+            {
+                e.Handled = true;
+                LoadPlanIntoActivePlanSubTab(xml, "Pasted Plan");
+            }
+        }
+    }
+
+    private void LoadMainWindowPlanFromFileIntoActiveTab(string path)
+    {
+        try
+        {
+            var xml = System.IO.File.ReadAllText(path);
+            LoadPlanIntoActivePlanSubTab(xml, System.IO.Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to load plan file:\n{ex.Message}", "Load Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private void LoadPlanIntoActivePlanSubTab(string planXml, string label)
+    {
+        var activeSubTab = GetActivePlanSubTab();
+        if (activeSubTab != null)
+            LoadPlanIntoSubTab(activeSubTab, planXml, label);
+    }
+
+    private static bool IsPlanFile(string path)
+    {
+        var ext = System.IO.Path.GetExtension(path);
+        return string.Equals(ext, ".sqlplan", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(ext, ".xml", StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -250,24 +250,38 @@
                     <TextBlock Text="Double-click to open a server tab" Foreground="#8B93A1" FontSize="11" Margin="0,0,0,6"/>
                 </StackPanel>
 
-                <!-- Sidebar footer: a small button stack pinned to the bottom of the server list. About
-                     only for now — the viewer writes no application log of its own (its diagnostics go to
-                     Debug output, and the shared store's collection log is a per-server tab), so there are
-                     no View Log / Open Log Folder buttons. Declared as the first Bottom-docked child so it
-                     sits at the very bottom, below the no-servers hint. -->
+                <!-- Sidebar footer: a small button stack pinned to the bottom of the server list. Open
+                     Plan Viewer (opens/focuses the standalone Plan Viewer aggregate tab — paste or open a
+                     .sqlplan independent of any server) and About. The viewer writes no application log of
+                     its own (its diagnostics go to Debug output, and the shared store's collection log is a
+                     per-server tab), so there are no View Log / Open Log Folder buttons. Declared as the
+                     first Bottom-docked child so it sits at the very bottom, below the no-servers hint. -->
                 <Border DockPanel.Dock="Bottom"
                         BorderBrush="#2a2d35" BorderThickness="0,1,0,0"
                         Margin="0,8,0,0" Padding="0,8,0,0">
-                    <Button Click="AboutButton_Click"
-                            Style="{StaticResource DarkButton}"
-                            Padding="8,5"
-                            ToolTip="About Performance Monitor Darling">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE897;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
-                            <TextBlock Text="About" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
+                    <StackPanel>
+                        <Button Click="OpenPlanViewerButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                ToolTip="Open or paste an execution plan (independent of any server)">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8A5;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Open Plan Viewer" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="AboutButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="About Performance Monitor Darling">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE897;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="About" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
                 </Border>
 
                 <TextBlock x:Name="ServersHintText"
@@ -558,6 +572,34 @@
                      owns its own load, so it isn't scoped by the sidebar selection. -->
                 <TabItem x:Name="AlertsTab" Header="Alerts">
                     <local:AlertsHistoryTab x:Name="AlertsHistoryContent" Margin="0,8,0,0"/>
+                </TabItem>
+
+                <!-- Plan Viewer: a standalone, hidden-until-used aggregate tab (mirrors Lite's
+                     MainWindowPlanViewerTab) — the one plan surface Lite and the Dashboard both have that
+                     the viewer lacked. Server-independent: the user opens or pastes a .sqlplan / plan XML
+                     (or drags a file in) and it renders in the SHARED PerformanceMonitor.Ui
+                     PlanViewerControl as closable sub-tabs, exactly like the per-server Plan Viewer — but
+                     with no store read and no server connection. Opened via the sidebar "Open Plan Viewer"
+                     button; the header's close button hides it again. Built in MainWindow.PlanViewer.cs.
+                     Its inner sub-tabs pick up the theme's implicit TabItem style automatically (no
+                     ItemContainerStyle), matching the per-server PlanTabControl. -->
+                <TabItem x:Name="MainWindowPlanViewerTab" Visibility="Collapsed">
+                    <TabItem.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Plan Viewer" VerticalAlignment="Center" FontWeight="SemiBold"/>
+                            <Button Style="{DynamicResource TabCloseButton}"
+                                    Click="MainWindowPlanViewerClose_Click"
+                                    Margin="4,0,0,0"/>
+                        </StackPanel>
+                    </TabItem.Header>
+                    <Grid AllowDrop="True" PreviewDrop="MainWindowPlanViewer_Drop"
+                          PreviewDragOver="MainWindowPlanViewer_DragOver"
+                          Background="Transparent"
+                          Focusable="True" KeyDown="MainWindowPlanViewer_KeyDown">
+                        <TabControl x:Name="MainWindowPlanTabControl"
+                                    Background="Transparent"
+                                    BorderThickness="0"/>
+                    </Grid>
                 </TabItem>
             </TabControl>
 


### PR DESCRIPTION
## What

Adds a top-level, **server-independent Plan Viewer** to the Darling viewer (`Darling/PerformanceMonitor.Darling.Viewer/`) — the one plan surface Lite and the Dashboard both have that Darling lacked. Darling previously only opened **stored** plans from per-server query-grid context menus into a per-server Plan Viewer tab; there was no "paste/open a plan and view it" surface.

## What was added

- **Standalone `Plan Viewer` aggregate tab** (`MainWindowPlanViewerTab`) in `MainTabs`, alongside Overview / Recommendations / Alerts. Hidden-until-used and closable (header "×" via the theme's `TabCloseButton`), mirroring Lite's `MainWindowPlanViewerTab`. It hosts the **shared `PerformanceMonitor.Ui.PlanViewerControl`** as closable sub-tabs — reused by reference, not modified, not reimplemented.
- **Plan input**, mirroring Lite's standalone viewer:
  - Open one or more `.sqlplan` / `.xml` files (multi-select)
  - Paste plan XML (button or **Ctrl+V**)
  - Drag & drop a plan file anywhere in the tab
  - A `+` sub-tab opens additional empty plan tabs; each renders its plan in its own sub-tab.
- **Entry point**: a new sidebar-footer **"Open Plan Viewer"** button, sitting above the About button (#1394) and matching its dark-theme `DarkButton` idiom (Segoe MDL2 glyph + label + tooltip). It opens and focuses the tab (or adds a fresh sub-tab if already open).

## How it's opened

Click **Open Plan Viewer** in the sidebar footer → the hidden `Plan Viewer` tab appears (after Alerts, before any per-server tabs), is selected, and gets a fresh empty sub-tab ready for a plan. The tab's header "×" closes it (cleaning up each hosted `PlanViewerControl`) and returns to the previous view.

## Viewer-only / no server connection

Reads no store data and needs no server connection — the plan comes entirely from the user. It works even with **zero servers registered**: the open handler shows `MainTabs` over the no-servers empty state, and the close handler restores that empty state. The 60s refresh path already tolerates the tab (its `LoadVisibleTabAsync` switch falls through — no data-service call).

## Implementation

- `MainWindow.xaml`: the sidebar-footer button + the `MainWindowPlanViewerTab` (drag/drop `Grid` + inner `MainWindowPlanTabControl`).
- `MainWindow.PlanViewer.cs` (new partial): ported from Lite's `MainWindow.PlanViewer.cs`, adapted to Darling's `MainTabs` shell and dark theme. Inner sub-tabs, close buttons, and empty-state controls resolve the app-merged `DarkTheme.xaml` implicit/keyed styles (implicit `Button`/`TabItem`/`TabControl`, `TabCloseButton`, `ForegroundMutedBrush`).
- Nothing outside the Darling viewer project is touched.

## Build

`dotnet build Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj -c Release` → **Build succeeded, 0 errors** (9 warnings, all pre-existing in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)