### PR TITLE
#1325: wire up installer --managed-identity / --service-principal flags

### DIFF
--- a/Installer.Tests/BuildConnectionStringTests.cs
+++ b/Installer.Tests/BuildConnectionStringTests.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using Installer.Core;
+using Microsoft.Data.SqlClient;
+
+namespace Installer.Tests;
+
+/// <summary>
+/// Unit tests for InstallationService.BuildConnectionString — the auth-mode mapping shared by the
+/// CLI installer flags (Windows / SQL / --entra / --managed-identity / --service-principal, #1325).
+/// Assertions round-trip the produced string through SqlConnectionStringBuilder so they check the
+/// typed Authentication/UserID/Password/IntegratedSecurity properties rather than brittle text.
+/// These run without a database.
+/// </summary>
+public class BuildConnectionStringTests
+{
+    private static SqlConnectionStringBuilder Parse(string connectionString) => new(connectionString);
+
+    [Fact]
+    public void WindowsAuth_UsesIntegratedSecurity_NoUserId()
+    {
+        var b = Parse(InstallationService.BuildConnectionString("SQL2022", useWindowsAuth: true));
+
+        Assert.True(b.IntegratedSecurity);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, b.Authentication);
+        Assert.True(string.IsNullOrEmpty(b.UserID));
+        Assert.Equal("master", b.InitialCatalog);
+    }
+
+    [Fact]
+    public void SqlAuth_SetsUserIdAndPassword_NoEntraAuth()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "SQL2022", useWindowsAuth: false, username: "sa", password: "p@ss!"));
+
+        Assert.False(b.IntegratedSecurity);
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, b.Authentication);
+        Assert.Equal("sa", b.UserID);
+        Assert.Equal("p@ss!", b.Password);
+    }
+
+    [Fact]
+    public void EntraInteractive_SetsInteractiveAuth_WithUpn()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "SQL2022", useWindowsAuth: false, username: "me@corp.com", useEntraAuth: true));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryInteractive, b.Authentication);
+        Assert.Equal("me@corp.com", b.UserID);
+    }
+
+    [Fact]
+    public void ServicePrincipal_SetsSpAuth_WithClientIdAndSecret()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "mi.database.windows.net", useWindowsAuth: false,
+            username: "client-id", password: "the-secret", authenticationType: "ServicePrincipal"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, b.Authentication);
+        Assert.Equal("client-id", b.UserID);
+        Assert.Equal("the-secret", b.Password);
+    }
+
+    [Fact]
+    public void ServicePrincipal_FallsBackToAzureClientId_WhenUsernameNull()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "mi.database.windows.net", useWindowsAuth: false,
+            username: null, password: "the-secret",
+            authenticationType: "ServicePrincipal", azureClientId: "app-id"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, b.Authentication);
+        Assert.Equal("app-id", b.UserID);
+    }
+
+    [Fact]
+    public void ManagedIdentity_SystemAssigned_OmitsUserId()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "mi.database.windows.net", useWindowsAuth: false, authenticationType: "ManagedIdentity"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, b.Authentication);
+        Assert.True(string.IsNullOrEmpty(b.UserID));
+    }
+
+    [Fact]
+    public void ManagedIdentity_UserAssigned_SetsClientIdAsUserId()
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "mi.database.windows.net", useWindowsAuth: false,
+            authenticationType: "ManagedIdentity", managedIdentityClientId: "mi-client-id"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, b.Authentication);
+        Assert.Equal("mi-client-id", b.UserID);
+    }
+
+    [Fact]
+    public void AuthenticationType_TakesPrecedence_OverWindowsAndEntraInteractiveFlags()
+    {
+        /* An explicit non-interactive Entra type must win even if the older
+           useWindowsAuth / useEntraAuth flags are also set by the caller. */
+        var b = Parse(InstallationService.BuildConnectionString(
+            "mi.database.windows.net", useWindowsAuth: true,
+            username: "client-id", password: "the-secret",
+            useEntraAuth: true, authenticationType: "ServicePrincipal"));
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, b.Authentication);
+        Assert.False(b.IntegratedSecurity);
+    }
+
+    [Theory]
+    [InlineData("Optional")]
+    [InlineData("Mandatory")]
+    [InlineData("Strict")]
+    public void Encryption_MapsToBuilderOption(string level)
+    {
+        var b = Parse(InstallationService.BuildConnectionString(
+            "SQL2022", useWindowsAuth: true, encryption: level));
+
+        var expected = level switch
+        {
+            "Optional" => SqlConnectionEncryptOption.Optional,
+            "Strict" => SqlConnectionEncryptOption.Strict,
+            _ => SqlConnectionEncryptOption.Mandatory
+        };
+        Assert.Equal(expected, b.Encrypt);
+    }
+}

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -58,6 +58,8 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username> <password>     SQL Auth");
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> <username>                SQL Auth (password via env var)");
                 Console.WriteLine("  PerformanceMonitorInstaller.exe <server> --entra <email>           Entra ID (MFA)");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> --managed-identity        Entra managed identity");
+                Console.WriteLine("  PerformanceMonitorInstaller.exe <server> --service-principal <id>  Entra service principal");
                 Console.WriteLine();
                 Console.WriteLine("Options:");
                 Console.WriteLine("  -h, --help           Show this help message");
@@ -68,11 +70,14 @@ namespace PerformanceMonitorInstaller
                 Console.WriteLine("  --encrypt=<level>    Connection encryption: mandatory (default), optional, strict");
                 Console.WriteLine("  --trust-cert         Trust server certificate without validation");
                 Console.WriteLine("  --entra <email>      Use Microsoft Entra ID interactive authentication (MFA)");
+                Console.WriteLine("  --managed-identity[=<clientId>]  Entra managed identity: system-assigned, or user-assigned via clientId");
+                Console.WriteLine("  --service-principal <clientId>   Entra service principal (secret via PM_AZURE_CLIENT_SECRET)");
                 Console.WriteLine("  --data-path <dir>    Server-side directory for the data (.mdf) file (first install only)");
                 Console.WriteLine("  --log-path <dir>     Server-side directory for the log (.ldf) file (first install only)");
                 Console.WriteLine();
                 Console.WriteLine("Environment Variables:");
-                Console.WriteLine("  PM_SQL_PASSWORD      SQL Auth password (avoids passing on command line)");
+                Console.WriteLine("  PM_SQL_PASSWORD         SQL Auth password (avoids passing on command line)");
+                Console.WriteLine("  PM_AZURE_CLIENT_SECRET  Service principal client secret (for --service-principal)");
                 Console.WriteLine();
                 Console.WriteLine("Exit Codes:");
                 Console.WriteLine("  0  Success");
@@ -107,6 +112,20 @@ namespace PerformanceMonitorInstaller
                     entraEmail = args[entraIndex + 1];
                 }
             }
+
+            /*#1325: non-interactive Entra auth for Managed Instance / AAD-enabled targets.
+              --managed-identity          -> system-assigned managed identity (no value)
+              --managed-identity=<id> / --managed-identity <id> -> user-assigned MI (client id)
+              --service-principal <id>    -> service principal; client secret via PM_AZURE_CLIENT_SECRET.
+              The service layer (InstallationService.BuildConnectionString) already maps these to
+              SqlAuthenticationMethod.ActiveDirectoryManagedIdentity / ActiveDirectoryServicePrincipal;
+              this only wires the CLI surface to it.*/
+            bool managedIdentityMode = args.Any(a => a.Equals("--managed-identity", StringComparison.OrdinalIgnoreCase)
+                || a.StartsWith("--managed-identity=", StringComparison.OrdinalIgnoreCase));
+            bool servicePrincipalMode = args.Any(a => a.Equals("--service-principal", StringComparison.OrdinalIgnoreCase)
+                || a.StartsWith("--service-principal=", StringComparison.OrdinalIgnoreCase));
+            string? managedIdentityClientId = GetOptionValue(args, "--managed-identity");
+            string? servicePrincipalClientId = GetOptionValue(args, "--service-principal");
 
             /*Parse encryption option (default: Mandatory)
               Supports both --encrypt=optional and --encrypt optional */
@@ -175,8 +194,10 @@ namespace PerformanceMonitorInstaller
 
             /*Filter out all --flags and their trailing values to get positional arguments
               (server, username, password). Flags like --entra <email>, --encrypt <level>,
-              --data-path <dir>, and --log-path <dir> have a following value that must also
-              be removed.*/
+              --data-path <dir>, --log-path <dir>, --service-principal <clientId>, and the
+              space form of --managed-identity <clientId> have a following value that must
+              also be removed. (The --flag=value forms are single tokens handled by the
+              continue below.)*/
             var filteredArgsList = new List<string>();
             for (int i = 0; i < args.Length; i++)
             {
@@ -186,7 +207,9 @@ namespace PerformanceMonitorInstaller
                     if ((args[i].Equals("--entra", StringComparison.OrdinalIgnoreCase)
                         || args[i].Equals("--encrypt", StringComparison.OrdinalIgnoreCase)
                         || args[i].Equals("--data-path", StringComparison.OrdinalIgnoreCase)
-                        || args[i].Equals("--log-path", StringComparison.OrdinalIgnoreCase))
+                        || args[i].Equals("--log-path", StringComparison.OrdinalIgnoreCase)
+                        || args[i].Equals("--service-principal", StringComparison.OrdinalIgnoreCase)
+                        || args[i].Equals("--managed-identity", StringComparison.OrdinalIgnoreCase))
                         && i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
                     {
                         i++; /*skip the value too*/
@@ -202,6 +225,10 @@ namespace PerformanceMonitorInstaller
             string? password = null;
             bool useWindowsAuth;
             bool useEntraAuth = false;
+            /*#1325: "ServicePrincipal" / "ManagedIdentity" for the non-interactive Entra modes; null
+              leaves the Windows/SQL/Entra-interactive paths unchanged. Matched as string literals by
+              BuildConnectionString (Installer.Core has no reference to PerformanceMonitor.Common).*/
+            string? authenticationType = null;
 
             if (automatedMode)
             {
@@ -227,6 +254,44 @@ namespace PerformanceMonitorInstaller
                     Console.WriteLine($"Server: {serverName}");
                     Console.WriteLine($"Authentication: Microsoft Entra ID ({username})");
                     Console.WriteLine("A browser window will open for interactive authentication...");
+                }
+                else if (servicePrincipalMode)
+                {
+                    /*Microsoft Entra service principal (client id + secret, non-interactive)*/
+                    useWindowsAuth = false;
+                    authenticationType = "ServicePrincipal";
+                    username = servicePrincipalClientId;   /*application (client) id*/
+                    password = Environment.GetEnvironmentVariable("PM_AZURE_CLIENT_SECRET");
+
+                    if (string.IsNullOrWhiteSpace(username))
+                    {
+                        Console.WriteLine("Error: Client (application) ID is required for service principal authentication.");
+                        Console.WriteLine("Usage: PerformanceMonitorInstaller.exe <server> --service-principal <clientId>");
+                        Console.WriteLine("       (client secret via the PM_AZURE_CLIENT_SECRET environment variable)");
+                        return (int)InstallationResultCode.InvalidArguments;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(password))
+                    {
+                        Console.WriteLine("Error: Client secret is required for service principal authentication.");
+                        Console.WriteLine("Set the PM_AZURE_CLIENT_SECRET environment variable to the application's client secret.");
+                        return (int)InstallationResultCode.InvalidArguments;
+                    }
+
+                    Console.WriteLine($"Server: {serverName}");
+                    Console.WriteLine($"Authentication: Microsoft Entra service principal ({username})");
+                }
+                else if (managedIdentityMode)
+                {
+                    /*Microsoft Entra managed identity (no secret). Blank client id = system-assigned;
+                      a client id (--managed-identity=<id> or --managed-identity <id>) = user-assigned.*/
+                    useWindowsAuth = false;
+                    authenticationType = "ManagedIdentity";
+
+                    Console.WriteLine($"Server: {serverName}");
+                    Console.WriteLine(string.IsNullOrWhiteSpace(managedIdentityClientId)
+                        ? "Authentication: Microsoft Entra managed identity (system-assigned)"
+                        : $"Authentication: Microsoft Entra managed identity (user-assigned: {managedIdentityClientId})");
                 }
                 else if (filteredArgs.Length >= 2)
                 {
@@ -274,6 +339,10 @@ namespace PerformanceMonitorInstaller
                     Console.WriteLine("  SQL Auth:       PerformanceMonitorInstaller.exe <server> <username> <password> [options]");
                     Console.WriteLine("  SQL Auth:       PerformanceMonitorInstaller.exe <server> <username> [options]");
                     Console.WriteLine("                  (with PM_SQL_PASSWORD environment variable set)");
+                    Console.WriteLine("  Entra ID:       PerformanceMonitorInstaller.exe <server> --entra <email>");
+                    Console.WriteLine("  Managed ID:     PerformanceMonitorInstaller.exe <server> --managed-identity[=<clientId>]");
+                    Console.WriteLine("  Service Prin.:  PerformanceMonitorInstaller.exe <server> --service-principal <clientId>");
+                    Console.WriteLine("                  (with PM_AZURE_CLIENT_SECRET environment variable set)");
                     Console.WriteLine();
                     Console.WriteLine("Options:");
                     Console.WriteLine("  --reinstall          Drop existing database and perform clean install");
@@ -379,7 +448,9 @@ namespace PerformanceMonitorInstaller
                 password,
                 encryptionLevel,
                 trustCert,
-                useEntraAuth);
+                useEntraAuth,
+                authenticationType: authenticationType,
+                managedIdentityClientId: managedIdentityClientId);
 
             /*
             Test connection and get SQL Server version

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ Entra ID (MFA) Authentication:
 PerformanceMonitorInstaller.exe YourServerName --entra user@domain.com
 ```
 
+Entra managed identity / service principal (non-interactive, for Azure SQL Managed Instance or other AAD-enabled targets):
+
+```
+PerformanceMonitorInstaller.exe YourMI.database.windows.net --managed-identity
+PerformanceMonitorInstaller.exe YourMI.database.windows.net --managed-identity=MI_CLIENT_ID
+PerformanceMonitorInstaller.exe YourMI.database.windows.net --service-principal APP_CLIENT_ID
+```
+
+Bare `--managed-identity` uses the system-assigned identity; pass a client id (`--managed-identity=ID` or `--managed-identity ID`) for a user-assigned one. `--service-principal` reads the client secret from the `PM_AZURE_CLIENT_SECRET` environment variable (never the command line).
+
 Clean reinstall (drops existing database and all collected data):
 
 ```
@@ -212,6 +222,8 @@ The installer automatically tests the connection, checks the SQL Server version 
 | `SERVER` | SQL Server instance name (positional, required) |
 | `USERNAME PASSWORD` | SQL Authentication credentials (positional, optional) |
 | `--entra EMAIL` | Microsoft Entra ID interactive authentication (MFA) |
+| `--managed-identity[=CLIENT_ID]` | Microsoft Entra managed identity (system-assigned, or user-assigned via `CLIENT_ID`) |
+| `--service-principal CLIENT_ID` | Microsoft Entra service principal (client secret via `PM_AZURE_CLIENT_SECRET`) |
 | `--reinstall` | Drop existing database and perform clean install |
 | `--uninstall` | Remove database, Agent jobs, and XE sessions |
 | `--reset-schedule` | Reset collection schedule to recommended defaults |
@@ -224,7 +236,7 @@ The installer automatically tests the connection, checks the SQL Server version 
 
 > **Custom file locations:** `--data-path` / `--log-path` set where SQL Server places the PerformanceMonitor data and log files. They take effect **only when the database is first created** — if the database already exists they are ignored. Either flag may be supplied independently; an omitted one falls back to the instance default (`SERVERPROPERTY('InstanceDefaultDataPath')` / `InstanceDefaultLogPath`). The directory is a path **on the SQL Server host** and must already exist, with the SQL Server service account holding write permission. Both `--data-path D:\SQLData` and `--data-path=D:\SQLData` forms are accepted; quote paths containing spaces. Not applicable to Azure SQL Managed Instance, which always uses its managed file layout.
 
-**Environment variable:** Set `PM_SQL_PASSWORD` to avoid passing the password on the command line.
+**Environment variables:** Set `PM_SQL_PASSWORD` to avoid passing the SQL Auth password on the command line, and `PM_AZURE_CLIENT_SECRET` to supply the `--service-principal` client secret.
 
 ### Exit Codes
 


### PR DESCRIPTION
## What

Wires up the CLI installer's `--managed-identity` and `--service-principal` flags. The service layer (`InstallationService.BuildConnectionString`) already mapped these to `ActiveDirectoryManagedIdentity` / `ActiveDirectoryServicePrincipal`, but `Installer/Program.cs` only exposed `--entra` — so the non-interactive Entra modes were unreachable from the command line.

## Flags

| Flag | Behavior |
|---|---|
| `--managed-identity` | System-assigned managed identity |
| `--managed-identity=<clientId>` (or `--managed-identity <clientId>`) | User-assigned managed identity |
| `--service-principal <clientId>` | Service principal; client secret read from `PM_AZURE_CLIENT_SECRET` (never the command line) |

Relevant for Azure SQL Managed Instance / other AAD-enabled targets that want non-interactive Entra auth for the installer itself. (Full Edition's installer still doesn't target Azure SQL Database; that path is Lite.)

## Changes

- **`Installer/Program.cs`** — flag detection + client-id parsing, two auth branches ordered before SQL/Windows auth, positional-arg filter entries (so space-form values don't leak into positionals), help text, and the invalid-args usage block. Passes `authenticationType` + `managedIdentityClientId` into the existing `BuildConnectionString` call.
- **`Installer.Tests/BuildConnectionStringTests.cs`** (new) — 11 tests covering Windows / SQL / Entra-interactive / service principal (client-id+secret and `azureClientId` fallback) / managed identity (system- and user-assigned) / auth-type precedence / encryption mapping. `BuildConnectionString` previously had **zero** coverage.
- **`README.md`** — install examples, options-table rows, and the `PM_AZURE_CLIENT_SECRET` env-var note.

## Test plan

- `dotnet build Installer/PerformanceMonitorInstaller.csproj -c Debug` — clean (0 warnings, 0 errors)
- `dotnet test Installer.Tests --filter "FullyQualifiedName~BuildConnectionStringTests"` — 11/11 pass (DB-touching Idempotency/Adversarial suites intentionally not run)
- Smoke-tested the built exe:
  - `--help` lists the new flags/options + `PM_AZURE_CLIENT_SECRET`
  - `--service-principal <id>` with no secret set → errors early (before any network)
  - `--managed-identity` → "system-assigned"; `--managed-identity=<id>` → "user-assigned: <id>", server positional preserved

**Not covered:** a live MI/SP connection handshake against a real Managed Instance (no MI available on the build machine). Connection-string construction is unit-tested; the live auth is not.

Closes #1325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
