### PR TITLE
Add Corruption + Contention Events to Darling viewer System Events

### DIFF
--- a/Darling/Darling.Tests/Fixtures/SystemHealth/sp_server_diagnostics_system.xml
+++ b/Darling/Darling.Tests/Fixtures/SystemHealth/sp_server_diagnostics_system.xml
@@ -1,0 +1,10 @@
+<event name="sp_server_diagnostics_component_result" package="sqlserver" timestamp="2026-07-05T12:07:00.000Z">
+  <data name="component"><type name="sql_server_diagnostics_component" package="sqlserver" /><value>0</value><text>SYSTEM</text></data>
+  <data name="state"><value>1</value><text>CLEAN</text></data>
+  <data name="data">
+    <type name="xml" package="package0" />
+    <value>
+      <system spinlockBackoffs="12345" sickSpinlockType="SOS_CACHESTORE" sickSpinlockTypeAfterAv="SOS_SUSPEND_QUEUE" latchWarnings="7" isAccessViolationOccurred="1" writeAccessViolationCount="3" totalDumpRequests="9" intervalDumpRequests="2" nonYieldingTasksReported="4" pageFaults="654321" systemCpuUtilization="65" sqlCpuUtilization="40" BadPagesDetected="6" BadPagesFixed="5" LastBadPageAddress="0x0" />
+    </value>
+  </data>
+</event>

--- a/Darling/Darling.Tests/SystemHealthParserTests.cs
+++ b/Darling/Darling.Tests/SystemHealthParserTests.cs
@@ -36,6 +36,7 @@ public class SystemHealthParserTests
     private static readonly DateTime IoTime = new(2026, 7, 5, 12, 5, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime CpuWarningTime = new(2026, 7, 5, 12, 6, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime CpuCleanTime = new(2026, 7, 5, 12, 1, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SystemTime = new(2026, 7, 5, 12, 7, 0, 0, DateTimeKind.Utc);
 
     // ── SchedulerIssues (scheduler_monitor_system_health_ring_buffer_recorded) ──
 
@@ -341,6 +342,42 @@ public class SystemHealthParserTests
         Assert.Empty(SystemHealthParser.ParseIoIssues(xml));
     }
 
+    // ── SystemHealth (sp_server_diagnostics_component_result / SYSTEM) ──
+
+    [Fact]
+    public void SystemHealth_ShredsEveryColumn()
+    {
+        var r = SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_system.xml"));
+
+        Assert.NotNull(r);
+        Assert.Equal(SystemTime, r!.EventTime);
+        Assert.Equal("CLEAN", r.State);                       // data[@name="state"]/text
+        Assert.Equal(12345L, r.SpinlockBackoffs);             // <system> attributes
+        Assert.Equal("SOS_CACHESTORE", r.SickSpinlockType);
+        Assert.Equal("SOS_SUSPEND_QUEUE", r.SickSpinlockTypeAfterAv);
+        Assert.Equal(7L, r.LatchWarnings);
+        Assert.Equal(1L, r.IsAccessViolationOccurred);        // bigint, not bit — matches the *_SystemHealth column
+        Assert.Equal(3L, r.WriteAccessViolationCount);
+        Assert.Equal(9L, r.TotalDumpRequests);
+        Assert.Equal(2L, r.IntervalDumpRequests);
+        Assert.Equal(4L, r.NonYieldingTasksReported);
+        Assert.Equal(654321L, r.PageFaults);
+        Assert.Equal(65L, r.SystemCpuUtilization);
+        Assert.Equal(40L, r.SqlCpuUtilization);
+        Assert.Equal(6L, r.BadPagesDetected);
+        Assert.Equal(5L, r.BadPagesFixed);
+    }
+
+    [Fact]
+    public void SystemHealth_NonSystemComponent_YieldsNoRecord()
+    {
+        // RESOURCE / QUERY_PROCESSING / IO_SUBSYSTEM components carry no <system> node — no system-health
+        // counters to report (parity with the CROSS APPLY over /event/data/value/system returning nothing).
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_resource.xml")));
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_query_processing.xml")));
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_io_subsystem.xml")));
+    }
+
     // ── dispatch (ParseEvents / ParseInto) ──
 
     [Fact]
@@ -350,6 +387,7 @@ public class SystemHealthParserTests
         {
             (SystemHealthParser.SchedulerMonitorEvent, LoadFixture("scheduler_monitor.xml")),
             (SystemHealthParser.ErrorReportedEvent, LoadFixture("error_reported.xml")),
+            (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_system.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_resource.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_query_processing.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_io_subsystem.xml")),
@@ -365,13 +403,16 @@ public class SystemHealthParserTests
         Assert.Single(result.MemoryBroker);
         Assert.Single(result.MemoryNodeOom);
         Assert.Single(result.SignificantWaits);
-        // Three sp_server_diagnostics events route by component: RESOURCE -> memory conditions,
-        // QUERY_PROCESSING -> CPU tasks, IO_SUBSYSTEM -> I/O issues (two files -> two rows).
+        // Four sp_server_diagnostics events route by component: SYSTEM -> system health,
+        // RESOURCE -> memory conditions, QUERY_PROCESSING -> CPU tasks, IO_SUBSYSTEM -> I/O issues
+        // (two files -> two rows). Each component parser is a no-op on the other three components.
+        Assert.Single(result.SystemHealth);
         Assert.Single(result.MemoryConditions);
         Assert.Single(result.CpuTasks);
         Assert.Equal(2, result.IoIssues.Count);
         Assert.Equal(10, result.SchedulerIssues[0].SchedulerId);
         Assert.Equal(823, result.SevereErrors[0].ErrorNumber);
+        Assert.Equal(6, result.SystemHealth[0].BadPagesDetected);
     }
 
     [Fact]
@@ -422,6 +463,7 @@ public class SystemHealthParserTests
         Assert.Null(SystemHealthParser.ParseMemoryNodeOom(xml));
         Assert.Null(SystemHealthParser.ParseSignificantWait(xml));
         Assert.Null(SystemHealthParser.ParseCpuTasks(xml));
+        Assert.Null(SystemHealthParser.ParseSystemHealth(xml));
         Assert.Empty(SystemHealthParser.ParseIoIssues(xml));   // list-returning shred: empty, never throws
     }
 

--- a/Darling/Darling.Tests/ViewerSystemEventsTests.cs
+++ b/Darling/Darling.Tests/ViewerSystemEventsTests.cs
@@ -294,6 +294,55 @@ public sealed class ViewerSystemEventsTests
         Assert.All(rows, r => Assert.True(SystemEventSignificance.IsSignificant(r)));
     }
 
+    // ── System Health (Corruption + Contention counter charts — NO significance filter) ──
+
+    [Fact]
+    public void SystemHealth_Fixture_ShredsBothCorruptionAndContentionCounters()
+    {
+        // The ONE SYSTEM-component record feeds BOTH chart sub-tabs: the Corruption Events charts read the
+        // bad-page / dump / access-violation columns; the Contention Events charts read the non-yielding /
+        // latch / spinlock / CPU columns. Pin that every column both tabs plot is present off one shred.
+        var r = SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_system.xml"))!;
+
+        // Corruption Events columns.
+        Assert.Equal(6L, r.BadPagesDetected);
+        Assert.Equal(2L, r.IntervalDumpRequests);
+        Assert.Equal(1L, r.IsAccessViolationOccurred);
+        Assert.Equal(3L, r.WriteAccessViolationCount);
+        // Contention Events columns.
+        Assert.Equal(4L, r.NonYieldingTasksReported);
+        Assert.Equal(7L, r.LatchWarnings);
+        Assert.Equal("SOS_CACHESTORE", r.SickSpinlockType);
+        Assert.Equal(12345L, r.SpinlockBackoffs);
+        Assert.Equal(65L, r.SystemCpuUtilization);
+        Assert.Equal(40L, r.SqlCpuUtilization);
+    }
+
+    [Fact]
+    public void SystemHealth_CleanSnapshot_IsStillKept_NoWarningsOnlyGate()
+    {
+        // Unlike the grid categories, the Corruption / Contention charts plot EVERY collected snapshot over
+        // time — there is no significance / warnings-only filter (GetSystemHealthAsync keeps every SYSTEM
+        // record with a timestamp). The representative fixture is a CLEAN snapshot, and it is a real record
+        // (not dropped), so the counter charts render it. This is the design contrast with the filtered grids.
+        var r = SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_system.xml"));
+
+        Assert.NotNull(r);
+        Assert.Equal("CLEAN", r!.State);
+        Assert.True(r.EventTime.HasValue);   // GetSystemHealthAsync requires a timestamp to sit on the time axis
+    }
+
+    [Fact]
+    public void SystemHealth_NonSystemComponent_YieldsNothing()
+    {
+        // The SYSTEM read shares the sp_server_diagnostics feed with Memory Conditions / CPU Tasks / I/O
+        // Issues; only the SYSTEM component contributes a record (the others parse to null, so the charts
+        // never plot a RESOURCE / QUERY_PROCESSING / IO_SUBSYSTEM snapshot).
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_resource.xml")));
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_query_processing.xml")));
+        Assert.Null(SystemHealthParser.ParseSystemHealth(LoadFixture("sp_server_diagnostics_io_subsystem.xml")));
+    }
+
     // ── End-to-end: shred the fixtures then apply the filters (the data-service path's logic) ──
 
     [Fact]
@@ -303,6 +352,7 @@ public sealed class ViewerSystemEventsTests
         {
             (SystemHealthParser.SchedulerMonitorEvent, LoadFixture("scheduler_monitor.xml")),
             (SystemHealthParser.ErrorReportedEvent, LoadFixture("error_reported.xml")),
+            (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_system.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_resource.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_query_processing.xml")),
             (SystemHealthParser.SpServerDiagnosticsEvent, LoadFixture("sp_server_diagnostics_query_processing_warning.xml")),
@@ -325,6 +375,9 @@ public sealed class ViewerSystemEventsTests
         // CPU: the WARNING+15-pending event passes; the CLEAN one is dropped. I/O: both WARNING file rows pass.
         Assert.Single(result.CpuTasks.Where(SystemEventSignificance.IsSignificant));
         Assert.Equal(2, result.IoIssues.Count(SystemEventSignificance.IsSignificant));
+        // System Health (Corruption + Contention charts) has NO significance filter — the CLEAN SYSTEM
+        // snapshot is kept, so the counter charts plot it (contrast with the dropped HIGH memory rows above).
+        Assert.Single(result.SystemHealth);
     }
 
     // ── Severe-Errors database_id resolution ──

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
@@ -488,4 +488,35 @@ public sealed partial class ViewerDataService
             return rows;
         }, cancellationToken);
     }
+
+    // ── System Health (Corruption + Contention counter charts) ──
+
+    /// <summary>
+    /// Every SYSTEM-component health snapshot for the window, oldest first (time-series order for the
+    /// charts). Reads the same sp_server_diagnostics feed as Memory Conditions / CPU Tasks / I/O Issues;
+    /// only the SYSTEM component yields a record. Unlike the grid categories this applies NO significance
+    /// filter — the Dashboard's Corruption Events + Contention Events tabs plot every collected snapshot's
+    /// counters over time, so the viewer returns them all (records with no event time can't sit on a time
+    /// axis and are dropped). Both chart sub-tabs read this one list and select their own columns.
+    /// </summary>
+    public async Task<List<SystemHealthRecord>> GetSystemHealthAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var xmls = await ReadSystemHealthEventXmlAsync(
+            serverId, startUtc, endUtc, SystemHealthParser.SpServerDiagnosticsEvent, cancellationToken);
+
+        return await Task.Run(() =>
+        {
+            var records = new List<SystemHealthRecord>();
+            foreach (var xml in xmls)
+            {
+                // Only the SYSTEM component yields a record; other sp_server_diagnostics components parse to null.
+                var record = SystemHealthParser.ParseSystemHealth(xml);
+                if (record != null && record.EventTime.HasValue)
+                    records.Add(record);
+            }
+            records.Sort((a, b) => Nullable.Compare(a.EventTime, b.EventTime));
+            return records;
+        }, cancellationToken);
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -90,6 +90,7 @@ public partial class ViewerServerTab : IDisposable
         DisposeCollectionHealthHelpers();
         DisposeQueriesTabHelpers();
         DisposePlanHelpers();
+        DisposeSystemHealthChartHelpers();
     }
 
     /// <summary>Loads the CPU tab: raw per-sample CPU utilization over the window.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
@@ -15,25 +15,36 @@ using PerformanceMonitor.Ui;
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The System Events inner tab (system_health parity, Stage 2b) — eight sub-tabs, one per unique
-/// system_health warning category, each a parse-on-read grid: <see cref="ViewerDataService"/> fetches the
-/// raw event_xml for the category over the toolbar's settable window, the Common <c>SystemHealthParser</c>
-/// shreds it, and <c>SystemEventSignificance</c> keeps the sp_HealthParser-significant rows. Mirrors the
-/// FinOps tab's inner sub-tab-strip + DataGrid conventions (visible-only load, shared column filters,
-/// per-sub-tab count indicator + refresh). Timestamps render machine-local like the deadlock / blocked-
-/// process grids (the event's naive-UTC XE @timestamp via <see cref="ViewerDataService.ToLocalTime"/>).
+/// The System Events inner tab (system_health parity, Stage 2b) — a faithful reproduction of the full
+/// Dashboard's System Events, covering all nine Dashboard categories. Two lead sub-tabs (Corruption Events
+/// + Contention Events) are the SYSTEM-component counter CHARTS — the Dashboard's presentation for those
+/// two — rendered from a single sp_server_diagnostics SYSTEM feed with no significance filter (every
+/// snapshot plotted over time), wired in <see cref="ViewerServerTab.SystemHealthCharts"/>. The remaining
+/// sub-tabs are parse-on-read GRIDS, one per unique warning category (plus Darling's extra Significant
+/// Waits): <see cref="ViewerDataService"/> fetches the raw event_xml for the category over the toolbar's
+/// settable window, the Common <c>SystemHealthParser</c> shreds it, and <c>SystemEventSignificance</c>
+/// keeps the sp_HealthParser-significant rows. Mirrors the FinOps tab's inner sub-tab-strip + DataGrid
+/// conventions (visible-only load, shared column filters, per-sub-tab count indicator + refresh).
+/// Timestamps render machine-local like the deadlock / blocked-process grids (the event's naive-UTC XE
+/// @timestamp via <see cref="ViewerDataService.ToLocalTime"/>).
 /// </summary>
 public partial class ViewerServerTab
 {
-    /* System Events sub-tab order (matches the XAML TabItem order). */
-    private const int SystemEventsSchedulerIssuesSubTabIndex = 0;
-    private const int SystemEventsSevereErrorsSubTabIndex = 1;
-    private const int SystemEventsMemoryConditionsSubTabIndex = 2;
-    private const int SystemEventsMemoryBrokerSubTabIndex = 3;
-    private const int SystemEventsMemoryNodeOomSubTabIndex = 4;
-    private const int SystemEventsSignificantWaitsSubTabIndex = 5;
-    private const int SystemEventsCpuTasksSubTabIndex = 6;
-    private const int SystemEventsIoIssuesSubTabIndex = 7;
+    /* System Events sub-tab order (matches the XAML TabItem order). Corruption + Contention lead — the
+       two SYSTEM-component counter-chart tabs, mirroring the Dashboard's System Events order (its
+       Corruption Events tab is the default). Both read the one SYSTEM-component feed and select their own
+       columns, so they share a single load (LoadSystemHealthChartsAsync). The rest keep Darling's existing
+       relative order. */
+    private const int SystemEventsCorruptionSubTabIndex = 0;
+    private const int SystemEventsContentionSubTabIndex = 1;
+    private const int SystemEventsSchedulerIssuesSubTabIndex = 2;
+    private const int SystemEventsSevereErrorsSubTabIndex = 3;
+    private const int SystemEventsMemoryConditionsSubTabIndex = 4;
+    private const int SystemEventsMemoryBrokerSubTabIndex = 5;
+    private const int SystemEventsMemoryNodeOomSubTabIndex = 6;
+    private const int SystemEventsSignificantWaitsSubTabIndex = 7;
+    private const int SystemEventsCpuTasksSubTabIndex = 8;
+    private const int SystemEventsIoIssuesSubTabIndex = 9;
 
     private DataGridFilterManager<SchedulerIssueRow>? _seSchedulerFilterMgr;
     private DataGridFilterManager<SevereErrorRow>? _seSevereErrorFilterMgr;
@@ -45,9 +56,10 @@ public partial class ViewerServerTab
     private DataGridFilterManager<IoIssuesRow>? _seIoIssuesFilterMgr;
 
     /// <summary>
-    /// Registers the six System Events grids' column-filter managers into the shared
+    /// Registers the eight System Events grids' column-filter managers into the shared
     /// <c>_filterManagers</c> map (defined in <c>ViewerServerTab.Filters.cs</c>). Called from the
-    /// constructor after InitializeComponent, alongside the other Initialize* hooks.
+    /// constructor after InitializeComponent, alongside the other Initialize* hooks. The Corruption /
+    /// Contention chart sub-tabs have no grids, so they register no filter manager here.
     /// </summary>
     private void InitializeSystemEventsTab()
     {
@@ -94,6 +106,9 @@ public partial class ViewerServerTab
     {
         switch (SystemEventsSubTabControl.SelectedIndex)
         {
+            case SystemEventsSchedulerIssuesSubTabIndex:
+                await LoadSchedulerIssuesAsync();
+                break;
             case SystemEventsSevereErrorsSubTabIndex:
                 await LoadSevereErrorsAsync();
                 break;
@@ -115,9 +130,13 @@ public partial class ViewerServerTab
             case SystemEventsIoIssuesSubTabIndex:
                 await LoadIoIssuesAsync();
                 break;
-            case SystemEventsSchedulerIssuesSubTabIndex:
+            // Corruption Events (0) and Contention Events (1) share the one SYSTEM-component feed, so both
+            // render from a single load — mirroring the Dashboard's case 0/case 1 → RefreshSystemHealthAsync.
+            // This is also the default, so the first-shown sub-tab (Corruption Events) loads on activation.
+            case SystemEventsCorruptionSubTabIndex:
+            case SystemEventsContentionSubTabIndex:
             default:
-                await LoadSchedulerIssuesAsync();
+                await LoadSystemHealthChartsAsync();
                 break;
         }
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The System Events tab's two SYSTEM-component counter-chart sub-tabs — Corruption Events and Contention
+/// Events — the faithful reproduction of the sibling Dashboard's <c>SystemEventsContent</c> Corruption /
+/// Contention 2x2 chart grids (<c>LoadCorruptionEventsCharts</c> / <c>LoadContentionEventsCharts</c>) in
+/// the viewer's chart idiom. Both sub-tabs read the ONE SYSTEM-component feed
+/// (<see cref="ViewerDataService.GetSystemHealthAsync"/>) and select their own columns, so a single load
+/// renders all eight charts — exactly as the Dashboard's <c>RefreshSystemHealthAsync</c> feeds both tabs.
+/// Unlike the grid categories these plot EVERY collected snapshot over time (no significance filter);
+/// counts floor at 0 and the time axis is bound to the toolbar's settable window
+/// (<see cref="ViewerServerTab.GetWindowUtc"/>). Chrome / line polish / colors flow through the shared
+/// <see cref="ChartStyle"/> / <see cref="ChartPalette"/> and the <c>ViewerServerTab.ChartHelpers.cs</c>
+/// bridge, matching the CPU / Latch-Spinlock chart tabs; hover tooltips are kept (no per-chart context
+/// menu, consistent with the viewer's other charts).
+/// </summary>
+public partial class ViewerServerTab
+{
+    private ChartHoverHelper? _badPagesHover;
+    private ChartHoverHelper? _dumpRequestsHover;
+    private ChartHoverHelper? _accessViolationsHover;
+    private ChartHoverHelper? _writeAccessViolationsHover;
+    private ChartHoverHelper? _nonYieldingTasksHover;
+    private ChartHoverHelper? _latchWarningsHover;
+    private ChartHoverHelper? _sickSpinlocksHover;
+    private ChartHoverHelper? _cpuComparisonHover;
+
+    /// <summary>Applies the shared chrome + hover to the eight Corruption/Contention charts up front
+    /// (constructor), so they don't flash white before the tab's first load — matching the CPU/Latch charts.
+    /// Hover units mirror the Dashboard's (events / backoffs / %).</summary>
+    private void InitializeSystemHealthCharts()
+    {
+        foreach (var chart in new[]
+        {
+            BadPagesChart, DumpRequestsChart, AccessViolationsChart, WriteAccessViolationsChart,
+            NonYieldingTasksChart, LatchWarningsChart, SickSpinlocksChart, CpuComparisonChart,
+        })
+        {
+            ApplyTheme(chart);
+            chart.Refresh();
+        }
+
+        _badPagesHover = new ChartHoverHelper(BadPagesChart, "events");
+        _dumpRequestsHover = new ChartHoverHelper(DumpRequestsChart, "events");
+        _accessViolationsHover = new ChartHoverHelper(AccessViolationsChart, "events");
+        _writeAccessViolationsHover = new ChartHoverHelper(WriteAccessViolationsChart, "events");
+        _nonYieldingTasksHover = new ChartHoverHelper(NonYieldingTasksChart, "events");
+        _latchWarningsHover = new ChartHoverHelper(LatchWarningsChart, "events");
+        _sickSpinlocksHover = new ChartHoverHelper(SickSpinlocksChart, "backoffs");
+        _cpuComparisonHover = new ChartHoverHelper(CpuComparisonChart, "%");
+    }
+
+    /// <summary>
+    /// Loads both Corruption + Contention chart sub-tabs from a single SYSTEM-component read over the
+    /// toolbar's settable window (the reads are already bounded on both ends, so no client-side end-trim
+    /// is needed unlike the start-only CPU/tempdb reads). Mirrors the Dashboard's one-refresh-feeds-both.
+    /// </summary>
+    private async Task LoadSystemHealthChartsAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetSystemHealthAsync(_server.ServerId, startUtc, endUtc);
+
+        double xMin = ViewerDataService.ToLocalTime(startUtc).ToOADate();
+        double xMax = ViewerDataService.ToLocalTime(endUtc).ToOADate();
+
+        // Corruption Events (2x2).
+        RenderCounterChart(BadPagesChart, _badPagesHover, data, d => d.BadPagesDetected, "Bad Pages",
+            ChartPalette.CyclingColor(3), xMin, xMax);
+        RenderCounterChart(DumpRequestsChart, _dumpRequestsHover, data, d => d.IntervalDumpRequests, "Dump Requests",
+            ChartPalette.CyclingColor(2), xMin, xMax);
+        RenderCounterChart(AccessViolationsChart, _accessViolationsHover, data, d => d.IsAccessViolationOccurred, "Access Violations",
+            ChartPalette.CyclingColor(4), xMin, xMax);
+        RenderCounterChart(WriteAccessViolationsChart, _writeAccessViolationsHover, data, d => d.WriteAccessViolationCount, "Write Access Violations",
+            ChartPalette.CyclingColor(0), xMin, xMax);
+
+        // Contention Events (2x2).
+        RenderCounterChart(NonYieldingTasksChart, _nonYieldingTasksHover, data, d => d.NonYieldingTasksReported, "Non-Yielding Tasks",
+            ChartPalette.CyclingColor(3), xMin, xMax);
+        RenderCounterChart(LatchWarningsChart, _latchWarningsHover, data, d => d.LatchWarnings, "Latch Warnings",
+            ChartPalette.CyclingColor(2), xMin, xMax);
+        RenderSickSpinlocksChart(data, xMin, xMax);
+        RenderCpuComparisonChart(data, xMin, xMax);
+    }
+
+    /// <summary>
+    /// One single-series counter chart (Bad Pages / Dump Requests / Access Violations / Write AV /
+    /// Non-Yielding Tasks / Latch Warnings): a scatter of the selected counter over event time, Y floored at
+    /// 0, no legend. Empty window shows the Dashboard's centered "No data" text. <paramref name="selector"/>
+    /// null-coalesces to 0 so a snapshot missing the attribute plots a zero, never a gap.
+    /// </summary>
+    private void RenderCounterChart(
+        ScottPlot.WPF.WpfPlot chart, ChartHoverHelper? hover, List<SystemHealthRecord> data,
+        Func<SystemHealthRecord, long?> selector, string label, string colorHex, double xMin, double xMax)
+    {
+        ClearChart(chart);
+        hover?.Clear();
+        ApplyTheme(chart);
+
+        double max = 0;
+        if (data.Count == 0)
+        {
+            AddNoDataText(chart, xMin, xMax);
+        }
+        else
+        {
+            var xs = data.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+            var ys = data.Select(d => (double)(selector(d) ?? 0)).ToArray();
+
+            var scatter = chart.Plot.Add.Scatter(xs, ys);
+            scatter.Color = ScottPlot.Color.FromHex(colorHex);
+            ChartStyle.StyleScatter(scatter);
+            hover?.Add(scatter, label);
+
+            max = ys.Length > 0 ? ys.Max() : 0;
+        }
+
+        chart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ReapplyAxisColors(chart);
+        chart.Plot.Axes.SetLimitsX(xMin, xMax);
+        chart.Plot.YLabel("Count");
+        chart.Plot.Axes.SetLimitsY(0, max > 0 ? max * 1.15 : 1);
+        chart.Refresh();
+    }
+
+    /// <summary>
+    /// Sick Spinlocks by Type: one series per distinct <c>sickSpinlockType</c> (top 5, to bound clutter)
+    /// plotting the spinlock backoffs over event time, with a bottom legend — mirrors the Dashboard's
+    /// grouped multi-series chart (backoffs, or 1 when the count is absent).
+    /// </summary>
+    private void RenderSickSpinlocksChart(List<SystemHealthRecord> data, double xMin, double xMax)
+    {
+        ClearChart(SickSpinlocksChart);
+        _sickSpinlocksHover?.Clear();
+        ApplyTheme(SickSpinlocksChart);
+
+        double max = 0;
+        if (data.Count == 0)
+        {
+            AddNoDataText(SickSpinlocksChart, xMin, xMax);
+        }
+        else
+        {
+            var spinlockTypes = data
+                .Where(d => !string.IsNullOrEmpty(d.SickSpinlockType))
+                .Select(d => d.SickSpinlockType)
+                .Distinct()
+                .Take(5)
+                .ToList();
+
+            int colorIdx = 0;
+            foreach (var spinlockType in spinlockTypes)
+            {
+                var typeData = data.Where(d => d.SickSpinlockType == spinlockType).ToList();
+                if (typeData.Count == 0)
+                    continue;
+
+                var xs = typeData.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+                var ys = typeData.Select(d => (double)(d.SpinlockBackoffs ?? 1)).ToArray();
+
+                var scatter = SickSpinlocksChart.Plot.Add.Scatter(xs, ys);
+                scatter.Color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
+                ChartStyle.StyleScatter(scatter);
+                scatter.LegendText = spinlockType ?? "Unknown";
+                _sickSpinlocksHover?.Add(scatter, spinlockType ?? "Unknown");
+                colorIdx++;
+
+                if (ys.Length > 0)
+                    max = Math.Max(max, ys.Max());
+            }
+
+            if (spinlockTypes.Count > 0)
+                ShowChartLegend(SickSpinlocksChart);
+        }
+
+        SickSpinlocksChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ReapplyAxisColors(SickSpinlocksChart);
+        SickSpinlocksChart.Plot.Axes.SetLimitsX(xMin, xMax);
+        SickSpinlocksChart.Plot.YLabel("Backoffs");
+        SetChartYLimitsWithLegendPadding(SickSpinlocksChart, 0, max);
+        SickSpinlocksChart.Refresh();
+    }
+
+    /// <summary>
+    /// SQL CPU vs System CPU: two percent series over event time on a fixed 0-100 axis with a bottom
+    /// legend — the Dashboard's CPU-comparison chart (System CPU on the cycling accent, SQL CPU on the
+    /// shared SqlCpu identity color).
+    /// </summary>
+    private void RenderCpuComparisonChart(List<SystemHealthRecord> data, double xMin, double xMax)
+    {
+        ClearChart(CpuComparisonChart);
+        _cpuComparisonHover?.Clear();
+        ApplyTheme(CpuComparisonChart);
+
+        if (data.Count == 0)
+        {
+            AddNoDataText(CpuComparisonChart, xMin, xMax);
+        }
+        else
+        {
+            var xs = data.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+
+            var sysScatter = CpuComparisonChart.Plot.Add.Scatter(xs, data.Select(d => (double)(d.SystemCpuUtilization ?? 0)).ToArray());
+            sysScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));
+            ChartStyle.StyleScatter(sysScatter);
+            sysScatter.LegendText = "System CPU %";
+            _cpuComparisonHover?.Add(sysScatter, "System CPU %");
+
+            var sqlScatter = CpuComparisonChart.Plot.Add.Scatter(xs, data.Select(d => (double)(d.SqlCpuUtilization ?? 0)).ToArray());
+            sqlScatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("SqlCpu"));
+            ChartStyle.StyleScatter(sqlScatter);
+            sqlScatter.LegendText = "SQL CPU %";
+            _cpuComparisonHover?.Add(sqlScatter, "SQL CPU %");
+
+            ShowChartLegend(CpuComparisonChart);
+        }
+
+        CpuComparisonChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ReapplyAxisColors(CpuComparisonChart);
+        CpuComparisonChart.Plot.Axes.SetLimitsX(xMin, xMax);
+        CpuComparisonChart.Plot.YLabel("CPU %");
+        CpuComparisonChart.Plot.Axes.SetLimitsY(0, 100);
+        CpuComparisonChart.Refresh();
+    }
+
+    /// <summary>Centered "No data for selected time range" annotation for an empty counter chart,
+    /// matching the Dashboard's no-data placeholder text (placeholder accent color).</summary>
+    private static void AddNoDataText(ScottPlot.WPF.WpfPlot chart, double xMin, double xMax)
+    {
+        double xCenter = xMin + (xMax - xMin) / 2;
+        var text = chart.Plot.Add.Text("No data for selected time range", xCenter, 0.5);
+        text.LabelFontSize = 14;
+        text.LabelFontColor = ScottPlot.Color.FromHex(ChartPalette.AccentColor("Placeholder"));
+        text.LabelAlignment = ScottPlot.Alignment.MiddleCenter;
+    }
+
+    /// <summary>Tears down the eight Corruption/Contention hover helpers (mirrors the other tabs' dispose)
+    /// so their tooltip popups + chart event handlers don't outlive a closed server tab.</summary>
+    public void DisposeSystemHealthChartHelpers()
+    {
+        _badPagesHover?.Dispose();
+        _dumpRequestsHover?.Dispose();
+        _accessViolationsHover?.Dispose();
+        _writeAccessViolationsHover?.Dispose();
+        _nonYieldingTasksHover?.Dispose();
+        _latchWarningsHover?.Dispose();
+        _sickSpinlocksHover?.Dispose();
+        _cpuComparisonHover?.Dispose();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2378,6 +2378,97 @@
                         ItemContainerStyle="{DynamicResource SubTabItemStyle}"
                         SelectionChanged="SystemEventsSubTabs_SelectionChanged">
 
+                <!-- Corruption Events Sub-Tab (sp_server_diagnostics SYSTEM component counter charts). Faithful
+                     reproduction of the Dashboard's Corruption Events 2x2 chart grid; every collected snapshot
+                     plotted over the settable window (no significance filter). -->
+                <TabItem Header="Corruption Events">
+                    <Grid>
+                        <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                            <TextBlock Text="Corruption Events (bad pages, dump requests, access violations)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                        </StackPanel>
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
+                            <Grid.RowDefinitions><RowDefinition Height="*"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+
+                            <Border Grid.Row="0" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Bad Pages Detected" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="BadPagesChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Interval Dump Requests" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="DumpRequestsChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Access Violations Occurred" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="AccessViolationsChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Write Access Violation Count" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="WriteAccessViolationsChart"/>
+                                </Grid>
+                            </Border>
+                        </Grid>
+                    </Grid>
+                </TabItem>
+
+                <!-- Contention Events Sub-Tab (sp_server_diagnostics SYSTEM component counter charts). Faithful
+                     reproduction of the Dashboard's Contention Events 2x2 chart grid. -->
+                <TabItem Header="Contention Events">
+                    <Grid>
+                        <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                            <TextBlock Text="Contention Events (non-yielding tasks, latches, spinlocks, CPU)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
+                        </StackPanel>
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
+                            <Grid.RowDefinitions><RowDefinition Height="*"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+
+                            <Border Grid.Row="0" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Non-Yielding Tasks Reported" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="NonYieldingTasksChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Latch Warnings" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="LatchWarningsChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="Sick Spinlocks by Type" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="SickSpinlocksChart"/>
+                                </Grid>
+                            </Border>
+                            <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
+                                <Grid>
+                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
+                                    <TextBlock Text="SQL CPU vs System CPU" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <scottplot:WpfPlot Grid.Row="1" x:Name="CpuComparisonChart"/>
+                                </Grid>
+                            </Border>
+                        </Grid>
+                    </Grid>
+                </TabItem>
+
                 <!-- Scheduler Issues Sub-Tab -->
                 <TabItem Header="Scheduler Issues">
                     <Grid>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -127,8 +127,12 @@ public partial class ViewerServerTab : UserControl
         /* Collection Health's Duration Trends chart (copied from Lite): up-front theme + hover. */
         InitializeCollectionHealthChart();
 
-        /* System Events inner tab (system_health parity): register the eight category grids' filter managers. */
+        /* System Events inner tab (system_health parity): register the category grids' filter managers. */
         InitializeSystemEventsTab();
+
+        /* System Events' Corruption + Contention counter charts (SYSTEM-component parity): theme the eight
+           charts up front + wire hover, mirroring the Dashboard's SystemEventsContent. */
+        InitializeSystemHealthCharts();
 
         /* Seed the toolbar's initial time window + auto-refresh state from the user's persisted defaults
            (the Settings window), replacing the XAML's hardcoded 24h / on / 1m. Set BEFORE

--- a/PerformanceMonitor.Common/SystemHealthModels.cs
+++ b/PerformanceMonitor.Common/SystemHealthModels.cs
@@ -459,13 +459,75 @@ namespace PerformanceMonitor.Common
     }
 
     /// <summary>
+    /// One system-component health snapshot, shredded from the SYSTEM component of an
+    /// <c>sp_server_diagnostics_component_result</c> event (the <c>&lt;system&gt;</c> node's attributes).
+    /// Mirrors sp_HealthParser's <c>*_SystemHealth</c> table — the counter set that carries BOTH the
+    /// corruption signals (bad pages, dump requests, access violations) and the contention signals
+    /// (non-yielding tasks, latch warnings, sick spinlocks, SQL-vs-system CPU). The sibling Dashboard
+    /// splits these same columns across its "Corruption Events" and "Contention Events" sub-tabs; here
+    /// they stay one record (one SYSTEM snapshot) and the viewer picks the columns per chart. Every
+    /// counter is a raw <c>bigint</c> off the <c>&lt;system&gt;</c> node (no unit conversion), and the two
+    /// spinlock-type strings are kept verbatim, exactly as sp_HealthParser logs them.
+    /// </summary>
+    public sealed record SystemHealthRecord
+    {
+        /// <summary>Event <c>@timestamp</c>, parsed as UTC.</summary>
+        public DateTime? EventTime { get; init; }
+
+        /// <summary>xpath <c>data[@name="state"]/text</c> — the component state text (CLEAN/WARNING/HAS_ISSUES).</summary>
+        public string? State { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@spinlockBackoffs</c> (bigint).</summary>
+        public long? SpinlockBackoffs { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@sickSpinlockType</c> (the sick spinlock's name, e.g. SOS_CACHESTORE).</summary>
+        public string? SickSpinlockType { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@sickSpinlockTypeAfterAv</c>.</summary>
+        public string? SickSpinlockTypeAfterAv { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@latchWarnings</c> (bigint).</summary>
+        public long? LatchWarnings { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@isAccessViolationOccurred</c> (bigint, as sp_HealthParser stores it).</summary>
+        public long? IsAccessViolationOccurred { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@writeAccessViolationCount</c> (bigint).</summary>
+        public long? WriteAccessViolationCount { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@totalDumpRequests</c> (bigint).</summary>
+        public long? TotalDumpRequests { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@intervalDumpRequests</c> (bigint).</summary>
+        public long? IntervalDumpRequests { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@nonYieldingTasksReported</c> (bigint).</summary>
+        public long? NonYieldingTasksReported { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@pageFaults</c> (bigint).</summary>
+        public long? PageFaults { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@systemCpuUtilization</c> (whole-percent bigint).</summary>
+        public long? SystemCpuUtilization { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@sqlCpuUtilization</c> (whole-percent bigint).</summary>
+        public long? SqlCpuUtilization { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@BadPagesDetected</c> (bigint).</summary>
+        public long? BadPagesDetected { get; init; }
+
+        /// <summary><c>&lt;system&gt;</c> attribute <c>@BadPagesFixed</c> (bigint).</summary>
+        public long? BadPagesFixed { get; init; }
+    }
+
+    /// <summary>
     /// The result of shredding a batch of raw system_health events: one list per unique warning category.
     /// Populated by <see cref="SystemHealthParser.ParseEvents"/>. Each event contributes to exactly one
     /// category — at most one record for every category except <see cref="IoIssues"/> (an IO_SUBSYSTEM
     /// event contributes one record per distinct pending-request file). An
     /// <c>sp_server_diagnostics_component_result</c> event routes to the category matching its component
-    /// (RESOURCE → memory conditions, QUERY_PROCESSING → CPU tasks, IO_SUBSYSTEM → IO issues); the other
-    /// components contribute nothing.
+    /// (SYSTEM → system health, RESOURCE → memory conditions, QUERY_PROCESSING → CPU tasks, IO_SUBSYSTEM →
+    /// IO issues); the other components contribute nothing.
     /// </summary>
     public sealed class SystemHealthParseResult
     {
@@ -477,5 +539,6 @@ namespace PerformanceMonitor.Common
         public List<SignificantWaitRecord> SignificantWaits { get; } = new();
         public List<CpuTasksRecord> CpuTasks { get; } = new();
         public List<IoIssuesRecord> IoIssues { get; } = new();
+        public List<SystemHealthRecord> SystemHealth { get; } = new();
     }
 }

--- a/PerformanceMonitor.Common/SystemHealthParser.cs
+++ b/PerformanceMonitor.Common/SystemHealthParser.cs
@@ -34,12 +34,13 @@ namespace PerformanceMonitor.Common
     ///
     /// <para>Dispatch is by XE event name (<c>event_type</c>): the ring-buffer / error / wait feeders each map
     /// to exactly one category, while an <c>sp_server_diagnostics_component_result</c> event routes on its
-    /// component — RESOURCE → memory conditions, QUERY_PROCESSING → CPU tasks, IO_SUBSYSTEM → IO issues. Each
-    /// component parser gates on the presence of its own node (<c>&lt;resource&gt;</c> /
-    /// <c>&lt;queryProcessing&gt;</c> / <c>&lt;ioSubsystem&gt;</c>), so a single event yields a record for its
-    /// component alone and nothing for the others (sp_HealthParser's remaining SYSTEM/EVENTS components are out
-    /// of scope). IO issues is the one many-per-event category: sp_HealthParser fans an IO_SUBSYSTEM event out
-    /// to one row per pending-request file, so its parser returns a list.</para>
+    /// component — SYSTEM → system health (corruption + contention counters), RESOURCE → memory conditions,
+    /// QUERY_PROCESSING → CPU tasks, IO_SUBSYSTEM → IO issues. Each component parser gates on the presence of
+    /// its own node (<c>&lt;system&gt;</c> / <c>&lt;resource&gt;</c> / <c>&lt;queryProcessing&gt;</c> /
+    /// <c>&lt;ioSubsystem&gt;</c>), so a single event yields a record for its component alone and nothing for
+    /// the others (sp_HealthParser's remaining EVENTS component is out of scope). IO issues is the one
+    /// many-per-event category: sp_HealthParser fans an IO_SUBSYSTEM event out to one row per pending-request
+    /// file, so its parser returns a list.</para>
     /// </summary>
     public static class SystemHealthParser
     {
@@ -94,6 +95,7 @@ namespace PerformanceMonitor.Common
                     break;
                 case SpServerDiagnosticsEvent:
                     // One event carries one component; each parser is a no-op unless its component node is present.
+                    Add(result.SystemHealth, ParseSystemHealth(eventXml));
                     Add(result.MemoryConditions, ParseMemoryConditions(eventXml));
                     Add(result.CpuTasks, ParseCpuTasks(eventXml));
                     result.IoIssues.AddRange(ParseIoIssues(eventXml));
@@ -164,6 +166,42 @@ namespace PerformanceMonitor.Common
                 Message = DataValue(ev, "message"),
                 DatabaseName = null, // sp_HealthParser: DB_NAME(database_id) — needs a live connection.
                 DatabaseId = ParseInt(DataValue(ev, "database_id")),
+            };
+        }
+
+        /// <summary>
+        /// Shreds the SYSTEM component of an <c>sp_server_diagnostics_component_result</c> event into a
+        /// <see cref="SystemHealthRecord"/> — the corruption + contention counter set carried on the
+        /// <c>&lt;system&gt;</c> node's attributes. Returns null for null/blank or unparseable XML, or when the
+        /// event carries no <c>&lt;system&gt;</c> node (i.e. it is a non-SYSTEM component). Every counter is a
+        /// raw bigint off the node; the two spinlock-type strings are kept verbatim (sp_HealthParser's
+        /// <c>*_SystemHealth</c> column set).
+        /// </summary>
+        public static SystemHealthRecord? ParseSystemHealth(string? eventXml)
+        {
+            var ev = EventRoot(eventXml);
+            var system = ev?.Descendants("system").FirstOrDefault();
+            if (ev == null || system == null)
+                return null;
+
+            return new SystemHealthRecord
+            {
+                EventTime = ParseTimestamp(ev),
+                State = DataText(ev, "state"),
+                SpinlockBackoffs = ParseLong((string?)system.Attribute("spinlockBackoffs")),
+                SickSpinlockType = (string?)system.Attribute("sickSpinlockType"),
+                SickSpinlockTypeAfterAv = (string?)system.Attribute("sickSpinlockTypeAfterAv"),
+                LatchWarnings = ParseLong((string?)system.Attribute("latchWarnings")),
+                IsAccessViolationOccurred = ParseLong((string?)system.Attribute("isAccessViolationOccurred")),
+                WriteAccessViolationCount = ParseLong((string?)system.Attribute("writeAccessViolationCount")),
+                TotalDumpRequests = ParseLong((string?)system.Attribute("totalDumpRequests")),
+                IntervalDumpRequests = ParseLong((string?)system.Attribute("intervalDumpRequests")),
+                NonYieldingTasksReported = ParseLong((string?)system.Attribute("nonYieldingTasksReported")),
+                PageFaults = ParseLong((string?)system.Attribute("pageFaults")),
+                SystemCpuUtilization = ParseLong((string?)system.Attribute("systemCpuUtilization")),
+                SqlCpuUtilization = ParseLong((string?)system.Attribute("sqlCpuUtilization")),
+                BadPagesDetected = ParseLong((string?)system.Attribute("BadPagesDetected")),
+                BadPagesFixed = ParseLong((string?)system.Attribute("BadPagesFixed")),
             };
         }
 


### PR DESCRIPTION
## What

Faithfully reproduces the **full Dashboard's System Events** in the Darling viewer by adding the two sub-tabs Darling still lacked: **Corruption Events** and **Contention Events**. Darling's System Events now covers **all nine Dashboard categories** (7 shared grids + Corruption + Contention) plus Darling's extra Significant Waits — 10 sub-tabs total, Corruption/Contention leading (matching the Dashboard's default order).

## STEP 0 — data-path investigation (determined the approach)

**Source.** Both Dashboard tabs are fed by `RefreshSystemHealthAsync` → `collect.HealthParser_SystemHealth` → `HealthParserSystemHealthItem`. That table is the **SYSTEM component of `sp_server_diagnostics_component_result`** — the `<system>` node's counters (`spinlockBackoffs`, `sickSpinlockType`, `latchWarnings`, `isAccessViolationOccurred`, `writeAccessViolationCount`, `intervalDumpRequests`, `nonYieldingTasksReported`, `systemCpuUtilization`, `sqlCpuUtilization`, `BadPagesDetected`, …). One SYSTEM record feeds **both** tabs; each just selects its own columns.

**Rendering.** The Dashboard renders these as **2×2 counter charts over time** (ScottPlot scatter), **not** grids, and applies **no significance filter** — every collected SYSTEM snapshot is plotted.

**Is it captured?** Yes. `SystemHealthEventsCollector` already captures `sp_server_diagnostics_component_result` (one of its six feeders — its own doc says "memory conditions, IO, **and system component health**"). The SYSTEM component was simply never shredded: `SystemHealthParser` explicitly called SYSTEM "out of scope." **So no collection/schema/migration work was required** — this is the preferred path: extend the parser + models and add the two sub-tabs (the CPU/IO pattern from #1396).

## What was added

- **Common** — `SystemHealthParser.ParseSystemHealth` shreds the `<system>` node into a new `SystemHealthRecord` (mirrors sp_HealthParser's `*_SystemHealth` column set), dispatched from the `sp_server_diagnostics_component_result` case alongside RESOURCE/QUERY_PROCESSING/IO_SUBSYSTEM. Gates on the `<system>` node so non-SYSTEM components yield nothing. Added `SystemHealth` list to `SystemHealthParseResult`; parser class doc updated (SYSTEM no longer out of scope).
- **Viewer** — two counter-chart sub-tabs faithfully reproducing the Dashboard's `LoadCorruptionEventsCharts` / `LoadContentionEventsCharts`:
  - *Corruption Events:* Bad Pages Detected, Interval Dump Requests, Access Violations Occurred, Write Access Violation Count.
  - *Contention Events:* Non-Yielding Tasks Reported, Latch Warnings, Sick Spinlocks by Type (multi-series), SQL CPU vs System CPU (dual-series, 0–100).
  - Same cycling-palette color assignments as the Dashboard, via the shared `ChartStyle` / `ChartPalette`; hover tooltips kept (no context menu, matching the viewer's other charts). `ViewerDataService.GetSystemHealthAsync` reads the one SYSTEM feed with **no significance filter** (every snapshot, oldest-first) and the time axis honors the toolbar's settable window (`GetWindowUtc`, #1399). Both tabs share a single load, exactly as the Dashboard's `case 0/case 1 → RefreshSystemHealthAsync`.
- **Tests** — `SystemHealthParserTests`: full-column shred of a representative SYSTEM fixture, non-SYSTEM no-op, malformed-safety, and the dispatch routing. `ViewerSystemEventsTests`: both-tab column parity off one record, the "CLEAN snapshot is still kept (no warnings-only gate)" design pin, and the end-to-end shred. New fixture `Fixtures/SystemHealth/sp_server_diagnostics_system.xml`.

## How it faithfully reproduces the Dashboard

Same source (SYSTEM component), same presentation (2×2 counter charts over time), same columns per tab, same colors, same one-feed-both-tabs load, and the same no-significance-filter "plot every snapshot" behavior — nothing dropped. All 9 Dashboard System Events categories are now present in Darling.

## Build + tests (Release)

- `PerformanceMonitor.Darling.Viewer` (pulls in Common): **Build succeeded, 0 errors** (only pre-existing CA warnings).
- `Darling/Darling.Tests`: **897 passed, 87 skipped, 0 failed** (the 87 skips are the pre-existing live-Postgres integration tests). The System Events suites alone: **90 passed, 0 failed, 0 skipped**.

No collector/storage changes (STEP 0 confirmed the source is already captured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
