### PR TITLE
Add a viewer-scoped Settings window (default time range + auto-refresh)

### DIFF
--- a/Darling/Darling.Tests/ViewerPreferencesStoreTests.cs
+++ b/Darling/Darling.Tests/ViewerPreferencesStoreTests.cs
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the viewer's per-user preferences store — the persisted DEFAULTS (default time range + auto-refresh
+/// on/off + interval) that seed a newly-opened server tab's toolbar. Covers the three behaviors the store
+/// promises: defaults when the file is missing, a lossless save/load round-trip, and clamping an
+/// out-of-range value back to its default (a corrupt / hand-edited / forward-version file must never leave
+/// a toolbar combo unselected). Each store points at a unique temp file so nothing touches the real profile.
+/// </summary>
+public sealed class ViewerPreferencesStoreTests : IDisposable
+{
+    private readonly string _tempFile =
+        Path.Combine(Path.GetTempPath(), $"viewer-preferences-test-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFile))
+        {
+            File.Delete(_tempFile);
+        }
+    }
+
+    [Fact]
+    public void Load_WhenFileMissing_ReturnsHistoricalToolbarDefaults()
+    {
+        var store = new ViewerPreferencesStore(_tempFile);
+
+        var prefs = store.Load();
+
+        /* The default-constructed values reproduce the toolbar's old hardcoded XAML defaults exactly:
+           index 3 = Last 24 hours, auto-refresh ON, interval index 1 = 1 minute. */
+        Assert.Equal(3, prefs.DefaultTimeRangeIndex);
+        Assert.True(prefs.AutoRefreshEnabled);
+        Assert.Equal(1, prefs.AutoRefreshIntervalIndex);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsAllThreeValues()
+    {
+        var store = new ViewerPreferencesStore(_tempFile);
+        store.Save(new ViewerPreferences
+        {
+            DefaultTimeRangeIndex = 0,      // Last 1 hour
+            AutoRefreshEnabled = false,
+            AutoRefreshIntervalIndex = 2,   // 5 minutes
+        });
+
+        /* A fresh store on the same path proves the values survived a real serialize → file → deserialize. */
+        var reloaded = new ViewerPreferencesStore(_tempFile).Load();
+
+        Assert.Equal(0, reloaded.DefaultTimeRangeIndex);
+        Assert.False(reloaded.AutoRefreshEnabled);
+        Assert.Equal(2, reloaded.AutoRefreshIntervalIndex);
+    }
+
+    [Fact]
+    public void Load_ClampsOutOfRangeIndices_BackToDefaults()
+    {
+        /* Persist deliberately invalid indices (Custom=5 is not a valid default; 99 is off the interval combo)
+           by writing the JSON directly, then confirm Load normalizes both back to their defaults while
+           leaving the valid auto-refresh flag untouched. */
+        File.WriteAllText(
+            _tempFile,
+            """
+            {
+              "DefaultTimeRangeIndex": 5,
+              "AutoRefreshEnabled": false,
+              "AutoRefreshIntervalIndex": 99
+            }
+            """);
+
+        var prefs = new ViewerPreferencesStore(_tempFile).Load();
+
+        Assert.Equal(3, prefs.DefaultTimeRangeIndex);       // clamped 5 -> 24h default
+        Assert.Equal(1, prefs.AutoRefreshIntervalIndex);    // clamped 99 -> 1m default
+        Assert.False(prefs.AutoRefreshEnabled);             // in-range value preserved
+    }
+
+    [Fact]
+    public void Load_WhenFileCorrupt_ReturnsDefaults()
+    {
+        File.WriteAllText(_tempFile, "{ not valid json");
+
+        var prefs = new ViewerPreferencesStore(_tempFile).Load();
+
+        Assert.Equal(3, prefs.DefaultTimeRangeIndex);
+        Assert.True(prefs.AutoRefreshEnabled);
+        Assert.Equal(1, prefs.AutoRefreshIntervalIndex);
+    }
+
+    [Fact]
+    public void Save_CreatesTheAppDataDirectory_WhenItDoesNotExist()
+    {
+        /* Point at a nested path whose directory does not exist yet — Save must create it (first-run). */
+        var nestedDir = Path.Combine(Path.GetTempPath(), $"viewer-prefs-dir-{Guid.NewGuid():N}");
+        var nestedFile = Path.Combine(nestedDir, "viewer-preferences.json");
+        try
+        {
+            new ViewerPreferencesStore(nestedFile).Save(new ViewerPreferences());
+
+            Assert.True(File.Exists(nestedFile));
+        }
+        finally
+        {
+            if (Directory.Exists(nestedDir))
+            {
+                Directory.Delete(nestedDir, recursive: true);
+            }
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -270,6 +270,17 @@
                                 <TextBlock Text="Open Plan Viewer" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
+                        <Button Click="SettingsButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="Viewer settings — defaults for newly-opened server tabs">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Settings" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <Button Click="AboutButton_Click"
                                 Style="{StaticResource DarkButton}"
                                 Padding="8,5"

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -55,9 +55,18 @@ public partial class MainWindow : Window
     /// </summary>
     private readonly OpenServerTabRegistry<TabItem> _openServerTabs = new();
 
+    /// <summary>
+    /// The viewer's per-user preferences store (a small JSON file in %APPDATA%) and the current in-memory
+    /// copy. These are the persisted DEFAULTS that seed each newly-opened <see cref="ViewerServerTab"/>'s
+    /// toolbar (time window + auto-refresh); the Settings dialog edits them. Loaded once on startup.
+    /// </summary>
+    private readonly ViewerPreferencesStore _preferencesStore = new();
+    private ViewerPreferences _preferences;
+
     public MainWindow()
     {
         InitializeComponent();
+        _preferences = _preferencesStore.Load();
         Loaded += OnLoaded;
         Closed += OnClosed;
     }
@@ -360,7 +369,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        var serverTab = new ViewerServerTab(_dataService, server);
+        var serverTab = new ViewerServerTab(_dataService, server, _preferences);
         serverTab.StatusChanged += OnServerTabStatusChanged;
         serverTab.ApplyTimeRangeRequested += OnApplyTimeRangeToAllRequested;
 
@@ -626,6 +635,23 @@ public partial class MainWindow : Window
 
         Clipboard.SetDataObject(card.AskAiPrompt, false);
         RecommendationsStatusText.Text = "AI prompt copied to clipboard.";
+    }
+
+    // ── Settings ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Opens the viewer's Settings dialog (default time range + auto-refresh for newly-opened server tabs).
+    /// On Save, persists the edited settings and updates the in-memory copy so the next opened server tab
+    /// seeds from them; already-open tabs keep their own toolbar state (the simple, predictable rule).
+    /// </summary>
+    private void SettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        var settings = new SettingsWindow(_preferences) { Owner = this };
+        if (settings.ShowDialog() == true && settings.Result is not null)
+        {
+            _preferences = settings.Result;
+            _preferencesStore.Save(_preferences);
+        }
     }
 
     // ── About ────────────────────────────────────────────────────────────────────────

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -1,0 +1,76 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings"
+        Height="300" Width="420"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="EDD.ico"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- The viewer's per-user Settings dialog. Dark-styled via the shared ViewerDarkTheme resource
+         dictionary like the viewer's other dialogs (About, Manage Mute Rules) — ComboBox / CheckBox /
+         Button / TextBlock all pick up ViewerDarkTheme's implicit styles, so only the window chrome
+         needs inline hex. Scope is deliberately tiny: the persisted DEFAULTS that seed a newly-opened
+         server tab's toolbar (ViewerServerTab.TimeRange.cs). It is NOT the service's darling.json
+         (collection/alerts/SMTP live there, not the viewer's business), and the viewer is dark-only,
+         so there is no theme toggle. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Settings"
+                   FontSize="18" FontWeight="Bold" Foreground="#E4E6EB" Margin="0,0,0,4"/>
+
+        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Defaults applied when a server tab is opened."
+                   Foreground="#8B93A1" TextWrapping="Wrap" Margin="0,0,0,18"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Default time range" Margin="0,0,16,12"/>
+        <ComboBox Grid.Row="2" Grid.Column="1" x:Name="TimeRangeCombo" Width="150"
+                  HorizontalAlignment="Left" Margin="0,0,0,12"
+                  ToolTip="Time window each newly-opened server tab starts on">
+            <ComboBoxItem Content="Last 1 hour"/>
+            <ComboBoxItem Content="Last 4 hours"/>
+            <ComboBoxItem Content="Last 12 hours"/>
+            <ComboBoxItem Content="Last 24 hours"/>
+            <ComboBoxItem Content="Last 7 days"/>
+        </ComboBox>
+
+        <CheckBox Grid.Row="3" Grid.ColumnSpan="2" x:Name="AutoRefreshCheckBox"
+                  Content="Auto-refresh new server tabs" Margin="0,0,0,12"
+                  Checked="AutoRefreshCheckBox_Toggled" Unchecked="AutoRefreshCheckBox_Toggled"/>
+
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Auto-refresh interval" Margin="0,0,16,0"/>
+        <ComboBox Grid.Row="4" Grid.Column="1" x:Name="AutoRefreshIntervalCombo" Width="150"
+                  HorizontalAlignment="Left"
+                  ToolTip="How often an auto-refreshing server tab reloads">
+            <ComboBoxItem Content="30 seconds"/>
+            <ComboBoxItem Content="1 minute"/>
+            <ComboBoxItem Content="5 minutes"/>
+        </ComboBox>
+
+        <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Save" Click="SaveButton_Click" IsDefault="True" MinWidth="80" Padding="16,4"/>
+            <Button Content="Cancel" Click="CancelButton_Click" IsCancel="True" MinWidth="80" Padding="16,4" Margin="8,0,0,0"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's per-user Settings dialog: the persisted DEFAULTS that seed a newly-opened server tab's
+/// toolbar (default time range + auto-refresh on/off + interval). Loaded from and saved to
+/// <see cref="ViewerPreferencesStore"/> by MainWindow; this window only edits an in-memory copy and hands
+/// the result back on Save. Changing settings applies to tabs opened afterward — open tabs keep their own
+/// toolbar state (the simple, predictable rule). The dialog's combo item order mirrors the toolbar's, so
+/// a selected index means the same thing here and there.
+/// </summary>
+public partial class SettingsWindow : Window
+{
+    /// <summary>The edited settings, populated on Save. Null until the user clicks Save (Cancel leaves it null).</summary>
+    public ViewerPreferences? Result { get; private set; }
+
+    public SettingsWindow(ViewerPreferences current)
+    {
+        InitializeComponent();
+
+        /* Seed the controls from the current settings (normalized so an out-of-range persisted index can
+           never leave a combo unselected). The combos mirror the toolbar's item order, so the stored
+           index selects the matching row directly. */
+        var normalized = new ViewerPreferences
+        {
+            DefaultTimeRangeIndex = current.DefaultTimeRangeIndex,
+            AutoRefreshEnabled = current.AutoRefreshEnabled,
+            AutoRefreshIntervalIndex = current.AutoRefreshIntervalIndex,
+        }.Normalize();
+
+        TimeRangeCombo.SelectedIndex = normalized.DefaultTimeRangeIndex;
+        AutoRefreshCheckBox.IsChecked = normalized.AutoRefreshEnabled;
+        AutoRefreshIntervalCombo.SelectedIndex = normalized.AutoRefreshIntervalIndex;
+
+        /* The interval only matters while auto-refresh is on, so grey it out when the box is unchecked. */
+        AutoRefreshIntervalCombo.IsEnabled = normalized.AutoRefreshEnabled;
+    }
+
+    private void AutoRefreshCheckBox_Toggled(object sender, RoutedEventArgs e)
+    {
+        /* Guard the load-time raise before the combo exists (Checked can fire during InitializeComponent). */
+        if (AutoRefreshIntervalCombo is not null)
+        {
+            AutoRefreshIntervalCombo.IsEnabled = AutoRefreshCheckBox.IsChecked == true;
+        }
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        Result = new ViewerPreferences
+        {
+            DefaultTimeRangeIndex = TimeRangeCombo.SelectedIndex,
+            AutoRefreshEnabled = AutoRefreshCheckBox.IsChecked == true,
+            AutoRefreshIntervalIndex = AutoRefreshIntervalCombo.SelectedIndex,
+        }.Normalize();
+
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's per-USER preferences — the persisted DEFAULTS that seed a newly-opened server tab's
+/// toolbar (see ViewerServerTab.TimeRange.cs). This is deliberately distinct from <see cref="ViewerSettings"/>,
+/// which reads the SERVICE's darling.json (the Postgres connection): those are the operator's collection
+/// config; these are the viewer's own tiny UI state, written when the user changes them in the Settings
+/// window and read when each server tab opens. Two settings, three values: the default time-range preset,
+/// and the default auto-refresh state (on/off + interval).
+/// The values are stored as the toolbar combos' own indices — the toolbar is the only consumer and is
+/// index-native (TimeRangeCombo.SelectedIndex, AutoRefreshIntervalCombo.SelectedIndex), so seeding a tab
+/// is a direct assignment with no second mapping layer. The Settings window mirrors the same item order,
+/// so an index means the same thing in both. Out-of-range values are clamped to the historical defaults
+/// on load (see <see cref="Normalize"/>), so a hand-edited or forward-version file never leaves a combo
+/// unselected. The mutable properties are what <see cref="System.Text.Json.JsonSerializer"/> round-trips.
+/// </summary>
+public sealed class ViewerPreferences
+{
+    /* The historical toolbar defaults (the XAML SelectedIndex / IsChecked values these settings replace):
+       time-range index 3 = "Last 24 hours", auto-refresh ON, interval index 1 = "1m". A default-constructed
+       ViewerPreferences therefore reproduces the pre-settings behavior exactly. */
+    internal const int DefaultTimeRangeIndexValue = 3;
+    internal const int DefaultAutoRefreshIntervalIndexValue = 1;
+
+    /* The toolbar's time-range combo lists 1h / 4h / 12h / 24h / 7d / Custom; a persisted DEFAULT only
+       covers the five presets (0..4) — "Custom Range" needs concrete From/To dates that make no sense as a
+       standing default, so it is intentionally not offered here. The interval combo lists 30s / 1m / 5m (0..2). */
+    internal const int MaxTimeRangeIndex = 4;
+    internal const int MaxAutoRefreshIntervalIndex = 2;
+
+    /// <summary>Default time window for a newly-opened server tab: 0=1h, 1=4h, 2=12h, 3=24h, 4=7d.</summary>
+    public int DefaultTimeRangeIndex { get; set; } = DefaultTimeRangeIndexValue;
+
+    /// <summary>Whether a newly-opened server tab starts with auto-refresh running.</summary>
+    public bool AutoRefreshEnabled { get; set; } = true;
+
+    /// <summary>Default auto-refresh cadence for a newly-opened server tab: 0=30s, 1=1m, 2=5m.</summary>
+    public int AutoRefreshIntervalIndex { get; set; } = DefaultAutoRefreshIntervalIndexValue;
+
+    /// <summary>
+    /// Clamps the two index values back to their defaults when they fall outside the combos' valid ranges
+    /// (a corrupt, hand-edited, or forward-version file), then returns this same instance for chaining.
+    /// Pure and side-effect-free beyond the clamp, so it is unit-testable without any file I/O.
+    /// </summary>
+    internal ViewerPreferences Normalize()
+    {
+        if (DefaultTimeRangeIndex < 0 || DefaultTimeRangeIndex > MaxTimeRangeIndex)
+        {
+            DefaultTimeRangeIndex = DefaultTimeRangeIndexValue;
+        }
+
+        if (AutoRefreshIntervalIndex < 0 || AutoRefreshIntervalIndex > MaxAutoRefreshIntervalIndex)
+        {
+            AutoRefreshIntervalIndex = DefaultAutoRefreshIntervalIndexValue;
+        }
+
+        return this;
+    }
+}
+
+/// <summary>
+/// Loads and saves <see cref="ViewerPreferences"/> as a small JSON file in the viewer's per-user app-data
+/// directory (mirroring the Dashboard's <c>UserPreferencesService</c> idiom — %APPDATA%\{app}\*.json,
+/// indented JSON, defaults on a missing or corrupt file). The default path is
+/// %APPDATA%\PerformanceMonitorDarling\viewer-preferences.json: the Darling-branded per-user folder (the
+/// Roaming root keeps it clear of the service's machine-wide %ProgramData%\PerformanceMonitorDarling data),
+/// with the file namespaced to the viewer. The file path is injectable so tests round-trip against a temp
+/// file instead of the real profile.
+/// </summary>
+public sealed class ViewerPreferencesStore
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+
+    /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
+    public ViewerPreferencesStore(string? filePath = null)
+    {
+        _filePath = filePath ?? DefaultFilePath();
+    }
+
+    /// <summary>The resolved settings file path (surfaced mainly so tests and diagnostics can name it).</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-preferences.json.</summary>
+    public static string DefaultFilePath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-preferences.json");
+    }
+
+    /// <summary>
+    /// Reads the settings, returning defaults when the file does not exist yet or cannot be read/parsed —
+    /// the viewer never blocks on a first run or a corrupt file. Loaded values are clamped to valid ranges.
+    /// </summary>
+    public ViewerPreferences Load()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new ViewerPreferences();
+            }
+
+            var json = File.ReadAllText(_filePath);
+            var preferences = JsonSerializer.Deserialize<ViewerPreferences>(json, s_jsonOptions);
+            return (preferences ?? new ViewerPreferences()).Normalize();
+        }
+        catch (Exception ex)
+        {
+            /* The viewer writes no application log of its own (its diagnostics go to Debug output), so a
+               corrupt-file fallback is a Debug trace, not a log entry — and never a crash on startup. */
+            Debug.WriteLine($"ViewerPreferencesStore: failed to load '{_filePath}', using defaults: {ex.Message}");
+            return new ViewerPreferences();
+        }
+    }
+
+    /// <summary>Writes the settings as indented JSON, creating the app-data directory on first save.</summary>
+    public void Save(ViewerPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(_filePath, JsonSerializer.Serialize(preferences, s_jsonOptions));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -76,7 +76,13 @@ public partial class ViewerServerTab : UserControl
     /// <summary>Raised after a load so MainWindow can surface progress/errors in its status bar.</summary>
     public event Action<string>? StatusChanged;
 
-    public ViewerServerTab(ViewerDataService dataService, DarlingServer server)
+    /// <param name="preferences">
+    /// The user's persisted viewer defaults (Settings window) that seed this tab's toolbar — default time
+    /// window and auto-refresh on/off + interval. Null (or omitted) uses a default-constructed
+    /// <see cref="ViewerPreferences"/>, which reproduces the toolbar's historical XAML defaults (24h / on / 1m)
+    /// exactly, so the tab is unchanged when no settings are supplied.
+    /// </param>
+    public ViewerServerTab(ViewerDataService dataService, DarlingServer server, ViewerPreferences? preferences = null)
     {
         _dataService = dataService;
         _server = server;
@@ -124,9 +130,20 @@ public partial class ViewerServerTab : UserControl
         /* System Events inner tab (system_health parity): register the eight category grids' filter managers. */
         InitializeSystemEventsTab();
 
+        /* Seed the toolbar's initial time window + auto-refresh state from the user's persisted defaults
+           (the Settings window), replacing the XAML's hardcoded 24h / on / 1m. Set BEFORE
+           InitializeAutoRefreshTimer, which reads AutoRefreshCheckBox + AutoRefreshIntervalCombo to decide
+           whether and how fast to start the timer. Assigning SelectedIndex/IsChecked here is inert: the
+           range handler no-ops while IsLoaded is false, and the checkbox handler no-ops while
+           _autoRefreshTimer is still null — so seeding drives no premature reload or timer churn. */
+        var toolbarDefaults = preferences ?? new ViewerPreferences();
+        TimeRangeCombo.SelectedIndex = toolbarDefaults.DefaultTimeRangeIndex;
+        AutoRefreshCheckBox.IsChecked = toolbarDefaults.AutoRefreshEnabled;
+        AutoRefreshIntervalCombo.SelectedIndex = toolbarDefaults.AutoRefreshIntervalIndex;
+
         /* Per-server toolbar (this wave): populate the custom-range hour/minute combos and start the
-           auto-refresh timer at the toolbar's interval (default 1m = the old fixed 60s cadence). The
-           settable window these controls drive replaces the removed 24-hour s_dataWindow constant. */
+           auto-refresh timer at the toolbar's interval (seeded above). The settable window these controls
+           drive replaces the removed 24-hour s_dataWindow constant. */
         InitializeTimeComboBoxes();
         InitializeAutoRefreshTimer();
     }


### PR DESCRIPTION
Adds a minimal, **viewer-scoped** Settings window to the Darling viewer. Scope is deliberately narrow: it persists two per-user **DEFAULTS** that seed a newly-opened server tab's per-server toolbar (#1399) — nothing about the Darling *service's* `darling.json` (collection/alerts/SMTP/webhook/MCP), no theme toggle (the viewer is dark-only), no time-display mode.

## The two persisted defaults
1. **Default time range** for newly-opened server tabs — `1h / 4h / 12h / 24h / 7d` (was hardcoded to 24h in `ViewerServerTab.TimeRange.cs`).
2. **Default auto-refresh** — on/off + interval (`30s / 1m / 5m`) (was hardcoded to on / 1m).

Changing settings applies to **newly-opened** tabs; already-open tabs keep their own toolbar state (the simple, predictable rule).

## Persistence mechanism / path
New `ViewerPreferences` (tiny POCO — three values behind the two settings) + `ViewerPreferencesStore`, mirroring the Dashboard's `UserPreferencesService` idiom: indented JSON, defaults on a missing/corrupt file, out-of-range indices clamped on load. This is **distinct from the existing `ViewerSettings`**, which reads the *service's* `darling.json` (the Postgres connection) — different concern, different file.

- **Path:** `%APPDATA%\PerformanceMonitorDarling\viewer-preferences.json` (Roaming per-user; the Roaming root keeps it clear of the service's machine-wide `%ProgramData%\PerformanceMonitorDarling`, and the filename namespaces it to the viewer).
- Loaded once on MainWindow startup; saved on Save. A default-constructed `ViewerPreferences` reproduces the toolbar's old XAML defaults (24h / on / 1m) exactly, so behavior is unchanged until the user changes something.

## Sidebar Settings button
A `Settings` button (gear glyph) in the MainWindow sidebar footer, next to the existing **Open Plan Viewer** + **About** buttons (same `DarkButton` idiom). Opens `SettingsWindow` — a small dark dialog (`ViewerDarkTheme` + `Icon="EDD.ico"`, mirroring `AboutWindow`) with a time-range dropdown, an auto-refresh checkbox, an interval dropdown (greyed when auto-refresh is off), and Save/Cancel. On Save, MainWindow persists the edited prefs and updates its in-memory copy.

## How the toolbar seeds from them
`ViewerServerTab`'s constructor takes an optional `ViewerPreferences` and seeds `TimeRangeCombo` / `AutoRefreshCheckBox` / `AutoRefreshIntervalCombo` from it **before** `InitializeAutoRefreshTimer()` (which reads the checkbox + interval to decide whether/how fast to start). Seeding is inert at construction time — the range handler no-ops while `IsLoaded` is false and the checkbox handler no-ops while the timer field is still null — so no premature reload or timer churn. MainWindow passes its loaded `_preferences` into each `new ViewerServerTab(...)`.

## Testing
- **Viewer build (Release):** 0 errors (9 pre-existing analyzer warnings, none from the new files).
- **Darling.Tests (Release):** 0 failed, 865 passed, 87 skipped (skips are the live-Postgres/SQL integration tests that need a dev environment).
- New `ViewerPreferencesStoreTests` (5 tests): defaults on a missing file, lossless save/load round-trip, out-of-range clamping, corrupt-file fallback, and first-run directory creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)