### PR TITLE
Port Lite's MainWindow sidebar chrome + server management into the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerServerChromeTests.cs
+++ b/Darling/Darling.Tests/ViewerServerChromeTests.cs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the ported MainWindow sidebar chrome: the server-row status-dot derivation (from collection
+/// freshness, the same signal the Overview cards use), the favorite flag, the <see cref="ViewerServerEntry"/>
+/// display helpers the Manage Servers grid binds, and the load-bearing clauses of the new status reads.
+/// </summary>
+public sealed class ViewerServerChromeTests
+{
+    private static DarlingServer Server() => new(1, "SQL2022", "Prod", true, 16);
+
+    [Fact]
+    public void DotStatus_IsUnknown_UntilFreshnessIsApplied()
+    {
+        Assert.Equal("Unknown", Server().DotStatus);
+    }
+
+    [Fact]
+    public void ApplyFreshness_FreshCollection_IsOnline()
+    {
+        var now = DateTime.UtcNow;
+        var server = Server();
+
+        server.ApplyFreshness(now.AddSeconds(-30), now);
+
+        Assert.True(server.IsOnline);
+        Assert.False(server.HasCollectorErrors);
+        Assert.Equal("Online", server.DotStatus);
+    }
+
+    [Fact]
+    public void ApplyFreshness_StaleCollection_IsWarning()
+    {
+        var now = DateTime.UtcNow;
+        var server = Server();
+
+        /* Older than 2x the 1-minute collector cadence but not yet offline (< 15 min). */
+        server.ApplyFreshness(now.AddMinutes(-5), now);
+
+        Assert.True(server.IsOnline);
+        Assert.True(server.HasCollectorErrors);
+        Assert.Equal("Warning", server.DotStatus);
+    }
+
+    [Fact]
+    public void ApplyFreshness_OldCollection_IsOffline()
+    {
+        var now = DateTime.UtcNow;
+        var server = Server();
+
+        server.ApplyFreshness(now.AddMinutes(-30), now);
+
+        Assert.False(server.IsOnline);
+        Assert.Equal("Offline", server.DotStatus);
+    }
+
+    [Fact]
+    public void ApplyFreshness_NeverCollected_IsOffline()
+    {
+        var server = Server();
+
+        server.ApplyFreshness(null, DateTime.UtcNow);
+
+        Assert.False(server.IsOnline);
+        Assert.Equal("Offline", server.DotStatus);
+    }
+
+    [Fact]
+    public void DotStatus_RaisesChangeNotification_ForLiveDotUpdates()
+    {
+        var server = Server();
+        var changed = 0;
+        server.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(DarlingServer.DotStatus)) changed++;
+        };
+
+        server.ApplyFreshness(DateTime.UtcNow, DateTime.UtcNow);
+
+        Assert.True(changed > 0);
+    }
+
+    [Fact]
+    public void IsFavorite_RaisesChangeNotification_ForLiveStarUpdates()
+    {
+        var server = Server();
+        var raised = false;
+        server.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DarlingServer.IsFavorite)) raised = true;
+        };
+
+        server.IsFavorite = true;
+
+        Assert.True(raised);
+    }
+
+    [Theory]
+    [InlineData(false, "Prod", "SQL2022")]
+    [InlineData(true, "Prod (Read-Only)", "SQL2022 (Read-Only)")]
+    public void ViewerServerEntry_DisplayHelpers_ReflectReadOnlyIntent(bool readOnly, string expectedDisplay, string expectedServer)
+    {
+        var entry = new ViewerServerEntry
+        {
+            ServerName = "SQL2022",
+            DisplayName = "Prod",
+            ReadOnlyIntent = readOnly
+        };
+
+        Assert.Equal(expectedDisplay, entry.DisplayNameWithIntent);
+        Assert.Equal(expectedServer, entry.ServerNameDisplay);
+    }
+
+    [Fact]
+    public void ViewerServerEntry_AuthenticationDisplay_MapsEachMode()
+    {
+        Assert.Equal("Windows", new ViewerServerEntry { AuthenticationType = AuthenticationTypes.Windows }.AuthenticationDisplay);
+        Assert.Equal("SQL Server", new ViewerServerEntry { AuthenticationType = AuthenticationTypes.SqlServer }.AuthenticationDisplay);
+        Assert.Equal("Microsoft Entra MFA", new ViewerServerEntry { AuthenticationType = AuthenticationTypes.EntraMFA }.AuthenticationDisplay);
+        Assert.Equal("Azure — Service Principal", new ViewerServerEntry { AuthenticationType = AuthenticationTypes.ServicePrincipal }.AuthenticationDisplay);
+        Assert.Equal("Azure — Managed Identity", new ViewerServerEntry { AuthenticationType = AuthenticationTypes.ManagedIdentity }.AuthenticationDisplay);
+    }
+
+    [Fact]
+    public void ServerFreshnessSql_ReadsNewestCollectionPerServer()
+    {
+        Assert.Contains("MAX(collection_time)", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
+        Assert.Contains("FROM v_collection_log", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY server_id", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StoreSizeSql_UsesPgDatabaseSize()
+    {
+        Assert.Contains("pg_database_size", ViewerDataService.StoreSizeSql, StringComparison.Ordinal);
+    }
+}

--- a/Darling/Darling.Tests/ViewerServerStoreTests.cs
+++ b/Darling/Darling.Tests/ViewerServerStoreTests.cs
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the viewer's server-definition registry (<see cref="ViewerServerStore"/>) — JSON round-trip,
+/// Lite's favorites-first ordering, ToggleFavorite (including the adopt-on-first-favorite path), CRUD,
+/// and Import. Every test uses a temp file and an in-memory secret fake, so nothing touches the real
+/// per-user profile or Windows Credential Manager.
+/// </summary>
+public sealed class ViewerServerStoreTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"viewer-servers-{Guid.NewGuid():N}.json");
+    private readonly FakeSecretStore _secrets = new();
+
+    private ViewerServerStore NewStore() => new(_path, _secrets);
+
+    public void Dispose()
+    {
+        try
+        {
+            if (File.Exists(_path))
+            {
+                File.Delete(_path);
+            }
+        }
+        catch
+        {
+            /* best-effort temp cleanup */
+        }
+    }
+
+    [Fact]
+    public void AddServer_RoundTripsThroughDisk()
+    {
+        var store = NewStore();
+        store.AddServer(new ViewerServerEntry
+        {
+            ServerName = "SQL2022",
+            DisplayName = "Prod",
+            AuthenticationType = AuthenticationTypes.SqlServer,
+            MonthlyCostUsd = 250m,
+            ReadOnlyIntent = true,
+            ExcludedDatabases = new List<string> { "junk" }
+        }, "sa", "secret");
+
+        /* A fresh store over the same file must see the persisted definition. */
+        var reloaded = NewStore().GetAllServers();
+        var entry = Assert.Single(reloaded);
+        Assert.Equal("SQL2022", entry.ServerName);
+        Assert.Equal("Prod", entry.DisplayName);
+        Assert.Equal(AuthenticationTypes.SqlServer, entry.AuthenticationType);
+        Assert.Equal(250m, entry.MonthlyCostUsd);
+        Assert.True(entry.ReadOnlyIntent);
+        Assert.Equal("Prod (Read-Only)", entry.DisplayNameWithIntent);
+        Assert.Contains("junk", entry.ExcludedDatabases);
+    }
+
+    [Fact]
+    public void AddServer_StoresSecret_AndGetCredentialReturnsIt()
+    {
+        var store = NewStore();
+        var entry = new ViewerServerEntry { ServerName = "A", DisplayName = "A", AuthenticationType = AuthenticationTypes.SqlServer };
+        store.AddServer(entry, "sa", "pw");
+
+        var cred = store.GetCredential(entry.Id);
+        Assert.True(cred.HasValue);
+        Assert.Equal("sa", cred!.Value.Username);
+        Assert.Equal("pw", cred.Value.Password);
+    }
+
+    [Fact]
+    public void AddServer_WithoutCredentials_ClearsAnyStaleSecret()
+    {
+        var store = NewStore();
+        var entry = new ViewerServerEntry { ServerName = "A", DisplayName = "A" };
+        _secrets.Save(entry.Id, "old", "old");
+
+        store.AddServer(entry, null, null);
+
+        Assert.Null(store.GetCredential(entry.Id));
+    }
+
+    [Fact]
+    public void GetAllServers_SortsFavoritesFirst_ThenByDisplayName()
+    {
+        var store = NewStore();
+        store.AddServer(new ViewerServerEntry { ServerName = "z", DisplayName = "Zeta" }, null, null);
+        store.AddServer(new ViewerServerEntry { ServerName = "a", DisplayName = "Alpha" }, null, null);
+        store.AddServer(new ViewerServerEntry { ServerName = "m", DisplayName = "Mu", IsFavorite = true }, null, null);
+
+        var order = store.GetAllServers().Select(s => s.DisplayName).ToList();
+
+        Assert.Equal(new[] { "Mu", "Alpha", "Zeta" }, order);
+    }
+
+    [Fact]
+    public void ToggleFavorite_AdoptsUnknownServer_ThenFlips()
+    {
+        var store = NewStore();
+
+        Assert.True(store.ToggleFavorite("SQL2019"));      // adopt + pin
+        Assert.True(store.IsFavorite("SQL2019"));
+        Assert.Single(store.GetAllServers());
+
+        Assert.False(store.ToggleFavorite("SQL2019"));     // unpin the same entry (not a second one)
+        Assert.False(store.IsFavorite("SQL2019"));
+        Assert.Single(store.GetAllServers());
+    }
+
+    [Fact]
+    public void ToggleFavorite_IsCaseInsensitiveOnServerName()
+    {
+        var store = NewStore();
+        store.AddServer(new ViewerServerEntry { ServerName = "SQL2022", DisplayName = "Prod" }, null, null);
+
+        Assert.True(store.ToggleFavorite("sql2022"));
+
+        Assert.True(store.IsFavorite("SQL2022"));
+        Assert.Single(store.GetAllServers());   // flipped the existing entry, didn't add a duplicate
+    }
+
+    [Fact]
+    public void UpdateServer_ReplacesById_AndPersists()
+    {
+        var store = NewStore();
+        var entry = new ViewerServerEntry { ServerName = "A", DisplayName = "A" };
+        store.AddServer(entry, null, null);
+
+        entry.DisplayName = "Renamed";
+        entry.MonthlyCostUsd = 99m;
+        store.UpdateServer(entry);
+
+        var reloaded = Assert.Single(NewStore().GetAllServers());
+        Assert.Equal("Renamed", reloaded.DisplayName);
+        Assert.Equal(99m, reloaded.MonthlyCostUsd);
+    }
+
+    [Fact]
+    public void DeleteServer_RemovesEntry_AndDeletesSecret()
+    {
+        var store = NewStore();
+        var entry = new ViewerServerEntry { ServerName = "A", DisplayName = "A", AuthenticationType = AuthenticationTypes.SqlServer };
+        store.AddServer(entry, "sa", "pw");
+
+        store.DeleteServer(entry.Id);
+
+        Assert.Empty(NewStore().GetAllServers());
+        Assert.Null(_secrets.Get(entry.Id));
+    }
+
+    [Fact]
+    public void ImportServersFromFile_UpsertsByName_SkippingDuplicates()
+    {
+        /* Source registry written by another install. */
+        var source = Path.Combine(Path.GetTempPath(), $"viewer-servers-src-{Guid.NewGuid():N}.json");
+        var sourceStore = new ViewerServerStore(source, new FakeSecretStore());
+        sourceStore.AddServer(new ViewerServerEntry { ServerName = "shared", DisplayName = "Shared" }, null, null);
+        sourceStore.AddServer(new ViewerServerEntry { ServerName = "extra", DisplayName = "Extra" }, null, null);
+
+        try
+        {
+            var store = NewStore();
+            store.AddServer(new ViewerServerEntry { ServerName = "shared", DisplayName = "Existing" }, null, null);
+
+            var (imported, skipped) = store.ImportServersFromFile(source);
+
+            Assert.Equal(1, imported);   // "extra"
+            Assert.Equal(1, skipped);    // "shared" already present
+            Assert.Equal(2, store.GetAllServers().Count);
+            Assert.NotNull(store.GetByServerName("extra"));
+        }
+        finally
+        {
+            try { File.Delete(source); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>In-memory <see cref="IViewerServerSecretStore"/> so tests never touch Windows Credential Manager.</summary>
+    private sealed class FakeSecretStore : IViewerServerSecretStore
+    {
+        private readonly Dictionary<string, (string Username, string Password)> _map = new();
+
+        public void Save(string id, string username, string password) => _map[id] = (username, password);
+
+        public (string Username, string Password)? Get(string id) =>
+            _map.TryGetValue(id, out var v) ? v : null;
+
+        public void Delete(string id) => _map.Remove(id);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
@@ -1,0 +1,158 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.AddServerDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add SQL Server"
+        SizeToContent="Height" Width="450"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" Text="Add SQL Server Connection" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"
+                   Foreground="{DynamicResource ForegroundBrush}"/>
+
+        <!-- Server Name -->
+        <TextBlock Grid.Row="1" Text="Server Name / Address" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <TextBox Grid.Row="2" x:Name="ServerNameBox" Margin="0,0,0,12"/>
+
+        <!-- Display Name -->
+        <TextBlock Grid.Row="3" Text="Display Name (optional)" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <TextBox Grid.Row="4" x:Name="DisplayNameBox" Margin="0,0,0,12"/>
+
+        <!-- Authentication (inline per-server auth — the viewer never connects, so this is declarative
+             config the Darling service will consume; there is no shared credential-profile picker here). -->
+        <TextBlock Grid.Row="5" Text="Authentication" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <StackPanel Grid.Row="6" Margin="0,0,0,12">
+            <StackPanel x:Name="InlineAuthRadios">
+                <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                             IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+                <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+                <RadioButton x:Name="EntraMfaAuthRadio" Content="Microsoft Entra MFA" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed"
+                             ToolTip="Interactive authentication with MFA for Azure SQL Database."/>
+                <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,4,0,0"
+                             ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+                <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
+                             Checked="AuthMode_Changed" Margin="0,4,0,0"
+                             ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running the Darling service."/>
+            </StackPanel>
+        </StackPanel>
+
+        <!-- SQL Auth Credentials -->
+        <StackPanel Grid.Row="7" x:Name="SqlCredentialsPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Username" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="UsernameBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Password" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="PasswordBox"/>
+        </StackPanel>
+
+        <!-- Entra MFA Credentials -->
+        <StackPanel Grid.Row="7" x:Name="EntraMfaPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Username (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="EntraMfaUsernameBox" Margin="0,0,0,8"
+                     ToolTip="Optional: the UPN the service should pre-populate the authentication dialog with."/>
+        </StackPanel>
+
+        <!-- Service Principal Credentials -->
+        <StackPanel Grid.Row="7" x:Name="ServicePrincipalPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Client (Application) ID" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureClientIdBox" Margin="0,0,0,8"
+                     ToolTip="The Application (client) ID of the Entra app registration / service principal."/>
+            <TextBlock Text="Client Secret" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="AzureClientSecretBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Tenant ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureTenantIdBox" Margin="0,0,0,4"
+                     ToolTip="Optional. Stored for reference; the tenant is resolved automatically from the target server."/>
+        </StackPanel>
+
+        <!-- Managed Identity Credentials -->
+        <StackPanel Grid.Row="7" x:Name="ManagedIdentityPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="User-Assigned Identity Client ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="ManagedIdentityClientIdBox" Margin="0,0,0,8"
+                     ToolTip="Leave blank to use the system-assigned managed identity. Set to a client id to use a specific user-assigned identity."/>
+            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                       Text="Managed Identity only works when the Darling service runs on an Azure VM / resource that has a managed identity assigned. Use Service Principal for non-interactive auth from a workstation."/>
+        </StackPanel>
+
+        <!-- Connection Options -->
+        <TextBlock Grid.Row="8" Text="Connection Options" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <StackPanel Grid.Row="9" Margin="0,0,0,12">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                <TextBlock Text="Encryption:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <ComboBox x:Name="EncryptModeComboBox" Width="150" SelectedIndex="1">
+                    <ComboBoxItem Content="Optional"/>
+                    <ComboBoxItem Content="Mandatory"/>
+                    <ComboBoxItem Content="Strict"/>
+                </ComboBox>
+            </StackPanel>
+            <CheckBox x:Name="TrustCertCheckBox" Content="Trust server certificate (skip certificate validation)"
+                      Foreground="{DynamicResource ForegroundBrush}" IsChecked="False"/>
+            <CheckBox x:Name="EnabledCheckBox" Content="Enable data collection for this server"
+                      Foreground="{DynamicResource ForegroundBrush}" IsChecked="True" Margin="0,6,0,0"/>
+            <CheckBox x:Name="FavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
+                      Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"/>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Description:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBox x:Name="DescriptionTextBox" Width="250"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Database:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBox x:Name="DatabaseNameBox" Width="250"
+                         ToolTip="Required for Azure SQL Database. Leave empty for on-premises SQL Server."/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Utility DB:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBox x:Name="UtilityDatabaseBox" Width="250"
+                         ToolTip="Database where community stored procedures (sp_IndexCleanup) are installed. Leave empty to use the connection database."/>
+            </StackPanel>
+            <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="Read-only intent (for AG listeners and readable replicas)"
+                      Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
+                      ToolTip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary."/>
+            <CheckBox x:Name="MultiSubnetFailoverCheckBox" Content="Multi-subnet failover (for AG listeners and FCIs)"
+                      Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
+                      ToolTip="Sets MultiSubnetFailover=true. Connects to all IPs in parallel during failover. Recommended for AG listeners and failover cluster instances spanning multiple subnets."/>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Monthly Cost ($):" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
+                <TextBox x:Name="MonthlyCostBox" Width="100" TextAlignment="Right" Text="0"
+                         ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Alert delivery:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
+                <ComboBox x:Name="AlertDeliveryOverrideBox" Width="240" SelectedIndex="0"
+                          ToolTip="How deadlock/blocking alerts for THIS server are delivered. 'Use global setting' follows the app-wide Alerts setting; override to force Summary or Per-event for just this server.">
+                    <ComboBoxItem Content="Use global setting"/>
+                    <ComboBoxItem Content="Summary — one card per cycle"/>
+                    <ComboBoxItem Content="Per-event — one notification per incident"/>
+                </ComboBox>
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Status -->
+        <TextBlock Grid.Row="10" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
+                   TextWrapping="Wrap" VerticalAlignment="Bottom" Margin="0,0,0,8"/>
+
+        <!-- Buttons (no Test Connection: the viewer never connects to monitored servers) -->
+        <StackPanel Grid.Row="11" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="SaveButton" Content="Save" Width="80" Height="30" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Width="80" Height="30" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using System.Windows;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's Add / Edit server dialog — a faithful port of Lite's <c>AddServerDialog</c>, with the two
+/// live-connection affordances dropped as hard viewer facts: there is no <b>Test Connection</b> button (the
+/// viewer never opens a SqlClient connection to a monitored server — it reads only the Postgres store) and
+/// no shared credential-profile picker (the viewer has no <c>ProfileManager</c>). Everything else — all five
+/// inline auth modes, encryption, connection options, database / utility DB, cost, alert-delivery override,
+/// favorite — is captured verbatim into a <see cref="ViewerServerEntry"/> and persisted through
+/// <see cref="ViewerServerStore"/> (secrets to Credential Manager). Making the running service honor the
+/// saved definition is the separate wiring flagged in the PR.
+/// </summary>
+public partial class AddServerDialog : Window
+{
+    private readonly ViewerServerStore _serverStore;
+
+    /// <summary>The server that was added or edited, or null when the dialog was cancelled.</summary>
+    public ViewerServerEntry? AddedServer { get; private set; }
+
+    public AddServerDialog(ViewerServerStore serverStore)
+    {
+        InitializeComponent();
+        _serverStore = serverStore;
+    }
+
+    /// <summary>Constructor for editing an existing server definition.</summary>
+    public AddServerDialog(ViewerServerStore serverStore, ViewerServerEntry existing)
+        : this(serverStore)
+    {
+        Title = "Edit SQL Server";
+        ServerNameBox.Text = existing.ServerName;
+        DisplayNameBox.Text = existing.DisplayName;
+        EnabledCheckBox.IsChecked = existing.IsEnabled;
+        TrustCertCheckBox.IsChecked = existing.TrustServerCertificate;
+
+        EncryptModeComboBox.SelectedIndex = existing.EncryptMode switch
+        {
+            "Mandatory" => 1,
+            "Strict" => 2,
+            _ => 0
+        };
+
+        FavoriteCheckBox.IsChecked = existing.IsFavorite;
+        DescriptionTextBox.Text = existing.Description ?? "";
+        DatabaseNameBox.Text = existing.DatabaseName ?? "";
+        UtilityDatabaseBox.Text = existing.UtilityDatabase ?? "";
+        ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
+        MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
+        MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(CultureInfo.InvariantCulture);
+        AlertDeliveryOverrideBox.SelectedIndex = existing.AlertDeliveryModeOverride switch
+        {
+            AlertNotificationMode.Summary => 1,
+            AlertNotificationMode.PerEvent => 2,
+            _ => 0
+        };
+
+        if (existing.AuthenticationType == AuthenticationTypes.EntraMFA)
+        {
+            EntraMfaAuthRadio.IsChecked = true;
+            EntraMfaUsernameBox.Text = existing.EntraUsername ?? "";
+        }
+        else if (existing.AuthenticationType == AuthenticationTypes.SqlServer)
+        {
+            SqlAuthRadio.IsChecked = true;
+            var cred = _serverStore.GetCredential(existing.Id);
+            if (cred.HasValue)
+            {
+                UsernameBox.Text = cred.Value.Username;
+                PasswordBox.Password = cred.Value.Password;
+            }
+        }
+        else if (existing.AuthenticationType == AuthenticationTypes.ServicePrincipal)
+        {
+            ServicePrincipalAuthRadio.IsChecked = true;
+            AzureClientIdBox.Text = existing.AzureClientId ?? "";
+            AzureTenantIdBox.Text = existing.AzureTenantId ?? "";
+            var cred = _serverStore.GetCredential(existing.Id);
+            if (cred.HasValue)
+            {
+                if (string.IsNullOrEmpty(AzureClientIdBox.Text))
+                {
+                    AzureClientIdBox.Text = cred.Value.Username;
+                }
+                AzureClientSecretBox.Password = cred.Value.Password;
+            }
+        }
+        else if (existing.AuthenticationType == AuthenticationTypes.ManagedIdentity)
+        {
+            ManagedIdentityAuthRadio.IsChecked = true;
+            ManagedIdentityClientIdBox.Text = existing.ManagedIdentityClientId ?? "";
+        }
+        else
+        {
+            WindowsAuthRadio.IsChecked = true;
+        }
+
+        AddedServer = existing;
+    }
+
+    private void AuthMode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (SqlCredentialsPanel is null || EntraMfaPanel is null ||
+            ServicePrincipalPanel is null || ManagedIdentityPanel is null)
+        {
+            return;
+        }
+
+        SqlCredentialsPanel.Visibility = SqlAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        EntraMfaPanel.Visibility = EntraMfaAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private AlertNotificationMode? GetSelectedDeliveryOverride() => AlertDeliveryOverrideBox.SelectedIndex switch
+    {
+        1 => AlertNotificationMode.Summary,
+        2 => AlertNotificationMode.PerEvent,
+        _ => null
+    };
+
+    private string GetSelectedEncryptMode() => EncryptModeComboBox.SelectedIndex switch
+    {
+        1 => "Mandatory",
+        2 => "Strict",
+        _ => "Optional"
+    };
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        var serverName = ServerNameBox.Text.Trim();
+        if (string.IsNullOrEmpty(serverName))
+        {
+            StatusText.Text = "Server name is required.";
+            return;
+        }
+
+        var displayName = DisplayNameBox.Text.Trim();
+        if (string.IsNullOrEmpty(displayName))
+        {
+            displayName = serverName;
+        }
+
+        string authenticationType;
+        string? username = null;
+        string? password = null;
+        string? entraUsername = null;
+
+        if (WindowsAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.Windows;
+        }
+        else if (EntraMfaAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.EntraMFA;
+            entraUsername = EntraMfaUsernameBox.Text.Trim();
+        }
+        else if (ServicePrincipalAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.ServicePrincipal;
+            username = AzureClientIdBox.Text.Trim();
+            password = AzureClientSecretBox.Password;
+
+            if (string.IsNullOrEmpty(username))
+            {
+                StatusText.Text = "Client (Application) ID is required for service principal authentication.";
+                return;
+            }
+            if (string.IsNullOrEmpty(password))
+            {
+                StatusText.Text = "Client secret is required for service principal authentication.";
+                return;
+            }
+        }
+        else if (ManagedIdentityAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.ManagedIdentity;
+        }
+        else if (SqlAuthRadio.IsChecked == true)
+        {
+            authenticationType = AuthenticationTypes.SqlServer;
+            username = UsernameBox.Text.Trim();
+            password = PasswordBox.Password;
+
+            if (string.IsNullOrEmpty(username))
+            {
+                StatusText.Text = "Username is required for SQL Server authentication.";
+                return;
+            }
+        }
+        else
+        {
+            authenticationType = AuthenticationTypes.Windows;
+        }
+
+        decimal monthlyCost = 0m;
+        if (decimal.TryParse(MonthlyCostBox.Text, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedCost) && parsedCost >= 0)
+        {
+            monthlyCost = parsedCost;
+        }
+
+        try
+        {
+            if (AddedServer is not null && Title == "Edit SQL Server")
+            {
+                /* Editing an existing definition — mutate in place and re-persist. */
+                var entry = AddedServer;
+                entry.ServerName = serverName;
+                entry.DisplayName = displayName;
+                entry.AuthenticationType = authenticationType;
+                entry.EntraUsername = authenticationType == AuthenticationTypes.EntraMFA
+                    ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
+                    : null;
+                entry.AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
+                    : null;
+                entry.AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
+                    : null;
+                entry.ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                    ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
+                    : null;
+                entry.IsEnabled = EnabledCheckBox.IsChecked == true;
+                entry.TrustServerCertificate = TrustCertCheckBox.IsChecked == true;
+                entry.EncryptMode = GetSelectedEncryptMode();
+                entry.IsFavorite = FavoriteCheckBox.IsChecked == true;
+                entry.Description = DescriptionTextBox.Text.Trim();
+                entry.DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
+                entry.UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim();
+                entry.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
+                entry.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
+                entry.MonthlyCostUsd = monthlyCost;
+                entry.AlertDeliveryModeOverride = GetSelectedDeliveryOverride();
+
+                _serverStore.UpdateServer(entry, username, password);
+            }
+            else
+            {
+                /* Adding a new definition. */
+                AddedServer = new ViewerServerEntry
+                {
+                    ServerName = serverName,
+                    DisplayName = displayName,
+                    AuthenticationType = authenticationType,
+                    EntraUsername = authenticationType == AuthenticationTypes.EntraMFA
+                        ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
+                        : null,
+                    AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                        ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
+                        : null,
+                    AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                        ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
+                        : null,
+                    ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                        ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
+                        : null,
+                    IsEnabled = EnabledCheckBox.IsChecked == true,
+                    TrustServerCertificate = TrustCertCheckBox.IsChecked == true,
+                    EncryptMode = GetSelectedEncryptMode(),
+                    IsFavorite = FavoriteCheckBox.IsChecked == true,
+                    Description = DescriptionTextBox.Text.Trim(),
+                    DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim(),
+                    UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim(),
+                    ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
+                    MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
+                    MonthlyCostUsd = monthlyCost,
+                    AlertDeliveryModeOverride = GetSelectedDeliveryOverride()
+                };
+
+                _serverStore.AddServer(AddedServer, username, password);
+            }
+
+            DialogResult = true;
+            Close();
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Error: {ex.Message}";
+            ViewerLogger.Error("AddServerDialog", "Failed to save server definition", ex);
+        }
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
@@ -6,7 +6,10 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
+using System.Reflection;
 using System.Windows;
+using System.Windows.Threading;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
@@ -28,6 +31,28 @@ public partial class App : Application
            creates MainWindow. Dark is the default; naming it keeps the source of truth explicit. */
         ThemeManager.Apply("Dark");
 
+        /* Minimal file logging (ported from Lite's AppLogger) so the sidebar's View Log / Open Log
+           Folder buttons have a real target and operator bug reports carry viewer diagnostics. */
+        ViewerLogger.Initialize();
+        ViewerLogger.Info("App", $"Starting PerformanceMonitor Darling Viewer v{Assembly.GetExecutingAssembly().GetName().Version}");
+
+        /* Surface otherwise-invisible crashes into the log now that we have one. */
+        DispatcherUnhandledException += OnDispatcherUnhandledException;
+        AppDomain.CurrentDomain.UnhandledException += OnDomainUnhandledException;
+
         base.OnStartup(e);
     }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        ViewerLogger.Info("App", "Shutting down");
+        ViewerLogger.Shutdown();
+        base.OnExit(e);
+    }
+
+    private static void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        => ViewerLogger.Error("App", "Unhandled UI exception", e.Exception);
+
+    private static void OnDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        => ViewerLogger.Error("App", "Unhandled domain exception", e.ExceptionObject as Exception);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml
@@ -1,0 +1,40 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.ExcludedDatabasesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Excluded Databases"
+        Height="440" Width="460"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" x:Name="HeaderText" Text="Excluded Databases" FontSize="16" FontWeight="Bold"
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+
+        <!-- The viewer never connects to the monitored server, so it can't enumerate the live database list
+             the way Lite's dialog does. This is a manual editor for the same field the Darling service will
+             consume — one database name per line. -->
+        <TextBlock Grid.Row="1" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,8"
+                   Text="User databases to skip in per-database collectors — one name per line. System databases and the connection database are always excluded. The viewer can't list the server's live databases (it never connects to it), so enter the names to exclude here."/>
+
+        <TextBox Grid.Row="2" x:Name="ExclusionsBox"
+                 AcceptsReturn="True" TextWrapping="NoWrap"
+                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                 FontFamily="Consolas" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="3" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
+                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Save" Width="80" Height="30" Click="Save_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Windows;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's Excluded Databases editor — adapted from Lite's dialog. Lite reads the server's LIVE
+/// database list (it connects to the monitored server) and offers a checkbox per database; the Darling
+/// viewer never connects to monitored servers, so this is a manual, one-name-per-line editor for the same
+/// <see cref="ViewerServerEntry.ExcludedDatabases"/> field the Darling service will consume. Persisted
+/// through <see cref="ViewerServerStore.UpdateServer(ViewerServerEntry)"/>.
+/// </summary>
+public partial class ExcludedDatabasesDialog : Window
+{
+    private readonly ViewerServerStore _serverStore;
+    private readonly ViewerServerEntry _entry;
+
+    /// <summary>Set true when the exclusion list was changed and saved, so the caller refreshes.</summary>
+    public bool ExclusionsModified { get; private set; }
+
+    public ExcludedDatabasesDialog(ViewerServerStore serverStore, ViewerServerEntry entry)
+    {
+        InitializeComponent();
+        _serverStore = serverStore;
+        _entry = entry;
+        HeaderText.Text = $"Excluded Databases — {entry.DisplayNameWithIntent}";
+        ExclusionsBox.Text = string.Join(Environment.NewLine, entry.ExcludedDatabases ?? new System.Collections.Generic.List<string>());
+        StatusText.Text = $"{(entry.ExcludedDatabases?.Count ?? 0)} database(s) currently excluded.";
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            _entry.ExcludedDatabases = ExclusionsBox.Text
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(name => name.Trim())
+                .Where(name => name.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            _serverStore.UpdateServer(_entry);
+            ExclusionsModified = true;
+            DialogResult = true;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Failed to save: {ex.Message}";
+            ViewerLogger.Error("ExcludedDatabasesDialog", "Failed to save exclusions", ex);
+        }
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The MainWindow server-management + status-chrome partial (ported to parity with Lite's MainWindow):
+/// the sidebar's favorite pinning + collection-freshness status dots, the right-click server menu, the
+/// footer Add / Manage / Import / log buttons, the sidebar collapse toggle, and the multi-field status bar.
+///
+/// <para>Adaptation (hard viewer facts, matching the rest of the Lite→Darling port). The sidebar lists the
+/// servers the Darling service is actually COLLECTING (the Postgres <c>servers</c> table), so its dots come
+/// from collection freshness — the viewer never pings a monitored server — and Connect/Disconnect have no
+/// meaning and are omitted. Add / Manage / Edit / Remove operate on the viewer's OWN registry
+/// (<see cref="ViewerServerStore"/> → viewer-servers.json); an added/edited server appears in the sidebar
+/// once the service registers it into the store (that service wiring is the follow-up flagged in the PR).
+/// Favorites are the one thing the viewer acts on today: pinned in the registry (matched by server name),
+/// starred and sorted-to-top here.</para>
+/// </summary>
+public partial class MainWindow
+{
+    /// <summary>The viewer's own server-definition registry, backing Add / Manage / Edit / Remove + favorites.</summary>
+    private readonly ViewerServerStore _serverStore = new();
+
+    private bool _sidebarCollapsed;
+
+    // ── Server-list enrichment (favorites + freshness) ──────────────────────────────
+
+    /// <summary>
+    /// Stamps each row's favorite flag from the registry (by server name) and returns the list sorted
+    /// favorites-first, then by display name — Lite's pin ordering. Called on load and after a registry change.
+    /// </summary>
+    private List<DarlingServer> ApplyFavoritesAndSort(List<DarlingServer> servers)
+    {
+        foreach (var s in servers)
+        {
+            s.IsFavorite = _serverStore.IsFavorite(s.ServerName);
+        }
+
+        return SortWithFavorites(servers);
+    }
+
+    private static List<DarlingServer> SortWithFavorites(List<DarlingServer> servers) =>
+        servers
+            .OrderByDescending(s => s.IsFavorite)
+            .ThenBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>Re-stamps favorites on the currently-shown rows and re-sorts, preserving the selection.</summary>
+    private void ReapplyFavoritesToServerList()
+    {
+        if (ServerList.ItemsSource is not IEnumerable<DarlingServer> current)
+        {
+            return;
+        }
+
+        foreach (var s in current)
+        {
+            s.IsFavorite = _serverStore.IsFavorite(s.ServerName);
+        }
+
+        var selected = ServerList.SelectedItem as DarlingServer;
+        ServerList.ItemsSource = SortWithFavorites(current.ToList());
+        if (selected is not null)
+        {
+            ServerList.SelectedItem = selected;
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the sidebar status dots and the status bar's collector-health + collection fields from a
+    /// single collection-freshness query (the same MAX(collection_time) signal the Overview cards use).
+    /// Updates each row in place so the dots recolour without resetting the list's selection.
+    /// </summary>
+    private async Task RefreshServerStatusAsync()
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        Dictionary<int, DateTime> freshness;
+        try
+        {
+            freshness = await _dataService.GetServerFreshnessAsync();
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("ServerStatus", $"freshness read failed: {ex.Message}");
+            return;
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        var servers = (ServerList.ItemsSource as IEnumerable<DarlingServer>)?.ToList() ?? new List<DarlingServer>();
+
+        var online = 0;
+        var warning = 0;
+        var offline = 0;
+        DateTime? newest = null;
+
+        foreach (var s in servers)
+        {
+            DateTime? last = freshness.TryGetValue(s.ServerId, out var t) ? t : null;
+            s.ApplyFreshness(last, nowUtc);
+
+            switch (s.DotStatus)
+            {
+                case "Online": online++; break;
+                case "Warning": warning++; break;
+                default: offline++; break;
+            }
+
+            if (last.HasValue && (newest is null || last.Value > newest.Value))
+            {
+                newest = last.Value;
+            }
+        }
+
+        if (servers.Count == 0)
+        {
+            CollectorHealthText.Text = "";
+        }
+        else if (warning + offline == 0)
+        {
+            CollectorHealthText.Text = $"Collectors: {online} OK";
+        }
+        else
+        {
+            CollectorHealthText.Text = $"Collectors: {warning} stale, {offline} offline";
+        }
+
+        if (newest is null)
+        {
+            CollectionStatusText.Text = "Collection: Idle";
+        }
+        else
+        {
+            var age = nowUtc - newest.Value;
+            CollectionStatusText.Text = age.TotalSeconds < 90
+                ? "Collection: Active"
+                : $"Collection: {FormatAge(age)} ago";
+        }
+    }
+
+    /// <summary>Refreshes the status bar's database-size field from the store's on-disk size.</summary>
+    private async Task RefreshStoreSizeAsync()
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var bytes = await _dataService.GetStoreSizeBytesAsync();
+            DatabaseSizeText.Text = bytes.HasValue ? $"Database: {FormatBytes(bytes.Value)}" : "Database: --";
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("ServerStatus", $"store size read failed: {ex.Message}");
+        }
+    }
+
+    private static string FormatAge(TimeSpan age)
+    {
+        if (age.TotalMinutes < 1) return $"{age.TotalSeconds:F0}s";
+        if (age.TotalHours < 1) return $"{age.TotalMinutes:F0}m";
+        if (age.TotalDays < 1) return $"{age.TotalHours:F0}h";
+        return $"{age.TotalDays:F0}d";
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const double mb = 1024.0 * 1024.0;
+        const double gb = mb * 1024.0;
+        return bytes >= gb ? $"{bytes / gb:F1} GB" : $"{bytes / mb:F0} MB";
+    }
+
+    // ── Server-row context menu (Toggle Favorite / Edit / Remove — no Connect/Disconnect) ─────
+
+    /// <summary>The <see cref="DarlingServer"/> behind a server-row context-menu click (mirrors Lite's resolver).</summary>
+    private static DarlingServer? GetServerFromContextMenu(object sender)
+    {
+        if (sender is not MenuItem menuItem)
+        {
+            return null;
+        }
+
+        var contextMenu = menuItem.Parent as ContextMenu;
+        var target = contextMenu?.PlacementTarget as FrameworkElement;
+        return target?.DataContext as DarlingServer;
+    }
+
+    private void ServerContextMenu_ToggleFavorite_Click(object sender, RoutedEventArgs e)
+    {
+        var server = GetServerFromContextMenu(sender);
+        if (server is null)
+        {
+            return;
+        }
+
+        var isFavorite = _serverStore.ToggleFavorite(server.ServerName);
+        server.IsFavorite = isFavorite;
+        ReapplyFavoritesToServerList();
+        StatusText.Text = isFavorite ? $"Pinned {server.DisplayName}" : $"Unpinned {server.DisplayName}";
+    }
+
+    private void ServerContextMenu_Edit_Click(object sender, RoutedEventArgs e)
+    {
+        var server = GetServerFromContextMenu(sender);
+        if (server is null)
+        {
+            return;
+        }
+
+        /* Edit the matching registry entry, or "adopt" the collected server into the registry by seeding a
+           new entry from its name/display (the service registered it; the viewer had no definition yet). */
+        var entry = _serverStore.GetByServerName(server.ServerName)
+            ?? new ViewerServerEntry { ServerName = server.ServerName, DisplayName = server.DisplayName };
+
+        var dialog = new AddServerDialog(_serverStore, entry) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ReapplyFavoritesToServerList();
+            StatusText.Text = $"Saved '{server.DisplayName}' to the viewer registry.";
+        }
+    }
+
+    private void ServerContextMenu_Remove_Click(object sender, RoutedEventArgs e)
+    {
+        var server = GetServerFromContextMenu(sender);
+        if (server is null)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"Remove '{server.DisplayName}' from the viewer's registry?\n\n" +
+            "This removes only the viewer-side definition and its favorite pin. The Darling service keeps " +
+            "collecting this server (stopping collection is service-side — see the release notes), so its row " +
+            "stays in the list until the service is reconfigured.",
+            "Remove Server",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var entry = _serverStore.GetByServerName(server.ServerName);
+        if (entry is not null)
+        {
+            _serverStore.DeleteServer(entry.Id);
+        }
+
+        server.IsFavorite = false;
+        ReapplyFavoritesToServerList();
+        StatusText.Text = $"Removed '{server.DisplayName}' from the viewer registry.";
+    }
+
+    // ── Footer buttons (Add / Manage / Import Settings / View Log / Open Log Folder) ─────
+
+    private void AddServerButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new AddServerDialog(_serverStore) { Owner = this };
+        if (dialog.ShowDialog() == true && dialog.AddedServer is not null)
+        {
+            ReapplyFavoritesToServerList();
+            StatusText.Text =
+                $"Saved server '{dialog.AddedServer.DisplayName}' to the viewer registry. " +
+                "The Darling service will collect it once server-registration wiring lands.";
+        }
+    }
+
+    private void ManageServersButton_Click(object sender, RoutedEventArgs e)
+    {
+        var window = new ManageServersWindow(_serverStore) { Owner = this };
+        window.ShowDialog();
+        if (window.ServersChanged)
+        {
+            ReapplyFavoritesToServerList();
+        }
+    }
+
+    private void ViewLogButton_Click(object sender, RoutedEventArgs e)
+    {
+        var logFile = ViewerLogger.GetCurrentLogFile();
+        try
+        {
+            var target = File.Exists(logFile) ? logFile : ViewerLogger.GetLogDirectory();
+            if (string.IsNullOrEmpty(target))
+            {
+                MessageBox.Show("No log file has been written yet.", "View Log", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Process.Start(new ProcessStartInfo { FileName = target, UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not open log file: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private void OpenLogFolderButton_Click(object sender, RoutedEventArgs e)
+    {
+        var logDir = ViewerLogger.GetLogDirectory();
+        if (string.IsNullOrEmpty(logDir))
+        {
+            logDir = ViewerLogger.DefaultLogDirectory();
+        }
+
+        try
+        {
+            Directory.CreateDirectory(logDir);
+            Process.Start(new ProcessStartInfo { FileName = logDir, UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not open log folder: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    /// <summary>
+    /// Imports server definitions (and copies viewer settings/preferences when absent) from a previous
+    /// viewer's per-user config folder — the Darling analog of Lite's Import Settings. Lite's DuckDB
+    /// "Import Data" has no viewer meaning and is omitted.
+    /// </summary>
+    private void ImportSettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new Microsoft.Win32.OpenFolderDialog
+        {
+            Title = "Select a previous PerformanceMonitorDarling config folder"
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var sourceServers = Path.Combine(dialog.FolderName, "viewer-servers.json");
+        if (!File.Exists(sourceServers))
+        {
+            MessageBox.Show(
+                "No viewer-servers.json found in the selected folder.\n\n" +
+                "Select the PerformanceMonitorDarling folder of a previous viewer install " +
+                "(under %APPDATA%).",
+                "Import Settings",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            return;
+        }
+
+        try
+        {
+            var (imported, skipped) = _serverStore.ImportServersFromFile(sourceServers);
+
+            var targetDir = Path.GetDirectoryName(ViewerServerStore.DefaultFilePath());
+            var copied = 0;
+            if (!string.IsNullOrEmpty(targetDir))
+            {
+                foreach (var fileName in new[] { "viewer-settings.json", "viewer-preferences.json" })
+                {
+                    var source = Path.Combine(dialog.FolderName, fileName);
+                    var destination = Path.Combine(targetDir, fileName);
+                    if (File.Exists(source) && !File.Exists(destination))
+                    {
+                        Directory.CreateDirectory(targetDir);
+                        File.Copy(source, destination);
+                        copied++;
+                    }
+                }
+            }
+
+            var message = $"Imported {imported} server definition(s).";
+            if (skipped > 0)
+            {
+                message += $"\nSkipped {skipped} already-configured server(s).";
+            }
+            if (copied > 0)
+            {
+                message += $"\nCopied {copied} settings file(s). Restart the viewer to apply them.";
+            }
+            message += "\n\nServer credentials are NOT importable (they live only in Windows Credential Manager, " +
+                       "per user). Re-enter any SQL/service-principal secret in Manage Servers.";
+
+            MessageBox.Show(message, "Import Settings", MessageBoxButton.OK, MessageBoxImage.Information);
+
+            if (imported > 0)
+            {
+                ReapplyFavoritesToServerList();
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ImportSettings", "Import failed", ex);
+            MessageBox.Show($"Failed to import settings: {ex.Message}", "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    // ── Sidebar collapse toggle ─────────────────────────────────────────────────────
+
+    private void ToggleSidebar_Click(object sender, RoutedEventArgs e)
+    {
+        _sidebarCollapsed = !_sidebarCollapsed;
+
+        if (_sidebarCollapsed)
+        {
+            SidebarColumn.Width = new GridLength(40);
+            SidebarHeaderText.Visibility = Visibility.Collapsed;
+            ServerList.Visibility = Visibility.Collapsed;
+            SidebarFooter.Visibility = Visibility.Collapsed;
+            ServersHintText.Visibility = Visibility.Collapsed;
+            SidebarToggleButton.Content = "»";
+        }
+        else
+        {
+            SidebarColumn.Width = new GridLength(280);
+            SidebarHeaderText.Visibility = Visibility.Visible;
+            ServerList.Visibility = Visibility.Visible;
+            SidebarFooter.Visibility = Visibility.Visible;
+            ServersHintText.Visibility = ServerList.Items.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+            SidebarToggleButton.Content = "«";
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -238,36 +238,101 @@
 
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="280"/>
+                <ColumnDefinition x:Name="SidebarColumn" Width="280" MinWidth="40"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Left: the server list. Single-click drives the aggregate tabs; double-click opens
-                 (or focuses) that server's per-server tab. -->
+                 (or focuses) that server's per-server tab. The header's « / » button collapses the
+                 sidebar to a thin rail (mirrors Lite's ToggleSidebar). -->
             <DockPanel Grid.Column="0" Margin="0,0,10,0">
-                <StackPanel DockPanel.Dock="Top">
-                    <TextBlock Text="Servers" Style="{StaticResource SectionHeader}" Margin="0,0,0,2"/>
-                    <TextBlock Text="Double-click to open a server tab" Foreground="#8B93A1" FontSize="11" Margin="0,0,0,6"/>
-                </StackPanel>
+                <Grid DockPanel.Dock="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" x:Name="SidebarHeaderText">
+                        <TextBlock Text="Servers" Style="{StaticResource SectionHeader}" Margin="0,0,0,2"/>
+                        <TextBlock Text="Double-click to open a server tab" Foreground="#8B93A1" FontSize="11" Margin="0,0,0,6"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" x:Name="SidebarToggleButton" Content="«" Click="ToggleSidebar_Click"
+                            Style="{StaticResource DarkButton}"
+                            ToolTip="Collapse/expand the sidebar" VerticalAlignment="Top"
+                            Width="24" Height="24" Padding="0" FontSize="14"/>
+                </Grid>
 
-                <!-- Sidebar footer: a small button stack pinned to the bottom of the server list. Open
-                     Plan Viewer (opens/focuses the standalone Plan Viewer aggregate tab — paste or open a
-                     .sqlplan independent of any server) and About. The viewer writes no application log of
-                     its own (its diagnostics go to Debug output, and the shared store's collection log is a
-                     per-server tab), so there are no View Log / Open Log Folder buttons. Declared as the
-                     first Bottom-docked child so it sits at the very bottom, below the no-servers hint. -->
-                <Border DockPanel.Dock="Bottom"
+                <!-- Sidebar footer: the button stack pinned to the bottom of the server list, ported to
+                     parity with Lite. Server management (Add Server / Manage Servers) writes the viewer's
+                     own registry; the service honoring it is separate wiring (see the PR). Import Data
+                     (Lite's DuckDB import) is omitted — it has no viewer meaning. Declared as the first
+                     Bottom-docked child so it sits at the very bottom, below the no-servers hint. -->
+                <Border x:Name="SidebarFooter" DockPanel.Dock="Bottom"
                         BorderBrush="#2a2d35" BorderThickness="0,1,0,0"
                         Margin="0,8,0,0" Padding="0,8,0,0">
                     <StackPanel>
+                        <Button Click="AddServerButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                ToolTip="Add a monitored SQL Server to the viewer's registry">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE710;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Add Server" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="ManageServersButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="Add, edit, or remove monitored servers">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8FD;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Manage Servers" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <Button Click="OpenPlanViewerButton_Click"
                                 Style="{StaticResource DarkButton}"
                                 Padding="8,5"
+                                Margin="0,8,0,0"
                                 ToolTip="Open or paste an execution plan (independent of any server)">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE8A5;" FontFamily="Segoe MDL2 Assets" FontSize="12"
                                            VerticalAlignment="Center" Margin="0,0,6,0"/>
                                 <TextBlock Text="Open Plan Viewer" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="ImportSettingsButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="Import server definitions and settings from a previous viewer install">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8FA;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Import Settings" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="ViewLogButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="Open the current application log file">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE7BA;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="View Log" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Click="OpenLogFolderButton_Click"
+                                Style="{StaticResource DarkButton}"
+                                Padding="8,5"
+                                Margin="0,8,0,0"
+                                ToolTip="Open the log folder in Explorer (for grabbing logs to attach to bug reports)">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE838;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="Open Log Folder" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Click="SettingsButton_Click"
@@ -339,10 +404,92 @@
                     </ListBox.ItemContainerStyle>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <StackPanel>
-                                <TextBlock Text="{Binding DisplayName}" FontSize="13" FontWeight="SemiBold"/>
-                                <TextBlock Text="{Binding VersionLabel}" FontSize="11" Foreground="#8B93A1"/>
-                            </StackPanel>
+                            <!-- Ported from Lite's server-row template: a freshness status dot (green/amber/red
+                                 from DotStatus), the name + version, a favorite star, and the right-click menu.
+                                 Connect/Disconnect are omitted — the viewer never connects to monitored servers
+                                 (it reads only the Postgres store). Transparent Border hosts the context menu so
+                                 the whole row is a right-click target; the item background comes from the
+                                 container style above. -->
+                            <Border Background="Transparent">
+                                <Border.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Toggle Favorite" Click="ServerContextMenu_ToggleFavorite_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x2B50;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                        <Separator/>
+                                        <MenuItem Header="Edit..." Click="ServerContextMenu_Edit_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x270F;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="Remove" Click="ServerContextMenu_Remove_Click">
+                                            <MenuItem.Icon><TextBlock Text="&#x1F5D1;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                    </ContextMenu>
+                                </Border.ContextMenu>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+
+                                    <!-- Status dot (collection freshness) -->
+                                    <Ellipse Grid.Column="0" Grid.RowSpan="2"
+                                             Width="10" Height="10"
+                                             Margin="0,0,8,0"
+                                             VerticalAlignment="Center">
+                                        <Ellipse.Style>
+                                            <Style TargetType="Ellipse">
+                                                <Setter Property="Fill" Value="{DynamicResource ForegroundMutedBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Online">
+                                                        <Setter Property="Fill" Value="{DynamicResource SuccessBrush}"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Offline">
+                                                        <Setter Property="Fill" Value="{DynamicResource ErrorBrush}"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DotStatus}" Value="Warning">
+                                                        <Setter Property="Fill" Value="{DynamicResource WarningBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Ellipse.Style>
+                                    </Ellipse>
+
+                                    <!-- Server name -->
+                                    <TextBlock Grid.Column="1" Grid.Row="0"
+                                               Text="{Binding DisplayName}"
+                                               FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ForegroundBrush}"/>
+
+                                    <!-- Details (SQL version) -->
+                                    <TextBlock Grid.Column="1" Grid.Row="1"
+                                               Text="{Binding VersionLabel}"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource ForegroundMutedBrush}"/>
+
+                                    <!-- Favorite star -->
+                                    <TextBlock Grid.Column="2" Grid.RowSpan="2"
+                                               Text="★" FontSize="16"
+                                               VerticalAlignment="Center"
+                                               Foreground="#FFD700"
+                                               Margin="4,0,0,0">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsFavorite}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
@@ -660,10 +807,22 @@
                        Foreground="#E4E6EB"/>
         </Border>
 
-        <TextBlock x:Name="StatusText"
-                   Grid.Row="1"
-                   Margin="0,8,0,0"
-                   FontSize="12"
-                   Foreground="#8B93A1"/>
+        <!-- Multi-field status bar (ported from Lite, adapted to what the viewer knows): general status,
+             collector health across all servers (from collection freshness), store database size, overall
+             collection status, and server count. -->
+        <Grid Grid.Row="1" Margin="0,8,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" x:Name="StatusText" FontSize="12" Foreground="#8B93A1" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1" x:Name="CollectorHealthText" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: --" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" FontSize="12" Foreground="#8B93A1" VerticalAlignment="Center"/>
+        </Grid>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -188,6 +188,11 @@ public partial class MainWindow : Window
 
     private async void OnRefreshTimerTick(object? sender, EventArgs e)
     {
+        /* Refresh the sidebar status dots + the status bar every cycle regardless of the visible tab (a
+           cheap pair of single-query reads), so freshness stays current even while a per-server tab is up. */
+        _ = RefreshServerStatusAsync();
+        _ = RefreshStoreSizeAsync();
+
         /* Two tabs opt out of the 60s auto-refresh: Recommendations refreshes on tab-activation only
            (matching Lite — analysis findings change on the service's 30-minute cadence, so a 60-second
            auto-refresh is pointless churn and would reset the incident expanders' state under the
@@ -214,6 +219,8 @@ public partial class MainWindow : Window
     {
         if (ReferenceEquals(MainTabs.SelectedItem, OverviewTab))
         {
+            /* Refresh the sidebar dots on the snappier Overview cadence too, so they track the cards. */
+            _ = RefreshServerStatusAsync();
             await RefreshVisibleAsync();
         }
     }
@@ -255,8 +262,11 @@ public partial class MainWindow : Window
 
         try
         {
-            var servers = await _dataService.GetServersAsync();
+            /* Enrich the Postgres-sourced list with the viewer's favorite pins (matched by server name) and
+               sort favorites-first (Lite's ordering) before it drives the sidebar and the selectors. */
+            var servers = ApplyFavoritesAndSort(await _dataService.GetServersAsync());
             ServerList.ItemsSource = servers;
+            ServerCountText.Text = $"Servers: {servers.Count}";
 
             /* The Recommendations tab has its OWN server selector (independent of the sidebar, matching
                Lite). Populate it from the same list; the guard suppresses its SelectionChanged during
@@ -289,6 +299,11 @@ public partial class MainWindow : Window
             {
                 StatusText.Text = $"connected — no servers registered yet ({DateTime.Now:HH:mm:ss})";
             }
+
+            /* Seed the sidebar status dots + the status bar's collector-health / collection / database-size
+               fields (each a single lightweight store read). */
+            _ = RefreshServerStatusAsync();
+            _ = RefreshStoreSizeAsync();
         }
         catch (Exception ex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
@@ -64,7 +64,9 @@
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
-                <DataGridTextColumn Header="Last Connected" Binding="{Binding LastConnected, StringFormat=yyyy-MM-dd HH:mm}" Width="140"/>
+                <!-- "Added" (creation time), not Lite's "Last Connected": the viewer never connects to a
+                     monitored server, so a last-connected time would be meaningless here. -->
+                <DataGridTextColumn Header="Added" Binding="{Binding CreatedDate, StringFormat=yyyy-MM-dd HH:mm}" Width="140"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
@@ -1,0 +1,80 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.ManageServersWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Manage Servers"
+        Height="500" Width="830"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Edit" Click="EditMenuItem_Click"/>
+                <MenuItem Header="Excluded Databases" Click="ExcludedDatabases_Click"/>
+                <MenuItem Header="Delete" Click="DeleteMenuItem_Click"
+                          Foreground="{DynamicResource ErrorBrush}"/>
+                <Separator/>
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="Manage Servers" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock Text="Add, edit, or remove monitored SQL Servers" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- Server Grid -->
+        <DataGrid Grid.Row="1" x:Name="ServersGrid"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  SelectionMode="Single"
+                  Background="Transparent" BorderThickness="0"
+                  HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                  MouseDoubleClick="ServersGrid_MouseDoubleClick"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayNameWithIntent}" Width="150"/>
+                <DataGridTextColumn Header="Server" Binding="{Binding ServerNameDisplay}" Width="200"/>
+                <DataGridTextColumn Header="Auth" Binding="{Binding AuthenticationDisplay}" Width="100"/>
+                <DataGridTextColumn Header="Installed Version" Binding="{Binding InstalledVersion}" Width="130"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="80"/>
+                <DataGridTextColumn Header="Monthly Cost ($)" Binding="{Binding MonthlyCostUsd, StringFormat='{}{0:N0}'}" Width="120">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Last Connected" Binding="{Binding LastConnected, StringFormat=yyyy-MM-dd HH:mm}" Width="140"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Add Server" Click="AddButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Edit" Click="EditButton_Click" Margin="0,0,8,0"/>
+            <Button Content="Excluded Databases" Click="ExcludedDatabases_Click" Margin="0,0,8,0"/>
+            <Button Content="Delete" Click="DeleteButton_Click" Margin="0,0,8,0"/>
+            <Button Content="Close" Click="CloseButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Input;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's Manage Servers window — a faithful port of Lite's, over the viewer's own registry
+/// (<see cref="ViewerServerStore"/>). Adds / edits / removes server DEFINITIONS and edits per-server
+/// excluded databases; the "Credential Profiles…" affordance is dropped (the viewer has no
+/// <c>ProfileManager</c> — profiles only matter for live shared connections the viewer never makes).
+/// Making the Darling service honor these definitions is the separate wiring flagged in the PR.
+/// </summary>
+public partial class ManageServersWindow : Window
+{
+    private readonly ViewerServerStore _serverStore;
+
+    /// <summary>True when servers were modified, so the caller refreshes the sidebar.</summary>
+    public bool ServersChanged { get; private set; }
+
+    public ManageServersWindow(ViewerServerStore serverStore)
+    {
+        InitializeComponent();
+        _serverStore = serverStore;
+        RefreshGrid();
+    }
+
+    private void RefreshGrid()
+    {
+        ServersGrid.ItemsSource = null;
+        var servers = _serverStore.GetAllServers();
+        var appVersion = GetAppVersion();
+        foreach (var s in servers)
+        {
+            s.InstalledVersion = appVersion;
+        }
+        ServersGrid.ItemsSource = servers;
+    }
+
+    private static string GetAppVersion()
+    {
+        var raw = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "0.0.0";
+
+        var plusIndex = raw.IndexOf('+');
+        var trimmed = plusIndex >= 0 ? raw[..plusIndex] : raw;
+        return Version.TryParse(trimmed, out var v)
+            ? new Version(v.Major, v.Minor, v.Build).ToString()
+            : trimmed;
+    }
+
+    private void AddButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new AddServerDialog(_serverStore) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void EditButton_Click(object sender, RoutedEventArgs e) => EditSelected();
+
+    private void ServersGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e) => EditSelected();
+
+    private void EditSelected()
+    {
+        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        {
+            return;
+        }
+
+        var dialog = new AddServerDialog(_serverStore, selected) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void EditMenuItem_Click(object sender, RoutedEventArgs e) => EditSelected();
+
+    private void DeleteMenuItem_Click(object sender, RoutedEventArgs e) => DeleteButton_Click(sender, e);
+
+    private void ExcludedDatabases_Click(object sender, RoutedEventArgs e)
+    {
+        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        {
+            return;
+        }
+
+        var dialog = new ExcludedDatabasesDialog(_serverStore, selected) { Owner = this };
+        if (dialog.ShowDialog() == true && dialog.ExclusionsModified)
+        {
+            ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void DeleteButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"Delete server '{selected.DisplayNameWithIntent}'?\n\nThis will remove the server definition and its stored credentials.",
+            "Delete Server",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+
+        if (result == MessageBoxResult.Yes)
+        {
+            _serverStore.DeleteServer(selected.Id);
+            ServersChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "servers", ViewerExportSettings.CsvSeparator);
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The lightweight store reads that drive the shell chrome ported from Lite's MainWindow: the sidebar
+/// status dot (one <c>v_collection_log</c> freshness query for every server at once) and the status bar's
+/// database-size field (<c>pg_database_size</c>). Both are single round-trips so they can run on the
+/// refresh timers without weighing anything down; the SQL lives in public constants so tests can pin the
+/// load-bearing clauses without a live Postgres.
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// Newest collection time per server across all collectors, in one pass — the sidebar dots and the
+    /// status bar's collection field derive freshness from this (the same <c>MAX(collection_time)</c> the
+    /// Overview cards use per server, so a dot and its card agree). Timestamps are the store's naive UTC.
+    /// </summary>
+    public const string ServerFreshnessSql = @"
+SELECT server_id, MAX(collection_time)
+FROM v_collection_log
+GROUP BY server_id";
+
+    /// <summary>The store's on-disk size in bytes (status-bar Database field). No parameters.</summary>
+    public const string StoreSizeSql = "SELECT pg_database_size(current_database())";
+
+    /// <summary>
+    /// Reads MAX(collection_time) for every server in a single query, keyed by server_id. A server with no
+    /// collection rows simply isn't in the dictionary (the caller treats a miss as "no collection" → Offline).
+    /// </summary>
+    public async Task<Dictionary<int, DateTime>> GetServerFreshnessAsync(CancellationToken cancellationToken = default)
+    {
+        var result = new Dictionary<int, DateTime>();
+
+        await using var command = _dataSource.CreateCommand(ServerFreshnessSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            if (!reader.IsDBNull(1))
+            {
+                result[reader.GetInt32(0)] = reader.GetDateTime(1);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>The store database's size in bytes, or null when it can't be read.</summary>
+    public async Task<long?> GetStoreSizeBytesAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(StoreSizeSql);
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is null || result == DBNull.Value ? null : Convert.ToInt64(result);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -8,23 +8,130 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
-/// <summary>One row of the servers table, as the viewer's server list shows it.</summary>
-public sealed record DarlingServer(
-    int ServerId,
-    string ServerName,
-    string DisplayName,
-    bool IsEnabled,
-    int? SqlMajorVersion,
-    decimal MonthlyCostUsd = 0)
+/// <summary>
+/// One row of the servers table, as the viewer's server list shows it. Was a positional record; it is now
+/// a class because the ported Lite server-row chrome needs mutable, change-notifying runtime state on each
+/// row — the favorite star (<see cref="IsFavorite"/>, matched from the viewer's registry) and the
+/// collection-freshness status dot (<see cref="IsOnline"/> / <see cref="HasCollectorErrors"/> →
+/// <see cref="DotStatus"/>) update in place on the refresh timers without resetting the list's selection.
+/// The Postgres-sourced fields stay immutable (get-only); only the sidebar overlay state is settable.
+/// Equality is now reference-based, which every consumer already relies on (they key on
+/// <see cref="ServerId"/> or hold the list's own instances).
+/// </summary>
+public sealed class DarlingServer : INotifyPropertyChanged
 {
+    public DarlingServer(
+        int serverId,
+        string serverName,
+        string displayName,
+        bool isEnabled,
+        int? sqlMajorVersion,
+        decimal monthlyCostUsd = 0)
+    {
+        ServerId = serverId;
+        ServerName = serverName;
+        DisplayName = displayName;
+        IsEnabled = isEnabled;
+        SqlMajorVersion = sqlMajorVersion;
+        MonthlyCostUsd = monthlyCostUsd;
+    }
+
+    public int ServerId { get; }
+    public string ServerName { get; }
+    public string DisplayName { get; }
+    public bool IsEnabled { get; }
+    public int? SqlMajorVersion { get; }
+    public decimal MonthlyCostUsd { get; }
+
     /// <summary>"SQL Server 2022"-style label for the server list; empty when the version is unknown.</summary>
     public string VersionLabel => ViewerDataService.SqlVersionLabel(SqlMajorVersion);
+
+    // ── Runtime-only sidebar state (not from Postgres; drives the ported Lite server-row chrome) ──
+
+    private bool _isFavorite;
+
+    /// <summary>Whether the user pinned this server (from the viewer's registry, matched by name). Drives the star.</summary>
+    public bool IsFavorite
+    {
+        get => _isFavorite;
+        set
+        {
+            if (_isFavorite != value)
+            {
+                _isFavorite = value;
+                OnPropertyChanged(nameof(IsFavorite));
+            }
+        }
+    }
+
+    private bool? _isOnline;
+
+    /// <summary>Freshness "reachability": true = fresh/stale (dot green/amber), false = offline (red), null = unknown.</summary>
+    public bool? IsOnline
+    {
+        get => _isOnline;
+        set
+        {
+            if (_isOnline != value)
+            {
+                _isOnline = value;
+                OnPropertyChanged(nameof(IsOnline));
+                OnPropertyChanged(nameof(DotStatus));
+            }
+        }
+    }
+
+    private bool _hasCollectorErrors;
+
+    /// <summary>Warning (amber) state — in the viewer this means the collection has gone stale.</summary>
+    public bool HasCollectorErrors
+    {
+        get => _hasCollectorErrors;
+        set
+        {
+            if (_hasCollectorErrors != value)
+            {
+                _hasCollectorErrors = value;
+                OnPropertyChanged(nameof(HasCollectorErrors));
+                OnPropertyChanged(nameof(DotStatus));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sidebar status-dot vocabulary — "Online"/"Warning"/"Offline"/"Unknown", identical to Lite's
+    /// <c>ServerConnection.DotStatus</c> so the ported server-row DataTriggers colour the Ellipse the same way.
+    /// </summary>
+    public string DotStatus => IsOnline switch
+    {
+        true => HasCollectorErrors ? "Warning" : "Online",
+        false => "Offline",
+        _ => "Unknown"
+    };
+
+    /// <summary>
+    /// Sets the dot from the same collection-freshness classification the Overview cards use
+    /// (<see cref="ServerSummaryItem.ClassifyFreshness"/>): Fresh → Online, Stale → the amber Warning,
+    /// Offline (or never collected) → red. Both instants are UTC (the store is naive UTC; nowUtc is
+    /// <see cref="DateTime.UtcNow"/>).
+    /// </summary>
+    public void ApplyFreshness(DateTime? lastCollectionUtc, DateTime nowUtc)
+    {
+        var freshness = ServerSummaryItem.ClassifyFreshness(lastCollectionUtc, nowUtc);
+        IsOnline = freshness != ServerFreshness.Offline;
+        HasCollectorErrors = freshness == ServerFreshness.Stale;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
 
 /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerLogger.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerLogger.cs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's minimal file-based application logger — a faithful port of Lite's front-end
+/// <c>AppLogger</c> (buffered, thread-safe, daily-rotated), added so the sidebar's "View Log" /
+/// "Open Log Folder" buttons have a real target. Before this the viewer wrote no application log of
+/// its own (diagnostics went to <see cref="System.Diagnostics.Debug"/> output), which is invisible to
+/// an operator collecting logs for a bug report. Writes one file per day under the viewer's per-user
+/// directory (%APPDATA%\PerformanceMonitorDarling\logs\darling-viewer_yyyyMMdd.log) — the same
+/// Darling-branded Roaming folder <see cref="ViewerPreferencesStore"/> and
+/// <see cref="ViewerAppSettingsStore"/> already use — so all viewer state sits in one place.
+/// </summary>
+public static class ViewerLogger
+{
+    private static readonly ConcurrentQueue<string> s_buffer = new();
+    private static readonly Timer s_flushTimer;
+    private static string s_logDirectory = "";
+    private static bool s_initialized;
+    private static readonly object s_flushLock = new();
+
+    static ViewerLogger()
+    {
+        s_flushTimer = new Timer(_ => Flush(), null, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\logs — the viewer's per-user log directory.</summary>
+    public static string DefaultLogDirectory() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "PerformanceMonitorDarling",
+        "logs");
+
+    /// <summary>
+    /// Points the logger at a directory (default <see cref="DefaultLogDirectory"/>) and starts the 5-second
+    /// flush timer. Safe to call once on startup; a failure to create the directory leaves the logger a
+    /// silent no-op rather than crashing the app.
+    /// </summary>
+    public static void Initialize(string? logDirectory = null)
+    {
+        try
+        {
+            s_logDirectory = logDirectory ?? DefaultLogDirectory();
+            if (!Directory.Exists(s_logDirectory))
+            {
+                Directory.CreateDirectory(s_logDirectory);
+            }
+            s_initialized = true;
+            s_flushTimer.Change(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+            Info("ViewerLogger", "Logging initialized");
+        }
+        catch
+        {
+            /* A logging directory we cannot create must never take down the viewer. */
+            s_initialized = false;
+        }
+    }
+
+    public static void Info(string source, string message) => Log("INFO", source, message);
+
+    public static void Warn(string source, string message) => Log("WARN", source, message);
+
+    public static void Error(string source, string message, Exception? ex = null)
+    {
+        if (ex is not null)
+        {
+            Log("ERROR", source, $"{message} | {ex.GetType().Name}: {ex.Message}");
+            Log("ERROR", source, $"Stack: {ex.StackTrace}");
+
+            var inner = ex.InnerException;
+            var depth = 1;
+            while (inner is not null)
+            {
+                Log("ERROR", source, $"Inner[{depth}]: {inner.GetType().Name}: {inner.Message}");
+                inner = inner.InnerException;
+                depth++;
+            }
+        }
+        else
+        {
+            Log("ERROR", source, message);
+        }
+    }
+
+    private static void Log(string level, string source, string message)
+    {
+        if (!s_initialized)
+        {
+            return;
+        }
+
+        s_buffer.Enqueue($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [{level,-5}] [{source}] {message}");
+    }
+
+    /// <summary>Drains the buffer to today's log file. Serialized so the timer and shutdown never collide.</summary>
+    public static void Flush()
+    {
+        if (!s_initialized || s_buffer.IsEmpty)
+        {
+            return;
+        }
+
+        lock (s_flushLock)
+        {
+            try
+            {
+                var sb = new StringBuilder();
+                while (s_buffer.TryDequeue(out var line))
+                {
+                    sb.AppendLine(line);
+                }
+
+                if (sb.Length > 0)
+                {
+                    File.AppendAllText(GetCurrentLogFile(), sb.ToString());
+                }
+            }
+            catch
+            {
+                /* Never let a logging failure crash the app. */
+            }
+        }
+    }
+
+    public static void Shutdown()
+    {
+        s_flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
+        Flush();
+        s_flushTimer.Dispose();
+    }
+
+    /// <summary>The resolved log directory (empty until <see cref="Initialize"/> succeeds).</summary>
+    public static string GetLogDirectory() => s_logDirectory;
+
+    /// <summary>Today's log file path (darling-viewer_yyyyMMdd.log under the log directory).</summary>
+    public static string GetCurrentLogFile() =>
+        Path.Combine(s_logDirectory, $"darling-viewer_{DateTime.Now:yyyyMMdd}.log");
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerEntry.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerEntry.cs
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// One monitored-server DEFINITION in the viewer's own registry — the Darling analog of Lite's
+/// <see cref="T:PerformanceMonitorLite.Models.ServerConnection"/>, ported for the viewer's Add / Manage /
+/// Edit surfaces (persisted by <see cref="ViewerServerStore"/> to viewer-servers.json).
+///
+/// <para><b>Persistence adaptation (matching the #1402 Settings port).</b> In Lite a
+/// <c>ServerConnection</c> both configures the app's in-process collector AND builds the live SqlClient
+/// connection string. The Darling viewer never connects to monitored SQL Servers (it reads only the
+/// Postgres store — see the README), so this is a pure DECLARATIVE record: the same operator-facing
+/// fields, but with no connection-string builder and no SqlClient dependency. The viewer persists these
+/// faithfully so the Add/Manage/Edit UI is complete and survives a restart; making the running SERVICE
+/// honor an added/edited server (it reads darling.json and registers servers into the store) is a
+/// separate wiring concern flagged in the PR. Favorites are the one field the viewer acts on today —
+/// the sidebar stars + pins them.</para>
+///
+/// <para>Secrets (the SQL password and the service-principal client secret) are NOT stored here — like
+/// Lite, they go to Windows Credential Manager, keyed by <see cref="Id"/>, via
+/// <see cref="ViewerServerStore"/>. The optional Entra UPN is a non-secret hint and IS persisted here
+/// (a small viewer adaptation of Lite, which parked it in the credential store).</para>
+/// </summary>
+public sealed class ViewerServerEntry : INotifyPropertyChanged
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string ServerName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Windows, SqlServer, EntraMFA, ServicePrincipal, or ManagedIdentity (see <see cref="AuthenticationTypes"/>).</summary>
+    public string AuthenticationType { get; set; } = AuthenticationTypes.Windows;
+
+    /// <summary>Service-principal application/client id (non-secret; the SP secret lives in Credential Manager).</summary>
+    public string? AzureClientId { get; set; }
+
+    /// <summary>Optional Entra tenant id (stored for reference only).</summary>
+    public string? AzureTenantId { get; set; }
+
+    /// <summary>Optional user-assigned managed-identity client id (blank = system-assigned).</summary>
+    public string? ManagedIdentityClientId { get; set; }
+
+    /// <summary>Optional Entra MFA UPN hint (non-secret). Viewer adaptation — Lite kept this in the credential store.</summary>
+    public string? EntraUsername { get; set; }
+
+    public string? Description { get; set; }
+    public DateTime CreatedDate { get; set; } = DateTime.Now;
+    public DateTime LastConnected { get; set; } = DateTime.Now;
+    public bool IsFavorite { get; set; }
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Encryption mode: Optional, Mandatory (default), or Strict.</summary>
+    public string EncryptMode { get; set; } = "Mandatory";
+
+    public bool TrustServerCertificate { get; set; }
+
+    /// <summary>Monthly cost in USD for FinOps cost attribution; 0 hides cost columns.</summary>
+    public decimal MonthlyCostUsd { get; set; }
+
+    /// <summary>Per-server override of the deadlock/blocking alert delivery mode; null = inherit the global setting.</summary>
+    public AlertNotificationMode? AlertDeliveryModeOverride { get; set; }
+
+    /// <summary>Optional initial-connection database (required for Azure SQL Database).</summary>
+    public string? DatabaseName { get; set; }
+
+    /// <summary>Optional database where community stored procedures (sp_IndexCleanup) are installed.</summary>
+    public string? UtilityDatabase { get; set; }
+
+    /// <summary>Sets ApplicationIntent=ReadOnly on the eventual connection (AG readable replicas).</summary>
+    public bool ReadOnlyIntent { get; set; }
+
+    /// <summary>Sets MultiSubnetFailover=true (AG listeners and FCIs spanning subnets).</summary>
+    public bool MultiSubnetFailover { get; set; }
+
+    /// <summary>User databases to skip in per-database collectors.</summary>
+    public List<string> ExcludedDatabases { get; set; } = new();
+
+    /// <summary>Server name with "(Read-Only)" suffix when <see cref="ReadOnlyIntent"/> is set (grid + status text).</summary>
+    [JsonIgnore]
+    public string ServerNameDisplay => ReadOnlyIntent ? $"{ServerName} (Read-Only)" : ServerName;
+
+    /// <summary>Display name with "(Read-Only)" suffix when <see cref="ReadOnlyIntent"/> is set.</summary>
+    [JsonIgnore]
+    public string DisplayNameWithIntent => ReadOnlyIntent ? $"{DisplayName} (Read-Only)" : DisplayName;
+
+    /// <summary>Human-readable authentication label for the Manage Servers grid.</summary>
+    [JsonIgnore]
+    public string AuthenticationDisplay => AuthenticationType switch
+    {
+        AuthenticationTypes.EntraMFA => "Microsoft Entra MFA",
+        AuthenticationTypes.SqlServer => "SQL Server",
+        AuthenticationTypes.ServicePrincipal => "Azure — Service Principal",
+        AuthenticationTypes.ManagedIdentity => "Azure — Managed Identity",
+        _ => "Windows"
+    };
+
+    /// <summary>"Enabled"/"Disabled" for the Manage Servers grid.</summary>
+    [JsonIgnore]
+    public string StatusDisplay => IsEnabled ? "Enabled" : "Disabled";
+
+    private string? _installedVersion;
+
+    /// <summary>
+    /// Viewer version populated by the Manage Servers window (runtime-only display field, not persisted).
+    /// Same value for every row since one viewer shows all servers.
+    /// </summary>
+    [JsonIgnore]
+    public string? InstalledVersion
+    {
+        get => _installedVersion;
+        set
+        {
+            if (_installedVersion == value)
+            {
+                return;
+            }
+
+            _installedVersion = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InstalledVersion)));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Windows Credential Manager access for a server entry's secret (SQL password / SP client secret),
+/// abstracted so tests can substitute an in-memory fake and never touch the real per-user vault.
+/// </summary>
+public interface IViewerServerSecretStore
+{
+    void Save(string id, string username, string password);
+    (string Username, string Password)? Get(string id);
+    void Delete(string id);
+}
+
+/// <summary>
+/// Production secret store: the shared <see cref="CredentialStore"/> with the Darling-specific prefix, so
+/// viewer per-server secrets never collide with Lite's, the Dashboard's, or the viewer's SMTP/webhook
+/// secrets (<see cref="ViewerSecretStore"/>). Failures fail safe to no-op/null — a server-management
+/// action must never crash because the credential vault is unavailable.
+/// </summary>
+public sealed class WindowsCredentialServerSecretStore : IViewerServerSecretStore
+{
+    private readonly CredentialStore _store = new("PerformanceMonitorDarling_");
+
+    public void Save(string id, string username, string password)
+    {
+        try
+        {
+            _store.SaveCredential(id, username, password);
+        }
+        catch
+        {
+            /* Never let a vault write crash server management. */
+        }
+    }
+
+    public (string Username, string Password)? Get(string id)
+    {
+        try
+        {
+            return _store.GetCredential(id);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Delete(string id)
+    {
+        try
+        {
+            _store.DeleteCredential(id);
+        }
+        catch
+        {
+            /* No-op on a missing key or vault error. */
+        }
+    }
+}
+
+/// <summary>
+/// The viewer's own registry of monitored-server DEFINITIONS — the Darling analog of Lite's
+/// <c>ServerManager</c>, backing the Add / Manage / Edit / Remove surfaces. Persists a list of
+/// <see cref="ViewerServerEntry"/> as indented JSON in the viewer's per-user directory
+/// (%APPDATA%\PerformanceMonitorDarling\viewer-servers.json), mirroring
+/// <see cref="ViewerPreferencesStore"/> / <see cref="ViewerAppSettingsStore"/>. Secrets go to Windows
+/// Credential Manager (keyed by <see cref="ViewerServerEntry.Id"/>), never to the JSON file.
+///
+/// <para>Both the on-disk path and the secret store are injectable so tests round-trip against a temp
+/// file and an in-memory secret fake without touching the real profile or vault. As with the rest of the
+/// Lite→Darling port, this persists faithfully; the running SERVICE honoring these definitions is a
+/// separate wiring concern (see the PR).</para>
+/// </summary>
+public sealed class ViewerServerStore
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+    private readonly IViewerServerSecretStore _secrets;
+    private readonly List<ViewerServerEntry> _servers;
+
+    /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
+    /// <param name="secretStore">Override the credential vault (tests pass an in-memory fake); null uses the real Credential Manager.</param>
+    public ViewerServerStore(string? filePath = null, IViewerServerSecretStore? secretStore = null)
+    {
+        _filePath = filePath ?? DefaultFilePath();
+        _secrets = secretStore ?? new WindowsCredentialServerSecretStore();
+        _servers = LoadFromDisk();
+    }
+
+    /// <summary>The resolved registry file path (surfaced for tests and diagnostics).</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-servers.json.</summary>
+    public static string DefaultFilePath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-servers.json");
+    }
+
+    /// <summary>
+    /// All registered server definitions, favorites first (Lite's pin rule), then by display name
+    /// (case-insensitive). Returns a fresh sorted snapshot; callers may safely mutate the list.
+    /// </summary>
+    public List<ViewerServerEntry> GetAllServers() =>
+        _servers
+            .OrderByDescending(s => s.IsFavorite)
+            .ThenBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>The first registered entry whose server name matches (case-insensitive), or null.</summary>
+    public ViewerServerEntry? GetByServerName(string serverName) =>
+        _servers.FirstOrDefault(s => string.Equals(s.ServerName, serverName, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Whether a server with this name is marked favorite in the registry.</summary>
+    public bool IsFavorite(string serverName) => GetByServerName(serverName)?.IsFavorite == true;
+
+    /// <summary>Adds a new server definition, persists it, and stores its secret when one was supplied.</summary>
+    public void AddServer(ViewerServerEntry entry, string? username, string? password)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _servers.Add(entry);
+        ApplySecret(entry.Id, username, password);
+        Save();
+    }
+
+    /// <summary>
+    /// Replaces the registered entry with the same <see cref="ViewerServerEntry.Id"/> (adding it if new),
+    /// updates its secret, and persists. Mirrors Lite's <c>ServerManager.UpdateServer</c>.
+    /// </summary>
+    public void UpdateServer(ViewerServerEntry entry, string? username, string? password)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ReplaceOrAdd(entry);
+        ApplySecret(entry.Id, username, password);
+        Save();
+    }
+
+    /// <summary>Persists an in-place edit of an existing entry (e.g. excluded databases) without touching its secret.</summary>
+    public void UpdateServer(ViewerServerEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ReplaceOrAdd(entry);
+        Save();
+    }
+
+    /// <summary>Removes the server with this id, deletes its stored secret, and persists.</summary>
+    public void DeleteServer(string id)
+    {
+        var removed = _servers.RemoveAll(s => s.Id == id) > 0;
+        if (removed)
+        {
+            _secrets.Delete(id);
+            Save();
+        }
+    }
+
+    /// <summary>
+    /// Imports server definitions from another viewer's registry file, upserting by server name — an
+    /// existing name is skipped (Lite's "skipped duplicate" behavior). Each imported entry gets a fresh id
+    /// because secrets never cross machines (they live in the source machine's Credential Manager). Returns
+    /// the imported and skipped counts.
+    /// </summary>
+    public (int Imported, int Skipped) ImportServersFromFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        var incoming = JsonSerializer.Deserialize<List<ViewerServerEntry>>(File.ReadAllText(path), s_jsonOptions)
+            ?? new List<ViewerServerEntry>();
+
+        var imported = 0;
+        var skipped = 0;
+        foreach (var entry in incoming)
+        {
+            if (string.IsNullOrWhiteSpace(entry.ServerName) || GetByServerName(entry.ServerName) is not null)
+            {
+                skipped++;
+                continue;
+            }
+
+            entry.Id = Guid.NewGuid().ToString();
+            _servers.Add(entry);
+            imported++;
+        }
+
+        if (imported > 0)
+        {
+            Save();
+        }
+
+        return (imported, skipped);
+    }
+
+    /// <summary>
+    /// Flips the favorite flag for the server with this name and persists, returning the new state. When no
+    /// registry entry exists yet (the sidebar server came straight from the Postgres store), a minimal entry
+    /// is created and marked favorite — "adopting" the collected server into the registry so the one favorites
+    /// source of truth stays in the registry, exactly like Lite pins on <c>ServerConnection.IsFavorite</c>.
+    /// </summary>
+    public bool ToggleFavorite(string serverName)
+    {
+        var entry = GetByServerName(serverName);
+        if (entry is null)
+        {
+            entry = new ViewerServerEntry
+            {
+                ServerName = serverName,
+                DisplayName = serverName,
+                IsFavorite = true
+            };
+            _servers.Add(entry);
+        }
+        else
+        {
+            entry.IsFavorite = !entry.IsFavorite;
+        }
+
+        Save();
+        return entry.IsFavorite;
+    }
+
+    /// <summary>The stored (username, password) for a server id, or null — used to pre-fill the Edit dialog.</summary>
+    public (string Username, string Password)? GetCredential(string id) => _secrets.Get(id);
+
+    private void ApplySecret(string id, string? username, string? password)
+    {
+        if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+        {
+            _secrets.Save(id, username, password);
+        }
+        else
+        {
+            /* Windows / Entra / Managed Identity carry no per-server secret — clear any stale one so a
+               later auth-mode switch can't resurrect it (mirrors Lite's scrub-on-zero-touch behavior). */
+            _secrets.Delete(id);
+        }
+    }
+
+    private void ReplaceOrAdd(ViewerServerEntry entry)
+    {
+        var index = _servers.FindIndex(s => s.Id == entry.Id);
+        if (index >= 0)
+        {
+            _servers[index] = entry;
+        }
+        else
+        {
+            _servers.Add(entry);
+        }
+    }
+
+    private List<ViewerServerEntry> LoadFromDisk()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new List<ViewerServerEntry>();
+            }
+
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize<List<ViewerServerEntry>>(json, s_jsonOptions)
+                ?? new List<ViewerServerEntry>();
+        }
+        catch (Exception ex)
+        {
+            /* A corrupt or unreadable registry must never block startup — begin empty and log. */
+            Debug.WriteLine($"ViewerServerStore: failed to load '{_filePath}', starting empty: {ex.Message}");
+            ViewerLogger.Warn("ViewerServerStore", $"Failed to load '{_filePath}': {ex.Message}");
+            return new List<ViewerServerEntry>();
+        }
+    }
+
+    private void Save()
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(_filePath, JsonSerializer.Serialize(_servers, s_jsonOptions));
+    }
+}


### PR DESCRIPTION
## Summary

Brings the **Darling viewer's** MainWindow chrome, server list, and server management to parity with **Lite's MainWindow**. The viewer is a copy of Lite's front end, but its sidebar had regressed to a reduced version (server rows were just name + version; no status dot, no favorites, no context menu, no Add/Manage Servers, no sidebar collapse, a single-field status bar). This is a faithful port with the same hard viewer-fact adaptations the rest of the port has used.

Follows the #1401/#1402 Settings-port pattern: UI ported faithfully; state persists to the viewer's **own** config; making the running **service** honor it is separate wiring, flagged below.

## Ported (faithful)

1. **Server-row template** — collection-freshness **status dot** (Online/Offline/Warning, derived from the newest `collection_log` age — the same signal the Overview cards use), **favorite star**, name + details, all bound exactly like Lite's `ListView.ItemTemplate`.
2. **Context menu** — Toggle Favorite / Edit / Remove.
3. **Favorites** — persisted in the viewer's registry (`viewer-servers.json`), matched by server name; sidebar **pins favorites to the top** and stars them (Lite's ordering). Live star + dot updates via `INotifyPropertyChanged` (no list-reset flicker).
4. **Sidebar footer** — added **Add Server, Manage Servers, View Log, Open Log Folder, Import Settings**; kept the existing Open Plan Viewer / Settings / About.
5. **Add / Manage / Edit / Remove servers** — ported Lite's `ManageServersWindow` + Add/Edit dialog + Excluded Databases, persisting to a new `ViewerServerStore` (the Darling analog of Lite's `ServerManager`/`servers.json`). Secrets go to Windows Credential Manager under the Darling prefix (mirrors Lite + the viewer's existing `ViewerSecretStore`).
6. **Logging + View Log / Open Log Folder** — the viewer had no app log (diagnostics went to `Debug` output), so this adds `ViewerLogger` (a faithful port of Lite's buffered, daily-rotated `AppLogger`) writing to `%APPDATA%\PerformanceMonitorDarling\logs\`, initialized in `App.OnStartup` (with unhandled-exception logging) and flushed on exit. The two buttons target it. *(Verified at runtime: the log file is written with startup lines.)*
7. **Sidebar collapse toggle** (« / ») + **multi-field status bar**: general status, collector health (from freshness across all servers), store **database size** (`pg_database_size`), collection status, and server count.
8. Tests added (favorites persistence + ordering + CRUD + import; status-dot derivation from freshness; entry display helpers; new SQL constants).

## Hard-fact adaptations (the viewer reads only the Postgres store and never connects to monitored servers — documented in the README)

- **Connect / Disconnect** context-menu items — **omitted**. The viewer has no live connection to open/close.
- **Test Connection** button in the Add/Edit dialog — **omitted**. Same reason (the viewer doesn't reference SqlClient); the dialog is a declarative config editor.
- **Import Data** (Lite's DuckDB historical import) — **omitted**. No viewer meaning.
- **Shared Credential Profiles** (Lite's `ProfileManager` + profiles dialog) — **omitted**. A distinct subsystem whose sole purpose is sharing credentials across *live* connections the viewer never makes; the Add/Edit dialog keeps inline per-server auth (all five modes) as declarative config. Available as a follow-up if wanted.
- **Excluded Databases** — **adapted** to a manual, one-name-per-line editor (Lite enumerates the server's live databases; the viewer can't, since it never connects). The `ExcludedDatabases` field itself round-trips faithfully.

## Follow-up: server-management service wiring (flagged, not dropped)

Add / Edit / Remove and favorites **persist to the viewer's registry** (`viewer-servers.json` + Credential Manager) and survive a restart, but the running **Darling service** does not yet read that registry. So:

- A newly **Added** server does not appear in the sidebar until the service registers it into the Postgres store (the sidebar lists servers the service is actually *collecting*). The Add success message says as much.
- **Remove** deletes only the viewer-side definition + favorite; the service keeps collecting until reconfigured (the confirm dialog says as much).
- Captured per-server **secrets** are written to the viewer's Credential Manager for future service use; the viewer itself never consumes them.

Wiring the service to read `viewer-servers.json` (or the viewer to write `darling.json`) and register servers into the store is the separate follow-up — exactly the shape of the #1402 Settings port's deferred wiring.

## Build + tests

- **Viewer** `-c Release`: **Build succeeded, 0 errors** (4 warnings, all pre-existing in dependency projects).
- **Darling.Tests** `-c Release`: **892 passed, 0 failed, 87 skipped** (the skips are the live-Postgres / live-SQL end-to-end tests that need a dev store). **+21 new tests** (all pass).
- Runtime smoke: the viewer launches and MainWindow initializes cleanly with all ported chrome; the log file is written.

## Files

New (viewer): `ViewerLogger.cs`, `ViewerServerEntry.cs`, `ViewerServerStore.cs`, `ViewerDataService.ServerStatus.cs`, `MainWindow.ServerManagement.cs`, `AddServerDialog.xaml(.cs)`, `ManageServersWindow.xaml(.cs)`, `ExcludedDatabasesDialog.xaml(.cs)`. New (tests): `ViewerServerStoreTests.cs`, `ViewerServerChromeTests.cs`. Modified: `App.xaml.cs`, `MainWindow.xaml(.cs)`, `ViewerDataService.cs` (`DarlingServer` record → change-notifying class with sidebar overlay state).

Scope: viewer + Darling.Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
