### PR TITLE
Add per-server toolbar (settable time window + auto-refresh) to Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerServerTabTimeRangeTests.cs
+++ b/Darling/Darling.Tests/ViewerServerTabTimeRangeTests.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the per-server toolbar's time-range dropdown → hours-back mapping (the pure core that replaced
+/// the viewer's old hardcoded 24-hour <c>s_dataWindow</c>). The combo lists 1h / 4h / 12h / 24h / 7d /
+/// Custom; a preset index resolves to its hours, and any non-preset slot (Custom, or a stray value)
+/// falls back to the viewer's historical 24-hour default so no surface is ever left window-less.
+/// </summary>
+public sealed class ViewerServerTabTimeRangeTests
+{
+    [Theory]
+    [InlineData(0, 1)]     // Last 1 hour
+    [InlineData(1, 4)]     // Last 4 hours
+    [InlineData(2, 12)]    // Last 12 hours
+    [InlineData(3, 24)]    // Last 24 hours
+    [InlineData(4, 168)]   // Last 7 days
+    public void PresetIndex_MapsToItsHours(int index, int expectedHours)
+    {
+        Assert.Equal(expectedHours, ViewerServerTab.TimeRangeIndexToHours(index));
+    }
+
+    [Theory]
+    [InlineData(5)]   // "Custom Range" — the absolute From/To drives the window, not hours-back
+    [InlineData(6)]   // out of range
+    [InlineData(-1)]  // out of range
+    public void NonPresetIndex_FallsBackTo24Hours(int index)
+    {
+        Assert.Equal(24, ViewerServerTab.TimeRangeIndexToHours(index));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -339,8 +339,9 @@
 
             <!-- Right: the top tab strip. Fixed aggregate tabs (Overview, Recommendations, Alerts) plus
                  the dynamically-added closable per-server tabs (appended in code). Only the visible tab
-                 loads (Lite's visible-only rule); the 60-second timer re-reads it (Overview on its own
-                 30-second timer). -->
+                 loads (Lite's visible-only rule); the 60-second timer re-reads the visible aggregate tab
+                 (Overview on its own 30-second timer), while per-server tabs self-refresh on their own
+                 toolbar auto-refresh timer. -->
             <TabControl x:Name="MainTabs"
                         Grid.Column="1"
                         Background="Transparent"

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -172,9 +172,17 @@ public partial class MainWindow : Window
            (matching Lite — analysis findings change on the service's 30-minute cadence, so a 60-second
            auto-refresh is pointless churn and would reset the incident expanders' state under the
            reader), and the Overview has its own faster 30s timer, so the 60s timer skips it too (they'd
-           otherwise double-refresh the same grid). Every other visible tab still auto-refreshes. */
+           otherwise double-refresh the same grid). Every other aggregate tab still auto-refreshes. */
         if (ReferenceEquals(MainTabs.SelectedItem, RecommendationsTab)
             || ReferenceEquals(MainTabs.SelectedItem, OverviewTab))
+        {
+            return;
+        }
+
+        /* Per-server tabs now self-refresh on their own toolbar auto-refresh timer (at the user's chosen
+           interval / on/off), so the global 60s timer skips them — otherwise both would fire and the
+           user's interval choice wouldn't stick. */
+        if (MainTabs.SelectedItem is TabItem { Content: ViewerServerTab })
         {
             return;
         }
@@ -354,6 +362,7 @@ public partial class MainWindow : Window
 
         var serverTab = new ViewerServerTab(_dataService, server);
         serverTab.StatusChanged += OnServerTabStatusChanged;
+        serverTab.ApplyTimeRangeRequested += OnApplyTimeRangeToAllRequested;
 
         var tabItem = new TabItem
         {
@@ -377,6 +386,7 @@ public partial class MainWindow : Window
         if (tab.Content is ViewerServerTab serverTab)
         {
             serverTab.StatusChanged -= OnServerTabStatusChanged;
+            serverTab.ApplyTimeRangeRequested -= OnApplyTimeRangeToAllRequested;
             /* One dispose path: tears down every chart hover helper the tab's partials own. */
             serverTab.Dispose();
         }
@@ -421,6 +431,22 @@ public partial class MainWindow : Window
     }
 
     private void OnServerTabStatusChanged(string message) => StatusText.Text = message;
+
+    /// <summary>
+    /// "Apply to All" from one server tab's toolbar: copy its selected range (and, for a custom range, the
+    /// From/To in machine-local display time) to every OTHER open server tab so they window on the same
+    /// period. The source tab is skipped — it already holds the range.
+    /// </summary>
+    private void OnApplyTimeRangeToAllRequested(ViewerServerTab source, int index, DateTime? customFromLocal, DateTime? customToLocal)
+    {
+        foreach (var tab in _openServerTabs.Values)
+        {
+            if (tab.Content is ViewerServerTab serverTab && !ReferenceEquals(serverTab, source))
+            {
+                serverTab.ApplyExternalTimeRange(index, customFromLocal, customToLocal);
+            }
+        }
+    }
 
     // ── Overview tab (all-servers server cards; refreshes on its own 30s timer) ──────
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/OpenServerTabRegistry.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/OpenServerTabRegistry.cs
@@ -25,6 +25,9 @@ internal sealed class OpenServerTabRegistry<TTab>
     /// <summary>How many server tabs are currently open.</summary>
     public int Count => _tabs.Count;
 
+    /// <summary>Every open tab payload, so MainWindow can broadcast (e.g. "Apply time range to all").</summary>
+    public IEnumerable<TTab> Values => _tabs.Values;
+
     /// <summary>The existing tab for a server; false when none is open (the caller opens a new one).</summary>
     public bool TryGet(int serverId, [MaybeNullWhen(false)] out TTab tab) => _tabs.TryGetValue(serverId, out tab);
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
@@ -19,7 +19,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// The Queries → Active Queries sub-tab (W1f-2): the <c>ActiveQueriesSlicer</c> + <c>QuerySnapshotsGrid</c>
 /// of captured running-query snapshots, copied from Lite's <c>ServerTab</c> (Slicers / Grids / Refresh
 /// partials) with reads rewired to <see cref="ViewerDataService"/> Postgres. The grid loads every stored
-/// snapshot over the fixed 24-hour window (newest first); dragging the slicer re-reads the grid over the
+/// snapshot over the toolbar's settable window (newest first); dragging the slicer re-reads the grid over the
 /// selection, and sorting the grid re-labels the slicer's aggregate curve (Lite's <c>QuerySnapshotsGrid_Sorting</c>).
 /// Two deliberate deviations from Lite:
 ///   (1) The "Latest Snapshot" button (Lite's "Live Snapshot") no longer queries the monitored server —

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.BlockChain.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.BlockChain.cs
@@ -83,8 +83,7 @@ public partial class ViewerServerTab
                 }
                 else
                 {
-                    end = DateTime.UtcNow;
-                    start = end - s_dataWindow;
+                    (start, end) = GetWindowUtc();
                 }
             }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -25,8 +25,8 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <c>ServerTab.Charts.cs</c> Update* methods, reads rewired to <see cref="ViewerDataService"/> Postgres.
 /// Two render-body deviations from Lite: (1) the time axis runs through
 /// <see cref="ViewerDataService.ToLocalTime"/> instead of Lite's per-server <c>UtcOffsetMinutes</c> shift;
-/// (2) the viewer's fixed 24-hour window supplies the X-axis range (Lite's hoursBack / custom-range
-/// parameters are dropped). The spike-plot / zero-line-when-empty shapes, the fixed
+/// (2) the per-server toolbar's settable window supplies the X-axis range. The spike-plot /
+/// zero-line-when-empty shapes, the fixed
 /// <see cref="ChartPalette.SeriesColor"/> identities for the single-series charts, and the cycling
 /// <see cref="ChartPalette"/> colors for the multi-series charts are preserved. W1e adds Lite's full
 /// Blocked Process Reports grid (widened + slicer + block-chain viewer) and the Deadlocks sub-tab
@@ -90,13 +90,12 @@ public partial class ViewerServerTab
     /// <summary>
     /// Loads the Blocking tab's ACTIVE sub-tab only (mirrors Lite's subTabOnly gating): Trends reads the
     /// three trend series concurrently, Current Waits reads the two current-waits series concurrently,
-    /// and Blocked Process Reports reads the XE-with-DMV-fallback grid. All window on the fixed 24-hour
-    /// range.
+    /// and Blocked Process Reports reads the XE-with-DMV-fallback grid. All window on the toolbar's
+    /// settable range.
     /// </summary>
     private async Task LoadBlockingAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
 
         switch (BlockingSubTabs.SelectedIndex)
         {
@@ -132,7 +131,7 @@ public partial class ViewerServerTab
     /// <summary>
     /// Loads the Blocked Process Reports sub-tab (W1e Lite parity): the widened XE-preferred / DMV-fallback
     /// grid bound through the filter manager (so active column filters survive the refresh) plus the UTC
-    /// slicer over the same window. The grid reads the full 24-hour window; dragging the slicer re-reads it
+    /// slicer over the same window. The grid reads the full window; dragging the slicer re-reads it
     /// over the selection (<see cref="OnBlockingSlicerChanged"/>). The Npgsql reads are genuinely async, so
     /// unlike Lite's DuckDB path there is no Task.Run wrap.
     /// </summary>
@@ -281,8 +280,9 @@ public partial class ViewerServerTab
         ClearChart(LockWaitTrendChart);
         ApplyTheme(LockWaitTrendChart);
 
-        var rangeStart = ViewerDataService.ToLocalTime(DateTime.UtcNow - s_dataWindow);
-        var rangeEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
 
         _lockWaitTrendHover?.Clear();
         if (data.Count == 0)
@@ -335,8 +335,9 @@ public partial class ViewerServerTab
         ClearChart(BlockingTrendChart);
         ApplyTheme(BlockingTrendChart);
 
-        var rangeStart = ViewerDataService.ToLocalTime(DateTime.UtcNow - s_dataWindow);
-        var rangeEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
 
         _blockingTrendHover?.Clear();
         if (data.Count == 0)
@@ -404,8 +405,9 @@ public partial class ViewerServerTab
         ClearChart(DeadlockTrendChart);
         ApplyTheme(DeadlockTrendChart);
 
-        var rangeStart = ViewerDataService.ToLocalTime(DateTime.UtcNow - s_dataWindow);
-        var rangeEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
 
         _deadlockTrendHover?.Clear();
         if (data.Count == 0)
@@ -473,8 +475,9 @@ public partial class ViewerServerTab
         ClearChart(CurrentWaitsDurationChart);
         ApplyTheme(CurrentWaitsDurationChart);
 
-        var rangeStart = ViewerDataService.ToLocalTime(DateTime.UtcNow - s_dataWindow);
-        var rangeEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
 
         _currentWaitsDurationHover?.Clear();
         if (data.Count == 0)
@@ -528,8 +531,9 @@ public partial class ViewerServerTab
         ClearChart(CurrentWaitsBlockedChart);
         ApplyTheme(CurrentWaitsBlockedChart);
 
-        var rangeStart = ViewerDataService.ToLocalTime(DateTime.UtcNow - s_dataWindow);
-        var rangeEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
 
         _currentWaitsBlockedHover?.Clear();
         if (data.Count == 0)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -66,6 +66,13 @@ public partial class ViewerServerTab : IDisposable
     /// MainWindow when the server tab closes.</summary>
     public void Dispose()
     {
+        /* Stop the toolbar's auto-refresh timer so a closed tab's timer can't fire against a torn-down UI. */
+        if (_autoRefreshTimer != null)
+        {
+            _autoRefreshTimer.Stop();
+            _autoRefreshTimer.Tick -= OnAutoRefreshTick;
+        }
+
         _cpuHover?.Dispose();
         _tempDbHover?.Dispose();
         _tempDbSizeHover?.Dispose();
@@ -85,21 +92,34 @@ public partial class ViewerServerTab : IDisposable
     /// <summary>Loads the CPU tab: raw per-sample CPU utilization over the window.</summary>
     private async Task LoadCpuAsync()
     {
-        var sinceUtc = DateTime.UtcNow - s_dataWindow;
-        var samples = await _dataService.GetCpuUtilizationAsync(_server.ServerId, sinceUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var samples = await _dataService.GetCpuUtilizationAsync(_server.ServerId, startUtc);
+        /* The read is start-only server-side; bound the end for a custom range so a window that ends in
+           the past doesn't trail to the newest sample. sample_time is de-skewed to naive UTC (matching endUtc). */
+        if (IsCustomRange)
+        {
+            samples = samples.Where(s => s.SampleTime <= endUtc).ToList();
+        }
         RenderCpuChart(samples);
     }
 
     /// <summary>Loads the tempdb tab: usage/size trend and per-file I/O latency, read concurrently.</summary>
     private async Task LoadTempDbAsync()
     {
-        var sinceUtc = DateTime.UtcNow - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
 
         /* Both reads run concurrently — NpgsqlDataSource pools a connection for each. */
-        var trendTask = _dataService.GetTempDbTrendAsync(_server.ServerId, sinceUtc);
-        var fileIoTask = _dataService.GetTempDbFileIoTrendAsync(_server.ServerId, sinceUtc);
+        var trendTask = _dataService.GetTempDbTrendAsync(_server.ServerId, startUtc);
+        var fileIoTask = _dataService.GetTempDbFileIoTrendAsync(_server.ServerId, startUtc);
         var trend = await trendTask;
         var fileIo = await fileIoTask;
+
+        /* Start-only reads; bound the end for a custom range (collection_time is naive UTC). */
+        if (IsCustomRange)
+        {
+            trend = trend.Where(t => t.CollectionTime <= endUtc).ToList();
+            fileIo = fileIo.Where(f => f.CollectionTime <= endUtc).ToList();
+        }
 
         RenderTempDbUsageChart(trend);
         RenderTempDbSizeChart(trend);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -56,7 +56,7 @@ public partial class ViewerServerTab
     private async Task LoadHealthAsync()
     {
         var healthTask = _dataService.GetCollectionHealthAsync(_server.ServerId);
-        var logTask = _dataService.GetRecentCollectionLogAsync(_server.ServerId, (int)s_dataWindow.TotalHours);
+        var logTask = _dataService.GetRecentCollectionLogAsync(_server.ServerId, GetWindowHoursBack());
         await Task.WhenAll(healthTask, logTask);
 
         _collectionHealthFilterMgr!.UpdateData(healthTask.Result);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
@@ -20,8 +20,9 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// handlers and the <c>RefreshDailySummaryAsync</c> load), reads rewired to Postgres. The date picker
 /// drives a single-row daily roll-up over the selected UTC day (default today). Matching Lite exactly,
 /// changing the date only updates the indicator — the load fires on the Today button or Refresh. The
-/// tab-refresh loop (MainWindow's 60-second timer, via <see cref="LoadDailySummaryAsync"/>) reloads
-/// whatever date is selected.
+/// tab-refresh loop (the per-server toolbar's auto-refresh timer, via <see cref="LoadDailySummaryAsync"/>)
+/// reloads whatever date is selected; this tab is date-picker-driven, so the toolbar's time-range window
+/// does not apply to it.
 /// </summary>
 public partial class ViewerServerTab
 {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FileIo.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FileIo.cs
@@ -76,12 +76,11 @@ public partial class ViewerServerTab
     /// <summary>
     /// Loads the File I/O tab's ACTIVE sub-tab only (mirrors Lite's subTabOnly gating): the Latency
     /// sub-tab reads the per-file latency trend, the Throughput sub-tab reads the per-file MB/s trend.
-    /// Both window on the fixed 24-hour range like every other viewer surface.
+    /// Both window on the toolbar's settable range like every other viewer surface.
     /// </summary>
     private async Task LoadFileIoAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
 
         switch (FileIoSubTabs.SelectedIndex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -85,14 +85,13 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// Loads the Memory tab (Lite's <c>RefreshMemoryAsync</c> full-refresh branch): the six feeds read
-    /// concurrently over the fixed 24-hour window, then the summary + four charts render and the clerk
+    /// concurrently over the toolbar's settable window, then the summary + four charts render and the clerk
     /// picker is populated + drawn. The reads are genuinely async (no <c>Task.Run</c>), so a single
     /// <see cref="Task.WhenAll"/> pools a connection per read.
     /// </summary>
     private async Task LoadMemoryAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
 
         var latestTask = _dataService.GetLatestMemoryStatsAsync(_server.ServerId);
         var trendTask = _dataService.GetMemoryTrendAsync(_server.ServerId, startUtc, endUtc);
@@ -315,7 +314,7 @@ public partial class ViewerServerTab
     /// The Memory Pressure Events sub-tab — Lite's <c>UpdateMemoryPressureEventsChart</c>: hour-bucketed
     /// stacked bars of pressure events, SQL Server (process) vs OS (system) side-by-side and stacked by
     /// severity (medium = indicator 2, severe = indicator ≥ 3). Bar geometry copied verbatim from Lite;
-    /// the X range is the fixed 24-hour window and every bar/bound runs through
+    /// the X range is the toolbar's settable window and every bar/bound runs through
     /// <see cref="ViewerDataService.ToLocalTime"/> (see the class remarks on pressure sample_time).
     /// </summary>
     private void RenderMemoryPressureEventsChart(List<MemoryPressureEventRow> data)
@@ -324,8 +323,7 @@ public partial class ViewerServerTab
         _memoryPressureEventsHover?.Clear();
         ApplyTheme(MemoryPressureEventsChart);
 
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
         double xMin = ViewerDataService.ToLocalTime(startUtc).ToOADate();
         double xMax = ViewerDataService.ToLocalTime(endUtc).ToOADate();
 
@@ -506,7 +504,7 @@ public partial class ViewerServerTab
     /// <c>UpdateMemoryClerksChartFromPickerAsync</c>): the batched trend for up to 20 selected clerks in
     /// one query, each on a cycling <c>SeriesColors</c> color, plus the non-buffer-pool total + top-clerk
     /// summary. The generation guard discards a stale run when the selection changes mid-query; the
-    /// fixed 24-hour window matches the tab load (Lite's custom-range branch is dropped).
+    /// toolbar's settable window matches the tab load (Lite's custom-range branch is dropped).
     /// </summary>
     private async Task UpdateMemoryClerksChartFromPickerAsync()
     {
@@ -527,8 +525,7 @@ public partial class ViewerServerTab
                 return;
             }
 
-            var endUtc = DateTime.UtcNow;
-            var startUtc = endUtc - s_dataWindow;
+            var (startUtc, endUtc) = GetWindowUtc();
 
             double globalMax = 0;
             double nonBpTotal = 0;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Perfmon.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Perfmon.cs
@@ -18,8 +18,8 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// The Perfmon inner tab — a COPY of Lite's perfmon picker + chart (ServerTab.Pickers.cs lines
-/// 396-593 plus the <c>_defaultPerfmonCounters</c> seed at line 26), reads rewired to Postgres and the
-/// custom-date-range branch dropped for the viewer's fixed 24-hour window. The picker behaviors are
+/// 396-593 plus the <c>_defaultPerfmonCounters</c> seed at line 26), reads rewired to Postgres and
+/// windowed on the per-server toolbar's settable range (preset or custom From/To). The picker behaviors are
 /// preserved verbatim: the pack ComboBox sourced from the SHARED <see cref="PerfmonPacks"/> (the same
 /// packs Lite/Dashboard use), the General-Throughput default selection, the 12-counter cap on pack
 /// fills / "Select All", the checked-to-top ordering, the search filter, "Clear All" clearing only the
@@ -45,7 +45,7 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// The Perfmon tab load (mirrors Lite's <c>RefreshPerfmonAsync</c>): fetch the distinct counters
-    /// over the fixed 24-hour window, (re)populate the picker preserving the current selection, and
+    /// over the toolbar's settable window, (re)populate the picker preserving the current selection, and
     /// redraw. The hover helper is created lazily on first load so the picker's chart carries the same
     /// tooltip behavior Lite's does.
     /// </summary>
@@ -53,8 +53,7 @@ public partial class ViewerServerTab
     {
         _perfmonHover ??= new ChartHoverHelper(PerfmonChart, "");
 
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
         var counters = await _dataService.GetDistinctPerfmonCountersAsync(_server.ServerId, startUtc, endUtc);
         PopulatePerfmonPicker(counters);
         await UpdatePerfmonChartFromPickerAsync();
@@ -196,10 +195,9 @@ public partial class ViewerServerTab
 
             if (selected.Count == 0) { PerfmonChart.Refresh(); return; }
 
-            /* Fixed 24-hour window — the viewer has no custom-range picker (Lite's IsCustomRange branch
-               is dropped). The store is naive-UTC; display converts via ViewerDataService.ToLocalTime. */
-            var endUtc = DateTime.UtcNow;
-            var startUtc = endUtc - s_dataWindow;
+            /* The per-server toolbar's settable window (preset or custom From/To). The store is naive-UTC;
+               display converts via ViewerDataService.ToLocalTime. */
+            var (startUtc, endUtc) = GetWindowUtc();
             double globalMax = 0;
 
             // Batched fetch: one query for all selected counters (mirrors Lite's batched read).

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
@@ -23,7 +23,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <see cref="ViewerDataService"/> Postgres reads. A sub-tab switch reloads through the shell's
 /// overlap-guarded <see cref="RefreshActiveInnerTabAsync"/> (the Queries tab is the active inner tab
 /// whenever its sub-tabs are visible), and <see cref="LoadQueriesAsync"/> loads only the newly-visible
-/// sub-tab (Lite's subTabOnly gating) over the fixed 24-hour window. The three grids each carry a UTC
+/// sub-tab (Lite's subTabOnly gating) over the toolbar's settable window. The three grids each carry a UTC
 /// time-range slicer whose drag re-reads over the selection; sorting a grid re-labels the slicer's
 /// aggregate curve (Lite's *Grid_Sorting). The Performance Trends charts / Active Queries grid+slicer /
 /// Query Heatmap live in their own partials (<c>ViewerServerTab.QueryTrends.cs</c> /
@@ -108,13 +108,12 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// Loads the Queries tab's ACTIVE sub-tab only (Lite's subTabOnly gating): Top Queries / Top
-    /// Procedures / Query Store each read their grid + slicer + comparison over the fixed 24-hour window.
+    /// Procedures / Query Store each read their grid + slicer + comparison over the toolbar's settable window.
     /// The shell's <see cref="LoadInnerTabAsync"/> owns the try/catch that surfaces failures.
     /// </summary>
     private async Task LoadQueriesAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
 
         switch (QueriesSubTabControl.SelectedIndex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueriesComparison.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueriesComparison.cs
@@ -20,15 +20,15 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// week); when active, each sub-tab hides its normal grid and shows a collapsed comparison grid bound to
 /// the shared <see cref="PerformanceMonitor.Ui.ComparisonItemBase"/> derivatives (delta % + NEW/GONE
 /// badges), sorted NEW-first then by duration-delta descending. Changing the combo reloads the active
-/// sub-tab (which re-applies the comparison over the fixed 24-hour window). The viewer has no custom
-/// time-range picker, so the baseline is a straight shift of the current window (no Lite display-mode
-/// conversion), and the baseline banner renders the window in the viewer machine's local time.
+/// sub-tab (which re-applies the comparison over the toolbar's current window). The baseline is a
+/// straight shift of the current window (no Lite display-mode conversion), and the baseline banner
+/// renders the window in the viewer machine's local time.
 /// </summary>
 public partial class ViewerServerTab
 {
     /// <summary>
     /// Changing the Compare combo reloads the active Queries sub-tab through the shell's overlap guard,
-    /// so <see cref="LoadQueriesAsync"/> re-applies the comparison mode over the 24-hour window. Gated on
+    /// so <see cref="LoadQueriesAsync"/> re-applies the comparison mode over the current window. Gated on
     /// <see cref="System.Windows.FrameworkElement.IsLoaded"/> so the SelectedIndex="0" set at build time
     /// is ignored.
     /// </summary>
@@ -54,7 +54,7 @@ public partial class ViewerServerTab
         {
             CompareToCombo.IsEnabled = true;
             CompareToCombo.Opacity = 1.0;
-            CompareToCombo.ToolTip = "Compare the current 24-hour window against a baseline period";
+            CompareToCombo.ToolTip = "Compare the current window against a baseline period";
         }
         else
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
@@ -140,8 +140,7 @@ public partial class ViewerServerTab
         if (!IsLoaded) return;
         try
         {
-            var endUtc = DateTime.UtcNow;
-            var startUtc = endUtc - s_dataWindow;
+            var (startUtc, endUtc) = GetWindowUtc();
             var metric = (HeatmapMetric)HeatmapMetricCombo.SelectedIndex;
             var result = await _dataService.GetQueryHeatmapAsync(_server.ServerId, metric, startUtc, endUtc);
             UpdateQueryHeatmapChart(result);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
@@ -17,7 +17,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <summary>
 /// The System Events inner tab (system_health parity, Stage 2b) — eight sub-tabs, one per unique
 /// system_health warning category, each a parse-on-read grid: <see cref="ViewerDataService"/> fetches the
-/// raw event_xml for the category over the fixed 24-hour window, the Common <c>SystemHealthParser</c>
+/// raw event_xml for the category over the toolbar's settable window, the Common <c>SystemHealthParser</c>
 /// shreds it, and <c>SystemEventSignificance</c> keeps the sp_HealthParser-significant rows. Mirrors the
 /// FinOps tab's inner sub-tab-strip + DataGrid conventions (visible-only load, shared column filters,
 /// per-sub-tab count indicator + refresh). Timestamps render machine-local like the deadlock / blocked-
@@ -124,8 +124,8 @@ public partial class ViewerServerTab
 
     private async Task LoadSchedulerIssuesAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetSchedulerIssuesAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetSchedulerIssuesAsync(_server.ServerId, startUtc, endUtc);
         _seSchedulerFilterMgr!.UpdateData(data);
         SchedulerIssuesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         SchedulerIssuesCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -133,8 +133,8 @@ public partial class ViewerServerTab
 
     private async Task LoadSevereErrorsAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetSevereErrorsAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetSevereErrorsAsync(_server.ServerId, startUtc, endUtc);
         _seSevereErrorFilterMgr!.UpdateData(data);
         SevereErrorsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         SevereErrorsCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -142,8 +142,8 @@ public partial class ViewerServerTab
 
     private async Task LoadMemoryConditionsAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetMemoryConditionsAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetMemoryConditionsAsync(_server.ServerId, startUtc, endUtc);
         _seMemoryConditionsFilterMgr!.UpdateData(data);
         MemoryConditionsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         MemoryConditionsCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -151,8 +151,8 @@ public partial class ViewerServerTab
 
     private async Task LoadMemoryBrokerAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetMemoryBrokerAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetMemoryBrokerAsync(_server.ServerId, startUtc, endUtc);
         _seMemoryBrokerFilterMgr!.UpdateData(data);
         MemoryBrokerNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         MemoryBrokerCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -160,8 +160,8 @@ public partial class ViewerServerTab
 
     private async Task LoadMemoryNodeOomAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetMemoryNodeOomAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetMemoryNodeOomAsync(_server.ServerId, startUtc, endUtc);
         _seMemoryNodeOomFilterMgr!.UpdateData(data);
         MemoryNodeOomNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         MemoryNodeOomCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -169,8 +169,8 @@ public partial class ViewerServerTab
 
     private async Task LoadSignificantWaitsAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetSignificantWaitsAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetSignificantWaitsAsync(_server.ServerId, startUtc, endUtc);
         _seSignificantWaitsFilterMgr!.UpdateData(data);
         SignificantWaitsNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         SignificantWaitsCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -178,8 +178,8 @@ public partial class ViewerServerTab
 
     private async Task LoadCpuTasksAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetCpuTasksAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetCpuTasksAsync(_server.ServerId, startUtc, endUtc);
         _seCpuTasksFilterMgr!.UpdateData(data);
         CpuTasksNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         CpuTasksCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";
@@ -187,8 +187,8 @@ public partial class ViewerServerTab
 
     private async Task LoadIoIssuesAsync()
     {
-        var endUtc = DateTime.UtcNow;
-        var data = await _dataService.GetIoIssuesAsync(_server.ServerId, endUtc - s_dataWindow, endUtc);
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetIoIssuesAsync(_server.ServerId, startUtc, endUtc);
         _seIoIssuesFilterMgr!.UpdateData(data);
         IoIssuesNoDataMessage.Visibility = data.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
         IoIssuesCountIndicator.Text = data.Count > 0 ? $"{data.Count} event(s)" : "";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The per-server toolbar's time-window + auto-refresh state (the header row added above the inner tab
+/// strip), mirroring Lite's <c>ServerTab.TimeRange.cs</c> but adapted to the viewer: there is no
+/// <c>ServerTimeHelper</c> / per-server UTC offset, so the custom-range pickers are read in the viewer's
+/// one machine-LOCAL display convention (<see cref="ViewerDataService.ToLocalTime"/>) and inverted back
+/// to the store's naive-UTC bounds here. This replaces the old hardcoded 24-hour <c>s_dataWindow</c>: every
+/// inner-tab load now reads <see cref="GetWindowUtc"/> (preset 1h/4h/12h/24h/7d or a custom From/To), and
+/// the auto-refresh cadence comes from the toolbar instead of MainWindow's fixed 60-second timer.
+/// </summary>
+public partial class ViewerServerTab
+{
+    /// <summary>The "Custom Range" slot in <c>TimeRangeCombo</c> (after 1h/4h/12h/24h/7d).</summary>
+    private const int CustomRangeIndex = 5;
+
+    /// <summary>Guards the range handlers while pickers/combo are set programmatically (Apply-to-all,
+    /// custom-range defaults) so one external change drives exactly one reload, not a cascade.</summary>
+    private bool _suppressRangeEvents;
+
+    private DispatcherTimer? _autoRefreshTimer;
+
+    /// <summary>
+    /// Raised when the user clicks "Apply to All": MainWindow broadcasts the selected range (index plus,
+    /// for a custom range, the From/To in machine-local display time) to every other open server tab. The
+    /// source tab is carried so the broadcast can skip it (it already holds the range).
+    /// </summary>
+    public event Action<ViewerServerTab, int, DateTime?, DateTime?>? ApplyTimeRangeRequested;
+
+    /// <summary>Preset combo index → hours back. Index 5 (custom) and any stray value fall to the
+    /// viewer's historical 24-hour default. Pure + static so the mapping is unit-testable.</summary>
+    internal static int TimeRangeIndexToHours(int index) => index switch
+    {
+        0 => 1,
+        1 => 4,
+        2 => 12,
+        3 => 24,
+        4 => 168,
+        _ => 24,
+    };
+
+    /// <summary>Populates the custom-range hour (00:00–23:00) and minute (:00/:15/:30/:45) combos,
+    /// matching Lite's <c>InitializeTimeComboBoxes</c>. Called from the constructor after
+    /// <c>InitializeComponent</c>.</summary>
+    private void InitializeTimeComboBoxes()
+    {
+        var hours = new List<string>();
+        for (int h = 0; h < 24; h++)
+        {
+            hours.Add(DateTime.Today.AddHours(h).ToString("HH:00"));
+        }
+
+        FromHourCombo.ItemsSource = hours;
+        ToHourCombo.ItemsSource = hours;
+        FromHourCombo.SelectedIndex = 0;   // 00:00
+        ToHourCombo.SelectedIndex = 23;    // 23:00
+
+        var minutes = new List<string> { ":00", ":15", ":30", ":45" };
+        FromMinuteCombo.ItemsSource = minutes;
+        ToMinuteCombo.ItemsSource = minutes;
+        FromMinuteCombo.SelectedIndex = 0; // :00
+        ToMinuteCombo.SelectedIndex = 3;   // :45
+    }
+
+    /// <summary>Wires the auto-refresh timer (default 1 minute, matching the old fixed 60-second cadence)
+    /// and starts it when the toolbar's checkbox is checked. Called from the constructor.</summary>
+    private void InitializeAutoRefreshTimer()
+    {
+        _autoRefreshTimer = new DispatcherTimer();
+        UpdateAutoRefreshInterval();
+        _autoRefreshTimer.Tick += OnAutoRefreshTick;
+        if (AutoRefreshCheckBox.IsChecked == true)
+        {
+            _autoRefreshTimer.Start();
+        }
+    }
+
+    private async void OnAutoRefreshTick(object? sender, EventArgs e)
+    {
+        /* Only the VISIBLE server tab auto-refreshes (the viewer's visible-only rule); a background tab's
+           timer no-ops until the user switches to it, at which point MainWindow reloads it on activation. */
+        if (!IsVisible)
+        {
+            return;
+        }
+
+        await RefreshActiveInnerTabAsync();
+    }
+
+    // ── Window computation ───────────────────────────────────────────────────────────
+
+    /// <summary>True when the user picked "Custom Range" AND both date pickers hold a value.</summary>
+    private bool IsCustomRange => TimeRangeCombo.SelectedIndex == CustomRangeIndex
+        && FromDatePicker?.SelectedDate != null
+        && ToDatePicker?.SelectedDate != null;
+
+    /// <summary>
+    /// The current window as store-native naive-UTC bounds, driving every inner-tab load (it replaces the
+    /// old fixed 24-hour <c>s_dataWindow</c>). A preset ends "now"; a valid custom range uses its From/To.
+    /// </summary>
+    private (DateTime startUtc, DateTime endUtc) GetWindowUtc()
+    {
+        if (IsCustomRange)
+        {
+            var (fromUtc, toUtc) = GetCustomRangeUtc();
+            if (fromUtc.HasValue && toUtc.HasValue)
+            {
+                return (fromUtc.Value, toUtc.Value);
+            }
+        }
+
+        var endUtc = DateTime.UtcNow;
+        return (endUtc.AddHours(-TimeRangeIndexToHours(TimeRangeCombo.SelectedIndex)), endUtc);
+    }
+
+    /// <summary>Hours-back for the reads that take an integer window (the Overview lanes + Collection
+    /// Health log). A custom range collapses to its rounded-up span so those surfaces still track it.</summary>
+    private int GetWindowHoursBack()
+    {
+        if (IsCustomRange)
+        {
+            var (fromUtc, toUtc) = GetCustomRangeUtc();
+            if (fromUtc.HasValue && toUtc.HasValue)
+            {
+                var hours = (int)Math.Ceiling((toUtc.Value - fromUtc.Value).TotalHours);
+                return hours < 1 ? 1 : hours;
+            }
+        }
+
+        return TimeRangeIndexToHours(TimeRangeCombo.SelectedIndex);
+    }
+
+    /// <summary>Custom From/To as naive-UTC bounds for the Overview lanes (null,null when not a valid
+    /// custom range — the lanes then fall back to their hours-back window).</summary>
+    private (DateTime? fromUtc, DateTime? toUtc) GetOverviewCustomRange()
+        => IsCustomRange ? GetCustomRangeUtc() : (null, null);
+
+    /// <summary>Reads the custom From/To pickers as naive-UTC bounds, or (null,null) when either is unset.</summary>
+    private (DateTime? fromUtc, DateTime? toUtc) GetCustomRangeUtc()
+    {
+        var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+        var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+        if (!fromLocal.HasValue || !toLocal.HasValue)
+        {
+            return (null, null);
+        }
+
+        return (LocalDisplayToNaiveUtc(fromLocal.Value), LocalDisplayToNaiveUtc(toLocal.Value));
+    }
+
+    /// <summary>
+    /// Inverts <see cref="ViewerDataService.ToLocalTime"/>: the pickers show machine-local wall-clock time
+    /// (the viewer's one display convention), and the store windows on naive UTC, so a picked local time
+    /// converts to UTC and drops its kind for the reads (which re-stamp it Unspecified).
+    /// </summary>
+    private static DateTime LocalDisplayToNaiveUtc(DateTime localDisplay)
+    {
+        var utc = DateTime.SpecifyKind(localDisplay, DateTimeKind.Local).ToUniversalTime();
+        return DateTime.SpecifyKind(utc, DateTimeKind.Unspecified);
+    }
+
+    private static DateTime? GetDateTimeFromPickers(DatePicker datePicker, ComboBox hourCombo, ComboBox minuteCombo)
+    {
+        if (datePicker?.SelectedDate is not { } date)
+        {
+            return null;
+        }
+
+        int hour = hourCombo.SelectedIndex >= 0 ? hourCombo.SelectedIndex : 0;
+        int minute = minuteCombo.SelectedIndex >= 0 ? minuteCombo.SelectedIndex * 15 : 0;
+        return date.Date.AddHours(hour).AddMinutes(minute);
+    }
+
+    // ── Toolbar handlers ─────────────────────────────────────────────────────────────
+
+    private async void TimeRangeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressRangeEvents)
+        {
+            return;
+        }
+
+        var isCustom = TimeRangeCombo.SelectedIndex == CustomRangeIndex;
+        var visibility = isCustom ? Visibility.Visible : Visibility.Collapsed;
+
+        if (FromDatePicker != null)
+        {
+            FromDatePicker.Visibility = visibility;
+            FromHourCombo.Visibility = visibility;
+            FromMinuteCombo.Visibility = visibility;
+            ToLabel.Visibility = visibility;
+            ToDatePicker.Visibility = visibility;
+            ToHourCombo.Visibility = visibility;
+            ToMinuteCombo.Visibility = visibility;
+
+            if (isCustom && FromDatePicker.SelectedDate == null)
+            {
+                /* Seed a sensible default so switching to Custom shows a real window; the picker changes
+                   below drive the reload. Suppress so the two picker writes coalesce into one load. */
+                _suppressRangeEvents = true;
+                FromDatePicker.SelectedDate = DateTime.Today.AddDays(-1);
+                ToDatePicker.SelectedDate = DateTime.Today;
+                _suppressRangeEvents = false;
+            }
+        }
+
+        /* Presets reload here; a custom range reloads off the picker changes (below), except the seeded
+           default above which is suppressed — so drive that one reload explicitly. */
+        if (!isCustom || FromDatePicker?.SelectedDate != null)
+        {
+            await RefreshActiveInnerTabAsync();
+        }
+    }
+
+    private async void CustomDateRange_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressRangeEvents)
+        {
+            return;
+        }
+
+        if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
+        {
+            await RefreshActiveInnerTabAsync();
+        }
+    }
+
+    private async void CustomTimeCombo_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressRangeEvents)
+        {
+            return;
+        }
+
+        if (FromDatePicker?.SelectedDate != null && ToDatePicker?.SelectedDate != null)
+        {
+            await RefreshActiveInnerTabAsync();
+        }
+    }
+
+    private async void RefreshDataButton_Click(object sender, RoutedEventArgs e)
+    {
+        RefreshDataButton.IsEnabled = false;
+        try
+        {
+            await RefreshActiveInnerTabAsync();
+        }
+        finally
+        {
+            RefreshDataButton.IsEnabled = true;
+        }
+    }
+
+    private void AutoRefreshCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_autoRefreshTimer == null)
+        {
+            return;
+        }
+
+        if (AutoRefreshCheckBox.IsChecked == true)
+        {
+            UpdateAutoRefreshInterval();
+            _autoRefreshTimer.Start();
+        }
+        else
+        {
+            _autoRefreshTimer.Stop();
+        }
+    }
+
+    private void AutoRefreshInterval_Changed(object sender, SelectionChangedEventArgs e)
+    {
+        if (_autoRefreshTimer == null)
+        {
+            return;
+        }
+
+        UpdateAutoRefreshInterval();
+    }
+
+    private void UpdateAutoRefreshInterval()
+    {
+        if (_autoRefreshTimer == null || AutoRefreshIntervalCombo == null)
+        {
+            return;
+        }
+
+        _autoRefreshTimer.Interval = AutoRefreshIntervalCombo.SelectedIndex switch
+        {
+            0 => TimeSpan.FromSeconds(30),
+            1 => TimeSpan.FromMinutes(1),
+            2 => TimeSpan.FromMinutes(5),
+            _ => TimeSpan.FromMinutes(1),
+        };
+    }
+
+    private void ApplyTimeRangeToAll_Click(object sender, RoutedEventArgs e)
+    {
+        DateTime? fromLocal = null;
+        DateTime? toLocal = null;
+        if (TimeRangeCombo.SelectedIndex == CustomRangeIndex)
+        {
+            fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+            toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+        }
+
+        ApplyTimeRangeRequested?.Invoke(this, TimeRangeCombo.SelectedIndex, fromLocal, toLocal);
+    }
+
+    /// <summary>
+    /// Applies a range chosen on another server tab (the "Apply to All" broadcast). Sets the pickers and
+    /// combo under the suppress guard so the copy doesn't cascade multiple reloads, then drives exactly
+    /// one reload of this tab's active inner tab.
+    /// </summary>
+    public void ApplyExternalTimeRange(int index, DateTime? customFromLocal, DateTime? customToLocal)
+    {
+        _suppressRangeEvents = true;
+        try
+        {
+            var isCustom = index == CustomRangeIndex && customFromLocal.HasValue && customToLocal.HasValue;
+            var visibility = isCustom ? Visibility.Visible : Visibility.Collapsed;
+
+            if (FromDatePicker != null)
+            {
+                FromDatePicker.Visibility = visibility;
+                FromHourCombo.Visibility = visibility;
+                FromMinuteCombo.Visibility = visibility;
+                ToLabel.Visibility = visibility;
+                ToDatePicker.Visibility = visibility;
+                ToHourCombo.Visibility = visibility;
+                ToMinuteCombo.Visibility = visibility;
+            }
+
+            if (isCustom)
+            {
+                FromDatePicker!.SelectedDate = customFromLocal!.Value.Date;
+                FromHourCombo.SelectedIndex = customFromLocal.Value.Hour;
+                FromMinuteCombo.SelectedIndex = customFromLocal.Value.Minute / 15;
+                ToDatePicker!.SelectedDate = customToLocal!.Value.Date;
+                ToHourCombo.SelectedIndex = customToLocal.Value.Hour;
+                ToMinuteCombo.SelectedIndex = customToLocal.Value.Minute / 15;
+            }
+
+            TimeRangeCombo.SelectedIndex = index;
+        }
+        finally
+        {
+            _suppressRangeEvents = false;
+        }
+
+        _ = RefreshActiveInnerTabAsync();
+    }
+
+    // ── Custom-range DatePicker calendar theming (viewer is fixed Dark) ───────────────
+
+    private void DatePicker_CalendarOpened(object sender, RoutedEventArgs e)
+    {
+        if (sender is not DatePicker datePicker)
+        {
+            return;
+        }
+
+        /* Defer so the popup's visual tree exists before we re-color it. */
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (datePicker.Template.FindName("PART_Popup", datePicker) is Popup { Child: Calendar calendar })
+            {
+                ApplyDarkThemeToCalendar(calendar);
+            }
+        }));
+    }
+
+    private static void ApplyDarkThemeToCalendar(Calendar calendar)
+    {
+        var primaryBg = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#111217")!);
+        var fg = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#E4E6EB")!);
+        var borderBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#2a2d35")!);
+
+        calendar.Background = primaryBg;
+        calendar.Foreground = fg;
+        calendar.BorderBrush = borderBrush;
+        ApplyDarkThemeRecursively(calendar, primaryBg, fg);
+    }
+
+    private static void ApplyDarkThemeRecursively(DependencyObject parent, Brush primaryBg, Brush fg)
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+
+            switch (child)
+            {
+                case CalendarItem calendarItem:
+                    calendarItem.Background = primaryBg;
+                    calendarItem.Foreground = fg;
+                    break;
+                case CalendarDayButton dayButton:
+                    dayButton.Background = Brushes.Transparent;
+                    dayButton.Foreground = fg;
+                    break;
+                case CalendarButton calButton:
+                    calButton.Background = Brushes.Transparent;
+                    calButton.Foreground = fg;
+                    break;
+                case Button button:
+                    button.Background = Brushes.Transparent;
+                    button.Foreground = fg;
+                    break;
+                case TextBlock textBlock:
+                    textBlock.Foreground = fg;
+                    break;
+                case Border { Background: SolidColorBrush bg } border when bg.Color is { R: > 200, G: > 200, B: > 200 }:
+                    border.Background = primaryBg;
+                    break;
+                case Grid { Background: SolidColorBrush gridBg } grid when gridBg.Color is { R: > 200, G: > 200, B: > 200 }:
+                    grid.Background = primaryBg;
+                    break;
+            }
+
+            ApplyDarkThemeRecursively(child, primaryBg, fg);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Waits.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Waits.cs
@@ -20,8 +20,8 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// The Wait Stats inner tab — a COPY of Lite's wait-stats picker + chart (ServerTab.Pickers.cs
-/// lines 30-221), reads rewired to Postgres and the custom-date-range branch dropped for the
-/// viewer's fixed 24-hour window. The picker behaviors are preserved verbatim: the poison /
+/// lines 30-221), reads rewired to Postgres and windowed on the per-server toolbar's settable range
+/// (preset or custom From/To). The picker behaviors are preserved verbatim: the poison /
 /// usual-suspect / PAGELATCH_ default selection with a 30-type cap, checked-to-top ordering, the
 /// search filter, "Top Waits" / "Clear All" (Clear All clears only the FILTERED visible set), the
 /// reentrancy guard on programmatic checkbox writes, and the generation-guarded batched chart
@@ -67,7 +67,7 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// The Wait Stats tab load (mirrors Lite's <c>RefreshWaitStatsAsync</c>): fetch the distinct wait
-    /// types over the fixed 24-hour window, (re)populate the picker preserving the current selection,
+    /// types over the toolbar's settable window, (re)populate the picker preserving the current selection,
     /// and redraw. The hover helper is created lazily on first load so the picker's chart carries the
     /// same tooltip + click-to-isolate behavior Lite's does.
     /// </summary>
@@ -75,8 +75,7 @@ public partial class ViewerServerTab
     {
         _waitStatsHover ??= new ChartHoverHelper(WaitStatsChart, "ms/sec");
 
-        var endUtc = DateTime.UtcNow;
-        var startUtc = endUtc - s_dataWindow;
+        var (startUtc, endUtc) = GetWindowUtc();
         var waitTypes = await _dataService.GetDistinctWaitTypesAsync(_server.ServerId, startUtc, endUtc);
         PopulateWaitTypePicker(waitTypes);
         await UpdateWaitStatsChartFromPickerAsync();
@@ -182,10 +181,9 @@ public partial class ViewerServerTab
             bool useAvgPerWait = WaitStatsMetricCombo?.SelectedIndex == 1;
             if (_waitStatsHover != null) _waitStatsHover.Unit = useAvgPerWait ? "ms/wait" : "ms/sec";
 
-            /* Fixed 24-hour window — the viewer has no custom-range picker (Lite's IsCustomRange branch
-               is dropped). The store is naive-UTC; display converts via ViewerDataService.ToLocalTime. */
-            var endUtc = DateTime.UtcNow;
-            var startUtc = endUtc - s_dataWindow;
+            /* The per-server toolbar's settable window (preset or custom From/To). The store is naive-UTC;
+               display converts via ViewerDataService.ToLocalTime. */
+            var (startUtc, endUtc) = GetWindowUtc();
             double globalMax = 0;
 
             // Batched fetch: one query for all selected wait types (mirrors Lite's batched read).

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -13,8 +13,8 @@
         (per-collector last-run status). The grids keep MainWindow's hardcoded Dark styling verbatim
         (pure relocation — no visual change); the inner tab chrome uses the shared SubTabItemStyle so
         the sub-tab hierarchy reads the same as Lite's ServerTab. Loads are lazy per inner tab (Lite's
-        visible-only rule): only the active inner tab reads, and MainWindow's 60-second timer refreshes
-        only the active inner tab of the visible server tab.
+        visible-only rule): only the active inner tab reads, and the per-server toolbar's auto-refresh
+        timer refreshes only the active inner tab of the visible server tab.
     -->
     <UserControl.Resources>
         <Style x:Key="SectionHeader" TargetType="TextBlock">
@@ -231,9 +231,76 @@
 
     </UserControl.Resources>
 
-    <!-- Inner tab strip. Only the ACTIVE inner tab loads (Lite's visible-only rule); MainWindow's
-         60-second timer refreshes only the active inner tab of the visible server tab. -->
-    <TabControl x:Name="InnerTabs"
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Per-server toolbar (mirrors Lite's ServerTab.xaml header): the time-range dropdown +
+             custom From/To, Apply-to-all, the shared Compare baseline (moved up from the Queries tab),
+             Refresh, and the auto-refresh toggle + interval. These drive a SETTABLE window (replacing
+             the old fixed 24-hour s_dataWindow) that every inner tab reads via GetWindowUtc. A
+             Server/Local/UTC time-display picker is intentionally NOT here yet — see the class summary /
+             the PR: the viewer has no per-server UTC offset for "Server Time", so that plumbing is a
+             follow-up rather than a half-wired control. -->
+        <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="12,8">
+            <WrapPanel Orientation="Horizontal">
+                <ComboBox x:Name="TimeRangeCombo" SelectedIndex="3" Width="120" Margin="0,0,8,4"
+                          SelectionChanged="TimeRangeCombo_SelectionChanged"
+                          ToolTip="Time window every inner tab reads">
+                    <ComboBoxItem Content="Last 1 hour"/>
+                    <ComboBoxItem Content="Last 4 hours"/>
+                    <ComboBoxItem Content="Last 12 hours"/>
+                    <ComboBoxItem Content="Last 24 hours"/>
+                    <ComboBoxItem Content="Last 7 days"/>
+                    <ComboBoxItem Content="Custom Range"/>
+                </ComboBox>
+                <DatePicker x:Name="FromDatePicker" Width="120" Margin="0,0,2,4" Visibility="Collapsed"
+                            SelectedDateChanged="CustomDateRange_Changed" CalendarOpened="DatePicker_CalendarOpened"/>
+                <ComboBox x:Name="FromHourCombo" Width="70" Margin="0,0,2,4" Visibility="Collapsed"
+                          SelectionChanged="CustomTimeCombo_Changed" ToolTip="Hour"/>
+                <ComboBox x:Name="FromMinuteCombo" Width="60" Margin="0,0,2,4" Visibility="Collapsed"
+                          SelectionChanged="CustomTimeCombo_Changed" ToolTip="Minute"/>
+                <TextBlock x:Name="ToLabel" Text="to" VerticalAlignment="Center" Margin="4,0,4,0" Visibility="Collapsed"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <DatePicker x:Name="ToDatePicker" Width="120" Margin="0,0,2,4" Visibility="Collapsed"
+                            SelectedDateChanged="CustomDateRange_Changed" CalendarOpened="DatePicker_CalendarOpened"/>
+                <ComboBox x:Name="ToHourCombo" Width="70" Margin="0,0,2,4" Visibility="Collapsed"
+                          SelectionChanged="CustomTimeCombo_Changed" ToolTip="Hour"/>
+                <ComboBox x:Name="ToMinuteCombo" Width="60" Margin="0,0,8,4" Visibility="Collapsed"
+                          SelectionChanged="CustomTimeCombo_Changed" ToolTip="Minute"/>
+                <Button Content="Apply to All" Click="ApplyTimeRangeToAll_Click" Padding="8,4" Margin="0,0,8,4"
+                        ToolTip="Apply this time range to all open server tabs"/>
+                <TextBlock Text="Compare:" VerticalAlignment="Center" Margin="0,0,4,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <ComboBox x:Name="CompareToCombo" SelectedIndex="0" Width="150" Margin="0,0,8,4"
+                          SelectionChanged="CompareToCombo_SelectionChanged"
+                          ToolTip="Compare the current window against a baseline period">
+                    <ComboBoxItem Content="None"/>
+                    <ComboBoxItem Content="Yesterday"/>
+                    <ComboBoxItem Content="Last week"/>
+                    <ComboBoxItem Content="Same day last week"/>
+                </ComboBox>
+                <Button x:Name="RefreshDataButton" Content="Refresh" Click="RefreshDataButton_Click"
+                        Padding="12,4" Margin="0,0,8,4"/>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,2"/>
+                <CheckBox x:Name="AutoRefreshCheckBox" Content="Auto-refresh" VerticalAlignment="Center"
+                          Margin="0,0,4,4" Foreground="{DynamicResource ForegroundBrush}"
+                          IsChecked="True" Checked="AutoRefreshCheckBox_Changed" Unchecked="AutoRefreshCheckBox_Changed"/>
+                <ComboBox x:Name="AutoRefreshIntervalCombo" SelectedIndex="1" Width="70" Margin="0,0,0,4"
+                          SelectionChanged="AutoRefreshInterval_Changed"
+                          ToolTip="Auto-refresh interval">
+                    <ComboBoxItem Content="30s"/>
+                    <ComboBoxItem Content="1m"/>
+                    <ComboBoxItem Content="5m"/>
+                </ComboBox>
+            </WrapPanel>
+        </Border>
+
+        <!-- Inner tab strip. Only the ACTIVE inner tab loads (Lite's visible-only rule); the toolbar's
+             auto-refresh timer refreshes only the active inner tab of the visible server tab. -->
+        <TabControl x:Name="InnerTabs" Grid.Row="1"
                 Background="Transparent"
                 BorderThickness="0"
                 Padding="0"
@@ -248,7 +315,7 @@
         </TabItem>
 
         <!-- Wait Stats Tab — copied from Lite's ServerTab.xaml (the 220px wait-type picker + metric
-             combo + chart); reads rewired to Postgres, fixed 24-hour window (no custom-range picker). -->
+             combo + chart); reads rewired to Postgres, windowed on the per-server toolbar's settable range. -->
         <TabItem Header="Wait Stats">
             <Grid Margin="8">
                 <Grid.ColumnDefinitions>
@@ -307,8 +374,8 @@
              exactly: Performance Trends, Active Queries (W1f-2), Top Queries / Top Procedures / Query
              Store by Duration (W1f-1), Query Heatmap (W1f-2). A shared "Compare:" combo above the
              sub-tabs drives the three grids' collapsed comparison grids (shared .Ui ComparisonItemBase
-             derivatives; the non-grid sub-tabs ignore it). Reads rewired to Postgres over the fixed
-             24-hour window, which supplies the slicer range. The Active Queries plan buttons open the
+             derivatives; the non-grid sub-tabs ignore it). Reads rewired to Postgres over the toolbar's
+             settable window, which supplies the slicer range. The Active Queries plan buttons open the
              stored plan through the OpenPlanTab hook the plan-host wave implements. Deferred within the
              three grids (no live server): the per-row double-click history windows and the slicer
              overlay-on-select — only the slicer's drag-to-narrow re-read and its sort-driven metric
@@ -317,7 +384,7 @@
              absorbed top-50 grid becomes the first sub-tab, replaced by Lite's full ~44-column Top
              Queries by Duration grid; Top Procedures and Query Store join it. A shared "Compare:" combo
              above the sub-tabs drives the collapsed comparison grids (shared .Ui ComparisonItemBase
-             derivatives). Reads rewired to Postgres over the fixed 24-hour window, which supplies the
+             derivatives). Reads rewired to Postgres over the toolbar's settable window, which supplies the
              slicer range. Performance Trends / Active Queries / Query Heatmap sub-tabs are deferred to
              W1f-2, so their slots are ABSENT. Now wired (headless-plan wave): Top Queries' "Query Plan"
              download column + a "View Plan" context item on Top Queries, Query Store, AND Top Procedures,
@@ -327,23 +394,10 @@
              history windows, and the slicer overlay-on-select — only the slicer's drag-to-narrow re-read and
              its sort-driven metric re-labeling are wired here. -->
         <TabItem Header="Queries">
+            <!-- The shared "Compare:" baseline combo lives in the per-server header now (it drives the
+                 whole tab's window, not just Queries); this tab is just the sub-tab group. -->
             <Grid Margin="0,8,0,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="4,0,0,4">
-                    <TextBlock Text="Compare:" VerticalAlignment="Center" Margin="0,0,4,0" Foreground="{DynamicResource ForegroundBrush}"/>
-                    <ComboBox x:Name="CompareToCombo" SelectedIndex="0" Width="150"
-                              SelectionChanged="CompareToCombo_SelectionChanged"
-                              ToolTip="Compare the current 24-hour window against a baseline period">
-                        <ComboBoxItem Content="None"/>
-                        <ComboBoxItem Content="Yesterday"/>
-                        <ComboBoxItem Content="Last week"/>
-                        <ComboBoxItem Content="Same day last week"/>
-                    </ComboBox>
-                </StackPanel>
-                <TabControl x:Name="QueriesSubTabControl" Grid.Row="1"
+                <TabControl x:Name="QueriesSubTabControl"
                             Background="Transparent" BorderThickness="0"
                             ItemContainerStyle="{DynamicResource SubTabItemStyle}"
                             SelectionChanged="QueriesSubTabs_SelectionChanged">
@@ -1780,8 +1834,8 @@
         <!-- Perfmon Tab — copied from Lite's ServerTab.xaml Perfmon tab: a 220px counter picker (pack
              ComboBox sourced from the SHARED PerformanceMonitor.Ui PerfmonPacks + Select All / Clear All
              + search + checkbox ListBox) and a full-bleed chart plotting each selected counter's delta
-             value (max 12 series). Reads rewired to Postgres; fixed 24-hour window (no custom-range
-             picker). Placed BEFORE Running Jobs, matching Lite's own tab order. -->
+             value (max 12 series). Reads rewired to Postgres; windowed on the per-server toolbar's
+             settable range. Placed BEFORE Running Jobs, matching Lite's own tab order. -->
         <TabItem Header="Perfmon">
             <Grid Margin="8">
                 <Grid.ColumnDefinitions>
@@ -2196,7 +2250,7 @@
         </TabItem>
 
         <!-- System Events Tab (system_health parity, Stage 2b): six parse-on-read sub-tabs, one per unique
-             system_health warning category. Each reads the raw event_xml over the fixed 24-hour window,
+             system_health warning category. Each reads the raw event_xml over the toolbar's settable window,
              shreds it with the Common SystemHealthParser, and shows only the sp_HealthParser-significant
              rows (SystemEventSignificance). Event times render machine-local (the XE @timestamp). -->
         <TabItem Header="System Events">
@@ -2227,7 +2281,7 @@
                                     <DataGridTextColumn Binding="{Binding ThreadQuantumMs, StringFormat=N0}" Width="135" ElementStyle="{StaticResource NumericCell}"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ThreadQuantumMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Thread Quantum ms" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="SchedulerIssuesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No scheduler warnings (non-yielding / offline schedulers) in the last 24 hours."/>
+                            <TextBlock x:Name="SchedulerIssuesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No scheduler warnings (non-yielding / offline schedulers) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2256,7 +2310,7 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="SevereErrorsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No severe errors (severity 19+) in the last 24 hours."/>
+                            <TextBlock x:Name="SevereErrorsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No severe errors (severity 19+) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2307,7 +2361,7 @@
                                     <DataGridTextColumn Binding="{Binding LastOsError, StringFormat=N0}" Width="105" ElementStyle="{StaticResource NumericCell}"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastOsError" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last OS Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="MemoryConditionsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No low-physical-memory conditions (RESOURCE_MEMPHYSICAL_LOW) in the last 24 hours."/>
+                            <TextBlock x:Name="MemoryConditionsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No low-physical-memory conditions (RESOURCE_MEMPHYSICAL_LOW) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2339,7 +2393,7 @@
                                     <DataGridTextColumn Binding="{Binding PreviouslyAllocated, StringFormat=N0}" Width="125" ElementStyle="{StaticResource NumericCell}"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PreviouslyAllocated" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Prev Allocated" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="MemoryBrokerNoDataMessage" Style="{StaticResource EmptyHint}" Text="No low-physical-memory broker notifications (RESOURCE_MEMPHYSICAL_LOW) in the last 24 hours."/>
+                            <TextBlock x:Name="MemoryBrokerNoDataMessage" Style="{StaticResource EmptyHint}" Text="No low-physical-memory broker notifications (RESOURCE_MEMPHYSICAL_LOW) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2386,7 +2440,7 @@
                                     <DataGridTextColumn Binding="{Binding IsProcessVirtualMemoryLow}" Width="105"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="IsProcessVirtualMemoryLow" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Proc Virt Low" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="MemoryNodeOomNoDataMessage" Style="{StaticResource EmptyHint}" Text="No memory-node out-of-memory events in the last 24 hours."/>
+                            <TextBlock x:Name="MemoryNodeOomNoDataMessage" Style="{StaticResource EmptyHint}" Text="No memory-node out-of-memory events in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2415,7 +2469,7 @@
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="SignificantWaitsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No significant waits (session queries waiting 500 ms+) in the last 24 hours."/>
+                            <TextBlock x:Name="SignificantWaitsNoDataMessage" Style="{StaticResource EmptyHint}" Text="No significant waits (session queries waiting 500 ms+) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2445,7 +2499,7 @@
                                     <DataGridTextColumn Binding="{Binding DidBlockingOccur}" Width="90"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DidBlockingOccur" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Blocking" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="CpuTasksNoDataMessage" Style="{StaticResource EmptyHint}" Text="No CPU-task warnings (WARNING state with 10+ pending tasks) in the last 24 hours."/>
+                            <TextBlock x:Name="CpuTasksNoDataMessage" Style="{StaticResource EmptyHint}" Text="No CPU-task warnings (WARNING state with 10+ pending tasks) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
@@ -2471,11 +2525,12 @@
                                     <DataGridTextColumn Binding="{Binding LongestPendingRequestsFilePath}" Width="360"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LongestPendingRequestsFilePath" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="File Path" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <TextBlock x:Name="IoIssuesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No potential I/O issues (WARNING state with pending I/O) in the last 24 hours."/>
+                            <TextBlock x:Name="IoIssuesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No potential I/O issues (WARNING state with pending I/O) in the selected time window."/>
                         </Grid>
                     </Grid>
                 </TabItem>
             </TabControl>
         </TabItem>
     </TabControl>
+    </Grid>
 </UserControl>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -24,13 +24,15 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// and Collection Health (per-collector last-run status). This is the per-server content relocated
 /// out of MainWindow's old flat tab list; the load/render bodies are unchanged (pure re-hosting).
 /// Loads are lazy per inner tab (Lite's visible-only rule): switching inner tabs loads the newly
-/// visible one, and <see cref="RefreshActiveInnerTabAsync"/> — driven by MainWindow's 60-second timer
-/// only when this server tab is the visible top-level tab — reloads just the active inner tab.
+/// visible one, and <see cref="RefreshActiveInnerTabAsync"/> — driven by the per-server toolbar's
+/// auto-refresh timer (see ViewerServerTab.TimeRange.cs) only when this server tab is the visible
+/// top-level tab, plus MainWindow's tab-activation reload — reloads just the active inner tab.
 /// </summary>
 public partial class ViewerServerTab : UserControl
 {
-    /// <summary>One window for every windowed surface: charts, queries, and blocking all read 24 hours.</summary>
-    private static readonly TimeSpan s_dataWindow = TimeSpan.FromHours(24);
+    /* The per-server data window is no longer a fixed 24-hour constant: it comes from the toolbar's
+       time-range dropdown / custom From-To (see ViewerServerTab.TimeRange.cs). Every inner-tab load
+       reads GetWindowUtc() / GetWindowHoursBack() instead of the removed s_dataWindow. */
 
     /* Inner-tab order mirrors Lite's ServerTab relative order (Overview, Wait Stats, Queries,
        Plan Viewer, CPU, Memory, File I/O, tempdb, Blocking, Perfmon, Running Jobs, Configuration, Daily
@@ -106,6 +108,12 @@ public partial class ViewerServerTab : UserControl
 
         /* System Events inner tab (system_health parity): register the eight category grids' filter managers. */
         InitializeSystemEventsTab();
+
+        /* Per-server toolbar (this wave): populate the custom-range hour/minute combos and start the
+           auto-refresh timer at the toolbar's interval (default 1m = the old fixed 60s cadence). The
+           settable window these controls drive replaces the removed 24-hour s_dataWindow constant. */
+        InitializeTimeComboBoxes();
+        InitializeAutoRefreshTimer();
     }
 
     /// <summary>The server this tab is bound to; MainWindow keys open tabs by this for dedupe/close.</summary>
@@ -119,8 +127,8 @@ public partial class ViewerServerTab : UserControl
     /// a bubbling routed event, so selections inside the tab content (a grid) reach here too — only
     /// react to the inner TabControl's own. Gated on <see cref="System.Windows.FrameworkElement.IsLoaded"/>
     /// so the selection raised while the TabControl is first built (before this tab is shown) is ignored:
-    /// MainWindow drives the initial load when it makes this server tab visible, and the 60-second timer
-    /// keeps it fresh — so the control loads exactly once per event, not on construction too.
+    /// MainWindow drives the initial load when it makes this server tab visible, and the toolbar's
+    /// auto-refresh timer keeps it fresh — so the control loads exactly once per event, not on construction too.
     /// </summary>
     private async void InnerTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
@@ -136,7 +144,7 @@ public partial class ViewerServerTab : UserControl
     /// Loads the ACTIVE inner tab, with the overlap guard mirroring MainWindow's aggregate-tab loop.
     /// If the inner tab switches while a load is in flight, the triggering event bounces off the guard,
     /// so after each load we loop when the selection moved on and load again — leaving no inner tab
-    /// stranded. A trigger that arrives mid-load (the 60-second tick, an inner-tab switch) sets
+    /// stranded. A trigger that arrives mid-load (the auto-refresh tick, an inner-tab switch) sets
     /// <see cref="_refreshRequested"/> instead of being dropped, so the running loop reloads once more.
     /// </summary>
     public async Task RefreshActiveInnerTabAsync()
@@ -185,7 +193,7 @@ public partial class ViewerServerTab : UserControl
                 case PlanViewerInnerTabIndex:
                     /* No data feed: plans are pushed into the host by OpenPlanTab (a "View Plan" click),
                        not loaded on tab-switch. Explicit no-op so selecting it doesn't fall through to the
-                       default Overview reload, and so the 60-second timer leaves any open plan tabs alone. */
+                       default Overview reload, and so the auto-refresh timer leaves any open plan tabs alone. */
                     break;
                 case BlockingInnerTabIndex:
                     await LoadBlockingAsync();
@@ -236,10 +244,11 @@ public partial class ViewerServerTab : UserControl
 
     private async Task LoadOverviewChartsAsync()
     {
-        /* The lanes control reads its own six feeds + four baselines concurrently over the fixed
-           24-hour window (s_dataWindow); the viewer has no custom-range picker, so fromDate/toDate
-           are null. Replaces wave-4's CPU-trend + wait-category interim charts. */
-        await OverviewLanes.RefreshAsync((int)s_dataWindow.TotalHours, null, null);
+        /* The lanes control reads its own six feeds + four baselines concurrently over the toolbar's
+           window: hours-back for a preset, or the custom From/To when the user picked a custom range
+           (the lanes bound their own X-axis to it). Replaces wave-4's CPU-trend + wait-category charts. */
+        var (fromDate, toDate) = GetOverviewCustomRange();
+        await OverviewLanes.RefreshAsync(GetWindowHoursBack(), fromDate, toDate);
     }
 
     /* LoadHealthAsync now lives in ViewerServerTab.CollectionHealth.cs (W1i moved it there with the


### PR DESCRIPTION
## What

The Darling viewer's `ViewerServerTab` had **no header row** — its root was directly the inner `TabControl`, so every per-server inner tab was hardwired to a fixed 24-hour window (a static `s_dataWindow` constant) with a hardcoded ~60s refresh driven by `MainWindow`, and no user control.

This adds a dark-themed header `Border` as Row 0 above the inner tab strip, mirroring Lite's `ServerTab.xaml` toolbar.

## Controls added (header row)

- **Time-range dropdown** — Last 1h / 4h / 12h / 24h / 7d + **Custom Range** (default 24h, keeping current behavior).
- **Custom From/To** — date pickers + hour/minute combos (shown only for Custom Range), read in the viewer's machine-local display convention and inverted to the store's naive-UTC bounds.
- **Apply to All** — broadcasts the selected range (and custom From/To) to every *other* open server tab.
- **Compare** baseline combo (None / Yesterday / Last week / Same day last week) — **MOVED** up from its Queries-tab-only spot (`ViewerServerTab.xaml`) to the shared header. It always drove the whole tab's window, so it belongs in the toolbar.
- **Refresh** — reloads the active inner tab now.
- **Auto-refresh** toggle + interval (30s / 1m / 5m). Default = **1m == the old fixed 60s cadence**.

## Settable window replaces the fixed 24h

`s_dataWindow` (static 24h) is removed. A settable window lives in the new `ViewerServerTab.TimeRange.cs` (`GetWindowUtc()` / `GetWindowHoursBack()`), and **every** inner-tab data load now reads the current window.

### Tabs that honor the settable window
| Tab | Custom-range fidelity |
|---|---|
| Overview (correlated lanes) | Full — lanes accept `fromDate/toDate` and bound their own X-axis |
| Wait Stats | Full — `(start,end)` read |
| Queries — all 6 sub-tabs (Perf Trends, Active Queries, Top Queries, Top Procedures, Query Store, Query Heatmap) | Full — `(start,end)` reads + slicers |
| Memory | Full |
| File I/O | Full |
| Blocking — Trends / Current Waits / Blocked Process Reports / Deadlocks | Full — `(start,end)` reads + chart X-axis |
| Perfmon | Full |
| System Events — all 8 category sub-tabs | Full — `(start,end)` reads |
| CPU | Preset full; custom range end-bounded client-side (read is start-only server-side) |
| tempdb (usage/size/file-I/O) | Preset full; custom range end-bounded client-side |
| Collection Health (recent log) | Preset full; **custom range uses the rounded-up span as hours-back-from-now**, not the exact `[start,end]` — the underlying read takes an integer `hoursBack`, not bounds. See "Called out" below. |

Per-tab slicers still narrow **within** the window (they're loaded with the window bounds; dragging re-reads the sub-range).

### Tabs that are window-independent by design (unchanged, not a gap)
- **Running Jobs** — live snapshot of currently-running jobs (no time dimension).
- **Configuration** — reads the *latest* config snapshots (`GetLatest*Async`).
- **Daily Summary** — has its own UTC-day date picker.
- **Plan Viewer** — no data feed; plans are pushed by "View Plan", not tab-switch.

## Auto-refresh + Compare wiring

- Auto-refresh moves to a **per-tab `DispatcherTimer`** driven by the toolbar checkbox + interval; its tick refreshes the active inner tab only when the tab is visible (viewer's visible-only rule).
- `MainWindow`'s 60s timer now **skips server tabs** (they self-refresh) so the two don't double-refresh and the user's interval choice sticks; it still drives the aggregate tabs (Overview/Recommendations/Alerts/FinOps).
- Changing the range (or Apply-to-all) re-queries the affected tab through the existing overlap-guarded `RefreshActiveInnerTabAsync`.
- `OpenServerTabRegistry` gains a `Values` accessor for the Apply-to-all broadcast; `MainWindow` skips the source tab in the broadcast.

## Time-display mode (Server/Local/UTC) — FLAGGED AS FOLLOW-UP (not half-wired)

Per the task's escape hatch, this is **not** included, and no dead control was added. Reasons it's genuinely cross-cutting in the viewer:
- **"Server Time" is not derivable** — the viewer has no per-server UTC offset config the way Lite does (`ServerTimeHelper.UtcOffsetMinutes`); this is documented across the codebase (e.g. the CPU de-skew notes). Only Local and UTC are cleanly derivable.
- Timestamp rendering is spread across **~34 hardcoded `ViewerDataService.ToLocalTime` sites in 15 files**, mostly computed display properties on record types. Routing all of them through a mode switch is a separate, sizable change.

Everything else in the task (Compare relocation + settable window + custom range + auto-refresh) is complete.

## Called out (not silently left at 24h)

**Collection Health** is the one surface whose custom-range fidelity is partial: its `GetRecentCollectionLogAsync` read takes an integer `hoursBack`, not `[start,end]` bounds, so for a custom range it uses the rounded-up span as hours-back-**from-now** rather than the exact custom window. All preset ranges (1h/4h/12h/24h/7d) are fully honored. A follow-up could add bounded overloads to that read.

## Testing

- **Viewer build (Release): 0 errors** (9 pre-existing CA warnings in unrelated files).
- **Darling.Tests (Release): 830 passed, 83 skipped, 0 failed.** The 83 skips are all environment-gated live-Postgres / live-SQL end-to-end tests (`*AgainstDevPostgres`, collector runner).
- Added `ViewerServerTabTimeRangeTests` (8 cases) pinning the combo-index -> hours-back mapping (the pure core that replaced the fixed 24h). No existing test asserted the fixed 24h window.
- Live GUI not driven (WPF background-window driving is unreliable here); gating visual sign-off to Erik.

## Files
- New: `ViewerServerTab.TimeRange.cs` (window state, toolbar handlers, auto-refresh timer, calendar theming), `ViewerServerTabTimeRangeTests.cs`.
- `ViewerServerTab.xaml` — header row + Compare relocation.
- 15 `ViewerServerTab.*.cs` partials + `MainWindow.xaml(.cs)` + `OpenServerTabRegistry.cs` — window plumbing + timer/broadcast wiring + stale-comment fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)