### PR TITLE
Port Lite's full SettingsWindow into the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerAppSettingsStoreTests.cs
+++ b/Darling/Darling.Tests/ViewerAppSettingsStoreTests.cs
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the viewer's application-settings store — the Darling equivalent of Lite's settings.json that the
+/// full Settings window (the port of Lite's SettingsWindow) reads and writes: MCP, every alert threshold and
+/// toggle, notification options, SMTP/webhook (non-secret) config, and the automated-analysis knobs. Covers
+/// the four behaviors the store promises: Lite-matching defaults when the file is missing, a lossless
+/// save/load round-trip across sections, clamping out-of-range values back into range (a corrupt / hand-edited
+/// / forward-version file must never seed an out-of-range control), and defaults on a corrupt file. Each store
+/// points at a unique temp file so nothing touches the real profile. Secrets (SMTP password, webhook URLs) are
+/// deliberately NOT covered here — they live in Windows Credential Manager, not this file.
+/// </summary>
+public sealed class ViewerAppSettingsStoreTests : IDisposable
+{
+    private readonly string _tempFile =
+        Path.Combine(Path.GetTempPath(), $"viewer-settings-test-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFile))
+        {
+            File.Delete(_tempFile);
+        }
+    }
+
+    [Fact]
+    public void Load_WhenFileMissing_ReturnsLiteMatchingDefaults()
+    {
+        var settings = new ViewerAppSettingsStore(_tempFile).Load();
+
+        /* Spot-check one value per section — every default mirrors Lite's App.* exactly, except the MCP
+           port, which is Darling's 5152 (avoids Lite 5151 / Dashboard 5150). */
+        Assert.False(settings.McpEnabled);
+        Assert.Equal(5152, settings.McpPort);
+        Assert.Equal(5, settings.ConnectionTimeoutSeconds);
+        Assert.Equal("ServerTime", settings.TimeDisplayMode);
+        Assert.True(settings.AlertsEnabled);
+        Assert.Equal(80, settings.AlertCpuThreshold);
+        Assert.Equal("Total", settings.AlertCpuMode);
+        Assert.Equal(500, settings.AlertPoisonWaitThresholdMs);
+        Assert.Equal("Summary", settings.AlertDeliveryMode);
+        Assert.Equal("24 hours", settings.MuteRuleDefaultExpiration);
+        Assert.Equal(1.5, settings.AnalysisNotifySeverity);
+        Assert.False(settings.SmtpEnabled);
+        Assert.Equal(587, settings.SmtpPort);
+        Assert.True(settings.SmtpUseSsl);
+        Assert.Empty(settings.AlertExcludedDatabases);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsValuesAcrossEverySection()
+    {
+        var store = new ViewerAppSettingsStore(_tempFile);
+        store.Save(new ViewerAppSettings
+        {
+            McpEnabled = true,
+            McpPort = 5200,
+            ConnectionTimeoutSeconds = 30,
+            CsvSeparator = ";",
+            TimeDisplayMode = "UTC",
+            AlertsEnabled = false,
+            AlertCpuThreshold = 65,
+            AlertCpuMode = "SqlOnly",
+            AlertBlockingThreshold = 3,
+            AlertLongRunningQueryMaxResults = 12,
+            AlertLongRunningQueryExcludeCdc = false,
+            AlertExcludedDatabases = new List<string> { "msdb", "tempdb", "DBAtools" },
+            AlertLowDiskThresholdGb = 20,
+            AlertDeliveryMode = "PerEvent",
+            AlertPerEventMaxPerCycle = 25,
+            MuteRuleDefaultExpiration = "7 days",
+            LogAlertDismissals = false,
+            AnalysisEnabled = false,
+            AnalysisIntervalMinutes = 120,
+            AnalysisNotifySeverity = 0.5,
+            SmtpEnabled = true,
+            SmtpServer = "smtp.example.com",
+            SmtpPort = 2525,
+            SmtpUseSsl = false,
+            SmtpUsername = "monitor",
+            SmtpFromAddress = "alerts@example.com",
+            SmtpRecipients = "dba@example.com",
+            TeamsWebhookEnabled = true,
+            TeamsProxyAddress = "http://proxy.corp:8080",
+            SlackWebhookEnabled = true,
+            SlackProxyAddress = "http://proxy.corp:3128",
+        });
+
+        /* A fresh store on the same path proves the values survived a real serialize -> file -> deserialize. */
+        var reloaded = new ViewerAppSettingsStore(_tempFile).Load();
+
+        Assert.True(reloaded.McpEnabled);
+        Assert.Equal(5200, reloaded.McpPort);
+        Assert.Equal(30, reloaded.ConnectionTimeoutSeconds);
+        Assert.Equal(";", reloaded.CsvSeparator);
+        Assert.Equal("UTC", reloaded.TimeDisplayMode);
+        Assert.False(reloaded.AlertsEnabled);
+        Assert.Equal(65, reloaded.AlertCpuThreshold);
+        Assert.Equal("SqlOnly", reloaded.AlertCpuMode);
+        Assert.Equal(3, reloaded.AlertBlockingThreshold);
+        Assert.Equal(12, reloaded.AlertLongRunningQueryMaxResults);
+        Assert.False(reloaded.AlertLongRunningQueryExcludeCdc);
+        Assert.Equal(new[] { "msdb", "tempdb", "DBAtools" }, reloaded.AlertExcludedDatabases);
+        Assert.Equal(20, reloaded.AlertLowDiskThresholdGb);
+        Assert.Equal("PerEvent", reloaded.AlertDeliveryMode);
+        Assert.Equal(25, reloaded.AlertPerEventMaxPerCycle);
+        Assert.Equal("7 days", reloaded.MuteRuleDefaultExpiration);
+        Assert.False(reloaded.LogAlertDismissals);
+        Assert.False(reloaded.AnalysisEnabled);
+        Assert.Equal(120, reloaded.AnalysisIntervalMinutes);
+        Assert.Equal(0.5, reloaded.AnalysisNotifySeverity);
+        Assert.True(reloaded.SmtpEnabled);
+        Assert.Equal("smtp.example.com", reloaded.SmtpServer);
+        Assert.Equal(2525, reloaded.SmtpPort);
+        Assert.False(reloaded.SmtpUseSsl);
+        Assert.Equal("monitor", reloaded.SmtpUsername);
+        Assert.Equal("alerts@example.com", reloaded.SmtpFromAddress);
+        Assert.Equal("dba@example.com", reloaded.SmtpRecipients);
+        Assert.True(reloaded.TeamsWebhookEnabled);
+        Assert.Equal("http://proxy.corp:8080", reloaded.TeamsProxyAddress);
+        Assert.True(reloaded.SlackWebhookEnabled);
+        Assert.Equal("http://proxy.corp:3128", reloaded.SlackProxyAddress);
+    }
+
+    [Fact]
+    public void Load_ClampsOutOfRangeValues_BackIntoRange()
+    {
+        /* Persist deliberately out-of-range numerics and unknown enum strings by writing the JSON directly,
+           then confirm Load normalizes each one so no control is ever seeded with a bad value. */
+        File.WriteAllText(
+            _tempFile,
+            """
+            {
+              "McpPort": 0,
+              "ConnectionTimeoutSeconds": 1,
+              "AlertCpuThreshold": 999,
+              "AlertCpuMode": "Bogus",
+              "AlertLongRunningQueryMaxResults": 99999,
+              "AlertCooldownMinutes": 500,
+              "AnalysisIntervalMinutes": 2,
+              "AnalysisNotifySeverity": 5.0,
+              "AlertDeliveryMode": "Whenever",
+              "MuteRuleDefaultExpiration": "Whenever",
+              "TimeDisplayMode": "Martian",
+              "CsvSeparator": "|"
+            }
+            """);
+
+        var settings = new ViewerAppSettingsStore(_tempFile).Load();
+
+        Assert.Equal(5152, settings.McpPort);                 // 0 (unset) -> Darling default
+        Assert.Equal(5, settings.ConnectionTimeoutSeconds);   // below min 5 -> 5
+        Assert.Equal(100, settings.AlertCpuThreshold);        // above max 100 -> 100
+        Assert.Equal("Total", settings.AlertCpuMode);         // unknown -> Total
+        Assert.Equal(1000, settings.AlertLongRunningQueryMaxResults); // above max 1000 -> 1000
+        Assert.Equal(120, settings.AlertCooldownMinutes);     // above max 120 -> 120
+        Assert.Equal(5, settings.AnalysisIntervalMinutes);    // below min 5 -> 5
+        Assert.Equal(2.0, settings.AnalysisNotifySeverity);   // above max 2.0 -> 2.0
+        Assert.Equal("Summary", settings.AlertDeliveryMode);  // unknown -> Summary
+        Assert.Equal("24 hours", settings.MuteRuleDefaultExpiration); // unknown -> 24 hours
+        Assert.Equal("ServerTime", settings.TimeDisplayMode); // unknown -> ServerTime
+        Assert.Contains(settings.CsvSeparator, new[] { ",", ";", "\t" }); // unknown -> a valid locale default
+    }
+
+    [Fact]
+    public void Load_WhenFileCorrupt_ReturnsDefaults()
+    {
+        File.WriteAllText(_tempFile, "{ not valid json");
+
+        var settings = new ViewerAppSettingsStore(_tempFile).Load();
+
+        Assert.Equal(5152, settings.McpPort);
+        Assert.True(settings.AlertsEnabled);
+        Assert.Equal(80, settings.AlertCpuThreshold);
+    }
+
+    [Fact]
+    public void ViewerExportSettings_Apply_SeedsTheRuntimeCsvSeparator()
+    {
+        /* The one persisted setting the viewer honors at runtime today: grid CSV export reads this static. */
+        ViewerExportSettings.Apply(new ViewerAppSettings { CsvSeparator = ";" });
+        Assert.Equal(";", ViewerExportSettings.CsvSeparator);
+
+        ViewerExportSettings.Apply(new ViewerAppSettings { CsvSeparator = "\t" });
+        Assert.Equal("\t", ViewerExportSettings.CsvSeparator);
+    }
+
+    [Fact]
+    public void Save_CreatesTheAppDataDirectory_WhenItDoesNotExist()
+    {
+        var nestedDir = Path.Combine(Path.GetTempPath(), $"viewer-settings-dir-{Guid.NewGuid():N}");
+        var nestedFile = Path.Combine(nestedDir, "viewer-settings.json");
+        try
+        {
+            new ViewerAppSettingsStore(nestedFile).Save(new ViewerAppSettings());
+
+            Assert.True(File.Exists(nestedFile));
+        }
+        finally
+        {
+            if (Directory.Exists(nestedDir))
+            {
+                Directory.Delete(nestedDir, recursive: true);
+            }
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/AlertsHistoryTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AlertsHistoryTab.xaml.cs
@@ -367,7 +367,7 @@ public partial class AlertsHistoryTab : UserControl
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
-        DataGridExport.ExportToCsv(sender, "alert_history", ",");
+        DataGridExport.ExportToCsv(sender, "alert_history", ViewerExportSettings.CsvSeparator);
 
     #endregion
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectionLogWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectionLogWindow.xaml.cs
@@ -82,7 +82,7 @@ namespace PerformanceMonitor.Darling.Viewer
         private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
         private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
         private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
-        private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "collection_log", ",");
+        private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "collection_log", ViewerExportSettings.CsvSeparator);
 
         private void Close_Click(object sender, RoutedEventArgs e)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml.cs
@@ -170,7 +170,7 @@ public partial class FinOpsTab : UserControl
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
-        DataGridExport.ExportToCsv(sender, _server.DisplayName, ",");
+        DataGridExport.ExportToCsv(sender, _server.DisplayName, ViewerExportSettings.CsvSeparator);
 
     // ── Column filtering (copied from ViewerServerTab.Filters.cs — the visual-tree-walk variant) ──
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -63,10 +63,21 @@ public partial class MainWindow : Window
     private readonly ViewerPreferencesStore _preferencesStore = new();
     private ViewerPreferences _preferences;
 
+    /// <summary>
+    /// The viewer's per-user application-settings store (the Darling equivalent of Lite's settings.json):
+    /// the MCP toggle, alert thresholds + toggles, notification options, SMTP/webhook config, and the
+    /// automated-analysis knobs the full Settings window edits. Held here so the Settings dialog loads from
+    /// and saves to one shared instance.
+    /// </summary>
+    private readonly ViewerAppSettingsStore _appSettingsStore = new();
+
     public MainWindow()
     {
         InitializeComponent();
         _preferences = _preferencesStore.Load();
+        /* Seed the one persisted app setting the viewer honors at runtime (the CSV export separator) so grid
+           exports use the chosen separator from the first one, before the Settings window is ever opened. */
+        ViewerExportSettings.Apply(_appSettingsStore.Load());
         Loaded += OnLoaded;
         Closed += OnClosed;
     }
@@ -640,18 +651,26 @@ public partial class MainWindow : Window
     // ── Settings ─────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Opens the viewer's Settings dialog (default time range + auto-refresh for newly-opened server tabs).
-    /// On Save, persists the edited settings and updates the in-memory copy so the next opened server tab
-    /// seeds from them; already-open tabs keep their own toolbar state (the simple, predictable rule).
+    /// Opens the viewer's full Settings window (the faithful port of Lite's SettingsWindow). It self-persists
+    /// the application settings (MCP, alerts, notifications, SMTP, webhooks, analysis) to
+    /// <see cref="_appSettingsStore"/> and secrets to Windows Credential Manager; the folded-in viewer
+    /// preferences (default time range + auto-refresh) come back via <see cref="SettingsWindow.Result"/> on a
+    /// successful Save, so we save them and update the in-memory copy that seeds newly-opened server tabs.
+    /// Already-open tabs keep their own toolbar state (the simple, predictable rule). The store connection is
+    /// passed through for "Manage Mute Rules" (null before the store is connected disables that button).
     /// </summary>
     private void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        var settings = new SettingsWindow(_preferences) { Owner = this };
+        var settings = new SettingsWindow(_preferences, _appSettingsStore, _dataService) { Owner = this };
         if (settings.ShowDialog() == true && settings.Result is not null)
         {
             _preferences = settings.Result;
             _preferencesStore.Save(_preferences);
         }
+
+        /* Re-seed the runtime export separator from whatever the window persisted (it self-saves the app
+           settings), so a CSV-separator change takes effect on the next export without a restart. */
+        ViewerExportSettings.Apply(_appSettingsStore.Load());
     }
 
     // ── About ────────────────────────────────────────────────────────────────────────

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -2,75 +2,551 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Settings"
-        Height="300" Width="420"
+        Height="750" Width="750"
+        MinHeight="500" MinWidth="600"
+        ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize"
         Icon="EDD.ico"
-        Background="#22252b"
-        Foreground="#E4E6EB">
-    <!-- The viewer's per-user Settings dialog. Dark-styled via the shared ViewerDarkTheme resource
-         dictionary like the viewer's other dialogs (About, Manage Mute Rules) — ComboBox / CheckBox /
-         Button / TextBlock all pick up ViewerDarkTheme's implicit styles, so only the window chrome
-         needs inline hex. Scope is deliberately tiny: the persisted DEFAULTS that seed a newly-opened
-         server tab's toolbar (ViewerServerTab.TimeRange.cs). It is NOT the service's darling.json
-         (collection/alerts/SMTP live there, not the viewer's business), and the viewer is dark-only,
-         so there is no theme toggle. -->
+        Background="{DynamicResource BackgroundBrush}">
+    <!-- Faithful port of Performance Monitor Lite's SettingsWindow (Lite/Windows/SettingsWindow.xaml),
+         section-for-section. Dark-only like the rest of the viewer: it does NOT merge ViewerDarkTheme.xaml
+         (the two small write-back dialogs do) — it relies on the app-merged Themes/DarkTheme.xaml (App.xaml)
+         for its implicit control styles + brush keys, exactly as the copied per-server / aggregate tab XAML
+         does, so {DynamicResource BackgroundLightBrush} / {StaticResource AccentButton} / the PasswordBox +
+         ComboBox + CheckBox chrome all resolve and render as they do in Lite.
+
+         Persistence adaptation (matching the port): the alert/notification/SMTP/webhook/MCP sections drive
+         Lite's in-process engine; in Darling those are the SERVICE's domain (darling.json). The viewer
+         persists them faithfully in ViewerAppSettings so the window is complete and its state survives a
+         restart — the service honoring a change is a separate wiring concern. The controls that act inside
+         the viewer today work immediately: Manage Mute Rules (writes Postgres), Send Test Email / Send Test
+         Notification (shared connection-independent renderers), and the folded-in viewer preferences
+         (default time range + auto-refresh, formerly #1401). Two Lite-only mechanisms are adapted sensibly:
+         Pause Collection can't reach the remote service (shown disabled/managed), and the per-server
+         Collector Schedule editor has no store model in Darling (shown as an informational panel). -->
     <Window.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="Hyperlink">
+                <Setter Property="Foreground" Value="#6CB6FF"/>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
-
-    <Grid Margin="24">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Settings"
-                   FontSize="18" FontWeight="Bold" Foreground="#E4E6EB" Margin="0,0,0,4"/>
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Settings" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock Text="Configure the viewer and the Darling monitoring service"
+                       FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
+        </StackPanel>
 
-        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Defaults applied when a server tab is opened."
-                   Foreground="#8B93A1" TextWrapping="Wrap" Margin="0,0,0,18"/>
+        <!-- Collection Control -->
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="Data Collection" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock x:Name="CollectionStatusText" Text="Status: Managed by the Darling service" FontSize="12"
+                               Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+                <Button Grid.Column="1" x:Name="PauseResumeButton" Content="Pause Collection"
+                        Click="PauseResumeButton_Click" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Text="Default time range" Margin="0,0,16,12"/>
-        <ComboBox Grid.Row="2" Grid.Column="1" x:Name="TimeRangeCombo" Width="150"
-                  HorizontalAlignment="Left" Margin="0,0,0,12"
-                  ToolTip="Time window each newly-opened server tab starts on">
-            <ComboBoxItem Content="Last 1 hour"/>
-            <ComboBoxItem Content="Last 4 hours"/>
-            <ComboBoxItem Content="Last 12 hours"/>
-            <ComboBoxItem Content="Last 24 hours"/>
-            <ComboBoxItem Content="Last 7 days"/>
-        </ComboBox>
+        <!-- MCP Server Settings -->
+        <Border Grid.Row="2" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="MCP Server (LLM Tool Access)" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Allows LLM clients (Claude Code, etc.) to query monitoring data via the Model Context Protocol. The MCP server is hosted by the Darling service."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <CheckBox x:Name="McpEnabledCheckBox" Content="Enable MCP server" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock Text="Port:" VerticalAlignment="Center" Margin="20,0,6,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="McpPortTextBox" Width="70" Text="5152" VerticalAlignment="Center"/>
+                    <Button Content="Auto" ToolTip="Find an available port"
+                            Margin="6,0,0,0" Padding="8,2"
+                            VerticalAlignment="Center"
+                            Click="AutoPortButton_Click"/>
+                </StackPanel>
+                <TextBlock x:Name="McpStatusText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,6,0,0"/>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button x:Name="CopyMcpCommandButton" Content="Copy Setup Command" Click="CopyMcpCommandButton_Click"/>
+                    <TextBlock Text="Works with Claude Code. Other LLMs may apply, but why would you?"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="8,0,0,0"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
 
-        <CheckBox Grid.Row="3" Grid.ColumnSpan="2" x:Name="AutoRefreshCheckBox"
-                  Content="Auto-refresh new server tabs" Margin="0,0,0,12"
-                  Checked="AutoRefreshCheckBox_Toggled" Unchecked="AutoRefreshCheckBox_Toggled"/>
+        <!-- Viewer Defaults -->
+        <Border Grid.Row="3" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Viewer Defaults" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Default time range:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="DefaultTimeRangeCombo" Width="140" VerticalAlignment="Center"
+                              ToolTip="Time window each newly-opened server tab starts on">
+                        <ComboBoxItem Content="Last 1 hour"/>
+                        <ComboBoxItem Content="Last 4 hours"/>
+                        <ComboBoxItem Content="Last 12 hours"/>
+                        <ComboBoxItem Content="Last 24 hours"/>
+                        <ComboBoxItem Content="Last 7 days"/>
+                    </ComboBox>
+                </StackPanel>
+                <!-- Folded in from #1401: the auto-refresh defaults for newly-opened server tabs. -->
+                <CheckBox x:Name="AutoRefreshCheckBox" Content="Auto-refresh newly-opened server tabs"
+                          Margin="0,10,0,0" Foreground="{DynamicResource ForegroundBrush}"
+                          Checked="AutoRefreshCheckBox_Toggled" Unchecked="AutoRefreshCheckBox_Toggled"/>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Auto-refresh interval:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="AutoRefreshIntervalCombo" Width="140" VerticalAlignment="Center"
+                              ToolTip="How often an auto-refreshing server tab reloads">
+                        <ComboBoxItem Content="30 seconds"/>
+                        <ComboBoxItem Content="1 minute"/>
+                        <ComboBoxItem Content="5 minutes"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                    <TextBlock Text="Connection timeout:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <TextBox x:Name="ConnectionTimeoutBox" Width="50" Text="5" VerticalAlignment="Center"/>
+                    <TextBlock Text="seconds (5–60, increase for VPN/remote connections)"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="6,0,0,0"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="CSV separator:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="CsvSeparatorCombo" Width="140" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Comma (,)" Tag=","/>
+                        <ComboBoxItem Content="Semicolon (;)" Tag=";"/>
+                        <ComboBoxItem Content="Tab" Tag="&#x9;"/>
+                    </ComboBox>
+                    <TextBlock Text="auto-detected from locale"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="6,0,0,0" x:Name="CsvSeparatorHint"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Show timestamps in:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="TimeDisplayModeCombo" Width="140" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                        <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                        <ComboBoxItem Content="UTC" Tag="UTC"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Color theme:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="ColorThemeCombo" Width="140" VerticalAlignment="Center" IsEnabled="False">
+                        <ComboBoxItem Content="Dark" IsSelected="True"/>
+                    </ComboBox>
+                    <TextBlock Text="the Darling viewer is dark-only"
+                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                               VerticalAlignment="Center" Margin="6,0,0,0"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Auto-refresh interval" Margin="0,0,16,0"/>
-        <ComboBox Grid.Row="4" Grid.Column="1" x:Name="AutoRefreshIntervalCombo" Width="150"
-                  HorizontalAlignment="Left"
-                  ToolTip="How often an auto-refreshing server tab reloads">
-            <ComboBoxItem Content="30 seconds"/>
-            <ComboBoxItem Content="1 minute"/>
-            <ComboBoxItem Content="5 minutes"/>
-        </ComboBox>
+        <!-- Notifications -->
+        <Border Grid.Row="4" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                    <Button x:Name="RestoreAlertDefaultsButton" Content="Restore Defaults" Margin="12,0,0,0"
+                            FontSize="11" VerticalAlignment="Center" Click="RestoreAlertDefaultsButton_Click"/>
+                </StackPanel>
+                <CheckBox x:Name="MinimizeToTrayCheckBox" Content="Minimize to system tray" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
+                <CheckBox x:Name="AlertsEnabledCheckBox" Content="Enable notifications" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="AlertsEnabledCheckBox_Changed" Unchecked="AlertsEnabledCheckBox_Changed"/>
+                <CheckBox x:Name="NotifyConnectionCheckBox" Content="Connection lost / restored" Margin="20,6,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertCpuCheckBox" Content="CPU above" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertCpuThresholdBox" Width="45" Text="80" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="%" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock Text="measured as" VerticalAlignment="Center" Margin="8,0,4,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="AlertCpuModeBox" Width="220" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Total non-idle CPU (SQL + other processes)" Tag="Total"/>
+                        <ComboBoxItem Content="SQL Server only (scheduler %)" Tag="SqlOnly"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertBlockingCheckBox" Content="Blocking sessions &#x2265;" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertBlockingThresholdBox" Width="45" Text="1" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertDeadlockCheckBox" Content="Deadlocks &#x2265;" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertDeadlockThresholdBox" Width="45" Text="1" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertPoisonWaitCheckBox" Content="Poison waits (THREADPOOL, etc.) avg wait &#x2265;" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertPoisonWaitThresholdBox" Width="45" Text="500" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="ms" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLongRunningQueryCheckBox" Content="Long-running queries over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLongRunningQueryThresholdBox" Width="45" Text="30" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes," VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock Text="return up to" VerticalAlignment="Center" Margin="6,0,6,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLongRunningQueryMaxResultsBox" Width="45" Text="5" VerticalAlignment="Center"/>
+                    <TextBlock Text="results" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <!-- Long Running Query Filters -->
+                <TextBlock Text="Long Running Query Filters" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,10,0,4"/>
+                <CheckBox x:Name="LrqExcludeSpServerDiagnosticsCheckBox"
+                          Content="Exclude SP_SERVER_DIAGNOSTICS"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
+                <CheckBox x:Name="LrqExcludeWaitForCheckBox"
+                          Content="Exclude WAITFOR / BROKER_RECEIVE_WAITFOR"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
+                <CheckBox x:Name="LrqExcludeBackupsCheckBox"
+                          Content="Exclude backup waits (BACKUPTHREAD, BACKUPIO)"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
+                <CheckBox x:Name="LrqExcludeMiscWaitsCheckBox"
+                          Content="Exclude miscellaneous waits (XE_LIVE_TARGET_TVF)"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4"/>
+                <CheckBox x:Name="LrqExcludeCdcCheckBox"
+                          Content="Exclude CDC capture jobs (sp_MScdc_capture_job, sp_cdc_scan)"
+                          Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,0"/>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertTempDbSpaceCheckBox" Content="tempdb space usage over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertTempDbSpaceThresholdBox" Width="45" Text="80" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="%" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLowDiskCheckBox" Content="Volume free space under" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLowDiskThresholdPercentBox" Width="45" Text="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% or" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLowDiskThresholdGbBox" Width="45" Text="5" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="GB free (Azure SQL DB excluded)" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertLongRunningJobCheckBox" Content="Agent jobs running over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertLongRunningJobMultiplierBox" Width="35" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="x historical average" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertFailedJobCheckBox" Content="Agent job failed in the last" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFailedJobLookbackBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,10,0,0">
+                    <TextBlock Text="Tray notification cooldown:" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertCooldownBox" Width="40" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Email alert cooldown:" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="EmailCooldownBox" Width="40" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <!-- deadlock/blocking notification delivery mode + per-event cap -->
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Deadlock/blocking delivery:" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="AlertDeliveryModeBox" Width="260" VerticalAlignment="Center">
+                        <ComboBoxItem Content="Summary — one card per cycle" Tag="Summary"/>
+                        <ComboBoxItem Content="Per-event — one notification per incident" Tag="PerEvent"/>
+                    </ComboBox>
+                    <TextBlock Text="max" VerticalAlignment="Center" Margin="8,0,4,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertPerEventMaxBox" Width="40" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="/cycle" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <TextBlock x:Name="AlertPreviewText" FontSize="11" FontStyle="Italic"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap" Margin="20,10,0,0"/>
+                <!-- Global Alert Filters -->
+                <TextBlock Text="Global Alert Filters" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,14,0,4"/>
+                <TextBlock Text="Exclude databases from alerts (comma-separated):"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,0,0,4" FontSize="12"/>
+                <TextBox x:Name="AlertExcludedDatabasesBox" Margin="20,0,0,4"/>
+                <TextBlock Text="e.g. DBAtools, msdb, tempdb — applies to blocking, deadlock, and long-running query alerts"
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,0,0,0" TextWrapping="Wrap"/>
 
-        <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Save" Click="SaveButton_Click" IsDefault="True" MinWidth="80" Padding="16,4"/>
-            <Button Content="Cancel" Click="CancelButton_Click" IsCancel="True" MinWidth="80" Padding="16,4" Margin="8,0,0,0"/>
+                <!-- Mute Rules -->
+                <TextBlock Text="Alert Muting" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,14,0,4"/>
+                <StackPanel Orientation="Horizontal" Margin="20,0,0,4">
+                    <TextBlock Text="Default expiration for new mute rules:" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="MuteRuleDefaultExpirationCombo" Width="130" VerticalAlignment="Center">
+                        <ComboBoxItem Content="1 hour"/>
+                        <ComboBoxItem Content="24 hours"/>
+                        <ComboBoxItem Content="7 days"/>
+                        <ComboBoxItem Content="Never"/>
+                    </ComboBox>
+                </StackPanel>
+                <Button x:Name="ManageMuteRulesButton" Content="Manage Mute Rules..."
+                        Click="ManageMuteRulesButton_Click" HorizontalAlignment="Left"
+                        Padding="12,4" Margin="20,4,0,4"/>
+                <TextBlock Text="Create rules to suppress specific recurring alerts while still logging them."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,0,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="LogAlertDismissalsCheckBox" Content="Log alert dismiss and mute actions"
+                          Margin="20,8,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+
+                <!-- Automated Analysis -->
+                <TextBlock Text="Automated Analysis" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="20,14,0,4"/>
+                <TextBlock Text="Periodically run the triage engine and record findings in the Alerts tab. Notifications below are optional — analysis runs and stores findings even with notifications off."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,0,0,4" TextWrapping="Wrap"/>
+                <CheckBox x:Name="AnalysisEnabledCheckBox" Content="Enable automated analysis"
+                          Margin="20,4,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                <CheckBox x:Name="AnalysisNotificationsCheckBox" Content="Send scheduled analysis notifications"
+                          Margin="20,4,0,0" Foreground="{DynamicResource ForegroundBrush}"/>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Run analysis every" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisIntervalBox" Width="45" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Notify on finding severity at or above" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisNotifySeverityBox" Width="45" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="(0.0 - 2.0)" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <TextBlock Text="Requires SMTP or a webhook configured below for delivery; findings are recorded in the Alerts tab either way."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="20,4,0,0" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Email Alerts (Optional) -->
+        <Border Grid.Row="5" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Email Alerts (Optional)" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Send email notifications alongside system tray alerts. Requires an SMTP server."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="SmtpEnabledCheckBox" Content="Enable email alerts" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="SmtpEnabledCheckBox_Changed" Unchecked="SmtpEnabledCheckBox_Changed"/>
+                <Grid Margin="20,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="100"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="SMTP Server:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" x:Name="SmtpServerBox" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Port:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,4">
+                        <TextBox x:Name="SmtpPortBox" Width="70" Text="587"/>
+                        <CheckBox x:Name="SmtpSslCheckBox" Content="Use SSL/TLS" VerticalAlignment="Center" Margin="16,0,0,0"
+                                  Foreground="{DynamicResource ForegroundBrush}" IsChecked="True"/>
+                    </StackPanel>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Username:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" x:Name="SmtpUsernameBox" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Password:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <PasswordBox Grid.Row="3" Grid.Column="1" x:Name="SmtpPasswordBox" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="From Address:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" x:Name="SmtpFromBox" Margin="0,0,0,4"/>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Recipients:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" x:Name="SmtpRecipientsBox" Margin="0,0,0,4"
+                             ToolTip="Comma-separated email addresses"/>
+
+                    <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestEmailButton" Content="Send Test Email" Click="TestEmailButton_Click"/>
+                        <Button x:Name="ValidateSmtpButton" Content="Validate Settings" Margin="8,0,0,0"
+                                Click="ValidateSmtpButton_Click"/>
+                        <TextBlock x:Name="SmtpStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <!-- Webhooks (Teams / Slack) -->
+        <Border Grid.Row="6" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <!-- Microsoft Teams -->
+                <TextBlock Text="Microsoft Teams Notifications" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Send alert notifications to a Teams channel via incoming webhook. Color-coded accent bars indicate alert severity."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="TeamsWebhookEnabledCheckBox" Content="Enable Teams notifications" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="TeamsWebhookEnabledCheckBox_Changed" Unchecked="TeamsWebhookEnabledCheckBox_Changed"/>
+                <Grid Margin="20,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="110"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" x:Name="TeamsWebhookUrlBox" Margin="0,0,0,4"
+                             ToolTip="Paste your Teams Incoming Webhook or Power Automate Workflows URL here"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" x:Name="TeamsProxyAddressBox" Margin="0,0,0,4"
+                             ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                    <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestTeamsButton" Content="Send Test Notification" Click="TestTeamsButton_Click"/>
+                        <TextBlock x:Name="TeamsStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+                <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Text="Setup: Create an Incoming Webhook connector or a Power Automate Workflows webhook for your Teams channel. "/>
+                    <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+                               RequestNavigate="Hyperlink_RequestNavigate">
+                        Teams Webhooks Documentation
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Slack -->
+                <TextBlock Text="Slack Notifications" FontSize="14" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,20,0,0"/>
+                <TextBlock Text="Send alert notifications to a Slack channel via incoming webhook. Color-coded sidebar indicates alert severity."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <CheckBox x:Name="SlackWebhookEnabledCheckBox" Content="Enable Slack notifications" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}" Checked="SlackWebhookEnabledCheckBox_Changed" Unchecked="SlackWebhookEnabledCheckBox_Changed"/>
+                <Grid Margin="20,6,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="110"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Webhook URL:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" x:Name="SlackWebhookUrlBox" Margin="0,0,0,4"
+                             ToolTip="Paste your Slack Incoming Webhook URL here"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Proxy Address:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,4"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" x:Name="SlackProxyAddressBox" Margin="0,0,0,4"
+                             ToolTip="Optional HTTP proxy (e.g. http://proxy.corp:8080). Leave blank for direct connection."/>
+
+                    <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button x:Name="TestSlackButton" Content="Send Test Notification" Click="TestSlackButton_Click"/>
+                        <TextBlock x:Name="SlackStatusText" FontSize="11" FontStyle="Italic"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+                <TextBlock Margin="20,8,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Text="Setup: Create an Incoming Webhook app in your Slack workspace settings. "/>
+                    <Hyperlink NavigateUri="https://api.slack.com/messaging/webhooks"
+                               RequestNavigate="Hyperlink_RequestNavigate">
+                        Slack Webhooks Documentation
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Severity Color Reference -->
+                <TextBlock Text="Alert Severity Colors" FontWeight="SemiBold" FontSize="12"
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,16,0,4"/>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#DC2626" FontWeight="Bold" Text="&#x25A0; Red" /> — Critical (Deadlocks, Poison Waits, Server Unreachable)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#D97706" FontWeight="Bold" Text="&#x25A0; Orange" /> — Alert / Warning (Blocking, Long-Running Queries, tempdb, Jobs)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#F59E0B" FontWeight="Bold" Text="&#x25A0; Yellow" /> — Warning (High CPU)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,2">
+                    <Run Foreground="#16A34A" FontWeight="Bold" Text="&#x25A0; Green" /> — Resolved (Server Restored)
+                </TextBlock>
+                <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
+                    <Run Foreground="#2eaef1" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
+                </TextBlock>
+            </StackPanel>
+        </Border>
+
+        <!-- Collection Schedule (service-managed) -->
+        <Border Grid.Row="7" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
+            <StackPanel>
+                <TextBlock Text="Collection Schedule" FontSize="14" FontWeight="SemiBold"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Collection cadence is managed by the Darling service (darling.json). The service collects from every registered server on its own schedule; the viewer reads what it has collected and does not control the schedule."
+                           FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,6,0,0" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Save" Click="SaveButton_Click" Style="{DynamicResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Close" Click="CloseButton_Click"/>
         </StackPanel>
     </Grid>
+    </ScrollViewer>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -6,44 +6,118 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The viewer's per-user Settings dialog: the persisted DEFAULTS that seed a newly-opened server tab's
-/// toolbar (default time range + auto-refresh on/off + interval). Loaded from and saved to
-/// <see cref="ViewerPreferencesStore"/> by MainWindow; this window only edits an in-memory copy and hands
-/// the result back on Save. Changing settings applies to tabs opened afterward — open tabs keep their own
-/// toolbar state (the simple, predictable rule). The dialog's combo item order mirrors the toolbar's, so
-/// a selected index means the same thing here and there.
+/// The viewer's full Settings window — a faithful, section-for-section port of Performance Monitor Lite's
+/// <c>SettingsWindow</c> (Lite/Windows/SettingsWindow.xaml.cs), adapted DuckDB/in-process → Postgres/service
+/// the same way the rest of the viewer was ported. Every section from Lite is present: Data Collection, MCP
+/// server, viewer defaults (with the #1401 time-range + auto-refresh preferences folded in), the full
+/// notifications block (alert thresholds, toggles, LRQ filters, cooldowns, delivery mode, global filters,
+/// mute-rule default, automated analysis), SMTP email, Teams/Slack webhooks, and the collection schedule.
+///
+/// <para>
+/// Persistence: the alert/notification/SMTP/webhook/MCP values are persisted in <see cref="ViewerAppSettings"/>
+/// (the Darling equivalent of Lite's <c>App.*</c> + settings.json); secrets go to Windows Credential Manager
+/// via <see cref="ViewerSecretStore"/>, exactly as Lite stores them. The folded-in viewer preferences round-trip
+/// through <see cref="ViewerPreferences"/> (handed back to <see cref="MainWindow"/> via <see cref="Result"/>).
+/// In Darling those alert/collection values are the SERVICE's domain (darling.json); the window persists them
+/// faithfully so it is complete and its state survives a restart — the service honoring a change is a separate
+/// wiring concern (see the PR body). The controls that act inside the viewer TODAY work immediately: Manage Mute
+/// Rules (writes Postgres), Send Test Email / Send Test Notification (the shared, connection-independent
+/// renderers), Validate Settings, and the viewer preferences.
+/// </para>
+///
+/// <para>
+/// Two Lite-only MECHANISMS are adapted sensibly (matching how "Pause Collection" is handled in the port):
+/// the Data Collection Pause button can't reach the remote service, so it is shown disabled with a
+/// service-managed status; and the per-server Collector Schedule editor (Lite's ScheduleManager +
+/// CollectorScheduleEditorWindow) has no store model in Darling, so the section is an informational panel.
+/// </para>
 /// </summary>
 public partial class SettingsWindow : Window
 {
-    /// <summary>The edited settings, populated on Save. Null until the user clicks Save (Cancel leaves it null).</summary>
+    /// <summary>Branding the shared email/webhook renderers stamp on test messages (mirrors the service's).</summary>
+    private static readonly AlertBranding s_branding = new("Performance Monitor Darling", null);
+
+    private readonly ViewerAppSettingsStore _appSettingsStore;
+    private readonly ViewerAppSettings _appSettings;
+    private readonly ViewerDataService? _dataService;
+
+    /// <summary>
+    /// The edited viewer preferences (default time range + auto-refresh), populated on a successful Save so
+    /// <see cref="MainWindow"/> can refresh its in-memory copy that seeds newly-opened server tabs. Null until
+    /// Save succeeds (Close without saving leaves it null).
+    /// </summary>
     public ViewerPreferences? Result { get; private set; }
 
-    public SettingsWindow(ViewerPreferences current)
+    /// <param name="preferences">Current viewer preferences (the toolbar-seed defaults) to seed the controls.</param>
+    /// <param name="appSettingsStore">The store this window loads from and saves the app settings to.</param>
+    /// <param name="dataService">The store connection, for "Manage Mute Rules"; null when not connected yet (button disabled).</param>
+    public SettingsWindow(ViewerPreferences preferences, ViewerAppSettingsStore appSettingsStore, ViewerDataService? dataService)
     {
+        ArgumentNullException.ThrowIfNull(preferences);
+        ArgumentNullException.ThrowIfNull(appSettingsStore);
+
         InitializeComponent();
 
-        /* Seed the controls from the current settings (normalized so an out-of-range persisted index can
-           never leave a combo unselected). The combos mirror the toolbar's item order, so the stored
-           index selects the matching row directly. */
+        _appSettingsStore = appSettingsStore;
+        _appSettings = appSettingsStore.Load();
+        _dataService = dataService;
+
+        LoadViewerPreferences(preferences);
+        UpdateCollectionStatus();
+        LoadMcpSettings();
+        UpdateMcpStatus();
+        LoadConnectionTimeout();
+        LoadCsvSeparator();
+        LoadTimeDisplayMode();
+        LoadAlertSettings();
+        LoadSmtpSettings();
+        LoadWebhookSettings();
+
+        /* Manage Mute Rules writes the shared Postgres config; needs a live store connection. */
+        ManageMuteRulesButton.IsEnabled = _dataService is not null;
+    }
+
+    // ── Viewer preferences (folded in from #1401: default time range + auto-refresh) ──
+
+    private void LoadViewerPreferences(ViewerPreferences preferences)
+    {
+        /* Normalize so an out-of-range persisted index can never leave a combo unselected; the combos mirror
+           the toolbar's item order, so the stored index selects the matching row directly. */
         var normalized = new ViewerPreferences
         {
-            DefaultTimeRangeIndex = current.DefaultTimeRangeIndex,
-            AutoRefreshEnabled = current.AutoRefreshEnabled,
-            AutoRefreshIntervalIndex = current.AutoRefreshIntervalIndex,
+            DefaultTimeRangeIndex = preferences.DefaultTimeRangeIndex,
+            AutoRefreshEnabled = preferences.AutoRefreshEnabled,
+            AutoRefreshIntervalIndex = preferences.AutoRefreshIntervalIndex,
         }.Normalize();
 
-        TimeRangeCombo.SelectedIndex = normalized.DefaultTimeRangeIndex;
+        DefaultTimeRangeCombo.SelectedIndex = normalized.DefaultTimeRangeIndex;
         AutoRefreshCheckBox.IsChecked = normalized.AutoRefreshEnabled;
         AutoRefreshIntervalCombo.SelectedIndex = normalized.AutoRefreshIntervalIndex;
-
-        /* The interval only matters while auto-refresh is on, so grey it out when the box is unchecked. */
         AutoRefreshIntervalCombo.IsEnabled = normalized.AutoRefreshEnabled;
     }
+
+    private ViewerPreferences BuildViewerPreferences() => new ViewerPreferences
+    {
+        DefaultTimeRangeIndex = DefaultTimeRangeCombo.SelectedIndex,
+        AutoRefreshEnabled = AutoRefreshCheckBox.IsChecked == true,
+        AutoRefreshIntervalIndex = AutoRefreshIntervalCombo.SelectedIndex,
+    }.Normalize();
 
     private void AutoRefreshCheckBox_Toggled(object sender, RoutedEventArgs e)
     {
@@ -54,22 +128,705 @@ public partial class SettingsWindow : Window
         }
     }
 
+    // ── Data Collection (adapted: collection runs in the remote service) ──
+
+    private void UpdateCollectionStatus()
+    {
+        /* The viewer has no in-process collector to pause — collection runs in the Darling service, which the
+           viewer cannot reach to pause. Present it honestly and disable the button (Lite disables it the same
+           way when it has no background service). */
+        CollectionStatusText.Text = "Status: Managed by the Darling service (the viewer cannot pause remote collection)";
+        PauseResumeButton.IsEnabled = false;
+    }
+
+    private void PauseResumeButton_Click(object sender, RoutedEventArgs e)
+    {
+        /* No-op: collection runs in the remote service. The button is disabled; this handler only satisfies
+           the XAML binding. */
+    }
+
+    // ── MCP server (the service hosts the MCP; the viewer persists the desired config) ──
+
+    private void LoadMcpSettings()
+    {
+        McpEnabledCheckBox.IsChecked = _appSettings.McpEnabled;
+        McpPortTextBox.Text = _appSettings.McpPort.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private void UpdateMcpStatus()
+    {
+        McpStatusText.Text = McpEnabledCheckBox.IsChecked == true
+            ? "The MCP server is hosted by the Darling service; restart the service to apply changes."
+            : "Status: Disabled";
+    }
+
+    /// <summary>Applies the MCP fields to <see cref="_appSettings"/>. Returns false only when an ENABLED server has a bad port.</summary>
+    private bool SaveMcpSettings()
+    {
+        _appSettings.McpEnabled = McpEnabledCheckBox.IsChecked == true;
+
+        if (int.TryParse(McpPortTextBox.Text, out var port) && port is >= 1024 and <= 65535)
+        {
+            _appSettings.McpPort = port;
+            return true;
+        }
+
+        if (_appSettings.McpEnabled)
+        {
+            MessageBox.Show(
+                "MCP port must be between 1024 and 65535.\nPorts 0–1023 are well-known privileged ports reserved by the operating system.",
+                "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void CopyMcpCommandButton_Click(object sender, RoutedEventArgs e)
+    {
+        var port = McpPortTextBox.Text;
+        var command = $"claude mcp add --transport http --scope user sql-monitor-darling http://localhost:{port}/";
+        /* SetDataObject with copy=false avoids WPF's problematic Clipboard.Flush(). */
+        Clipboard.SetDataObject(command, false);
+        McpStatusText.Text = "Copied to clipboard!";
+    }
+
+    private void AutoPortButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            McpPortTextBox.Text = FindFreeTcpPort().ToString(CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not find an available port: {ex.Message}",
+                "Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    /// <summary>Asks the OS for a free loopback TCP port (bind to port 0, read the assignment, release).</summary>
+    private static int FindFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    // ── Viewer defaults (connection timeout, CSV separator, timestamp display) ──
+
+    private void LoadConnectionTimeout() =>
+        ConnectionTimeoutBox.Text = _appSettings.ConnectionTimeoutSeconds.ToString(CultureInfo.InvariantCulture);
+
+    private void SaveConnectionTimeout()
+    {
+        if (int.TryParse(ConnectionTimeoutBox.Text, out var timeout) && timeout is >= 5 and <= 60)
+        {
+            _appSettings.ConnectionTimeoutSeconds = timeout;
+        }
+    }
+
+    private void LoadCsvSeparator()
+    {
+        foreach (ComboBoxItem item in CsvSeparatorCombo.Items)
+        {
+            if (item.Tag?.ToString() == _appSettings.CsvSeparator)
+            {
+                CsvSeparatorCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (CsvSeparatorCombo.SelectedItem == null)
+        {
+            CsvSeparatorCombo.SelectedIndex = 0;
+        }
+    }
+
+    private void SaveCsvSeparator()
+    {
+        if (CsvSeparatorCombo.SelectedItem is ComboBoxItem { Tag: string sep })
+        {
+            _appSettings.CsvSeparator = sep;
+        }
+    }
+
+    private void LoadTimeDisplayMode()
+    {
+        foreach (ComboBoxItem item in TimeDisplayModeCombo.Items)
+        {
+            if (item.Tag?.ToString() == _appSettings.TimeDisplayMode)
+            {
+                TimeDisplayModeCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (TimeDisplayModeCombo.SelectedItem == null)
+        {
+            TimeDisplayModeCombo.SelectedIndex = 0;
+        }
+    }
+
+    private void SaveTimeDisplayMode()
+    {
+        if (TimeDisplayModeCombo.SelectedItem is ComboBoxItem { Tag: string mode })
+        {
+            _appSettings.TimeDisplayMode = mode;
+        }
+    }
+
+    // ── Notifications / alert thresholds ──
+
+    private void LoadAlertSettings()
+    {
+        MinimizeToTrayCheckBox.IsChecked = _appSettings.MinimizeToTray;
+        AlertsEnabledCheckBox.IsChecked = _appSettings.AlertsEnabled;
+        NotifyConnectionCheckBox.IsChecked = _appSettings.NotifyConnectionChanges;
+        AlertCpuCheckBox.IsChecked = _appSettings.AlertCpuEnabled;
+        AlertCpuThresholdBox.Text = _appSettings.AlertCpuThreshold.ToString(CultureInfo.InvariantCulture);
+        AlertCpuModeBox.SelectedIndex = _appSettings.AlertCpuMode == "SqlOnly" ? 1 : 0;
+        AlertBlockingCheckBox.IsChecked = _appSettings.AlertBlockingEnabled;
+        AlertBlockingThresholdBox.Text = _appSettings.AlertBlockingThreshold.ToString(CultureInfo.InvariantCulture);
+        AlertDeadlockCheckBox.IsChecked = _appSettings.AlertDeadlockEnabled;
+        AlertDeadlockThresholdBox.Text = _appSettings.AlertDeadlockThreshold.ToString(CultureInfo.InvariantCulture);
+        AlertPoisonWaitCheckBox.IsChecked = _appSettings.AlertPoisonWaitEnabled;
+        AlertPoisonWaitThresholdBox.Text = _appSettings.AlertPoisonWaitThresholdMs.ToString(CultureInfo.InvariantCulture);
+        AlertLongRunningQueryCheckBox.IsChecked = _appSettings.AlertLongRunningQueryEnabled;
+        AlertLongRunningQueryThresholdBox.Text = _appSettings.AlertLongRunningQueryThresholdMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertLongRunningQueryMaxResultsBox.Text = _appSettings.AlertLongRunningQueryMaxResults.ToString(CultureInfo.InvariantCulture);
+        LrqExcludeSpServerDiagnosticsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeSpServerDiagnostics;
+        LrqExcludeWaitForCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeWaitFor;
+        LrqExcludeBackupsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeBackups;
+        LrqExcludeMiscWaitsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeMiscWaits;
+        LrqExcludeCdcCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeCdc;
+        AlertExcludedDatabasesBox.Text = string.Join(", ", _appSettings.AlertExcludedDatabases);
+        AlertTempDbSpaceCheckBox.IsChecked = _appSettings.AlertTempDbSpaceEnabled;
+        AlertTempDbSpaceThresholdBox.Text = _appSettings.AlertTempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
+        AlertLowDiskCheckBox.IsChecked = _appSettings.AlertLowDiskEnabled;
+        AlertLowDiskThresholdPercentBox.Text = _appSettings.AlertLowDiskThresholdPercent.ToString(CultureInfo.InvariantCulture);
+        AlertLowDiskThresholdGbBox.Text = _appSettings.AlertLowDiskThresholdGb.ToString(CultureInfo.InvariantCulture);
+        AlertLongRunningJobCheckBox.IsChecked = _appSettings.AlertLongRunningJobEnabled;
+        AlertLongRunningJobMultiplierBox.Text = _appSettings.AlertLongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
+        AlertFailedJobCheckBox.IsChecked = _appSettings.AlertFailedJobEnabled;
+        AlertFailedJobLookbackBox.Text = _appSettings.AlertFailedJobLookbackMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertCooldownBox.Text = _appSettings.AlertCooldownMinutes.ToString(CultureInfo.InvariantCulture);
+        EmailCooldownBox.Text = _appSettings.EmailCooldownMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertDeliveryModeBox.SelectedIndex = _appSettings.AlertDeliveryMode == "PerEvent" ? 1 : 0;
+        AlertPerEventMaxBox.Text = _appSettings.AlertPerEventMaxPerCycle.ToString(CultureInfo.InvariantCulture);
+        MuteRuleDefaultExpirationCombo.SelectedIndex = _appSettings.MuteRuleDefaultExpiration switch
+        {
+            "1 hour" => 0,
+            "24 hours" => 1,
+            "7 days" => 2,
+            _ => 3
+        };
+        LogAlertDismissalsCheckBox.IsChecked = _appSettings.LogAlertDismissals;
+        AnalysisEnabledCheckBox.IsChecked = _appSettings.AnalysisEnabled;
+        AnalysisNotificationsCheckBox.IsChecked = _appSettings.AnalysisNotificationsEnabled;
+        AnalysisIntervalBox.Text = _appSettings.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
+        AnalysisNotifySeverityBox.Text = _appSettings.AnalysisNotifySeverity.ToString("0.0", CultureInfo.InvariantCulture);
+        UpdateAlertControlStates();
+    }
+
+    private bool SaveAlertSettings()
+    {
+        _appSettings.MinimizeToTray = MinimizeToTrayCheckBox.IsChecked == true;
+        _appSettings.AlertsEnabled = AlertsEnabledCheckBox.IsChecked == true;
+        _appSettings.NotifyConnectionChanges = NotifyConnectionCheckBox.IsChecked == true;
+        _appSettings.AlertCpuEnabled = AlertCpuCheckBox.IsChecked == true;
+        if (int.TryParse(AlertCpuThresholdBox.Text, out var cpu) && cpu is > 0 and <= 100)
+            _appSettings.AlertCpuThreshold = cpu;
+        _appSettings.AlertCpuMode = AlertCpuModeBox.SelectedIndex == 1 ? "SqlOnly" : "Total";
+        _appSettings.AlertBlockingEnabled = AlertBlockingCheckBox.IsChecked == true;
+        if (int.TryParse(AlertBlockingThresholdBox.Text, out var blocking) && blocking > 0)
+            _appSettings.AlertBlockingThreshold = blocking;
+        _appSettings.AlertDeadlockEnabled = AlertDeadlockCheckBox.IsChecked == true;
+        if (int.TryParse(AlertDeadlockThresholdBox.Text, out var deadlock) && deadlock > 0)
+            _appSettings.AlertDeadlockThreshold = deadlock;
+        _appSettings.AlertPoisonWaitEnabled = AlertPoisonWaitCheckBox.IsChecked == true;
+        if (int.TryParse(AlertPoisonWaitThresholdBox.Text, out var poisonWait) && poisonWait > 0)
+            _appSettings.AlertPoisonWaitThresholdMs = poisonWait;
+        _appSettings.AlertLongRunningQueryEnabled = AlertLongRunningQueryCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLongRunningQueryThresholdBox.Text, out var lrq) && lrq > 0)
+            _appSettings.AlertLongRunningQueryThresholdMinutes = lrq;
+        if (int.TryParse(AlertLongRunningQueryMaxResultsBox.Text, out var lrqMax) && lrqMax >= 1)
+            _appSettings.AlertLongRunningQueryMaxResults = lrqMax;
+        _appSettings.AlertLongRunningQueryExcludeSpServerDiagnostics = LrqExcludeSpServerDiagnosticsCheckBox.IsChecked == true;
+        _appSettings.AlertLongRunningQueryExcludeWaitFor = LrqExcludeWaitForCheckBox.IsChecked == true;
+        _appSettings.AlertLongRunningQueryExcludeBackups = LrqExcludeBackupsCheckBox.IsChecked == true;
+        _appSettings.AlertLongRunningQueryExcludeMiscWaits = LrqExcludeMiscWaitsCheckBox.IsChecked == true;
+        _appSettings.AlertLongRunningQueryExcludeCdc = LrqExcludeCdcCheckBox.IsChecked == true;
+        _appSettings.AlertExcludedDatabases = AlertExcludedDatabasesBox.Text
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0)
+            .ToList();
+        _appSettings.AlertTempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true;
+        if (int.TryParse(AlertTempDbSpaceThresholdBox.Text, out var tempDb) && tempDb is > 0 and <= 100)
+            _appSettings.AlertTempDbSpaceThresholdPercent = tempDb;
+        _appSettings.AlertLowDiskEnabled = AlertLowDiskCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLowDiskThresholdPercentBox.Text, out var lowDiskPct) && lowDiskPct is >= 0 and <= 100)
+            _appSettings.AlertLowDiskThresholdPercent = lowDiskPct;
+        if (int.TryParse(AlertLowDiskThresholdGbBox.Text, out var lowDiskGb) && lowDiskGb >= 0)
+            _appSettings.AlertLowDiskThresholdGb = lowDiskGb;
+        _appSettings.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
+        if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult is >= 2 and <= 20)
+            _appSettings.AlertLongRunningJobMultiplier = jobMult;
+        _appSettings.AlertFailedJobEnabled = AlertFailedJobCheckBox.IsChecked == true;
+        if (int.TryParse(AlertFailedJobLookbackBox.Text, out var failedJobLookback) && failedJobLookback is >= 1 and <= 1440)
+            _appSettings.AlertFailedJobLookbackMinutes = failedJobLookback;
+
+        var validationErrors = new List<string>();
+        if (int.TryParse(AlertCooldownBox.Text, out var alertCooldown) && alertCooldown is >= 1 and <= 120)
+            _appSettings.AlertCooldownMinutes = alertCooldown;
+        else
+            validationErrors.Add("Tray notification cooldown must be between 1 and 120 minutes.");
+        if (int.TryParse(EmailCooldownBox.Text, out var emailCooldown) && emailCooldown is >= 1 and <= 120)
+            _appSettings.EmailCooldownMinutes = emailCooldown;
+        else
+            validationErrors.Add("Email alert cooldown must be between 1 and 120 minutes.");
+        _appSettings.AlertDeliveryMode = AlertDeliveryModeBox.SelectedIndex == 1 ? "PerEvent" : "Summary";
+        if (int.TryParse(AlertPerEventMaxBox.Text, out var perEventMax) && perEventMax is >= 1 and <= 100)
+            _appSettings.AlertPerEventMaxPerCycle = perEventMax;
+        else
+            validationErrors.Add("Per-event max-per-cycle must be between 1 and 100.");
+        _appSettings.MuteRuleDefaultExpiration = (MuteRuleDefaultExpirationCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "24 hours";
+        _appSettings.LogAlertDismissals = LogAlertDismissalsCheckBox.IsChecked == true;
+        _appSettings.AnalysisEnabled = AnalysisEnabledCheckBox.IsChecked == true;
+        _appSettings.AnalysisNotificationsEnabled = AnalysisNotificationsCheckBox.IsChecked == true;
+        if (int.TryParse(AnalysisIntervalBox.Text, out var analysisInterval) && analysisInterval is >= 5 and <= 360)
+            _appSettings.AnalysisIntervalMinutes = analysisInterval;
+        else
+            validationErrors.Add("Analysis interval must be between 5 and 360 minutes.");
+        if (double.TryParse(AnalysisNotifySeverityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var analysisSeverity)
+            && analysisSeverity is >= 0.0 and <= 2.0)
+            _appSettings.AnalysisNotifySeverity = analysisSeverity;
+        else
+            validationErrors.Add("Analysis notify severity must be between 0.0 and 2.0.");
+
+        if (validationErrors.Count > 0)
+        {
+            MessageBox.Show(
+                "Some alert settings have invalid values and were not changed:\n\n" +
+                string.Join("\n", validationErrors),
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void AlertsEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateAlertControlStates();
+
+    private void RestoreAlertDefaultsButton_Click(object sender, RoutedEventArgs e)
+    {
+        AlertCpuThresholdBox.Text = "80";
+        AlertCpuModeBox.SelectedIndex = 0; // Total
+        AlertBlockingThresholdBox.Text = "1";
+        AlertDeadlockThresholdBox.Text = "1";
+        AlertPoisonWaitThresholdBox.Text = "500";
+        AlertLongRunningQueryThresholdBox.Text = "30";
+        AlertTempDbSpaceThresholdBox.Text = "80";
+        AlertLowDiskThresholdPercentBox.Text = "10";
+        AlertLowDiskThresholdGbBox.Text = "5";
+        AlertLongRunningJobMultiplierBox.Text = "3";
+        AlertFailedJobLookbackBox.Text = "60";
+        AlertCooldownBox.Text = "5";
+        EmailCooldownBox.Text = "15";
+        AlertDeliveryModeBox.SelectedIndex = 0;
+        AlertPerEventMaxBox.Text = "10";
+        AnalysisIntervalBox.Text = "30";
+        AnalysisNotifySeverityBox.Text = "1.5";
+        AlertExcludedDatabasesBox.Text = "";
+        MuteRuleDefaultExpirationCombo.SelectedIndex = 1; // 24 hours
+        UpdateAlertPreviewText();
+    }
+
+    private void ManageMuteRulesButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        var window = new MuteRulesWindow(_dataService) { Owner = this };
+        window.ShowDialog();
+    }
+
+    private void UpdateAlertPreviewText()
+    {
+        var parts = new List<string>();
+
+        if (AlertCpuCheckBox.IsChecked == true)
+        {
+            var cpuLabel = AlertCpuModeBox.SelectedIndex == 1 ? "SQL CPU" : "Total CPU";
+            parts.Add($"{cpuLabel} > {AlertCpuThresholdBox.Text}%");
+        }
+        if (AlertBlockingCheckBox.IsChecked == true)
+            parts.Add($"blocking >= {AlertBlockingThresholdBox.Text}");
+        if (AlertDeadlockCheckBox.IsChecked == true)
+            parts.Add($"deadlocks >= {AlertDeadlockThresholdBox.Text}");
+        if (AlertPoisonWaitCheckBox.IsChecked == true)
+            parts.Add($"poison waits >= {AlertPoisonWaitThresholdBox.Text}ms avg");
+        if (AlertLongRunningQueryCheckBox.IsChecked == true)
+            parts.Add($"queries > {AlertLongRunningQueryThresholdBox.Text}min");
+        if (AlertTempDbSpaceCheckBox.IsChecked == true)
+            parts.Add($"tempdb > {AlertTempDbSpaceThresholdBox.Text}%");
+        if (AlertLowDiskCheckBox.IsChecked == true)
+            parts.Add($"disk free < {AlertLowDiskThresholdPercentBox.Text}% or {AlertLowDiskThresholdGbBox.Text}GB");
+        if (AlertLongRunningJobCheckBox.IsChecked == true)
+            parts.Add($"jobs > {AlertLongRunningJobMultiplierBox.Text}x avg");
+        if (AlertFailedJobCheckBox.IsChecked == true)
+            parts.Add($"failed jobs (last {AlertFailedJobLookbackBox.Text}m)");
+
+        AlertPreviewText.Text = parts.Count > 0
+            ? $"Will alert when: {string.Join(", ", parts)}"
+            : "No alerts enabled";
+    }
+
+    private void UpdateAlertControlStates()
+    {
+        var enabled = AlertsEnabledCheckBox.IsChecked == true;
+        NotifyConnectionCheckBox.IsEnabled = enabled;
+        AlertCpuCheckBox.IsEnabled = enabled;
+        AlertCpuThresholdBox.IsEnabled = enabled;
+        AlertCpuModeBox.IsEnabled = enabled;
+        AlertBlockingCheckBox.IsEnabled = enabled;
+        AlertBlockingThresholdBox.IsEnabled = enabled;
+        AlertDeadlockCheckBox.IsEnabled = enabled;
+        AlertDeadlockThresholdBox.IsEnabled = enabled;
+        AlertPoisonWaitCheckBox.IsEnabled = enabled;
+        AlertPoisonWaitThresholdBox.IsEnabled = enabled;
+        AlertLongRunningQueryCheckBox.IsEnabled = enabled;
+        AlertLongRunningQueryThresholdBox.IsEnabled = enabled;
+        AlertTempDbSpaceCheckBox.IsEnabled = enabled;
+        AlertTempDbSpaceThresholdBox.IsEnabled = enabled;
+        AlertLowDiskCheckBox.IsEnabled = enabled;
+        AlertLowDiskThresholdPercentBox.IsEnabled = enabled;
+        AlertLowDiskThresholdGbBox.IsEnabled = enabled;
+        AlertLongRunningJobCheckBox.IsEnabled = enabled;
+        AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
+        AlertFailedJobCheckBox.IsEnabled = enabled;
+        AlertFailedJobLookbackBox.IsEnabled = enabled;
+        UpdateAlertPreviewText();
+    }
+
+    // ── SMTP email ──
+
+    private void LoadSmtpSettings()
+    {
+        SmtpEnabledCheckBox.IsChecked = _appSettings.SmtpEnabled;
+        SmtpServerBox.Text = _appSettings.SmtpServer;
+        SmtpPortBox.Text = _appSettings.SmtpPort.ToString(CultureInfo.InvariantCulture);
+        SmtpSslCheckBox.IsChecked = _appSettings.SmtpUseSsl;
+        SmtpUsernameBox.Text = _appSettings.SmtpUsername;
+        SmtpFromBox.Text = _appSettings.SmtpFromAddress;
+        SmtpRecipientsBox.Text = _appSettings.SmtpRecipients;
+
+        var password = ViewerSecretStore.GetSmtpPassword();
+        if (!string.IsNullOrEmpty(password))
+        {
+            SmtpPasswordBox.Password = password;
+        }
+
+        UpdateSmtpControlStates();
+    }
+
+    private void SaveSmtpSettings()
+    {
+        _appSettings.SmtpEnabled = SmtpEnabledCheckBox.IsChecked == true;
+        _appSettings.SmtpServer = SmtpServerBox.Text?.Trim() ?? "";
+        if (int.TryParse(SmtpPortBox.Text, out var port) && port is > 0 and < 65536)
+            _appSettings.SmtpPort = port;
+        _appSettings.SmtpUseSsl = SmtpSslCheckBox.IsChecked == true;
+        _appSettings.SmtpUsername = SmtpUsernameBox.Text?.Trim() ?? "";
+        _appSettings.SmtpFromAddress = SmtpFromBox.Text?.Trim() ?? "";
+        _appSettings.SmtpRecipients = SmtpRecipientsBox.Text?.Trim() ?? "";
+
+        /* Password goes to Windows Credential Manager, never the JSON settings file. */
+        if (!string.IsNullOrEmpty(SmtpPasswordBox.Password))
+        {
+            ViewerSecretStore.SaveSmtpPassword(_appSettings.SmtpUsername, SmtpPasswordBox.Password);
+        }
+    }
+
+    private void SmtpEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateSmtpControlStates();
+
+    private void UpdateSmtpControlStates()
+    {
+        var enabled = SmtpEnabledCheckBox.IsChecked == true;
+        SmtpServerBox.IsEnabled = enabled;
+        SmtpPortBox.IsEnabled = enabled;
+        SmtpSslCheckBox.IsEnabled = enabled;
+        SmtpUsernameBox.IsEnabled = enabled;
+        SmtpPasswordBox.IsEnabled = enabled;
+        SmtpFromBox.IsEnabled = enabled;
+        SmtpRecipientsBox.IsEnabled = enabled;
+        TestEmailButton.IsEnabled = enabled;
+        ValidateSmtpButton.IsEnabled = enabled;
+    }
+
+    private void ValidateSmtpButton_Click(object sender, RoutedEventArgs e)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(SmtpServerBox.Text))
+            errors.Add("SMTP server is required");
+        if (!int.TryParse(SmtpPortBox.Text, out var port) || port is < 1 or > 65535)
+            errors.Add("Port must be between 1 and 65535");
+        if (string.IsNullOrWhiteSpace(SmtpFromBox.Text))
+            errors.Add("From address is required");
+        else if (!SmtpFromBox.Text.Trim().Contains('@'))
+            errors.Add("From address must be a valid email");
+        if (string.IsNullOrWhiteSpace(SmtpRecipientsBox.Text))
+            errors.Add("At least one recipient is required");
+
+        if (errors.Count == 0)
+        {
+            SmtpStatusText.Text = "Settings look good. Use 'Send Test Email' to verify delivery.";
+        }
+        else
+        {
+            SmtpStatusText.Text = "";
+            MessageBox.Show(
+                "SMTP configuration has issues:\n\n" + string.Join("\n", errors),
+                "SMTP Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private async void TestEmailButton_Click(object sender, RoutedEventArgs e)
+    {
+        TestEmailButton.IsEnabled = false;
+        TestEmailButton.Content = "Sending...";
+
+        try
+        {
+            /* Build the test settings straight from the live UI (test before save), so the user verifies
+               exactly what they typed. The shared EmailSendCore renders + sends — no store/service needed. */
+            var settings = TestAlertSettings.FromUi(this);
+            var error = await EmailSendCore.SendTestEmailAsync(settings, s_branding);
+            if (error == null)
+            {
+                MessageBox.Show("Test email sent successfully!", "Test Email", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show($"Failed to send test email:\n\n{error}", "Test Email Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        finally
+        {
+            TestEmailButton.Content = "Send Test Email";
+            TestEmailButton.IsEnabled = true;
+        }
+    }
+
+    // ── Webhooks (Teams / Slack) ──
+
+    private void LoadWebhookSettings()
+    {
+        TeamsWebhookEnabledCheckBox.IsChecked = _appSettings.TeamsWebhookEnabled;
+        TeamsWebhookUrlBox.Text = ViewerSecretStore.GetTeamsWebhookUrl();
+        TeamsProxyAddressBox.Text = _appSettings.TeamsProxyAddress;
+        SlackWebhookEnabledCheckBox.IsChecked = _appSettings.SlackWebhookEnabled;
+        SlackWebhookUrlBox.Text = ViewerSecretStore.GetSlackWebhookUrl();
+        SlackProxyAddressBox.Text = _appSettings.SlackProxyAddress;
+        UpdateTeamsControlStates();
+        UpdateSlackControlStates();
+    }
+
+    private void SaveWebhookSettings()
+    {
+        _appSettings.TeamsWebhookEnabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+        _appSettings.TeamsProxyAddress = TeamsProxyAddressBox.Text?.Trim() ?? "";
+        _appSettings.SlackWebhookEnabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+        _appSettings.SlackProxyAddress = SlackProxyAddressBox.Text?.Trim() ?? "";
+
+        /* Webhook URLs go to Windows Credential Manager, never the JSON settings file. */
+        ViewerSecretStore.SaveTeamsWebhookUrl(TeamsWebhookUrlBox.Text?.Trim() ?? "");
+        ViewerSecretStore.SaveSlackWebhookUrl(SlackWebhookUrlBox.Text?.Trim() ?? "");
+    }
+
+    private void TeamsWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateTeamsControlStates();
+
+    private void SlackWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateSlackControlStates();
+
+    private void UpdateTeamsControlStates()
+    {
+        var enabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
+        TeamsWebhookUrlBox.IsEnabled = enabled;
+        TeamsProxyAddressBox.IsEnabled = enabled;
+        TestTeamsButton.IsEnabled = enabled;
+    }
+
+    private void UpdateSlackControlStates()
+    {
+        var enabled = SlackWebhookEnabledCheckBox.IsChecked == true;
+        SlackWebhookUrlBox.IsEnabled = enabled;
+        SlackProxyAddressBox.IsEnabled = enabled;
+        TestSlackButton.IsEnabled = enabled;
+    }
+
+    private async void TestTeamsButton_Click(object sender, RoutedEventArgs e)
+    {
+        TestTeamsButton.IsEnabled = false;
+        TestTeamsButton.Content = "Sending...";
+
+        try
+        {
+            var url = TeamsWebhookUrlBox.Text?.Trim() ?? "";
+            var proxy = TeamsProxyAddressBox.Text?.Trim();
+            var error = await WebhookAlertService.SendTestTeamsAsync(url, proxy, s_branding);
+
+            if (error == null)
+            {
+                MessageBox.Show("Teams test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show($"Failed to send Teams test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to send Teams test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            TestTeamsButton.Content = "Send Test Notification";
+            TestTeamsButton.IsEnabled = true;
+        }
+    }
+
+    private async void TestSlackButton_Click(object sender, RoutedEventArgs e)
+    {
+        TestSlackButton.IsEnabled = false;
+        TestSlackButton.Content = "Sending...";
+
+        try
+        {
+            var url = SlackWebhookUrlBox.Text?.Trim() ?? "";
+            var proxy = SlackProxyAddressBox.Text?.Trim();
+            var error = await WebhookAlertService.SendTestSlackAsync(url, proxy, s_branding);
+
+            if (error == null)
+            {
+                MessageBox.Show("Slack test notification sent successfully!", "Test Webhook", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show($"Failed to send Slack test notification:\n\n{error}", "Test Webhook Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to send Slack test notification:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            TestSlackButton.Content = "Send Test Notification";
+            TestSlackButton.IsEnabled = true;
+        }
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = e.Uri.AbsoluteUri, UseShellExecute = true });
+        }
+        catch { /* A missing default browser must not crash the settings window. */ }
+        e.Handled = true;
+    }
+
+    // ── Save / Close ──
+
     private void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        Result = new ViewerPreferences
+        var mcpValid = SaveMcpSettings();
+        SaveConnectionTimeout();
+        SaveCsvSeparator();
+        SaveTimeDisplayMode();
+        var alertsValid = SaveAlertSettings();
+        SaveSmtpSettings();
+        SaveWebhookSettings();
+
+        /* Persist the app settings (valid values were applied above; invalid ones were skipped and warned
+           about) and capture the edited viewer preferences for MainWindow to save + re-seed tabs from. */
+        _appSettingsStore.Save(_appSettings);
+        Result = BuildViewerPreferences();
+
+        /* Leave the window open on a validation warning so the user can fix the flagged value; otherwise
+           the close IS the confirmation (mirrors the viewer's other dialogs). */
+        if (!alertsValid || !mcpValid)
         {
-            DefaultTimeRangeIndex = TimeRangeCombo.SelectedIndex,
-            AutoRefreshEnabled = AutoRefreshCheckBox.IsChecked == true,
-            AutoRefreshIntervalIndex = AutoRefreshIntervalCombo.SelectedIndex,
-        }.Normalize();
+            return;
+        }
 
         DialogResult = true;
         Close();
     }
 
-    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// A throwaway <see cref="IAlertSettings"/> built from the live SMTP/webhook controls, so "Send Test
+    /// Email" verifies exactly what the user typed without first saving (Lite's "test before save"). Only the
+    /// SMTP members matter for the email test; the rest satisfy the interface with the current UI values.
+    /// </summary>
+    private sealed class TestAlertSettings : IAlertSettings
     {
-        DialogResult = false;
-        Close();
+        public bool SmtpEnabled { get; private init; }
+        public string SmtpServer { get; private init; } = "";
+        public int SmtpPort { get; private init; }
+        public bool SmtpUseSsl { get; private init; }
+        public string SmtpUsername { get; private init; } = "";
+        public string SmtpFromAddress { get; private init; } = "";
+        public string SmtpRecipients { get; private init; } = "";
+        private string SmtpPassword { get; init; } = "";
+        public string? GetSmtpPassword() => string.IsNullOrEmpty(SmtpPassword) ? null : SmtpPassword;
+
+        public int EmailCooldownMinutes { get; private init; }
+
+        public bool TeamsWebhookEnabled { get; private init; }
+        public string TeamsWebhookUrl { get; private init; } = "";
+        public string TeamsProxyAddress { get; private init; } = "";
+
+        public bool SlackWebhookEnabled { get; private init; }
+        public string SlackWebhookUrl { get; private init; } = "";
+        public string SlackProxyAddress { get; private init; } = "";
+
+        public double AnalysisNotifySeverity { get; private init; }
+        public int AnalysisNotifyCooldownMinutes { get; private init; }
+
+        public static TestAlertSettings FromUi(SettingsWindow w)
+        {
+            int.TryParse(w.SmtpPortBox.Text, out var smtpPort);
+            return new TestAlertSettings
+            {
+                SmtpEnabled = w.SmtpEnabledCheckBox.IsChecked == true,
+                SmtpServer = w.SmtpServerBox.Text?.Trim() ?? "",
+                SmtpPort = smtpPort,
+                SmtpUseSsl = w.SmtpSslCheckBox.IsChecked == true,
+                SmtpUsername = w.SmtpUsernameBox.Text?.Trim() ?? "",
+                SmtpFromAddress = w.SmtpFromBox.Text?.Trim() ?? "",
+                SmtpRecipients = w.SmtpRecipientsBox.Text?.Trim() ?? "",
+                SmtpPassword = w.SmtpPasswordBox.Password,
+                EmailCooldownMinutes = w._appSettings.EmailCooldownMinutes,
+                TeamsWebhookEnabled = w.TeamsWebhookEnabledCheckBox.IsChecked == true,
+                TeamsWebhookUrl = w.TeamsWebhookUrlBox.Text?.Trim() ?? "",
+                TeamsProxyAddress = w.TeamsProxyAddressBox.Text?.Trim() ?? "",
+                SlackWebhookEnabled = w.SlackWebhookEnabledCheckBox.IsChecked == true,
+                SlackWebhookUrl = w.SlackWebhookUrlBox.Text?.Trim() ?? "",
+                SlackProxyAddress = w.SlackProxyAddressBox.Text?.Trim() ?? "",
+                AnalysisNotifySeverity = w._appSettings.AnalysisNotifySeverity,
+                AnalysisNotifyCooldownMinutes = w._appSettings.AnalysisNotifyCooldownMinutes,
+            };
+        }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's per-USER application settings — the Darling equivalent of Performance Monitor Lite's
+/// <c>App.*</c> statics (persisted to Lite's settings.json). This is the settings model the full
+/// <see cref="SettingsWindow"/> port reads and writes: the MCP server toggle/port, every alert threshold
+/// and toggle, notification options, SMTP (non-secret fields), Teams/Slack (non-secret fields), automated
+/// analysis, the mute-rule default, and the viewer-side display preferences (connection timeout, CSV
+/// separator, timestamp display mode). Every default mirrors Lite's <c>App.*</c> exactly.
+///
+/// <para>
+/// This is deliberately distinct from the two existing viewer stores:
+/// <see cref="ViewerPreferences"/> holds the tiny toolbar-seed defaults (time range + auto-refresh) that the
+/// server tabs consume directly, and <see cref="ViewerSettings"/> reads the SERVICE's darling.json (the
+/// Postgres connection). These are the front-end's own copy of the operator-facing settings.
+/// </para>
+///
+/// <para>
+/// Scope note (persistence adaptation, matching the rest of the Lite→Darling port): in Lite these values
+/// drive Lite's in-process collector and alert engine; in Darling those are the SERVICE's domain
+/// (darling.json). The viewer persists them here faithfully so the Settings window is complete and its
+/// state survives a restart — making the running service honor a change is a separate wiring concern
+/// (the service reads darling.json, not this file). The controls that DO act inside the viewer today —
+/// Manage Mute Rules (writes Postgres), Send Test Email / Send Test Notification (the shared, connection-
+/// independent renderers), and the viewer preferences folded in — work immediately.
+/// </para>
+///
+/// <para>
+/// Secrets (the SMTP password and the Teams/Slack webhook URLs) are NOT stored in this file — like Lite,
+/// they go to Windows Credential Manager via <see cref="ViewerSecretStore"/>. The mutable properties here
+/// are what <see cref="JsonSerializer"/> round-trips; <see cref="Normalize"/> clamps hand-edited or
+/// forward-version values back into range on load.
+/// </para>
+/// </summary>
+public sealed class ViewerAppSettings
+{
+    /* ---------------- MCP server (service's embedded MCP; darling.json mcp.*) ---------------- */
+
+    /// <summary>Whether the Darling service's embedded MCP server should run. Persisted here; honored by the service.</summary>
+    public bool McpEnabled { get; set; }
+
+    /// <summary>MCP HTTP port. Darling's default (5152) avoids Lite (5151) and the Dashboard (5150).</summary>
+    public int McpPort { get; set; } = 5152;
+
+    /* ---------------- Viewer display preferences ---------------- */
+
+    /// <summary>Connection timeout in seconds for the viewer's store reads (5-60).</summary>
+    public int ConnectionTimeoutSeconds { get; set; } = 5;
+
+    /// <summary>CSV export separator: "," ";" or a tab. Auto-detected from locale on first run.</summary>
+    public string CsvSeparator { get; set; } = DefaultCsvSeparator();
+
+    /// <summary>Timestamp display mode: "ServerTime", "LocalTime", or "UTC".</summary>
+    public string TimeDisplayMode { get; set; } = "ServerTime";
+
+    /* ---------------- Notifications / alert thresholds (mirrors Lite App.*) ---------------- */
+
+    public bool MinimizeToTray { get; set; } = true;
+    public bool AlertsEnabled { get; set; } = true;
+    public bool NotifyConnectionChanges { get; set; } = true;
+
+    public bool AlertCpuEnabled { get; set; } = true;
+    public int AlertCpuThreshold { get; set; } = 80;
+
+    /// <summary>Which CPU metric the alert evaluates against: "Total" (SQL + other processes) or "SqlOnly".</summary>
+    public string AlertCpuMode { get; set; } = "Total";
+
+    public bool AlertBlockingEnabled { get; set; } = true;
+    public int AlertBlockingThreshold { get; set; } = 1;
+    public bool AlertDeadlockEnabled { get; set; } = true;
+    public int AlertDeadlockThreshold { get; set; } = 1;
+    public bool AlertPoisonWaitEnabled { get; set; } = true;
+    public int AlertPoisonWaitThresholdMs { get; set; } = 500;
+
+    public bool AlertLongRunningQueryEnabled { get; set; } = true;
+    public int AlertLongRunningQueryThresholdMinutes { get; set; } = 30;
+    public int AlertLongRunningQueryMaxResults { get; set; } = 5;
+    public bool AlertLongRunningQueryExcludeSpServerDiagnostics { get; set; } = true;
+    public bool AlertLongRunningQueryExcludeWaitFor { get; set; } = true;
+    public bool AlertLongRunningQueryExcludeBackups { get; set; } = true;
+    public bool AlertLongRunningQueryExcludeMiscWaits { get; set; } = true;
+    public bool AlertLongRunningQueryExcludeCdc { get; set; } = true;
+
+    public List<string> AlertExcludedDatabases { get; set; } = new();
+
+    public bool AlertTempDbSpaceEnabled { get; set; } = true;
+    public int AlertTempDbSpaceThresholdPercent { get; set; } = 80;
+
+    public bool AlertLowDiskEnabled { get; set; } = true;
+    public int AlertLowDiskThresholdPercent { get; set; } = 10;
+    public int AlertLowDiskThresholdGb { get; set; } = 5;
+
+    public bool AlertLongRunningJobEnabled { get; set; } = true;
+    public int AlertLongRunningJobMultiplier { get; set; } = 3;
+    public bool AlertFailedJobEnabled { get; set; } = true;
+    public int AlertFailedJobLookbackMinutes { get; set; } = 60;
+
+    public int AlertCooldownMinutes { get; set; } = 5;
+    public int EmailCooldownMinutes { get; set; } = 15;
+
+    /// <summary>Deadlock/blocking notification delivery: "Summary" (one card per cycle) or "PerEvent".</summary>
+    public string AlertDeliveryMode { get; set; } = "Summary";
+    public int AlertPerEventMaxPerCycle { get; set; } = 10;
+
+    /// <summary>Default expiration for new mute rules: "1 hour", "24 hours", "7 days", or "Never".</summary>
+    public string MuteRuleDefaultExpiration { get; set; } = "24 hours";
+    public bool LogAlertDismissals { get; set; } = true;
+
+    public bool AnalysisEnabled { get; set; } = true;
+    public bool AnalysisNotificationsEnabled { get; set; }
+    public int AnalysisIntervalMinutes { get; set; } = 30;
+    public double AnalysisNotifySeverity { get; set; } = 1.5;
+    public int AnalysisNotifyCooldownMinutes { get; set; } = 360;
+
+    /* ---------------- SMTP (non-secret; password lives in Credential Manager) ---------------- */
+
+    public bool SmtpEnabled { get; set; }
+    public string SmtpServer { get; set; } = "";
+    public int SmtpPort { get; set; } = 587;
+    public bool SmtpUseSsl { get; set; } = true;
+    public string SmtpUsername { get; set; } = "";
+    public string SmtpFromAddress { get; set; } = "";
+    public string SmtpRecipients { get; set; } = "";
+
+    /* ---------------- Webhooks (non-secret; URLs live in Credential Manager) ---------------- */
+
+    public bool TeamsWebhookEnabled { get; set; }
+    public string TeamsProxyAddress { get; set; } = "";
+    public bool SlackWebhookEnabled { get; set; }
+    public string SlackProxyAddress { get; set; } = "";
+
+    /// <summary>
+    /// Auto-detect the CSV separator: semicolon when the locale's decimal separator is a comma
+    /// (Italian, German, French, ...), otherwise a comma. Mirrors Lite's <c>App.GetDefaultCsvSeparator</c>.
+    /// </summary>
+    internal static string DefaultCsvSeparator() =>
+        CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator == "," ? ";" : ",";
+
+    /// <summary>
+    /// Clamps every numeric value back into the range the Settings window accepts and coerces the small
+    /// string enums to a known value, then returns this same instance for chaining. Mirrors the clamps in
+    /// Lite's <c>App.LoadAlertSettings</c> plus the window's save-time validation, so a corrupt, hand-edited,
+    /// or forward-version file can never seed an out-of-range control. Pure and file-I/O-free (unit-testable).
+    /// </summary>
+    internal ViewerAppSettings Normalize()
+    {
+        McpPort = Clamp(McpPort, 1024, 65535, 5152);
+        ConnectionTimeoutSeconds = Clamp(ConnectionTimeoutSeconds, 5, 60, 5);
+        CsvSeparator = (CsvSeparator == "," || CsvSeparator == ";" || CsvSeparator == "\t") ? CsvSeparator : DefaultCsvSeparator();
+        TimeDisplayMode = (TimeDisplayMode is "ServerTime" or "LocalTime" or "UTC") ? TimeDisplayMode : "ServerTime";
+
+        AlertCpuThreshold = Clamp(AlertCpuThreshold, 1, 100, 80);
+        AlertCpuMode = (AlertCpuMode is "Total" or "SqlOnly") ? AlertCpuMode : "Total";
+        AlertBlockingThreshold = Clamp(AlertBlockingThreshold, 1, int.MaxValue, 1);
+        AlertDeadlockThreshold = Clamp(AlertDeadlockThreshold, 1, int.MaxValue, 1);
+        AlertPoisonWaitThresholdMs = Clamp(AlertPoisonWaitThresholdMs, 1, int.MaxValue, 500);
+        AlertLongRunningQueryThresholdMinutes = Clamp(AlertLongRunningQueryThresholdMinutes, 1, int.MaxValue, 30);
+        AlertLongRunningQueryMaxResults = Clamp(AlertLongRunningQueryMaxResults, 1, 1000, 5);
+        AlertTempDbSpaceThresholdPercent = Clamp(AlertTempDbSpaceThresholdPercent, 1, 100, 80);
+        AlertLowDiskThresholdPercent = Clamp(AlertLowDiskThresholdPercent, 0, 100, 10);
+        AlertLowDiskThresholdGb = Clamp(AlertLowDiskThresholdGb, 0, int.MaxValue, 5);
+        AlertLongRunningJobMultiplier = Clamp(AlertLongRunningJobMultiplier, 2, 20, 3);
+        AlertFailedJobLookbackMinutes = Clamp(AlertFailedJobLookbackMinutes, 1, 1440, 60);
+        AlertCooldownMinutes = Clamp(AlertCooldownMinutes, 1, 120, 5);
+        EmailCooldownMinutes = Clamp(EmailCooldownMinutes, 1, 120, 15);
+        AlertDeliveryMode = (AlertDeliveryMode is "Summary" or "PerEvent") ? AlertDeliveryMode : "Summary";
+        AlertPerEventMaxPerCycle = Clamp(AlertPerEventMaxPerCycle, 1, 100, 10);
+        MuteRuleDefaultExpiration = (MuteRuleDefaultExpiration is "1 hour" or "24 hours" or "7 days" or "Never")
+            ? MuteRuleDefaultExpiration : "24 hours";
+
+        AnalysisIntervalMinutes = Clamp(AnalysisIntervalMinutes, 5, 360, 30);
+        AnalysisNotifySeverity = Math.Clamp(AnalysisNotifySeverity, 0.0, 2.0);
+        AnalysisNotifyCooldownMinutes = Clamp(AnalysisNotifyCooldownMinutes, 30, 10080, 360);
+
+        if (SmtpPort is < 1 or > 65535)
+        {
+            SmtpPort = 587;
+        }
+
+        AlertExcludedDatabases ??= new List<string>();
+
+        return this;
+    }
+
+    private static int Clamp(int value, int min, int max, int fallback)
+    {
+        if (value < min || value > max)
+        {
+            /* Snap a value that landed off the low/high end to the nearest bound, but a completely
+               absent (zero) numeric on a min>=1 field reads as "unset" -> use the historical default. */
+            return value <= 0 && min >= 1 ? fallback : Math.Clamp(value, min, max);
+        }
+
+        return value;
+    }
+}
+
+/// <summary>
+/// Loads and saves <see cref="ViewerAppSettings"/> as a JSON file in the viewer's per-user app-data
+/// directory, mirroring <see cref="ViewerPreferencesStore"/> exactly (indented JSON, defaults on a missing
+/// or corrupt file, an injectable path so tests round-trip against a temp file). Default path:
+/// %APPDATA%\PerformanceMonitorDarling\viewer-settings.json — the same Darling-branded per-user folder
+/// <see cref="ViewerPreferencesStore"/> uses, with the file namespaced to the settings.
+/// </summary>
+public sealed class ViewerAppSettingsStore
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+
+    /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
+    public ViewerAppSettingsStore(string? filePath = null)
+    {
+        _filePath = filePath ?? DefaultFilePath();
+    }
+
+    /// <summary>The resolved settings file path (surfaced mainly so tests and diagnostics can name it).</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-settings.json.</summary>
+    public static string DefaultFilePath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-settings.json");
+    }
+
+    /// <summary>
+    /// Reads the settings, returning defaults when the file does not exist yet or cannot be read/parsed —
+    /// the viewer never blocks on a first run or a corrupt file. Loaded values are normalized into range.
+    /// </summary>
+    public ViewerAppSettings Load()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new ViewerAppSettings();
+            }
+
+            var json = File.ReadAllText(_filePath);
+            var settings = JsonSerializer.Deserialize<ViewerAppSettings>(json, s_jsonOptions);
+            return (settings ?? new ViewerAppSettings()).Normalize();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ViewerAppSettingsStore: failed to load '{_filePath}', using defaults: {ex.Message}");
+            return new ViewerAppSettings();
+        }
+    }
+
+    /// <summary>Writes the settings as indented JSON, creating the app-data directory on first save.</summary>
+    public void Save(ViewerAppSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(_filePath, JsonSerializer.Serialize(settings, s_jsonOptions));
+    }
+}
+
+/// <summary>
+/// The one <see cref="ViewerAppSettings"/> value the viewer honors at RUNTIME today: the CSV export
+/// separator, read by the grid copy/export handlers (they call <c>DataGridExport.ExportToCsv(..., separator)</c>).
+/// Held as a process-wide value that <see cref="MainWindow"/> seeds from the persisted settings on startup and
+/// re-applies whenever the Settings window closes, so a change takes effect on the next export without a
+/// restart — mirroring how Lite's export reads <c>App.CsvSeparator</c>. The other persisted settings
+/// (alerts/SMTP/webhooks/MCP/timestamp-display/connection-timeout) are the service's or a larger wiring
+/// concern and are not consumed here yet (see the PR body).
+/// </summary>
+public static class ViewerExportSettings
+{
+    /// <summary>Current CSV export separator ("," ";" or a tab). Defaults to the locale-based default.</summary>
+    public static string CsvSeparator { get; set; } = ViewerAppSettings.DefaultCsvSeparator();
+
+    /// <summary>Seeds the runtime export values from a loaded settings instance.</summary>
+    public static void Apply(ViewerAppSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        CsvSeparator = settings.CsvSeparator;
+    }
+}
+
+/// <summary>
+/// The viewer's secret store for the Settings window: the SMTP password and the Teams/Slack webhook URLs,
+/// kept out of viewer-settings.json and in Windows Credential Manager (DPAPI-encrypted, per-user), exactly
+/// as Lite keeps them. Wraps the shared <see cref="CredentialStore"/> with a Darling-specific prefix so the
+/// viewer's secrets never collide with Lite's or the Dashboard's. Failures are swallowed to null/no-op —
+/// a Settings window must never crash because the credential vault is unavailable.
+/// </summary>
+public static class ViewerSecretStore
+{
+    /* Distinct per-app prefix (see CredentialStore's load-bearing-prefix note). */
+    private static readonly CredentialStore s_store = new("PerformanceMonitorDarling_");
+
+    private const string SmtpKey = "SMTP";
+    private const string TeamsKey = "TeamsWebhook";
+    private const string SlackKey = "SlackWebhook";
+
+    public static string? GetSmtpPassword() => s_store.GetCredential(SmtpKey)?.Password;
+
+    public static void SaveSmtpPassword(string username, string password) =>
+        s_store.SaveCredential(SmtpKey, string.IsNullOrEmpty(username) ? "smtp" : username, password);
+
+    public static string GetTeamsWebhookUrl() => s_store.GetCredential(TeamsKey)?.Password ?? "";
+
+    public static string GetSlackWebhookUrl() => s_store.GetCredential(SlackKey)?.Password ?? "";
+
+    public static void SaveTeamsWebhookUrl(string url) => SaveWebhookUrl(TeamsKey, url);
+
+    public static void SaveSlackWebhookUrl(string url) => SaveWebhookUrl(SlackKey, url);
+
+    private static void SaveWebhookUrl(string key, string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            s_store.DeleteCredential(key);
+        }
+        else
+        {
+            s_store.SaveCredential(key, "webhook", url);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
@@ -45,7 +45,7 @@ public partial class ViewerServerTab
     private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
 
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
-        DataGridExport.ExportToCsv(sender, _server.DisplayName, ",");
+        DataGridExport.ExportToCsv(sender, _server.DisplayName, ViewerExportSettings.CsvSeparator);
 
     private void DownloadBlockedProcessXml_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary

Replaces the Darling viewer's 2-knob Settings **stub** (#1401, "nowhere near complete") with a **faithful, section-for-section port of Performance Monitor Lite's `SettingsWindow`** (`Lite/Windows/SettingsWindow.xaml(.cs)`), adapted DuckDB/in-process → Postgres/service the same way the rest of the viewer was ported from Lite. Nothing from Lite's window is dropped.

The window is dark-only like the rest of the viewer, uses `Icon="EDD.ico"`, and relies on the app-merged `Themes/DarkTheme.xaml` for its control chrome + brush keys (`{DynamicResource BackgroundLightBrush}`, `AccentButton`, PasswordBox/ComboBox/CheckBox), exactly as the copied per-server/aggregate tab XAML does — so it renders as it does in Lite.

## Every section ported (section-for-section with Lite)

1. **Data Collection** — status + Pause button *(adapted: see below)*.
2. **MCP Server** — enable + port + Auto (free-port finder) + Copy Setup Command + status. Default port **5152** (Darling's; avoids Lite 5151 / Dashboard 5150).
3. **Viewer Defaults** (Lite's "Dashboard Defaults") — default time range, connection timeout, CSV separator, timestamp display mode, color theme *(adapted: fixed Dark)*. **The #1401 time-range + auto-refresh viewer prefs are folded in here** as their natural section.
4. **Notifications** — Restore Defaults, minimize-to-tray, enable notifications, connection lost/restored, CPU threshold + mode, blocking, deadlock, poison waits, long-running queries + max results, all 5 LRQ filters, tempdb, low disk (% or GB), long-running job multiplier, failed-job lookback, tray + email cooldowns, deadlock/blocking delivery mode + per-event cap, live alert-preview text, global alert filters (excluded databases), **Alert Muting** (default expiration + **Manage Mute Rules** + description), log dismissals, **Automated Analysis** (enable, notifications, interval, notify severity).
5. **Email Alerts (SMTP)** — server, port, SSL, username, password, from, recipients, **Send Test Email**, **Validate Settings**, status.
6. **Webhooks** — **Microsoft Teams** (enable, URL, proxy, **Send Test Notification**, status, docs link) + **Slack** (same) + the Alert Severity Colors reference.
7. **Collection Schedule** — *(adapted: see below)*.
8. **Save / Close**.

## Persistence adaptation

New **`ViewerAppSettings` + `ViewerAppSettingsStore`** — the Darling equivalent of Lite's `App.*` statics + `settings.json` — persisted to `%APPDATA%\PerformanceMonitorDarling\viewer-settings.json` (mirroring `ViewerPreferencesStore`), with load-time clamping of out-of-range values and Lite-matching defaults. Secrets (SMTP password, Teams/Slack URLs) go to **Windows Credential Manager** via `ViewerSecretStore` (shared `CredentialStore`, Darling-specific prefix), exactly as Lite stores them. The folded-in viewer preferences still round-trip through `ViewerPreferences` (handed back to `MainWindow` via `Result`).

## Works inside the viewer today (no service needed)

- **Manage Mute Rules** → opens the existing `MuteRulesWindow(ViewerDataService)` (writes Postgres `config_mute_rules`); disabled until the store is connected.
- **Send Test Email / Send Test Notification / Validate Settings** → the shared, connection-independent `EmailSendCore.SendTestEmailAsync` / `WebhookAlertService.SendTest{Teams,Slack}Async` renderers with a `Performance Monitor Darling` `AlertBranding`.
- **CSV export separator** → wired into all four viewer grid-export sites (Alerts, Collection Log, FinOps, per-server Blocking), seeded on startup and re-applied when Settings closes.
- The **viewer preferences** (default time range + auto-refresh) seed newly-opened server tabs as before.

## Adapted, not dropped

- **Pause Collection** — the viewer can't reach the remote service to pause it, so the button is shown disabled with a "Managed by the Darling service" status (mirrors how Lite disables it when it has no background service).
- **Color theme** — the viewer is dark-only (no `ThemeManager`/light dictionaries), so the row shows a disabled "Dark" with a "dark-only" hint.
- **Collector Schedules** — Lite's per-server schedule grid + `CollectorScheduleEditorWindow` drive Lite's `ScheduleManager`; Darling has no per-server schedule model in the store (cadence is fixed in the service), so the section is an informational panel pointing at the service (`darling.json`), matching how the Recommendations tab explains the service's own cadence.

## Noted follow-ups (service-side / larger wiring — persisted here, honored elsewhere)

These sections are persisted faithfully in the viewer; making the **service** honor a change is separate wiring (the service reads `darling.json`, not this file):

- **Alerts / notifications / SMTP / webhooks / MCP** — the Darling **service** owns these (`darling.json` `alerts`/`smtp`/`webhooks`/`mcp`). The window edits + persists them and the Test buttons work; wiring the service to read the viewer's file (or writing `darling.json`) is out of scope for this UI port.
- **Timestamp display mode** and **connection timeout** are viewer-side but need a central conversion hook / connection-string rebuild the viewer doesn't have yet; persisted, not yet consumed. (CSV separator, by contrast, *is* wired.)

## Build + tests

- **Viewer** `PerformanceMonitor.Darling.Viewer -c Release`: **Build succeeded, 0 errors** (9 pre-existing CA warnings in other files).
- **`Darling/Darling.Tests` -c Release**: **871 passed, 87 skipped, 0 failed** (958 total). Skips are the live-Postgres-gated tests. Adds `ViewerAppSettingsStoreTests` (defaults, cross-section round-trip, out-of-range clamping, corrupt-file, export-separator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
