### PR TITLE
Surface latch/spinlock/CPU-scheduler/plan-cache stats in the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerCpuSchedulerTests.cs
+++ b/Darling/Darling.Tests/ViewerCpuSchedulerTests.cs
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the CPU Scheduler sub-tab's two reads against the Darling store contract (no live Postgres): the
+/// pressure trend (runnable / blocked / queued task counts per collection, a point-in-time collector so
+/// no delta math) and the latest-snapshot read (the single most recent cpu_scheduler_stats row in the
+/// window). Both run on the <c>v_cpu_scheduler_stats</c> passthrough view.
+/// </summary>
+public sealed class ViewerCpuSchedulerSqlTests
+{
+    [Fact]
+    public void CpuSchedulerTrendSql_SelectsPressureCounts_OverTheWindow_OrderedByTime()
+    {
+        var sql = ViewerDataService.CpuSchedulerTrendSql;
+
+        Assert.Contains("FROM v_cpu_scheduler_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("total_runnable_tasks_count", sql, StringComparison.Ordinal);
+        Assert.Contains("total_blocked_task_count", sql, StringComparison.Ordinal);
+        Assert.Contains("total_queued_request_count", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+
+        /* A point-in-time snapshot collector: the counts plot directly — no averaging, no delta. */
+        Assert.DoesNotContain("AVG(", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("LAG(", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CpuSchedulerSnapshotSql_LatestRowInWindow_AllPressureColumns()
+    {
+        var sql = ViewerDataService.CpuSchedulerSnapshotSql;
+
+        Assert.Contains("FROM v_cpu_scheduler_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+
+        /* The warning flags + NUMA / OS-memory columns the metric grid renders. */
+        foreach (var column in new[]
+        {
+            "worker_thread_exhaustion_warning", "runnable_tasks_warning", "blocked_tasks_warning",
+            "queued_requests_warning", "physical_memory_pressure_warning", "offline_cpu_warning",
+            "runnable_percent", "system_memory_state_desc", "total_node_count",
+        })
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("trend")]
+    [InlineData("snapshot")]
+    public void CpuSchedulerSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals(string which)
+    {
+        var sql = which == "trend" ? ViewerDataService.CpuSchedulerTrendSql : ViewerDataService.CpuSchedulerSnapshotSql;
+
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CpuSchedulerSql_ReadsColumnsThatExistInTheGeneratedTable()
+    {
+        Assert.Equal("cpu_scheduler_stats", CpuSchedulerStatsCollector.Instance.TargetTable);
+
+        var ddl = PgSchemaGenerator.CreateTable(CpuSchedulerStatsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "collection_time", "total_runnable_tasks_count", "total_blocked_task_count",
+            "total_queued_request_count", "max_workers_count", "total_current_workers_count",
+            "runnable_percent", "worker_thread_exhaustion_warning", "system_memory_state_desc",
+            "total_physical_memory_kb", "nodes_online_count",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void CpuSchedulerView_IsPinnedInTheAuthoritativeViewList()
+        => Assert.Contains("v_cpu_scheduler_stats", PgSchemaGenerator.AllPassthroughViews);
+}
+
+/// <summary>
+/// Pins the CPU Scheduler latest-snapshot metric-grid projection (<see
+/// cref="ViewerServerTab.BuildCpuSchedulerMetrics"/>): the collector's pressure flags land on the right
+/// labelled rows (driving the grid highlight), worker-utilization is current/max*100, nullable request
+/// columns degrade to "N/A", and a null snapshot yields an empty grid.
+/// </summary>
+public sealed class ViewerCpuSchedulerProjectionTests
+{
+    private static CpuSchedulerSnapshot Snapshot(
+        bool workerExhaustion = false, bool runnableWarn = false, bool blockedWarn = false,
+        bool queuedWarn = false, bool memPressure = false, bool offlineWarn = false,
+        int maxWorkers = 512, int currentWorkers = 128,
+        int? runnableRequests = 3, decimal? runnablePercent = 12.5m)
+        => new(
+            CollectionTime: new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Unspecified),
+            MaxWorkersCount: maxWorkers,
+            SchedulerCount: 8,
+            CpuCount: 8,
+            TotalRunnableTasksCount: 4,
+            TotalWorkQueueCount: 0,
+            TotalCurrentWorkersCount: currentWorkers,
+            AvgRunnableTasksCount: 0.5m,
+            TotalActiveRequestCount: 2,
+            TotalQueuedRequestCount: 0,
+            TotalBlockedTaskCount: 0,
+            TotalActiveParallelThreadCount: 0,
+            RunnableRequestCount: runnableRequests,
+            TotalRequestCount: runnableRequests.HasValue ? 20 : (int?)null,
+            RunnablePercent: runnablePercent,
+            WorkerThreadExhaustionWarning: workerExhaustion,
+            RunnableTasksWarning: runnableWarn,
+            BlockedTasksWarning: blockedWarn,
+            QueuedRequestsWarning: queuedWarn,
+            TotalPhysicalMemoryKb: 67_108_864, // 64 GB
+            AvailablePhysicalMemoryKb: 8_388_608, // 8 GB
+            SystemMemoryStateDesc: "Available physical memory is high",
+            PhysicalMemoryPressureWarning: memPressure,
+            TotalNodeCount: 2,
+            NodesOnlineCount: 2,
+            OfflineCpuCount: 0,
+            OfflineCpuWarning: offlineWarn);
+
+    [Fact]
+    public void BuildMetrics_NullSnapshot_YieldsEmptyGrid()
+        => Assert.Empty(ViewerServerTab.BuildCpuSchedulerMetrics(null));
+
+    [Fact]
+    public void BuildMetrics_WarningFlags_HighlightTheirOwnRows()
+    {
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(
+            Snapshot(runnableWarn: true, blockedWarn: true, memPressure: true));
+
+        Assert.True(rows.Single(r => r.Metric == "Runnable Tasks").IsWarning);
+        Assert.True(rows.Single(r => r.Metric == "Blocked Tasks").IsWarning);
+        Assert.True(rows.Single(r => r.Metric == "Physical Memory Pressure").IsWarning);
+        Assert.True(rows.Single(r => r.Metric == "System Memory State").IsWarning);
+
+        /* A metric whose flag is off must NOT highlight. */
+        Assert.False(rows.Single(r => r.Metric == "Queued Requests").IsWarning);
+        Assert.False(rows.Single(r => r.Metric == "Offline CPUs").IsWarning);
+    }
+
+    [Fact]
+    public void BuildMetrics_WorkerUtilization_IsCurrentOverMaxTimes100()
+    {
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(Snapshot(maxWorkers: 400, currentWorkers: 100));
+
+        /* 100 / 400 * 100 = 25.0 %. */
+        Assert.Equal("25.0", rows.Single(r => r.Metric == "Worker Utilization %").Value);
+    }
+
+    [Fact]
+    public void BuildMetrics_WorkerUtilization_ZeroMaxWorkers_DoesNotDivideByZero()
+    {
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(Snapshot(maxWorkers: 0, currentWorkers: 0));
+
+        Assert.Equal("0.0", rows.Single(r => r.Metric == "Worker Utilization %").Value);
+    }
+
+    [Fact]
+    public void BuildMetrics_NullableRequestColumns_DegradeToNa()
+    {
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(Snapshot(runnableRequests: null, runnablePercent: null));
+
+        Assert.Equal("N/A", rows.Single(r => r.Metric == "Runnable Requests").Value);
+        Assert.Equal("N/A", rows.Single(r => r.Metric == "Total Requests").Value);
+        Assert.Equal("N/A", rows.Single(r => r.Metric == "Runnable %").Value);
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the CPU Scheduler reads: the pressure trend order and the
+/// latest-snapshot selection (newest row in the window, all pressure columns round-tripped). Shares the
+/// serialized "live-postgres" collection; uses a negative sentinel server_id and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerCpuSchedulerLivePostgresTests
+{
+    private const int ServerId = -940003;
+    private const string ServerName = "viewer-cpusched-e2e";
+
+    [Fact]
+    public async Task Trend_OrdersByCollectionTime_AndSnapshot_TakesNewestRow_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live cpu-scheduler test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteAsync(connection, ServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t1 = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var t2 = t1.AddMinutes(5);
+
+            await InsertAsync(connection, 1, t1, runnable: 2, blocked: 0, queued: 0, workerWarn: false);
+            await InsertAsync(connection, 2, t2, runnable: 9, blocked: 4, queued: 1, workerWarn: true);
+
+            var trend = await viewer.GetCpuSchedulerTrendAsync(ServerId, t1.AddMinutes(-1), t2.AddMinutes(1));
+            Assert.Equal(2, trend.Count);
+            Assert.Equal(new[] { t1.Ticks, t2.Ticks }, trend.Select(p => p.CollectionTime.Ticks));
+            Assert.Equal(new[] { 2, 9 }, trend.Select(p => p.RunnableTasks));
+            Assert.Equal(new[] { 0, 4 }, trend.Select(p => p.BlockedTasks));
+
+            /* Snapshot = the newest row (t2), warning flag round-trips. */
+            var snapshot = await viewer.GetCpuSchedulerSnapshotAsync(ServerId, t1.AddMinutes(-1), t2.AddMinutes(1));
+            Assert.NotNull(snapshot);
+            Assert.Equal(t2.Ticks, snapshot!.CollectionTime.Ticks);
+            Assert.Equal(9, snapshot.TotalRunnableTasksCount);
+            Assert.True(snapshot.WorkerThreadExhaustionWarning);
+        }
+        finally
+        {
+            await DeleteAsync(connection, ServerId);
+        }
+    }
+
+    private static async Task InsertAsync(
+        NpgsqlConnection connection, long collectionId, DateTime collectionTimeUtc,
+        int runnable, int blocked, int queued, bool workerWarn)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO cpu_scheduler_stats
+    (collection_id, collection_time, server_id, server_name,
+     max_workers_count, scheduler_count, cpu_count,
+     total_runnable_tasks_count, total_work_queue_count, total_current_workers_count,
+     avg_runnable_tasks_count, total_active_request_count, total_queued_request_count,
+     total_blocked_task_count, total_active_parallel_thread_count,
+     runnable_request_count, total_request_count, runnable_percent,
+     worker_thread_exhaustion_warning, runnable_tasks_warning, blocked_tasks_warning,
+     queued_requests_warning, total_physical_memory_kb, available_physical_memory_kb,
+     system_memory_state_desc, physical_memory_pressure_warning,
+     total_node_count, nodes_online_count, offline_cpu_count, offline_cpu_warning)
+VALUES ($1, $2, $3, $4, 512, 8, 8, $5, 0, 128, 0.5, 2, $6, $7, 0, 3, 20, 12.5,
+        $8, false, false, false, 67108864, 8388608, 'ok', false, 2, 2, 0, false)", connection);
+        command.Parameters.AddWithValue(collectionId);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(runnable);
+        command.Parameters.AddWithValue(queued);
+        command.Parameters.AddWithValue(blocked);
+        command.Parameters.AddWithValue(workerWarn);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteAsync(NpgsqlConnection connection, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM cpu_scheduler_stats WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/Darling.Tests/ViewerLatchSpinlockTests.cs
+++ b/Darling/Darling.Tests/ViewerLatchSpinlockTests.cs
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Latches &amp; Spinlocks tab's four reads against the Darling store contract (no live
+/// Postgres): the two per-second trend reads (top-5 by delta, normalized to ms/sec and collisions/sec via
+/// the per-contender LAG interval — Darling's cumulative-delta tables carry no stored
+/// sample_interval_seconds, so the seconds come from the same truncate-then-diff epoch idiom the wait
+/// trend uses) and the two latest-snapshot grid reads (most recent collection in the window, ordered by
+/// recent delta). All four run on the <c>v_latch_stats</c> / <c>v_spinlock_stats</c> passthrough views.
+/// </summary>
+public sealed class ViewerLatchSpinlockSqlTests
+{
+    [Fact]
+    public void LatchTrendSql_TopFiveByDeltaWait_PerClassLagPerSecond_OverTheWindow()
+    {
+        var sql = ViewerDataService.LatchTrendSql;
+
+        Assert.Contains("FROM v_latch_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", sql, StringComparison.Ordinal);
+
+        /* Top-5 latch classes by total delta wait time (mirrors the Dashboard's GetLatchStatsTopNAsync). */
+        Assert.Contains("WITH top_latches AS", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY SUM(delta_wait_time_ms) DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 5", sql, StringComparison.Ordinal);
+        Assert.Contains("latch_class IN (SELECT latch_class FROM top_latches)", sql, StringComparison.Ordinal);
+
+        /* Per-class LAG interval → ms/sec, the wait-stats truncate-then-diff epoch idiom. */
+        Assert.Contains("LAG(collection_time) OVER (PARTITION BY latch_class ORDER BY collection_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("extract(epoch FROM (date_trunc('second', collection_time) - date_trunc('second', LAG(collection_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(delta_wait_time_ms AS DOUBLE PRECISION) / interval_seconds", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY latch_class, collection_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LatchSnapshotSql_LatestCollectionInWindow_OrderedByRecentDelta_CapAt20()
+    {
+        var sql = ViewerDataService.LatchSnapshotSql;
+
+        Assert.Contains("FROM v_latch_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SELECT MAX(collection_time) AS mx", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time = (SELECT mx FROM latest)", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY delta_wait_time_ms DESC, wait_time_ms DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 20", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SpinlockTrendSql_TopFiveByDeltaCollisions_PerNameLagPerSecond_OverTheWindow()
+    {
+        var sql = ViewerDataService.SpinlockTrendSql;
+
+        Assert.Contains("FROM v_spinlock_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("WITH top_spinlocks AS", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY SUM(delta_collisions) DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 5", sql, StringComparison.Ordinal);
+        Assert.Contains("spinlock_name IN (SELECT spinlock_name FROM top_spinlocks)", sql, StringComparison.Ordinal);
+        Assert.Contains("LAG(collection_time) OVER (PARTITION BY spinlock_name ORDER BY collection_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(delta_collisions AS DOUBLE PRECISION) / interval_seconds", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY spinlock_name, collection_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SpinlockSnapshotSql_LatestCollectionInWindow_OrderedByRecentDelta_CapAt20()
+    {
+        var sql = ViewerDataService.SpinlockSnapshotSql;
+
+        Assert.Contains("FROM v_spinlock_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SELECT MAX(collection_time) AS mx", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time = (SELECT mx FROM latest)", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY delta_collisions DESC, collisions DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 20", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("latch-trend")]
+    [InlineData("latch-snapshot")]
+    [InlineData("spinlock-trend")]
+    [InlineData("spinlock-snapshot")]
+    public void LatchSpinlockSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals(string which)
+    {
+        var sql = which switch
+        {
+            "latch-trend" => ViewerDataService.LatchTrendSql,
+            "latch-snapshot" => ViewerDataService.LatchSnapshotSql,
+            "spinlock-trend" => ViewerDataService.SpinlockTrendSql,
+            _ => ViewerDataService.SpinlockSnapshotSql,
+        };
+
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LatchSql_ReadsColumnsThatExistInTheGeneratedLatchTable()
+    {
+        Assert.Equal("latch_stats", LatchStatsCollector.Instance.TargetTable);
+
+        var ddl = PgSchemaGenerator.CreateTable(LatchStatsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "collection_time", "latch_class", "waiting_requests_count", "wait_time_ms",
+            "max_wait_time_ms", "delta_waiting_requests_count", "delta_wait_time_ms",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void SpinlockSql_ReadsColumnsThatExistInTheGeneratedSpinlockTable()
+    {
+        Assert.Equal("spinlock_stats", SpinlockStatsCollector.Instance.TargetTable);
+
+        var ddl = PgSchemaGenerator.CreateTable(SpinlockStatsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "collection_time", "spinlock_name", "collisions", "spins", "spins_per_collision",
+            "sleep_time", "backoffs", "delta_collisions", "delta_spins",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void LatchAndSpinlockViews_ArePinnedInTheAuthoritativeViewList()
+    {
+        /* The tab reads the v_ passthrough views; both must be in the store's authoritative view set
+           (so V14 refreshes them and the migration test cross-checks them). */
+        Assert.Contains("v_latch_stats", PgSchemaGenerator.AllPassthroughViews);
+        Assert.Contains("v_spinlock_stats", PgSchemaGenerator.AllPassthroughViews);
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the Latches &amp; Spinlocks reads: the latch trend's
+/// top-5 selection + per-class ms/sec math, and the spinlock snapshot's latest-collection + recent-delta
+/// ordering. Shares the serialized "live-postgres" collection; uses negative sentinel server_ids and
+/// cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerLatchSpinlockLivePostgresTests
+{
+    private const int LatchServerId = -940001;
+    private const string LatchServerName = "viewer-latch-e2e";
+    private const int SpinlockServerId = -940002;
+    private const string SpinlockServerName = "viewer-spinlock-e2e";
+
+    [Fact]
+    public async Task LatchTrend_TopFiveByDelta_PerSecond_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live latch-trend test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteAsync(connection, "latch_stats", LatchServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t1 = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var t2 = t1.AddMinutes(5);   // 300 seconds later
+
+            /* BUFFER across two collections: 300 ms delta over 300 s = 1.0 ms/sec at t2; 0 at t1 (no LAG). */
+            await InsertLatchAsync(connection, 1, t1, "BUFFER", deltaWait: 100, deltaReqs: 5);
+            await InsertLatchAsync(connection, 2, t2, "BUFFER", deltaWait: 300, deltaReqs: 3);
+
+            var trend = await viewer.GetLatchStatsTrendAsync(LatchServerId, t1.AddMinutes(-1), t2.AddMinutes(1));
+
+            var buffer = trend.Where(p => p.LatchClass == "BUFFER").OrderBy(p => p.CollectionTime).ToList();
+            Assert.Equal(2, buffer.Count);
+            Assert.Equal(0.0, buffer[0].WaitTimeMsPerSecond, precision: 3);
+            Assert.Equal(1.0, buffer[1].WaitTimeMsPerSecond, precision: 3);
+        }
+        finally
+        {
+            await DeleteAsync(connection, "latch_stats", LatchServerId);
+        }
+    }
+
+    [Fact]
+    public async Task SpinlockSnapshot_LatestCollection_OrderedByRecentDelta_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live spinlock-snapshot test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteAsync(connection, "spinlock_stats", SpinlockServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t1 = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var t2 = t1.AddMinutes(5);
+
+            /* Older collection (t1) must be ignored; the snapshot is the latest (t2). At t2, LOCK_HASH
+               has the larger delta so it sorts above SOS_CACHESTORE. */
+            await InsertSpinlockAsync(connection, 1, t1, "LOCK_HASH", collisions: 10, deltaCollisions: 10);
+            await InsertSpinlockAsync(connection, 2, t2, "SOS_CACHESTORE", collisions: 500, deltaCollisions: 50);
+            await InsertSpinlockAsync(connection, 2, t2, "LOCK_HASH", collisions: 900, deltaCollisions: 400);
+
+            var snapshot = await viewer.GetSpinlockStatsSnapshotAsync(SpinlockServerId, t1.AddMinutes(-1), t2.AddMinutes(1));
+
+            Assert.Equal(2, snapshot.Count);
+            Assert.Equal("LOCK_HASH", snapshot[0].SpinlockName);   // larger delta first
+            Assert.Equal(400, snapshot[0].DeltaCollisions);
+            Assert.Equal("SOS_CACHESTORE", snapshot[1].SpinlockName);
+        }
+        finally
+        {
+            await DeleteAsync(connection, "spinlock_stats", SpinlockServerId);
+        }
+    }
+
+    private static async Task InsertLatchAsync(
+        NpgsqlConnection connection, long collectionId, DateTime collectionTimeUtc,
+        string latchClass, long deltaWait, long deltaReqs)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO latch_stats
+    (collection_id, collection_time, server_id, server_name, latch_class,
+     waiting_requests_count, wait_time_ms, max_wait_time_ms,
+     delta_waiting_requests_count, delta_wait_time_ms, delta_max_wait_time_ms)
+VALUES ($1, $2, $3, $4, $5, 0, 0, 0, $6, $7, 0)", connection);
+        command.Parameters.AddWithValue(collectionId);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(LatchServerId);
+        command.Parameters.AddWithValue(LatchServerName);
+        command.Parameters.AddWithValue(latchClass);
+        command.Parameters.AddWithValue(deltaReqs);
+        command.Parameters.AddWithValue(deltaWait);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertSpinlockAsync(
+        NpgsqlConnection connection, long collectionId, DateTime collectionTimeUtc,
+        string spinlockName, long collisions, long deltaCollisions)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO spinlock_stats
+    (collection_id, collection_time, server_id, server_name, spinlock_name,
+     collisions, spins, spins_per_collision, sleep_time, backoffs,
+     delta_collisions, delta_spins, delta_sleep_time, delta_backoffs)
+VALUES ($1, $2, $3, $4, $5, $6, 0, 0, 0, 0, $7, 0, 0, 0)", connection);
+        command.Parameters.AddWithValue(collectionId);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(SpinlockServerId);
+        command.Parameters.AddWithValue(SpinlockServerName);
+        command.Parameters.AddWithValue(spinlockName);
+        command.Parameters.AddWithValue(collisions);
+        command.Parameters.AddWithValue(deltaCollisions);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteAsync(NpgsqlConnection connection, string table, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/Darling.Tests/ViewerPlanCacheTests.cs
+++ b/Darling/Darling.Tests/ViewerPlanCacheTests.cs
@@ -63,12 +63,33 @@ public sealed class ViewerPlanCacheSqlTests
         }
     }
 
+    [Fact]
+    public void PlanCacheSummarySql_SumsAllGroups_LatestCollection_Uncapped()
+    {
+        var sql = ViewerDataService.PlanCacheSummarySql;
+
+        Assert.Contains("FROM v_plan_cache_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SELECT MAX(collection_time) AS mx", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time = (SELECT mx FROM latest)", sql, StringComparison.Ordinal);
+        /* TRUE total across every group + oldest plan; COALESCE so an empty window yields 0 not NULL. */
+        Assert.Contains("COALESCE(SUM(total_plans), 0)", sql, StringComparison.Ordinal);
+        Assert.Contains("MIN(oldest_plan_create_time)", sql, StringComparison.Ordinal);
+        /* Must NOT be capped — the summary is the exact total, independent of the grid's LIMIT 30. */
+        Assert.DoesNotContain("LIMIT", sql, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("trend")]
     [InlineData("snapshot")]
+    [InlineData("summary")]
     public void PlanCacheSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals(string which)
     {
-        var sql = which == "trend" ? ViewerDataService.PlanCacheTrendSql : ViewerDataService.PlanCacheSnapshotSql;
+        var sql = which switch
+        {
+            "trend" => ViewerDataService.PlanCacheTrendSql,
+            "snapshot" => ViewerDataService.PlanCacheSnapshotSql,
+            _ => ViewerDataService.PlanCacheSummarySql,
+        };
 
         Assert.DoesNotContain("now(", sql.ToLowerInvariant());
         Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
@@ -148,6 +169,11 @@ public sealed class ViewerPlanCacheLivePostgresTests
             Assert.Equal("Adhoc", snapshot[0].Objtype);
             Assert.Equal(210, snapshot[0].TotalSizeMb);
             Assert.Equal(oldest.Ticks, snapshot[0].OldestPlanCreateTime!.Value.Ticks);
+
+            /* Summary sums total_plans across BOTH groups (5 + 30 = 35, uncapped) and takes MIN(oldest). */
+            var summary = await viewer.GetPlanCacheSummaryAsync(ServerId, t1.AddMinutes(-1), t1.AddMinutes(1));
+            Assert.Equal(35L, summary.TotalPlans);
+            Assert.Equal(oldest.Ticks, summary.OldestPlanCreateTime!.Value.Ticks);
         }
         finally
         {

--- a/Darling/Darling.Tests/ViewerPlanCacheTests.cs
+++ b/Darling/Darling.Tests/ViewerPlanCacheTests.cs
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Plan Cache sub-tab's two reads against the Darling store contract (no live Postgres): the
+/// size trend (single-use vs multi-use MB, summed across every cacheobjtype/objtype group per collection,
+/// the Dashboard's single-use bloat shape) and the latest-snapshot composition read (the most recent
+/// collection in the window, per group, top by size). Both run on the <c>v_plan_cache_stats</c>
+/// passthrough view.
+/// </summary>
+public sealed class ViewerPlanCacheSqlTests
+{
+    [Fact]
+    public void PlanCacheTrendSql_SumsSingleVsMultiUseMb_PerCollection_OverTheWindow()
+    {
+        var sql = ViewerDataService.PlanCacheTrendSql;
+
+        Assert.Contains("FROM v_plan_cache_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(SUM(single_use_size_mb) AS double precision)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(SUM(multi_use_size_mb) AS double precision)", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY collection_time", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlanCacheSnapshotSql_LatestCollection_Composition_OrderedBySize_CapAt30()
+    {
+        var sql = ViewerDataService.PlanCacheSnapshotSql;
+
+        Assert.Contains("FROM v_plan_cache_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SELECT MAX(collection_time) AS mx", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time = (SELECT mx FROM latest)", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY total_size_mb DESC, total_plans DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 30", sql, StringComparison.Ordinal);
+
+        /* The composition + stability columns the grid + summary render. */
+        foreach (var column in new[]
+        {
+            "cacheobjtype", "objtype", "total_plans", "single_use_plans", "single_use_size_mb",
+            "multi_use_plans", "multi_use_size_mb", "avg_use_count", "avg_size_kb", "oldest_plan_create_time",
+        })
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("trend")]
+    [InlineData("snapshot")]
+    public void PlanCacheSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals(string which)
+    {
+        var sql = which == "trend" ? ViewerDataService.PlanCacheTrendSql : ViewerDataService.PlanCacheSnapshotSql;
+
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlanCacheSql_ReadsColumnsThatExistInTheGeneratedTable()
+    {
+        Assert.Equal("plan_cache_stats", PlanCacheStatsCollector.Instance.TargetTable);
+
+        var ddl = PgSchemaGenerator.CreateTable(PlanCacheStatsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "collection_time", "cacheobjtype", "objtype", "total_plans", "total_size_mb",
+            "single_use_plans", "single_use_size_mb", "multi_use_plans", "multi_use_size_mb",
+            "avg_use_count", "avg_size_kb", "oldest_plan_create_time",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void PlanCacheView_IsPinnedInTheAuthoritativeViewList()
+        => Assert.Contains("v_plan_cache_stats", PgSchemaGenerator.AllPassthroughViews);
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the Plan Cache reads: the trend SUMs single/multi-use MB
+/// across the per-collection groups, and the snapshot takes the latest collection's composition ordered by
+/// size (with oldest_plan_create_time round-tripped for the summary). Shares the serialized "live-postgres"
+/// collection; uses a negative sentinel server_id and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerPlanCacheLivePostgresTests
+{
+    private const int ServerId = -940004;
+    private const string ServerName = "viewer-plancache-e2e";
+
+    [Fact]
+    public async Task Trend_SumsAcrossGroups_AndSnapshot_TakesLatestCompositionBySize_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live plan-cache test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteAsync(connection, ServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t1 = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var oldest = t1.AddDays(-2);
+
+            /* Two groups at the same collection: single-use MB 40 + 10 = 50; multi-use 100 + 200 = 300. */
+            await InsertAsync(connection, t1, "Compiled Plan", "Proc",
+                totalPlans: 5, totalSizeMb: 140, singlePlans: 1, singleMb: 40, multiPlans: 4, multiMb: 100, oldest: oldest);
+            await InsertAsync(connection, t1, "Compiled Plan", "Adhoc",
+                totalPlans: 30, totalSizeMb: 210, singlePlans: 25, singleMb: 10, multiPlans: 5, multiMb: 200, oldest: oldest);
+
+            var trend = await viewer.GetPlanCacheTrendAsync(ServerId, t1.AddMinutes(-1), t1.AddMinutes(1));
+            Assert.Single(trend);
+            Assert.Equal(50.0, trend[0].SingleUseSizeMb, precision: 3);
+            Assert.Equal(300.0, trend[0].MultiUseSizeMb, precision: 3);
+
+            var snapshot = await viewer.GetPlanCacheSnapshotAsync(ServerId, t1.AddMinutes(-1), t1.AddMinutes(1));
+            Assert.Equal(2, snapshot.Count);
+            /* Ordered by total_size_mb DESC → the Adhoc group (210) first. */
+            Assert.Equal("Adhoc", snapshot[0].Objtype);
+            Assert.Equal(210, snapshot[0].TotalSizeMb);
+            Assert.Equal(oldest.Ticks, snapshot[0].OldestPlanCreateTime!.Value.Ticks);
+        }
+        finally
+        {
+            await DeleteAsync(connection, ServerId);
+        }
+    }
+
+    private static async Task InsertAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string cacheobjtype, string objtype,
+        int totalPlans, int totalSizeMb, int singlePlans, int singleMb, int multiPlans, int multiMb, DateTime oldest)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO plan_cache_stats
+    (collection_id, collection_time, server_id, server_name, cacheobjtype, objtype,
+     total_plans, total_size_mb, single_use_plans, single_use_size_mb,
+     multi_use_plans, multi_use_size_mb, avg_use_count, avg_size_kb, oldest_plan_create_time)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 1.5, 64, $13)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(cacheobjtype);
+        command.Parameters.AddWithValue(objtype);
+        command.Parameters.AddWithValue(totalPlans);
+        command.Parameters.AddWithValue(totalSizeMb);
+        command.Parameters.AddWithValue(singlePlans);
+        command.Parameters.AddWithValue(singleMb);
+        command.Parameters.AddWithValue(multiPlans);
+        command.Parameters.AddWithValue(multiMb);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(oldest, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteAsync(NpgsqlConnection connection, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM plan_cache_stats WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CpuScheduler.cs
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>One point on the CPU-scheduler pressure trend: the runnable / blocked / queued task
+/// counts at a collection instant. A point-in-time snapshot collector (one row per collection), so
+/// these plot directly with no delta math.</summary>
+public sealed record CpuSchedulerTrendPoint(
+    DateTime CollectionTime,
+    int RunnableTasks,
+    int BlockedTasks,
+    int QueuedRequests);
+
+/// <summary>
+/// The most recent CPU-scheduler snapshot in the window — every column the cpu_scheduler_stats
+/// collector captures (scheduler / worker / NUMA / OS-memory pressure), feeding the CPU Scheduler
+/// sub-tab's latest-snapshot metric grid and its warning highlights.
+/// </summary>
+public sealed record CpuSchedulerSnapshot(
+    DateTime CollectionTime,
+    int MaxWorkersCount,
+    int SchedulerCount,
+    int CpuCount,
+    int TotalRunnableTasksCount,
+    long TotalWorkQueueCount,
+    int TotalCurrentWorkersCount,
+    decimal AvgRunnableTasksCount,
+    int TotalActiveRequestCount,
+    int TotalQueuedRequestCount,
+    int TotalBlockedTaskCount,
+    long TotalActiveParallelThreadCount,
+    int? RunnableRequestCount,
+    int? TotalRequestCount,
+    decimal? RunnablePercent,
+    bool WorkerThreadExhaustionWarning,
+    bool RunnableTasksWarning,
+    bool BlockedTasksWarning,
+    bool QueuedRequestsWarning,
+    long TotalPhysicalMemoryKb,
+    long AvailablePhysicalMemoryKb,
+    string? SystemMemoryStateDesc,
+    bool PhysicalMemoryPressureWarning,
+    int TotalNodeCount,
+    int NodesOnlineCount,
+    int OfflineCpuCount,
+    bool OfflineCpuWarning);
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The CPU Scheduler pressure trend read: the runnable / blocked / queued task counts per collection
+    /// over the window, from the <c>v_cpu_scheduler_stats</c> passthrough view. A point-in-time collector
+    /// (single row per collection), so the three counts plot directly — no delta normalization.
+    /// $1 server_id, $2 window start, $3 window end (all naive UTC).
+    /// </summary>
+    public const string CpuSchedulerTrendSql = """
+        SELECT
+            collection_time,
+            total_runnable_tasks_count,
+            total_blocked_task_count,
+            total_queued_request_count
+        FROM v_cpu_scheduler_stats
+        WHERE server_id = $1
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        ORDER BY collection_time
+        """;
+
+    /// <summary>
+    /// The CPU Scheduler latest-snapshot read: the single most recent cpu_scheduler_stats row in the
+    /// window (all pressure columns), for the metric grid. $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string CpuSchedulerSnapshotSql = """
+        SELECT
+            collection_time,
+            max_workers_count,
+            scheduler_count,
+            cpu_count,
+            total_runnable_tasks_count,
+            total_work_queue_count,
+            total_current_workers_count,
+            avg_runnable_tasks_count,
+            total_active_request_count,
+            total_queued_request_count,
+            total_blocked_task_count,
+            total_active_parallel_thread_count,
+            runnable_request_count,
+            total_request_count,
+            runnable_percent,
+            worker_thread_exhaustion_warning,
+            runnable_tasks_warning,
+            blocked_tasks_warning,
+            queued_requests_warning,
+            total_physical_memory_kb,
+            available_physical_memory_kb,
+            system_memory_state_desc,
+            physical_memory_pressure_warning,
+            total_node_count,
+            nodes_online_count,
+            offline_cpu_count,
+            offline_cpu_warning
+        FROM v_cpu_scheduler_stats
+        WHERE server_id = $1
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        ORDER BY collection_time DESC
+        LIMIT 1
+        """;
+
+    /// <summary>The scheduler pressure trend (runnable/blocked/queued counts) over the window.</summary>
+    public async Task<List<CpuSchedulerTrendPoint>> GetCpuSchedulerTrendAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<CpuSchedulerTrendPoint>();
+
+        await using var command = _dataSource.CreateCommand(CpuSchedulerTrendSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new CpuSchedulerTrendPoint(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt32(3)));
+        }
+
+        return result;
+    }
+
+    /// <summary>The most recent CPU-scheduler snapshot in the window, or null when none was collected.</summary>
+    public async Task<CpuSchedulerSnapshot?> GetCpuSchedulerSnapshotAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(CpuSchedulerSnapshotSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new CpuSchedulerSnapshot(
+            CollectionTime: reader.GetDateTime(0),
+            MaxWorkersCount: reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+            SchedulerCount: reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+            CpuCount: reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+            TotalRunnableTasksCount: reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+            TotalWorkQueueCount: reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
+            TotalCurrentWorkersCount: reader.IsDBNull(6) ? 0 : reader.GetInt32(6),
+            AvgRunnableTasksCount: reader.IsDBNull(7) ? 0m : reader.GetDecimal(7),
+            TotalActiveRequestCount: reader.IsDBNull(8) ? 0 : reader.GetInt32(8),
+            TotalQueuedRequestCount: reader.IsDBNull(9) ? 0 : reader.GetInt32(9),
+            TotalBlockedTaskCount: reader.IsDBNull(10) ? 0 : reader.GetInt32(10),
+            TotalActiveParallelThreadCount: reader.IsDBNull(11) ? 0 : reader.GetInt64(11),
+            RunnableRequestCount: reader.IsDBNull(12) ? null : reader.GetInt32(12),
+            TotalRequestCount: reader.IsDBNull(13) ? null : reader.GetInt32(13),
+            RunnablePercent: reader.IsDBNull(14) ? null : reader.GetDecimal(14),
+            WorkerThreadExhaustionWarning: !reader.IsDBNull(15) && reader.GetBoolean(15),
+            RunnableTasksWarning: !reader.IsDBNull(16) && reader.GetBoolean(16),
+            BlockedTasksWarning: !reader.IsDBNull(17) && reader.GetBoolean(17),
+            QueuedRequestsWarning: !reader.IsDBNull(18) && reader.GetBoolean(18),
+            TotalPhysicalMemoryKb: reader.IsDBNull(19) ? 0 : reader.GetInt64(19),
+            AvailablePhysicalMemoryKb: reader.IsDBNull(20) ? 0 : reader.GetInt64(20),
+            SystemMemoryStateDesc: reader.IsDBNull(21) ? null : reader.GetString(21),
+            PhysicalMemoryPressureWarning: !reader.IsDBNull(22) && reader.GetBoolean(22),
+            TotalNodeCount: reader.IsDBNull(23) ? 0 : reader.GetInt32(23),
+            NodesOnlineCount: reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
+            OfflineCpuCount: reader.IsDBNull(25) ? 0 : reader.GetInt32(25),
+            OfflineCpuWarning: !reader.IsDBNull(26) && reader.GetBoolean(26));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LatchSpinlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LatchSpinlock.cs
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>One point on a latch class's per-second wait trend (this interval's
+/// <c>delta_wait_time_ms</c> divided by the seconds since the previous collection of the SAME
+/// class, via a per-class <c>LAG</c> window — the wait-stats idiom, minus the avg-per-wait metric).</summary>
+public sealed record LatchStatsTrendPoint(string LatchClass, DateTime CollectionTime, double WaitTimeMsPerSecond);
+
+/// <summary>One row of the Latch Stats latest-snapshot grid: the cumulative counters plus the last
+/// interval's deltas for one latch class at the most recent collection in the window.</summary>
+public sealed record LatchStatsSnapshotRow(
+    string LatchClass,
+    long WaitingRequestsCount,
+    long WaitTimeMs,
+    long MaxWaitTimeMs,
+    long DeltaWaitingRequestsCount,
+    long DeltaWaitTimeMs);
+
+/// <summary>One point on a spinlock's per-second collision trend (this interval's
+/// <c>delta_collisions</c> divided by the seconds since the previous collection of the SAME
+/// spinlock, via a per-name <c>LAG</c> window).</summary>
+public sealed record SpinlockStatsTrendPoint(string SpinlockName, DateTime CollectionTime, double CollisionsPerSecond);
+
+/// <summary>One row of the Spinlock Stats latest-snapshot grid: the cumulative counters plus the
+/// last interval's deltas for one spinlock at the most recent collection in the window.</summary>
+public sealed record SpinlockStatsSnapshotRow(
+    string SpinlockName,
+    long Collisions,
+    long Spins,
+    double SpinsPerCollision,
+    long SleepTime,
+    long Backoffs,
+    long DeltaCollisions,
+    long DeltaSpins);
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The Latch Stats trend read: the per-second wait rate for the TOP 5 latch classes (by total delta
+    /// wait time over the window), mirroring the Dashboard's <c>GetLatchStatsTopNAsync</c> top-5 grouping
+    /// but normalizing to ms/sec in SQL via the per-class <c>LAG</c> interval (Darling's cumulative-delta
+    /// tables have no stored <c>sample_interval_seconds</c>, so the seconds come from the same
+    /// truncate-then-diff epoch idiom the wait-stats trend uses). Runs on the <c>v_latch_stats</c>
+    /// passthrough view. $1 server_id, $2 window start, $3 window end (all naive UTC).
+    /// </summary>
+    public const string LatchTrendSql = """
+        WITH top_latches AS
+        (
+            SELECT latch_class
+            FROM v_latch_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+            GROUP BY latch_class
+            ORDER BY SUM(delta_wait_time_ms) DESC
+            LIMIT 5
+        ),
+        raw AS
+        (
+            SELECT
+                latch_class,
+                collection_time,
+                delta_wait_time_ms,
+                extract(epoch FROM (date_trunc('second', collection_time) - date_trunc('second', LAG(collection_time) OVER (PARTITION BY latch_class ORDER BY collection_time)))) AS interval_seconds
+            FROM v_latch_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+            AND   latch_class IN (SELECT latch_class FROM top_latches)
+        )
+        SELECT
+            latch_class,
+            collection_time,
+            CASE WHEN interval_seconds > 0 THEN CAST(delta_wait_time_ms AS DOUBLE PRECISION) / interval_seconds ELSE 0 END AS wait_time_ms_per_second
+        FROM raw
+        ORDER BY latch_class, collection_time
+        """;
+
+    /// <summary>
+    /// The Latch Stats latest-snapshot grid read: every latch class captured at the most recent
+    /// collection in the window, ordered by the last interval's delta wait time (recent contention)
+    /// then cumulative wait time, capped at 20 rows. $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string LatchSnapshotSql = """
+        WITH latest AS
+        (
+            SELECT MAX(collection_time) AS mx
+            FROM v_latch_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+        )
+        SELECT
+            latch_class,
+            waiting_requests_count,
+            wait_time_ms,
+            max_wait_time_ms,
+            delta_waiting_requests_count,
+            delta_wait_time_ms
+        FROM v_latch_stats
+        WHERE server_id = $1
+        AND   collection_time = (SELECT mx FROM latest)
+        ORDER BY delta_wait_time_ms DESC, wait_time_ms DESC
+        LIMIT 20
+        """;
+
+    /// <summary>
+    /// The Spinlock Stats trend read: the per-second collision rate for the TOP 5 spinlocks (by total
+    /// delta collisions over the window), the collision analog of <see cref="LatchTrendSql"/> — top-5
+    /// grouping mirrors the Dashboard's <c>GetSpinlockStatsTopNAsync</c>, collisions/sec via the per-name
+    /// <c>LAG</c> interval. Runs on <c>v_spinlock_stats</c>. $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string SpinlockTrendSql = """
+        WITH top_spinlocks AS
+        (
+            SELECT spinlock_name
+            FROM v_spinlock_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+            GROUP BY spinlock_name
+            ORDER BY SUM(delta_collisions) DESC
+            LIMIT 5
+        ),
+        raw AS
+        (
+            SELECT
+                spinlock_name,
+                collection_time,
+                delta_collisions,
+                extract(epoch FROM (date_trunc('second', collection_time) - date_trunc('second', LAG(collection_time) OVER (PARTITION BY spinlock_name ORDER BY collection_time)))) AS interval_seconds
+            FROM v_spinlock_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+            AND   spinlock_name IN (SELECT spinlock_name FROM top_spinlocks)
+        )
+        SELECT
+            spinlock_name,
+            collection_time,
+            CASE WHEN interval_seconds > 0 THEN CAST(delta_collisions AS DOUBLE PRECISION) / interval_seconds ELSE 0 END AS collisions_per_second
+        FROM raw
+        ORDER BY spinlock_name, collection_time
+        """;
+
+    /// <summary>
+    /// The Spinlock Stats latest-snapshot grid read: every spinlock captured at the most recent
+    /// collection in the window, ordered by the last interval's delta collisions then cumulative
+    /// collisions, capped at 20 rows. $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string SpinlockSnapshotSql = """
+        WITH latest AS
+        (
+            SELECT MAX(collection_time) AS mx
+            FROM v_spinlock_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+        )
+        SELECT
+            spinlock_name,
+            collisions,
+            spins,
+            spins_per_collision,
+            sleep_time,
+            backoffs,
+            delta_collisions,
+            delta_spins
+        FROM v_spinlock_stats
+        WHERE server_id = $1
+        AND   collection_time = (SELECT mx FROM latest)
+        ORDER BY delta_collisions DESC, collisions DESC
+        LIMIT 20
+        """;
+
+    /// <summary>The per-second wait trend for the top-5 latch classes over the window (empty when none).</summary>
+    public async Task<List<LatchStatsTrendPoint>> GetLatchStatsTrendAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<LatchStatsTrendPoint>();
+
+        await using var command = _dataSource.CreateCommand(LatchTrendSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new LatchStatsTrendPoint(
+                reader.GetString(0),
+                reader.GetDateTime(1),
+                reader.IsDBNull(2) ? 0 : reader.GetDouble(2)));
+        }
+
+        return result;
+    }
+
+    /// <summary>The latest-snapshot latch-class rows (top 20 by recent delta wait) for the window.</summary>
+    public async Task<List<LatchStatsSnapshotRow>> GetLatchStatsSnapshotAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<LatchStatsSnapshotRow>();
+
+        await using var command = _dataSource.CreateCommand(LatchSnapshotSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new LatchStatsSnapshotRow(
+                reader.GetString(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                reader.IsDBNull(5) ? 0 : reader.GetInt64(5)));
+        }
+
+        return result;
+    }
+
+    /// <summary>The per-second collision trend for the top-5 spinlocks over the window (empty when none).</summary>
+    public async Task<List<SpinlockStatsTrendPoint>> GetSpinlockStatsTrendAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<SpinlockStatsTrendPoint>();
+
+        await using var command = _dataSource.CreateCommand(SpinlockTrendSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new SpinlockStatsTrendPoint(
+                reader.GetString(0),
+                reader.GetDateTime(1),
+                reader.IsDBNull(2) ? 0 : reader.GetDouble(2)));
+        }
+
+        return result;
+    }
+
+    /// <summary>The latest-snapshot spinlock rows (top 20 by recent delta collisions) for the window.</summary>
+    public async Task<List<SpinlockStatsSnapshotRow>> GetSpinlockStatsSnapshotAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<SpinlockStatsSnapshotRow>();
+
+        await using var command = _dataSource.CreateCommand(SpinlockSnapshotSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new SpinlockStatsSnapshotRow(
+                reader.GetString(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                reader.IsDBNull(3) ? 0 : reader.GetDouble(3),
+                reader.IsDBNull(4) ? 0 : reader.GetInt64(4),
+                reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
+                reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                reader.IsDBNull(7) ? 0 : reader.GetInt64(7)));
+        }
+
+        return result;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>One point on the plan-cache size trend: single-use vs multi-use plan cache size (MB) at a
+/// collection instant, summed across every (cacheobjtype, objtype) group — the single-use bloat signal
+/// the Dashboard's Plan Cache chart plots.</summary>
+public sealed record PlanCacheTrendPoint(DateTime CollectionTime, double SingleUseSizeMb, double MultiUseSizeMb);
+
+/// <summary>One row of the Plan Cache latest-snapshot composition grid: one (cacheobjtype, objtype)
+/// group's plan/size breakdown at the most recent collection in the window. <c>OldestPlanCreateTime</c>
+/// is the store-wide MIN(creation_time) the collector stamps on every group row identically, so the
+/// summary can read it off any row.</summary>
+public sealed record PlanCacheSnapshotRow(
+    string Cacheobjtype,
+    string Objtype,
+    int TotalPlans,
+    int TotalSizeMb,
+    int SingleUsePlans,
+    int SingleUseSizeMb,
+    int MultiUsePlans,
+    int MultiUseSizeMb,
+    decimal AvgUseCount,
+    int AvgSizeKb,
+    DateTime? OldestPlanCreateTime);
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The Plan Cache size trend read: single-use vs multi-use cache size (MB) per collection, summed
+    /// across every (cacheobjtype, objtype) group, from the <c>v_plan_cache_stats</c> passthrough view —
+    /// the Dashboard's Plan Cache chart shape (single-use vs multi-use bloat), windowed on the settable
+    /// range. The integer MB sums are CAST to double precision for the typed reader. $1 server_id,
+    /// $2 window start, $3 window end (all naive UTC).
+    /// </summary>
+    public const string PlanCacheTrendSql = """
+        SELECT
+            collection_time,
+            CAST(SUM(single_use_size_mb) AS double precision) AS single_use_mb,
+            CAST(SUM(multi_use_size_mb) AS double precision) AS multi_use_mb
+        FROM v_plan_cache_stats
+        WHERE server_id = $1
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        GROUP BY collection_time
+        ORDER BY collection_time
+        """;
+
+    /// <summary>
+    /// The Plan Cache latest-snapshot composition read: every (cacheobjtype, objtype) group captured at
+    /// the most recent collection in the window, ordered by total cache size then plan count, capped at
+    /// 30 rows. $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string PlanCacheSnapshotSql = """
+        WITH latest AS
+        (
+            SELECT MAX(collection_time) AS mx
+            FROM v_plan_cache_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+        )
+        SELECT
+            cacheobjtype,
+            objtype,
+            total_plans,
+            total_size_mb,
+            single_use_plans,
+            single_use_size_mb,
+            multi_use_plans,
+            multi_use_size_mb,
+            avg_use_count,
+            avg_size_kb,
+            oldest_plan_create_time
+        FROM v_plan_cache_stats
+        WHERE server_id = $1
+        AND   collection_time = (SELECT mx FROM latest)
+        ORDER BY total_size_mb DESC, total_plans DESC
+        LIMIT 30
+        """;
+
+    /// <summary>The single-use vs multi-use plan-cache size trend over the window (empty when none).</summary>
+    public async Task<List<PlanCacheTrendPoint>> GetPlanCacheTrendAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<PlanCacheTrendPoint>();
+
+        await using var command = _dataSource.CreateCommand(PlanCacheTrendSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new PlanCacheTrendPoint(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? 0 : reader.GetDouble(1),
+                reader.IsDBNull(2) ? 0 : reader.GetDouble(2)));
+        }
+
+        return result;
+    }
+
+    /// <summary>The latest-snapshot plan-cache composition rows (top 30 by size) for the window.</summary>
+    public async Task<List<PlanCacheSnapshotRow>> GetPlanCacheSnapshotAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<PlanCacheSnapshotRow>();
+
+        await using var command = _dataSource.CreateCommand(PlanCacheSnapshotSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new PlanCacheSnapshotRow(
+                Cacheobjtype: reader.IsDBNull(0) ? string.Empty : reader.GetString(0),
+                Objtype: reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                TotalPlans: reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+                TotalSizeMb: reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+                SingleUsePlans: reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+                SingleUseSizeMb: reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+                MultiUsePlans: reader.IsDBNull(6) ? 0 : reader.GetInt32(6),
+                MultiUseSizeMb: reader.IsDBNull(7) ? 0 : reader.GetInt32(7),
+                AvgUseCount: reader.IsDBNull(8) ? 0m : reader.GetDecimal(8),
+                AvgSizeKb: reader.IsDBNull(9) ? 0 : reader.GetInt32(9),
+                OldestPlanCreateTime: reader.IsDBNull(10) ? null : reader.GetDateTime(10)));
+        }
+
+        return result;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
@@ -35,6 +35,11 @@ public sealed record PlanCacheSnapshotRow(
     int AvgSizeKb,
     DateTime? OldestPlanCreateTime);
 
+/// <summary>The Plan Cache summary strip's two stability figures for the latest snapshot in the window:
+/// the TRUE total plan count (summed across every group, not just the displayed top-N) and the oldest
+/// cached plan's create time — matching the Dashboard, which computes both over the full latest snapshot.</summary>
+public sealed record PlanCacheSummary(long TotalPlans, DateTime? OldestPlanCreateTime);
+
 public sealed partial class ViewerDataService
 {
     /// <summary>
@@ -90,6 +95,31 @@ public sealed partial class ViewerDataService
         LIMIT 30
         """;
 
+    /// <summary>
+    /// The Plan Cache summary read: the TRUE total plan count (SUM over EVERY group, uncapped) and the
+    /// oldest cached plan's create time (MIN) at the most recent collection in the window — the summary
+    /// strip's two figures, computed independently of the top-30 grid read so "Total Plans" is exact even
+    /// when the composition grid is capped (matching the Dashboard, which sums the full latest snapshot).
+    /// An aggregate with no GROUP BY always returns one row, so an empty window yields (0, NULL).
+    /// $1 server_id, $2 start, $3 end (naive UTC).
+    /// </summary>
+    public const string PlanCacheSummarySql = """
+        WITH latest AS
+        (
+            SELECT MAX(collection_time) AS mx
+            FROM v_plan_cache_stats
+            WHERE server_id = $1
+            AND   collection_time >= $2
+            AND   collection_time <= $3
+        )
+        SELECT
+            COALESCE(SUM(total_plans), 0) AS total_plans,
+            MIN(oldest_plan_create_time) AS oldest_plan_create_time
+        FROM v_plan_cache_stats
+        WHERE server_id = $1
+        AND   collection_time = (SELECT mx FROM latest)
+        """;
+
     /// <summary>The single-use vs multi-use plan-cache size trend over the window (empty when none).</summary>
     public async Task<List<PlanCacheTrendPoint>> GetPlanCacheTrendAsync(
         int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
@@ -136,5 +166,23 @@ public sealed partial class ViewerDataService
         }
 
         return result;
+    }
+
+    /// <summary>The exact total-plans + oldest-plan figures for the summary strip (uncapped), or
+    /// (0, null) when the window holds no snapshot.</summary>
+    public async Task<PlanCacheSummary> GetPlanCacheSummaryAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(PlanCacheSummarySql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return new PlanCacheSummary(0, null);
+        }
+
+        return new PlanCacheSummary(
+            reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
+            reader.IsDBNull(1) ? null : reader.GetDateTime(1));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -138,6 +138,25 @@ public sealed partial class ViewerDataService : IAsyncDisposable
     public static DateTime ToLocalTime(DateTime naiveUtc)
         => DateTime.SpecifyKind(naiveUtc, DateTimeKind.Utc).ToLocalTime();
 
+    /// <summary>
+    /// Binds the standard per-server window parameters shared by the settable-window tab reads:
+    /// $1 server_id, $2 window start, $3 window end. Both bounds are sent Kind=Unspecified because the
+    /// store's columns are naive UTC (<c>timestamp without time zone</c>) — a Kind=Utc DateTime would
+    /// map to timestamptz and throw since Npgsql 6.0 (see the class remarks).
+    /// </summary>
+    internal static void AddWindowParameters(NpgsqlCommand command, int serverId, DateTime startUtc, DateTime endUtc)
+    {
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified),
+        });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified),
+        });
+    }
+
     /// <summary>Postgres SQLSTATE 42501 (insufficient_privilege) — a write refused on a read-only connection.</summary>
     internal const string InsufficientPrivilegeSqlState = "42501";
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -81,6 +81,9 @@ public partial class ViewerServerTab : IDisposable
            so the whole tab tears down through one path. */
         DisposeChartHelpers();
         DisposeMemoryHelpers();
+        DisposePlanCacheHelpers();
+        DisposeCpuSchedulerHelpers();
+        DisposeLatchSpinlockHelpers();
         DisposeFileIoHelpers();
         DisposeBlockingHelpers();
         DisposePerfmonHelpers();
@@ -101,6 +104,10 @@ public partial class ViewerServerTab : IDisposable
             samples = samples.Where(s => s.SampleTime <= endUtc).ToList();
         }
         RenderCpuChart(samples);
+
+        /* The CPU tab is a sub-TabControl (CPU Utilization + CPU Scheduler); load the scheduler sub-tab in
+           the same pass — the CPU tab's full-refresh branch, mirroring the Memory tab's all-sub-tabs load. */
+        await LoadCpuSchedulerAsync();
     }
 
     /// <summary>Loads the tempdb tab: usage/size trend and per-file I/O latency, read concurrently.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>One row of the CPU Scheduler latest-snapshot metric grid: a labelled scalar from the most
+/// recent cpu_scheduler_stats row, plus whether the collector flagged it as pressure (drives the row
+/// highlight). A single-row point-in-time collector has no natural top-N, so its "latest snapshot" is
+/// presented as this metric/value list — the grid analog of the Dashboard's CPU-pressure summary strip.</summary>
+public sealed record CpuSchedulerMetricRow(string Metric, string Value, bool IsWarning);
+
+/// <summary>
+/// The CPU Scheduler sub-tab (under the CPU tab, alongside CPU Utilization) — the Darling-viewer surface
+/// for the cpu_scheduler_stats collector (scheduler / worker-thread / runnable-task / NUMA / OS-memory
+/// pressure), mirroring the Dashboard's CPU-pressure reporting. A point-in-time collector, so the trend
+/// chart plots the runnable / blocked / queued task counts directly over the settable window and the
+/// latest snapshot renders as a metric/value grid whose warning rows highlight (the collector's own
+/// CASE-computed pressure flags). Loaded from <c>LoadCpuAsync</c> alongside CPU Utilization (the CPU
+/// tab's full-refresh branch), so the CPU sub-TabControl needs no SelectionChanged handler. Chart chrome
+/// flows through the shared <see cref="ChartStyle"/> / <see cref="ChartPalette"/> and the ChartHelpers
+/// bridge, so the Y-floor-at-0 fix applies.
+/// </summary>
+public partial class ViewerServerTab
+{
+    private ChartHoverHelper? _cpuSchedulerHover;
+
+    /// <summary>Applies the shared chrome + hover to the scheduler chart up front (constructor).</summary>
+    private void InitializeCpuSchedulerChart()
+    {
+        ApplyTheme(CpuSchedulerChart);
+        CpuSchedulerChart.Refresh();
+        _cpuSchedulerHover = new ChartHoverHelper(CpuSchedulerChart, "tasks");
+    }
+
+    /// <summary>
+    /// Loads the CPU Scheduler sub-tab over the toolbar's settable window: the pressure trend and the
+    /// latest-snapshot metric read fire concurrently, then the chart and metric grid render.
+    /// </summary>
+    private async Task LoadCpuSchedulerAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+
+        var trendTask = _dataService.GetCpuSchedulerTrendAsync(_server.ServerId, startUtc, endUtc);
+        var snapshotTask = _dataService.GetCpuSchedulerSnapshotAsync(_server.ServerId, startUtc, endUtc);
+        await Task.WhenAll(trendTask, snapshotTask);
+
+        RenderCpuSchedulerChart(trendTask.Result);
+        CpuSchedulerGrid.ItemsSource = BuildCpuSchedulerMetrics(snapshotTask.Result);
+    }
+
+    private void RenderCpuSchedulerChart(List<CpuSchedulerTrendPoint> data)
+    {
+        ClearChart(CpuSchedulerChart);
+        _cpuSchedulerHover?.Clear();
+        ApplyTheme(CpuSchedulerChart);
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        CpuSchedulerChart.Plot.YLabel("Task Count");
+
+        double globalMax = 0;
+        if (data.Count > 0)
+        {
+            var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+
+            var series = new (string Name, Func<CpuSchedulerTrendPoint, double> Selector)[]
+            {
+                ("Runnable Tasks", d => d.RunnableTasks),
+                ("Blocked Tasks", d => d.BlockedTasks),
+                ("Queued Requests", d => d.QueuedRequests),
+            };
+
+            int colorIdx = 0;
+            foreach (var s in series)
+            {
+                var values = data.Select(s.Selector).ToArray();
+                var plot = CpuSchedulerChart.Plot.Add.Scatter(times, values);
+                plot.LegendText = s.Name;
+                plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
+                ChartStyle.StyleScatter(plot);
+                _cpuSchedulerHover?.Add(plot, s.Name);
+                colorIdx++;
+                if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
+            }
+        }
+
+        CpuSchedulerChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        CpuSchedulerChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(CpuSchedulerChart);
+        SetChartYLimitsWithLegendPadding(CpuSchedulerChart, 0, globalMax > 0 ? globalMax : 5);
+        ShowChartLegend(CpuSchedulerChart);
+        CpuSchedulerChart.Refresh();
+    }
+
+    /// <summary>Projects the latest snapshot into the metric grid's labelled rows (with the collector's
+    /// pressure flags driving the highlight). An empty window yields an empty grid. Internal so the
+    /// projection (warning flags, worker-utilization math, memory formatting) is unit-testable.</summary>
+    internal static List<CpuSchedulerMetricRow> BuildCpuSchedulerMetrics(CpuSchedulerSnapshot? s)
+    {
+        if (s is null)
+        {
+            return new List<CpuSchedulerMetricRow>();
+        }
+
+        double workerUtil = s.MaxWorkersCount > 0
+            ? (double)s.TotalCurrentWorkersCount / s.MaxWorkersCount * 100.0
+            : 0;
+
+        var rows = new List<CpuSchedulerMetricRow>
+        {
+            new("Schedulers", Int(s.SchedulerCount), false),
+            new("Logical CPUs", Int(s.CpuCount), false),
+            new("NUMA Nodes (online / total)", $"{s.NodesOnlineCount} / {s.TotalNodeCount}", false),
+            new("Offline CPUs", Int(s.OfflineCpuCount), s.OfflineCpuWarning),
+            new("Max Worker Threads", Int(s.MaxWorkersCount), false),
+            new("Current Workers", Int(s.TotalCurrentWorkersCount), s.WorkerThreadExhaustionWarning),
+            new("Worker Utilization %", workerUtil.ToString("F1", CultureInfo.CurrentCulture), s.WorkerThreadExhaustionWarning),
+            new("Runnable Tasks", Int(s.TotalRunnableTasksCount), s.RunnableTasksWarning),
+            new("Avg Runnable / Scheduler", s.AvgRunnableTasksCount.ToString("F2", CultureInfo.CurrentCulture), s.RunnableTasksWarning),
+            new("Work Queue Length", Long(s.TotalWorkQueueCount), false),
+            new("Active Requests", Int(s.TotalActiveRequestCount), false),
+            new("Queued Requests", Int(s.TotalQueuedRequestCount), s.QueuedRequestsWarning),
+            new("Blocked Tasks", Int(s.TotalBlockedTaskCount), s.BlockedTasksWarning),
+            new("Active Parallel Threads", Long(s.TotalActiveParallelThreadCount), false),
+            new("Runnable Requests", NullableInt(s.RunnableRequestCount), false),
+            new("Total Requests", NullableInt(s.TotalRequestCount), false),
+            new("Runnable %", s.RunnablePercent.HasValue ? s.RunnablePercent.Value.ToString("F2", CultureInfo.CurrentCulture) : "N/A", false),
+            new("Total Physical Memory", FormatKbAsGb(s.TotalPhysicalMemoryKb), false),
+            new("Available Physical Memory", FormatKbAsGb(s.AvailablePhysicalMemoryKb), s.PhysicalMemoryPressureWarning),
+            new("System Memory State", string.IsNullOrEmpty(s.SystemMemoryStateDesc) ? "N/A" : s.SystemMemoryStateDesc, s.PhysicalMemoryPressureWarning),
+            new("Physical Memory Pressure", s.PhysicalMemoryPressureWarning ? "Yes" : "No", s.PhysicalMemoryPressureWarning),
+        };
+
+        return rows;
+    }
+
+    private static string Int(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string Long(long value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string NullableInt(int? value) => value.HasValue ? value.Value.ToString("N0", CultureInfo.CurrentCulture) : "N/A";
+
+    private static string FormatKbAsGb(long kb)
+    {
+        double gb = kb / 1024.0 / 1024.0;
+        return gb >= 1 ? $"{gb:F1} GB" : $"{kb / 1024.0:F0} MB";
+    }
+
+    /// <summary>Tears down the scheduler hover helper (mirrors the other tabs' dispose).</summary>
+    public void DisposeCpuSchedulerHelpers()
+    {
+        _cpuSchedulerHover?.Dispose();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Latches &amp; Spinlocks inner tab — the Dashboard-parity port of ResourceMetricsContent's Latch
+/// Stats / Spinlock Stats sub-tabs into the Darling viewer. Each sub-tab pairs a per-second trend chart
+/// for the TOP 5 contenders (latch classes by delta wait time, spinlocks by delta collisions) with a
+/// latest-snapshot grid of the most recent collection in the settable window. The Darling cumulative-delta
+/// tables carry no stored <c>sample_interval_seconds</c> (unlike the Dashboard's), so the ms/sec and
+/// collisions/sec rates are computed in SQL from the per-contender <c>LAG</c> interval — the same idiom
+/// the Wait Stats trend uses. Both sub-tabs (re)load on the parent tab's activation (mirroring the Memory
+/// tab's full-refresh branch), so the sub-TabControl needs no SelectionChanged handler. Chart chrome /
+/// legend / line polish flow through the shared <see cref="ChartStyle"/> / <see cref="ChartPalette"/> and
+/// the <c>ViewerServerTab.ChartHelpers.cs</c> bridge, so the Y-floor-at-0 fix applies; series ride the
+/// cycling <c>SeriesColors</c> (declared in ViewerServerTab.Charts.cs).
+/// </summary>
+public partial class ViewerServerTab
+{
+    private ChartHoverHelper? _latchStatsHover;
+    private ChartHoverHelper? _spinlockStatsHover;
+
+    /// <summary>Applies the shared chrome + hover to the latch/spinlock charts up front (constructor),
+    /// so they don't flash white before the tab's first load — matching the CPU/Memory charts.</summary>
+    private void InitializeLatchSpinlockCharts()
+    {
+        ApplyTheme(LatchStatsChart);
+        LatchStatsChart.Refresh();
+        ApplyTheme(SpinlockStatsChart);
+        SpinlockStatsChart.Refresh();
+
+        _latchStatsHover = new ChartHoverHelper(LatchStatsChart, "ms/sec");
+        _spinlockStatsHover = new ChartHoverHelper(SpinlockStatsChart, "/sec");
+    }
+
+    /// <summary>
+    /// Loads both sub-tabs (Latch Stats + Spinlock Stats) over the toolbar's settable window: the four
+    /// reads (two trends, two snapshots) fire concurrently — NpgsqlDataSource pools a connection each —
+    /// then the charts and grids render.
+    /// </summary>
+    private async Task LoadLatchSpinlockAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+
+        var latchTrendTask = _dataService.GetLatchStatsTrendAsync(_server.ServerId, startUtc, endUtc);
+        var latchSnapshotTask = _dataService.GetLatchStatsSnapshotAsync(_server.ServerId, startUtc, endUtc);
+        var spinlockTrendTask = _dataService.GetSpinlockStatsTrendAsync(_server.ServerId, startUtc, endUtc);
+        var spinlockSnapshotTask = _dataService.GetSpinlockStatsSnapshotAsync(_server.ServerId, startUtc, endUtc);
+
+        await Task.WhenAll(latchTrendTask, latchSnapshotTask, spinlockTrendTask, spinlockSnapshotTask);
+
+        RenderLatchStatsChart(latchTrendTask.Result);
+        LatchStatsGrid.ItemsSource = latchSnapshotTask.Result;
+        RenderSpinlockStatsChart(spinlockTrendTask.Result);
+        SpinlockStatsGrid.ItemsSource = spinlockSnapshotTask.Result;
+    }
+
+    private void RenderLatchStatsChart(List<LatchStatsTrendPoint> data)
+    {
+        ClearChart(LatchStatsChart);
+        _latchStatsHover?.Clear();
+        ApplyTheme(LatchStatsChart);
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        LatchStatsChart.Plot.YLabel("Wait Time (ms/sec)");
+
+        if (data.Count == 0)
+        {
+            FinishContentionChart(LatchStatsChart, startUtc, endUtc, 0);
+            return;
+        }
+
+        /* Order the series by total ms/sec desc so the heaviest latch gets the first palette color
+           (deterministic, mirrors the Dashboard's re-group-by-total). */
+        var byClass = data
+            .GroupBy(d => d.LatchClass)
+            .OrderByDescending(g => g.Sum(d => d.WaitTimeMsPerSecond))
+            .ToList();
+
+        double globalMax = 0;
+        int colorIdx = 0;
+        foreach (var group in byClass)
+        {
+            var points = group.OrderBy(d => d.CollectionTime).ToList();
+            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var values = points.Select(d => d.WaitTimeMsPerSecond).ToArray();
+
+            var plot = LatchStatsChart.Plot.Add.Scatter(times, values);
+            plot.LegendText = TruncateName(group.Key);
+            plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
+            ChartStyle.StyleScatter(plot);
+            _latchStatsHover?.Add(plot, group.Key);
+            colorIdx++;
+
+            if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
+        }
+
+        FinishContentionChart(LatchStatsChart, startUtc, endUtc, globalMax);
+    }
+
+    private void RenderSpinlockStatsChart(List<SpinlockStatsTrendPoint> data)
+    {
+        ClearChart(SpinlockStatsChart);
+        _spinlockStatsHover?.Clear();
+        ApplyTheme(SpinlockStatsChart);
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        SpinlockStatsChart.Plot.YLabel("Collisions/sec");
+
+        if (data.Count == 0)
+        {
+            FinishContentionChart(SpinlockStatsChart, startUtc, endUtc, 0);
+            return;
+        }
+
+        var byName = data
+            .GroupBy(d => d.SpinlockName)
+            .OrderByDescending(g => g.Sum(d => d.CollisionsPerSecond))
+            .ToList();
+
+        double globalMax = 0;
+        int colorIdx = 0;
+        foreach (var group in byName)
+        {
+            var points = group.OrderBy(d => d.CollectionTime).ToList();
+            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var values = points.Select(d => d.CollisionsPerSecond).ToArray();
+
+            var plot = SpinlockStatsChart.Plot.Add.Scatter(times, values);
+            plot.LegendText = TruncateName(group.Key);
+            plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
+            ChartStyle.StyleScatter(plot);
+            _spinlockStatsHover?.Add(plot, group.Key);
+            colorIdx++;
+
+            if (values.Length > 0) globalMax = Math.Max(globalMax, values.Max());
+        }
+
+        FinishContentionChart(SpinlockStatsChart, startUtc, endUtc, globalMax);
+    }
+
+    /// <summary>Shared chart finish for the latch/spinlock trends: date axis, window X-limits, Y floor at
+    /// 0 with legend padding, and the legend — the one place the window bounds + Y-floor fix apply.</summary>
+    private void FinishContentionChart(ScottPlot.WPF.WpfPlot chart, DateTime startUtc, DateTime endUtc, double globalMax)
+    {
+        chart.Plot.Axes.DateTimeTicksBottomDateChange();
+        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        chart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(chart);
+        SetChartYLimitsWithLegendPadding(chart, 0, globalMax > 0 ? globalMax : 10);
+        ShowChartLegend(chart);
+        chart.Refresh();
+    }
+
+    /// <summary>Legend names for latch classes / spinlock names get long; clip to 20 chars + ellipsis
+    /// exactly like the Dashboard's Latch/Spinlock chart legends.</summary>
+    private static string TruncateName(string name)
+        => name.Length > 20 ? name.Substring(0, 20) + "..." : name;
+
+    /// <summary>Tears down the latch/spinlock hover helpers (mirrors the other tabs' dispose) so their
+    /// tooltip popups + chart event handlers don't outlive a closed server tab.</summary>
+    public void DisposeLatchSpinlockHelpers()
+    {
+        _latchStatsHover?.Dispose();
+        _spinlockStatsHover?.Dispose();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -108,6 +108,10 @@ public partial class ViewerServerTab
         RenderMemoryPressureEventsChart(pressureTask.Result);
         PopulateMemoryClerkPicker(clerkTypesTask.Result);
         await UpdateMemoryClerksChartFromPickerAsync();
+
+        /* Plan Cache sub-tab (under Memory, matching the Dashboard's Memory > Plan Cache): loaded in the
+           same pass as the other Memory sub-tabs (the Memory tab's full-refresh branch). */
+        await LoadPlanCacheAsync();
     }
 
     /// <summary>The Overview summary strip — Lite's <c>UpdateMemorySummary</c> verbatim.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Plan Cache sub-tab (under the Memory tab, matching the Dashboard's Memory &gt; Plan Cache) — the
+/// Darling-viewer surface for the plan_cache_stats collector. The trend chart plots single-use vs
+/// multi-use plan-cache size (MB) over the settable window (the single-use bloat signal, the Dashboard's
+/// Plan Cache chart shape), the summary strip shows total plans + oldest-plan age, and the latest-snapshot
+/// grid breaks the cache down per (cacheobjtype, objtype) group. Loaded from <c>LoadMemoryAsync</c>
+/// alongside the other Memory sub-tabs (the Memory tab's full-refresh branch). Chart chrome flows through
+/// the shared <see cref="ChartStyle"/> / <see cref="ChartPalette"/> and the ChartHelpers bridge, so the
+/// Y-floor-at-0 fix applies, and the two series ride the same palette keys the Dashboard uses for cross-app
+/// color identity.
+/// </summary>
+public partial class ViewerServerTab
+{
+    private ChartHoverHelper? _planCacheHover;
+
+    /// <summary>Applies the shared chrome + hover to the plan-cache chart up front (constructor).</summary>
+    private void InitializePlanCacheChart()
+    {
+        ApplyTheme(PlanCacheChart);
+        PlanCacheChart.Refresh();
+        _planCacheHover = new ChartHoverHelper(PlanCacheChart, "MB");
+    }
+
+    /// <summary>
+    /// Loads the Plan Cache sub-tab over the toolbar's settable window: the size trend and the latest
+    /// composition snapshot read concurrently, then the chart, summary strip, and grid render. Called from
+    /// <see cref="LoadMemoryAsync"/> (the Memory tab loads all its sub-tabs on activation).
+    /// </summary>
+    private async Task LoadPlanCacheAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+
+        var trendTask = _dataService.GetPlanCacheTrendAsync(_server.ServerId, startUtc, endUtc);
+        var snapshotTask = _dataService.GetPlanCacheSnapshotAsync(_server.ServerId, startUtc, endUtc);
+        await Task.WhenAll(trendTask, snapshotTask);
+
+        RenderPlanCacheChart(trendTask.Result);
+
+        var snapshot = snapshotTask.Result;
+        PlanCacheCompositionGrid.ItemsSource = snapshot;
+        RenderPlanCacheSummary(snapshot);
+    }
+
+    private void RenderPlanCacheChart(List<PlanCacheTrendPoint> data)
+    {
+        ClearChart(PlanCacheChart);
+        _planCacheHover?.Clear();
+        ApplyTheme(PlanCacheChart);
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        PlanCacheChart.Plot.YLabel("Plan Cache Size (MB)");
+
+        double globalMax = 0;
+        if (data.Count > 0)
+        {
+            var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+
+            var singleUse = data.Select(d => d.SingleUseSizeMb).ToArray();
+            var singlePlot = PlanCacheChart.Plot.Add.Scatter(times, singleUse);
+            singlePlot.LegendText = "Single-Use";
+            singlePlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SinglePagePlans"));
+            ChartStyle.StyleScatter(singlePlot);
+            _planCacheHover?.Add(singlePlot, "Single-Use");
+
+            var multiUse = data.Select(d => d.MultiUseSizeMb).ToArray();
+            var multiPlot = PlanCacheChart.Plot.Add.Scatter(times, multiUse);
+            multiPlot.LegendText = "Multi-Use";
+            multiPlot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MultiPagePlans"));
+            ChartStyle.StyleScatter(multiPlot);
+            _planCacheHover?.Add(multiPlot, "Multi-Use");
+
+            globalMax = Math.Max(singleUse.DefaultIfEmpty(0).Max(), multiUse.DefaultIfEmpty(0).Max());
+        }
+
+        PlanCacheChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
+        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        PlanCacheChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(PlanCacheChart);
+        SetChartYLimitsWithLegendPadding(PlanCacheChart, 0, globalMax > 0 ? globalMax : 10);
+        ShowChartLegend(PlanCacheChart);
+        PlanCacheChart.Refresh();
+    }
+
+    /// <summary>The summary strip: total plans at the latest snapshot + the oldest cached plan's age
+    /// (a plan-cache-stability signal — older = more stable), mirroring the Dashboard's Plan Cache summary.</summary>
+    private void RenderPlanCacheSummary(List<PlanCacheSnapshotRow> snapshot)
+    {
+        if (snapshot.Count == 0)
+        {
+            PlanCacheTotalPlansText.Text = "--";
+            PlanCacheOldestPlanText.Text = "--";
+            return;
+        }
+
+        int totalPlans = snapshot.Sum(r => r.TotalPlans);
+        PlanCacheTotalPlansText.Text = totalPlans.ToString("N0", CultureInfo.CurrentCulture);
+
+        /* oldest_plan_create_time is the store-wide MIN the collector stamps on every group row, so any
+           non-null row carries it. It comes from a DMV (sys.dm_exec_query_stats.creation_time) in the
+           monitored server's local clock, which the viewer — having no per-server offset — measures against
+           UtcNow: exact for a UTC server, off by the server's offset otherwise (the same approximation the
+           viewer already accepts for server-local sample_time; a reliable de-skew is deferred). Age is a
+           coarse d/h/m stability bucket, so a few hours' offset rarely changes the qualitative read. */
+        var oldest = snapshot
+            .Where(r => r.OldestPlanCreateTime.HasValue)
+            .Select(r => r.OldestPlanCreateTime!.Value)
+            .DefaultIfEmpty()
+            .Min();
+
+        if (oldest == default)
+        {
+            PlanCacheOldestPlanText.Text = "--";
+            return;
+        }
+
+        var age = DateTime.UtcNow - DateTime.SpecifyKind(oldest, DateTimeKind.Utc);
+        if (age < TimeSpan.Zero) age = TimeSpan.Zero;
+        PlanCacheOldestPlanText.Text = age.TotalDays >= 1
+            ? $"{(int)age.TotalDays}d {age.Hours}h"
+            : age.TotalHours >= 1
+                ? $"{age.Hours}h {age.Minutes}m"
+                : $"{age.Minutes}m";
+    }
+
+    /// <summary>Tears down the plan-cache hover helper (mirrors the other tabs' dispose).</summary>
+    public void DisposePlanCacheHelpers()
+    {
+        _planCacheHover?.Dispose();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
@@ -50,13 +50,14 @@ public partial class ViewerServerTab
 
         var trendTask = _dataService.GetPlanCacheTrendAsync(_server.ServerId, startUtc, endUtc);
         var snapshotTask = _dataService.GetPlanCacheSnapshotAsync(_server.ServerId, startUtc, endUtc);
-        await Task.WhenAll(trendTask, snapshotTask);
+        /* The summary strip's totals come from a dedicated uncapped aggregate, NOT the top-30 grid rows,
+           so "Total Plans" is exact even though the composition grid is capped (Dashboard parity). */
+        var summaryTask = _dataService.GetPlanCacheSummaryAsync(_server.ServerId, startUtc, endUtc);
+        await Task.WhenAll(trendTask, snapshotTask, summaryTask);
 
         RenderPlanCacheChart(trendTask.Result);
-
-        var snapshot = snapshotTask.Result;
-        PlanCacheCompositionGrid.ItemsSource = snapshot;
-        RenderPlanCacheSummary(snapshot);
+        PlanCacheCompositionGrid.ItemsSource = snapshotTask.Result;
+        RenderPlanCacheSummary(summaryTask.Result);
     }
 
     private void RenderPlanCacheChart(List<PlanCacheTrendPoint> data)
@@ -100,33 +101,26 @@ public partial class ViewerServerTab
         PlanCacheChart.Refresh();
     }
 
-    /// <summary>The summary strip: total plans at the latest snapshot + the oldest cached plan's age
-    /// (a plan-cache-stability signal — older = more stable), mirroring the Dashboard's Plan Cache summary.</summary>
-    private void RenderPlanCacheSummary(List<PlanCacheSnapshotRow> snapshot)
+    /// <summary>The summary strip: TRUE total plans at the latest snapshot (uncapped, from the dedicated
+    /// aggregate — not the top-30 grid) + the oldest cached plan's age (a plan-cache-stability signal —
+    /// older = more stable), mirroring the Dashboard's Plan Cache summary.</summary>
+    private void RenderPlanCacheSummary(PlanCacheSummary summary)
     {
-        if (snapshot.Count == 0)
+        if (summary.TotalPlans <= 0 && summary.OldestPlanCreateTime is null)
         {
             PlanCacheTotalPlansText.Text = "--";
             PlanCacheOldestPlanText.Text = "--";
             return;
         }
 
-        int totalPlans = snapshot.Sum(r => r.TotalPlans);
-        PlanCacheTotalPlansText.Text = totalPlans.ToString("N0", CultureInfo.CurrentCulture);
+        PlanCacheTotalPlansText.Text = summary.TotalPlans.ToString("N0", CultureInfo.CurrentCulture);
 
-        /* oldest_plan_create_time is the store-wide MIN the collector stamps on every group row, so any
-           non-null row carries it. It comes from a DMV (sys.dm_exec_query_stats.creation_time) in the
-           monitored server's local clock, which the viewer — having no per-server offset — measures against
-           UtcNow: exact for a UTC server, off by the server's offset otherwise (the same approximation the
-           viewer already accepts for server-local sample_time; a reliable de-skew is deferred). Age is a
-           coarse d/h/m stability bucket, so a few hours' offset rarely changes the qualitative read. */
-        var oldest = snapshot
-            .Where(r => r.OldestPlanCreateTime.HasValue)
-            .Select(r => r.OldestPlanCreateTime!.Value)
-            .DefaultIfEmpty()
-            .Min();
-
-        if (oldest == default)
+        /* oldest_plan_create_time comes from a DMV (sys.dm_exec_query_stats.creation_time) in the monitored
+           server's local clock, which the viewer — having no per-server offset — measures against UtcNow:
+           exact for a UTC server, off by the server's offset otherwise (the same approximation the viewer
+           already accepts for server-local sample_time; a reliable de-skew is deferred). Age is a coarse
+           d/h/m stability bucket, so a few hours' offset rarely changes the qualitative read. */
+        if (summary.OldestPlanCreateTime is not { } oldest)
         {
             PlanCacheOldestPlanText.Text = "--";
             return;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -370,6 +370,56 @@
             </Grid>
         </TabItem>
 
+        <!-- Latches & Spinlocks Tab — the Dashboard-parity port of ResourceMetricsContent's Latch Stats /
+             Spinlock Stats sub-tabs. Two sub-tabs, each a per-second trend chart (top 5 by delta) over the
+             settable window + a latest-snapshot grid. Placed BETWEEN Wait Stats and Queries (the
+             contention-stats grouping). Both sub-tabs load on parent-tab activation, so this sub-TabControl
+             needs no SelectionChanged handler (mirrors the Memory tab). -->
+        <TabItem Header="Latches &amp; Spinlocks">
+            <TabControl x:Name="LatchSpinlockSubTabControl" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                <TabItem Header="Latch Stats">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="LatchStatsChart"/>
+                        <DataGrid Grid.Row="1" x:Name="LatchStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Latch Class" Binding="{Binding LatchClass}" Width="*"/>
+                                <DataGridTextColumn Header="Δ Wait (ms)" Binding="{Binding DeltaWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Δ Waiting Reqs" Binding="{Binding DeltaWaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Wait Time (ms)" Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Max Wait (ms)" Binding="{Binding MaxWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Waiting Reqs (total)" Binding="{Binding WaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="140"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+                <TabItem Header="Spinlock Stats">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="SpinlockStatsChart"/>
+                        <DataGrid Grid.Row="1" x:Name="SpinlockStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Spinlock" Binding="{Binding SpinlockName}" Width="*"/>
+                                <DataGridTextColumn Header="Δ Collisions" Binding="{Binding DeltaCollisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Δ Spins" Binding="{Binding DeltaSpins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Spins/Collision" Binding="{Binding SpinsPerCollision, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Collisions (total)" Binding="{Binding Collisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                                <DataGridTextColumn Header="Spins (total)" Binding="{Binding Spins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Sleep Time" Binding="{Binding SleepTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                                <DataGridTextColumn Header="Backoffs" Binding="{Binding Backoffs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+            </TabControl>
+        </TabItem>
+
         <!-- Queries Tab — the full six-sub-tab group matching Lite's ServerTab.xaml QueriesSubTabControl
              exactly: Performance Trends, Active Queries (W1f-2), Top Queries / Top Procedures / Query
              Store by Duration (W1f-1), Query Heatmap (W1f-2). A shared "Compare:" combo above the
@@ -1352,10 +1402,43 @@
         <!-- CPU Tab — copied from Lite's ServerTab.xaml CPU tab: one full-bleed chart of raw
              per-sample CPU (SQL Server vs other processes), distinct from the Overview's
              averaged-per-collection CPU trend. -->
+        <!-- CPU Tab — a sub-TabControl: "CPU Utilization" (the existing raw per-sample CPU chart) and
+             "CPU Scheduler" (the cpu_scheduler_stats parity surface: runnable/blocked/queued pressure
+             trend + a latest-snapshot metric grid whose warning rows highlight). Both sub-tabs load on
+             CPU-tab activation (LoadCpuAsync), so this sub-TabControl needs no SelectionChanged handler. -->
         <TabItem Header="CPU">
-            <Grid Margin="8">
-                <scottplot:WpfPlot x:Name="CpuChart"/>
-            </Grid>
+            <TabControl x:Name="CpuSubTabControl" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                <TabItem Header="CPU Utilization">
+                    <Grid Margin="8">
+                        <scottplot:WpfPlot x:Name="CpuChart"/>
+                    </Grid>
+                </TabItem>
+                <TabItem Header="CPU Scheduler">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="CpuSchedulerChart"/>
+                        <DataGrid Grid.Row="1" x:Name="CpuSchedulerGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0"
+                                  HeadersVisibility="Column" AutoGenerateColumns="False">
+                            <DataGrid.RowStyle>
+                                <Style TargetType="DataGridRow" BasedOn="{StaticResource DarkGridRow}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsWarning}" Value="True">
+                                            <Setter Property="Background" Value="#33FF6B6B"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </DataGrid.RowStyle>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Metric" Binding="{Binding Metric}" Width="2*"/>
+                                <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+            </TabControl>
         </TabItem>
 
         <!-- Memory Tab — copied from Lite's ServerTab.xaml Memory tab (control names verbatim): a nested
@@ -1493,6 +1576,43 @@
                         </Grid.RowDefinitions>
                         <scottplot:WpfPlot Grid.Row="0" x:Name="MemoryGrantSizingChart" Margin="5,5,5,2"/>
                         <scottplot:WpfPlot Grid.Row="1" x:Name="MemoryGrantActivityChart" Margin="5,2,5,5"/>
+                    </Grid>
+                </TabItem>
+
+                <!-- Plan Cache Sub-Tab (plan_cache_stats parity, matching the Dashboard's Memory > Plan
+                     Cache): single-use vs multi-use size trend + total-plans / oldest-plan summary + a
+                     per-(cacheobjtype, objtype) composition grid for the latest snapshot in the window. -->
+                <TabItem Header="Plan Cache">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="PlanCacheChart"/>
+                        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <TextBlock Text="Total Plans:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="PlanCacheTotalPlansText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                <TextBlock Text="Oldest Plan Age:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="PlanCacheOldestPlanText" Text="--" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
+                        <DataGrid Grid.Row="2" x:Name="PlanCacheCompositionGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0"
+                                  HeadersVisibility="Column" AutoGenerateColumns="False">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Cache Object Type" Binding="{Binding Cacheobjtype}" Width="*"/>
+                                <DataGridTextColumn Header="Object Type" Binding="{Binding Objtype}" Width="120"/>
+                                <DataGridTextColumn Header="Total Plans" Binding="{Binding TotalPlans, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                                <DataGridTextColumn Header="Total Size (MB)" Binding="{Binding TotalSizeMb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Single-Use Plans" Binding="{Binding SingleUsePlans, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Single-Use (MB)" Binding="{Binding SingleUseSizeMb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                                <DataGridTextColumn Header="Multi-Use Plans" Binding="{Binding MultiUsePlans, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                                <DataGridTextColumn Header="Multi-Use (MB)" Binding="{Binding MultiUseSizeMb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Avg Use Count" Binding="{Binding AvgUseCount, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Avg Size (KB)" Binding="{Binding AvgSizeKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="105"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
                     </Grid>
                 </TabItem>
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -43,24 +43,29 @@ public partial class ViewerServerTab : UserControl
        wave lands between existing tabs. */
     private const int OverviewInnerTabIndex = 0;
     private const int WaitStatsInnerTabIndex = 1;
-    private const int QueriesInnerTabIndex = 2;
-    private const int PlanViewerInnerTabIndex = 3;
-    private const int CpuInnerTabIndex = 4;
-    private const int MemoryInnerTabIndex = 5;
-    private const int FileIoInnerTabIndex = 6;
-    private const int TempDbInnerTabIndex = 7;
-    private const int BlockingInnerTabIndex = 8;
-    private const int PerfmonInnerTabIndex = 9;
-    private const int RunningJobsInnerTabIndex = 10;
-    private const int ConfigurationInnerTabIndex = 11;
-    private const int DailySummaryInnerTabIndex = 12;
-    private const int HealthInnerTabIndex = 13;
+
+    /* Latches & Spinlocks sits BETWEEN Wait Stats and Queries — the contention-stats grouping mirroring
+       the Dashboard (its Latch/Spinlock sub-tabs live alongside waits in ResourceMetrics). A new top-level
+       tab holding two sub-tabs (Latch Stats + Spinlock Stats); everything after it renumbers by one. */
+    private const int LatchSpinlockInnerTabIndex = 2;
+    private const int QueriesInnerTabIndex = 3;
+    private const int PlanViewerInnerTabIndex = 4;
+    private const int CpuInnerTabIndex = 5;
+    private const int MemoryInnerTabIndex = 6;
+    private const int FileIoInnerTabIndex = 7;
+    private const int TempDbInnerTabIndex = 8;
+    private const int BlockingInnerTabIndex = 9;
+    private const int PerfmonInnerTabIndex = 10;
+    private const int RunningJobsInnerTabIndex = 11;
+    private const int ConfigurationInnerTabIndex = 12;
+    private const int DailySummaryInnerTabIndex = 13;
+    private const int HealthInnerTabIndex = 14;
 
     /* System Events is appended AFTER Collection Health (system_health parity, Stage 2b): six parse-on-read
        sub-tabs, one per unique system_health warning category. FinOps used to sit between them as a per-server
        inner tab, but it was promoted to a top-level cross-server aggregate tab (FinOpsTab, in MainWindow's
        MainTabs), so System Events now takes Collection Health's next slot. */
-    private const int SystemEventsInnerTabIndex = 14;
+    private const int SystemEventsInnerTabIndex = 15;
 
     private readonly ViewerDataService _dataService;
     private readonly DarlingServer _server;
@@ -91,9 +96,19 @@ public partial class ViewerServerTab : UserControl
         /* CPU + tempdb inner-tab charts (copied from Lite): theme up front + wire hover. */
         InitializeCpuTempDbCharts();
 
+        /* CPU Scheduler sub-tab chart (cpu_scheduler_stats parity): pressure trend + latest-snapshot grid. */
+        InitializeCpuSchedulerChart();
+
         /* Memory inner-tab charts (copied from Lite): same up-front theme + hover for the five Memory
            charts (Overview trend, Clerks, Grant sizing/activity, Pressure events). */
         InitializeMemoryCharts();
+
+        /* Plan Cache sub-tab chart (plan_cache_stats parity, under Memory): single-use vs multi-use trend. */
+        InitializePlanCacheChart();
+
+        /* Latches & Spinlocks inner-tab charts (latch_stats/spinlock_stats parity): the two per-second
+           contention trend charts, themed up front + hover. */
+        InitializeLatchSpinlockCharts();
 
         /* File I/O + Blocking-trend inner-tab charts (copied from Lite): same up-front theme + hover. */
         InitializeFileIoCharts();
@@ -186,6 +201,9 @@ public partial class ViewerServerTab : UserControl
             {
                 case WaitStatsInnerTabIndex:
                     await LoadWaitStatsAsync();
+                    break;
+                case LatchSpinlockInnerTabIndex:
+                    await LoadLatchSpinlockAsync();
                     break;
                 case QueriesInnerTabIndex:
                     await LoadQueriesAsync();


### PR DESCRIPTION
## What

Surfaces four collected-but-unsurfaced diagnostic stats in the **Darling viewer**. The data is already collected into Postgres with `v_` views (latch/spinlock #1374, cpu-scheduler/plan-cache #1375); the Dashboard shows these, Lite/Darling did not. This closes that data-present, UI-absent gap.

Each new surface is a **trend chart over the settable time window + a latest-snapshot grid**, in the existing Darling tab idiom. All reads honor the per-server toolbar's settable window (`GetWindowUtc` / `collection_time BETWEEN $2 AND $3`) and refresh via the same per-tab mechanism as the sibling tabs; charts reuse the shared `ChartStyle`/`ChartPalette` so the Y-floor-at-0 fix applies.

## The 4 tabs + placement

| Stat | Placement | Chart | Grid |
|------|-----------|-------|------|
| **Latch Stats** | New top-level **"Latches & Spinlocks"** tab (sub-tab 1), inserted after **Wait Stats** | Top-5 latch classes by Δ wait, ms/sec | Latest snapshot: Δ/total wait, waiting reqs, max wait |
| **Spinlock Stats** | Same new tab (sub-tab 2) | Top-5 spinlocks by Δ collisions, collisions/sec | Latest snapshot: Δ/total collisions, spins, spins/collision, sleep, backoffs |
| **CPU Scheduler** | Sub-tab under the existing **CPU** tab (CPU Utilization + CPU Scheduler) | Runnable / blocked / queued task counts | Latest-snapshot metric grid (scheduler/worker/NUMA/OS-memory), pressure-warning rows highlight |
| **Plan Cache** | Sub-tab under the existing **Memory** tab (matches Dashboard's Memory > Plan Cache) | Single-use vs multi-use size (MB) | Total-plans + oldest-plan summary + per-(cacheobjtype, objtype) composition grid |

**Placement rationale:** Latches & Spinlocks go next to Wait Stats — the contention-stats grouping, mirroring the Dashboard where the Latch/Spinlock sub-tabs live alongside waits in `ResourceMetricsContent`. CPU Scheduler and Plan Cache mirror the Dashboard's own groupings (scheduler pressure under CPU; plan cache under Memory).

## Views read

`v_latch_stats`, `v_spinlock_stats`, `v_cpu_scheduler_stats`, `v_plan_cache_stats` — all confirmed present in `PgSchemaGenerator.AllPassthroughViews` (V10/V11 migrations). Since the Darling cumulative-delta tables carry no stored `sample_interval_seconds` (unlike the Dashboard's), the latch/spinlock per-second rates are computed in SQL from the per-contender `LAG` interval — the same truncate-then-diff epoch idiom the Wait Stats trend uses.

## Settable-window honoring

Every read takes `startUtc`/`endUtc` from the toolbar and filters `collection_time BETWEEN $2 AND $3`. For the point-in-time collectors (CPU scheduler, plan cache) the "latest snapshot" is `MAX(collection_time)` **within the window**, so a custom past range shows that range's last sample. New sub-tabs load on parent-tab activation (the Memory tab's full-refresh idiom), and the toolbar's auto-refresh drives the active tab.

## Tests

32 new `Darling.Tests` (viewer-service test pattern): SQL contract (load-bearing clauses, top-5/LAG per-second math, latest-snapshot ordering), PG-dialect (positional params, no bare `now(`/`N'`/`@`), column-existence against the generated collector DDL, the CPU-scheduler metric-grid projection (warning flags → rows, worker-utilization math, N/A degradation), plus gated (`DARLING_TEST_PG`) live round-trips.

## Code review

A code-review pass found no material correctness bugs (SQL columns, reader getter/ordinal mapping incl. the 27-column CPU snapshot, per-second math, window handling, WPF bindings, tab renumbering all verified). One parity nit fixed in a follow-up commit: the Plan Cache "Total Plans" summary now comes from a dedicated uncapped aggregate (`PlanCacheSummarySql`) instead of summing only the top-30 grid rows, so it's exact regardless of the grid's display cap — matching the Dashboard, which sums the full latest snapshot.

## Build + tests

- Viewer `-c Release`: **Build succeeded, 0 errors**.
- `Darling/Darling.Tests -c Release`: **860 passed, 87 skipped (gated live-PG), 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
